### PR TITLE
[Modal] Make close button clickable

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 - Added `flex: 1 1 auto` to `Banner` `.ContentWrapper` CSS selector ([#3062](https://github.com/Shopify/polaris-react/pull/3062))
 - Fixed mis-alignment on `Page` action rollup ([#3064](https://github.com/Shopify/polaris-react/pull/3064))
 - Ensured Sass mixins can compile in Dart Sass ([#3064](https://github.com/Shopify/polaris-react/pull/3063))
+- Fixed stacking order of `CloseButton` on `Modal` without a title ([#3077](https://github.com/Shopify/polaris-react/pull/3077))
 
 ### Documentation
 

--- a/src/components/Modal/components/CloseButton/CloseButton.scss
+++ b/src/components/Modal/components/CloseButton/CloseButton.scss
@@ -16,4 +16,5 @@
 .withoutTitle {
   position: absolute;
   right: spacing(tight);
+  z-index: 1;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2559

The modal close button is not clickable when modal doesn't have a title.

### WHAT is this pull request doing?

Setting `z-index` to the close button for a Modal without a title so that the modal can be closed.

<details>
	<summary>Clicking close button closes the Modal without a title</summary>
	<img src="https://user-images.githubusercontent.com/15054990/85623638-b9357900-b636-11ea-9918-1e04751b0379.gif" alt="Clicking the close button closes the modal without a title">
</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
