### PR TITLE
[Button] Adding new iconPlacement property to Button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
 - Added an `onError` hook to the `Avatar` component ([#4052](https://github.com/Shopify/polaris-react/pull/4052))
 - Added `zIndexOverride` prop to `Popover` ([#3937](https://github.com/Shopify/polaris-react/pull/3937))
+- Button `icon` can now be place `before` or `after` button content by using new `iconPlacement` property
+  - Button connected disclosure now follows loading & disabled states from the attached button
 
 ### Bug fixes
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -77,16 +77,15 @@ $stacking-order: (
 }
 
 .Icon {
-  // This compensates for the typical icon used in buttons being
-  // inset within its bounding box.
-  margin-left: -(spacing(extra-tight));
+  margin-left: spacing(extra-tight);
+
+  &:first-child {
+    margin-left: -(spacing(extra-tight));
+    margin-right: 0;
+  }
 
   &:last-child {
-    // This compensates for the disclosure icon, which is substantially
-    // inset within the viewbox (and makes it look like there is too much
-    // spacing on the right of the button)
     margin-right: -(spacing(tight));
-    margin-left: spacing(extra-tight);
   }
 
   // stylelint-disable-next-line selector-max-class, selector-max-specificity

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,6 +48,8 @@ export interface ButtonProps extends BaseButton {
   removeUnderline?: boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactElement | IconSource;
+  /** does the icon display on the left or right of the content */
+  iconPlacement?: 'before' | 'after';
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
 }
@@ -110,6 +112,7 @@ export function Button({
   onMouseEnter,
   onTouchStart,
   icon,
+  iconPlacement = 'before',
   primary,
   outline,
   destructive,
@@ -144,17 +147,23 @@ export function Button({
     removeUnderline && styles.removeUnderline,
   );
 
-  const disclosureMarkup = disclosure ? (
-    <span className={styles.Icon}>
-      <div
-        className={classNames(styles.DisclosureIcon, loading && styles.hidden)}
-      >
-        <Icon
-          source={loading ? 'placeholder' : getDisclosureIconSource(disclosure)}
-        />
-      </div>
-    </span>
-  ) : null;
+  const disclosureMarkup =
+    disclosure && !connectedDisclosure ? (
+      <span className={styles.Icon}>
+        <div
+          className={classNames(
+            styles.DisclosureIcon,
+            loading && styles.hidden,
+          )}
+        >
+          <Icon
+            source={
+              loading ? 'placeholder' : getDisclosureIconSource(disclosure)
+            }
+          />
+        </div>
+      </span>
+    ) : null;
 
   const iconSource = isIconSource(icon) ? (
     <Icon source={loading ? 'placeholder' : icon} />
@@ -201,6 +210,7 @@ export function Button({
       styles.Button,
       primary && styles.primary,
       outline && styles.outline,
+      isDisabled && styles.disabled,
       size && size !== DEFAULT_SIZE && styles[variationName('size', size)],
       textAlign && styles[variationName('textAlign', textAlign)],
       destructive && styles.destructive,
@@ -215,7 +225,6 @@ export function Button({
     );
 
     const {
-      disabled,
       accessibilityLabel: disclosureLabel = defaultLabel,
     } = connectedDisclosure;
 
@@ -223,7 +232,7 @@ export function Button({
       <button
         type="button"
         className={connectedDisclosureClassName}
-        disabled={disabled}
+        disabled={isDisabled}
         aria-label={disclosureLabel}
         aria-describedby={ariaDescribedBy}
         onClick={toggleDisclosureActive}
@@ -284,8 +293,9 @@ export function Button({
     <UnstyledButton {...commonProps} {...linkProps} {...actionProps}>
       <span className={styles.Content}>
         {spinnerSVGMarkup}
-        {iconMarkup}
+        {iconPlacement === 'before' && iconMarkup}
         {childMarkup}
+        {iconPlacement === 'after' && iconMarkup}
         {disclosureMarkup}
       </span>
     </UnstyledButton>

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -425,6 +425,24 @@ Use when a button has been pressed and the associated action is in progress.
 <Button loading>Save product</Button>
 ```
 
+### Button with Icon
+
+Use the icon property to add an icon to your Button
+
+```jsx
+<Button icon={ExternalMinor}>Add to Cart</Button>
+```
+
+### Button with Icon after
+
+By default icons are placed before the button content, use the `iconPlacement` property to display the icon after the content instead.
+
+```jsx
+<Button iconPlacement="after" icon={ExternalMinor}>
+  Continue
+</Button>
+```
+
 ---
 
 ## Related components

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -3,6 +3,7 @@ import {
   CaretDownMinor,
   CaretUpMinor,
   PlusMinor,
+  AddImageMajor,
   SelectMinor,
 } from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
@@ -104,8 +105,19 @@ describe('<Button />', () => {
       expect(button.find(Spinner).exists()).toBeTruthy();
     });
 
-    it.todo('renders a placeholder disclosure icon');
-    it.todo('renders a placeholder inner icon');
+    it('renders a placeholder disclosure icon', () => {
+      const button = mountWithAppProvider(<Button loading disclosure />);
+      expect(button.find(UnstyledButton).find(Icon).prop('source')).toBe(
+        'placeholder',
+      );
+    });
+
+    it('renders a placeholder inner icon', () => {
+      const button = mountWithAppProvider(<Button loading icon={PlusMinor} />);
+      expect(button.find(UnstyledButton).find(Icon).prop('source')).toBe(
+        'placeholder',
+      );
+    });
   });
 
   describe('submit', () => {
@@ -130,6 +142,46 @@ describe('<Button />', () => {
     it('does not render the markup for the icon if none is provided', () => {
       const button = mountWithAppProvider(<Button />);
       expect(button.find(Icon).exists()).toBe(false);
+    });
+  });
+
+  describe('iconPlacement', () => {
+    it('renders the icon before content by default', () => {
+      const button = mountWithAppProvider(
+        <Button icon={AddImageMajor}>content</Button>,
+      );
+
+      const container = button.find(UnstyledButton).find('span');
+      const kids: React.ReactElement[] = Array.from(
+        container.children().getElements(),
+      );
+
+      const contentIndex = kids.findIndex(
+        (el) => el.props.className === 'Text',
+      );
+      const iconIndex = kids.findIndex((el) => el.props.className === 'Icon');
+
+      expect(contentIndex > iconIndex).toBe(true);
+    });
+
+    it('renders the icon after content if iconPlacement set to after', () => {
+      const button = mountWithAppProvider(
+        <Button icon={AddImageMajor} iconPlacement="after">
+          content
+        </Button>,
+      );
+
+      const container = button.find(UnstyledButton).find('span');
+      const kids: React.ReactElement[] = Array.from(
+        container.children().getElements(),
+      );
+
+      const contentIndex = kids.findIndex(
+        (el) => el.props.className === 'Text',
+      );
+      const iconIndex = kids.findIndex((el) => el.props.className === 'Icon');
+
+      expect(contentIndex < iconIndex).toBe(true);
     });
   });
 
@@ -246,16 +298,15 @@ describe('<Button />', () => {
 
     it('disables the disclosure button when disabled is true', () => {
       const disclosure = {
-        disabled: true,
         actions: [
           {
-            content: 'Save and mark as ordered',
+            content: 'Save',
           },
         ],
       };
 
       const button = mountWithAppProvider(
-        <Button connectedDisclosure={disclosure} />,
+        <Button connectedDisclosure={disclosure} disabled />,
       );
 
       const disclosureButton = button.find('button').at(1);
@@ -284,6 +335,23 @@ describe('<Button />', () => {
       expect(actionList.prop('items')).toStrictEqual(
         expect.arrayContaining(actions),
       );
+    });
+
+    it('takes precedence over the disclosure arrow', () => {
+      const actions = [
+        {
+          content: 'Save and mark as ordered',
+        },
+      ];
+
+      const disclosure = {actions};
+
+      const button = mountWithAppProvider(
+        <Button disclosure="up" connectedDisclosure={disclosure} />,
+      );
+
+      expect(button.find('.DisclosureIcon').exists()).toBe(false);
+      expect(button.find('button')).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION

### WHY are these changes introduced?

`Button`'s icon property previously only rendered an optional icon to the left - or preceding - the content of the button. Our UX team had created several designs that included a right arrow after the content, essentially visually representing that we're moving to a next step, or continuation in a process.

We've heard from a few other teams looking for ways of accomplishing something similar now, so thought the time was right to add this to Polaris.

### WHAT is this pull request doing?

- Button `icon` can now be place `before` or `after` button content by using new `iconPlacement` property
- Button connected disclosure now follows loading & disabled states from the attached button, so if the Button is in disabled or loading state, you will no longer be able to interact with the connectedDisclosure button as it will also become disabled.
- Slight cleanup in inner Button markup logic to make shortcircuiting a bit more readable.

    <details>
      <summary>Many combinations of Button parameters showing the new iconPlacement in various contexts</summary>
<img width="985" alt="Many combinations of Button parameters showing the new iconPlacement in various contexts" src="https://user-images.githubusercontent.com/1128934/107470628-b17d0300-6b39-11eb-93f2-608ba0cd0a69.png">
    </details>

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {
  ArrowRightMinor,
  AddImageMajor,
  AnalyticsMajor,
} from '@shopify/polaris-icons';

import {Page, Card, Button, ButtonGroup, Icon} from '../src';

export function Playground() {
  const disc = {
    actions: [
      {
        content: 'bloop',
      },
    ],
  };

  return (
    <Page title="Playground">
      <Card sectioned>
        <div style={{color: '#bf0711'}}>
          <Button plain monochrome loading disclosure>
            Try again
          </Button>
        </div>
      </Card>

      <Card sectioned>
        <ButtonGroup>
          <Button
            newDesignLanguage={true}
            icon={ArrowRightMinor}
            iconPlacement="after"
            plain
          >
            icon after
          </Button>
          <Button
            newDesignLanguage={true}
            icon={ArrowRightMinor}
            iconPlacement="after"
            connectedDisclosure={disc}
            plain
          >
            after & connected
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AddImageMajor}
            iconPlacement="after"
            disclosure="up"
            plain
          >
            after & disclosure
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AddImageMajor}
            iconPlacement="after"
            disclosure="up"
            connectedDisclosure={disc}
            plain
          >
            after & disclosure & connected
          </Button>
        </ButtonGroup>
      </Card>
      <Card sectioned>
        <ButtonGroup>
          <Button
            newDesignLanguage={true}
            icon={ArrowRightMinor}
            iconPlacement="after"
            primary={true}
          >
            icon after
          </Button>
          <Button
            newDesignLanguage={true}
            icon={ArrowRightMinor}
            iconPlacement="after"
            connectedDisclosure={disc}
            primary={true}
          >
            after & connected
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AddImageMajor}
            iconPlacement="after"
            disclosure="up"
            primary={true}
          >
            after & disclosure
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AddImageMajor}
            iconPlacement="after"
            disclosure="up"
            connectedDisclosure={disc}
            primary={true}
          >
            after & disclosure & connected
          </Button>
        </ButtonGroup>
      </Card>
      <Card sectioned>
        <ButtonGroup>
          <Button
            newDesignLanguage={true}
            icon={ArrowRightMinor}
            iconPlacement="after"
            primary={true}
            loading={true}
          >
            icon after
          </Button>
          <Button
            newDesignLanguage={true}
            icon={ArrowRightMinor}
            iconPlacement="after"
            connectedDisclosure={disc}
            primary={true}
            loading={true}
          >
            after & connected
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AddImageMajor}
            iconPlacement="after"
            disclosure="up"
            primary={true}
            loading={true}
          >
            after & disclosure
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AddImageMajor}
            iconPlacement="after"
            disclosure="up"
            connectedDisclosure={disc}
            primary={true}
            loading={true}
          >
            after & disclosure & connected
          </Button>
        </ButtonGroup>
      </Card>
      <Card sectioned>
        <ButtonGroup>
          <Button
            newDesignLanguage={true}
            icon={ArrowRightMinor}
            iconPlacement="after"
            plain
            monochrome
            loading={true}
          >
            icon after
          </Button>
          <Button
            newDesignLanguage={true}
            icon={ArrowRightMinor}
            iconPlacement="after"
            connectedDisclosure={disc}
            plain
            monochrome
            loading={true}
          >
            after & connected
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AddImageMajor}
            iconPlacement="after"
            disclosure="up"
            monochrome
            loading={true}
          >
            after & disclosure
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AddImageMajor}
            iconPlacement="after"
            disclosure="up"
            connectedDisclosure={disc}
            plain
            loading={true}
          >
            after & disclosure & connected
          </Button>
        </ButtonGroup>
      </Card>
      <Card sectioned>
        <ButtonGroup>
          <Button newDesignLanguage={true} icon={AnalyticsMajor} primary={true}>
            icon before
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AnalyticsMajor}
            connectedDisclosure={disc}
            primary={true}
          >
            before & connected
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AnalyticsMajor}
            disclosure="up"
            primary={true}
          >
            before & disclosure
          </Button>
          <Button
            newDesignLanguage={true}
            icon={AnalyticsMajor}
            disclosure="up"
            connectedDisclosure={disc}
            primary={true}
          >
            before & disclosure & connected
          </Button>
        </ButtonGroup>
      </Card>
      <Card sectioned>
        <ButtonGroup>
          <Button newDesignLanguage={true}>no icon</Button>
          <Button newDesignLanguage={true} connectedDisclosure={disc}>
            connected
          </Button>
          <Button newDesignLanguage={true} disclosure="up">
            disclosure
          </Button>
          <Button
            newDesignLanguage={true}
            disclosure="up"
            connectedDisclosure={disc}
          >
            disclosure & connected
          </Button>
        </ButtonGroup>
      </Card>
      <Card sectioned>
        <ButtonGroup>
          <Button newDesignLanguage={true} disabled={true}>
            no icon
          </Button>
          <Button
            newDesignLanguage={true}
            connectedDisclosure={disc}
            disabled={true}
          >
            connected
          </Button>
          <Button newDesignLanguage={true} disclosure="up" disabled={true}>
            disclosure
          </Button>
          <Button
            newDesignLanguage={true}
            disclosure="up"
            connectedDisclosure={disc}
            disabled={true}
          >
            disclosure & connected
          </Button>
        </ButtonGroup>
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
