### PR TITLE
[Tooltip] Remove light prop

### DIFF
--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -26,19 +26,12 @@ $content-max-width: rem(200px);
   margin: spacing() spacing() $offset-from-activator;
 }
 
-.light {
-  .Wrapper {
-    background: color('white');
-    color: color('ink');
-  }
-}
-
 .Wrapper {
   position: relative;
   display: flex;
-  background-color: color('ink');
+  background: color('white');
   border-radius: border-radius();
-  color: color('white');
+  color: color('ink');
   max-height: $content-max-height;
 }
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -12,8 +12,6 @@ export interface TooltipProps {
   children?: React.ReactNode;
   /** The content to display within the tooltip */
   content: string;
-  /** Display tooltip with a light background */
-  light?: boolean;
   /** Toggle whether the tooltip is visible */
   active?: boolean;
   /**
@@ -59,7 +57,6 @@ export class Tooltip extends React.PureComponent<TooltipProps, State> {
     const {
       children,
       content,
-      light,
       preferredPosition = 'below',
       activatorWrapper: WrapperComponent = 'span' as any,
     } = this.props;
@@ -74,7 +71,6 @@ export class Tooltip extends React.PureComponent<TooltipProps, State> {
           activator={activatorNode}
           active={active}
           onClose={noop}
-          light={light}
         >
           <div className={styles.Label} testID="TooltipOverlayLabel">
             {content}

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -13,7 +13,6 @@ import styles from '../../Tooltip.scss';
 export interface TooltipOverlayProps {
   id: string;
   active: boolean;
-  light?: boolean;
   preferredPosition?: PreferredPosition;
   children?: React.ReactNode;
   activator: HTMLElement;
@@ -46,11 +45,10 @@ export class TooltipOverlay extends React.PureComponent<
   private renderTooltip = (overlayDetails: OverlayDetails) => {
     const {measuring, desiredHeight, positioning} = overlayDetails;
 
-    const {id, children, light} = this.props;
+    const {id, children} = this.props;
 
     const containerClassName = classNames(
       styles.Tooltip,
-      light && styles.light,
       measuring && styles.measuring,
       positioning === 'above' && styles.positionedAbove,
     );


### PR DESCRIPTION
### WHY are these changes introduced?

We had some discussion in Slack on whether or not we should keep this `light` prop.

https://shopify.slack.com/archives/CJZP6GX6C/p1573765466012900

TLDR; 
- Dark Tooltips add emphasis to content that may be an indication _not_ to use a Tooltip
- 3 out of 55 Tooltips in Web are light, so this change will be noticed
- The design language has some complications with this prop, i.e "Things that are dark in light-mode might not make sense to be light in dark-mode."

### WHAT is this pull request doing?

Removes the `light` prop and sets the Tooltip to be light by default.

### Anything for reviewers to consider?

Whether or not we want to make this change.