### PR TITLE
[Page] Improve the accessibility of the rollup actions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Reduced the size of the `progress` pip in `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 - Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
+- Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
 
 ### Bug fixes
 

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Akce"
+        "rollupButton": "Zobrazit akce"
+      },
+      "Actions": {
+        "moreActions": "Další akce"
       }
     },
     "Filters": {
@@ -306,9 +309,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Další akce"
-    },
     "Loading": {
       "label": "Panel načítání stránky"
     },
@@ -336,6 +336,11 @@
       "selectAllItems": "Vybrat všechno zboží typu {resourceNamePlural} ({itemsLength} a více)",
       "selectItem": "Vybrat: {resourceName}",
       "selectButtonText": "Vybrat"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Zobrazte akce pro: {title}"
+      }
     }
   }
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Handlinger"
+        "rollupButton": "Se handlinger"
+      },
+      "Actions": {
+        "moreActions": "Flere handlinger"
       }
     },
     "Filters": {
@@ -301,9 +304,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Flere handlinger"
-    },
     "Loading": {
       "label": "Statuslinje for sideindlæsning"
     },
@@ -331,6 +331,11 @@
       "selectAllItems": "Vælg alle {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Vælg {resourceName}",
       "selectButtonText": "Vælg"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Se handlinger for {title}"
+      }
     }
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Aktionen"
+        "rollupButton": "Aktionen anzeigen"
+      },
+      "Actions": {
+        "moreActions": "Weitere Aktionen"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Weitere Aktionen"
-    },
     "Loading": {
       "label": "Seiten-Ladeleiste"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Alle {itemsLength}+ {resourceNamePlural} auswählen",
       "selectItem": "{resourceName} auswählen",
       "selectButtonText": "Auswählen"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Aktionen für {title} anzeigen"
+      }
     }
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,12 @@
 {
   "Polaris": {
-    "Actions": {
-      "moreActions": "More actions"
+    "ActionMenu": {
+      "Actions": {
+        "moreActions": "More actions"
+      },
+      "RollupActions": {
+        "rollupButton": "View actions"
+      }
     },
     "Avatar": {
       "label": "Avatar",
@@ -130,11 +135,6 @@
         "closeMobileNavigationLabel": "Close navigation"
       }
     },
-    "ActionMenu": {
-      "RollupActions": {
-        "rollupButton": "Actions"
-      }
-    },
     "Filters": {
       "moreFilters": "More filters",
       "moreFiltersWithCount": "More filters ({count})",
@@ -174,6 +174,11 @@
     "Modal": {
       "iFrameTitle": "body markup",
       "modalWarning": "These required properties are missing from Modal: {missingProps}"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "View actions for {title}"
+      }
     },
     "Pagination": {
       "previous": "Previous",

--- a/locales/es.json
+++ b/locales/es.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Acciones"
+        "rollupButton": "Ver acciones"
+      },
+      "Actions": {
+        "moreActions": "Más acciones"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Más acciones"
-    },
     "Loading": {
       "label": "Barra de \"cargando página\""
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Seleccionar todos los {itemsLength}+{resourceNamePlural}",
       "selectItem": "Seleccionar {resourceName}",
       "selectButtonText": "Seleccionar"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Ver acciones para {title}"
+      }
     }
   }
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Toiminnat"
+        "rollupButton": "Näytä toiminnot"
+      },
+      "Actions": {
+        "moreActions": "Lisää toimintoja"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Lisää toimintoja"
-    },
     "Loading": {
       "label": "Sivun latautumisen palkki"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Valitse kaikki {itemsLength} ja {resourceNamePlural}",
       "selectItem": "Valitse {resourceName}",
       "selectButtonText": "Valitse"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Näytä nimikettä {title} koskevat toiminnot"
+      }
     }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Actions"
+        "rollupButton": "Afficher les actions"
+      },
+      "Actions": {
+        "moreActions": "Autres actions"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Autres opérations"
-    },
     "Loading": {
       "label": "Barre de chargement de la page"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Sélectionner la totalité des {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Sélectionner {resourceName}",
       "selectButtonText": "Sélectionner"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Voir les actions pour {title}"
+      }
     }
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Azioni"
+        "rollupButton": "Visualizza azioni"
+      },
+      "Actions": {
+        "moreActions": "Altre azioni"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Altre azioni"
-    },
     "Loading": {
       "label": "Barra di caricamento della pagina"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Seleziona tutti i {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Seleziona {resourceName}",
       "selectButtonText": "Seleziona"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Visualizza azioni per {title}"
+      }
     }
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "アクション"
+        "rollupButton": "アクションを表示する"
+      },
+      "Actions": {
+        "moreActions": "その他の操作"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "その他の操作"
-    },
     "Loading": {
       "label": "ページの読み込み表示バー"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "すべての{itemsLength}+{resourceNamePlural}を選択する",
       "selectItem": "{resourceName}を選択する",
       "selectButtonText": "選択"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "{title}のアクションを表示"
+      }
     }
   }
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "작업"
+        "rollupButton": "작업 보기"
+      },
+      "Actions": {
+        "moreActions": "기타 작업"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "기타 작업"
-    },
     "Loading": {
       "label": "페이지 로딩 표시줄"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "길이가 {itemsLength} 이상인 모든 {resourceNamePlural} 선택",
       "selectItem": "{resourceName} 선택",
       "selectButtonText": "선택"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "{title} 작업 보기"
+      }
     }
   }
 }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Handlinger"
+        "rollupButton": "Vis handlinger"
+      },
+      "Actions": {
+        "moreActions": "Flere handlinger"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Flere handlinger"
-    },
     "Loading": {
       "label": "Sidelastingslinje"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Velg alle {itemsLength} {resourceNamePlural}",
       "selectItem": "Velg {resourceName}",
       "selectButtonText": "Velg"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Vis handlinger for {title}"
+      }
     }
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Acties"
+        "rollupButton": "Acties bekijken"
+      },
+      "Actions": {
+        "moreActions": "Meer acties"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Meer acties"
-    },
     "Loading": {
       "label": "Pagina laadbalk"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Selecteer alle {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Selecteer {resourceName}",
       "selectButtonText": "Selecteren"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Acties voor {title} bekijken"
+      }
     }
   }
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Czynności"
+        "rollupButton": "Wyświetl czynności"
+      },
+      "Actions": {
+        "moreActions": "Więcej czynności"
       }
     },
     "Filters": {
@@ -306,9 +309,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Więcej czynności"
-    },
     "Loading": {
       "label": "Pasek ładowania strony"
     },
@@ -336,6 +336,11 @@
       "selectAllItems": "Wybierz wszystkie {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Wybierz {resourceName}",
       "selectButtonText": "Wybierz"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Wyświetl czynności dla {title}"
+      }
     }
   }
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Ações"
+        "rollupButton": "Ver ações"
+      },
+      "Actions": {
+        "moreActions": "Mais ações"
       }
     },
     "Filters": {
@@ -301,9 +304,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Mais ações"
-    },
     "Loading": {
       "label": "Barra de carregamento de página"
     },
@@ -331,6 +331,11 @@
       "selectAllItems": "Selecionar todos os {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Selecionar {resourceName}",
       "selectButtonText": "Selecionar"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Ver ações para {title}"
+      }
     }
   }
 }

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Ações"
+        "rollupButton": "Visualizar ações"
+      },
+      "Actions": {
+        "moreActions": "Mais ações"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Mais ações"
-    },
     "Loading": {
       "label": "Barra de carregamento da página"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Selecionar todos os itens de {resourceNamePlural} de {itemsLength}+",
       "selectItem": "Selecionar {resourceName}",
       "selectButtonText": "Selecionar"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Ver ações para {title}"
+      }
     }
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Åtgärder"
+        "rollupButton": "Visa åtgärder"
+      },
+      "Actions": {
+        "moreActions": "Fler åtgärder"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "Fler åtgärder"
-    },
     "Loading": {
       "label": "Fält för att ladda sida"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "Välj alla {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Välj {resourceName}",
       "selectButtonText": "Välj"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Visa åtgärder för {title}"
+      }
     }
   }
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "การดำเนินการ"
+        "rollupButton": "ดูการดำเนินการ"
+      },
+      "Actions": {
+        "moreActions": "การดำเนินการเพิ่มเติม"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "การดำเนินการเพิ่มเติม"
-    },
     "Loading": {
       "label": "แถบแสดงการโหลดหน้า"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "เลือก {itemsLength}+ {resourceNamePlural} ทั้งหมด",
       "selectItem": "เลือก {resourceName}",
       "selectButtonText": "เลือก"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "ดูการดำเนินการสำหรับ {title}"
+      }
     }
   }
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "İşlemler"
+        "rollupButton": "İşlemleri görüntüle"
+      },
+      "Actions": {
+        "moreActions": "Diğer işlemler"
       }
     },
     "Filters": {
@@ -303,9 +306,6 @@
           }
         }
       }
-    },
-    "Actions": {
-      "moreActions": "Diğer işlemler"
     },
     "Loading": {
       "label": "Sayfa yüklenme çubuğu"

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -1,8 +1,5 @@
 {
   "Polaris": {
-    "Actions": {
-      "moreActions": "Thao tác khác"
-    },
     "Avatar": {
       "label": "Hình đại diện",
       "labelWithInitials": "Hình đại diện là tên viết tắt {initials}"
@@ -132,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "Thao tác"
+        "rollupButton": "Xem thao tác"
+      },
+      "Actions": {
+        "moreActions": "Thao tác khác"
       }
     },
     "Filters": {
@@ -334,6 +334,11 @@
       "selectAllItems": "Chọn tất cả {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Chọn {resourceName}",
       "selectButtonText": "Chọn"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "Xem thao tác đối với {title}"
+      }
     }
   }
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "编辑"
+        "rollupButton": "查看操作"
+      },
+      "Actions": {
+        "moreActions": "更多操作"
       }
     },
     "Filters": {
@@ -301,9 +304,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "其他操作"
-    },
     "Loading": {
       "label": "页面加载条"
     },
@@ -331,6 +331,11 @@
       "selectAllItems": "选择所有 {itemsLength}+ 的 {resourceNamePlural}",
       "selectItem": "选择 {resourceName}",
       "selectButtonText": "选择"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "查看用于 {title} 的操作"
+      }
     }
   }
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -129,7 +129,10 @@
     },
     "ActionMenu": {
       "RollupActions": {
-        "rollupButton": "動作"
+        "rollupButton": "檢視動作"
+      },
+      "Actions": {
+        "moreActions": "更多動作"
       }
     },
     "Filters": {
@@ -304,9 +307,6 @@
         }
       }
     },
-    "Actions": {
-      "moreActions": "更多動作"
-    },
     "Loading": {
       "label": "頁面載入進度條"
     },
@@ -334,6 +334,11 @@
       "selectAllItems": "選取全部 {itemsLength} + {resourceNamePlural}",
       "selectItem": "選取 {resourceName}",
       "selectButtonText": "選取"
+    },
+    "Page": {
+      "Header": {
+        "rollupActionsLabel": "檢視 {title} 的動作"
+      }
     }
   }
 }

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -17,12 +17,15 @@ export interface ActionMenuProps {
   groups?: MenuGroupDescriptor[];
   /** Roll up all actions into a Popover > ActionList */
   rollup?: boolean;
+  /** Label for rolled up actions activator */
+  rollupActionsLabel?: string;
 }
 
 export function ActionMenu({
   actions = [],
   groups = [],
   rollup,
+  rollupActionsLabel,
 }: ActionMenuProps) {
   if (actions.length === 0 && groups.length === 0) {
     return null;
@@ -38,7 +41,11 @@ export function ActionMenu({
   return (
     <div className={actionMenuClassNames}>
       {rollup ? (
-        <RollupActions items={actions} sections={rollupSections} />
+        <RollupActions
+          accessibilityLabel={rollupActionsLabel}
+          items={actions}
+          sections={rollupSections}
+        />
       ) : (
         <Actions actions={actions} groups={groups} />
       )}

--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -44,7 +44,7 @@ export function Actions({actions = [], groups = []}: Props) {
     rolledUp: [],
   });
   const defaultRollupGroup: MenuGroupDescriptor = {
-    title: i18n.translate('Polaris.Actions.moreActions'),
+    title: i18n.translate('Polaris.ActionMenu.Actions.moreActions'),
     actions: [],
   };
   const lastMenuGroup = [...groups].pop();

--- a/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
+++ b/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
@@ -14,13 +14,19 @@ import {Popover} from '../../../Popover';
 import styles from './RollupActions.scss';
 
 export interface RollupActionsProps {
+  /** Accessibilty label */
+  accessibilityLabel?: string;
   /** Collection of actions for the list */
   items?: ActionListItemDescriptor[];
   /** Collection of sectioned action items */
   sections?: ActionListSection[];
 }
 
-export function RollupActions({items = [], sections = []}: RollupActionsProps) {
+export function RollupActions({
+  accessibilityLabel,
+  items = [],
+  sections = [],
+}: RollupActionsProps) {
   const i18n = useI18n();
 
   const {value: rollupOpen, toggle: toggleRollupOpen} = useToggle(false);
@@ -34,9 +40,10 @@ export function RollupActions({items = [], sections = []}: RollupActionsProps) {
       <Button
         outline
         icon={HorizontalDotsMinor}
-        accessibilityLabel={i18n.translate(
-          'Polaris.ActionMenu.RollupActions.rollupButton',
-        )}
+        accessibilityLabel={
+          accessibilityLabel ||
+          i18n.translate('Polaris.ActionMenu.RollupActions.rollupButton')
+        }
         onClick={toggleRollupOpen}
       />
     </div>

--- a/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
+++ b/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
@@ -12,6 +12,7 @@ import {RollupActions} from '../RollupActions';
 
 describe('<RollupActions />', () => {
   const mockProps = {
+    accessibilityLabel: undefined,
     items: undefined,
     sections: undefined,
   };
@@ -33,6 +34,16 @@ describe('<RollupActions />', () => {
         url: 'https://www.shopify.ca',
       },
     ];
+
+    it('renders a Button with the default accessibility label', () => {
+      const wrapper = mountWithApp(
+        <RollupActions {...mockProps} items={mockItems} />,
+      );
+
+      expect(wrapper).toContainReactComponent(Button, {
+        accessibilityLabel: 'View actions',
+      });
+    });
 
     it('gets rendered as ActionList > Item', () => {
       const wrapper = mountWithApp(
@@ -62,6 +73,23 @@ describe('<RollupActions />', () => {
       popoverComponent = wrapper.find(Popover);
       expect(popoverComponent!).toHaveReactProps({
         active: false,
+      });
+    });
+
+    describe('accessibilityLabel', () => {
+      it('renders a Button with the accessibilityLabel', () => {
+        const accessibilityLabel = 'View test actions';
+        const wrapper = mountWithApp(
+          <RollupActions
+            {...mockProps}
+            items={mockItems}
+            accessibilityLabel={accessibilityLabel}
+          />,
+        );
+
+        expect(wrapper).toContainReactComponent(Button, {
+          accessibilityLabel,
+        });
       });
     });
   });

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -4,6 +4,7 @@ import {classNames} from '../../../../utilities/css';
 import {buttonsFrom} from '../../../Button';
 import {TextStyle} from '../../../TextStyle';
 import {useMediaQuery} from '../../../../utilities/media-query';
+import {useI18n} from '../../../../utilities/i18n';
 import {
   ConditionalRender,
   ConditionalWrapper,
@@ -78,6 +79,7 @@ export function Header({
   actionGroups = [],
   compactTitle = false,
 }: HeaderProps) {
+  const i18n = useI18n();
   const {isNavigationCollapsed} = useMediaQuery();
   const isSingleRow =
     !primaryAction &&
@@ -136,6 +138,11 @@ export function Header({
         actions={secondaryActions}
         groups={actionGroups}
         rollup={isNavigationCollapsed}
+        rollupActionsLabel={
+          title
+            ? i18n.translate('Polaris.Page.Header.rollupActionsLabel', {title})
+            : undefined
+        }
       />
     ) : null;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/4072

### WHAT is this pull request doing?

- Updates the default accessibility label of the `RollupActions` button to be "View actions" to better match our content guidelines
- Updates the accessibility label of the `RollupActions` button within the `Page` header to be related to the title "View actions for {title}". This will provide consistency across all pages.

<details>
  <summary>Media</summary>

<img width="1102" alt="Screen Shot 2021-11-18 at 12 02 06 PM" src="https://user-images.githubusercontent.com/12960456/142462193-919f411c-c41c-493e-a3ee-604d84378a48.png">
</details>

### How to 🎩

- View the `Page with all header elements` story on small screen
- Enable VoiceOver and tab to the "..." button or look at the Form Controls in the rotor

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
