### PR TITLE
[MediaCard] Add breakpoint for border radius on media within MediaCard

### DIFF
--- a/src/components/MediaCard/MediaCard.scss
+++ b/src/components/MediaCard/MediaCard.scss
@@ -19,8 +19,11 @@ $portrait-breakpoint: 804px;
 
 .MediaContainer {
   overflow: hidden;
-  border-top-left-radius: var(--p-border-radius-wide);
-  border-top-right-radius: var(--p-border-radius-wide);
+
+  @include page-content-when-not-fully-condensed {
+    border-top-right-radius: var(--p-border-radius-wide);
+    border-top-left-radius: var(--p-border-radius-wide);
+  }
 
   &:not(.portrait) {
     flex-basis: 40%;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4486

The media within the media card has a border-radius that is always active. The parent, which is a regular card, only has the border-radius when the page is not fully condensed. You can see the problem live in the docs: [https://polaris.shopify.com/components/structure/media-card](https://polaris.shopify.com/components/structure/media-card)

### WHAT is this pull request doing?

This PR changes the media to act the same as the parent when the page is condensed.

Before:
<img width="480" alt="Before image which shows background peeking out" src="https://user-images.githubusercontent.com/31804757/134729406-c2ce4ef7-ba65-4fcf-87e4-0732d3f21e13.png">

After:
<img width="478" alt="After image which shows no border radius anymore" src="https://user-images.githubusercontent.com/31804757/134729414-1b3cadb2-3a48-4650-a2c9-48000d2bc8a9.png">

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
