### PR TITLE
[Filters] Add filter query read only prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `variableHeight` prop to `DropZone` so children control its height ([#4136](https://github.com/Shopify/polaris-react/pull/4136))
 - Add print styles to `Card`, `Heading`, `Layout`, `Layout.Section`, `Subheading`, `TextStyle` components ([#4142](https://github.com/Shopify/polaris-react/pull/4142))
 - Add `fullWidth` prop to `ColorPicker` so the color picker can take the full width ([#4152](https://github.com/Shopify/polaris-react/pull/4152))
+- Added `readOnlyQueryField` prop to `Filters` ([#4199](https://github.com/Shopify/polaris-react/pull/4199))
 - Add `noScroll` prop to `Modal` which prevents modal contents from scrolling ([#4153](https://github.com/Shopify/polaris-react/pull/4153))
 - Added new `color` prop to ProgressBar ([#3415](https://github.com/Shopify/polaris-react/pull/3415))
 - Added `requiredIndicator` prop to `Label`, `Labelled`, `Select` and `TextField` ([#4119](https://github.com/Shopify/polaris-react/pull/4119))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,7 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `variableHeight` prop to `DropZone` so children control its height ([#4136](https://github.com/Shopify/polaris-react/pull/4136))
 - Add print styles to `Card`, `Heading`, `Layout`, `Layout.Section`, `Subheading`, `TextStyle` components ([#4142](https://github.com/Shopify/polaris-react/pull/4142))
 - Add `fullWidth` prop to `ColorPicker` so the color picker can take the full width ([#4152](https://github.com/Shopify/polaris-react/pull/4152))
-- Added `readOnlyQueryField` prop to `Filters` ([#4199](https://github.com/Shopify/polaris-react/pull/4199))
+- Added `readOnlyQueryField` prop to `Filters` ([#4204](https://github.com/Shopify/polaris-react/pull/4204))
 - Add `noScroll` prop to `Modal` which prevents modal contents from scrolling ([#4153](https://github.com/Shopify/polaris-react/pull/4153))
 - Added new `color` prop to ProgressBar ([#3415](https://github.com/Shopify/polaris-react/pull/3415))
 - Added `requiredIndicator` prop to `Label`, `Labelled`, `Select` and `TextField` ([#4119](https://github.com/Shopify/polaris-react/pull/4119))

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -93,6 +93,8 @@ export interface FiltersProps {
   hideTags?: boolean;
   /** Hide the query field */
   hideQueryField?: boolean;
+  /** Sets the query field as read only */
+  readOnlyQueryField?: boolean;
 }
 
 type CombinedProps = FiltersProps & {
@@ -141,6 +143,7 @@ class FiltersInner extends Component<CombinedProps, State> {
       hideTags,
       hideQueryField,
       i18n,
+      readOnlyQueryField,
       mediaQuery: {isNavigationCollapsed},
     } = this.props;
     const {resourceName} = this.context;
@@ -286,6 +289,7 @@ class FiltersInner extends Component<CombinedProps, State> {
             clearButton
             onClearButtonClick={onQueryClear}
             disabled={disabled}
+            readOnly={readOnlyQueryField}
           />
         )}
       </ConnectedFilterControl>

--- a/src/components/Filters/README.md
+++ b/src/components/Filters/README.md
@@ -1456,3 +1456,189 @@ function ResourceListFiltersExample() {
   }
 }
 ```
+
+### Filters with readOnly query field
+
+```jsx
+function ResourceListFiltersExample() {
+  const [accountStatus, setAccountStatus] = useState(null);
+  const [moneySpent, setMoneySpent] = useState(null);
+  const [taggedWith, setTaggedWith] = useState(null);
+  const [queryValue, setQueryValue] = useState("Mae");
+  const handleAccountStatusChange = useCallback(
+    (value) => setAccountStatus(value),
+    [],
+  );
+  const handleMoneySpentChange = useCallback(
+    (value) => setMoneySpent(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value) => setQueryValue(value),
+    [],
+  );
+  const handleAccountStatusRemove = useCallback(
+    () => setAccountStatus(null),
+    [],
+  );
+  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+  const handleFiltersClearAll = useCallback(() => {
+    handleAccountStatusRemove();
+    handleMoneySpentRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAccountStatusRemove,
+    handleMoneySpentRemove,
+    handleQueryValueRemove,
+    handleTaggedWithRemove,
+  ]);
+  const filters = [
+    {
+      key: 'accountStatus',
+      label: 'Account status',
+      filter: (
+        <ChoiceList
+          title="Account status"
+          titleHidden
+          choices={[
+            {label: 'Enabled', value: 'enabled'},
+            {label: 'Not invited', value: 'not invited'},
+            {label: 'Invited', value: 'invited'},
+            {label: 'Declined', value: 'declined'},
+          ]}
+          selected={accountStatus || []}
+          onChange={handleAccountStatusChange}
+          allowMultiple
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'moneySpent',
+      label: 'Money spent',
+      filter: (
+        <RangeSlider
+          label="Money spent is between"
+          labelHidden
+          value={moneySpent || [0, 500]}
+          prefix="$"
+          output
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleMoneySpentChange}
+        />
+      ),
+    },
+  ];
+  const appliedFilters = [];
+  if (!isEmpty(accountStatus)) {
+    const key = 'accountStatus';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountStatus),
+      onRemove: handleAccountStatusRemove,
+    });
+  }
+  if (!isEmpty(moneySpent)) {
+    const key = 'moneySpent';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, moneySpent),
+      onRemove: handleMoneySpentRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, taggedWith),
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+  return (
+    <div style={{height: '568px'}}>
+      <Card>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <Filters
+              queryValue={queryValue}
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleFiltersQueryChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleFiltersClearAll}
+              readOnlyQueryField
+            />
+          }
+          items={[
+            {
+              id: 341,
+              url: 'customers/341',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            }
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <h3>
+                  <TextStyle variation="strong">{name}</TextStyle>
+                </h3>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </Card>
+    </div>
+  );
+  function disambiguateLabel(key, value) {
+    switch (key) {
+      case 'moneySpent':
+        return `Money spent is between $${value[0]} and $${value[1]}`;
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'accountStatus':
+        return value.map((val) => `Customer ${val}`).join(', ');
+      default:
+        return value;
+    }
+  }
+  function isEmpty(value) {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+```

--- a/src/components/Filters/README.md
+++ b/src/components/Filters/README.md
@@ -1464,7 +1464,7 @@ function ResourceListFiltersExample() {
   const [accountStatus, setAccountStatus] = useState(null);
   const [moneySpent, setMoneySpent] = useState(null);
   const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState("Mae");
+  const [queryValue, setQueryValue] = useState('Mae');
   const handleAccountStatusChange = useCallback(
     (value) => setAccountStatus(value),
     [],
@@ -1598,7 +1598,7 @@ function ResourceListFiltersExample() {
               url: 'customers/341',
               name: 'Mae Jemison',
               location: 'Decatur, USA',
-            }
+            },
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -265,6 +265,23 @@ describe('<Filters />', () => {
       ).toBe(true);
     });
 
+    it('receives a readOnly TextField when the readOnlyQueryField is true', () => {
+      const resourceFilters = mountWithApp(
+        <Filters
+          {...mockPropsWithShortcuts}
+          readOnlyQueryField
+        />,
+      );
+
+      const connectedFilterControl = resourceFilters.find(
+        ConnectedFilterControl,
+      )!;
+
+      expect(connectedFilterControl).toContainReactComponent(TextField, {
+        readOnly: true,
+      });
+    });
+
     it('forces showing the "More Filters" button if there are filters without shortcuts', () => {
       const resourceFilters = mountWithAppProvider(
         <Filters {...mockPropsWithShortcuts} />,

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -267,10 +267,7 @@ describe('<Filters />', () => {
 
     it('receives a readOnly TextField when the readOnlyQueryField is true', () => {
       const resourceFilters = mountWithApp(
-        <Filters
-          {...mockPropsWithShortcuts}
-          readOnlyQueryField
-        />,
+        <Filters {...mockPropsWithShortcuts} readOnlyQueryField />,
       );
 
       const connectedFilterControl = resourceFilters.find(


### PR DESCRIPTION
### WHY are these changes introduced?

A SFN application is introducing filter limits to into its indices. As the search query is a filter, we would like to set search query as read only when the filter limit has been reached. The current disable prop is not sufficient as it will disable all filters, not just the search query. Disabling the TextField also prevents the field from being clearable.

### WHAT is this pull request doing?

- Adding a prop to readOnly the filter query field
- add test
- add docs

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

- Run storybook

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

