### PR TITLE
[Navigation] Fix SubNavigationItem onClick

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- OnClick handling now functions for SubNavigationItem
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -53,7 +53,7 @@ export interface ItemProps extends ItemURLDetails {
   new?: boolean;
   subNavigationItems?: SubNavigationItem[];
   secondaryAction?: SecondaryAction;
-  onClick?(event: MouseEvent<HTMLElement>): void;
+  onClick?(event?: MouseEvent<HTMLElement>): void;
 }
 
 enum MatchState {

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -244,12 +244,7 @@ export function Item({
       <div className={SecondaryNavigationClassName}>
         <Secondary expanded={showExpanded}>
           {subNavigationItems.map((item) => {
-            const {label, onClick, ...rest} = item;
-
-            const clickHandler = (event: MouseEvent<HTMLElement>): void => {
-              if (onClick) onClick(event);
-              if (onNavigationDismiss) onNavigationDismiss();
-            };
+            const {label, ...rest} = item;
 
             return (
               <Item
@@ -257,7 +252,6 @@ export function Item({
                 key={label}
                 label={label}
                 matches={item === longestMatch}
-                onClick={clickHandler}
               />
             );
           })}
@@ -309,7 +303,7 @@ export function Item({
         setExpanded(!expanded);
       } else if (onNavigationDismiss) {
         onNavigationDismiss();
-        if (onClick && onClick !== onNavigationDismiss) {
+        if (onClick) {
           onClick(event);
         }
         return;

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -53,7 +53,7 @@ export interface ItemProps extends ItemURLDetails {
   new?: boolean;
   subNavigationItems?: SubNavigationItem[];
   secondaryAction?: SecondaryAction;
-  onClick?(): void;
+  onClick?(event: MouseEvent<HTMLElement>): void;
 }
 
 enum MatchState {
@@ -244,14 +244,20 @@ export function Item({
       <div className={SecondaryNavigationClassName}>
         <Secondary expanded={showExpanded}>
           {subNavigationItems.map((item) => {
-            const {label, ...rest} = item;
+            const {label, onClick, ...rest} = item;
+
+            const clickHandler = (event: MouseEvent<HTMLElement>): void => {
+              if (onClick) onClick(event);
+              if (onNavigationDismiss) onNavigationDismiss();
+            };
+
             return (
               <Item
                 {...rest}
                 key={label}
                 label={label}
                 matches={item === longestMatch}
-                onClick={onNavigationDismiss}
+                onClick={clickHandler}
               />
             );
           })}
@@ -304,13 +310,13 @@ export function Item({
       } else if (onNavigationDismiss) {
         onNavigationDismiss();
         if (onClick && onClick !== onNavigationDismiss) {
-          onClick();
+          onClick(event);
         }
         return;
       }
 
       if (onClick) {
-        onClick();
+        onClick(event);
       }
     };
   }

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -323,6 +323,34 @@ describe('<Nav.Item />', () => {
       item.find(UnstyledLink).last().find('a').simulate('click');
       expect(context.onNavigationDismiss).toHaveBeenCalledTimes(1);
     });
+
+    it('calls onClick for the SubNavigationItem when clicked', () => {
+      const context = {
+        location: 'foo',
+        onNavigationDismiss: jest.fn(),
+      };
+
+      const subNavigationItemOnClick = jest.fn();
+
+      const item = mountWithNavigationProvider(
+        <Item
+          label="some label"
+          url="foo"
+          disabled={false}
+          subNavigationItems={[
+            {
+              label: 'bar',
+              url: 'baz',
+              disabled: false,
+              onClick: subNavigationItemOnClick,
+            },
+          ]}
+        />,
+        {...context},
+      );
+      item.find(UnstyledLink).last().find('a').simulate('click');
+      expect(subNavigationItemOnClick).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('renders an indicator if a sub navigation item is marked as new', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3150 #3017 

The onclick handler does nothing, despite the prop being present.

### WHAT is this pull request doing?

- The onNavigationDismiss in the SubNavigationItem was removed, as it is handled by the main Item. This is confirmed through a test, and when I called it in the subitem, it got called twice.
- Test is added so this does not regress.