### PR TITLE
[useIndexResourceState] Expose SelectionType enum

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added `id` prop to `Layout` and `Heading` for hash linking ([#4307](https://github.com/Shopify/polaris-react/pull/4307))
 - Added `external` prop to `Navigation.Item` component ([#4310](https://github.com/Shopify/polaris-react/pull/4310))
+- Added `SelectionType` export from `useIndexResourceState` hook ([#4348](https://github.com/Shopify/polaris-react/pull/4348))
 
 ### Bug fixes
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,10 @@ export {
 
 export {ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT} from './utilities/scroll-lock-manager';
 export {WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT} from './utilities/within-content-context';
-export {useIndexResourceState} from './utilities/use-index-resource-state';
+export {
+  useIndexResourceState,
+  SelectionType,
+} from './utilities/use-index-resource-state';
 
 export {
   toCssCustomPropertySyntax as UNSTABLE_toCssCustomPropertySyntax,


### PR DESCRIPTION
### WHY are these changes introduced?

Closes: https://github.com/Shopify/polaris-react/issues/4346

Removing resources from an IndexTable requires updating the selection. There is a `handleSelectionChange` callback that can be used for doing so but we don't expose the `SelectionType` enum for TS consumers. Another approach could be to expose a separate callback for resetting the selection but this shouldn't be necessary, unless for some reason we don't want to expose the enum, in which case this approach makes sense.

### WHAT is this pull request doing?

Simply exports `SelectionType`