### PR TITLE
[Page] Change `Page` `subtitle` prop to take `React.ReactNode`

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Allow `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
+- Allow `Page` `subtitle` property to support `React.ReactNode` ([#3594](https://github.com/Shopify/polaris-react/pull/3594))
 
 ### Bug fixes
 

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -137,7 +137,11 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
   breadcrumbs={[{content: 'Products', url: '/products'}]}
   title="3/4 inch Leather pet collar"
   titleMetadata={<Badge status="success">Paid</Badge>}
-  subtitle="Perfect for any pet"
+  subtitle={
+    <React.Fragment>
+      Perfect for <strong>any</strong> pet
+    </React.Fragment>
+  }
   thumbnail={
     <Thumbnail
       source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -12,8 +12,8 @@ import styles from './Title.scss';
 export interface TitleProps {
   /** Page title, in large type */
   title?: string;
-  /** Page subtitle, in regular type*/
-  subtitle?: string;
+  /** Page subtitle, in regular type */
+  subtitle?: React.ReactNode;
   /** Important and non-interactive status information shown immediately after the title. */
   titleMetadata?: React.ReactNode;
   /** thumbnail that precedes the title */
@@ -56,7 +56,7 @@ export function Title({title, subtitle, titleMetadata, thumbnail}: TitleProps) {
 
   const subtitleMarkup = subtitle ? (
     <div className={styles.SubTitle}>
-      <p>{subtitle}</p>
+      {typeof subtitle === 'string' ? <p>{subtitle}</p> : <div>{subtitle}</div>}
     </div>
   ) : null;
 


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3593 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

We're changing the `subtitle` prop on the `Page` component to accept a `React.ReactNode` instead of a `string`. This allows for custom components (that often return simple strings) as the subtitle.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<img width="501" alt="20-11-ct4r3-odpz4" src="https://user-images.githubusercontent.com/49090/97911837-eb0fc800-1d19-11eb-99b9-45d40ba2e050.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

You can view the updated story by running `yarn dev` and viewing [this example](http://localhost:6006/?path=/story/all-components-page--all-examples). Notice the bolded word `any` in the subtitle.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground" subtitle={<strong>Hello!</strong>}>
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

<img width="458" alt="20-11-up9e6-k1cy5" src="https://user-images.githubusercontent.com/49090/97914016-32e41e80-1d1d-11eb-9d03-1bc60e5da1f2.png">
<img width="455" alt="20-11-mz6r4-pjaau" src="https://user-images.githubusercontent.com/49090/97914018-337cb500-1d1d-11eb-904c-7278dfd2f703.png">


### 🎩 checklist

* ~Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)~
* ~Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)~
* ~Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* ~For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
