### PR TITLE
[WIP][TextField] Add new labelWithRequiredAsterisk prop

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -268,7 +268,8 @@
     },
     "TextField": {
       "characterCount": "{count} characters",
-      "characterCountWithMaxLength": "{count} of {limit} characters used"
+      "characterCountWithMaxLength": "{count} of {limit} characters used",
+      "requiredAsterisk": "This field is required"
     },
     "TooltipOverlay": {
       "accessibilityLabel": "Tooltip: {label}"

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -309,3 +309,8 @@ $stacking-order: (
     margin-top: 0;
   }
 }
+
+.Asterisk {
+  vertical-align: middle;
+  padding-left: spacing(extra-tight);
+}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -16,6 +16,7 @@ import {Labelled, LabelledProps, helpTextID, labelID} from '../Labelled';
 import {Connected} from '../Connected';
 import {Error, Key} from '../../types';
 import {Icon} from '../Icon';
+import {TextStyle} from '../TextStyle';
 
 import {Resizer, Spinner, SpinnerProps} from './components';
 import styles from './TextField.scss';
@@ -64,6 +65,8 @@ interface NonMutuallyExclusiveProps {
   labelAction?: LabelledProps['action'];
   /** Visually hide the label */
   labelHidden?: boolean;
+  /** Show an asterisk to mark the field as required  */
+  labelWithRequiredAsterisk?: boolean;
   /** Disable the input */
   disabled?: boolean;
   /** Show a clear text button in the input */
@@ -146,6 +149,7 @@ export function TextField({
   value,
   helpText,
   label,
+  labelWithRequiredAsterisk,
   labelAction,
   labelHidden,
   disabled,
@@ -431,6 +435,7 @@ export function TextField({
     'aria-autocomplete': ariaAutocomplete,
     'aria-controls': ariaControls,
     'aria-expanded': ariaExpanded,
+    'aria-required': labelWithRequiredAsterisk,
     ...normalizeAriaMultiline(multiline),
   });
 
@@ -442,7 +447,21 @@ export function TextField({
 
   return (
     <Labelled
-      label={label}
+      label={
+        labelWithRequiredAsterisk ? (
+          <>
+            {label}
+            <span
+              className={styles.Asterisk}
+              aria-label={i18n.translate('Polaris.TextField.requiredAsterisk')}
+            >
+              <TextStyle variation="negative">*</TextStyle>
+            </span>
+          </>
+        ) : (
+          label
+        )
+      }
       id={id}
       error={error}
       action={labelAction}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/40128

### WHAT is this pull request doing?

The goal of this PR is to add a new prop to TextField in order to display an asterisk that would mark it as required.

TO DO:
- Should we update `Select` and `ChoiceList` in that PR?
- How can we share the "asterisk component" across above components?
- Write unite tests.
- Confirm `aria-label` copy with a content designer.
- Confirm design and accessibility.
- Should we update the TextField documentation. Right now it mentions this:
> Be labeled as “Optional” when you need to request input that’s not required

### How to 🎩 

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <TextField
        label="Name"
        labelWithRequiredAsterisk
        value=""
        onChange={() => {}}
      />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

