### PR TITLE
[TextField] Fix border-top color to meet 3:1 contrast ratio

### DIFF
--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -182,6 +182,7 @@ export function DetailsPage() {
       open={userMenuActive}
       onToggle={toggleUserMenuActive}
       colorScheme="dark"
+      accessibilityLabel="User menu"
     />
   );
 

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -397,7 +397,7 @@ $stacking-order: (
     background-color: var(--p-surface);
     position: absolute;
     border: 1px solid var(--p-border-subdued);
-    border-top-color: var(--p-border-shadow);
+    border-top-color: #8c959b;
     box-shadow: none;
 
     &::after {

--- a/src/components/TopBar/components/Menu/Menu.tsx
+++ b/src/components/TopBar/components/Menu/Menu.tsx
@@ -24,6 +24,8 @@ export interface MenuProps {
   onClose(): void;
   /** Accepts a color scheme for the contents of the menu */
   colorScheme?: InversableColorScheme;
+  /** A string that provides the accessibility labeling */
+  accessibilityLabel?: string;
 }
 
 export function Menu(props: MenuProps) {
@@ -35,6 +37,7 @@ export function Menu(props: MenuProps) {
     activatorContent,
     message,
     colorScheme,
+    accessibilityLabel,
   } = props;
 
   const badgeProps = message &&
@@ -61,7 +64,12 @@ export function Menu(props: MenuProps) {
     <Popover
       activator={
         <div className={styles.ActivatorWrapper}>
-          <button type="button" className={styles.Activator} onClick={onOpen}>
+          <button
+            type="button"
+            className={styles.Activator}
+            onClick={onOpen}
+            aria-label={accessibilityLabel}
+          >
             {activatorContent}
           </button>
         </div>

--- a/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {ActionList, Popover} from 'components';
 
 import {Menu} from '../Menu';
@@ -128,6 +129,18 @@ describe('<Menu />', () => {
       const menu = mountWithAppProvider(<Menu {...defaultProps} open />);
 
       expect(menu.find(Popover).prop('fullHeight')).toBe(true);
+    });
+  });
+
+  describe('accessibilityLabel', () => {
+    it('passes accessibilityLabel to the popover activator', () => {
+      const menu = mountWithApp(
+        <Menu {...defaultProps} accessibilityLabel="User menu" />,
+      );
+
+      expect(menu).toContainReactComponent('button', {
+        'aria-label': 'User menu',
+      });
     });
   });
 });

--- a/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -17,6 +17,8 @@ export interface UserMenuProps {
   name: string;
   /** A string allowing further detail on the merchant’s name displayed in the user menu */
   detail?: string;
+  /** A string that provides the accessibility labeling */
+  accessibilityLabel?: string;
   /** The merchant’s initials, rendered in place of an avatar image when not provided */
   initials: AvatarProps['initials'];
   /** An avatar image representing the merchant */
@@ -39,6 +41,7 @@ export function UserMenu({
   onToggle,
   open,
   colorScheme,
+  accessibilityLabel,
 }: UserMenuProps) {
   const showIndicator = Boolean(message);
 
@@ -67,6 +70,7 @@ export function UserMenu({
       actions={actions}
       message={message}
       colorScheme={colorScheme}
+      accessibilityLabel={accessibilityLabel}
     />
   );
 }

--- a/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {ViewMinor} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {UserMenu} from '../UserMenu';
 
@@ -12,6 +13,7 @@ describe('<UserMenu />', () => {
     initials: '',
     open: false,
     onToggle: noop,
+    accessibilityLabel: 'User menu',
   };
 
   it('renders with the given props', () => {


### PR DESCRIPTION
### WHY are these changes introduced? WHAT is this pull request doing?
This pull request fixes #Shopify/polaris-ux#163. In order to meet the minimum threshold of 3:1 for user interface controls (outlined in https://github.com/Shopify/polaris-ux/issues/450), this PR modifies the border-top color of TextField. 

The approach taken was, instead of modifying the entire border-color of the TextField (which may impact the experience & cohesiveness with other components), modifying the existing border-top color so that it meets the 3:1 ratio.

Originally, the border-top color of the TextField was var(--p-border-shadow) / hsl(207deg 7% 70%). When we put these in contrast-ratio, it has a contrast of 2.11 (https://contrast-ratio.com/#hsl%28207deg%207%25%2070%25%29-on-%23fff). 

With these changes, the border-top color of the TextField becomes  #8c959b / hsl(207deg 7% 58%). When we put these in contrast-ratio, it has a contrast of 3.04 (https://contrast-ratio.com/#hsl%28207deg%207%25%2058%25%29-on-%23fff). 

Before:
<img width="638" alt="Screen Shot 2020-11-25 at 9 34 09 AM" src="https://user-images.githubusercontent.com/54586463/100250330-8ce69700-2f0b-11eb-96a3-d244cd74d88f.png">


After:
<img width="646" alt="Screen Shot 2020-11-25 at 9 35 49 AM" src="https://user-images.githubusercontent.com/54586463/100250339-9112b480-2f0b-11eb-830f-0a651f51a7c1.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
