### PR TITLE
[WIP][Popover] Fix focus placement when popover closes

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -131,16 +131,17 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
       return;
     }
 
-    if (
-      (source === PopoverCloseSource.FocusOut ||
-        source === PopoverCloseSource.EscapeKeypress) &&
-      activatorNode
-    ) {
+    if (activatorNode) {
       const focusableActivator =
         findFirstFocusableNodeIncludingDisabled(activatorNode) ||
         findFirstFocusableNodeIncludingDisabled(activatorContainer.current) ||
         activatorContainer.current;
-      if (!focusNextFocusableNode(focusableActivator, isInPortal)) {
+
+      if (
+        source === PopoverCloseSource.EscapeKeypress ||
+        (source === PopoverCloseSource.FocusOut &&
+          !focusNextFocusableNode(focusableActivator, isInPortal))
+      ) {
         focusableActivator.focus();
       }
     }

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -424,6 +424,7 @@ A popover can contain many numerous types of content. Whether it's a menu, grid 
 - When a popover opens, focus moves to the first focusable element or to the popover container
 - Once focus is in the popover, merchants can access controls in the popover using the <kbd>tab</kbd> key (and <kbd>shift</kbd> + <kbd>tab</kbd> backwards) and standard keystrokes for interacting
 - Merchants can dismiss the popover by tabbing out of it, pressing the <kbd>esc</kbd> key, or clicking outside of it
-- When the popover is closed, focus returns to the element that launched it
+- When the popover is closed by pressing the <kbd>esc</kbd> key, focus returns to the element that launched it
+- Tabbing out of a popover will place the focus on the next focusable element
 
 <!-- /content-for -->

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -261,7 +261,7 @@ describe('<Popover />', () => {
     expect(onCloseSpy).not.toHaveBeenCalled();
   });
 
-  it('focuses the next available element when the popover is closed', () => {
+  it('focuses the next available element when the popover is closed by tabbing out', () => {
     const id = 'focus-target';
     function PopoverTest() {
       return (
@@ -276,7 +276,7 @@ describe('<Popover />', () => {
 
     const popover = mountWithApp(<PopoverTest />);
 
-    popover.find(PopoverOverlay)!.trigger('onClose', 1);
+    popover.find(PopoverOverlay)!.trigger('onClose', 2);
     const focusTarget = popover.find('button', {id})!.domNode;
 
     expect(document.activeElement).toBe(focusTarget);
@@ -288,6 +288,25 @@ describe('<Popover />', () => {
       return (
         <>
           <Popover active activator={<button id={id} />} onClose={noop} />
+        </>
+      );
+    }
+
+    const popover = mountWithApp(<PopoverTest />);
+
+    popover.find(PopoverOverlay)!.trigger('onClose', 1);
+    const focusTarget = popover.find('button', {id})!.domNode;
+
+    expect(document.activeElement).toBe(focusTarget);
+  });
+
+  it('focuses on the activator when closing the popover by escape key', () => {
+    const id = 'activator';
+    function PopoverTest() {
+      return (
+        <>
+          <Popover active activator={<button id={id} />} onClose={noop} />
+          <button />
         </>
       );
     }

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -6,7 +6,7 @@ export type MouseUpBlurHandler = (
 ) => void;
 
 const FOCUSABLE_SELECTOR =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not(:disabled)';
 const KEYBOARD_FOCUSABLE_SELECTORS =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Fixes #3866
Fixes #3856 

<!--
  Context about the problem that’s being addressed.
-->
Closing a popover can lead to several unexpected behaviours to the focus.

1. Closing a popover by clicking the escape key places the focus on the next focusable element.


2. Tabbing out of a popover can place the focus on a disabled element with tabindex, which causes the focus to be lost.
 

### WHAT is this pull request doing?
This PR addresses the behaviours listed above. More specifically: 

1. Closing a popover by hitting the escape key will return the focus to the activator. 
2. Focus will not be lost when closing a popover - Disabled elements with tabindex will not be focusable.
3. Polaris documentation updated to better describe the expected behaviour to the focus when closing a popover.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
          <div>
            <div style={{height: '250px'}}>
              <Popover
                active={popoverActive}
                activator={popoverActivator}
                onClose={togglePopoverActive}
              >
                <ActionList
                  items={[{content: 'Import'}, {content: 'Export'}]}
                />
              </Popover>
            </div>
            <button disabled tabIndex={0}>
              test1
            </button>
            <button>test2</button>
          </div>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
