### PR TITLE
♻️ [Button] Incompatible prop groups

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,7 +5,13 @@ import {
   SelectMinor,
 } from '@shopify/polaris-icons';
 
-import type {BaseButton, ConnectedDisclosure, IconSource} from '../../types';
+import type {
+  ButtonActionProps,
+  ButtonUrlProps,
+  BaseButton,
+  ConnectedDisclosure,
+  IconSource,
+} from '../../types';
 import {classNames, variationName} from '../../utilities/css';
 import {
   handleMouseUpByBlurring,
@@ -20,7 +26,7 @@ import {UnstyledButton, UnstyledButtonProps} from '../UnstyledButton';
 
 import styles from './Button.scss';
 
-export interface ButtonProps extends BaseButton {
+interface BaseProps {
   /** The content to display inside the button */
   children?: string | string[];
   /** Provides extra visual weight and identifies the primary action in a set of buttons */
@@ -52,12 +58,13 @@ export interface ButtonProps extends BaseButton {
   connectedDisclosure?: ConnectedDisclosure;
 }
 
+export type ButtonProps = BaseButton & BaseProps;
+
 interface CommonButtonProps
   extends Pick<
     ButtonProps,
     | 'id'
     | 'accessibilityLabel'
-    | 'ariaDescribedBy'
     | 'role'
     | 'onClick'
     | 'onFocus'
@@ -69,20 +76,20 @@ interface CommonButtonProps
   onMouseUp: MouseUpBlurHandler;
 }
 
-type LinkButtonProps = Pick<ButtonProps, 'url' | 'external' | 'download'>;
+type LinkButtonProps = Pick<ButtonUrlProps, 'url' | 'external' | 'download'>;
 
 type ActionButtonProps = Pick<
-  ButtonProps,
+  ButtonActionProps,
   | 'submit'
-  | 'disabled'
-  | 'loading'
   | 'ariaControls'
   | 'ariaExpanded'
+  | 'ariaDescribedBy'
   | 'pressed'
   | 'onKeyDown'
   | 'onKeyUp'
   | 'onKeyPress'
->;
+> &
+  Pick<ButtonProps, 'disabled' | 'loading'>;
 
 const DEFAULT_SIZE = 'medium';
 
@@ -254,7 +261,6 @@ export function Button({
     id,
     className,
     accessibilityLabel,
-    ariaDescribedBy,
     role,
     onClick,
     onFocus,
@@ -263,25 +269,28 @@ export function Button({
     onMouseEnter,
     onTouchStart,
   };
-  const linkProps: LinkButtonProps = {
-    url,
-    external,
-    download,
-  };
-  const actionProps: ActionButtonProps = {
-    submit,
-    disabled: isDisabled,
-    loading,
-    ariaControls,
-    ariaExpanded,
-    pressed,
-    onKeyDown,
-    onKeyUp,
-    onKeyPress,
-  };
+
+  const conditionalProps: LinkButtonProps | ActionButtonProps = url
+    ? {
+        url,
+        external,
+        download,
+      }
+    : {
+        submit,
+        disabled: isDisabled,
+        loading,
+        ariaControls,
+        ariaExpanded,
+        ariaDescribedBy,
+        pressed,
+        onKeyDown,
+        onKeyUp,
+        onKeyPress,
+      };
 
   const buttonMarkup = (
-    <UnstyledButton {...commonProps} {...linkProps} {...actionProps}>
+    <UnstyledButton {...commonProps} {...conditionalProps}>
       <span className={styles.Content}>
         {spinnerSVGMarkup}
         {iconMarkup}

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -4,13 +4,15 @@ import type {BaseButton} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {UnstyledLink} from '../UnstyledLink';
 
-export interface UnstyledButtonProps extends BaseButton {
+interface BaseProps {
   /** The content to display inside the button */
   children?: React.ReactNode;
   /** A custom class name to apply styles to button */
   className?: string;
   [key: string]: any;
 }
+
+export type UnstyledButtonProps = BaseButton & BaseProps;
 
 export function UnstyledButton({
   id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,50 +10,72 @@ export type Error =
   | React.ReactElement
   | (string | React.ReactElement)[];
 
-export interface BaseButton {
+export interface ButtonCommonProps {
   /** A unique identifier for the button */
   id?: string;
-  /** A destination to link to, rendered in the href attribute of a link */
-  url?: string;
-  /** Forces url to open in a new tab */
-  external?: boolean;
-  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
-  download?: string | boolean;
-  /** Allows the button to submit a form */
-  submit?: boolean;
   /** Disables the button, disallowing merchant interaction */
   disabled?: boolean;
   /** Replaces button text with a spinner while a background action is being performed */
   loading?: boolean;
-  /** Sets the button in a pressed state */
-  pressed?: boolean;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
   /** A valid WAI-ARIA role to define the semantic value of this element */
   role?: string;
+  /** Callback when button becomes focussed */
+  onFocus?(): void;
+  /** Callback when focus leaves button */
+  onBlur?(): void;
+  /** Callback when mouse enter */
+  onMouseEnter?(): void;
+  /** Callback when element is touched */
+  onTouchStart?(): void;
+}
+
+export interface ButtonActionProps {
+  /** Allows the button to submit a form */
+  submit?: boolean;
+  /** Sets the button in a pressed state */
+  pressed?: boolean;
   /** Id of the element the button controls */
   ariaControls?: string;
   /** Tells screen reader the controlled element is expanded */
   ariaExpanded?: boolean;
   /** Indicates the ID of the element that describes the button */
   ariaDescribedBy?: string;
-  /** Callback when clicked */
-  onClick?(): void;
-  /** Callback when button becomes focussed */
-  onFocus?(): void;
-  /** Callback when focus leaves button */
-  onBlur?(): void;
   /** Callback when a keypress event is registered on the button */
   onKeyPress?(event: React.KeyboardEvent<HTMLButtonElement>): void;
   /** Callback when a keyup event is registered on the button */
   onKeyUp?(event: React.KeyboardEvent<HTMLButtonElement>): void;
   /** Callback when a keydown event is registered on the button */
   onKeyDown?(event: React.KeyboardEvent<HTMLButtonElement>): void;
-  /** Callback when mouse enter */
-  onMouseEnter?(): void;
-  /** Callback when element is touched */
-  onTouchStart?(): void;
+  /** Callback when clicked */
+  onClick(): void;
+  // Incompatible props:
+  url?: never;
+  external?: never;
+  download?: never;
 }
+
+export interface ButtonUrlProps {
+  /** A destination to link to, rendered in the href attribute of a link */
+  url: string;
+  /** Forces url to open in a new tab */
+  external?: boolean;
+  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
+  download?: string | boolean;
+  // Incompatible props:
+  submit?: never;
+  pressed?: never;
+  ariaControls?: never;
+  ariaExpanded?: never;
+  ariaDescribedBy?: never;
+  onKeyPress?: never;
+  onKeyUp?: never;
+  onKeyDown?: never;
+}
+
+export type BaseButton = ButtonCommonProps &
+  (ButtonUrlProps | ButtonActionProps);
 
 export interface Action {
   /** A unique identifier for the action */


### PR DESCRIPTION
> **Important!** This PR is an experiment

Often times, we will define a `Props` interface that contains some props that will never be used together.

### Problem

In the example of our `Button` component, we want the consumer to provide either a `url` or an `onClick`.
- We won't ever utilize both of these props at once.
- In order to allow for one-or-the-other, we set them both to `optional (?)` and trust the consumer to understand the API.

The usual tactic is to single out one of the props as having higher priority - in case both are provided. In the case of `Button`:
1. We first check for the `url` prop
2. If present, render _something_ based on that condition
3. Otherwise, we pursue a different condition and hope that `onClick` was provided instead

This gets even trickier when there are "dependant props". Imagine a series of props that are only relevant in the `url` condition - such as `external` or `download`.

### Desire

It would be nice if we could more easily separate out these compatible prop groupings, and provide feedback to the developer when they are providing a prop that is not compatible / missing props that are relevant.

### Solution

We can actually define [compatible/incompatible type groupings](https://user-images.githubusercontent.com/643944/116140715-b87dd100-a6a5-11eb-8c20-5f1179ad66d2.png). This PR is a quick and dirty example of having an interface specifically for `url`, and a separate interface for `onClick`. _Credit goes to Clauderic for showing me this technique._

**Some examples of usage:**

```tsx
// Fail: Does not have url or onClick
<Button />

// Pass: has url
<Button url="https://google.ca/" />

// Pass: has onClick
<Button onClick={onDismiss} />

// Fail: external is not compatible with onClick
<Button onClick={onDismiss} external />

// Pass: external is compatible with url
<Button url="https://google.ca/" external />
```

https://user-images.githubusercontent.com/643944/116140722-ba479480-a6a5-11eb-8d47-4c1876497819.mp4

I currently have an [experimental Draft PR open elsewhere](https://github.com/Shopify/online-store-ui/pull/2754) that explores this same technique. All the various `type/interface` definitions can get a little cumbersome. Part of my exploration here is to decide if that is a worthwhile trade-off for the better type handling on the consumer side.

### Alternative solution

Another way of solving this _could look something like this_ (code untested):

<details>
<summary><strong>Example code:</strong></summary>

```tsx

enum ButtonType {
  Action = 'action',
  Link = 'link',
}

interface ButtonCommonProps {
  content: string;
  id?: string;
}

interface ButtonActionProps extends ButtonCommonProps {
  type: ButtonType.Action;
  onClick(): void;
  ariaControls?: string;
}

interface ButtonLinkProps extends ButtonCommonProps {
  type: ButtonType.Link;
  url: string;
  external?: boolean;
}

type ButtonProps = ButtonActionProps | ButtonLinkProps;

export function Button({
  type,
  id,
  content,
  onClick,
  ariaControls,
  url,
  external,
}: ButtonProps) {
  return type === ButtonType.Action (
    <button type="button" id={id} aria-controls={ariaControls} onClick={onClick}>
      {content}
    </button>
  ) : (
    <a id={id} href={url} external={external}>{content}</a>
  );
}

```

</details>

### Ask for reviewers

What are your thoughts? Is this a pattern we should move forward with?