### PR TITLE
[Frame] Fix frame content overlapping frame top bar and navigation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - `IndexTable` Remove parent resource name from bulk select action ([#4013](https://github.com/Shopify/polaris-react/pull/4013))
 - Ensured `@charset` declaration is the first thing in our styles.css file ([#4019](https://github.com/Shopify/polaris-react/pull/4019))
 - Fix `Modal.Section` divider color to match header and footer divider ([#4021](https://github.com/Shopify/polaris-react/pull/4021))
+- Fix frame content overlapping frame navigation ([#](https://github.com/Shopify/polaris-react/pull/))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,7 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - `IndexTable` Remove parent resource name from bulk select action ([#4013](https://github.com/Shopify/polaris-react/pull/4013))
 - Ensured `@charset` declaration is the first thing in our styles.css file ([#4019](https://github.com/Shopify/polaris-react/pull/4019))
 - Fix `Modal.Section` divider color to match header and footer divider ([#4021](https://github.com/Shopify/polaris-react/pull/4021))
-- Fix frame content overlapping frame navigation ([#](https://github.com/Shopify/polaris-react/pull/))
+- Fix frame content overlapping frame navigation ([#4040](https://github.com/Shopify/polaris-react/pull/4040))
 
 ### Documentation
 

--- a/src/components/Frame/Frame.scss
+++ b/src/components/Frame/Frame.scss
@@ -180,7 +180,16 @@ $skip-vertical-offset: rem(10px);
   position: relative;
   padding-bottom: var(--global-ribbon-height, 0);
   flex: 1;
+  overflow: auto;
+
   @include layout-flex-fix;
+
+  .hasTopBar & {
+    height: calc(100vh - #{top-bar-height()});
+    @include when-printing {
+      height: auto;
+    }
+  }
 }
 
 .GlobalRibbonContainer {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4035, https://github.com/Shopify/marketing-automations/issues/68.

Frame content overflow cause layout issue when content has elements with z-index higher than Frame navigation or top bar.

In my use case, we are trying to render Shopify Flow's flow-app components where the top bar has z-index: 4 while Frame navigation has z-index: 1 when displayed.

### WHAT is this pull request doing?
Approach A:
Remove `z-index: 1` from Frame content where navigation is displayed.
This is not a long term solution since we cannot guarantee the z-index of frame top bar and navigation are always higher than frame content's children elements.

Approach B: ✅ 
Restrict scrolling within frame content.
Added `overflow: auto` to frame content element and calculate heigh to prevent content overflowing on the Y axis (Top bar).

Before:
<img width="1291" alt="Screen Shot 2021-03-05 at 12 38 38 PM" src="https://user-images.githubusercontent.com/39597748/110152446-c141dd00-7daf-11eb-92a9-f1c65c915f32.png">
After:
<img width="1297" alt="Screen Shot 2021-03-05 at 12 40 35 PM" src="https://user-images.githubusercontent.com/39597748/110152657-0239f180-7db0-11eb-88eb-36060e2d6dcc.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Frame, Navigation, TopBar} from '../src';

export function Playground() {
  const topBarMarkup = <TopBar showNavigationToggle />;
  const navigationMarkup = (
    <Navigation location="/">
      <Navigation.Section
        items={[
          {
            label: 'link',
          },
        ]}
      />
    </Navigation>
  );

  return (
    <Frame navigation={navigationMarkup} topBar={topBarMarkup}>
      <div
        style={{
          height: '200vh',
          width: '200vw',
          position: 'relative',
          zIndex: 600,
          background: 'red',
          opacity: 0.5,
          'font-size': '2rem',
          color: 'white',
        }}
      >
        Try scroll on the x and y axis. Turn off overflow: auto on the frame
        content element to see overlapping issue.
      </div>
    </Frame>
  );
}

```
</details>

- Run `yarn dev` in terminal

- Go to playground, scroll within the frame in  the X and Y axis and content should not breakout onto frame navigation or topbar

- Open dev tool uncheck `overflow: auto` to see the issue



### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
