### PR TITLE
[ScrollLock] Remove lock scrolling wrapper

### DIFF
--- a/src/components/ScrollLock/ScrollLock.scss
+++ b/src/components/ScrollLock/ScrollLock.scss
@@ -1,10 +1,4 @@
 [data-lock-scrolling] {
-  overflow-y: scroll;
+  overflow: hidden;
   margin: 0;
-
-  // stylelint-disable selector-max-attribute
-  [data-lock-scrolling-wrapper] {
-    overflow: hidden;
-    height: 100%;
-  }
 }

--- a/src/utilities/scroll-lock-manager/scroll-lock-manager.ts
+++ b/src/utilities/scroll-lock-manager/scroll-lock-manager.ts
@@ -2,8 +2,6 @@ import {isServer} from '../target';
 
 export const SCROLL_LOCKING_ATTRIBUTE = 'data-lock-scrolling';
 
-const SCROLL_LOCKING_WRAPPER_ATTRIBUTE = 'data-lock-scrolling-wrapper';
-
 let scrollPosition = 0;
 
 export class ScrollLockManager {
@@ -25,23 +23,15 @@ export class ScrollLockManager {
 
     const {scrollLocks} = this;
     const {body} = document;
-    const wrapper = body.firstElementChild;
 
     if (scrollLocks === 0) {
       body.removeAttribute(SCROLL_LOCKING_ATTRIBUTE);
-      if (wrapper) {
-        wrapper.removeAttribute(SCROLL_LOCKING_WRAPPER_ATTRIBUTE);
-      }
       window.scroll(0, scrollPosition);
       this.locked = false;
     } else if (scrollLocks > 0 && !this.locked) {
       scrollPosition = window.pageYOffset;
       body.setAttribute(SCROLL_LOCKING_ATTRIBUTE, '');
 
-      if (wrapper) {
-        wrapper.setAttribute(SCROLL_LOCKING_WRAPPER_ATTRIBUTE, '');
-        wrapper.scrollTop = scrollPosition;
-      }
       this.locked = true;
     }
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes issue 2 in #3467<!-- link to issue if one exists -->
> 2. scroll lock component does not work as intended when the first child is not a visual DOM element

The existing approach relies on a wrapper data attribute to apply styles to the first child element in the document, presumably under the assumption that this is also the main content container. In cases where that first child element is not the main content container, the wrapper attribute doesn't prevent scrolling of the main content.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This moves `overflow:hidden` from the wrapper to the body element to prevent scrolling on the page when ScrollLock is applied.

I am not sure why the wrapper was introduced in the first place, so feedback on whether removing it may cause unexpected side effects would be appreciated! Currently, `overflow:hidden` applied to the body element should prevent scrolling in all browsers, including iOS Safari.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
<img width="750" alt="Screen Shot 2020-12-09 at 2 27 26 PM" src="https://user-images.githubusercontent.com/3474483/101699288-bafdc800-3a2f-11eb-857e-42d80a6f0753.png">|<img width="750" alt="Screen Shot 2020-12-09 at 2 25 35 PM" src="https://user-images.githubusercontent.com/3474483/101699191-973a8200-3a2f-11eb-9612-07d0a86a28bd.png">
:----:|:----:
Before with scrollbar showing |After with no scrollbar


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

This can be reviewed on the **Details Page** when the window size is smaller than the content to force scrolling, and the **Settings** modal is triggered.

The scrolling position of the page shouldn't change when ScrollLock is applied or removed.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
