### PR TITLE
Use spacing(tight) for breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -1,5 +1,5 @@
 $vertical-padding: (control-height() - line-height(body)) / 2;
-$horizontal-padding: rem(10px);
+$horizontal-padding: spacing(tight);
 $icon-size: rem(20px);
 
 // The inset bounding box of the icon causes it not to be lined up with


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify/pull/113510#discussion_r116391618 by using our spacing values.