### PR TITLE
[TextField] fix maxLength prop to work with input type number

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -419,7 +419,7 @@ export function TextField({
     style,
     autoComplete,
     className: inputClassName,
-    onChange: handleChange,
+    onChange: inputType === 'number' ? handleChangeForNumbers : handleChange,
     ref: inputRef,
     min,
     max,
@@ -497,6 +497,16 @@ export function TextField({
       ((prefixRef.current && prefixRef.current.contains(target)) ||
         (suffixRef.current && suffixRef.current.contains(target)))
     );
+  }
+
+  function handleChangeForNumbers(event: React.ChangeEvent<HTMLInputElement>) {
+    if (maxLength && onChange) {
+      if (event.currentTarget.value.length <= maxLength) {
+        onChange(event.currentTarget.value, id);
+      }
+      return;
+    }
+    onChange && onChange(event.currentTarget.value, id);
   }
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4468

<img src="https://user-images.githubusercontent.com/47506129/132285351-2e0e8d21-1514-4cfe-afc4-6d746a4b7479.png" alt="maxLength prop not working for input type 'number'" />

Applying the maxLength prop to a textField that is of type 'number' does not work.

From [MDN's documentation for input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-maxlength)

> Valid for `text`, `search`, `url`, `tel`, `email`, and `password`, it defines the maximum number of characters (as UTF-16 code units) the user can enter into the field.

An immediate workaround would be to set the min and max to be -999 and 999 for this scenario.

### WHAT is this pull request doing?

Creating a new handleChange function that will validate the length of the input before reaching the user provided onChange function. This new function will only be used for type 'number'. (This could perhaps be used for type 'currency' as well?)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Page, TextField} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <TextFieldExample />
      {/* Add the code you want to test in here */}
    </Page>
  );
}

function TextFieldExample() {
  const [value, setValue] = useState('');

  const handleChange = useCallback((newValue) => setValue(newValue), []);

  return (
    <TextField
      label="Type a number"
      value={value}
      onChange={handleChange}
      maxLength={3}
      type="number"
      showCharacterCount
      autoComplete="off"
    />
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->