### PR TITLE
[DataTable] Add prop to DataTable to handle width of each column

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Add `variableHeight` prop to `DropZone` so children control its height ([#4136](https://github.com/Shopify/polaris-react/pull/4136))
+- Add `columnWidth` prop to `DataTable` to handle width of each column [#4143](https://github.com/Shopify/polaris-react/issues/4143)
 
 ### Bug fixes
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -339,8 +339,8 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
   };
 
   private renderColSize = (widthInPercent: number, index: number) => {
-    let widthPercentage = `${widthInPercent}%`
-    return <col key={index} width={widthPercentage} />
+    const widthPercentage = `${widthInPercent}%`;
+    return <col key={index} width={widthPercentage} />;
   }
 
   private totalsRowHeading = () => {

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -26,6 +26,8 @@ export type ColumnContentType = 'text' | 'numeric';
 export interface DataTableProps {
   /** List of data types, which determines content alignment for each column. Data types are "text," which aligns left, or "numeric," which aligns right. */
   columnContentTypes: ColumnContentType[];
+  /** List of column widths. */
+  columnWidths?: Array<number>;
   /** List of column headings. */
   headings: React.ReactNode[];
   /** List of numeric column totals, highlighted in the table’s header below column headings. Use empty strings as placeholders for columns with no total. */
@@ -126,6 +128,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
   render() {
     const {
       headings,
+      columnWidths,
       totals,
       showTotalsInFooter,
       rows,
@@ -148,6 +151,12 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
       styles.TableWrapper,
       condensed && styles.condensed,
     );
+
+    const columnWidthMarkup = columnWidths ? (
+      <colgroup>
+        {columnWidths.map(this.renderColSize)}
+      </colgroup>
+    ) : null;
 
     const headingMarkup = <tr>{headings.map(this.renderHeadings)}</tr>;
 
@@ -188,6 +197,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
               handler={this.scrollListener}
             />
             <table className={styles.Table} ref={this.table}>
+              {columnWidthMarkup}
               <thead>
                 {headingMarkup}
                 {headerTotalsMarkup}
@@ -327,6 +337,11 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
       />
     );
   };
+
+  private renderColSize = (widthInPercent: number, index: number) => {
+    let widthPercentage = `${widthInPercent}%`
+    return <col key={index} width={widthPercentage} />
+  }
 
   private totalsRowHeading = () => {
     const {i18n, totals, totalsName} = this.props;

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -62,6 +62,51 @@ function DataTableExample() {
 }
 ```
 
+### Flexible column size data table
+Use `columnWidths` to override default column size.
+
+```jsx
+function DataTableExample() {
+  const rows = [
+    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+    [
+      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
+
+  return (
+    <Page title="Sales by product">
+      <Card>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          columnWidths={[40, 20, 10, 10, 20]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={rows}
+          totals={['', '', '', 255, '$155,830.00']}
+        />
+      </Card>
+    </Page>
+  );
+}
+```
+
 ### Sortable data table
 
 Use when clarity of the table’s content is needed. For example, to note the number of rows currently shown in a data table with pagination.

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -98,6 +98,37 @@ describe('<DataTable />', () => {
     });
   });
 
+  describe('columnWidths', () => {
+    it('sets the provided percentage width for each column', () => {
+      const headings = ['Column 1', 'Column 2', 'Column 3'];
+      const rows = [['Cell 1', '2', '3']];
+      const columnContentTypes: DataTableProps['columnContentTypes'] = [
+        'text',
+        'numeric',
+        'numeric'
+      ];
+      const columnWidths = [80, 15, 5];
+      const dataTable = mountWithAppProvider(
+        <DataTable
+          {...defaultProps}
+          columnContentTypes={columnContentTypes}
+          columnWidths={columnWidths}
+          headings={headings}
+          rows={rows}
+        />,
+      );
+
+      const cols = dataTable.find('colgroup col');
+      const firstCol = cols.get(0);
+      const secondCol = cols.get(1);
+      const thirdCol = cols.get(2);
+
+      expect(firstCol.props.width).toBe('80%');
+      expect(secondCol.props.width).toBe('15%');
+      expect(thirdCol.props.width).toBe('5%');
+    });
+  });
+
   describe('headings', () => {
     it('renders a single table header row', () => {
       const headings = ['Heading 1', 'Heading 2', 'Heading 3'];


### PR DESCRIPTION
### WHY are these changes introduced?

Currently there is no way to change column size programmatically. The component tries to detect automatically needed widths.
Request https://github.com/Shopify/polaris-react/issues/832

### WHAT is this pull request doing?

This PR adds `columnWidths` to use HTML `colgroup -> col` to achieve the goal.

Before:
![before](https://user-images.githubusercontent.com/3995852/116414247-fa8f4a00-a840-11eb-85eb-a3e5ed175a29.png)
After:
![after](https://user-images.githubusercontent.com/3995852/116408784-e137cf00-a83b-11eb-9d62-1dc87ac3a45a.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page} from '../src';
import {DataTable} from '../src'

export function Playground() {
  return (
    <Page title="Playground">
      <DataTable
        columnWidths={[1, 1, 98]}
        columnContentTypes={['text', 'text', 'numeric']}
        headings={['Short', 'Short', 'Long']}
        rows={[['A', 1, 'Lorem Ipsum is simply dummy text. Lorem Ipsum...']]}
      />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
