### PR TITLE
[WIP] [OptionList] [a11y] Switch singleSelect to input type='radio'

### DIFF
--- a/src/components/OptionList/components/Checkbox/Checkbox.tsx
+++ b/src/components/OptionList/components/Checkbox/Checkbox.tsx
@@ -62,7 +62,6 @@ export function Checkbox({
         checked={checked}
         disabled={disabled}
         className={inputClassName}
-        aria-checked={checked}
         onChange={onChange}
         onBlur={handleBlur}
         onKeyUp={handleKeyUp}

--- a/src/components/OptionList/components/Option/Option.scss
+++ b/src/components/OptionList/components/Option/Option.scss
@@ -134,20 +134,15 @@ $control-vertical-adjustment: rem(2px);
   }
 
   .SingleSelectOption {
-    // stylelint-disable-next-line selector-max-combinators, selector-max-compound-selectors
-    [type='radio'] + label {
-      @include focus-ring;
+    position: relative;
+    @include focus-ring;
 
-      // stylelint-disable-next-line selector-max-combinators, selector-max-compound-selectors
-      &.select::before {
-        @include list-selected-indicator;
-      }
-    }
-
-    // stylelint-disable-next-line selector-max-combinators, selector-max-compound-selectors
-    [type='radio'].active + label,
-    [type='radio']:focus:not(:active) + label {
+    &:focus-within {
       @include focus-ring($style: 'focused');
+    }
+    // stylelint-disable-next-line selector-max-combinators, selector-max-compound-selectors
+    &.select::before {
+      @include list-selected-indicator;
     }
   }
 }

--- a/src/components/OptionList/components/Option/Option.scss
+++ b/src/components/OptionList/components/Option/Option.scss
@@ -25,8 +25,7 @@ $control-vertical-adjustment: rem(2px);
   }
 }
 
-.Label,
-.SingleSelectOption {
+.Label {
   display: flex;
   align-items: flex-start;
   width: 100%;
@@ -92,29 +91,11 @@ $control-vertical-adjustment: rem(2px);
   }
 
   .select {
+    box-shadow: inset 0.2rem 0 0 color('indigo');
     background-image: linear-gradient(
       rgba(179, 188, 245, 0.15),
       rgba(179, 188, 245, 0.15)
     );
-
-    &.focused {
-      box-shadow: inset 0.2rem 0 0 color('indigo');
-      background-image: linear-gradient(
-          rgba(179, 188, 245, 0.15),
-          rgba(179, 188, 245, 0.15)
-        ),
-        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
-
-      &:hover {
-        box-shadow: inset 0.2rem 0 0 color('indigo');
-        background-image: linear-gradient(
-            rgba(179, 188, 245, 0.15),
-            rgba(179, 188, 245, 0.15)
-          ),
-          linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3)),
-          linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
-      }
-    }
   }
 
   .active {
@@ -129,11 +110,9 @@ $control-vertical-adjustment: rem(2px);
   border-radius: var(--p-border-radius-base);
   margin-top: spacing(tight) / 2;
 
-  .Label,
-  .SingleSelectOption {
+  .Label {
     cursor: pointer;
     border-radius: var(--p-border-radius-base);
-    padding: spacing(tight);
 
     &:hover:not(.disabled) {
       background: var(--p-surface-hovered);
@@ -155,15 +134,20 @@ $control-vertical-adjustment: rem(2px);
   }
 
   .SingleSelectOption {
-    @include focus-ring;
+    // stylelint-disable-next-line selector-max-combinators, selector-max-compound-selectors
+    [type='radio'] + label {
+      @include focus-ring;
 
-    &.active,
-    &.focused:not(:active) {
-      @include focus-ring($style: 'focused');
+      // stylelint-disable-next-line selector-max-combinators, selector-max-compound-selectors
+      &.select::before {
+        @include list-selected-indicator;
+      }
     }
 
-    &.select::before {
-      @include list-selected-indicator;
+    // stylelint-disable-next-line selector-max-combinators, selector-max-compound-selectors
+    [type='radio'].active + label,
+    [type='radio']:focus:not(:active) + label {
+      @include focus-ring($style: 'focused');
     }
   }
 }

--- a/src/components/OptionList/components/Option/Option.tsx
+++ b/src/components/OptionList/components/Option/Option.tsx
@@ -54,20 +54,21 @@ export function Option({
     <div className={styles.Media}>{media}</div>
   ) : null;
 
-  const singleSelectClassName = classNames(styles.SingleSelectOption);
-
-  const singleSelectLabelClassName = classNames(
+  const labelClassName = classNames(
     styles.Label,
-    select && styles.select,
     disabled && styles.disabled,
     active && styles.active,
   );
 
   const multiSelectClassName = classNames(
-    styles.Label,
-    disabled && styles.disabled,
-    active && styles.active,
+    labelClassName,
     newDesignLanguage && select && styles.select,
+  );
+
+  const singleSelectClassName = classNames(
+    labelClassName,
+    styles.SingleSelectOption,
+    select && styles.select,
   );
 
   const optionRole = role === 'option' ? 'presentation' : undefined;
@@ -89,7 +90,7 @@ export function Option({
       {label}
     </label>
   ) : (
-    <div className={singleSelectClassName}>
+    <label htmlFor={id} className={singleSelectClassName}>
       <RadioButton
         id={id}
         value={value}
@@ -99,11 +100,9 @@ export function Option({
         onChange={handleClick}
         role={optionRole}
       />
-      <label htmlFor={id} className={singleSelectLabelClassName}>
-        {mediaMarkup}
-        {label}
-      </label>
-    </div>
+      {mediaMarkup}
+      {label}
+    </label>
   );
 
   const scrollMarkup = active ? <Scrollable.ScrollTo /> : null;

--- a/src/components/OptionList/components/Option/Option.tsx
+++ b/src/components/OptionList/components/Option/Option.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback} from 'react';
 
-import {useToggle} from '../../../../utilities/use-toggle';
 import {classNames} from '../../../../utilities/css';
 import {useFeatures} from '../../../../utilities/features';
 import type {IconProps} from '../../../../types';
@@ -8,6 +7,7 @@ import type {ThumbnailProps} from '../../../Thumbnail';
 import type {AvatarProps} from '../../../Avatar';
 import {Scrollable} from '../../../Scrollable';
 import {Checkbox} from '../Checkbox';
+import {RadioButton} from '../RadioButton';
 
 import styles from './Option.scss';
 
@@ -40,7 +40,6 @@ export function Option({
   section,
   index,
 }: OptionProps) {
-  const {value: focused, toggle: toggleFocused} = useToggle(false);
   const {newDesignLanguage} = useFeatures();
 
   const handleClick = useCallback(() => {
@@ -55,11 +54,12 @@ export function Option({
     <div className={styles.Media}>{media}</div>
   ) : null;
 
-  const singleSelectClassName = classNames(
-    styles.SingleSelectOption,
-    focused && styles.focused,
-    disabled && styles.disabled,
+  const singleSelectClassName = classNames(styles.SingleSelectOption);
+
+  const singleSelectLabelClassName = classNames(
+    styles.Label,
     select && styles.select,
+    disabled && styles.disabled,
     active && styles.active,
   );
 
@@ -70,7 +70,7 @@ export function Option({
     newDesignLanguage && select && styles.select,
   );
 
-  const checkBoxRole = role === 'option' ? 'presentation' : undefined;
+  const optionRole = role === 'option' ? 'presentation' : undefined;
 
   const optionMarkup = allowMultiple ? (
     <label htmlFor={id} className={multiSelectClassName}>
@@ -82,25 +82,28 @@ export function Option({
           active={active}
           disabled={disabled}
           onChange={handleClick}
-          role={checkBoxRole}
+          role={optionRole}
         />
       </div>
       {mediaMarkup}
       {label}
     </label>
   ) : (
-    <button
-      id={id}
-      type="button"
-      className={singleSelectClassName}
-      onClick={handleClick}
-      disabled={disabled}
-      onFocus={toggleFocused}
-      onBlur={toggleFocused}
-    >
-      {mediaMarkup}
-      {label}
-    </button>
+    <div className={singleSelectClassName}>
+      <RadioButton
+        id={id}
+        value={value}
+        checked={select}
+        active={active}
+        disabled={disabled}
+        onChange={handleClick}
+        role={optionRole}
+      />
+      <label htmlFor={id} className={singleSelectLabelClassName}>
+        {mediaMarkup}
+        {label}
+      </label>
+    </div>
   );
 
   const scrollMarkup = active ? <Scrollable.ScrollTo /> : null;

--- a/src/components/OptionList/components/RadioButton/RadioButton.scss
+++ b/src/components/OptionList/components/RadioButton/RadioButton.scss
@@ -1,0 +1,5 @@
+@import '../../../../styles/common';
+
+.Input {
+  @include visually-hidden;
+}

--- a/src/components/OptionList/components/RadioButton/RadioButton.tsx
+++ b/src/components/OptionList/components/RadioButton/RadioButton.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import {useUniqueId} from '../../../../utilities/unique-id';
+
+import styles from './RadioButton.scss';
+
+export interface RadioButtonProps {
+  checked?: boolean;
+  disabled?: boolean;
+  active?: boolean;
+  id?: string;
+  name?: string;
+  value?: string;
+  role?: string;
+  onChange(): void;
+}
+
+export function RadioButton({
+  id: idProp,
+  checked = false,
+  disabled,
+  onChange,
+  name,
+  value,
+  role,
+}: RadioButtonProps) {
+  const id = useUniqueId('RadioButton', idProp);
+
+  return (
+    <input
+      id={id}
+      name={name}
+      value={value}
+      type="radio"
+      checked={checked}
+      disabled={disabled}
+      className={styles.Input}
+      onChange={onChange}
+      role={role}
+    />
+  );
+}

--- a/src/components/OptionList/components/RadioButton/index.ts
+++ b/src/components/OptionList/components/RadioButton/index.ts
@@ -1,0 +1,1 @@
+export * from './RadioButton';


### PR DESCRIPTION
Fixes #3358 

### What this PR is doing

- Converts the singleSelect `OptionList` to an `<input type="radio">` for improved accessibility. (the component currently renders a list of buttons). 

### Questions

- is this the right approach?  
- should the label for the RadioButton be moved into the component, to avoid selectors such as ` [type='radio'] + label` in the Option.tsx file? this would make the styling tidier, but hamper the readability of the `allowMultiple ?` structure, which currently highlights parallels between the media/label markup. It would also mean the label styles would be repeated in two files. Maybe these could be a mixin? 
- still need to add disabled styles and tidy up old styles




### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
