### PR TITLE
[Frame] Allow for custom navigation width

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added a theme prop for `navWidth` ([#3273](https://github.com/Shopify/polaris-react/pull/3273))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -668,6 +668,7 @@ function FrameExample() {
       url: 'http://jadedpixel.com',
       accessibilityLabel: 'Jaded Pixel',
     },
+    navWidth: 90,
   };
 
   return (

--- a/src/styles/foundation/_layout.scss
+++ b/src/styles/foundation/_layout.scss
@@ -1,4 +1,4 @@
-$navigation-width: 240px !default;
+$navigation-width: calc(var(--p-nav-width) / 10 * 1rem) !default;
 
 ////
 /// Layout
@@ -21,7 +21,7 @@ $layout-width-data: (
     base: rem(240px),
   ),
   nav: (
-    base: rem($navigation-width),
+    base: $navigation-width,
   ),
   page-with-nav: (
     base: rem(769px),

--- a/src/styles/shared/_breakpoints.scss
+++ b/src/styles/shared/_breakpoints.scss
@@ -1,6 +1,6 @@
 $page-max-width: layout-width(primary, max) + layout-width(secondary, max) +
   layout-width(inner-spacing);
-$frame-with-nav-max-width: layout-width(nav) + $page-max-width;
+$frame-with-nav-max-width: calc(var(--p-nav-width) + $page-max-width);
 
 $stacked-content: em(
   layout-width(primary, min) + layout-width(secondary, min) +
@@ -18,7 +18,7 @@ $not-condensed-min-page: $not-condensed-content + $not-condensed-outer-spacing;
 $partially-condensed-min-page: $partially-condensed-content +
   $partially-condensed-outer-spacing;
 
-$nav-size: em(layout-width(nav));
+$nav-size: calc(var(--p-nav-width) / 16 * 1em);
 $nav-min-window: em(layout-width(page-with-nav));
 
 @function breakpoint($value, $adjustment: 0) {

--- a/src/utilities/custom-properties/custom-properties.ts
+++ b/src/utilities/custom-properties/custom-properties.ts
@@ -14,6 +14,7 @@ export const nonDesignLangaugeCustomProperties = [
   '--top-bar-background-darker',
   '--top-bar-border',
   '--p-frame-offset',
+  '--p-nav-width',
 ];
 
 export const designLangaugeCustomProperties = ([] as string[]).concat(

--- a/src/utilities/theme/tests/utils.test.ts
+++ b/src/utilities/theme/tests/utils.test.ts
@@ -79,6 +79,7 @@ describe('needsVariant', () => {
 describe('buildCustomProperties', () => {
   const legacyCustomProperties = {
     '--p-frame-offset': '0px',
+    '--p-nav-width': '240',
     '--top-bar-background': '#eeeeee',
     '--top-bar-background-lighter': 'hsla(0, 10%, 100%, 1)',
     '--top-bar-border': 'rgb(99, 115, 129)',
@@ -162,6 +163,48 @@ describe('buildCustomProperties', () => {
 
     const colors = buildCustomProperties(theme, true);
     expect(colors).toMatchObject({'--p-frame-offset': '80px'});
+  });
+
+  it('creates default custom property of 240 for navWidth when navWidth is undefined and newDesignLanguage is false', () => {
+    const theme = {
+      colors: {topBar: {background: '#eeeeee'}, surface: '#ffffff'},
+      colorScheme: DefaultColorScheme,
+    };
+
+    const colors = buildCustomProperties(theme, false);
+    expect(colors).toMatchObject({'--p-nav-width': '240'});
+  });
+
+  it('creates default custom property of 240 for navWidth when navWidth is undefined and newDesignLanguage is true', () => {
+    const theme = {
+      colors: {topBar: {background: '#eeeeee'}, surface: '#ffffff'},
+      colorScheme: DefaultColorScheme,
+    };
+
+    const colors = buildCustomProperties(theme, true);
+    expect(colors).toMatchObject({'--p-nav-width': '240'});
+  });
+
+  it('creates custom property with value for navWidth when navWidth is provided and newDesignLanguage is false', () => {
+    const theme = {
+      navWidth: 90,
+      colors: {topBar: {background: '#eeeeee'}, surface: '#ffffff'},
+      colorScheme: DefaultColorScheme,
+    };
+
+    const colors = buildCustomProperties(theme, false);
+    expect(colors).toMatchObject({'--p-nav-width': '90'});
+  });
+
+  it('creates custom property with value for navWidth when navWidth is provided and newDesignLanguage is true', () => {
+    const theme = {
+      navWidth: 150,
+      colors: {topBar: {background: '#eeeeee'}, surface: '#ffffff'},
+      colorScheme: DefaultColorScheme,
+    };
+
+    const colors = buildCustomProperties(theme, true);
+    expect(colors).toMatchObject({'--p-nav-width': '150'});
   });
 
   it('uses light adjustments by default', () => {

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -53,6 +53,7 @@ export interface ThemeConfig {
   colorScheme?: ColorScheme;
   config?: Config;
   frameOffset?: number;
+  navWidth?: number;
 }
 
 export type CustomPropertiesLike = Record<string, string>;

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -26,7 +26,13 @@ export function buildCustomProperties(
   newDesignLanguage: boolean,
   tokens?: Record<string, string>,
 ): CustomPropertiesLike {
-  const {colors = {}, colorScheme, config, frameOffset = 0} = themeConfig;
+  const {
+    colors = {},
+    colorScheme,
+    config,
+    frameOffset = 0,
+    navWidth = 240,
+  } = themeConfig;
   const mergedConfig = mergeConfigs(base, config || {});
 
   return newDesignLanguage
@@ -34,10 +40,14 @@ export function buildCustomProperties(
         ...colorFactory(colors, colorScheme, mergedConfig),
         ...tokens,
         frameOffset: `${frameOffset}px`,
+        navWidth: `${navWidth}`,
       })
     : {
         ...buildLegacyColors(themeConfig),
-        ...customPropertyTransformer({frameOffset: `${frameOffset}px`}),
+        ...customPropertyTransformer({
+          frameOffset: `${frameOffset}px`,
+          navWidth: `${navWidth}`,
+        }),
       };
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3212

Allowing consumers to define a custom navigation width. Consumers can already pass to the Frame a custom navigation component, yet the Frame is opinionated on this component's width.

<img width="100%" alt="Screen Shot 2020-09-18 at 11 24 55 AM" src="https://user-images.githubusercontent.com/15054990/93615642-a7e3da80-f9a1-11ea-9793-f719ed7f0bf7.png">


### WHAT is this pull request doing?

This adds a `navWidth` property to the theme provider which 
- generates a custom property
- which is used to make the existing `$navigation-width` dynamic based on the provided width
- existing `$navigation-width` plays the same role as currently: pushes the frame's main content and its sub-components to the right by the pixel value provided

#### Before
<img width="100%" alt="Fixed navigation width" src="https://user-images.githubusercontent.com/15054990/93617294-cba82000-f9a3-11ea-8f71-fb695a2af51a.png">

#### After
<img width="100%" alt="Allowing for custom navigation width" src="https://user-images.githubusercontent.com/15054990/93617341-d95da580-f9a3-11ea-848a-e7e5536bc587.png">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### Another approach I explored
<details>
<summary>Context</summary>

@alex-page [proposed](https://shopify.slack.com/archives/CQK6FNLJK/p1599074350061600?thread_ts=1599074063.061200&cid=CQK6FNLJK) to slightly change direction by **removing existing Frame navigation styles and making the navigation be a 100% width of its parent container**.

🏗 [Branch with exploration](https://github.com/Shopify/polaris-react/compare/3212-allow-for-custom-nav-width)

After exploring this option, even though this approach is how the layout ideally should be structured, **I'm not opening PR with these changes for the following reasons**:
- ❌ Making this happen requires removing fixed position from the nav which changes the document flow 
- ❌ Because of that, it’s a breaking change, and it can potentially negatively impact consumers
	- Consumers will need to add a wrapper to the nav with their own custom width
	- Changes in the document flow might break the layout of the pages that are currently relying on the fixed position of the nav being removed from regular flow. 
	- One example of this could be Vault legacy rails pages that worked with the fixed position but to make them work with a different position will require foundational structure changes. I can imagine other consumers might run into this problem too.
	- Changing the nav width while also keeping the nav ‘fixed’ on the page as user scrolls can be achieved with `position: sticky` support of which is [not the highest](https://caniuse.com/?search=position%20sticky)
- ❌ It’s too foundational change for us to make
	- It’s a foundational change in the Polaris layout, and we think we’d need support from the Polaris team to ensure we’re not only delivering the best long-term solution, but also that this approach works for most consumers

🔗 [Slack thread](https://shopify.slack.com/archives/CQK6FNLJK/p1599074063061200) for more context


</details>


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<!--
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```
-->

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
