### PR TITLE
[Card] Update Card to hide Button actions when printing

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 Updated `Textfield` with a `type` of `number` to not render a spinner if step is set to `0` ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
 
+Updated `Card` to hide Button actions when printing ([#3537](https://github.com/Shopify/polaris-react/pull/3537))
+
 ### Bug fixes
 
 ### Documentation

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,9 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-Updated `Textfield` with a `type` of `number` to not render a spinner if step is set to `0` ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
-
-Updated `Card` to hide Button actions when printing ([#3537](https://github.com/Shopify/polaris-react/pull/3537))
+- Updated `Textfield` with a `type` of `number` to not render a spinner if step is set to `0` ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
+- Updated `Card` to hide Button actions when printing ([#3537](https://github.com/Shopify/polaris-react/pull/3537))
 
 ### Bug fixes
 

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -31,6 +31,10 @@
   @include page-content-when-not-fully-condensed {
     padding: spacing(loose) spacing(loose) 0;
   }
+
+  button {
+    @include hidden-when-printing;
+  }
 }
 
 .Section {


### PR DESCRIPTION
WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3539 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

I was unable to target `.ButtonGroup` in this case however `button` does what is expected but I was unable to find this pattern in Polaris. Would love some advice :)

### WHAT is this pull request doing?

<img src="https://screenshot.click/21-10-btbpl-fioii.jpg" alt="Description of what the gif shows">
   <img src="https://screenshot.click/21-10-tkoxp-sytrc.jpg" alt="Description of what the gif shows">


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card, ButtonGroup, Button} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Card>
        <Card.Section>
          <Card.Header>
            <ButtonGroup>
              <Button>HI</Button>
            </ButtonGroup>
          </Card.Header>
        </Card.Section>
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
