### PR TITLE
[Textfield] Support scrolling on long prefix/suffix

### DIFF
--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -93,8 +93,8 @@ $stacking-order: (
   z-index: z-index(contents, $stacking-order);
   display: block;
   flex: 1 1 0%;
+  min-width: 100%;
   width: 100%;
-  min-width: 0;
   min-height: control-height();
   margin: 0;
   padding: control-vertical-padding() $backdrop-horizontal-spacing;
@@ -106,6 +106,7 @@ $stacking-order: (
   appearance: none;
   caret-color: var(--p-text);
   color: var(--p-text);
+  resize: none;
 
   .Prefix + & {
     padding-left: 0;
@@ -309,4 +310,16 @@ $stacking-order: (
 
 .monospaced {
   font-family: font-family($family: 'monospace');
+}
+
+.Scroll {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  overflow: scroll;
+  width: 100%;
+}
+
+::-webkit-scrollbar {
+  display: none;
 }

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -108,6 +108,10 @@ $stacking-order: (
   color: var(--p-text);
   resize: none;
 
+  @include breakpoint-after(nav-min-window-corrected()) {
+    min-width: 0;
+  }
+
   .Prefix + & {
     padding-left: 0;
   }

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -462,9 +462,11 @@ export function TextField({
           onBlur={handleBlur}
           onClick={handleClick}
         >
-          {prefixMarkup}
-          {input}
-          {suffixMarkup}
+          <div className={styles.Scroll}>
+            {prefixMarkup}
+            {input}
+            {suffixMarkup}
+          </div>
           {characterCountMarkup}
           {clearButtonMarkup}
           {spinnerMarkup}


### PR DESCRIPTION
### WHAT is this pull request doing?

Improves the TextField component by allowing horizontal scrolling when the field contains a long prefix/suffix.

Fixes https://github.com/Shopify/shopify-markets/issues/3025

### Known limitation/edge case
If the inputted text is longer than 100% of the input field, there will be some double scrolling (ie: scrolling for the suffix + scrolling within the `<input/>` element.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


<details>
<summary>copy/paste into `playground/Playground.tsx`</summary>

```javascript
import {TextField, Page} from '../src';

export function Playground() {
  const [value, setValue] = useState('1776 Barnes Street\nOrlando, FL 32801');

  const handleChange = useCallback((newValue) => setValue(newValue), []);

  return (
    <Page title="Playground">
      <div style={{margin: '20px'}}>
        <TextField
          label="hello"
          autoComplete="off"
          value={value}
          onChange={handleChange}
          prefix="SUPER SUPER LONG PREFIX"
        />
        <TextField
          label="hello"
          autoComplete="off"
          value={value}
          onChange={handleChange}
          prefix="SUPER SUPER LONG PREFIX"
          suffix="EXTRA LONG SUFFIX"
        />
      </div>
    </Page>
  );
}
```
</details>

|Before | After |
|---|---|
|![Screen Cast 2021-09-14 at 5 09 39 PM](https://user-images.githubusercontent.com/19173529/133334355-66379cf8-a20a-4310-9ad5-e73e3c11e921.gif)|![Screen Cast 2021-09-14 at 5 05 25 PM](https://user-images.githubusercontent.com/19173529/133333978-345b147f-619d-4d8f-8c24-7d946b8fcda0.gif)|

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
