### PR TITLE
Extend support for split button to ContextualSaveBar and Page

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 - Added `preventFocusOnClose` to `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 - Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
+- Added support for `connectedDisclosure` to `Page.primaryAction` and `ContextualSaveBar.saveAction` ([#2731](https://github.com/Shopify/polaris-react/pull/2731))
 
 ### Bug fixes
 

--- a/src/components/ContextualSaveBar/README.md
+++ b/src/components/ContextualSaveBar/README.md
@@ -239,8 +239,61 @@ Use the fullWidth flag when you want to remove the default max-width set on the 
         message="Unsaved changes"
         saveAction={{
           onAction: () => console.log('add form submit logic'),
+        }}
+        discardAction={{
+          onAction: () => console.log('add clear form logic'),
+        }}
+      />
+    </Frame>
+  </AppProvider>
+</div>
+```
+
+### Contextual save bar with split primary action
+
+Use when there is only one primary action but other related actions can be taken. The save action should be the same as the primary action set on the page component.
+
+```jsx
+<div style={{height: '250px'}}>
+  <AppProvider
+    theme={{
+      logo: {
+        width: 124,
+        contextualSaveBarSource:
+          'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+      },
+    }}
+    i18n={{
+      Polaris: {
+        Frame: {
+          skipToContent: 'Skip to content',
+        },
+        ContextualSaveBar: {
+          save: 'Save',
+          discard: 'Discard',
+        },
+        Button: {
+          connectedDisclosureAccessibilityLabel: 'Other save actions',
+        },
+      },
+    }}
+  >
+    <Frame>
+      <ContextualSaveBar
+        message="Unsaved product"
+        saveAction={{
+          content: 'Save',
+          connectedDisclosure: {
+            actions: [
+              {
+                content: 'Save as draft',
+                onAction: () => {},
+              },
+            ],
+          },
           loading: false,
           disabled: false,
+          onAction: () => console.log('add form submit logic'),
         }}
         discardAction={{
           onAction: () => console.log('add clear form logic'),

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -4,6 +4,7 @@ import {Button} from '../../../Button';
 import {Image} from '../../../Image';
 import {Stack} from '../../../Stack';
 import {ThemeProvider} from '../../../ThemeProvider';
+import {ContextualSaveBarContext} from '../../../../utilities/contextualsavebar-context';
 import {classNames} from '../../../../utilities/css';
 import {useFeatures} from '../../../../utilities/features';
 import type {ContextualSaveBarProps} from '../../../../utilities/frame';
@@ -120,7 +121,7 @@ export function ContextualSaveBar({
   );
 
   return (
-    <>
+    <ContextualSaveBarContext.Provider value>
       <ThemeProvider theme={{colorScheme: 'inverse'}}>
         <div className={contexualSaveBarClassName}>
           {contextControlMarkup}
@@ -135,8 +136,8 @@ export function ContextualSaveBar({
             </div>
           </div>
         </div>
+        {discardConfirmationModalMarkup}
       </ThemeProvider>
-      {discardConfirmationModalMarkup}
-    </>
+    </ContextualSaveBarContext.Provider>
   );
 }

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -86,6 +86,7 @@ export function ContextualSaveBar({
       loading={saveAction.loading}
       disabled={saveAction.disabled}
       accessibilityLabel={saveAction.content}
+      connectedDisclosure={saveAction.connectedDisclosure}
     >
       {saveActionContent}
     </Button>

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -182,6 +182,28 @@ describe('<ContextualSaveBar />', () => {
       expect(button.prop('onClick')).toBe(saveAction.onAction);
       expect(button.prop('children')).toBe(saveAction.content);
     });
+
+    describe('connectedDisclosure', () => {
+      it('gets set on the save action Button when provided', () => {
+        const saveAction = {
+          content: 'Save',
+          connectedDisclosure: {
+            actions: [{content: 'Save as draft', onAction: jest.fn()}],
+          },
+          onAction: jest.fn(),
+        };
+
+        const contextualSaveBar = mountWithAppProvider(
+          <ContextualSaveBar saveAction={saveAction} />,
+        );
+
+        const button = contextualSaveBar.find(Button);
+
+        expect(button.prop('connectedDisclosure')).toMatchObject(
+          saveAction.connectedDisclosure,
+        );
+      });
+    });
   });
 
   describe('default content', () => {

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -430,6 +430,33 @@ Use action groups for sets of actions that relate to one another, particularly w
 </Page>
 ```
 
+### Page with split primary action
+
+<!-- example-for: web -->
+
+Use when there is only one primary action but other related actions can be taken. The primary action should be the same as the save action set on the contextual save bar component.
+
+```jsx
+<Page
+  title="#1085"
+  primaryAction={{
+    content: 'Save',
+    connectedDisclosure: {
+      actions: [{content: 'Save as draft'}],
+    },
+  }}
+>
+  <Card sectioned title="Fulfill order">
+    <Stack alignment="center">
+      <Stack.Item fill>
+        <p>Buy postage and ship remaining 2 items</p>
+      </Stack.Item>
+      <Button primary>Continue</Button>
+    </Stack>
+  </Card>
+</Page>
+```
+
 ### Page with separator
 
 <!-- example-for: web -->

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -16,6 +16,7 @@ import type {
   DisableableAction,
   LoadableAction,
   IconableAction,
+  ConnectedDisclosure,
 } from '../../../../types';
 import {Breadcrumbs, BreadcrumbsProps} from '../../../Breadcrumbs';
 import {Pagination, PaginationDescriptor} from '../../../Pagination';
@@ -34,6 +35,8 @@ interface PrimaryAction
     IconableAction {
   /** Provides extra visual weight and identifies the primary action in a set of buttons */
   primary?: boolean;
+  /** Disclosure button connected right of the button. Toggles a popover action list. */
+  connectedDisclosure?: ConnectedDisclosure;
 }
 
 export interface HeaderProps extends TitleProps {

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -110,6 +110,28 @@ describe('<Header />', () => {
     });
   });
 
+  describe('connectedDisclosure', () => {
+    it('gets set on the primary action Button when provided', () => {
+      const primaryAction = {
+        content: 'Save',
+        connectedDisclosure: {
+          actions: [{content: 'Save as draft', onAction: jest.fn()}],
+        },
+        onAction: jest.fn(),
+      };
+
+      const header = mountWithAppProvider(
+        <Header primaryAction={primaryAction} />,
+      );
+
+      const button = header.find(Button);
+
+      expect(button.prop('connectedDisclosure')).toMatchObject(
+        primaryAction.connectedDisclosure,
+      );
+    });
+  });
+
   describe('pagination', () => {
     it('gets passed into Pagination', () => {
       const pagination = {

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react';
 
 import {classNames} from '../../utilities/css';
 import {getRectForNode, Rect} from '../../utilities/geometry';
+import {ContextualSaveBarContext} from '../../utilities/contextualsavebar-context';
 import {EventListener} from '../EventListener';
 import {Scrollable} from '../Scrollable';
 import {layer} from '../shared';
@@ -18,6 +19,8 @@ import {
 import styles from './PositionedOverlay.scss';
 
 type Positioning = 'above' | 'below';
+
+const CONTEXTUAL_SAVE_BAR_ZINDEX = 513;
 
 interface OverlayDetails {
   left?: number;
@@ -145,10 +148,20 @@ export class PositionedOverlay extends PureComponent<
     );
 
     return (
-      <div className={className} style={style} ref={this.setOverlay}>
-        <EventListener event="resize" handler={this.handleMeasurement} />
-        {render(this.overlayDetails())}
-      </div>
+      <ContextualSaveBarContext.Consumer>
+        {(ContextualSaveBarContext) => {
+          if (ContextualSaveBarContext) {
+            style.zIndex = CONTEXTUAL_SAVE_BAR_ZINDEX;
+          }
+
+          return (
+            <div className={className} style={style} ref={this.setOverlay}>
+              <EventListener event="resize" handler={this.handleMeasurement} />
+              {render(this.overlayDetails())}
+            </div>
+          );
+        }}
+      </ContextualSaveBarContext.Consumer>
     );
   }
 

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -20,7 +20,7 @@ import styles from './PositionedOverlay.scss';
 
 type Positioning = 'above' | 'below';
 
-const CONTEXTUAL_SAVE_BAR_ZINDEX = 513;
+export const CONTEXTUAL_SAVE_BAR_ZINDEX = 513;
 
 interface OverlayDetails {
   left?: number;
@@ -149,8 +149,8 @@ export class PositionedOverlay extends PureComponent<
 
     return (
       <ContextualSaveBarContext.Consumer>
-        {(ContextualSaveBarContext) => {
-          if (ContextualSaveBarContext) {
+        {(isWithinContextualSaveBar) => {
+          if (isWithinContextualSaveBar) {
             style.zIndex = CONTEXTUAL_SAVE_BAR_ZINDEX;
           }
 

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
+import {ContextualSaveBarContext} from '../../../utilities/contextualsavebar-context';
 import {EventListener} from '../../EventListener';
-import {PositionedOverlay} from '../PositionedOverlay';
+import {
+  PositionedOverlay,
+  CONTEXTUAL_SAVE_BAR_ZINDEX,
+} from '../PositionedOverlay';
 import * as mathModule from '../utilities/math';
 import * as geometry from '../../../utilities/geometry';
 import styles from '../PositionedOverlay.scss';
@@ -117,6 +121,20 @@ describe('<PositionedOverlay />', () => {
       );
       expect(positionedOverlay.find('div').prop('className')).not.toContain(
         styles.preventInteraction,
+      );
+    });
+  });
+
+  describe('context', () => {
+    it('sets the z-index to the contextual save bar z-index when within a contextual save bar', () => {
+      const positionedOverlay = mountWithAppProvider(
+        <ContextualSaveBarContext.Provider value>
+          <PositionedOverlay {...mockProps} />
+        </ContextualSaveBarContext.Provider>,
+      );
+
+      expect((positionedOverlay.find('div').prop('style') as any).zIndex).toBe(
+        CONTEXTUAL_SAVE_BAR_ZINDEX,
       );
     });
   });

--- a/src/utilities/contextualsavebar-context.tsx
+++ b/src/utilities/contextualsavebar-context.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const ContextualSaveBarContext = React.createContext(false);

--- a/src/utilities/frame/types.ts
+++ b/src/utilities/frame/types.ts
@@ -1,4 +1,4 @@
-import type {Action} from '../../types';
+import type {Action, ConnectedDisclosure} from '../../types';
 
 interface ContextualSaveBarAction {
   /** A destination to link to */
@@ -13,13 +13,15 @@ interface ContextualSaveBarAction {
   onAction?(): void;
 }
 
-interface ContextualSaveBarDiscardActionProps {
+interface ContextualSaveBarSaveAction extends ContextualSaveBarAction {
+  /** Disclosure button connected right of the button. Toggles a popover action list. */
+  connectedDisclosure?: ConnectedDisclosure;
+}
+
+interface ContextualSaveBarDiscardAction extends ContextualSaveBarAction {
   /** Whether to show a modal confirming the discard action */
   discardConfirmationModal?: boolean;
 }
-
-type ContextualSaveBarCombinedActionProps = ContextualSaveBarDiscardActionProps &
-  ContextualSaveBarAction;
 
 export interface ContextualSaveBarProps {
   /** Extend the contents section to be flush with the left edge  */
@@ -27,9 +29,9 @@ export interface ContextualSaveBarProps {
   /** Accepts a string of content that will be rendered to the left of the actions */
   message?: string;
   /** Save or commit contextual save bar action with text defaulting to 'Save' */
-  saveAction?: ContextualSaveBarAction;
+  saveAction?: ContextualSaveBarSaveAction;
   /** Discard or cancel contextual save bar action with text defaulting to 'Discard' */
-  discardAction?: ContextualSaveBarCombinedActionProps;
+  discardAction?: ContextualSaveBarDiscardAction;
   /** Remove the normal max-width on the contextual save bar */
   fullWidth?: boolean;
   /** Accepts a component that is used to help users switch between different contexts */


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced and WHAT is this PR doing?

As a follow-up to #2329, which added a split variant to `Button`, this PR extends support for this variant to `ContextualSaveBar.saveAction` and `Page.primaryAction` in order to unblock  https://github.com/Shopify/shopify/issues/214434 (currently have a hack in production in the meantime).  

In order to add support for a split `saveAction` in `ContextualSaveBar`, this PR uses the new context API so that `PositionedOverlay` ups its `z-index` when in the context of a contextual save bar.

cc @HYPD @sarahill for UI Kit 🎨

<!--
  Context about the problem that’s being addressed. Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Frame, ContextualSaveBar, TopBar} from '../src';

export function Playground() {
  return (
    <Frame topBar={<TopBar />}>
      <ContextualSaveBar
        message="Unsaved changes"
        saveAction={{
          onAction: () => console.log('add form submit logic'),
          connectedDisclosure: {
            actions: [
              {
                content: 'Save as Draft',
                onAction: () => {},
              },
            ],
          },
          loading: false,
          disabled: false,
        }}
        discardAction={{
          onAction: () => console.log('add clear form logic'),
        }}
      />
      <Page
        title="Playground"
        primaryAction={{
          content: 'Save',
          connectedDisclosure: {
            actions: [
              {
                content: 'Save as Draft',
                onAction: () => {},
              },
            ],
          },
          onAction: () => console.log('add form submit logic'),
        }}
      />
    </Frame>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
