### PR TITLE
[WIP] Storybook docs playing

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,7 +15,11 @@ const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 const enableDocs = !parseInt(process.env.STORYBOOK_DISABLE_DOCS || '0', 10);
 
 module.exports = {
-  stories: ['../playground/stories.tsx', '../src/components/**/*/README.md'],
+  stories: [
+    '../playground/stories.tsx',
+    '../playground/**/*.stories.{tsx,mdx}',
+    '../src/components/**/*/README.md',
+  ],
   addons: [
     {name: '@storybook/addon-essentials', options: {docs: enableDocs}},
     '@storybook/addon-a11y',

--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -45,9 +45,7 @@ module.exports = function loader(source) {
     return `
 const ${example.storyName}Component = (${example.code})();
 export function ${example.storyName}() {
-  return <div data-omit-app-provider="${readme.omitAppProvider}"><${
-      example.storyName
-    }Component /></div>;
+  return <${example.storyName}Component />;
 }
 
 ${example.storyName}.storyName = ${JSON.stringify(example.name)};

--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -77,6 +77,12 @@ ${example.storyName}.parameters = {
 `.trim();
     });
 
+    if (readme.sbComponent) {
+      csfExports.unshift(
+        `export const WithArgs = (args) => <${readme.sbComponent} {...args} />;`,
+      );
+    }
+
     csfExports.unshift(`export function AllExamples() {
   return (
     <React.Fragment>
@@ -97,6 +103,14 @@ AllExamples.parameters = {
 
   return `
 import React, {${hooks}} from 'react';
+import {
+  Title,
+  Subtitle,
+  Description,
+  Primary,
+  Props,
+  Stories,
+  Meta, AddContext } from "@storybook/addon-docs/blocks";
 import {
   AccountConnection,
   ActionList,
@@ -252,6 +266,24 @@ import {
 export default {
   title: ${JSON.stringify(`All Components/${readme.name}`)},
   component: ${readme.component},
+  parameters: {
+    docs: {
+      page: () => {
+        return (<>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <Props />
+          <Stories />
+
+          <div dangerouslySetInnerHTML={{__html: ${JSON.stringify(
+            readme.docHtml,
+          )}}} />
+        </>);
+      },
+    }
+  }
 };
 
 ${csfExports.join('\n\n')}
@@ -292,6 +324,7 @@ function parseCodeExamples(data) {
     category: matter.data.category,
     component: examples.length ? toPascalCase(matter.data.name) : undefined,
     examples,
+    docHtml: new MdParser().parse(matter.content),
     omitAppProvider: matter.data.omitAppProvider || false,
   };
 }

--- a/playground/Button.stories.mdx
+++ b/playground/Button.stories.mdx
@@ -1,0 +1,30 @@
+import {Meta, Story, Preview, Props} from '@storybook/addon-docs/blocks';
+import {Button} from '../src';
+
+<Meta title="Docs Playing/0-Button - MDX" component="Button" />
+
+# Button
+
+With `MDX` we can define a story for `Button` right in the middle of our
+markdown documentation.
+
+We can write sume bulleted lists:
+
+- Item one
+- Item two
+
+## Subheadings
+
+They're a thing.
+
+## Examples
+
+<Preview>
+  <Story name="basic">
+    <Button>Label</Button>
+  </Story>
+</Preview>
+
+## Props
+
+<Props of={Button} />

--- a/playground/Button.stories.tsx
+++ b/playground/Button.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {Button, ButtonProps} from '../src';
+
+export default {
+  title: 'Docs Playing/0-Button - CSF',
+  component: Button,
+  argTypes: {
+    primary: 'boolean',
+  },
+};
+
+// Using a template to avoid repeating configuration
+export function ButtonDefault(args: ButtonProps) {
+  return <Button {...args} />;
+}
+ButtonDefault.args = {
+  children: 'Hello Button',
+} as ButtonProps;
+
+export const ButtonWithPrimary = ButtonDefault.bind({});
+ButtonWithPrimary.args = {...ButtonDefault.args, primary: true};
+
+export const ButtonWithPlain = ButtonDefault.bind({});
+ButtonWithPlain.args = {...ButtonDefault.args, plain: true};
+
+// Going old school and writing explicit Stories
+// - downside, these properties can't be modified with controls
+
+export function ButtonDefaultAlt() {
+  return <Button>Hello Button</Button>;
+}
+
+export function ButtonWithPrimaryAlt() {
+  return <Button primary>Hello Button</Button>;
+}
+
+export function ButtonWithPlainAlt() {
+  return <Button plain>Hello Button</Button>;
+}

--- a/playground/Guidelines.stories.mdx
+++ b/playground/Guidelines.stories.mdx
@@ -1,0 +1,14 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs Playing/0-Guidelines - MDX" />
+
+# Guildlines
+
+You can also write longform content without associating it to a component.
+
+- Point one
+- Point 2
+
+## Subheadings
+
+They're a thing.


### PR DESCRIPTION
Some silly little examples to show what you can do with storybook docs / global types

We can use this as a little testbed for playing with text-only doc generation.

- Button.stories.mdx to show component examples with mdx
- JustWords.stories.mdx to show you can have docs unrelated to a
component
- Some rather hacky stuff to showcase generating docs files from our
markdown format. This is pretty crappy atm but shows we can generate our
on docs html from markdown. Stuff like replacing code blocks with
rendered examples will take more work.

This PR also migrates us away from the deprecated contexts configuration to use the new globalTypes. Unfortunatly this loses us some some functionality.
- globalTypes can not yet be programatically set when loading the preview iframe (this means we can't a11y check dark mode)
- globalTypes lacks a good way to configure a complex object so we can't replace the knobs for configuring the color scheme items (surface, critical etc)


### To Play

Open up the deployed storybook, and look at the new "Playground/Button" "Playground/Just Words" docs views, and hit the docs view from any of our existing readmes.

See https://5d559397bae39100201eedc1-wnkvmeevfo.chromatic.com/?path=/story/playground-0-button-csf--button-default