### PR TITLE
[ChoiceList] [OptionList] [Select] [Autocomplete] converted to generic components

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,7 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
-- Made `OptionList`, `ChoiceList`, and `Select` optionally generic for improved typechecking ([#4043](https://github.com/Shopify/polaris-react/pull/4043))
+- Made `OptionList`, `ChoiceList`, `Select`, and `Autocomplete` optionally generic for improved typechecking ([#4043](https://github.com/Shopify/polaris-react/pull/4043))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
+- Made `OptionList`, `ChoiceList`, and `Select` optionally generic for improved typechecking ([#4043](https://github.com/Shopify/polaris-react/pull/4043))
 
 ### Bug fixes
 

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -7,17 +7,17 @@ import {Spinner} from '../Spinner';
 import {TextField, ComboBox, ComboBoxProps} from './components';
 import styles from './Autocomplete.scss';
 
-export interface AutocompleteProps {
+export interface AutocompleteProps<Value extends string = string> {
   /** A unique identifier for the Autocomplete */
   id?: string;
   /** Collection of options to be listed */
-  options: ComboBoxProps['options'];
+  options: ComboBoxProps<Value>['options'];
   /** The selected options */
-  selected: string[];
+  selected: Value[];
   /** The text field component attached to the list of options */
   textField: React.ReactElement;
   /** The preferred direction to open the popover */
-  preferredPosition?: ComboBoxProps['preferredPosition'];
+  preferredPosition?: ComboBoxProps<Value>['preferredPosition'];
   /** Title of the list of options */
   listTitle?: string;
   /** Allow more than one option to be selected */
@@ -31,7 +31,7 @@ export interface AutocompleteProps {
   /** Is rendered when there are no options */
   emptyState?: React.ReactNode;
   /** Callback when the selection of options is changed */
-  onSelect(selected: string[]): void;
+  onSelect(selected: Value[]): void;
   /** Callback when the end of the list is reached */
   onLoadMoreResults?(): void;
 }
@@ -41,10 +41,15 @@ export interface AutocompleteProps {
 // Letting this be implicit works in this project but fails in projects that use
 // generated *.d.ts files.
 
-export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
+interface AutoCompleteComponent {
+  <Value extends string = string>(props: AutocompleteProps<Value>): JSX.Element;
   ComboBox: typeof ComboBox;
   TextField: typeof TextField;
-} = function Autocomplete({
+}
+
+export const Autocomplete: AutoCompleteComponent = function Autocomplete<
+  Value extends string = string
+>({
   id,
   options,
   selected,
@@ -58,7 +63,7 @@ export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
   emptyState,
   onSelect,
   onLoadMoreResults,
-}: AutocompleteProps) {
+}: AutocompleteProps<Value>) {
   const i18n = useI18n();
 
   const spinnerMarkup = loading ? (

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -13,13 +13,13 @@ import {isServer} from '../../../../utilities/target';
 import {ComboBoxContext} from './context';
 import styles from './ComboBox.scss';
 
-export interface ComboBoxProps {
+export interface ComboBoxProps<Value extends string = string> {
   /** A unique identifier for the ComboBox */
   id?: string;
   /** Collection of options to be listed */
-  options: OptionDescriptor[];
+  options: OptionDescriptor<Value>[];
   /** The selected options */
-  selected: string[];
+  selected: Value[];
   /** The text field component attached to the list of options */
   textField: React.ReactElement;
   /** The preferred direction to open the popover */
@@ -39,12 +39,12 @@ export interface ComboBoxProps {
   /** Is rendered when there are no options */
   emptyState?: React.ReactNode;
   /** Callback when the selection of options is changed */
-  onSelect(selected: string[]): void;
+  onSelect(selected: Value[]): void;
   /** Callback when the end of the list is reached */
   onEndReached?(): void;
 }
 
-export function ComboBox({
+export function ComboBox<Value extends string = string>({
   id: idProp,
   options,
   selected,
@@ -59,11 +59,11 @@ export function ComboBox({
   emptyState,
   onSelect,
   onEndReached,
-}: ComboBoxProps) {
+}: ComboBoxProps<Value>) {
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [selectedOptions, setSelectedOptions] = useState(selected);
   const [navigableOptions, setNavigableOptions] = useState<
-    (OptionDescriptor | ActionListItemDescriptor)[]
+    (OptionDescriptor<Value> | ActionListItemDescriptor)[]
   >([]);
   const {
     value: popoverActive,
@@ -87,8 +87,8 @@ export function ComboBox({
 
   const visuallyUpdateSelectedOption = useCallback(
     (
-      newOption: OptionDescriptor | ActionListItemDescriptor,
-      oldOption: OptionDescriptor | ActionListItemDescriptor | undefined,
+      newOption: OptionDescriptor<Value> | ActionListItemDescriptor,
+      oldOption: OptionDescriptor<Value> | ActionListItemDescriptor | undefined,
     ) => {
       if (oldOption) {
         oldOption.active = false;
@@ -156,7 +156,7 @@ export function ComboBox({
   }, [navigableOptions, selectOptionAtIndex, selectedIndex]);
 
   const selectOptions = useCallback(
-    (selected: string[]) => {
+    (selected: Value[]) => {
       selected && onSelect(selected);
       if (!allowMultiple) {
         resetVisuallySelectedOptions();
@@ -172,7 +172,7 @@ export function ComboBox({
   );
 
   const handleSelection = useCallback(
-    (newSelected: string) => {
+    (newSelected: Value) => {
       let newlySelectedOptions = selected;
       if (selected.includes(newSelected)) {
         newlySelectedOptions.splice(
@@ -219,7 +219,7 @@ export function ComboBox({
   }, [forcePopoverActiveTrue, popoverActive]);
 
   const updateIndexOfSelectedOption = useCallback(
-    (newOptions: (OptionDescriptor | ActionListItemDescriptor)[]) => {
+    (newOptions: (OptionDescriptor<Value> | ActionListItemDescriptor)[]) => {
       const selectedOption = navigableOptions[selectedIndex];
       if (selectedOption && newOptions.includes(selectedOption)) {
         selectOptionAtIndex(newOptions.indexOf(selectedOption));
@@ -245,7 +245,7 @@ export function ComboBox({
 
   useIsomorphicLayoutEffect(() => {
     let newNavigableOptions: (
-      | OptionDescriptor
+      | OptionDescriptor<Value>
       | ActionListItemDescriptor
     )[] = [];
     if (actionsBefore) {
@@ -357,24 +357,24 @@ export function ComboBox({
   );
 }
 
-function assignOptionIds(
-  options: (OptionDescriptor | ActionListItemDescriptor)[],
+function assignOptionIds<Value extends string = string>(
+  options: (OptionDescriptor<Value> | ActionListItemDescriptor)[],
   id: string,
-): OptionDescriptor[] | ActionListItemDescriptor[] {
+): OptionDescriptor<Value>[] | ActionListItemDescriptor[] {
   return options.map((option, optionIndex) => ({
     ...option,
     id: `${id}-${optionIndex}`,
   }));
 }
 
-function isOption(
-  navigableOption: OptionDescriptor | ActionListItemDescriptor,
-): navigableOption is OptionDescriptor {
+function isOption<Value extends string = string>(
+  navigableOption: OptionDescriptor<Value> | ActionListItemDescriptor,
+): navigableOption is OptionDescriptor<Value> {
   return 'value' in navigableOption && navigableOption.value !== undefined;
 }
 
-function filterForOptions(
-  mixedArray: (ActionListItemDescriptor | OptionDescriptor)[],
-): OptionDescriptor[] {
+function filterForOptions<Value extends string = string>(
+  mixedArray: (ActionListItemDescriptor | OptionDescriptor<Value>)[],
+): OptionDescriptor<Value>[] {
   return mixedArray.filter(isOption);
 }

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {OptionList, ActionList, Popover} from 'components';
+import {OptionList, OptionListProps, ActionList, Popover} from 'components';
 import {mountWithApp} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, act} from 'test-utilities/legacy';
@@ -35,7 +35,9 @@ describe('<ComboBox/>', () => {
 
       comboBox.simulate('click');
 
-      const optionListOptions = comboBox.find(OptionList).prop('options') || [
+      const optionListOptions = comboBox
+        .find<OptionListProps>(OptionList)
+        .prop('options') || [
         {
           value: '',
           label: '',

--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -9,9 +9,9 @@ import {InlineError, errorTextID} from '../InlineError';
 
 import styles from './ChoiceList.scss';
 
-interface Choice {
+interface Choice<Value extends string = string> {
   /** Value of the choice */
-  value: string;
+  value: Value;
   /** Label for the choice */
   label: React.ReactNode;
   /** Disable choice */
@@ -24,13 +24,13 @@ interface Choice {
   renderChildren?(isSelected: boolean): React.ReactNode | false;
 }
 
-export interface ChoiceListProps {
+export interface ChoiceListProps<Value extends string = string> {
   /** Label for list of choices */
   title: React.ReactNode;
   /** Collection of choices */
-  choices: Choice[];
+  choices: Choice<Value>[];
   /** Collection of selected choices */
-  selected: string[];
+  selected: Value[];
   /** Name for form input */
   name?: string;
   /** Allow merchants to select multiple options at once */
@@ -42,10 +42,10 @@ export interface ChoiceListProps {
   /** Disable all choices **/
   disabled?: boolean;
   /** Callback when the selected choices change */
-  onChange?(selected: string[], name: string): void;
+  onChange?(selected: Value[], name: string): void;
 }
 
-export function ChoiceList({
+export function ChoiceList<Value extends string = string>({
   title,
   titleHidden,
   allowMultiple,
@@ -55,7 +55,7 @@ export function ChoiceList({
   error,
   disabled = false,
   name: nameProp,
-}: ChoiceListProps) {
+}: ChoiceListProps<Value>) {
   // Type asserting to any is required for TS3.2 but can be removed when we update to 3.3
   // see https://github.com/Microsoft/TypeScript/issues/28768
   const ControlComponent: any = allowMultiple ? Checkbox : RadioButton;
@@ -132,16 +132,19 @@ export function ChoiceList({
 
 function noop() {}
 
-function choiceIsSelected({value}: Choice, selected: string[]) {
+function choiceIsSelected<Value extends string = string>(
+  {value}: Choice<Value>,
+  selected: Value[],
+): boolean {
   return selected.includes(value);
 }
 
-function updateSelectedChoices(
-  {value}: Choice,
+function updateSelectedChoices<Value extends string = string>(
+  {value}: Choice<Value>,
   checked: boolean,
-  selected: string[],
+  selected: Value[],
   allowMultiple = false,
-) {
+): Value[] {
   if (checked) {
     return allowMultiple ? [...selected, value] : [value];
   }

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -10,9 +10,9 @@ import {useDeepEffect} from '../../utilities/use-deep-effect';
 import {Option} from './components';
 import styles from './OptionList.scss';
 
-export interface OptionDescriptor {
+export interface OptionDescriptor<Value extends string = string> {
   /** Value of the option */
-  value: string;
+  value: Value;
   /** Display label for the option */
   label: React.ReactNode;
   /** Whether the option is disabled or not */
@@ -25,37 +25,39 @@ export interface OptionDescriptor {
   media?: React.ReactElement<IconProps | ThumbnailProps | AvatarProps>;
 }
 
-interface SectionDescriptor {
+interface SectionDescriptor<Value extends string = string> {
   /** Collection of options within the section */
-  options: OptionDescriptor[];
+  options: OptionDescriptor<Value>[];
   /** Section title */
   title?: string;
 }
 
-type Descriptor = OptionDescriptor | SectionDescriptor;
+type Descriptor<Value extends string = string> =
+  | OptionDescriptor<Value>
+  | SectionDescriptor<Value>;
 
-export interface OptionListProps {
+export interface OptionListProps<Value extends string = string> {
   /** A unique identifier for the option list */
   id?: string;
   /** List title */
   title?: string;
   /** Collection of options to be listed */
-  options?: OptionDescriptor[];
+  options?: OptionDescriptor<Value>[];
   /** Defines a specific role attribute for the list itself */
   role?: 'listbox' | 'combobox' | string;
   /** Defines a specific role attribute for each option in the list */
   optionRole?: string;
   /** Sections containing a header and related options */
-  sections?: SectionDescriptor[];
+  sections?: SectionDescriptor<Value>[];
   /** The selected options */
-  selected: string[];
+  selected: Value[];
   /** Allow more than one option to be selected */
   allowMultiple?: boolean;
   /** Callback when selection is changed */
-  onChange(selected: string[]): void;
+  onChange(selected: Value[]): void;
 }
 
-export function OptionList({
+export function OptionList<Value extends string = string>({
   options,
   sections,
   title,
@@ -65,7 +67,7 @@ export function OptionList({
   optionRole,
   onChange,
   id: idProp,
-}: OptionListProps) {
+}: OptionListProps<Value>) {
   const [normalizedOptions, setNormalizedOptions] = useState(
     createNormalizedOptions(options, sections, title),
   );
@@ -153,11 +155,11 @@ export function OptionList({
   );
 }
 
-function createNormalizedOptions(
-  options?: OptionDescriptor[],
-  sections?: SectionDescriptor[],
+function createNormalizedOptions<Value extends string = string>(
+  options?: OptionDescriptor<Value>[],
+  sections?: SectionDescriptor<Value>[],
   title?: string,
-): SectionDescriptor[] {
+): SectionDescriptor<Value>[] {
   if (options == null) {
     const section = {options: [], title};
     return sections == null ? [] : [section, ...sections];
@@ -179,19 +181,21 @@ function createNormalizedOptions(
   ];
 }
 
-function isSection(arr: Descriptor[]): arr is SectionDescriptor[] {
+function isSection<Value extends string = string>(
+  arr: Descriptor<Value>[],
+): arr is SectionDescriptor<Value>[] {
   return (
     typeof arr[0] === 'object' &&
     Object.prototype.hasOwnProperty.call(arr[0], 'options')
   );
 }
 
-function optionArraysAreEqual(
-  firstArray: Descriptor[],
-  secondArray: Descriptor[],
+function optionArraysAreEqual<Value extends string = string>(
+  firstArray: Descriptor<Value>[],
+  secondArray: Descriptor<Value>[],
 ) {
   if (isSection(firstArray) && isSection(secondArray)) {
-    return arraysAreEqual<SectionDescriptor>(
+    return arraysAreEqual<SectionDescriptor<Value>>(
       firstArray,
       secondArray,
       testSectionsPropEquality,
@@ -201,9 +205,9 @@ function optionArraysAreEqual(
   return arraysAreEqual(firstArray, secondArray);
 }
 
-function testSectionsPropEquality(
-  previousSection: SectionDescriptor,
-  currentSection: SectionDescriptor,
+function testSectionsPropEquality<Value extends string = string>(
+  previousSection: SectionDescriptor<Value>,
+  currentSection: SectionDescriptor<Value>,
 ) {
   const {options: previousOptions} = previousSection;
   const {options: currentOptions} = currentSection;


### PR DESCRIPTION

### WHY are these changes introduced?

Currently, these three components expect any string value for the `value` property of their options. As a result, typed options have to be cast in the onChange handler (see below):

```tsx
const options = [
  {value: 'a' as const, label: 'A'},
  {value: 'b' as const, label: 'B'},
  {value: 'c' as const, label: 'C'},
];

type OptionValue = typeof options[number]['value'];

function Test() {
  const [selected, setSelected] = useState<OptionValue[]>(['a']);

  return (
    <OptionList
      selected={selected}
      // we have to cast here since `newSelected` will be `string[]`
      onChange={(newSelected) => setSelected(newSelected as OptionValue[])}
      options={options}
    />
  );
}
```

### WHAT is this pull request doing?

This PR updates the three components to accept a generic type for the `value` property (in a backwards compatible manner) so that we can achieve the following without any type errors or casting:

```tsx
const options = [
  {value: 'a' as const, label: 'A'},
  {value: 'b' as const, label: 'B'},
  {value: 'c' as const, label: 'C'},
];

type OptionValue = typeof options[number]['value'];

function Test() {
  const [selected, setSelected] = useState<OptionValue[]>(['a']);

  return (
    <OptionList
      selected={selected}
      // no need to cast here since `newSelected` is already typed
      onChange={(newSelected) => setSelected(newSelected)}
      options={options}
    />
  );
}
```

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

You should be able to run and use the components as you previously did without any issues since the generic types default to `string` for backwards compatibility. If you want to opt into the stricter typing, you can easily (and in some cases, automatically) do so.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```tsx
import React, {useState} from 'react';
import {Page, OptionList} from '../src';

export function Playground() {
  const [selected, setSelected] = useState<('a' | 'b' | 'c')[]>(['a']);

  return (
    <Page title="Playground">
        <OptionList
        selected={selected}
        onChange={(newSelected) => setSelected(newSelected)}
        options={[
          {value: 'a', label: 'A'},
          {value: 'b', label: 'B'},
          {value: 'c', label: 'C'},
        ]}
      />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
