### PR TITLE
[TextField] Add default behaviour if onClearButtonClick is not provided

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `focus-visible` polyfill and default styles ([#3695](https://github.com/Shopify/polaris-react/pull/3695))
+- Add default onChange behaviour to `TextField` when `clearButton` is provided
 
 ### Bug fixes
 

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -785,7 +785,38 @@ function TextFieldWithClearButtonExample() {
     [],
   );
 
-  const handleClearButtonClick = useCallback(() => setTextFieldValue(''), []);
+  return (
+    <TextField
+      label="Store name"
+      value={textFieldValue}
+      onChange={handleTextFieldChange}
+      clearButton
+    />
+  );
+}
+```
+
+### Text field with clear button and custom clearing behaviour
+
+<!-- example-for: web -->
+
+Customize the behaviour of hitting the clear button.
+
+```jsx
+function TextFieldWithCustomClearButtonExample() {
+  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
+
+  const handleTextFieldChange = useCallback(
+    (value) => setTextFieldValue(value),
+    [],
+  );
+
+  const handleClearButtonClick = useCallback(
+    () =>
+      window.confirm('Are you sure you want to clear this field?') &&
+      setTextFieldValue(''),
+    [],
+  );
 
   return (
     <TextField

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -470,7 +470,11 @@ export function TextField({
   );
 
   function handleClearButtonPress() {
-    onClearButtonClick && onClearButtonClick(id);
+    if (onClearButtonClick) {
+      onClearButtonClick(id);
+    } else if (onChange) {
+      onChange('', id);
+    }
   }
 
   function handleKeyPress(event: React.KeyboardEvent) {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1101,6 +1101,22 @@ describe('<TextField />', () => {
       expect(spy).toHaveBeenCalledWith('MyTextField');
     });
 
+    it('calls onChange with an empty string when clear button is clicked if onClearButtonClicked is not provided', () => {
+      const spy = jest.fn();
+      const textField = mountWithAppProvider(
+        <TextField
+          id="MyTextField"
+          label="TextField"
+          type="search"
+          onChange={spy}
+          value="test value"
+          clearButton
+        />,
+      );
+      findByTestID(textField, 'clearButton').simulate('click');
+      expect(spy).toHaveBeenCalledWith('', 'MyTextField');
+    });
+
     it('does not render a clear button by default', () => {
       const textField = mountWithAppProvider(
         <TextField

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1084,7 +1084,7 @@ describe('<TextField />', () => {
       expect(clearButton.prop('tabIndex')).toBe(-1);
     });
 
-    it('calls onClearButtonClicked() with an id when the clear button is clicked', () => {
+    it('calls onClearButtonClick() with an id when the clear button is clicked', () => {
       const spy = jest.fn();
       const textField = mountWithAppProvider(
         <TextField
@@ -1101,7 +1101,7 @@ describe('<TextField />', () => {
       expect(spy).toHaveBeenCalledWith('MyTextField');
     });
 
-    it('calls onChange with an empty string when clear button is clicked if onClearButtonClicked is not provided', () => {
+    it('calls onChange with an empty string when clear button is clicked if onClearButtonClick is not provided', () => {
       const spy = jest.fn();
       const textField = mountWithAppProvider(
         <TextField


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

It would be nice if `onClearButtonClicked` wasn't required if it only needed to provide the same behaviour as calling `onChange('')`. This would allow us to get "clearing" functionality by only needing to add `clearButton={true}`.


### WHAT is this pull request doing?

Adds new behaviour to the function that handles "clear button" presses. Previously if no `onClearButtonClick` function was provided, pressing the clear button would have no effect. Now if no value is provided, it will try to fallback to calling the `onChange` function with an empty string, which is likely to be what the user expected as default behaviour.

This means that we can save developers a step in not having to pass a second function to `TextField`. As a comparison, if you previously wrote this:

```tsx
function Component() {
  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
  
  const handleTextFieldChange = useCallback(
    (value) => setTextFieldValue(value),
    [],
  );

  const handleClearButtonClick = useCallback(
    (value) => setTextFieldValue(value),
    [],
  );

  return (
    <TextField
      label="Store name"
      value={textFieldValue}
      onChange={handleTextFieldChange}
      clearButton
      onClearButtonClick={handleClearButtonClick}
    />
  );
}
```

you can now avoid the second function and instead write:

```tsx
function Component() {
  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
  
  const handleTextFieldChange = useCallback(
    (value) => setTextFieldValue(value),
    [],
  );

  return (
    <TextField
      label="Store name"
      value={textFieldValue}
      onChange={handleTextFieldChange}
      clearButton
    />
  );
}
```

to get the same behaviour. (Note: this doesn't change the behaviour of `onClearButtonClick` itself. If provided it will still take precedence).