### PR TITLE
[Dropzone] Support fixed height

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Constrained `DropZone` height based on inherited wrapper height ([#2846](https://github.com/Shopify/polaris-react/pull/2846))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -49,6 +49,7 @@ $dropzone-stacking-order: (
 }
 
 .DropZone {
+  position: relative;
   flex: 1;
   display: flex;
   position: relative;

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -52,7 +52,6 @@ $dropzone-stacking-order: (
   position: relative;
   flex: 1;
   display: flex;
-  position: relative;
   justify-content: center;
   background-color: $dropzone-background;
   border-radius: $dropzone-border-radius;

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -41,7 +41,7 @@ $dropzone-stacking-order: (
 .DropZoneWrapper {
   height: 100%;
 
-  & > div {
+  > div {
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -38,9 +38,20 @@ $dropzone-stacking-order: (
   border: border-width(thick) $dropzone-border-style transparent;
 }
 
+.DropZoneWrapper {
+  height: 100%;
+
+  & > div {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
 .DropZone {
-  position: relative;
+  flex: 1;
   display: flex;
+  position: relative;
   justify-content: center;
   background-color: $dropzone-background;
   border-radius: $dropzone-border-radius;

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -378,31 +378,33 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
 
   return (
     <DropZoneContext.Provider value={context}>
-      <Labelled
-        id={id}
-        label={labelValue}
-        action={labelAction}
-        labelHidden={labelHiddenValue}
-      >
-        <div
-          ref={node}
-          className={classes}
-          aria-disabled={disabled}
-          onClick={handleClick}
-          onDragStart={stopEvent}
+      <div className={styles.DropZoneWrapper}>
+        <Labelled
+          id={id}
+          label={labelValue}
+          action={labelAction}
+          labelHidden={labelHiddenValue}
         >
-          {dragOverlay}
-          {dragErrorOverlay}
-          <div className={styles.Container}>{children}</div>
-          <VisuallyHidden>
-            <DropZoneInput
-              {...inputAttributes}
-              openFileDialog={openFileDialog}
-              onFileDialogClose={onFileDialogClose}
-            />
-          </VisuallyHidden>
-        </div>
-      </Labelled>
+          <div
+            ref={node}
+            className={classes}
+            aria-disabled={disabled}
+            onClick={handleClick}
+            onDragStart={stopEvent}
+          >
+            {dragOverlay}
+            {dragErrorOverlay}
+            <div className={styles.Container}>{children}</div>
+            <VisuallyHidden>
+              <DropZoneInput
+                {...inputAttributes}
+                openFileDialog={openFileDialog}
+                onFileDialogClose={onFileDialogClose}
+              />
+            </VisuallyHidden>
+          </div>
+        </Labelled>
+      </div>
     </DropZoneContext.Provider>
   );
 

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -571,7 +571,7 @@ function fireEvent({
 
     element
       .find('div')
-      .at(3)
+      .at(4)
       .getDOMNode()
       .dispatchEvent(event);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #742

The DropZone determines its size (height and width) based on width only. This makes certain valid use cases, where the default DropZone height isn't appropriate, impossible.

### WHAT is this pull request doing?

Adding a new Dropzone wrapper that use the power of flexbox to determine the height.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
