### PR TITLE
partial fix for popover a11y issue

### DIFF
--- a/src/components/ActionList/ActionList.tsx
+++ b/src/components/ActionList/ActionList.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, {useContext, useRef} from 'react';
 
-import type {ActionListItemDescriptor, ActionListSection} from '../../types';
+import {KeypressListener} from '../KeypressListener';
+import {PopoverContext} from '../../utilities/popover-context';
+import {ActionListItemDescriptor, ActionListSection, Key} from '../../types';
 import {classNames} from '../../utilities/css';
+import {
+  findFirstFocusableNodeIncludingDisabled,
+  focusFirstFocusableNode,
+  focusNextFocusableNode,
+} from '../../utilities/focus';
 
 import {Section} from './components';
 import styles from './ActionList.scss';
@@ -24,6 +31,8 @@ export function ActionList({
   onActionAnyItem,
 }: ActionListProps) {
   let finalSections: ActionListSection[] = [];
+  const isWithinPopover = useContext(PopoverContext);
+  const elementRef = useRef<any>(null);
 
   if (items) {
     finalSections = [{items}, ...sections];
@@ -48,5 +57,22 @@ export function ActionList({
     ) : null;
   });
 
-  return <Element className={className}>{sectionMarkup}</Element>;
+  const handleKeyPress = () => {
+    if (elementRef.current.contains(document.activeElement)) {
+      if (document.activeElement) {
+        focusNextFocusableNode(document.activeElement as HTMLElement);
+      }
+    } else {
+      focusFirstFocusableNode(elementRef.current);
+    }
+  };
+
+  return (
+    <Element ref={elementRef} className={className}>
+      {isWithinPopover ? (
+        <KeypressListener keyCode={Key.DownArrow} handler={handleKeyPress} />
+      ) : null}
+      {sectionMarkup}
+    </Element>
+  );
 }

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -16,6 +16,7 @@ import {
 import {Portal} from '../Portal';
 import {portal} from '../shared';
 import {useUniqueId} from '../../utilities/unique-id';
+import {PopoverContext} from '../../utilities/popover-context';
 
 import {
   PopoverCloseSource,
@@ -198,20 +199,22 @@ const PopoverComponent = forwardRef<PopoverPublicAPI, PopoverProps>(
 
     const portal = activatorNode ? (
       <Portal idPrefix="popover">
-        <PopoverOverlay
-          ref={overlayRef}
-          id={id}
-          activator={activatorNode}
-          preferInputActivator={preferInputActivator}
-          onClose={handleClose}
-          active={active}
-          fixed={fixed}
-          colorScheme={colorScheme}
-          zIndexOverride={zIndexOverride}
-          {...rest}
-        >
-          {children}
-        </PopoverOverlay>
+        <PopoverContext.Provider value>
+          <PopoverOverlay
+            ref={overlayRef}
+            id={id}
+            activator={activatorNode}
+            preferInputActivator={preferInputActivator}
+            onClose={handleClose}
+            active={active}
+            fixed={fixed}
+            colorScheme={colorScheme}
+            zIndexOverride={zIndexOverride}
+            {...rest}
+          >
+            {children}
+          </PopoverOverlay>
+        </PopoverContext.Provider>
       </Portal>
     ) : null;
 

--- a/src/utilities/popover-context.tsx
+++ b/src/utilities/popover-context.tsx
@@ -1,0 +1,3 @@
+import {createContext} from 'react';
+
+export const PopoverContext = createContext(false);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [#4419](https://github.com/Shopify/polaris-react/issues/4419)
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {ActionList, Button, Page, Popover} from '../src';

export function Playground() {
  const {
    value: collectPaymentPopoverActive,
    setTrue: openCollectPaymentPopover,
    setFalse: closeCollectPaymentPopover,
  } = useToggle(false);

  return (
    <Page title="Playground">
      <div style={{height: '150px'}}>
        <Popover
          active={collectPaymentPopoverActive}
          activator={
            <Button primary disclosure onClick={openCollectPaymentPopover}>
              Collect payment
            </Button>
          }
          fullWidth
          onClose={closeCollectPaymentPopover}
        >
          <ActionList
            items={[
              {
                content: 'Pay by ccard',
                onAction: () => {
                  alert('clicked');
                },
              },
              {
                content: 'Mark as paid',
                onAction: () => {
                  alert('clicked');
                },
              },
            ]}
          />
        </Popover>
      </div>
    </Page>
  );
}

function useToggle(initialState: boolean) {
  const [value, setState] = useState(initialState);
  return {
    value,
    toggle: useCallback(() => setState((state) => !state), []),
    setTrue: useCallback(() => setState(true), []),
    setFalse: useCallback(() => setState(false), []),
  };
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
