### PR TITLE
[Button] Fix low contract on primary outlined button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -28,6 +28,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed offset in `DualThumb` when used with a min value different from 0 [#4172](https://github.com/Shopify/polaris-react/pull/4172)
 - Fixed loading state stacking in `ResourceList` ([#4208](https://github.com/Shopify/polaris-react/issues/4208))
 - Fixed focus order of visually hidden input in `DropZone` ([#4219](https://github.com/Shopify/polaris-react/pull/4219))
+- Fixed low contrast on primary outlined `Button` ([4233](https://github.com/Shopify/polaris-react/pull/4233))
 
 ### Documentation
 

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -134,7 +134,6 @@
   &:focus {
     border: border-width() solid var(--p-border);
     box-shadow: none;
-    color: var(--p-text);
     @include focus-ring($style: 'focused');
   }
 

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -140,7 +140,6 @@
   &:active {
     border: border-width() solid var(--p-border);
     box-shadow: none;
-    color: var(--p-text);
     background: var(--p-surface-pressed);
     &::after {
       box-shadow: none;

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -127,18 +127,21 @@
   &:hover {
     border: border-width() solid var(--p-border);
     box-shadow: none;
+    color: var(--p-text);
     background: var(--p-surface-hovered);
   }
 
   &:focus {
     border: border-width() solid var(--p-border);
     box-shadow: none;
+    color: var(--p-text);
     @include focus-ring($style: 'focused');
   }
 
   &:active {
     border: border-width() solid var(--p-border);
     box-shadow: none;
+    color: var(--p-text);
     background: var(--p-surface-pressed);
     &::after {
       box-shadow: none;


### PR DESCRIPTION

### WHY are these changes introduced?

A primaryAction button with `outline` has very low contrast on hover.
![](https://user-images.githubusercontent.com/35752699/110684085-b5d52400-81aa-11eb-9eca-d59cd4ff3465.png)


Fixes #4054 

### WHAT is this pull request doing?

* Adds the color property to the `hover`, `focus` and `active` CSS selectors for an outlined button.

#### AFTER THE FIX
![After the fix](https://user-images.githubusercontent.com/4933232/119906608-879af100-bf1c-11eb-8dd9-61c15285fdd8.png)
