### PR TITLE
[TextField] Restore pointing device interactivity to prefix and suffix slots

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -36,6 +36,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Properly support `selected` prop for `Navigation.Item` when `url` prop is not specified ([#4375](https://github.com/Shopify/polaris-react/pull/4375))
 - Fixed an accessibility bug in `Icon` where `aria-label` was used incorrectly ([#4414](https://github.com/Shopify/polaris-react/pull/4414))
 - Fixed a bug in `Option` where the label would cause scrollbars to appear instead of wrapping ([#4411](https://github.com/Shopify/polaris-react/pull/4411))
+- Restored pointing device interactivity to prefix and suffix slots of the `TextField` component ([#4477](https://github.com/Shopify/polaris-react/pull/4477))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -191,7 +191,6 @@ $stacking-order: (
   flex: 0 0 auto;
   color: var(--p-text-subdued);
   user-select: none;
-  pointer-events: none;
 }
 
 .Prefix {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4256

Consumers sometimes use the prefix and suffix slots of the `TextField` component to house interactive elements like tooltips that provide helpful context, which #4207 didn't take into account based on a wrong assumption and oversimplification of the usage of slots.


### WHAT is this pull request doing?

This is essentially a revert of the initial PR which introduced the regression in the component. We simply get rid of the `pointer-events: none` property declaration.


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {QuestionMarkMinor} from '@shopify/polaris-icons';

import {Page, TextField, Tooltip, Icon} from '../src';

export function Playground() {
  const tooltipMarkup = (
    <Tooltip content="Help content goes here">
      <Icon source={QuestionMarkMinor} color="base" />
    </Tooltip>
  );

  return (
    <Page title="Playground">
      <TextField
        suffix={tooltipMarkup}
        autoComplete="off"
        label="Label"
        onChange={() => {}}
      />
    </Page>
  );
}
```
</details>

|Before | After |
|---|---|
|<video src="https://user-images.githubusercontent.com/8625066/133954888-c06bc832-d4f3-4df6-9db9-913ccc7941f8.mov"></video>|<video src="https://user-images.githubusercontent.com/8625066/133954929-1d47c787-d51f-4060-83a8-7e8b037c1e10.mov"></video>|

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit
