### PR TITLE
[Popover] center full width popovers on small viewports

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
+- Center full width `Popover` on small viewports ([#4114](https://github.com/Shopify/polaris-react/pull/4114))
+
 ### Documentation
 
 ### Development workflow

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
-- Center full width `Popover` on small viewports ([#4114](https://github.com/Shopify/polaris-react/pull/4114))
+- Centered full width `Popover` on small viewports ([#4114](https://github.com/Shopify/polaris-react/pull/4114))
 
 ### Documentation
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -42,7 +42,7 @@ $vertical-motion-offset: rem(-5px);
 }
 
 .fullWidth {
-  margin: $visible-portion-of-arrow auto 0;
+  margin: $visible-portion-of-arrow auto 0 auto;
 
   .Content {
     max-width: none;
@@ -53,7 +53,7 @@ $vertical-motion-offset: rem(-5px);
   margin: spacing() spacing(tight) $visible-portion-of-arrow;
 
   &.fullWidth {
-    margin: 0 auto $visible-portion-of-arrow;
+    margin: 0 auto $visible-portion-of-arrow auto;
   }
 }
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -42,8 +42,7 @@ $vertical-motion-offset: rem(-5px);
 }
 
 .fullWidth {
-  margin: 0;
-  margin-top: $visible-portion-of-arrow;
+  margin: $visible-portion-of-arrow auto 0;
 
   .Content {
     max-width: none;
@@ -54,7 +53,7 @@ $vertical-motion-offset: rem(-5px);
   margin: spacing() spacing(tight) $visible-portion-of-arrow;
 
   &.fullWidth {
-    margin: 0 0 $visible-portion-of-arrow;
+    margin: 0 auto $visible-portion-of-arrow;
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?
Full width popovers have a max width of `100vw - 3.2rem`, which results in a popover that is smaller than the viewport on narrow screens. Since no horizontal margins are applied, the popover defaults to being left aligned on the screen. 

<img src="https://user-images.githubusercontent.com/12417232/114414540-e67af580-9b7c-11eb-9613-d5a78b7d7dd3.png" alt="Narrow screen with an open popover that is left aligned"  width="300" />


Given the popover is smaller than the viewport width and has rounded corners, it should be centered aligned on the screen regardless of the preferred alignment. 

### WHAT is this pull request doing?
* Add in auto horizontal margins to full width popovers to ensure that it is centered on smaller viewports 

<img src="https://user-images.githubusercontent.com/12417232/114415111-62753d80-9b7d-11eb-94b0-5438603f0e7d.png" alt="Narrow screen with an open popover that is center aligned" width="300" />


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

* Verify that full width popovers still take up the full width on larger viewports (positioned above and below the activator)
* Verify that the popover is centered above/below the activator when its width is smaller

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Button, Page, Popover} from '../src';

export function Playground() {
  const [popover1Active, setPopover1Active] = useState(false);
  const [popover2Active, setPopover2Active] = useState(false);

  const togglePopover1 = () => {
    setPopover1Active(!popover1Active);
  };

  const togglePopover2 = () => {
    setPopover2Active(!popover2Active);
  };

  const activatorBelow = (
    <Button onClick={togglePopover1}>Button with popover below</Button>
  );

  const activatorAbove = (
    <Button onClick={togglePopover2}>Button with popover above</Button>
  );

  return (
    <Page title="Playground">
      <Popover
        active={popover1Active}
        onClose={togglePopover1}
        fullWidth
        activator={activatorBelow}
        sectioned
      >
        <p>some text</p>
      </Popover>
      <br />
      <br />
      <Popover
        active={popover2Active}
        onClose={togglePopover2}
        fullWidth
        preferredPosition="above"
        activator={activatorAbove}
        sectioned
      >
        <p>some text</p>
      </Popover>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
