### PR TITLE
Add message type event listener for styleguide

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -17,3 +17,24 @@
     }
   }
 </style>
+<script>
+  window.addEventListener('message', (event) => {
+    if (event.origin === window.location.origin) return;
+
+    const storyData = JSON.parse(
+      JSON.stringify(
+        window.__STORYBOOK_CLIENT_API__
+          .raw()
+          .map(({id, kind, name}) => ({id, kind, name})),
+      ),
+    );
+
+    event.source.postMessage(
+      {
+        height: document.body.scrollHeight,
+        storyData,
+      },
+      event.origin,
+    );
+  });
+</script>


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-styleguide/issues/3832

If we're going to be primarily client side based we need a hook into story book to grab the content height and component data

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
