### PR TITLE
[Test Modernization] Switch to using mountWithApp on ResourceItem and ResourceList tests.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -44,5 +44,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for DualThumb ([#4341](https://github.com/Shopify/polaris-react/pull/4341))
 - Modernized tests for AppProvider, AfterInitialMount components([#4315](https://github.com/Shopify/polaris-react/pull/4331))
 - Modernized tests for ResourceItem ([#4362](https://github.com/Shopify/polaris-react/pull/4362))
+- Modernized tests for ResourceItem, ResourceList ([#4362](https://github.com/Shopify/polaris-react/pull/4362))
 
 ### Deprecations

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -43,7 +43,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Breadcrumbs, BulkActions, Button, ButtonGroup/Item, and ButtonGroup components([#4315](https://github.com/Shopify/polaris-react/pull/4315))
 - Modernized tests for DualThumb ([#4341](https://github.com/Shopify/polaris-react/pull/4341))
 - Modernized tests for AppProvider, AfterInitialMount components([#4315](https://github.com/Shopify/polaris-react/pull/4331))
-- Modernized tests for ResourceItem ([#4362](https://github.com/Shopify/polaris-react/pull/4362))
 - Modernized tests for ResourceItem, ResourceList ([#4362](https://github.com/Shopify/polaris-react/pull/4362))
 
 ### Deprecations

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -43,6 +43,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Breadcrumbs, BulkActions, Button, ButtonGroup/Item, and ButtonGroup components([#4315](https://github.com/Shopify/polaris-react/pull/4315))
 - Modernized tests for DualThumb ([#4341](https://github.com/Shopify/polaris-react/pull/4341))
 - Modernized tests for AppProvider, AfterInitialMount components([#4315](https://github.com/Shopify/polaris-react/pull/4331))
-- Modernized tests for ResourceItem, ResourceList ([#4362](https://github.com/Shopify/polaris-react/pull/4362))
+- Modernized tests for `ResourceItem`, `ResourceList` ([#4362](https://github.com/Shopify/polaris-react/pull/4362))
 
 ### Deprecations

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -43,5 +43,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Breadcrumbs, BulkActions, Button, ButtonGroup/Item, and ButtonGroup components([#4315](https://github.com/Shopify/polaris-react/pull/4315))
 - Modernized tests for DualThumb ([#4341](https://github.com/Shopify/polaris-react/pull/4341))
 - Modernized tests for AppProvider, AfterInitialMount components([#4315](https://github.com/Shopify/polaris-react/pull/4331))
+- Modernized tests for ResourceItem ([#4362](https://github.com/Shopify/polaris-react/pull/4362))
 
 ### Deprecations

--- a/src/components/ResourceItem/ResourceItem.tsx
+++ b/src/components/ResourceItem/ResourceItem.tsx
@@ -167,11 +167,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
         name || accessibilityLabel || i18n.translate('Polaris.Common.checkbox');
 
       handleMarkup = (
-        <div
-          className={styles.Handle}
-          onClick={this.handleLargerSelectionArea}
-          testID="LargerSelectionArea"
-        >
+        <div className={styles.Handle} onClick={this.handleLargerSelectionArea}>
           <div onClick={stopPropagation} className={styles.CheckboxWrapper}>
             <div onChange={this.handleLargerSelectionArea}>
               <Checkbox

--- a/src/components/ResourceItem/ResourceItem.tsx
+++ b/src/components/ResourceItem/ResourceItem.tsx
@@ -159,9 +159,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
     let handleMarkup: React.ReactNode = null;
 
     const mediaMarkup = media ? (
-      <div className={styles.Media} testID="Media">
-        {media}
-      </div>
+      <div className={styles.Media}>{media}</div>
     ) : null;
 
     if (selectable) {
@@ -177,7 +175,6 @@ class BaseResourceItem extends Component<CombinedProps, State> {
           <div onClick={stopPropagation} className={styles.CheckboxWrapper}>
             <div onChange={this.handleLargerSelectionArea}>
               <Checkbox
-                testID="Checkbox"
                 id={this.checkboxId}
                 label={checkboxAccessibilityLabel}
                 labelHidden
@@ -261,7 +258,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
       } else {
         actionsMarkup = (
           <div className={styles.Actions} onClick={stopPropagation}>
-            <ButtonGroup segmented testID="ShortcutActions">
+            <ButtonGroup segmented>
               {buttonsFrom(shortcutActions, {
                 size: 'slim',
               })}
@@ -282,11 +279,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
     );
 
     const containerMarkup = (
-      <div
-        testID="Item-Content"
-        className={containerClassName}
-        id={this.props.id}
-      >
+      <div className={containerClassName} id={this.props.id}>
         {ownedMarkup}
         {content}
         {actionsMarkup}
@@ -335,7 +328,6 @@ class BaseResourceItem extends Component<CombinedProps, State> {
             onBlur={this.handleBlur}
             onKeyUp={this.handleKeyUp}
             onMouseOut={this.handleMouseOut}
-            testID="Item-Wrapper"
             data-href={url}
           >
             {accessibleMarkup}

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -10,7 +10,6 @@ import {
 } from 'components';
 
 import {ResourceItem} from '../ResourceItem';
-import {classNames} from '../../../utilities/css';
 import {ResourceListContext} from '../../../utilities/resource-list';
 import styles from '../ResourceItem.scss';
 
@@ -70,6 +69,10 @@ describe('<ResourceItem />', () => {
   const url = 'http://test-link.com';
   const external = false;
   const ariaLabel = 'View Item';
+
+  const resourceItemSelector = {className: styles.ResourceItem};
+  const resourceItemFilter = (node: any) =>
+    node.prop('className').includes(styles.ResourceItem);
 
   describe('accessibilityLabel', () => {
     it('is used on the <UnstyledLink /> for the aria-label attribute', () => {
@@ -214,8 +217,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      const div = element.find('div', {'data-href': url} as any);
-      expect(div).not.toBeNull();
+      expect(element).toContainReactComponent('div', {'data-href': url} as any);
     });
   });
 
@@ -299,12 +301,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div', {className: styles.ResourceItem})!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {},
-        });
+      wrapper.find('div', resourceItemSelector)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
       expect(onClick).toHaveBeenCalledWith(itemId);
     });
 
@@ -321,12 +321,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div', {className: styles.ResourceItem})!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {},
-        });
+      wrapper.find('div', resourceItemSelector)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
       expect(onClick).toHaveBeenCalledWith(itemId);
     });
 
@@ -337,12 +335,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div', {className: styles.ResourceItem})!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {metaKey: true},
-        });
+      wrapper.find('div', resourceItemSelector)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {metaKey: true},
+      });
       expect(spy).toHaveBeenCalledWith(url, '_blank');
     });
 
@@ -355,7 +351,7 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', {className: styles.ResourceItem})!
+        .find('div', resourceItemSelector)!
         .trigger('onKeyUp', {key: 'Enter'});
 
       expect(onClick).toHaveBeenCalled();
@@ -370,7 +366,7 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', {className: styles.ResourceItem})!
+        .find('div', resourceItemSelector)!
         .trigger('onKeyUp', {key: 'Tab'});
 
       expect(onClick).not.toHaveBeenCalled();
@@ -385,13 +381,8 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', {
-          className: classNames(
-            styles.ResourceItem,
-            styles.selectable,
-            styles.selectMode,
-          ),
-        })!
+        .find('div')
+        .findWhere(resourceItemFilter)!
         .trigger('onKeyUp', {key: 'Enter'});
 
       expect(onClick).not.toHaveBeenCalled();
@@ -404,12 +395,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div', {className: styles.ResourceItem})!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {ctrlKey: true},
-        });
+      wrapper.find('div', resourceItemSelector)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {ctrlKey: true},
+      });
       expect(spy).toHaveBeenCalledWith(url, '_blank');
     });
   });
@@ -465,13 +454,8 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', {
-          className: classNames(
-            styles.ResourceItem,
-            styles.selectable,
-            styles.selectMode,
-          ),
-        })!
+        .find('div')
+        .findWhere(resourceItemFilter)!
         .trigger('onClick', {
           stopPropagation: () => {},
           nativeEvent: {},
@@ -495,13 +479,8 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', {
-          className: classNames(
-            styles.ResourceItem,
-            styles.selectable,
-            styles.selectMode,
-          ),
-        })!
+        .find('div')
+        .findWhere(resourceItemFilter)!
         .trigger('onClick', {
           stopPropagation: () => {},
           nativeEvent: {shiftKey: false},
@@ -531,14 +510,8 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', {
-          className: classNames(
-            styles.ResourceItem,
-            styles.selectable,
-            styles.selected,
-            styles.selectMode,
-          ),
-        })!
+        .find('div')
+        .findWhere(resourceItemFilter)!
         .trigger('onClick', {
           stopPropagation: () => {},
           nativeEvent: {metaKey: true},
@@ -554,14 +527,8 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', {
-          className: classNames(
-            styles.ResourceItem,
-            styles.selectable,
-            styles.selected,
-            styles.selectMode,
-          ),
-        })!
+        .find('div')
+        .findWhere(resourceItemFilter)!
         .trigger('onClick', {
           stopPropagation: () => {},
           nativeEvent: {ctrlKey: true},
@@ -799,8 +766,10 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-      const li = item.find('li', {'data-href': 'google.com'} as any);
-      expect(li).not.toBeNull();
+
+      expect(item).toContainReactComponent('li', {
+        'data-href': 'google.com',
+      } as any);
     });
 
     it('renders a data-href tag on the li when the dataHref prop is not specified', () => {
@@ -814,8 +783,9 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      const li = item.find('li', {'data-href': undefined} as any);
-      expect(li).not.toBeNull();
+      expect(item).toContainReactComponent('li', {
+        'data-href': undefined,
+      } as any);
     });
   });
 });

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mountWithApp} from 'test-utilities';
+import {mountWithApp, Node} from 'test-utilities';
 import {
   Avatar,
   ButtonGroup,
@@ -70,8 +70,7 @@ describe('<ResourceItem />', () => {
   const external = false;
   const ariaLabel = 'View Item';
 
-  const resourceItemSelector = {className: styles.ResourceItem};
-  const resourceItemFilter = (node: any) =>
+  const resourceItemFilter = (node: Node<unknown>) =>
     node.prop('className').includes(styles.ResourceItem);
 
   describe('accessibilityLabel', () => {
@@ -301,10 +300,13 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.find('div', resourceItemSelector)!.trigger('onClick', {
-        stopPropagation: () => {},
-        nativeEvent: {},
-      });
+      wrapper
+        .find('div')!
+        .findWhere(resourceItemFilter)!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {},
+        });
       expect(onClick).toHaveBeenCalledWith(itemId);
     });
 
@@ -321,10 +323,13 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.find('div', resourceItemSelector)!.trigger('onClick', {
-        stopPropagation: () => {},
-        nativeEvent: {},
-      });
+      wrapper
+        .find('div')!
+        .findWhere(resourceItemFilter)!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {},
+        });
       expect(onClick).toHaveBeenCalledWith(itemId);
     });
 
@@ -335,10 +340,13 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.find('div', resourceItemSelector)!.trigger('onClick', {
-        stopPropagation: () => {},
-        nativeEvent: {metaKey: true},
-      });
+      wrapper
+        .find('div')!
+        .findWhere(resourceItemFilter)!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {metaKey: true},
+        });
       expect(spy).toHaveBeenCalledWith(url, '_blank');
     });
 
@@ -351,7 +359,8 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', resourceItemSelector)!
+        .find('div')!
+        .findWhere(resourceItemFilter)!
         .trigger('onKeyUp', {key: 'Enter'});
 
       expect(onClick).toHaveBeenCalled();
@@ -366,7 +375,8 @@ describe('<ResourceItem />', () => {
       );
 
       wrapper
-        .find('div', resourceItemSelector)!
+        .find('div')!
+        .findWhere(resourceItemFilter)!
         .trigger('onKeyUp', {key: 'Tab'});
 
       expect(onClick).not.toHaveBeenCalled();
@@ -384,7 +394,6 @@ describe('<ResourceItem />', () => {
         .find('div')
         .findWhere(resourceItemFilter)!
         .trigger('onKeyUp', {key: 'Enter'});
-
       expect(onClick).not.toHaveBeenCalled();
     });
 
@@ -395,10 +404,13 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.find('div', resourceItemSelector)!.trigger('onClick', {
-        stopPropagation: () => {},
-        nativeEvent: {ctrlKey: true},
-      });
+      wrapper
+        .find('div')!
+        .findWhere(resourceItemFilter)!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {ctrlKey: true},
+        });
       expect(spy).toHaveBeenCalledWith(url, '_blank');
     });
   });

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -214,7 +214,8 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(element).toContainReactComponent('div', {'data-href': url});
+      const div = element.find('div', {'data-href': url} as any);
+      expect(div).not.toBeNull();
     });
   });
 
@@ -798,9 +799,10 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-
-      expect(item).toContainReactComponent('li', {'data-href': 'google.com'});
+      const li = item.find('li', {'data-href': 'google.com'} as any);
+      expect(li).not.toBeNull();
     });
+
     it('renders a data-href tag on the li when the dataHref prop is not specified', () => {
       const item = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
@@ -812,7 +814,8 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(item).toContainReactComponent('li', {'data-href': undefined});
+      const li = item.find('li', {'data-href': undefined} as any);
+      expect(li).not.toBeNull();
     });
   });
 });

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -1,10 +1,4 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {
-  findByTestID,
-  mountWithAppProvider,
-  trigger,
-} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {
   Avatar,
@@ -15,8 +9,10 @@ import {
   Button,
 } from 'components';
 
-import {ResourceListContext} from '../../../utilities/resource-list';
 import {ResourceItem} from '../ResourceItem';
+import {classNames} from '../../../utilities/css';
+import {ResourceListContext} from '../../../utilities/resource-list';
+import styles from '../ResourceItem.scss';
 
 describe('<ResourceItem />', () => {
   let spy: jest.SpyInstance;
@@ -77,7 +73,7 @@ describe('<ResourceItem />', () => {
 
   describe('accessibilityLabel', () => {
     it('is used on the <UnstyledLink /> for the aria-label attribute', () => {
-      const item = mountWithAppProvider(
+      const item = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             accessibilityLabel={accessibilityLabel}
@@ -87,15 +83,15 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(item.find(UnstyledLink).prop('aria-label')).toBe(
-        accessibilityLabel,
-      );
+      expect(item).toContainReactComponent(UnstyledLink, {
+        'aria-label': accessibilityLabel,
+      });
     });
   });
 
   describe('name', () => {
     it('is used as the Checkbox label', () => {
-      const item = mountWithAppProvider(
+      const item = mountWithApp(
         <ResourceListContext.Provider value={mockSelectableContext}>
           <ResourceItem
             accessibilityLabel={accessibilityLabel}
@@ -108,11 +104,11 @@ describe('<ResourceItem />', () => {
 
       const expectedLabel = name;
 
-      expect(item.find(Checkbox).prop('label')).toBe(expectedLabel);
+      expect(item).toContainReactComponent(Checkbox, {label: expectedLabel});
     });
 
     it('is used on <UnstyledLink /> for the aria-label attribute if an `accessibilityLabel` is not provided', () => {
-      const item = mountWithAppProvider(
+      const item = mountWithApp(
         <ResourceListContext.Provider value={mockSelectableContext}>
           <ResourceItem id={itemId} url="https://shopify.com" name={name} />
         </ResourceListContext.Provider>,
@@ -120,11 +116,13 @@ describe('<ResourceItem />', () => {
 
       const expectedLabel = `View details for ${name}`;
 
-      expect(item.find(UnstyledLink).prop('aria-label')).toBe(expectedLabel);
+      expect(item).toContainReactComponent(UnstyledLink, {
+        'aria-label': expectedLabel,
+      });
     });
 
     it('is used on the disclosure action menu when there are persistent actions', () => {
-      const item = mountWithAppProvider(
+      const item = mountWithApp(
         <ResourceListContext.Provider value={mockSelectableContext}>
           <ResourceItem
             accessibilityLabel={accessibilityLabel}
@@ -139,21 +137,16 @@ describe('<ResourceItem />', () => {
 
       const expectedLabel = `Actions for ${name}`;
 
-      expect(
-        item
-          .find(Button)
-          .findWhere(
-            (node) =>
-              node.prop('plain') &&
-              node.prop('accessibilityLabel') === expectedLabel,
-          ),
-      ).toHaveLength(1);
+      expect(item).toContainReactComponentTimes(Button, 1, {
+        plain: true,
+        accessibilityLabel: expectedLabel,
+      });
     });
   });
 
   describe('ResourceName.singular', () => {
     it('is used on <UnstyledLink /> for the aria-label attribute if a `name` and `accessibilityLabel` is not provided', () => {
-      const item = mountWithAppProvider(
+      const item = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id={itemId} url="https://shopify.com" />
         </ResourceListContext.Provider>,
@@ -161,13 +154,15 @@ describe('<ResourceItem />', () => {
 
       const expectedLabel = `View details for ${mockDefaultContext.resourceName.singular}`;
 
-      expect(item.find(UnstyledLink).prop('aria-label')).toBe(expectedLabel);
+      expect(item).toContainReactComponent(UnstyledLink, {
+        'aria-label': expectedLabel,
+      });
     });
   });
 
   describe('url', () => {
     it('does not render an <UnstyledLink /> by default', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id="itemId"
@@ -177,63 +172,67 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(element.find(UnstyledLink).exists()).toBe(false);
+      expect(element).not.toContainReactComponent(UnstyledLink);
     });
 
     it('renders an <UnstyledLink />', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id="itemId" url={url} accessibilityLabel={ariaLabel} />
         </ResourceListContext.Provider>,
       );
 
-      expect(element.find(UnstyledLink).exists()).toBe(true);
+      expect(element).toContainReactComponent(UnstyledLink);
     });
 
     it('renders an <UnstyledLink /> with url', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id="itemId" url={url} accessibilityLabel={ariaLabel} />
         </ResourceListContext.Provider>,
       );
 
-      expect(element.find(UnstyledLink).prop('url')).toBe(url);
+      expect(element).toContainReactComponent(UnstyledLink, {url});
     });
 
     it('renders an <UnstyledLink /> with an aria-label of ariaLabel', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id="itemId" url={url} accessibilityLabel={ariaLabel} />
         </ResourceListContext.Provider>,
       );
 
-      expect(element.find(UnstyledLink).prop('aria-label')).toBe(ariaLabel);
+      expect(element).toContainReactComponent(UnstyledLink, {
+        'aria-label': ariaLabel,
+      });
     });
 
     it('adds a data-href to the wrapper element', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id="itemId" url={url} />
         </ResourceListContext.Provider>,
       );
 
-      expect(findByTestID(element, 'Item-Wrapper').prop('data-href')).toBe(url);
+      expect(element).toContainReactComponent('div', {'data-href': url});
     });
   });
 
   describe('external', () => {
     it('renders an <UnstyledLink /> with undefined external prop', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id="itemId" url={url} />
         </ResourceListContext.Provider>,
       );
 
-      expect(element.find(UnstyledLink).prop('external')).toBeUndefined();
+      expect(element).toContainReactComponent(UnstyledLink, {
+        external: undefined,
+      });
     });
 
     it('renders an <UnstyledLink /> with external set to true', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id="itemId"
@@ -244,11 +243,13 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(element.find(UnstyledLink).prop('external')).toBe(true);
+      expect(element).toContainReactComponent(UnstyledLink, {
+        external: true,
+      });
     });
 
     it('renders an <UnstyledLink /> with external set to false', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id="itemId"
@@ -259,13 +260,15 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(element.find(UnstyledLink).prop('external')).toBe(false);
+      expect(element).toContainReactComponent(UnstyledLink, {
+        external: false,
+      });
     });
   });
 
   describe('id', () => {
     it('is used on the content node and for the description of a link', () => {
-      const item = mountWithAppProvider(
+      const item = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id={itemId}
@@ -275,15 +278,17 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(findByTestID(item, 'Item-Content').prop('id')).toBe(itemId);
-      expect(item.find(UnstyledLink).prop('aria-describedby')).toBe(itemId);
+      expect(item).toContainReactComponent('div', {id: itemId});
+      expect(item).toContainReactComponent(UnstyledLink, {
+        'aria-describedby': itemId,
+      });
     });
   });
 
   describe('onClick()', () => {
     it('calls onClick when clicking on the item when onClick exists', () => {
       const onClick = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id={itemId}
@@ -293,13 +298,18 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'Item-Wrapper').simulate('click');
+      wrapper
+        .find('div', {className: styles.ResourceItem})!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {},
+        });
       expect(onClick).toHaveBeenCalledWith(itemId);
     });
 
     it('calls onClick when clicking on the item when both onClick and url exist', () => {
       const onClick = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id={itemId}
@@ -310,80 +320,95 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'Item-Wrapper').simulate('click');
+      wrapper
+        .find('div', {className: styles.ResourceItem})!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {},
+        });
       expect(onClick).toHaveBeenCalledWith(itemId);
     });
 
     it('calls window.open on metaKey + click', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id={itemId} url={url} accessibilityLabel={ariaLabel} />
         </ResourceListContext.Provider>,
       );
-      const item = findByTestID(wrapper, 'Item-Wrapper');
-      trigger(item, 'onClick', {
-        stopPropagation: () => {},
-        nativeEvent: {metaKey: true},
-      });
+
+      wrapper
+        .find('div', {className: styles.ResourceItem})!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {metaKey: true},
+        });
       expect(spy).toHaveBeenCalledWith(url, '_blank');
     });
 
     it('calls onClick when hitting keyUp on the item when onClick and URL exists', () => {
       const onClick = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id={itemId} url="#" onClick={onClick} />
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'Item-Wrapper').simulate('keyup', {
-        key: 'Enter',
-      });
+      wrapper
+        .find('div', {className: styles.ResourceItem})!
+        .trigger('onKeyUp', {key: 'Enter'});
 
       expect(onClick).toHaveBeenCalled();
     });
 
     it('does not call onClick when hitting keyUp on non Enter key', () => {
       const onClick = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id={itemId} url="#" onClick={onClick} />
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'Item-Wrapper').simulate('keyup', {
-        key: 'Tab',
-      });
+      wrapper
+        .find('div', {className: styles.ResourceItem})!
+        .trigger('onKeyUp', {key: 'Tab'});
 
       expect(onClick).not.toHaveBeenCalled();
     });
 
     it('does not call onClick when hitting keyUp on the item when no URL exists', () => {
       const onClick = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockSelectModeContext}>
           <ResourceItem id={itemId} onClick={onClick} />
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'Item-Wrapper').simulate('keyup', {
-        key: 'Enter',
-      });
+      wrapper
+        .find('div', {
+          className: classNames(
+            styles.ResourceItem,
+            styles.selectable,
+            styles.selectMode,
+          ),
+        })!
+        .trigger('onKeyUp', {key: 'Enter'});
 
       expect(onClick).not.toHaveBeenCalled();
     });
 
     it('calls window.open on ctrlKey + click', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id={itemId} url={url} accessibilityLabel={ariaLabel} />
         </ResourceListContext.Provider>,
       );
-      const item = findByTestID(wrapper, 'Item-Wrapper');
-      trigger(item, 'onClick', {
-        stopPropagation: () => {},
-        nativeEvent: {ctrlKey: true},
-      });
+
+      wrapper
+        .find('div', {className: styles.ResourceItem})!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {ctrlKey: true},
+        });
       expect(spy).toHaveBeenCalledWith(url, '_blank');
     });
   });
@@ -391,25 +416,29 @@ describe('<ResourceItem />', () => {
   describe('Selectable', () => {
     it('does not call the Item onClick when clicking the LargerSelectionArea', () => {
       const onClick = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockSelectableContext}>
           <ResourceItem id={itemId} onClick={onClick} />
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'LargerSelectionArea').simulate('click');
+      wrapper.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
       expect(onClick).not.toHaveBeenCalled();
     });
 
     it('calls onSelectionChange with the id of the item when clicking the LargerSelectionArea', () => {
       const sortOrder = 0;
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockSelectableContext}>
           <ResourceItem id={itemId} url={url} sortOrder={sortOrder} />
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'LargerSelectionArea').simulate('click', {
+      wrapper.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
         nativeEvent: {shiftKey: false},
       });
       expect(mockSelectableContext.onSelectionChange).toHaveBeenCalledWith(
@@ -424,7 +453,7 @@ describe('<ResourceItem />', () => {
   describe('SelectMode', () => {
     it('calls onClick when item is clicked', () => {
       const onClick = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockSelectModeContext}>
           <ResourceItem
             id={itemId}
@@ -434,14 +463,25 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'Item-Wrapper').simulate('click');
+      wrapper
+        .find('div', {
+          className: classNames(
+            styles.ResourceItem,
+            styles.selectable,
+            styles.selectMode,
+          ),
+        })!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {},
+        });
       expect(onClick).not.toHaveBeenCalledWith(itemId);
     });
 
     it('calls onSelectionChange with the id of the item even if url or onClick is present', () => {
       const onClick = jest.fn();
       const sortOrder = 0;
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockSelectModeContext}>
           <ResourceItem
             id={itemId}
@@ -453,9 +493,18 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      findByTestID(wrapper, 'Item-Wrapper').simulate('click', {
-        nativeEvent: {shiftKey: false},
-      });
+      wrapper
+        .find('div', {
+          className: classNames(
+            styles.ResourceItem,
+            styles.selectable,
+            styles.selectMode,
+          ),
+        })!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {shiftKey: false},
+        });
       expect(mockSelectModeContext.onSelectionChange).toHaveBeenCalledWith(
         true,
         itemId,
@@ -465,69 +514,94 @@ describe('<ResourceItem />', () => {
     });
 
     it('renders a checked Checkbox if the item is in the selectedItems context', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockSelectableContext}>
           <ResourceItem id={selectedItemId} url={url} />
         </ResourceListContext.Provider>,
       );
-      expect(wrapper.find(Checkbox).props().checked).toBe(true);
+      expect(wrapper).toContainReactComponent(Checkbox, {checked: true});
     });
 
     it('does not call window.open when clicking the item with metaKey', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockSelectModeContext}>
           <ResourceItem id={selectedItemId} url={url} />
         </ResourceListContext.Provider>,
       );
-      findByTestID(wrapper, 'Item-Wrapper').simulate('click', {
-        nativeEvent: {metaKey: true},
-      });
+
+      wrapper
+        .find('div', {
+          className: classNames(
+            styles.ResourceItem,
+            styles.selectable,
+            styles.selected,
+            styles.selectMode,
+          ),
+        })!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {metaKey: true},
+        });
       expect(spy).not.toHaveBeenCalled();
     });
 
     it('does not call window.open when clicking the item with ctrlKey', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockSelectModeContext}>
           <ResourceItem id={selectedItemId} url={url} />
         </ResourceListContext.Provider>,
       );
-      findByTestID(wrapper, 'Item-Wrapper').simulate('click', {
-        nativeEvent: {ctrlKey: true},
-      });
+
+      wrapper
+        .find('div', {
+          className: classNames(
+            styles.ResourceItem,
+            styles.selectable,
+            styles.selected,
+            styles.selectMode,
+          ),
+        })!
+        .trigger('onClick', {
+          stopPropagation: () => {},
+          nativeEvent: {ctrlKey: true},
+        });
       expect(spy).not.toHaveBeenCalled();
     });
   });
 
   describe('media', () => {
     it('does not include media if not provided', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id={itemId} url={url} />
         </ResourceListContext.Provider>,
       );
-      expect(findByTestID(wrapper, 'Media').exists()).toBe(false);
+      expect(wrapper).not.toContainReactComponent('div', {
+        className: styles.Media,
+      });
     });
 
     it('renders a disabled checked Checkbox if loading context is true', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockLoadingContext}>
           <ResourceItem id={selectedItemId} url={url} />
         </ResourceListContext.Provider>,
       );
-      expect(wrapper.find(Checkbox).prop('disabled')).toBe(true);
+      expect(wrapper).toContainReactComponent(Checkbox, {disabled: true});
     });
 
     it('includes an <Avatar /> if one is provided', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id={itemId} url={url} media={<Avatar customer />} />
         </ResourceListContext.Provider>,
       );
-      expect(findByTestID(wrapper, 'Media').find(Avatar).exists()).toBe(true);
+      const media = wrapper.find('div', {className: styles.Media});
+      expect(media).toContainReactComponent(Avatar);
     });
 
     it('includes a <Thumbnail /> if one is provided', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id={itemId}
@@ -536,24 +610,25 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-      expect(findByTestID(wrapper, 'Media').find(Thumbnail).exists()).toBe(
-        true,
-      );
+      const media = wrapper.find('div', {className: styles.Media});
+      expect(media).toContainReactComponent(Thumbnail);
     });
   });
 
   describe('shortcutActions', () => {
     it('does not render shortcut actions if none are provided', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem id={itemId} url={url} />
         </ResourceListContext.Provider>,
       );
-      expect(findByTestID(wrapper, 'ShortcutActions').exists()).toBe(false);
+      expect(wrapper).not.toContainReactComponent('div', {
+        className: styles.Actions,
+      });
     });
 
     it('renders shortcut actions when some are provided', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id={itemId}
@@ -562,11 +637,13 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-      expect(findByTestID(wrapper, 'ShortcutActions').exists()).toBe(true);
+      expect(wrapper).toContainReactComponent('div', {
+        className: styles.Actions,
+      });
     });
 
     it('renders persistent shortcut actions if persistActions is true', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id={itemId}
@@ -576,11 +653,11 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-      expect(wrapper.find(ButtonGroup).exists()).toBe(true);
+      expect(wrapper).toContainReactComponent(ButtonGroup);
     });
 
     it('does not render while loading', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={{...mockLoadingContext}}>
           <ResourceItem
             id={itemId}
@@ -590,13 +667,13 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-      expect(wrapper.find(ButtonGroup)).toHaveLength(0);
+      expect(wrapper).not.toContainReactComponent(ButtonGroup);
     });
   });
 
   describe('accessibleMarkup', () => {
     it('renders with a tab index of -1 when loading is true', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockLoadingContext}>
           <ResourceItem
             id={itemId}
@@ -606,11 +683,11 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-      expect(wrapper.find(UnstyledLink).prop('tabIndex')).toBe(-1);
+      expect(wrapper).toContainReactComponent(UnstyledLink, {tabIndex: -1});
     });
 
     it('renders with a tab index of 0 when loading is false', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             id={itemId}
@@ -620,7 +697,7 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-      expect(wrapper.find(UnstyledLink).prop('tabIndex')).toBe(0);
+      expect(wrapper).toContainReactComponent(UnstyledLink, {tabIndex: 0});
     });
   });
 
@@ -711,7 +788,7 @@ describe('<ResourceItem />', () => {
 
   describe('dataHref', () => {
     it('renders a data-href tag on the li when the dataHref prop is specified', () => {
-      const item = mountWithAppProvider(
+      const item = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             accessibilityLabel={accessibilityLabel}
@@ -722,10 +799,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(item.find('li').prop('data-href')).toBe('google.com');
+      expect(item).toContainReactComponent('li', {'data-href': 'google.com'});
     });
     it('renders a data-href tag on the li when the dataHref prop is not specified', () => {
-      const item = mountWithAppProvider(
+      const item = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
             accessibilityLabel={accessibilityLabel}
@@ -735,7 +812,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(item.find('li').prop('data-href')).toBeUndefined();
+      expect(item).toContainReactComponent('li', {'data-href': undefined});
     });
   });
 });

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -71,7 +71,7 @@ describe('<ResourceItem />', () => {
   const ariaLabel = 'View Item';
 
   const resourceItemFilter = (node: Node<unknown>) =>
-    node.prop('className').includes(styles.ResourceItem);
+    node.is('div') && node!.domNode.classList.contains(styles.ResourceItem);
 
   describe('accessibilityLabel', () => {
     it('is used on the <UnstyledLink /> for the aria-label attribute', () => {
@@ -300,13 +300,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')!
-        .findWhere(resourceItemFilter)!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {},
-        });
+      wrapper.findWhere(resourceItemFilter)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
       expect(onClick).toHaveBeenCalledWith(itemId);
     });
 
@@ -323,13 +320,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')!
-        .findWhere(resourceItemFilter)!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {},
-        });
+      wrapper.findWhere(resourceItemFilter)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
       expect(onClick).toHaveBeenCalledWith(itemId);
     });
 
@@ -340,13 +334,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')!
-        .findWhere(resourceItemFilter)!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {metaKey: true},
-        });
+      wrapper.findWhere(resourceItemFilter)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {metaKey: true},
+      });
       expect(spy).toHaveBeenCalledWith(url, '_blank');
     });
 
@@ -358,10 +349,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')!
-        .findWhere(resourceItemFilter)!
-        .trigger('onKeyUp', {key: 'Enter'});
+      wrapper.findWhere(resourceItemFilter)!.trigger('onKeyUp', {key: 'Enter'});
 
       expect(onClick).toHaveBeenCalled();
     });
@@ -374,10 +362,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')!
-        .findWhere(resourceItemFilter)!
-        .trigger('onKeyUp', {key: 'Tab'});
+      wrapper.findWhere(resourceItemFilter)!.trigger('onKeyUp', {key: 'Tab'});
 
       expect(onClick).not.toHaveBeenCalled();
     });
@@ -390,10 +375,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')
-        .findWhere(resourceItemFilter)!
-        .trigger('onKeyUp', {key: 'Enter'});
+      wrapper.findWhere(resourceItemFilter)!.trigger('onKeyUp', {key: 'Enter'});
       expect(onClick).not.toHaveBeenCalled();
     });
 
@@ -404,13 +386,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')!
-        .findWhere(resourceItemFilter)!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {ctrlKey: true},
-        });
+      wrapper.findWhere(resourceItemFilter)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {ctrlKey: true},
+      });
       expect(spy).toHaveBeenCalledWith(url, '_blank');
     });
   });
@@ -465,13 +444,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')
-        .findWhere(resourceItemFilter)!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {},
-        });
+      wrapper.findWhere(resourceItemFilter)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
       expect(onClick).not.toHaveBeenCalledWith(itemId);
     });
 
@@ -490,13 +466,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')
-        .findWhere(resourceItemFilter)!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {shiftKey: false},
-        });
+      wrapper.findWhere(resourceItemFilter)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {shiftKey: false},
+      });
       expect(mockSelectModeContext.onSelectionChange).toHaveBeenCalledWith(
         true,
         itemId,
@@ -521,13 +494,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')
-        .findWhere(resourceItemFilter)!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {metaKey: true},
-        });
+      wrapper.findWhere(resourceItemFilter)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {metaKey: true},
+      });
       expect(spy).not.toHaveBeenCalled();
     });
 
@@ -538,13 +508,10 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper
-        .find('div')
-        .findWhere(resourceItemFilter)!
-        .trigger('onClick', {
-          stopPropagation: () => {},
-          nativeEvent: {ctrlKey: true},
-        });
+      wrapper.findWhere(resourceItemFilter)!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {ctrlKey: true},
+      });
       expect(spy).not.toHaveBeenCalled();
     });
   });

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -575,9 +575,7 @@ export const ResourceList: ResourceListType = function ResourceList<ItemType>({
     ) : null;
 
   const headerTitleMarkup = (
-    <div className={styles.HeaderTitleWrapper} testID="headerTitleWrapper">
-      {headerTitle()}
-    </div>
+    <div className={styles.HeaderTitleWrapper}>{headerTitle()}</div>
   );
 
   const selectButtonMarkup = isSelectable ? (
@@ -639,7 +637,7 @@ export const ResourceList: ResourceListType = function ResourceList<ItemType>({
               isSticky && styles['HeaderWrapper-isSticky'],
             );
             return (
-              <div className={headerClassName} testID="ResourceList-Header">
+              <div className={headerClassName}>
                 <EventListener event="resize" handler={handleResize} />
                 {headerWrapperOverlay}
                 <div className={styles.HeaderContentWrapper}>

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -10,16 +10,14 @@ import {
   EmptyState,
 } from 'components';
 import {mountWithApp} from 'test-utilities';
-// eslint-disable-next-line no-restricted-imports
-import {
-  findByTestID,
-  mountWithAppProvider,
-  trigger,
-} from 'test-utilities/legacy';
 import {SELECT_ALL_ITEMS} from 'utilities/resource-list';
 
 import {BulkActions} from '../../BulkActions';
 import {CheckableButton} from '../../CheckableButton';
+
+import {classNames} from '../../../utilities/css';
+
+import styles from '../ResourceList.scss';
 
 const itemsNoID = [{url: 'item 1'}, {url: 'item 2'}];
 const singleItemNoID = [{url: 'item 1'}];
@@ -53,10 +51,10 @@ const defaultWindowWidth = window.innerWidth;
 describe('<ResourceList />', () => {
   describe('renderItem', () => {
     it('renders list items', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(resourceList.find('li')).toHaveLength(3);
+      expect(resourceList).toContainReactComponentTimes('li', 3);
     });
 
     it('renders custom markup and warns user', () => {
@@ -64,10 +62,11 @@ describe('<ResourceList />', () => {
       const warningSpy = jest
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={itemsWithID} renderItem={renderCustomMarkup} />,
       );
-      expect(resourceList.find('li').first().text()).toBe('title 1');
+      expect(resourceList).toContainReactText('title 1');
+      // expect(resourceList.find('li').first().text()).toBe('title 1');
       expect(warningSpy).toHaveBeenCalledWith(
         '<ResourceList /> renderItem function should return a <ResourceItem />.',
       );
@@ -78,66 +77,65 @@ describe('<ResourceList />', () => {
 
   describe('Selectable', () => {
     it('does not render bulk actions if the promotedBulkActions and the bulkActions props are not provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(resourceList.find(BulkActions).exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent(BulkActions);
     });
 
     it('does not render a `CheckableButton` if the `selectable` prop is not provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(resourceList.find(CheckableButton).exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent(CheckableButton);
     });
 
     it('does render bulk actions if the promotedBulkActions prop is provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           renderItem={renderItem}
           promotedBulkActions={promotedBulkActions}
         />,
       );
-
-      expect(resourceList.find(BulkActions).exists()).toBe(true);
+      expect(resourceList).toContainReactComponent(BulkActions);
     });
 
     it('renders bulk actions if the bulkActions prop is provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           renderItem={renderItem}
           bulkActions={bulkActions}
         />,
       );
-      expect(resourceList.find(BulkActions).exists()).toBe(true);
+      expect(resourceList).toContainReactComponent(BulkActions);
     });
 
     it('renders a `CheckableButton` if the `selectable` prop is true', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList selectable items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(resourceList.find(CheckableButton).exists()).toBe(true);
+      expect(resourceList).toContainReactComponent(CheckableButton);
     });
   });
 
   describe('hasMoreItems', () => {
     it('does not add a prop of paginatedSelectAllAction to BulkActions if omitted', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           renderItem={renderItem}
           bulkActions={bulkActions}
         />,
       );
-      expect(
-        resourceList.find(BulkActions).prop('paginatedSelectAllAction'),
-      ).toBeUndefined();
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        paginatedSelectAllAction: undefined,
+      });
     });
 
     it('adds a prop of paginatedSelectAllAction to BulkActions if included', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           hasMoreItems
@@ -145,29 +143,31 @@ describe('<ResourceList />', () => {
           bulkActions={bulkActions}
         />,
       );
+      expect(resourceList).toContainReactComponent(BulkActions);
       expect(
-        resourceList.find(BulkActions).prop('paginatedSelectAllAction'),
-      ).toBeDefined();
+        resourceList.find(BulkActions)!.props.paginatedSelectAllAction,
+      ).not.toBe(undefined);
     });
   });
 
   describe('resourceName', () => {
     describe('resoureName.singular', () => {
       it('renders default singular resource name when resourceName isn’t provided', () => {
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             showHeader
             items={singleItemNoID}
             renderItem={renderItem}
           />,
         );
-        expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
-          'Showing 1 item',
-        );
+        const headerTitleWrapper = resourceList.find('div', {
+          className: styles.HeaderTitleWrapper,
+        });
+        expect(headerTitleWrapper).toContainReactText('Showing 1 item');
       });
 
       it('renders the given singular resource name when resourceName is provided', () => {
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             items={singleItemNoID}
             renderItem={renderItem}
@@ -175,24 +175,26 @@ describe('<ResourceList />', () => {
             showHeader
           />,
         );
-        expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
-          'Showing 1 product',
-        );
+        const headerTitleWrapper = resourceList.find('div', {
+          className: styles.HeaderTitleWrapper,
+        });
+        expect(headerTitleWrapper).toContainReactText('Showing 1 product');
       });
     });
 
-    describe('resoureName.plural', () => {
+    describe('resourceName.plural', () => {
       it('renders default plural resource name when resourceName isn’t provided', () => {
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList items={itemsNoID} renderItem={renderItem} showHeader />,
         );
-        expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
-          'Showing 2 items',
-        );
+        const headerTitleWrapper = resourceList.find('div', {
+          className: styles.HeaderTitleWrapper,
+        });
+        expect(headerTitleWrapper).toContainReactText('Showing 2 items');
       });
 
       it('renders the given plural resource name when resourceName is provided', () => {
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             items={itemsNoID}
             renderItem={renderItem}
@@ -200,16 +202,17 @@ describe('<ResourceList />', () => {
             showHeader
           />,
         );
-        expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
-          'Showing 2 products',
-        );
+        const headerTitleWrapper = resourceList.find('div', {
+          className: styles.HeaderTitleWrapper,
+        });
+        expect(headerTitleWrapper).toContainReactText('Showing 2 products');
       });
     });
   });
 
   describe('headerTitle', () => {
     it('prints loading text when loading is true', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={singleItemWithID}
           renderItem={renderItem}
@@ -218,13 +221,14 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
-        'Loading items',
-      );
+      const headerTitleWrapper = resourceList.find('div', {
+        className: styles.HeaderTitleWrapper,
+      });
+      expect(headerTitleWrapper).toContainReactText('Loading items');
     });
 
     it('prints number of items shown when totalItemsCount is not provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           renderItem={renderItem}
@@ -233,13 +237,14 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
-        'Showing 2 products',
-      );
+      const headerTitleWrapper = resourceList.find('div', {
+        className: styles.HeaderTitleWrapper,
+      });
+      expect(headerTitleWrapper).toContainReactText('Showing 2 products');
     });
 
     it('prints number of items shown of totalItemsCount when totalItemsCount is provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           renderItem={renderItem}
@@ -249,13 +254,14 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
-        'Showing 2 of 5 products',
-      );
+      const headerTitleWrapper = resourceList.find('div', {
+        className: styles.HeaderTitleWrapper,
+      });
+      expect(headerTitleWrapper).toContainReactText('Showing 2 of 5 products');
     });
 
     it('prints number of items shown of totalItemsCount plural when totalItemsCount is provided and items is one resource', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={singleItemNoID}
           renderItem={renderItem}
@@ -265,28 +271,29 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
-        'Showing 1 of 5 products',
-      );
+      const headerTitleWrapper = resourceList.find('div', {
+        className: styles.HeaderTitleWrapper,
+      });
+      expect(headerTitleWrapper).toContainReactText('Showing 1 of 5 products');
     });
   });
 
   describe('bulkActionsAccessibilityLabel', () => {
     it('provides the BulkActions with the right accessibilityLabel if there’s 1 item and it isn’t selected', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={singleItemWithID}
           renderItem={renderItem}
           bulkActions={bulkActions}
         />,
       );
-      expect(resourceList.find(BulkActions).prop('accessibilityLabel')).toBe(
-        'Select item',
-      );
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        accessibilityLabel: 'Select item',
+      });
     });
 
     it('provides the BulkActions with the right accessibilityLabel if there’s 1 item and it is selected', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={singleItemWithID}
           renderItem={renderItem}
@@ -294,13 +301,13 @@ describe('<ResourceList />', () => {
           selectedItems={['1']}
         />,
       );
-      expect(resourceList.find(BulkActions).prop('accessibilityLabel')).toBe(
-        'Deselect item',
-      );
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        accessibilityLabel: 'Deselect item',
+      });
     });
 
     it('provides the BulkActions with the right accessibilityLabel if there are multiple items and they are selected', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           renderItem={renderItem}
@@ -308,28 +315,29 @@ describe('<ResourceList />', () => {
           selectedItems={['5', '6', '7']}
         />,
       );
-      expect(resourceList.find(BulkActions).prop('accessibilityLabel')).toBe(
-        'Deselect all 3 items',
-      );
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        accessibilityLabel: 'Deselect all 3 items',
+      });
     });
+
     it('provides the BulkActions with the right accessibilityLabel if there’s multiple items and some or none are selected', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           renderItem={renderItem}
           bulkActions={bulkActions}
         />,
       );
-      expect(resourceList.find(BulkActions).prop('accessibilityLabel')).toBe(
-        'Select all 3 items',
-      );
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        accessibilityLabel: 'Select all 3 items',
+      });
     });
   });
 
   describe('onSelectionChange()', () => {
     it('calls onSelectionChange() when an item is clicked', () => {
       const onSelectionChange = jest.fn();
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           selectedItems={[]}
@@ -338,24 +346,26 @@ describe('<ResourceList />', () => {
           onSelectionChange={onSelectionChange}
         />,
       );
-      const firstItem = resourceList.find(ResourceItem).first();
-      findByTestID(firstItem, 'LargerSelectionArea').simulate('click');
+      resourceList.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
       expect(onSelectionChange).toHaveBeenCalled();
     });
   });
 
   describe('header markup', () => {
     it('renders header markup if the list isn’t selectable but the showHeader prop is true', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList showHeader items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(findByTestID(resourceList, 'ResourceList-Header').exists()).toBe(
-        true,
-      );
+      expect(resourceList).toContainReactComponent('div', {
+        className: styles.HeaderWrapper,
+      });
     });
 
     it('doesn’t render header markup if the list is selectable but the showHeader prop is false', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           showHeader={false}
           selectable
@@ -363,23 +373,28 @@ describe('<ResourceList />', () => {
           renderItem={renderItem}
         />,
       );
-      expect(findByTestID(resourceList, 'ResourceList-Header').exists()).toBe(
-        false,
-      );
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderWrapper,
+      });
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderContentWrapper,
+      });
     });
 
     it('does not render when items is empty', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={[]} renderItem={renderItem} />,
       );
-
-      expect(findByTestID(resourceList, 'ResourceList-Header').exists()).toBe(
-        false,
-      );
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderWrapper,
+      });
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderContentWrapper,
+      });
     });
 
     it('renders when sort options are given', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           sortOptions={sortOptions}
           onSortChange={noop}
@@ -387,98 +402,128 @@ describe('<ResourceList />', () => {
           renderItem={renderItem}
         />,
       );
-      expect(findByTestID(resourceList, 'ResourceList-Header').exists()).toBe(
-        true,
-      );
+      expect(resourceList).toContainReactComponent('div', {
+        className: classNames(
+          styles.HeaderWrapper,
+          styles['HeaderWrapper-hasSort'],
+        ),
+      });
     });
 
     it('renders when an alternateTool is provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           alternateTool={alternateTool}
           items={itemsWithID}
           renderItem={renderItem}
         />,
       );
-      expect(findByTestID(resourceList, 'ResourceList-Header').exists()).toBe(
-        true,
-      );
+      expect(resourceList).toContainReactComponent('div', {
+        className: classNames(
+          styles.HeaderWrapper,
+          styles['HeaderWrapper-hasAlternateTool'],
+        ),
+      });
     });
 
     it('renders when bulkActions are given', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           bulkActions={bulkActions}
           items={itemsWithID}
           renderItem={renderItem}
         />,
       );
-      expect(findByTestID(resourceList, 'ResourceList-Header').exists()).toBe(
-        true,
-      );
+      expect(resourceList).toContainReactComponent('div', {
+        className: classNames(
+          styles.HeaderWrapper,
+          styles['HeaderWrapper-hasSelect'],
+        ),
+      });
     });
 
     it('renders when promotedBulkActions are given', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           promotedBulkActions={promotedBulkActions}
           items={itemsWithID}
           renderItem={renderItem}
         />,
       );
-      expect(findByTestID(resourceList, 'ResourceList-Header').exists()).toBe(
-        true,
-      );
+      expect(resourceList).toContainReactComponent('div', {
+        className: classNames(
+          styles.HeaderWrapper,
+          styles['HeaderWrapper-hasSelect'],
+        ),
+      });
     });
 
     it('does not render when sort options, bulkActions and promotedBulkActions are not given', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(findByTestID(resourceList, 'ResourceList-Header').exists()).toBe(
-        false,
-      );
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderWrapper,
+      });
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderContentWrapper,
+      });
     });
 
     it('renders on non-initial load when items are provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           bulkActions={bulkActions}
           items={[]}
           renderItem={renderItem}
         />,
       );
-
-      expect(findByTestID(resourceList, 'ResourceList-Header')).toHaveLength(0);
+      // initially not rendered
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderWrapper,
+      });
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderContentWrapper,
+      });
+      // update props
       resourceList.setProps({items: itemsWithID});
-      resourceList.update();
-      expect(findByTestID(resourceList, 'ResourceList-Header')).toHaveLength(1);
+      // now it's rendered
+      expect(resourceList).toContainReactComponent('div', {
+        className: classNames(
+          styles.HeaderWrapper,
+          styles['HeaderWrapper-hasSelect'],
+        ),
+      });
     });
 
     it('does not render when EmptySearchResult exists', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={[]}
           renderItem={renderItem}
           filterControl={<div>fake filterControl</div>}
         />,
       );
-
-      expect(resourceList.find(EmptySearchResult).exists()).toBe(true);
-      expect(findByTestID(resourceList, 'ResourceList-Header')).toHaveLength(0);
+      expect(resourceList).toContainReactComponent(EmptySearchResult);
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderWrapper,
+      });
+      expect(resourceList).not.toContainReactComponent('div', {
+        className: styles.HeaderContentWrapper,
+      });
     });
   });
 
   describe('filterControl', () => {
     it('renders when exists', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           renderItem={renderItem}
           filterControl={<div id="test123">Test</div>}
         />,
       );
-      expect(resourceList.find('#test123').exists()).toBe(true);
+      expect(resourceList).toContainReactComponent('div', {id: 'test123'});
     });
   });
 
@@ -497,7 +542,7 @@ describe('<ResourceList />', () => {
         </EmptyState>
       );
 
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={[]}
           renderItem={renderItem}
@@ -505,7 +550,7 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(EmptyState)).toHaveLength(1);
+      expect(resourceList).toContainReactComponentTimes(EmptyState, 1);
     });
 
     it('does not render when exists but items are provided', () => {
@@ -522,7 +567,7 @@ describe('<ResourceList />', () => {
         </EmptyState>
       );
 
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           renderItem={renderItem}
@@ -530,7 +575,7 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(EmptyState)).toHaveLength(0);
+      expect(resourceList).not.toContainReactComponent(EmptyState);
     });
 
     it('does not render when exists, items is empty, but loading is true', () => {
@@ -547,7 +592,7 @@ describe('<ResourceList />', () => {
         </EmptyState>
       );
 
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           loading
           items={[]}
@@ -556,42 +601,42 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(EmptyState)).toHaveLength(0);
+      expect(resourceList).not.toContainReactComponent(EmptyState);
     });
   });
 
   describe('<EmptySearchResult />', () => {
     it('renders when filterControl exists and items is empty', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={[]}
           renderItem={renderItem}
           filterControl={<div>fake filterControl</div>}
         />,
       );
-      expect(resourceList.find(EmptySearchResult).exists()).toBe(true);
+      expect(resourceList).toContainReactComponent(EmptySearchResult);
     });
 
     it('does not render when filterControl does not exist', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={[]} renderItem={renderItem} />,
       );
-      expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent(EmptySearchResult);
     });
 
     it('does not render when items is not empty', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           renderItem={renderItem}
           filterControl={<div id="test123">Test</div>}
         />,
       );
-      expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent(EmptySearchResult);
     });
 
     it('does not render when filterControl exists, items is empty, and loading is true', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={[]}
           renderItem={renderItem}
@@ -599,7 +644,7 @@ describe('<ResourceList />', () => {
           loading
         />,
       );
-      expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent(EmptySearchResult);
     });
 
     it('does not render when filterControl exists, items is empty, and emptyState is set', () => {
@@ -616,7 +661,7 @@ describe('<ResourceList />', () => {
         </EmptyState>
       );
 
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={[]}
           renderItem={renderItem}
@@ -625,11 +670,11 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent(EmptySearchResult);
     });
 
     it('renders the provided markup when emptySearchState is set', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={[]}
           renderItem={renderItem}
@@ -640,21 +685,23 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
-      expect(resourceList.find('div#emptySearchState').exists()).toBe(true);
+      expect(resourceList).not.toContainReactComponent(EmptySearchResult);
+      expect(resourceList).toContainReactComponent('div', {
+        id: 'emptySearchState',
+      });
     });
   });
 
   describe('Sorting', () => {
     it('does not render a sort select if sortOptions aren’t provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(resourceList.find(Select).exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent(Select);
     });
 
     it('renders a sort select if sortOptions are provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           sortOptions={sortOptions}
@@ -662,11 +709,11 @@ describe('<ResourceList />', () => {
           renderItem={renderItem}
         />,
       );
-      expect(resourceList.find(Select).exists()).toBe(true);
+      expect(resourceList).toContainReactComponent(Select);
     });
 
     it('does not render a sort select if an alternateTool is provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           renderItem={renderItem}
@@ -675,12 +722,12 @@ describe('<ResourceList />', () => {
           alternateTool={alternateTool}
         />,
       );
-      expect(resourceList.find(Select).exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent(Select);
     });
 
     describe('sortOptions', () => {
       it('passes a sortOptions to the Select options', () => {
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             items={itemsWithID}
             sortOptions={sortOptions}
@@ -688,17 +735,16 @@ describe('<ResourceList />', () => {
             renderItem={renderItem}
           />,
         );
-        expect(resourceList.find(Select).props()).toHaveProperty(
-          'options',
-          sortOptions,
-        );
+        expect(resourceList).toContainReactComponent(Select, {
+          options: sortOptions,
+        });
       });
     });
 
     describe('sortValue', () => {
       it('passes a sortValue to the Select value', () => {
         const onSortChange = jest.fn();
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             items={itemsWithID}
             sortOptions={sortOptions}
@@ -707,17 +753,16 @@ describe('<ResourceList />', () => {
             renderItem={renderItem}
           />,
         );
-        expect(resourceList.find(Select).props()).toHaveProperty(
-          'value',
-          'sortValue',
-        );
+        expect(resourceList).toContainReactComponent(Select, {
+          value: 'sortValue',
+        });
       });
     });
 
     describe('onSortChange', () => {
       it('calls onSortChange when the Sort Select changes', () => {
         const onSortChange = jest.fn();
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             items={itemsWithID}
             onSortChange={onSortChange}
@@ -725,7 +770,7 @@ describe('<ResourceList />', () => {
             renderItem={renderItem}
           />,
         );
-        trigger(resourceList.find(Select), 'onChange', 'PRODUCT_TITLE_DESC');
+        resourceList.find(Select)!.trigger('onChange', 'PRODUCT_TITLE_DESC');
         expect(onSortChange).toHaveBeenCalledWith('PRODUCT_TITLE_DESC');
       });
     });
@@ -733,25 +778,29 @@ describe('<ResourceList />', () => {
 
   describe('Alternate Tool', () => {
     it('does not render if an alternateTool is not provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(resourceList.find('#AlternateTool').exists()).toBe(false);
+      expect(resourceList).not.toContainReactComponent('div', {
+        id: 'AlternateTool',
+      });
     });
 
     it('renders if an alternateTool is provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           renderItem={renderItem}
           alternateTool={alternateTool}
         />,
       );
-      expect(resourceList.find('#AlternateTool').exists()).toBe(true);
+      expect(resourceList).toContainReactComponent('div', {
+        id: 'AlternateTool',
+      });
     });
 
     it('renders even if sortOptions are provided', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           renderItem={renderItem}
@@ -759,12 +808,14 @@ describe('<ResourceList />', () => {
           alternateTool={alternateTool}
         />,
       );
-      expect(resourceList.find('#AlternateTool').exists()).toBe(true);
+      expect(resourceList).toContainReactComponent('div', {
+        id: 'AlternateTool',
+      });
     });
 
     describe('sortOptions', () => {
       it('passes a sortOptions to the Select options', () => {
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             items={itemsWithID}
             sortOptions={sortOptions}
@@ -772,17 +823,16 @@ describe('<ResourceList />', () => {
             onSortChange={noop}
           />,
         );
-        expect(resourceList.find(Select).props()).toHaveProperty(
-          'options',
-          sortOptions,
-        );
+        expect(resourceList).toContainReactComponent(Select, {
+          options: sortOptions,
+        });
       });
     });
 
     describe('sortValue', () => {
       it('passes a sortValue to the Select value', () => {
         const onSortChange = jest.fn();
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             items={itemsWithID}
             sortOptions={sortOptions}
@@ -791,17 +841,16 @@ describe('<ResourceList />', () => {
             renderItem={renderItem}
           />,
         );
-        expect(resourceList.find(Select).props()).toHaveProperty(
-          'value',
-          'sortValue',
-        );
+        expect(resourceList).toContainReactComponent(Select, {
+          value: 'sortValue',
+        });
       });
     });
 
     describe('onSortChange', () => {
       it('calls onSortChange when the Sort Select changes', () => {
         const onSortChange = jest.fn();
-        const resourceList = mountWithAppProvider(
+        const resourceList = mountWithApp(
           <ResourceList
             items={itemsWithID}
             onSortChange={onSortChange}
@@ -809,7 +858,7 @@ describe('<ResourceList />', () => {
             renderItem={renderItem}
           />,
         );
-        trigger(resourceList.find(Select), 'onChange', 'PRODUCT_TITLE_DESC');
+        resourceList.find(Select)!.trigger('onChange', 'PRODUCT_TITLE_DESC');
         expect(onSortChange).toHaveBeenCalledWith('PRODUCT_TITLE_DESC');
       });
     });
@@ -817,7 +866,7 @@ describe('<ResourceList />', () => {
 
   describe('loading', () => {
     it('renders a spinner', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           sortOptions={sortOptions}
@@ -827,11 +876,11 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(Spinner).exists()).toBe(true);
+      expect(resourceList).toContainReactComponent(Spinner);
     });
 
     it('renders a spinner after initial load when loading is true', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           sortOptions={sortOptions}
@@ -841,11 +890,11 @@ describe('<ResourceList />', () => {
       );
 
       resourceList.setProps({loading: true});
-      expect(resourceList.find(Spinner).exists()).toBe(true);
+      expect(resourceList).toContainReactComponent(Spinner);
     });
 
     it('does not render an <Item /> if loading is true and there are no items', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={[]}
           sortOptions={sortOptions}
@@ -855,13 +904,13 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(ResourceItem)).toHaveLength(0);
+      expect(resourceList).not.toContainReactComponent(ResourceItem);
     });
   });
 
   describe('BulkActions', () => {
     it('renders on initial load when items are selected', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={singleItemWithID}
           renderItem={renderItem}
@@ -869,11 +918,11 @@ describe('<ResourceList />', () => {
           selectedItems={['1']}
         />,
       );
-      expect(resourceList.find(BulkActions)).toHaveLength(1);
+      expect(resourceList).toContainReactComponentTimes(BulkActions, 1);
     });
 
     it('enables select mode when items are programmatically selected', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={singleItemWithID}
           renderItem={renderItem}
@@ -882,14 +931,17 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(BulkActions).prop('selectMode')).toBe(false);
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        selectMode: false,
+      });
       resourceList.setProps({selectedItems: ['1']});
-      resourceList.update();
-      expect(resourceList.find(BulkActions).prop('selectMode')).toBe(true);
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        selectMode: true,
+      });
     });
 
     it('disables select mode when items are deselected programmatically selected', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={singleItemWithID}
           renderItem={renderItem}
@@ -898,10 +950,13 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(resourceList.find(BulkActions).prop('selectMode')).toBe(true);
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        selectMode: true,
+      });
       resourceList.setProps({selectedItems: []});
-      resourceList.update();
-      expect(resourceList.find(BulkActions).prop('selectMode')).toBe(false);
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        selectMode: false,
+      });
     });
 
     describe('focus', () => {
@@ -1029,7 +1084,7 @@ describe('<ResourceList />', () => {
         return item.id;
       }
       const onSelectionChange = jest.fn();
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           selectedItems={[]}
@@ -1039,20 +1094,23 @@ describe('<ResourceList />', () => {
           resolveItemId={resolveItemId}
         />,
       );
-      const firstItem = resourceList.find(ResourceItem).first();
-      findByTestID(firstItem, 'LargerSelectionArea').simulate('click');
-
-      const lastItem = resourceList.find(ResourceItem).last();
-      findByTestID(lastItem, 'LargerSelectionArea').simulate('click', {
+      const firstItem = resourceList.find(ResourceItem);
+      firstItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
+      const allItems = resourceList.findAll(ResourceItem);
+      const lastItem = allItems[allItems.length - 1];
+      lastItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
-
       expect(onSelectionChange).toHaveBeenCalledWith(['5', '6', '7']);
     });
 
     it('does not select shift selected items if resolveItemId was not provided', () => {
       const onSelectionChange = jest.fn();
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           selectedItems={[]}
@@ -1061,11 +1119,15 @@ describe('<ResourceList />', () => {
           onSelectionChange={onSelectionChange}
         />,
       );
-      const firstItem = resourceList.find(ResourceItem).first();
-      findByTestID(firstItem, 'LargerSelectionArea').simulate('click');
-
-      const lastItem = resourceList.find(ResourceItem).last();
-      findByTestID(lastItem, 'LargerSelectionArea').simulate('click', {
+      const firstItem = resourceList.find(ResourceItem);
+      firstItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
+      const allItems = resourceList.findAll(ResourceItem);
+      const lastItem = allItems[allItems.length - 1];
+      lastItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
 
@@ -1091,7 +1153,7 @@ describe('<ResourceList />', () => {
       }
 
       const onSelectionChange = jest.fn();
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           selectedItems={[]}
@@ -1101,11 +1163,15 @@ describe('<ResourceList />', () => {
           resolveItemId={resolveItemId}
         />,
       );
-      const firstItem = resourceList.find(ResourceItem).first();
-      findByTestID(firstItem, 'LargerSelectionArea').simulate('click');
-
-      const lastItem = resourceList.find(ResourceItem).last();
-      findByTestID(lastItem, 'LargerSelectionArea').simulate('click', {
+      const firstItem = resourceList.find(ResourceItem);
+      firstItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
+      const allItems = resourceList.findAll(ResourceItem);
+      const lastItem = allItems[allItems.length - 1];
+      lastItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
 
@@ -1118,7 +1184,7 @@ describe('<ResourceList />', () => {
         return item.id;
       }
       const onSelectionChange = jest.fn();
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           selectedItems={selectedItems}
@@ -1128,12 +1194,16 @@ describe('<ResourceList />', () => {
           resolveItemId={resolveItemId}
         />,
       );
-      // Sets {lastSeleced: 0}
-      const firstItem = resourceList.find(ResourceItem).first();
-      findByTestID(firstItem, 'LargerSelectionArea').simulate('click');
-
-      const lastItem = resourceList.find(ResourceItem).last();
-      findByTestID(lastItem, 'LargerSelectionArea').simulate('click', {
+      // Sets {lastSelected: 0}
+      const firstItem = resourceList.find(ResourceItem);
+      firstItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
+        nativeEvent: {},
+      });
+      const allItems = resourceList.findAll(ResourceItem);
+      const lastItem = allItems[allItems.length - 1];
+      lastItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+        stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
 
@@ -1147,7 +1217,7 @@ describe('<ResourceList />', () => {
     });
 
     it('an inline label is hidden on small screen', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsWithID}
           sortOptions={sortOptions}
@@ -1157,13 +1227,14 @@ describe('<ResourceList />', () => {
       );
 
       setSmallScreen();
-      trigger(resourceList.find(EventListener), 'handler');
-
-      expect(resourceList.find(Select).first().prop('labelInline')).toBe(false);
+      resourceList.find(EventListener)!.trigger('handler');
+      expect(resourceList).toContainReactComponent(Select, {
+        labelInline: false,
+      });
     });
 
     it('select mode is turned off on large screen when no items are selected', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={singleItemWithID}
           renderItem={renderItem}
@@ -1172,15 +1243,17 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      trigger(resourceList.find(BulkActions), 'onSelectModeToggle', true);
-      trigger(resourceList.find(EventListener).first(), 'handler');
-      expect(resourceList.find(BulkActions).prop('selectMode')).toBe(false);
+      resourceList.find(BulkActions)!.trigger('onSelectModeToggle', true);
+      resourceList.find(EventListener)!.trigger('handler');
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        selectMode: false,
+      });
     });
   });
 
   describe('isFiltered', () => {
     it('renders `selectAllFilteredItems` label if true', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           resourceName={{singular: 'customer', plural: 'customers'}}
@@ -1191,11 +1264,11 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(
-        resourceList.find(BulkActions).prop('paginatedSelectAllAction'),
-      ).toStrictEqual({
-        content: 'Select all 2+ customers in this filter',
-        onAction: expect.any(Function),
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        paginatedSelectAllAction: {
+          content: 'Select all 2+ customers in this filter',
+          onAction: expect.any(Function),
+        },
       });
     });
 
@@ -1215,13 +1288,13 @@ describe('<ResourceList />', () => {
 
       resourceList.find(BulkActions)!.find(Button)!.trigger('onClick');
 
-      expect(
-        resourceList.find(BulkActions)!.prop('paginatedSelectAllText'),
-      ).toBe('All 2+ customers in this filter are selected.');
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        paginatedSelectAllText: 'All 2+ customers in this filter are selected.',
+      });
     });
 
     it('renders `selectAllItems` label if not passed', () => {
-      const resourceList = mountWithAppProvider(
+      const resourceList = mountWithApp(
         <ResourceList
           items={itemsNoID}
           resourceName={{singular: 'customer', plural: 'customers'}}
@@ -1231,11 +1304,11 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      expect(
-        resourceList.find(BulkActions).prop('paginatedSelectAllAction'),
-      ).toStrictEqual({
-        content: 'Select all 2+ customers in your store',
-        onAction: expect.any(Function),
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        paginatedSelectAllAction: {
+          content: 'Select all 2+ customers in your store',
+          onAction: expect.any(Function),
+        },
       });
     });
 
@@ -1254,9 +1327,9 @@ describe('<ResourceList />', () => {
 
       resourceList.find(BulkActions)!.find(Button)!.trigger('onClick');
 
-      expect(
-        resourceList.find(BulkActions)!.prop('paginatedSelectAllText'),
-      ).toBe('All 2+ customers in your store are selected.');
+      expect(resourceList).toContainReactComponent(BulkActions, {
+        paginatedSelectAllText: 'All 2+ customers in your store are selected.',
+      });
     });
   });
 });

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -14,9 +14,7 @@ import {SELECT_ALL_ITEMS} from 'utilities/resource-list';
 
 import {BulkActions} from '../../BulkActions';
 import {CheckableButton} from '../../CheckableButton';
-
 import {classNames} from '../../../utilities/css';
-
 import styles from '../ResourceList.scss';
 
 const itemsNoID = [{url: 'item 1'}, {url: 'item 2'}];
@@ -143,10 +141,9 @@ describe('<ResourceList />', () => {
           bulkActions={bulkActions}
         />,
       );
-      expect(resourceList).toContainReactComponent(BulkActions);
       expect(
         resourceList.find(BulkActions)!.props.paginatedSelectAllAction,
-      ).not.toBe(undefined);
+      ).not.toBeUndefined();
     });
   });
 

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -14,7 +14,6 @@ import {SELECT_ALL_ITEMS} from 'utilities/resource-list';
 
 import {BulkActions} from '../../BulkActions';
 import {CheckableButton} from '../../CheckableButton';
-import {classNames} from '../../../utilities/css';
 import styles from '../ResourceList.scss';
 
 const itemsNoID = [{url: 'item 1'}, {url: 'item 2'}];
@@ -371,10 +370,7 @@ describe('<ResourceList />', () => {
         />,
       );
       expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderWrapper,
-      });
-      expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderContentWrapper,
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
 
@@ -383,10 +379,7 @@ describe('<ResourceList />', () => {
         <ResourceList items={[]} renderItem={renderItem} />,
       );
       expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderWrapper,
-      });
-      expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderContentWrapper,
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
 
@@ -400,10 +393,7 @@ describe('<ResourceList />', () => {
         />,
       );
       expect(resourceList).toContainReactComponent('div', {
-        className: classNames(
-          styles.HeaderWrapper,
-          styles['HeaderWrapper-hasSort'],
-        ),
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
 
@@ -416,10 +406,7 @@ describe('<ResourceList />', () => {
         />,
       );
       expect(resourceList).toContainReactComponent('div', {
-        className: classNames(
-          styles.HeaderWrapper,
-          styles['HeaderWrapper-hasAlternateTool'],
-        ),
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
 
@@ -432,10 +419,7 @@ describe('<ResourceList />', () => {
         />,
       );
       expect(resourceList).toContainReactComponent('div', {
-        className: classNames(
-          styles.HeaderWrapper,
-          styles['HeaderWrapper-hasSelect'],
-        ),
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
 
@@ -448,10 +432,7 @@ describe('<ResourceList />', () => {
         />,
       );
       expect(resourceList).toContainReactComponent('div', {
-        className: classNames(
-          styles.HeaderWrapper,
-          styles['HeaderWrapper-hasSelect'],
-        ),
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
 
@@ -460,10 +441,7 @@ describe('<ResourceList />', () => {
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
       expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderWrapper,
-      });
-      expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderContentWrapper,
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
 
@@ -477,19 +455,13 @@ describe('<ResourceList />', () => {
       );
       // initially not rendered
       expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderWrapper,
-      });
-      expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderContentWrapper,
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
       // update props
       resourceList.setProps({items: itemsWithID});
       // now it's rendered
       expect(resourceList).toContainReactComponent('div', {
-        className: classNames(
-          styles.HeaderWrapper,
-          styles['HeaderWrapper-hasSelect'],
-        ),
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
 
@@ -503,10 +475,7 @@ describe('<ResourceList />', () => {
       );
       expect(resourceList).toContainReactComponent(EmptySearchResult);
       expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderWrapper,
-      });
-      expect(resourceList).not.toContainReactComponent('div', {
-        className: styles.HeaderContentWrapper,
+        className: expect.stringContaining(styles.HeaderWrapper),
       });
     });
   });

--- a/src/test-utilities/react-testing.tsx
+++ b/src/test-utilities/react-testing.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createMount, mount} from '@shopify/react-testing';
+import {createMount, mount, Node} from '@shopify/react-testing';
 
 import translations from '../../locales/en.json';
 import {
@@ -7,7 +7,7 @@ import {
   WithPolarisTestProviderOptions,
 } from '../components';
 
-export {createMount, mount};
+export {createMount, mount, Node};
 
 export const mountWithApp = createMount<
   WithPolarisTestProviderOptions,

--- a/src/test-utilities/react-testing.tsx
+++ b/src/test-utilities/react-testing.tsx
@@ -7,7 +7,8 @@ import {
   WithPolarisTestProviderOptions,
 } from '../components';
 
-export {createMount, mount, Node};
+export {createMount, mount};
+export type {Node};
 
 export const mountWithApp = createMount<
   WithPolarisTestProviderOptions,


### PR DESCRIPTION
### WHY are these changes introduced?

Modernizes tests to use the new modern framework (`{mountWithApp}` from `test-utilities`).

### WHAT is this pull request doing?

Updates tests using `{mountWithAppProvider}` from `test-utilities/legacy` to use `{mountWithApp}` from `test-utilities`