### PR TITLE
[ContextualSaveBar] Fix action overflow on small screens

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "Speichern",
-      "discard": "Verwerfen"
+      "discard": "Verwerfen",
+      "message": "Nicht gespeicherte Änderungen"
     },
     "DataTable": {
       "sortAccessibilityLabel": "von {direction} sortieren nach",

--- a/locales/en.json
+++ b/locales/en.json
@@ -40,6 +40,7 @@
     },
 
     "ContextualSaveBar": {
+      "message": "Unsaved changes",
       "save": "Save",
       "discard": "Discard"
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "Guardar",
-      "discard": "Descartar"
+      "discard": "Descartar",
+      "message": "Cambios no guardados"
     },
     "DataTable": {
       "sortAccessibilityLabel": "ordenar {direction} por",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "Enregistrer",
-      "discard": "Annuler"
+      "discard": "Annuler",
+      "message": "Modifications non enregistrées"
     },
     "DataTable": {
       "sortAccessibilityLabel": "trier {direction} par",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "सहेजें",
-      "discard": "छोड़ें"
+      "discard": "छोड़ें",
+      "message": "ना सहेजे गए परिवर्तन"
     },
     "DataTable": {
       "sortAccessibilityLabel": "{direction} के अनुसार क्रमबद्ध करें",

--- a/locales/it.json
+++ b/locales/it.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "Salva",
-      "discard": "Rimuovi"
+      "discard": "Rimuovi",
+      "message": "Modifiche non salvate"
     },
     "DataTable": {
       "sortAccessibilityLabel": "ordina per {direction}",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "保存する",
-      "discard": "破棄する"
+      "discard": "破棄する",
+      "message": "保存されていない変更"
     },
     "DataTable": {
       "sortAccessibilityLabel": "で{direction}を並び替える",

--- a/locales/ms.json
+++ b/locales/ms.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "Simpan",
-      "discard": "Buang"
+      "discard": "Buang",
+      "message": "Perubahan yang tidak disimpan"
     },
     "DataTable": {
       "sortAccessibilityLabel": "isih {direction} mengikut",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "Opslaan",
-      "discard": "Verwerpen"
+      "discard": "Verwerpen",
+      "message": "Niet-opgeslagen wijzigingen"
     },
     "DataTable": {
       "sortAccessibilityLabel": "sorteer {direction} op",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "Salvar",
-      "discard": "Descartar"
+      "discard": "Descartar",
+      "message": "Alterações não salvas"
     },
     "DataTable": {
       "sortAccessibilityLabel": "ordenar {direction} por",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "保存",
-      "discard": "取消"
+      "discard": "取消",
+      "message": "未保存的更改"
     },
     "DataTable": {
       "sortAccessibilityLabel": "向 {direction} 排序",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -37,7 +37,7 @@
     "ContextualSaveBar": {
       "save": "儲存",
       "discard": "捨棄",
-      "message": "尚未儲存的變更內容"
+      "message": "變更尚未儲存"
     },
     "DataTable": {
       "sortAccessibilityLabel": "向 {direction} 排序，依據",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -36,7 +36,8 @@
     },
     "ContextualSaveBar": {
       "save": "儲存",
-      "discard": "捨棄"
+      "discard": "捨棄",
+      "message": "尚未儲存的變更內容"
     },
     "DataTable": {
       "sortAccessibilityLabel": "向 {direction} 排序，依據",

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -3,10 +3,10 @@
 $off-white: rgb(250, 251, 252);
 $off-white-border: rgb(235, 238, 240);
 $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+$min-message-width: 280px;
 
 .ContextualSaveBar {
   display: flex;
-  height: top-bar-height();
   background-color: color('white');
   box-shadow: $shadow;
 
@@ -26,7 +26,6 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     display: flex;
     flex: 0 0 layout-width(nav);
     align-items: center;
-    height: 100%;
     padding: 0 spacing();
     border-right: 1px solid $off-white-border;
     background-color: $off-white;
@@ -36,32 +35,35 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 .Contents {
   display: flex;
   flex: 1 1 auto;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+  min-height: top-bar-height();
   min-width: 1px;
   max-width: layout-width(primary, max) + layout-width(secondary, max) +
     layout-width(inner-spacing);
   height: 100%;
   margin: 0 auto;
-  padding: 0 spacing();
+  padding: 0 spacing() 1rem;
 
   @include page-content-when-not-fully-condensed {
-    padding: 0 spacing(loose);
+    padding: 0 spacing(loose) 1rem;
   }
 
   @include page-content-when-not-partially-condensed {
-    padding: 0 spacing(extra-loose);
+    padding: 0 spacing(extra-loose) 1rem;
+  }
+
+  > * {
+    margin-top: 1rem;
   }
 }
 
 .Message {
-  @include truncate;
   @include text-style-heading;
   @include text-emphasis-subdued;
-}
-
-.ActionContainer {
-  flex-shrink: 0;
+  margin-right: spacing(loose);
+  flex-basis: $min-message-width;
 }
 
 .Action {

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -60,6 +60,10 @@ export function ContextualSaveBar({
       />
     );
 
+  const messageMarkup = message
+    ? message
+    : i18n.translate('Polaris.ContextualSaveBar.message');
+
   const discardActionMarkup = discardAction && (
     <Button
       url={discardAction.url}
@@ -107,7 +111,7 @@ export function ContextualSaveBar({
       <div className={styles.ContextualSaveBar}>
         {logoMarkup}
         <div className={styles.Contents}>
-          <h2 className={styles.Message}>{message}</h2>
+          <h2 className={styles.Message}>{messageMarkup}</h2>
           <div className={styles.ActionContainer}>
             <Stack spacing="tight" wrap={false}>
               {discardActionMarkup}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1983

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR wraps the actions on small screens when they do not fit inline with the bar's `message` content. 

### Blockers ⚠️ 

This is blocked from shipping because `Frame` adds `padding-top` to its content hardcoded to the height of the top bar. The `Frame`'s `padding-top` will need to be set in the JSX instead of in the SCSS based on the height of the `ContextualSaveBar` when it's present.

<img width="460" alt="Screen Shot 2019-10-01 at 7 08 50 PM" src="https://user-images.githubusercontent.com/18447883/66007098-f6415600-e47e-11e9-9916-489d4d88440c.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Check that the contextual save bar layout responds to all screen size as expected in the ContextualSaveBar and Frame examples of the [Chrome UI deployment](url) 

*_or_*

- `git checkout fix-context-bar-overflow`
- Copy the playground code collapsed below and paste it into `playground/Playground.tsx`
- `yarn dev`

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {AppProvider, ContextualSaveBar, Frame} from '../src';
import de from '../locales/de.json';

export function Playground() {
  return (
    <div style={{height: '250px'}}>
      <AppProvider
        theme={{
          logo: {
            width: 124,
            contextualSaveBarSource:
              'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
          },
        }}
        i18n={de}
      >
        <Frame>
          <ContextualSaveBar
            message="Nicht gespeicherte Änderungen"
            saveAction={{
              onAction: () => console.log('add form submit logic'),
              loading: false,
              disabled: false,
            }}
            discardAction={{
              onAction: () => console.log('add clear form logic'),
            }}
          />
        </Frame>
      </AppProvider>
    </div>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
