### PR TITLE
[IndexTable] Allow multiple triggers of `data-primary-link` when not navigating away

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Bring back borders on the `IndexTable` sticky cells ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Adjust `IndexTable` sticky z-index to avoid collisions with focused `TextField` ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Adjust `IndexTable` rows to have a grey hover state when unselected ([#4359](https://github.com/Shopify/polaris-react/pull/4359))
+- Allow reusable `data-primary-link` on `IndexTable.Row` ([#4361](https://github.com/Shopify/polaris-react/pull/4361))
 
 ### Documentation
 

--- a/src/components/IndexTable/components/Row/Row.tsx
+++ b/src/components/IndexTable/components/Row/Row.tsx
@@ -107,9 +107,10 @@ export const Row = memo(function Row({
         new MouseEvent(event.type, event.nativeEvent),
       );
     } else {
-      isNavigating.current = false;
       handleInteraction(event);
     }
+
+    isNavigating.current = false;
   };
 
   const RowWrapper = condensed ? 'li' : 'tr';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4345  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR allows multiple triggers of `data-primary-link`. Previously, only one trigger would be allowed (assuming this was done as its main intention would be to navigate pages.) This change allows you to use an `onClick` with `data-primary-link` more than once.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->