### PR TITLE
[TextField] Fix resizer converting comma to undefined

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed resizer converting a comma to undefined and growing the TextField larger than it needed ([#3500](https://github.com/Shopify/polaris-react/pull/3500))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/TextField/components/Resizer/Resizer.tsx
+++ b/src/components/TextField/components/Resizer/Resizer.tsx
@@ -89,6 +89,7 @@ const ENTITIES_TO_REPLACE = {
   '>': '&gt;',
   '\n': '<br>',
   '\r': '',
+  ',': ','
 };
 
 const REPLACE_REGEX = new RegExp(

--- a/src/components/TextField/components/Resizer/Resizer.tsx
+++ b/src/components/TextField/components/Resizer/Resizer.tsx
@@ -89,7 +89,7 @@ const ENTITIES_TO_REPLACE = {
   '>': '&gt;',
   '\n': '<br>',
   '\r': '',
-  ',': ','
+  ',': ',',
 };
 
 const REPLACE_REGEX = new RegExp(

--- a/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
+++ b/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
@@ -95,7 +95,6 @@ describe('<Resizer />', () => {
       const contentsNode = findByTestID(resizer, 'ContentsNode');
       expect(contentsNode.html()).toContain(contents);
     });
-
   });
 
   describe('minimumLines', () => {

--- a/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
+++ b/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
@@ -86,6 +86,16 @@ describe('<Resizer />', () => {
         '&lt;div&gt;&amp;<br>Contents&lt;/div&gt;<br></div>';
       expect(contentsNode.html()).toContain(expectedEncodedContents);
     });
+
+    it('keeps a comma as a comma', () => {
+      const contents = `Contents1,Contents2, Contents3`;
+      const resizer = mountWithAppProvider(
+        <Resizer {...mockProps} contents={contents} />,
+      );
+      const contentsNode = findByTestID(resizer, 'ContentsNode');
+      expect(contentsNode.html()).toContain(contents);
+    });
+
   });
 
   describe('minimumLines', () => {


### PR DESCRIPTION
Without this the regex and replace methods were replacing a comma with 'undefined'  so long comma separated lists would grow much larger than they actually were.


### WHY are these changes introduced?

When using a comma inside a multi line text field, the resizer component converts it to "undefined".  While not noticable for paragraph text, doing a long comma separated list, the text field grows considerably larger than it needs to be.

### WHAT is this pull request doing?

<details>
<summary>Before</summary>
<img src="https://i.imgur.com/dvmUp3S.png" alt="All the undefined and how big the text field is" />
</details>

<details>
<summary>After</summary>
<img src="https://i.imgur.com/u7Ws381.png" alt="After the fix the text field is just big enough for the contents" />
</details>


### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
