### PR TITLE
Link: Add `rel` attribute for <Link /> component.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Hide `ActionMenu`, `Actions`, `RollupActions` menu popover overlays when printing ([#3277](https://github.com/Shopify/polaris-react/pull/3277))
+- Updated `Link` component to support `rel` prop. ([#3310](https://github.com/Shopify/polaris-react/pull/3310))
 
 ### Bug fixes
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -23,6 +23,8 @@ export interface LinkProps {
   monochrome?: boolean;
   /** Callback when a link is clicked */
   onClick?(): void;
+  /** The relation of the link */
+  rel?: void;
 }
 
 export function Link({
@@ -30,6 +32,7 @@ export function Link({
   children,
   onClick,
   external,
+  rel,
   id,
   monochrome,
 }: LinkProps) {
@@ -72,6 +75,7 @@ export function Link({
             url={url}
             external={external}
             id={id}
+            rel={rel}
           >
             {childrenMarkup}
           </UnstyledLink>

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -20,11 +20,18 @@ export const UnstyledLink = memo(
       return <LinkComponent {...unstyled.props} {...props} />;
     }
 
-    const {external, url, ...rest} = props;
+    const {external, url, rel, ...rest} = props;
     const target = external ? '_blank' : undefined;
-    const rel = external ? 'noopener noreferrer' : undefined;
+    const defaultRel = () => (external ? 'noopener noreferrer' : undefined);
+
     return (
-      <a target={target} {...rest} href={url} rel={rel} {...unstyled.props} />
+      <a
+        target={target}
+        href={url}
+        rel={rel ? rel : defaultRel()}
+        {...rest}
+        {...unstyled.props}
+      />
     );
   }),
 );

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -34,6 +34,13 @@ describe('<UnstyledLink />', () => {
       expect(anchorElement.prop('target')).toBe('_blank');
       expect(anchorElement.prop('rel')).toBe('noopener noreferrer');
     });
+
+    it('adds custom rel attributes when provided', () => {
+      const anchorElement = mountWithAppProvider(
+        <UnstyledLink external rel="nofollow" />,
+      ).find('a');
+      expect(anchorElement.prop('rel')).toBe('nofollow');
+    });
   });
 
   describe('download', () => {


### PR DESCRIPTION
This allows users to pass in their own `rel` prop to the Link component,
instead of using the default when the external prop is provided (`noreferrer noopener`).

### WHY are these changes introduced?

The default `rel` for links when the `external` prop is provided is `noreferrer noopener`. We have a case in Shopify/athena-flex where we want to allow the referrer to be passed through.

### WHAT is this pull request doing?

Allowing the `rel` attribute on links to be set through the `rel` prop on the Link component. If its unset, it'll default to the current state: `noreferrer noopener`, so backwards compatibility should be fine.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit