### PR TITLE
[v4] Don’t try to size html to 10px

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -26,6 +26,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Updated translation.yml with the new locales path ([#1649](https://github.com/Shopify/polaris-react/pull/1649))
+- Fixed a bug that affected sizing and spacing of elements in some writing systems (notably Chinese, Japanese, and Korean) ([#1590](https://github.com/Shopify/polaris-react/pull/1590))
+- Fixed a bug when converting `em` units to `rem` units ([#1590](https://github.com/Shopify/polaris-react/pull/1590))
 
 ### Documentation
 

--- a/src/components/Sheet/README.md
+++ b/src/components/Sheet/README.md
@@ -151,7 +151,7 @@ class SheetExample extends React.Component {
       : null;
 
     return (
-      <div style={{maxHeight: '640px', overflow: 'visible'}}>
+      <div style={{maxHeight: '40rem', overflow: 'visible'}}>
         <AppProvider
           theme={theme}
           i18n={{
@@ -205,7 +205,7 @@ class SheetExample extends React.Component {
                       borderBottom: '1px solid #DFE3E8',
                       display: 'flex',
                       justifyContent: 'space-between',
-                      padding: '1.6rem',
+                      padding: '1rem',
                       width: '100%',
                     }}
                   >
@@ -217,7 +217,7 @@ class SheetExample extends React.Component {
                       plain
                     />
                   </div>
-                  <Scrollable style={{padding: '1.6rem', height: '100%'}}>
+                  <Scrollable style={{padding: '1rem', height: '100%'}}>
                     <ChoiceList
                       title="Select a sales channel"
                       name="salesChannelsList"
@@ -234,7 +234,7 @@ class SheetExample extends React.Component {
                       borderTop: '1px solid #DFE3E8',
                       display: 'flex',
                       justifyContent: 'space-between',
-                      padding: '1.6rem',
+                      padding: '1rem',
                       width: '100%',
                     }}
                   >

--- a/src/styles/foundation/utilities.scss
+++ b/src/styles/foundation/utilities.scss
@@ -1,11 +1,11 @@
-$default-browser-font-size: 16px;
-$base-font-size: 10px;
+$root-font-size: 16px;
 
 /// Returns the value in rem for a given pixel value.
 /// @param {Number} $value - The pixel value to be converted.
+/// @param {Number} $current-font-size - For converting ems, defines the pixel value of 1em.
 /// @return {Number} The converted value in rem.
 
-@function rem($value) {
+@function rem($value, $current-font-size: $root-font-size) {
   $unit: unit($value);
 
   @if $value == 0 {
@@ -13,9 +13,11 @@ $base-font-size: 10px;
   } @else if $unit == 'rem' {
     @return $value;
   } @else if $unit == 'px' {
-    @return $value / $base-font-size * 1rem;
+    @return $value * (1rem / $root-font-size);
+    // e.g. 16px × 1rem/16px = 1rem
   } @else if $unit == 'em' {
-    @return $unit / 1em * 1rem;
+    @return $value * ($current-font-size / 1em) * (1rem / $root-font-size);
+    // e.g. 1em × 24px/em = 24px × 1rem/16px = 1.5rem
   } @else {
     @error 'Value must be in px, em, or rem.';
   }
@@ -23,9 +25,10 @@ $base-font-size: 10px;
 
 /// Returns the value in pixels for a given rem value.
 /// @param {Number} $value - The rem value to be converted.
+/// @param {Number} $current-font-size - For converting ems, defines the pixel value of 1em.
 /// @return {Number} The converted value in pixels.
 
-@function px($value) {
+@function px($value, $current-font-size: $root-font-size) {
   $unit: unit($value);
 
   @if $value == 0 {
@@ -33,20 +36,22 @@ $base-font-size: 10px;
   } @else if $unit == 'px' {
     @return $value;
   } @else if $unit == 'em' {
-    @return ($value / 1em) * $base-font-size;
+    @return $value * ($current-font-size / 1em);
+    // e.g. 1em × 24px/em = 24px
   } @else if $unit == 'rem' {
-    @return ($value / 1rem) * $base-font-size;
+    @return $value * ($root-font-size / 1rem);
+    // e.g. 1rem × 16px/rem = 16px
   } @else {
     @error 'Value must be in rem, em, or px.';
   }
 }
 
-/// Returns the value in ems for a given pixel value. Note that this
-/// only works for elements that have had no font-size changes.
-/// @param {Number} $value - The pixel value to be converted.
+/// Returns the value in ems for a given pixel value.
+/// @param {Number} $value - The value (em, rem, or px) to be converted.
+/// @param {Number} $current-font-size - For converting ems, defines the pixel value of 1em.
 /// @return {Number} The converted value in ems.
 
-@function em($value) {
+@function em($value, $current-font-size: $root-font-size) {
   $unit: unit($value);
 
   @if $value == 0 {
@@ -54,9 +59,11 @@ $base-font-size: 10px;
   } @else if $unit == 'em' {
     @return $value;
   } @else if $unit == 'rem' {
-    @return $value / 1rem * 1em * ($base-font-size / $default-browser-font-size);
+    @return $value * ($root-font-size / 1rem) * (1em / $current-font-size);
+    // e.g. 1rem × 16px/rem = 16px × 1em/24px = 0.667em
   } @else if $unit == 'px' {
-    @return $value / $default-browser-font-size * 1em;
+    @return $value * (1em / $current-font-size);
+    // e.g. 16px × 1em/24px = 0.667em
   } @else {
     @error 'Value must be in px, rem, or em.';
   }

--- a/src/styles/foundation/utilities.scss
+++ b/src/styles/foundation/utilities.scss
@@ -1,11 +1,11 @@
 $root-font-size: 16px;
 
-/// Returns the value in rem for a given pixel value.
-/// @param {Number} $value - The pixel value to be converted.
-/// @param {Number} $current-font-size - For converting ems, defines the pixel value of 1em.
+/// Returns the value in rem for a given length value.
+/// Note: converting ems only works for elements that have had no font-size changes.
+/// @param {Number} $value - The value (em, rem, or px) to be converted.
 /// @return {Number} The converted value in rem.
 
-@function rem($value, $current-font-size: $root-font-size) {
+@function rem($value) {
   $unit: unit($value);
 
   @if $value == 0 {
@@ -13,22 +13,22 @@ $root-font-size: 16px;
   } @else if $unit == 'rem' {
     @return $value;
   } @else if $unit == 'px' {
-    @return $value * (1rem / $root-font-size);
     // e.g. 16px × 1rem/16px = 1rem
+    @return $value * (1rem / $root-font-size);
   } @else if $unit == 'em' {
-    @return $value * ($current-font-size / 1em) * (1rem / $root-font-size);
-    // e.g. 1em × 24px/em = 24px × 1rem/16px = 1.5rem
+    // This is a fudge; it assumes 1em == 1rem
+    @return $value / 1em * 1rem;
   } @else {
     @error 'Value must be in px, em, or rem.';
   }
 }
 
-/// Returns the value in pixels for a given rem value.
+/// Returns the value in pixels for a given length value.
+/// Note: converting ems only works for elements that have had no font-size changes.
 /// @param {Number} $value - The rem value to be converted.
-/// @param {Number} $current-font-size - For converting ems, defines the pixel value of 1em.
 /// @return {Number} The converted value in pixels.
 
-@function px($value, $current-font-size: $root-font-size) {
+@function px($value) {
   $unit: unit($value);
 
   @if $value == 0 {
@@ -36,22 +36,23 @@ $root-font-size: 16px;
   } @else if $unit == 'px' {
     @return $value;
   } @else if $unit == 'em' {
-    @return $value * ($current-font-size / 1em);
-    // e.g. 1em × 24px/em = 24px
+    // This is a fudge; it assumes 1em == 1rem
+    // e.g. 1em × 16px/em = 16px
+    @return $value * ($root-font-size / 1em);
   } @else if $unit == 'rem' {
-    @return $value * ($root-font-size / 1rem);
     // e.g. 1rem × 16px/rem = 16px
+    @return $value * ($root-font-size / 1rem);
   } @else {
     @error 'Value must be in rem, em, or px.';
   }
 }
 
-/// Returns the value in ems for a given pixel value.
+/// Returns the value in ems for a given length value.
+/// Note: only works for elements that have had no font-size changes.
 /// @param {Number} $value - The value (em, rem, or px) to be converted.
-/// @param {Number} $current-font-size - For converting ems, defines the pixel value of 1em.
 /// @return {Number} The converted value in ems.
 
-@function em($value, $current-font-size: $root-font-size) {
+@function em($value) {
   $unit: unit($value);
 
   @if $value == 0 {
@@ -59,11 +60,12 @@ $root-font-size: 16px;
   } @else if $unit == 'em' {
     @return $value;
   } @else if $unit == 'rem' {
-    @return $value * ($root-font-size / 1rem) * (1em / $current-font-size);
-    // e.g. 1rem × 16px/rem = 16px × 1em/24px = 0.667em
+    // This is a fudge; it assumes 1em == 1rem
+    @return $value / 1rem * 1em;
   } @else if $unit == 'px' {
-    @return $value * (1em / $current-font-size);
-    // e.g. 16px × 1em/24px = 0.667em
+    // This is a fudge; it assumes 1em == 1rem
+    // e.g. 14px × 1em/16px = 0.875em
+    @return $value * (1em / $root-font-size);
   } @else {
     @error 'Value must be in px, rem, or em.';
   }

--- a/src/styles/global/elements.scss
+++ b/src/styles/global/elements.scss
@@ -16,7 +16,7 @@ button {
 
 html {
   position: relative;
-  font-size: ($base-font-size / $default-browser-font-size) * 100%;
+  font-size: ($root-font-size / 16px) * 100%;
   -webkit-font-smoothing: antialiased;
 
   // This needs to come after -webkit-font-smoothing


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #431

**TL;DR**

Polaris sets the font-size on the html element to 62.5% (10px). We do this as a developer convenience, but it causes most elements to be larger than intended in some locales.

**Long version** 

Polaris uses rem units in order to support people who choose a larger or smaller font size at the browser level. However, Shopifolk are used to thinking in `px`. When we inspect CSS in the browser, the rem output is harder to make sense of: how many px is `0.875rem`? But when we set the html element to a font-size of 10px, it’s easier: `1.4rem` is 14px.

However, languages that use ideographic writing systems (e.g. Chinese, Korean, Japanese) need larger font sizes for legibility, so browsers like Chrome have a minimum font size of 12px. This means the font size of html computes to 12px, not 10, and many elements get rendered larger than intended.

### WHAT is this pull request doing?

This PR removes a small amount of developer convenience in favor of a UI that is sized the same across locales. This PR should not affect the size of rendered text, only the size of interface elements.

### HOW does this PR work?

Because we’re now going with the browser default as our root em, we had some redundant code. The code has been refactored and improved to handle conversions involving ems more accurately, fix a bug in one code path, and be (hopefully) more readable.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

**Part 1**
1. In Chrome, go to Chrome > Preferences
1. In Appearance section, click “Customize fonts”
1. For “Minimum font size”, change the value from 10px (default) to 12px
1. Log into a test Shopify store (production)
1. Verify that elements are larger than normal, but text sizes are normal (body font size should still be 14px)

**Part 2**
1. Run the local Storybook for this repo, or open it from the Deployment link in this PR
2. With the browser still set to 12px min font-size, view several components
3. Verify that padding, margin, heights and other dimensions are now back to normal
4. Verify that text is not smaller than normal (body font size should still be 14px)

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
