### PR TITLE
Add space before (opens in new window) text

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -88,7 +88,7 @@ export function Icon({source, color, backdrop, accessibilityLabel}: IconProps) {
 
   return (
     <span className={className}>
-      <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
+      <VisuallyHidden> {accessibilityLabel}</VisuallyHidden>
       {contentMarkup[sourceType]}
     </span>
   );

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -14,7 +14,7 @@ describe('<Icon />', () => {
       ).find('span');
 
       expect(element).toContainReactComponent(VisuallyHidden, {
-        children: label,
+        children: [' ', label],
       });
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Looking at tests in `shopify/web` it had `Billing(opens in a new window)` this is a poor screen reader experience.

### WHAT is this pull request doing?

Adds a space

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
