### PR TITLE
[SkeletonPage] render Loading by default

### DIFF
--- a/src/components/SkeletonPage/README.md
+++ b/src/components/SkeletonPage/README.md
@@ -150,6 +150,48 @@ Use this component to compose a loading version of a page where the page title a
 </SkeletonPage>
 ```
 
+### Page inside a Frame
+
+Use this component to compose a loading version of a page that includes a frame loading bar.
+
+```jsx
+<Frame>
+  <SkeletonPage title="Products" primaryAction secondaryActions={2} loading>
+    <Layout>
+      <Layout.Section>
+        <Card sectioned>
+          <SkeletonBodyText />
+        </Card>
+        <Card sectioned title="Images">
+          <SkeletonBodyText />
+        </Card>
+        <Card sectioned title="Variants">
+          <SkeletonBodyText />
+        </Card>
+      </Layout.Section>
+      <Layout.Section secondary>
+        <Card title="Sales channels">
+          <Card.Section>
+            <SkeletonBodyText lines={2} />
+          </Card.Section>
+          <Card.Section>
+            <SkeletonBodyText lines={1} />
+          </Card.Section>
+        </Card>
+        <Card title="Organization" subdued>
+          <Card.Section>
+            <SkeletonBodyText lines={2} />
+          </Card.Section>
+          <Card.Section>
+            <SkeletonBodyText lines={2} />
+          </Card.Section>
+        </Card>
+      </Layout.Section>
+    </Layout>
+  </SkeletonPage>
+</Frame>
+```
+
 ---
 
 ## Related components

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -3,6 +3,7 @@ import {useAppBridge} from '../../utilities/app-bridge';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {DisplayText} from '../DisplayText';
+import {Loading} from '../Loading';
 import {SkeletonDisplayText} from '../SkeletonDisplayText';
 import {SkeletonBodyText} from '../SkeletonBodyText';
 
@@ -21,6 +22,8 @@ export interface SkeletonPageProps {
   secondaryActions?: number;
   /** Shows a skeleton over the breadcrumb */
   breadcrumbs?: boolean;
+  /** Shows the frame loading bar */
+  loading?: boolean;
   /** The child elements to render in the skeleton page. */
   children?: React.ReactNode;
   /** Decreases the maximum layout width. Intended for single-column layouts
@@ -38,6 +41,7 @@ export function SkeletonPage({
   secondaryActions,
   title = '',
   breadcrumbs,
+  loading,
 }: SkeletonPageProps) {
   if (singleColumn) {
     // eslint-disable-next-line no-console
@@ -79,6 +83,8 @@ export function SkeletonPage({
     </div>
   ) : null;
 
+  const loadingMarkup = loading ? <Loading /> : null;
+
   const headerMarkup = !appBridge ? (
     <div className={headerClassName}>
       {breadcrumbMarkup}
@@ -98,6 +104,7 @@ export function SkeletonPage({
     >
       {headerMarkup}
       <div className={styles.Content}>{children}</div>
+      {loadingMarkup}
     </div>
   );
 }

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {
   Layout,
+  Loading,
   Card,
   SkeletonBodyText,
   DisplayText,
@@ -85,6 +86,18 @@ describe('<SkeletonPage />', () => {
   it('renders breadcrumbs', () => {
     const skeletonPage = mountWithAppProvider(<SkeletonPage breadcrumbs />);
     expect(skeletonPage.find(SkeletonBodyText)).toHaveLength(1);
+  });
+
+  describe('loading', () => {
+    it('does not render a <Loading /> by default', () => {
+      const skeletonPage = mountWithAppProvider(<SkeletonPage />);
+      expect(skeletonPage.find(Loading)).toHaveLength(0);
+    });
+
+    it('renders a <Loading /> when loading is set', () => {
+      const skeletonPage = mountWithAppProvider(<SkeletonPage loading />);
+      expect(skeletonPage.find(Loading)).toHaveLength(1);
+    });
   });
 
   describe('primaryAction', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Because `<SkeletonPage />` is typically used as a _loading_ component, it stands to reason that rendering a `<Loading />` component would also be desired within a `<Frame />` so that the page UX includes loading feedback.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

To resolve this, I am adding a new optional `loading` prop to `SkeletonPage` that defaults to `false` so that `<Loading />` is only included in a skeleton page when opted in.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Frame, SkeletonPage} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Frame>
        <SkeletonPage title="Loading UX" loading>
          <Layout sectioned>
            <SkeletonBodyText />
          </Layout>
        </SkeletonPage>
      </Frame>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
