### PR TITLE
[WIP][Popover] Fix premature popover activation bug

### DIFF
--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -56,7 +56,8 @@ $content-max-width: rem(400px);
 .Wrapper {
   position: relative;
   overflow: hidden;
-  background-color: var(--p-surface);
+  // background-color: var(--p-surface);
+  background-color: pink;
   border-radius: var(--p-border-radius-wide);
   outline: 1px solid transparent;
 }

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -234,6 +234,10 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       </div>
     );
 
+    console.log({content});
+
+    const [firstGrandChild] = content.props.children.props.children;
+
     return (
       <div className={className} {...overlay.props}>
         <EventListener event="click" handler={this.handleClick} />
@@ -246,7 +250,9 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
           onFocus={this.handleFocusFirstItem}
         />
         <ThemeProvider alwaysRenderCustomProperties theme={{colorScheme}}>
-          <div className={styles.Wrapper}>{content}</div>
+          {firstGrandChild.props.items.length > 0 && (
+            <div className={styles.Wrapper}>{content}</div>
+          )}
         </ThemeProvider>
         <div
           className={styles.FocusTracker}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When the `fullWidth` prop is true, the `<Popover/>` prematurely renders an empty `div` even when no children items are present:
![image](https://user-images.githubusercontent.com/38010031/114942401-7dacab00-9e12-11eb-8336-355e2ff6c10e.png)

### WHAT is this pull request doing?

This PR adds a check to only render the content wrapper when children items are present.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import {CirclePlusMinor} from '@shopify/polaris-icons';
import React, {useCallback, useState} from 'react';

import {ActionList, Popover, TextField} from '../src';

export function Playground() {
  const [value, setValue] = useState('');
  const [active, setActive] = useState(false);

  const toggleActive = useCallback(() => setActive((active) => !active), []);
  const show = useCallback(() => setActive(true), []);

  const activator = (
    <TextField
      prefix="@"
      label="SHRAMP"
      onFocus={show}
      value={value}
      onChange={setValue}
    />
  );

  return (
    <div style={{width: 300, height: 200}}>
      <Popover
        fullWidth
        active={active}
        activator={activator}
        onClose={toggleActive}
      >
        <ActionList
          items={
            value.length > 0
              ? [
                  {
                    content: `Add "${value}"`,
                    icon: CirclePlusMinor,
                  },
                ]
              : []
          }
        />
      </Popover>
    </div>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
