### PR TITLE
 [Test Modernization] Modernizing Filters and Form tests.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -73,5 +73,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Pane, Section, PositionedOverlay, SingleThumb, RangeSlider, and ConnectedFilter components ([#4429](https://github.com/Shopify/polaris-react/pull/4429))
 - Modernized tests for ContextualSaveBar and DataTable and its subcomponents ([#4397](https://github.com/Shopify/polaris-react/pull/4397))
 - Modernized tests for IndexTable, Indicator, InlineError, KeyboardKey, and KeypressListener components([#4431](https://github.com/Shopify/polaris-react/pull/4431))
+- Modernized tests for Form and Filters components ([#4434](https://github.com/Shopify/polaris-react/pull/4434)).
 
 ### Deprecations

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -150,11 +150,7 @@ class FiltersInner extends Component<CombinedProps, State> {
     const backdropMarkup = open ? (
       <>
         <ScrollLock />
-        <div
-          className={styles.Backdrop}
-          onClick={this.closeFilters}
-          testID="Backdrop"
-        />
+        <div className={styles.Backdrop} onClick={this.closeFilters} />
       </>
     ) : null;
 
@@ -233,11 +229,7 @@ class FiltersInner extends Component<CombinedProps, State> {
 
     const rightActionMarkup = filters.length ? (
       <div ref={this.moreFiltersButtonContainer}>
-        <Button
-          onClick={this.toggleFilters}
-          testID="SheetToggleButton"
-          disabled={disabled}
-        >
+        <Button onClick={this.toggleFilters} disabled={disabled}>
           {moreFiltersLabel}
         </Button>
       </div>

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -9,6 +9,11 @@ import {
   TextStyle,
   ButtonProps,
 } from 'components';
+import {
+  findByTestID,
+  mountWithAppProvider,
+  trigger,
+} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
 import {WithinFilterContext} from '../../../utilities/within-filter-context';
@@ -16,8 +21,6 @@ import {Filters, FiltersProps} from '../Filters';
 import {ConnectedFilterControl, TagsWrapper} from '../components';
 import {Collapsible} from '../../Collapsible';
 import * as focusUtils from '../../../utilities/focus';
-import {classNames} from '../../../utilities/css';
-import styles from '../Filters.scss';
 
 const MockFilter = (props: {id: string}) => <div id={props.id} />;
 const MockChild = () => <div />;
@@ -342,49 +345,21 @@ describe('<Filters />', () => {
       });
     });
 
-    it.only('toggles a shortcut filter', () => {
-      const resourceFilters = mountWithApp(
+    it('toggles a shortcut filter', () => {
+      const resourceFilters = mountWithAppProvider(
         <Filters {...mockPropsWithShortcuts} />,
       );
 
-      let connected = resourceFilters.find(ConnectedFilterControl);
-      connected!.instance.setState({availableWidth: 999});
-      connected = resourceFilters.find(ConnectedFilterControl);
-      // console.log(
-      //   ':::: connected:',
-      //   connected?.domNodes[1].children[0].children,
-      // );
-      const shortcut = connected!
-        .find('div')!
-        .findWhere((node) => {
-          node!.domNodes.forEach((domNode) => {
-            console.log(':::: domNode.classList:', domNode.classList);
-            const contains = domNode.classList.contains(styles.ResourceItem);
-            if (contains) {
-              return true;
-            }
-          });
-        })!
-        .find(Button);
-      // const shortcut = connected!
-      //   .find('div', {className: 'RightContainer'})!
-      //   .find(Button);
+      const connected = resourceFilters.find(ConnectedFilterControl).first();
+      connected.setState({availableWidth: 999});
+      const shortcut = findByTestID(resourceFilters, 'FilterShortcutContainer')
+        .find(Button)
+        .first();
 
-      shortcut!.trigger('onClick');
-      expect(resourceFilters).toContainReactComponent(Popover, {active: true});
-      shortcut!.trigger('onClick');
-      expect(resourceFilters).toContainReactComponent(Popover, {active: false});
-
-      // const connected = resourceFilters.find(ConnectedFilterControl).first();
-      // connected.setState({availableWidth: 999});
-      // const shortcut = findByTestID(resourceFilters, 'FilterShortcutContainer')
-      //   .find(Button)
-      //   .first();
-
-      // trigger(shortcut, 'onClick');
-      // expect(resourceFilters.find(Popover).first().props().active).toBe(true);
-      // trigger(shortcut, 'onClick');
-      // expect(resourceFilters.find(Popover).first().props().active).toBe(false);
+      trigger(shortcut, 'onClick');
+      expect(resourceFilters.find(Popover).first().props().active).toBe(true);
+      trigger(shortcut, 'onClick');
+      expect(resourceFilters.find(Popover).first().props().active).toBe(false);
     });
 
     it('receives the expected props when there are no shortcut filters', () => {

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -375,7 +375,7 @@ describe('<Filters />', () => {
         <Filters {...mockProps} filters={[]} />,
       );
       expect(resourceFilters).not.toContainReactComponent(Button, {
-        testID: 'SheetToggleButton',
+        children: 'More filters',
       } as ButtonProps);
     });
   });

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -9,6 +9,7 @@ import {
   TextStyle,
   ButtonProps,
 } from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {
   findByTestID,
   mountWithAppProvider,
@@ -277,9 +278,8 @@ describe('<Filters />', () => {
       );
 
       expect(
-        resourceFilters.find(ConnectedFilterControl)!.props[
-          'rightPopoverableActions'
-        ],
+        resourceFilters.find(ConnectedFilterControl)!.props
+          .rightPopoverableActions,
       ).toHaveLength(2);
     });
 
@@ -338,7 +338,7 @@ describe('<Filters />', () => {
 
       const rightPopoverableActions = resourceFilters.find(
         ConnectedFilterControl,
-      )!.props['rightPopoverableActions'];
+      )!.props.rightPopoverableActions;
 
       rightPopoverableActions!.forEach((action) => {
         expect(action.popoverOpen).toBe(false);
@@ -420,7 +420,8 @@ describe('<Filters />', () => {
         id: 'filterOneCollapsible',
       });
       const buttons = collapsible!.findAll(Button);
-      const clearButton = buttons[buttons.length - 1]; // last button
+      // last button
+      const clearButton = buttons[buttons.length - 1];
 
       clearButton!.trigger('onClick');
 
@@ -549,11 +550,12 @@ describe('<Filters />', () => {
         .find(Button, {children: 'More filters'})!
         .trigger('onClick');
 
-      let clearAllButton = resourceFilters.find(Button, {
-        children: 'Clear all filters',
-        disabled: false,
-      });
-      clearAllButton!.trigger('onClick');
+      resourceFilters
+        .find(Button, {
+          children: 'Clear all filters',
+          disabled: false,
+        })!
+        .trigger('onClick');
 
       expect(resourceFilters).toContainReactComponent(Button, {
         children: 'Clear all filters',

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -9,19 +9,15 @@ import {
   TextStyle,
   ButtonProps,
 } from 'components';
-// eslint-disable-next-line no-restricted-imports
-import {
-  mountWithAppProvider,
-  trigger,
-  findByTestID,
-  ReactWrapper,
-} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
 import {WithinFilterContext} from '../../../utilities/within-filter-context';
 import {Filters, FiltersProps} from '../Filters';
 import {ConnectedFilterControl, TagsWrapper} from '../components';
+import {Collapsible} from '../../Collapsible';
 import * as focusUtils from '../../../utilities/focus';
+import {classNames} from '../../../utilities/css';
+import styles from '../Filters.scss';
 
 const MockFilter = (props: {id: string}) => <div id={props.id} />;
 const MockChild = () => <div />;
@@ -77,126 +73,154 @@ describe('<Filters />', () => {
 
   it('calls the onQueryFocus callback when the query field is focused', () => {
     const onQueryFocus = jest.fn();
-    const filters = mountWithAppProvider(
+    const filters = mountWithApp(
       <Filters {...mockProps} onQueryFocus={onQueryFocus} />,
     );
 
-    trigger(filters.find(TextField), 'onFocus');
+    filters.find(TextField)!.trigger('onFocus');
 
     expect(onQueryFocus).toHaveBeenCalledTimes(1);
   });
 
   it('does not render the TextField when "hideQueryField" is "true"', () => {
-    const filters = mountWithAppProvider(
-      <Filters {...mockProps} hideQueryField />,
-    );
+    const filters = mountWithApp(<Filters {...mockProps} hideQueryField />);
 
-    expect(filters.find(TextField).exists()).toBe(false);
+    expect(filters).not.toContainReactComponent(TextField);
   });
 
   it('renders the TextField when "hideQueryField" is false', () => {
-    const filters = mountWithAppProvider(<Filters {...mockProps} />);
+    const filters = mountWithApp(<Filters {...mockProps} />);
 
-    expect(filters.find(TextField).exists()).toBe(true);
+    expect(filters).toContainReactComponent(TextField);
   });
 
   describe('toggleFilters()', () => {
     it('opens the sheet on toggle button click', () => {
-      const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />);
+      const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
       jest.runAllTimers();
-      expect(resourceFilters.find(Sheet).props().open).toBe(true);
+      expect(resourceFilters).toContainReactComponent(Sheet, {open: true});
     });
 
     it('closes the sheet on second toggle button click', () => {
-      const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />);
+      const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
 
-      expect(resourceFilters.find(Sheet).props().open).toBe(false);
+      expect(resourceFilters).toContainReactComponent(Sheet, {open: false});
     });
 
     describe('isMobile()', () => {
       it('renders a sheet on desktop size with right origin', () => {
-        const resourceFilters = mountWithAppProvider(
-          <Filters {...mockProps} />,
-        );
+        const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-        expect(resourceFilters.find(Sheet).exists()).toBe(true);
+        expect(resourceFilters).toContainReactComponent(Sheet);
       });
 
       it('renders a sheet on mobile size with bottom origin', () => {
         matchMedia.setMedia(() => ({matches: true}));
-        const resourceFilters = mountWithAppProvider(
-          <Filters {...mockProps} />,
-        );
+        const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-        expect(resourceFilters.find(Sheet).exists()).toBe(true);
+        expect(resourceFilters).toContainReactComponent(Sheet);
       });
 
       it('opens the sheet at mobile size on toggle button click', () => {
         matchMedia.setMedia(() => ({matches: true}));
-        const resourceFilters = mountWithAppProvider(
-          <Filters {...mockProps} />,
-        );
+        const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-        trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-        expect(resourceFilters.find(Sheet).props().open).toBe(true);
+        resourceFilters
+          .find(Button, {children: 'More filters'})!
+          .trigger('onClick');
+
+        expect(resourceFilters).toContainReactComponent(Sheet, {open: true});
       });
 
       it('closes the sheet at mobile size on second toggle button click', () => {
         matchMedia.setMedia(() => ({matches: true}));
-        const resourceFilters = mountWithAppProvider(
-          <Filters {...mockProps} />,
-        );
+        const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-        trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-        trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
+        resourceFilters
+          .find(Button, {children: 'More filters'})!
+          .trigger('onClick');
+        resourceFilters
+          .find(Button, {children: 'More filters'})!
+          .trigger('onClick');
 
-        expect(resourceFilters.find(Sheet).props().open).toBe(false);
+        expect(resourceFilters).toContainReactComponent(Sheet, {open: false});
       });
     });
   });
 
   describe('toggleFilter()', () => {
     it('opens the filter on toggle button click', () => {
-      const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />);
+      const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-      trigger(findById(resourceFilters, 'filterOneToggleButton'), 'onClick');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
 
-      expect(
-        findById(resourceFilters, 'filterOneCollapsible').props().open,
-      ).toBe(true);
+      resourceFilters
+        .find('button', {id: 'filterOneToggleButton'})!
+        .trigger('onClick');
+
+      expect(resourceFilters).toContainReactComponent(Collapsible, {
+        id: 'filterOneCollapsible',
+        open: true,
+      });
     });
 
     it('closes the filter on second toggle button click', () => {
-      const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />);
+      const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-      trigger(findById(resourceFilters, 'filterTwoToggleButton'), 'onClick');
-      trigger(findById(resourceFilters, 'filterTwoToggleButton'), 'onClick');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
 
-      expect(
-        findById(resourceFilters, 'filterTwoCollapsible').props().open,
-      ).toBe(false);
+      const button = resourceFilters.find('button', {
+        id: 'filterTwoToggleButton',
+      });
+
+      button!.trigger('onClick');
+      button!.trigger('onClick');
+
+      expect(resourceFilters).toContainReactComponent(Collapsible, {
+        id: 'filterTwoCollapsible',
+        open: false,
+      });
     });
 
     it('does not close other filters when a filter is toggled', () => {
-      const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />);
+      const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-      trigger(findById(resourceFilters, 'filterOneToggleButton'), 'onClick');
-      trigger(findById(resourceFilters, 'filterThreeToggleButton'), 'onClick');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
 
-      expect(
-        findById(resourceFilters, 'filterOneCollapsible').props().open,
-      ).toBe(true);
-      expect(
-        findById(resourceFilters, 'filterThreeCollapsible').props().open,
-      ).toBe(true);
+      resourceFilters
+        .find('button', {id: 'filterOneToggleButton'})!
+        .trigger('onClick');
+
+      resourceFilters
+        .find('button', {id: 'filterThreeToggleButton'})!
+        .trigger('onClick');
+
+      expect(resourceFilters).toContainReactComponent(Collapsible, {
+        id: 'filterOneCollapsible',
+        open: true,
+      });
+
+      expect(resourceFilters).toContainReactComponent(Collapsible, {
+        id: 'filterThreeCollapsible',
+        open: true,
+      });
     });
   });
 
@@ -227,53 +251,53 @@ describe('<Filters />', () => {
     };
 
     it('renders', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts} />,
       );
 
-      expect(resourceFilters.find(ConnectedFilterControl).exists()).toBe(true);
+      expect(resourceFilters).toContainReactComponent(ConnectedFilterControl);
     });
 
     it('renders children', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts}>
           <MockChild />
         </Filters>,
       );
 
-      expect(resourceFilters.find(MockChild).exists()).toBe(true);
+      expect(resourceFilters).toContainReactComponent(MockChild);
     });
 
     it('receives the expected props when there are shortcut filters', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts} />,
       );
 
       expect(
-        resourceFilters.find(ConnectedFilterControl).props()
-          .rightPopoverableActions,
+        resourceFilters.find(ConnectedFilterControl)!.props[
+          'rightPopoverableActions'
+        ],
       ).toHaveLength(2);
     });
 
     it('receives the expected props when the query field is hidden', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts} hideQueryField />,
       );
 
-      expect(
-        resourceFilters.find(ConnectedFilterControl).props().queryFieldHidden,
-      ).toBe(true);
+      expect(resourceFilters).toContainReactComponent(ConnectedFilterControl, {
+        queryFieldHidden: true,
+      });
     });
 
     it('forces showing the "More Filters" button if there are filters without shortcuts', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts} />,
       );
 
-      expect(
-        resourceFilters.find(ConnectedFilterControl).props()
-          .forceShowMorefiltersButton,
-      ).toBe(true);
+      expect(resourceFilters).toContainReactComponent(ConnectedFilterControl, {
+        forceShowMorefiltersButton: true,
+      });
     });
 
     it('does not force showing the "More Filters" button if all the filters have shorcuts', () => {
@@ -296,53 +320,79 @@ describe('<Filters />', () => {
           },
         ],
       };
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts} />,
       );
-      expect(
-        resourceFilters.find(ConnectedFilterControl).props()
-          .forceShowMorefiltersButton,
-      ).toBe(false);
+      expect(resourceFilters).toContainReactComponent(ConnectedFilterControl, {
+        forceShowMorefiltersButton: false,
+      });
     });
 
     it('receives shortcut filters with popoverOpen set to false on mount', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts} />,
       );
 
-      const rightPopoverableActions = resourceFilters
-        .find(ConnectedFilterControl)
-        .props().rightPopoverableActions;
+      const rightPopoverableActions = resourceFilters.find(
+        ConnectedFilterControl,
+      )!.props['rightPopoverableActions'];
 
       rightPopoverableActions!.forEach((action) => {
         expect(action.popoverOpen).toBe(false);
       });
     });
 
-    it('toggles a shortcut filter', () => {
-      const resourceFilters = mountWithAppProvider(
+    it.only('toggles a shortcut filter', () => {
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts} />,
       );
 
-      const connected = resourceFilters.find(ConnectedFilterControl).first();
-      connected.setState({availableWidth: 999});
-      const shortcut = findByTestID(resourceFilters, 'FilterShortcutContainer')
-        .find(Button)
-        .first();
+      let connected = resourceFilters.find(ConnectedFilterControl);
+      connected!.instance.setState({availableWidth: 999});
+      connected = resourceFilters.find(ConnectedFilterControl);
+      // console.log(
+      //   ':::: connected:',
+      //   connected?.domNodes[1].children[0].children,
+      // );
+      const shortcut = connected!
+        .find('div')!
+        .findWhere((node) => {
+          node!.domNodes.forEach((domNode) => {
+            console.log(':::: domNode.classList:', domNode.classList);
+            const contains = domNode.classList.contains(styles.ResourceItem);
+            if (contains) {
+              return true;
+            }
+          });
+        })!
+        .find(Button);
+      // const shortcut = connected!
+      //   .find('div', {className: 'RightContainer'})!
+      //   .find(Button);
 
-      trigger(shortcut, 'onClick');
-      expect(resourceFilters.find(Popover).first().props().active).toBe(true);
-      trigger(shortcut, 'onClick');
-      expect(resourceFilters.find(Popover).first().props().active).toBe(false);
+      shortcut!.trigger('onClick');
+      expect(resourceFilters).toContainReactComponent(Popover, {active: true});
+      shortcut!.trigger('onClick');
+      expect(resourceFilters).toContainReactComponent(Popover, {active: false});
+
+      // const connected = resourceFilters.find(ConnectedFilterControl).first();
+      // connected.setState({availableWidth: 999});
+      // const shortcut = findByTestID(resourceFilters, 'FilterShortcutContainer')
+      //   .find(Button)
+      //   .first();
+
+      // trigger(shortcut, 'onClick');
+      // expect(resourceFilters.find(Popover).first().props().active).toBe(true);
+      // trigger(shortcut, 'onClick');
+      // expect(resourceFilters.find(Popover).first().props().active).toBe(false);
     });
 
     it('receives the expected props when there are no shortcut filters', () => {
-      const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />);
+      const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-      expect(
-        resourceFilters.find(ConnectedFilterControl).props()
-          .rightPopoverableActions,
-      ).toHaveLength(0);
+      expect(resourceFilters).toContainReactComponent(ConnectedFilterControl, {
+        rightPopoverableActions: [],
+      });
     });
 
     it('does not render the filter button when no filters are passed in', () => {
@@ -360,7 +410,7 @@ describe('<Filters />', () => {
       const spy = jest.fn();
       const appliedFilters = [{key: 'filterOne', label: 'foo', onRemove: spy}];
 
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters
           {...mockProps}
           queryValue="bar"
@@ -368,10 +418,10 @@ describe('<Filters />', () => {
         />,
       );
 
-      const tag = resourceFilters.find(Tag).first();
-      const removeButton = tag.find('button').first();
+      const tag = resourceFilters.find(Tag);
+      const removeButton = tag!.find('button');
 
-      trigger(removeButton, 'onClick');
+      removeButton!.trigger('onClick');
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith('filterOne');
     });
@@ -380,16 +430,24 @@ describe('<Filters />', () => {
       const spy = jest.fn();
       const appliedFilters = [{key: 'filterOne', label: 'foo', onRemove: spy}];
 
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockProps} appliedFilters={appliedFilters} />,
       );
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-      trigger(findById(resourceFilters, 'filterOneToggleButton'), 'onClick');
-      const collapsible = findById(resourceFilters, 'filterOneCollapsible');
-      const clearButton = collapsible.find(Button).last();
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
 
-      trigger(clearButton, 'onClick');
+      resourceFilters
+        .find('button', {id: 'filterOneToggleButton'})!
+        .trigger('onClick');
+      const collapsible = resourceFilters.find(Collapsible, {
+        id: 'filterOneCollapsible',
+      });
+      const buttons = collapsible!.findAll(Button);
+      const clearButton = buttons[buttons.length - 1]; // last button
+
+      clearButton!.trigger('onClick');
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith('filterOne');
@@ -400,18 +458,25 @@ describe('<Filters />', () => {
         {key: 'filterOne', label: 'foo', onRemove: () => {}, filter: null},
       ];
 
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockProps} filters={filters} />,
       );
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-      trigger(findById(resourceFilters, 'filterOneToggleButton'), 'onClick');
-      const collapsible = findById(resourceFilters, 'filterOneCollapsible');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
+      resourceFilters
+        .find('button', {id: 'filterOneToggleButton'})!
+        .trigger('onClick');
 
-      expect(collapsible.text().toLowerCase()).toContain('clear');
+      const collapsible = resourceFilters.find(Collapsible, {
+        id: 'filterOneCollapsible',
+      });
+
+      expect(collapsible).toContainReactText('Clear');
     });
 
-    it("doesn't renders a clear button when clearButton is not provided", () => {
+    it("doesn't render a clear button when clearButton is not provided", () => {
       const filters = [
         {
           hideClearButton: true,
@@ -422,21 +487,28 @@ describe('<Filters />', () => {
         },
       ];
 
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockProps} filters={filters} />,
       );
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-      trigger(findById(resourceFilters, 'filterOneToggleButton'), 'onClick');
-      const collapsible = findById(resourceFilters, 'filterOneCollapsible');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
+      resourceFilters
+        .find('button', {id: 'filterOneToggleButton'})!
+        .trigger('onClick');
 
-      expect(collapsible.text().toLowerCase()).not.toContain('clear');
+      const collapsible = resourceFilters.find(Collapsible, {
+        id: 'filterOneCollapsible',
+      });
+
+      expect(collapsible).not.toContainReactText('Clear');
     });
 
     it('tags are not shown if hideTags prop is given', () => {
       const appliedFilters = [{key: 'filterOne', label: 'foo', onRemove: noop}];
 
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters
           {...mockProps}
           queryValue=""
@@ -444,7 +516,7 @@ describe('<Filters />', () => {
           hideTags
         />,
       );
-      expect(resourceFilters.find(Tag)).toHaveLength(0);
+      expect(resourceFilters).not.toContainReactComponent(Tag);
     });
 
     it('hides the tags container when applied filters are not provided', () => {
@@ -468,7 +540,7 @@ describe('<Filters />', () => {
         {key: 'filterTwo', label: 'bar', onRemove: noop},
       ];
 
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters
           {...mockProps}
           queryValue=""
@@ -476,11 +548,10 @@ describe('<Filters />', () => {
           hideTags
         />,
       );
-      const rightActionButton = findByTestID(
-        resourceFilters,
-        'SheetToggleButton',
-      );
-      expect(rightActionButton.text()).toBe('More filters (2)');
+
+      expect(resourceFilters).toContainReactComponent(Button, {
+        children: 'More filters (2)',
+      });
     });
 
     it('calls clear all callback and shifts focus when clear all filters is clicked to prevent visual loss of focus', () => {
@@ -488,7 +559,7 @@ describe('<Filters />', () => {
       const spy = jest.fn();
       const appliedFilters = [{key: 'filterOne', label: 'foo', onRemove: spy}];
 
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockProps} appliedFilters={appliedFilters} />,
       );
       resourceFilters.setProps({
@@ -499,21 +570,20 @@ describe('<Filters />', () => {
         },
       });
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
 
-      let clearAllButton = resourceFilters
-        .findWhere((node) => node.prop('children') === 'Clear all filters')
-        .first();
+      let clearAllButton = resourceFilters.find(Button, {
+        children: 'Clear all filters',
+        disabled: false,
+      });
+      clearAllButton!.trigger('onClick');
 
-      expect(clearAllButton.prop('disabled')).toBeFalsy();
-
-      trigger(clearAllButton, 'onClick');
-
-      clearAllButton = resourceFilters
-        .findWhere((node) => node.prop('children') === 'Clear all filters')
-        .first();
-
-      expect(clearAllButton.prop('disabled')).toBeTruthy();
+      expect(resourceFilters).toContainReactComponent(Button, {
+        children: 'Clear all filters',
+        disabled: true,
+      });
       expect(focusSpy).toHaveBeenCalled();
       focusSpy.mockRestore();
     });
@@ -521,104 +591,103 @@ describe('<Filters />', () => {
 
   describe('disabled', () => {
     it('disables the search field when true', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockProps} queryValue="bar" disabled />,
       );
 
-      expect(resourceFilters.find(TextField).prop('disabled')).toBe(true);
+      expect(resourceFilters).toContainReactComponent(TextField, {
+        disabled: true,
+      });
     });
 
     it('disables <ConnectedFilterControl /> when true', () => {
-      const resourceFilters = mountWithAppProvider(
-        <Filters {...mockProps} disabled />,
-      );
-      const rightActionButton = findByTestID(
-        resourceFilters,
-        'SheetToggleButton',
-      );
+      const resourceFilters = mountWithApp(<Filters {...mockProps} disabled />);
 
-      expect(rightActionButton.prop('disabled')).toBe(true);
+      const rightActionButton = resourceFilters.find(Button, {
+        children: 'More filters',
+      });
+
+      expect(rightActionButton).toHaveReactProps({disabled: true});
     });
 
     it('passes disabled prop to connected filters', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockProps} queryValue="bar" disabled />,
       );
 
-      expect(
-        resourceFilters.find(ConnectedFilterControl).prop('disabled'),
-      ).toBe(true);
+      expect(resourceFilters).toContainReactComponent(ConnectedFilterControl, {
+        disabled: true,
+      });
     });
 
     it('subdues each filter headings <Filter /> is mounted with prop disabled as true', () => {
-      const resourceFilters = mountWithAppProvider(
-        <Filters {...mockProps} disabled />,
-      );
+      const resourceFilters = mountWithApp(<Filters {...mockProps} disabled />);
 
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
 
       mockProps.filters.forEach((filter) => {
-        const toggleButton = findById(
-          resourceFilters,
-          `${filter.key}ToggleButton`,
-        );
+        const toggleButton = resourceFilters.find('button', {
+          id: `${filter.key}ToggleButton`,
+        });
 
-        expect(toggleButton.find(TextStyle).prop('variation')).toBe('subdued');
+        expect(toggleButton!).toContainReactComponent(TextStyle, {
+          variation: 'subdued',
+        });
       });
     });
 
     it('is passed to <Tag /> with set value', () => {
       const appliedFilters = [{key: 'filterOne', label: 'foo', onRemove: noop}];
 
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockProps} appliedFilters={appliedFilters} disabled />,
       );
 
-      resourceFilters.find(Tag).forEach((tag) => {
-        expect(tag.prop('disabled')).toBe(true);
+      resourceFilters.findAll(Tag).forEach((tag) => {
+        expect(tag).toHaveReactProps({disabled: true});
       });
     });
 
     describe('individual filters', () => {
       it('subdues disabled filters heading', () => {
-        const resourceFilters = mountWithAppProvider(
-          <Filters {...mockProps} />,
-        );
+        const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-        trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
+        resourceFilters
+          .find(Button, {children: 'More filters'})!
+          .trigger('onClick');
 
         mockProps.filters
           .filter(({disabled}) => disabled)
           .forEach((filter) => {
-            const toggleButton = findById(
-              resourceFilters,
-              `${filter.key}ToggleButton`,
-            );
+            const toggleButton = resourceFilters.find('button', {
+              id: `${filter.key}ToggleButton`,
+            });
 
-            expect(toggleButton.find(TextStyle).prop('variation')).toBe(
-              'subdued',
-            );
+            expect(toggleButton).toContainReactComponent(TextStyle, {
+              variation: 'subdued',
+            });
           });
       });
 
       it('does not subdue active filters heading', () => {
-        const resourceFilters = mountWithAppProvider(
-          <Filters {...mockProps} />,
-        );
+        const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-        trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
+        resourceFilters
+          .find(Button, {children: 'More filters'})!
+          .trigger('onClick');
 
         mockProps.filters
           .filter(({disabled}) => !disabled)
           .forEach((filter) => {
-            const toggleButton = findById(
-              resourceFilters,
-              `${filter.key}ToggleButton`,
-            );
+            const toggleButton = resourceFilters.find('button', {
+              id: `${filter.key}ToggleButton`,
+            });
 
-            expect(
-              toggleButton.find(TextStyle).prop('variation'),
-            ).toBeUndefined();
+            expect(toggleButton).toContainReactComponent(TextStyle, {
+              variation: undefined,
+            });
           });
       });
     });
@@ -627,26 +696,27 @@ describe('<Filters />', () => {
   describe('helpText', () => {
     it('renders a subdued <TextStyle /> when provided', () => {
       const helpText = 'Important filters information';
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockProps} helpText={helpText} />,
       );
 
-      const helpTextMarkup = findById(resourceFilters, 'FiltersHelpText');
+      const helpTextMarkup = resourceFilters.findAll('div', {
+        id: 'FiltersHelpText',
+      });
       expect(helpTextMarkup).toHaveLength(1);
-      expect(helpTextMarkup.text()).toBe(helpText);
+      expect(helpTextMarkup[0]).toContainReactComponent(TextStyle, {
+        children: helpText,
+      });
     });
 
     it('is not rendered when not provided', () => {
-      const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />);
+      const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
-      const helpTextMarkup = findById(resourceFilters, 'FiltersHelpText');
-      expect(helpTextMarkup).toHaveLength(0);
+      expect(resourceFilters).not.toContainReactComponent('div', {
+        id: 'FiltersHelpText',
+      });
     });
   });
 });
 
 function noop() {}
-
-function findById(wrapper: ReactWrapper, id: string) {
-  return wrapper.find(`#${id}`).first();
-}

--- a/src/components/Form/tests/Form.test.tsx
+++ b/src/components/Form/tests/Form.test.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
 import {Form} from '../Form';

--- a/src/components/Form/tests/Form.test.tsx
+++ b/src/components/Form/tests/Form.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {Form} from '../Form';
 
@@ -16,91 +17,83 @@ const target = '_blank';
 describe('<Form />', () => {
   describe('acceptCharset', () => {
     it('sets the acceptCharset attribute when provided', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Form acceptCharset={acceptCharset} onSubmit={noop} />,
       );
-      expect(wrapper.find('form').prop('acceptCharset')).toBe(acceptCharset);
+      expect(wrapper).toContainReactComponent('form', {acceptCharset});
     });
   });
 
   describe('action', () => {
     it('sets the action attribute when provided', () => {
-      const wrapper = mountWithAppProvider(
-        <Form action={action} onSubmit={noop} />,
-      );
-      expect(wrapper.find('form').prop('action')).toBe(action);
+      const wrapper = mountWithApp(<Form action={action} onSubmit={noop} />);
+      expect(wrapper).toContainReactComponent('form', {action});
     });
   });
 
   describe('autoComplete', () => {
     it('sets the autocomplete attribute to "off" when provided as false', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Form autoComplete={false} onSubmit={noop} />,
       );
-      expect(wrapper.find('form').prop('autoComplete')).toBe('off');
+      expect(wrapper).toContainReactComponent('form', {autoComplete: 'off'});
     });
   });
 
   describe('encType', () => {
     it('sets the encType attribute when provided', () => {
-      const wrapper = mountWithAppProvider(
-        <Form encType={encType} onSubmit={noop} />,
-      );
-      expect(wrapper.find('form').prop('encType')).toBe(encType);
+      const wrapper = mountWithApp(<Form encType={encType} onSubmit={noop} />);
+      expect(wrapper).toContainReactComponent('form', {encType});
     });
   });
 
   describe('implicitSubmit', () => {
     it('renders a button when the prop is set to true', () => {
-      const wrapper = mountWithAppProvider(<Form onSubmit={noop} />);
-      expect(wrapper.find('button')).toHaveLength(1);
+      const wrapper = mountWithApp(<Form onSubmit={noop} />);
+      expect(wrapper).toContainReactComponentTimes('button', 1);
     });
 
     it('does not render a button when the prop is set to false', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Form onSubmit={noop} implicitSubmit={false} />,
       );
-      expect(wrapper.find('button')).toHaveLength(0);
+      expect(wrapper).not.toContainReactComponent('button');
     });
   });
 
   describe('method', () => {
     it('sets the method attribute when provided', () => {
-      const wrapper = mountWithAppProvider(
-        <Form method={method} onSubmit={noop} />,
-      );
-      expect(wrapper.find('form').prop('method')).toBe(method);
+      const wrapper = mountWithApp(<Form method={method} onSubmit={noop} />);
+      expect(wrapper).toContainReactComponent('form', {method});
     });
 
     it('defaults to post when no method is set', () => {
-      const wrapper = mountWithAppProvider(<Form onSubmit={noop} />);
-      expect(wrapper.find('form').prop('method')).toBe('post');
+      const wrapper = mountWithApp(<Form onSubmit={noop} />);
+      expect(wrapper).toContainReactComponent('form', {method: 'post'});
     });
   });
 
   describe('name', () => {
     it('sets the name attribute when provided', () => {
-      const wrapper = mountWithAppProvider(
-        <Form name={name} onSubmit={noop} />,
-      );
-      expect(wrapper.find('form').prop('name')).toBe(name);
+      const wrapper = mountWithApp(<Form name={name} onSubmit={noop} />);
+      expect(wrapper).toContainReactComponent('form', {name});
     });
   });
 
   describe('noValidate', () => {
     it('sets the noValidate attribute when provided', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Form noValidate={noValidate} onSubmit={noop} />,
       );
-      expect(wrapper.find('form').prop('noValidate')).toBe(noValidate);
+      expect(wrapper).toContainReactComponent('form', {noValidate});
     });
   });
 
   describe('onSubmit', () => {
     it('is called when the form is submitted', () => {
       const spy = jest.fn();
-      const wrapper = mountWithAppProvider(<Form onSubmit={spy} />);
-      wrapper.simulate('submit');
+      const wrapper = mountWithApp(<Form onSubmit={spy} />);
+      wrapper.trigger('onSubmit');
 
       expect(spy).toHaveBeenCalled();
     });
@@ -111,11 +104,11 @@ describe('<Form />', () => {
       const onSubmitSpy = jest.fn();
       const preventDefaultSpy = jest.fn();
 
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Form preventDefault={false} onSubmit={onSubmitSpy} />,
       );
 
-      wrapper.simulate('submit', {
+      wrapper.trigger('onSubmit', {
         preventDefault: preventDefaultSpy,
       });
 
@@ -126,9 +119,9 @@ describe('<Form />', () => {
       const onSubmitSpy = jest.fn();
       const preventDefaultSpy = jest.fn();
 
-      const wrapper = mountWithAppProvider(<Form onSubmit={onSubmitSpy} />);
+      const wrapper = mountWithApp(<Form onSubmit={onSubmitSpy} />);
 
-      wrapper.simulate('submit', {
+      wrapper.trigger('onSubmit', {
         preventDefault: preventDefaultSpy,
       });
 
@@ -139,11 +132,11 @@ describe('<Form />', () => {
       const onSubmitSpy = jest.fn();
       const preventDefaultSpy = jest.fn();
 
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Form preventDefault onSubmit={onSubmitSpy} />,
       );
 
-      wrapper.simulate('submit', {
+      wrapper.trigger('onSubmit', {
         preventDefault: preventDefaultSpy,
       });
 
@@ -153,10 +146,8 @@ describe('<Form />', () => {
 
   describe('target', () => {
     it('sets the target attribute when provided', () => {
-      const wrapper = mountWithAppProvider(
-        <Form target={target} onSubmit={noop} />,
-      );
-      expect(wrapper.find('form').prop('target')).toBe(target);
+      const wrapper = mountWithApp(<Form target={target} onSubmit={noop} />);
+      expect(wrapper).toContainReactComponent('form', {target});
     });
   });
 });

--- a/src/components/Form/tests/Form.test.tsx
+++ b/src/components/Form/tests/Form.test.tsx
@@ -91,8 +91,7 @@ describe('<Form />', () => {
     it('is called when the form is submitted', () => {
       const spy = jest.fn();
       const wrapper = mountWithApp(<Form onSubmit={spy} />);
-      wrapper.trigger('onSubmit');
-
+      wrapper!.find('form')!.trigger('onSubmit', {preventDefault: () => {}});
       expect(spy).toHaveBeenCalled();
     });
   });
@@ -106,9 +105,9 @@ describe('<Form />', () => {
         <Form preventDefault={false} onSubmit={onSubmitSpy} />,
       );
 
-      wrapper.trigger('onSubmit', {
-        preventDefault: preventDefaultSpy,
-      });
+      wrapper!
+        .find('form')!
+        .trigger('onSubmit', {preventDefault: preventDefaultSpy});
 
       expect(preventDefaultSpy).not.toHaveBeenCalled();
     });
@@ -119,9 +118,9 @@ describe('<Form />', () => {
 
       const wrapper = mountWithApp(<Form onSubmit={onSubmitSpy} />);
 
-      wrapper.trigger('onSubmit', {
-        preventDefault: preventDefaultSpy,
-      });
+      wrapper!
+        .find('form')!
+        .trigger('onSubmit', {preventDefault: preventDefaultSpy});
 
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
@@ -134,9 +133,9 @@ describe('<Form />', () => {
         <Form preventDefault onSubmit={onSubmitSpy} />,
       );
 
-      wrapper.trigger('onSubmit', {
-        preventDefault: preventDefaultSpy,
-      });
+      wrapper!
+        .find('form')!
+        .trigger('onSubmit', {preventDefault: preventDefaultSpy});
 
       expect(preventDefaultSpy).toHaveBeenCalled();
     });


### PR DESCRIPTION
# Disclaimer

~There is one test in the `Filters.test.tsx` suite that wasn't modernized. It seems like we've found a bug on `react-testing` regarding using `.find()` to search for components in a tree that contains React Fragments (it can't find the component if it's a few levels deep). Decided to submit the PR anyways as all the other tests have been modernized.~

UPDATE: disclaimer no longer needed, as the aforementioned suite has already been modernized here: https://github.com/Shopify/polaris-react/pull/4458

### WHY are these changes introduced?

Modernizes tests to use the new modern framework (`{mountWithApp}` from `test-utilities`).

### WHAT is this pull request doing?

Updates tests using `{mountWithAppProvider}` from `test-utilities/legacy` to use `{mountWithApp}` from `test-utilities`