### PR TITLE
[Scrollable] Fix scrolled to bottom checking for sub-pixel values

### DIFF
--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -160,7 +160,7 @@ export class Scrollable extends Component<ScrollableProps, State> {
     const shouldTopShadow = Boolean(shadow && scrollTop > 0);
 
     const canScroll = scrollHeight > clientHeight;
-    const hasScrolledToBottom = scrollHeight - scrollTop === clientHeight;
+    const hasScrolledToBottom = scrollHeight - scrollTop <= clientHeight;
 
     if (canScroll && hasScrolledToBottom && onScrolledToBottom) {
       onScrolledToBottom();


### PR DESCRIPTION


<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3607, Fixes https://github.com/Shopify/polaris-react/issues/3225

### WHAT is this pull request doing?

Certain resolutions, OSes, and browser zoom-level combinations cause `scrollTop` to be a sub-pixel value ([StackOverflow example](https://stackoverflow.com/questions/52470549/subpixel-scroll-issue-cant-set-scrolltop-properly-on-chrome-69)), which does not satisfy the strict-equality check on the `hasScrolledToBottom` calculation of the `Scrollable` component.

In order to catch these cases, and fire the `onScrolledToBottom` callback prop, I've made the strict-equality check a less-than-or-equal to operator.

Notes: 
- "less-than" might seem like a counter-intuitive operator here, but I didn't want to modify the original calculation and it is the appropriate comparison
- I experimented using `Math.ceil(scrollTop)` to catch sub-pixel values that are _under_ the threshold, but this introduces another issue whereby scrolling up from the "at bottom" state can cause a re-fire of the callback. In testing, it seems to me that `clientHeight` is increased by a pixel at zoom levels where `scrollTop` is under the threshold anyway.

You can reproduce the original issue on Mac / Chrome by setting your browser zoom level to 67%, 75%, or 125%.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>


**Important** — To emulate a breaking resolution, in certain cases you need to set the browser zoom level (e.g. Chrome on Mac) to 67%, 75%, or 125%...

```jsx
import React, {useState} from 'react';

import {Page} from '../src';
import {Scrollable} from '../src/components';

export function Playground() {
  const [atBottom, setAtBottom] = useState(false);
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Scrollable
        style={{height: 100, background: 'yellow'}}
        onScrolledToBottom={() => setAtBottom(true)}
      >
        <div
          style={{
            background: 'blue',
            height: 150,
          }}
        />
      </Scrollable>
      {atBottom && (
        <h1
          style={{color: 'red', background: '#ccc'}}
          onClick={() => setAtBottom(false)}
        >
          BOTTOMED_OUT (click to reset)
        </h1>
      )}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- ~Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)~
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- ~Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~
- ~Updated the component's `README.md` with documentation changes~
- ~[Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~
- ~For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
