### PR TITLE
[MenuGroup] Add fullWidth prop to page actionGroups popover

### DIFF
--- a/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
@@ -66,6 +66,7 @@ export function MenuGroup({
       preferredAlignment="left"
       onClose={handleClose}
       hideOnPrint
+      fullWidth
     >
       <ActionList items={actions} onActionAnyItem={handleClose} />
       {details && <div className={styles.Details}>{details}</div>}

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -223,7 +223,10 @@ export class PositionedOverlay extends PureComponent<
         const scrollableContainerRect = getRectForNode(scrollableElement);
 
         const overlayRect = fullWidth
-          ? new Rect({...currentOverlayRect, width: activatorRect.width})
+          ? new Rect({
+              ...currentOverlayRect,
+              width: Math.max(activatorRect.width, currentOverlayRect.width),
+            })
           : currentOverlayRect;
 
         // If `body` is 100% height, it still acts as though it were not constrained to that size. This adjusts for that.


### PR DESCRIPTION
### WHY are these changes introduced?

Right now a pages action group is left aligned and this can look quite jarring if the content of the actions within the group is short. Defaulting to `fullwidth` would prevent things like this:

<img width="243" alt="Screen Shot 2021-08-16 at 5 04 28 PM" src="https://user-images.githubusercontent.com/18032127/129623018-18e4440f-8a69-42ab-85a0-16474e9b3af1.png">


### WHAT is this pull request doing?

This PR
- adds the `fullWidth` prop to the Popover rendered by MenuGroup.
- slightly changes behaviour of the `PositionedOverlay` component's `fullWidth` prop to make the overlay take on the width of the larger value between the `currentOverlayRect` and the `activatorRect`. (So if the overlay rect is smaller than the width of the activator it takes on the activator width and if it is larger then it just takes on its own width)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
