### PR TITLE
[Tabs] Prevent Tabs’s onSelect prop from triggering a window scroll

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Prevented the `onSelect` prop of `Tabs` from changing scroll position ([#2196](https://github.com/Shopify/polaris-react/pull/2196))
+
 ### Documentation
 
 - Converted `Form`, `Frame`, and `Loading` examples to functional components ([#2130](https://github.com/Shopify/polaris-react/pull/2130))

--- a/src/components/Tabs/components/Tab/Tab.tsx
+++ b/src/components/Tabs/components/Tab/Tab.tsx
@@ -145,7 +145,7 @@ class Tab extends React.PureComponent<CombinedProps, never> {
 function focusPanelID(panelID: string) {
   const panel = document.getElementById(panelID);
   if (panel) {
-    panel.focus();
+    panel.focus({preventScroll: true});
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2165 

Tabs focus on their contents when onSelect is triggered. When the contents of a tab are larger than the screen, this would alter scroll position in a jarring way. These changes prevent the scrolling.

### WHAT is this pull request doing?

Passes `preventScroll` to `focus`

<details>
  <summary>Before GIF</summary>
  <img src="http://g.recordit.co/Gbc9qwCKpf.gif" alt="Scroll problem">
</details>

<details>
  <summary>After GIF ✨</summary>
  <img src="http://g.recordit.co/QUh15jtOHa.gif" alt="Constant scroll position">
</details>

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';
import {Page, Tabs, Card} from '../src';

export function Playground() {
  const [currentTab, changeTab] = useState(0);
  const tabs = [
    {
      id: 'tab-1',
      content: 'Tab 1',
    },
    {
      id: 'tab-2',
      content: 'Tab 2',
    },
    {
      id: 'tab-3',
      content: 'Tab 3',
    },
  ];
  const height = 100 + currentTab * 1000;

  return (
    <Page title="Playground">
      <Card>
        <Tabs tabs={tabs} selected={currentTab} onSelect={changeTab}>
          <Card.Section title={tabs[currentTab].content}>
            <div style={{border: 'solid 1px black', height}} />
          </Card.Section>
        </Tabs>
      </Card>
    </Page>
  );
}


```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)— fails in some browsers (see comment)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
