### PR TITLE
[ResourceList] Missing space in totalItemsCount italian locale translation

### DIFF
--- a/locales/it.json
+++ b/locales/it.json
@@ -213,7 +213,7 @@
           "on_or_after": "dopo il {date}"
         }
       },
-      "showingTotalCount": "Visualizzazione di {itemsCount} su {totalItemsCount}{resource}",
+      "showingTotalCount": "Visualizzazione di {itemsCount} su {totalItemsCount} {resource}",
       "allFilteredItemsSelected": "Tutti i {resourceNamePlural} {itemsLength}+ in questo filtro sono selezionati.",
       "selectAllFilteredItems": "Seleziona tutti i {resourceNamePlural} {itemsLength}+ in questo filtro"
     },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The totalItemsCount label has a missing space in italian locale
<img width="905" alt="Screenshot 2020-09-08 at 12 24 58" src="https://user-images.githubusercontent.com/7805759/92465380-ce9a5800-f1ce-11ea-9059-99c5b47139f1.png">

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Just adding that missing space

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
