### PR TITLE
[EmptyState] fix svgs not displaying in empty state

### DIFF
--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -63,7 +63,14 @@ $centered-illustration-width: rem(226px);
 
 .Image {
   margin: 0;
-  width: initial;
+  height: 100%;
+  max-height: 300px;
+}
+
+.ImageContainer {
+  display: flex;
+  justify-content: center;
+  width: 100%;
 }
 
 .ImageContainer,
@@ -72,12 +79,8 @@ $centered-illustration-width: rem(226px);
   padding: 0;
   margin: 0;
 
-  @include page-content-when-not-partially-condensed {
-    flex-basis: 50%;
-  }
-
   @include page-content-when-fully-condensed {
-    overflow-x: hidden;
+    overflow: hidden;
   }
 }
 
@@ -102,11 +105,6 @@ $centered-illustration-width: rem(226px);
     @include page-content-when-not-fully-condensed {
       max-width: $detail-width;
     }
-  }
-
-  .Image {
-    margin: 0;
-    width: initial;
   }
 
   .Content {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2611

### WHAT is this pull request doing?

The suggested solution is to provide a width of 100% to the image element. This works in chrome as it computes to an appropriate 300px width. When used in safari this will stretch the image container to 100% of the width, making the image way too big.

What I've done is mimic the safari behaviour and stretch the image container to a width of 100% at all times. We then have the image set to a height of 100% to follow this container, but constrain it to a max-height of 300px.

If a static max-height is not preferable we could set the image container to a width of 50%.

<br/>
I've added the playground snippet below with three different images, one svg and two pngs, for testing/visualization.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card, EmptyState} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Card title="Online store dashboard" sectioned>
        <EmptyState
          heading="Manage your inventory transfers"
          action={{content: 'Add transfer'}}
          secondaryAction={{
            content: 'Learn more',
            url: 'https://help.shopify.com',
          }}
          image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
          // image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
          // image="https://freesvg.org/img/portablejim-Chess-tile-King-3.png"
        >
          <p>Track and receive your incoming inventory from suppliers.</p>
        </EmptyState>
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
