### PR TITLE
[ActionList] add arrow navigation and menu role support

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,12 +9,17 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Removed animtion from `Skeleton` components ([#4697](https://github.com/Shopify/polaris-react/pull/4697))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
 - Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
+- Keyboard arrow navigation support added in `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+- Menu role attribute value support added in `ActionList/Section` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
 
 ### Bug fixes
 
 - Centered full width `Popover` on small viewports ([#4114](https://github.com/Shopify/polaris-react/pull/4114))
 
 ### Documentation
+
+- Added arrow navigation instructions in keyboard support for `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+- Updated examples to properly support JAWS screen reader for `Popover` and `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
 
 ### Development workflow
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -6,6 +6,7 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
 $titleVerticalSpacing: spacing(tight) * 1.5;
 
 .ActionList {
+  outline: none;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -16,6 +17,7 @@ $titleVerticalSpacing: spacing(tight) * 1.5;
 }
 
 .Actions {
+  outline: none;
   list-style: none;
   margin: 0;
   border-top: border('divider');

--- a/src/components/ActionList/ActionList.tsx
+++ b/src/components/ActionList/ActionList.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, {useRef} from 'react';
 
-import type {ActionListItemDescriptor, ActionListSection} from '../../types';
+import {
+  wrapFocusNextFocusableMenuItem,
+  wrapFocusPreviousFocusableMenuItem,
+} from '../../utilities/focus';
+import {KeypressListener} from '../KeypressListener';
+import {ActionListItemDescriptor, ActionListSection, Key} from '../../types';
 import {classNames} from '../../utilities/css';
 
 import {Section} from './components';
@@ -12,7 +17,7 @@ export interface ActionListProps {
   /** Collection of sectioned action items */
   sections?: readonly ActionListSection[];
   /** Defines a specific role attribute for each action in the list */
-  actionRole?: string;
+  actionRole?: 'menuitem' | string;
   /** Callback when any item is clicked or keypressed */
   onActionAnyItem?: ActionListItemDescriptor['onAction'];
 }
@@ -24,6 +29,7 @@ export function ActionList({
   onActionAnyItem,
 }: ActionListProps) {
   let finalSections: readonly ActionListSection[] = [];
+  const actionListRef = useRef<HTMLDivElement & HTMLUListElement>(null);
 
   if (items) {
     finalSections = [{items}, ...sections];
@@ -35,6 +41,11 @@ export function ActionList({
 
   const hasMultipleSections = finalSections.length > 1;
   const Element = hasMultipleSections ? 'ul' : 'div';
+  const elementRole =
+    hasMultipleSections && actionRole === 'menuitem' ? 'menu' : undefined;
+  const elementTabIndex =
+    hasMultipleSections && actionRole === 'menuitem' ? -1 : undefined;
+
   const sectionMarkup = finalSections.map((section, index) => {
     return section.items.length > 0 ? (
       <Section
@@ -48,5 +59,55 @@ export function ActionList({
     ) : null;
   });
 
-  return <Element className={className}>{sectionMarkup}</Element>;
+  const handleFocusPreviousItem = (evt: KeyboardEvent) => {
+    evt.preventDefault();
+    if (actionListRef.current && evt.target) {
+      if (actionListRef.current.contains(evt.target as HTMLElement)) {
+        wrapFocusPreviousFocusableMenuItem(
+          actionListRef.current,
+          evt.target as HTMLElement,
+        );
+      }
+    }
+  };
+
+  const handleFocusNextItem = (evt: KeyboardEvent) => {
+    evt.preventDefault();
+    if (actionListRef.current && evt.target) {
+      if (actionListRef.current.contains(evt.target as HTMLElement)) {
+        wrapFocusNextFocusableMenuItem(
+          actionListRef.current,
+          evt.target as HTMLElement,
+        );
+      }
+    }
+  };
+
+  const listeners =
+    actionRole === 'menuitem' ? (
+      <>
+        <KeypressListener
+          keyEvent="keydown"
+          keyCode={Key.DownArrow}
+          handler={handleFocusNextItem}
+        />
+        <KeypressListener
+          keyEvent="keydown"
+          keyCode={Key.UpArrow}
+          handler={handleFocusPreviousItem}
+        />
+      </>
+    ) : null;
+
+  return (
+    <Element
+      ref={actionListRef}
+      className={className}
+      role={elementRole}
+      tabIndex={elementTabIndex}
+    >
+      {listeners}
+      {sectionMarkup}
+    </Element>
+  );
 }

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -108,8 +108,14 @@ function ActionListInPopoverExample() {
 
   return (
     <div style={{height: '250px'}}>
-      <Popover active={active} activator={activator} onClose={toggleActive}>
+      <Popover
+        active={active}
+        activator={activator}
+        autofocusTarget="first-node"
+        onClose={toggleActive}
+      >
         <ActionList
+          actionRole="menuitem"
           items={[
             {
               content: 'Import file',
@@ -145,8 +151,14 @@ function ActionListWithMediaExample() {
 
   return (
     <div style={{height: '200px'}}>
-      <Popover active={active} activator={activator} onClose={toggleActive}>
+      <Popover
+        active={active}
+        activator={activator}
+        autofocusTarget="first-node"
+        onClose={toggleActive}
+      >
         <ActionList
+          actionRole="menuitem"
           items={[
             {content: 'Import file', icon: ImportMinor},
             {content: 'Export file', icon: ExportMinor},
@@ -176,14 +188,20 @@ function ActionListWithSuffixExample() {
 
   return (
     <div style={{height: '200px'}}>
-      <Popover active={active} activator={activator} onClose={toggleActive}>
+      <Popover
+        active={active}
+        activator={activator}
+        autofocusTarget="first-node"
+        onClose={toggleActive}
+      >
         <ActionList
+          actionRole="menuitem"
           items={[
             {
+              active: true,
               content: 'Import file',
               icon: ImportMinor,
               suffix: <Icon source={TickSmallMinor} />,
-              active: true,
             },
             {content: 'Export file', icon: ExportMinor},
           ]}
@@ -212,8 +230,14 @@ function SectionedActionListExample() {
 
   return (
     <div style={{height: '250px'}}>
-      <Popover active={active} activator={activator} onClose={toggleActive}>
+      <Popover
+        active={active}
+        activator={activator}
+        autofocusTarget="first-node"
+        onClose={toggleActive}
+      >
         <ActionList
+          actionRole="menuitem"
           sections={[
             {
               title: 'File options',
@@ -255,13 +279,23 @@ function ActionListWithDestructiveItemExample() {
 
   return (
     <div style={{height: '250px'}}>
-      <Popover active={active} activator={activator} onClose={toggleActive}>
+      <Popover
+        active={active}
+        activator={activator}
+        autofocusTarget="first-node"
+        onClose={toggleActive}
+      >
         <ActionList
+          actionRole="menuitem"
           sections={[
             {
               title: 'File options',
               items: [
-                {content: 'Import file', icon: ImportMinor, active: true},
+                {
+                  active: true,
+                  content: 'Import file',
+                  icon: ImportMinor,
+                },
                 {content: 'Export file', icon: ExportMinor},
                 {
                   destructive: true,
@@ -296,8 +330,14 @@ function ActionListWithHelpTextExample() {
 
   return (
     <div style={{height: '250px'}}>
-      <Popover active={active} activator={activator} onClose={toggleActive}>
+      <Popover
+        active={active}
+        activator={activator}
+        autofocusTarget="first-node"
+        onClose={toggleActive}
+      >
         <ActionList
+          actionRole="menuitem"
           sections={[
             {
               items: [
@@ -328,6 +368,7 @@ function ActionListWithPrefixSuffixExample() {
   return (
     <div style={{height: '250px', maxWidth: '350px'}}>
       <ActionList
+        actionRole="menuitem"
         items={[
           {
             content: 'Go here',
@@ -388,6 +429,7 @@ Items in an action list are organized as list items (`<li>`) in an unordered lis
 ### Keyboard support
 
 - Give the action list items keyboard focus with the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
+- When action list items have a role of `menuitem`, navigate through the list with <kbd>down arrow</kbd> (<kbd>up arrow</kbd> to move backwards)
 - Activate buttons with the <kbd>enter</kbd>/<kbd>return</kbd> key or the <kbd>space</kbd> key
 
 ### High contrast support

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -100,6 +100,7 @@ export function Item({
       external={external}
       aria-label={accessibilityLabel}
       onClick={disabled ? null : onAction}
+      role={role}
     >
       {contentElement}
     </UnstyledLink>
@@ -112,13 +113,14 @@ export function Item({
       aria-label={accessibilityLabel}
       onClick={onAction}
       onMouseUp={handleMouseUpByBlurring}
+      role={role}
     >
       {contentElement}
     </button>
   );
 
   return (
-    <li role={role}>
+    <li role={role === 'menuitem' ? 'presentation' : undefined}>
       {scrollMarkup}
       {control}
     </li>

--- a/src/components/ActionList/components/Section/Section.tsx
+++ b/src/components/ActionList/components/Section/Section.tsx
@@ -14,7 +14,7 @@ export interface SectionProps {
   /** Should there be multiple sections */
   hasMultipleSections: boolean;
   /** Defines a specific role attribute for each action in the list */
-  actionRole?: string;
+  actionRole?: 'option' | 'menuitem' | string;
   /** Whether or not the section is the first to appear */
   firstSection?: boolean;
   /** Callback when any item is clicked or keypressed */
@@ -63,19 +63,36 @@ export function Section({
     <p className={titleClassName}>{section.title}</p>
   ) : null;
 
-  const sectionRole = actionRole === 'option' ? 'presentation' : undefined;
+  let sectionRole;
+  switch (actionRole) {
+    case 'option':
+      sectionRole = 'presentation';
+      break;
+    case 'menuitem':
+      sectionRole = !hasMultipleSections ? 'menu' : 'presentation';
+      break;
+    default:
+      sectionRole = undefined;
+      break;
+  }
 
   const sectionMarkup = (
     <div className={className}>
       {titleMarkup}
-      <ul className={styles.Actions} role={sectionRole}>
+      <ul
+        className={styles.Actions}
+        role={sectionRole}
+        tabIndex={!hasMultipleSections ? -1 : undefined}
+      >
         {actionMarkup}
       </ul>
     </div>
   );
 
   return hasMultipleSections ? (
-    <li className={styles.Section}>{sectionMarkup}</li>
+    <li className={styles.Section} role="presentation">
+      {sectionMarkup}
+    </li>
   ) : (
     sectionMarkup
   );

--- a/src/components/ActionList/tests/ActionList.test.tsx
+++ b/src/components/ActionList/tests/ActionList.test.tsx
@@ -5,6 +5,8 @@ import {mountWithApp} from 'tests/utilities';
 import {ActionList} from '../ActionList';
 import {Badge} from '../../Badge';
 import {Item, Section} from '../components';
+import {Key} from '../../../types';
+import {KeypressListener} from '../../KeypressListener';
 
 describe('<ActionList />', () => {
   let mockOnActionAnyItem: jest.Mock;
@@ -176,5 +178,97 @@ describe('<ActionList />', () => {
       children: 'badge',
       status: 'new',
     });
+  });
+
+  it('wraps focus to first item in action list after keydown event on last element', () => {
+    const actionList = mountWithApp(
+      <ActionList
+        sections={[
+          {
+            title: 'One',
+            items: [
+              {content: 'First section'},
+              {content: 'First section second item'},
+            ],
+          },
+          {
+            title: 'Two',
+            items: [
+              {content: 'Second section'},
+              {content: 'Second section second item'},
+            ],
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="menuitem"
+      />,
+    );
+
+    const actionListButtons = actionList.findAll('button');
+    const keypressListener = actionList.find(KeypressListener, {
+      keyCode: Key.DownArrow,
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      keyCode: Key.DownArrow,
+    });
+
+    Object.defineProperty(event, 'target', {
+      writable: false,
+      // set target to last focusable item in list
+      value: actionListButtons[actionListButtons.length - 1].domNode,
+    });
+
+    keypressListener?.trigger('handler', event);
+
+    // expect focus to wrap back to first item in action list
+    expect(document.activeElement).toStrictEqual(actionListButtons[0].domNode);
+  });
+
+  it('wraps focus to last item in action list after keyup event on first element', () => {
+    const actionList = mountWithApp(
+      <ActionList
+        sections={[
+          {
+            title: 'One',
+            items: [
+              {content: 'First section'},
+              {content: 'First section second item'},
+            ],
+          },
+          {
+            title: 'Two',
+            items: [
+              {content: 'Second section'},
+              {content: 'Second section second item'},
+            ],
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="menuitem"
+      />,
+    );
+
+    const actionListButtons = actionList.findAll('button');
+    const keypressListener = actionList.find(KeypressListener, {
+      keyCode: Key.UpArrow,
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      keyCode: Key.UpArrow,
+    });
+
+    Object.defineProperty(event, 'target', {
+      writable: false,
+      // set target to first focusable item in list
+      value: actionListButtons[0].domNode,
+    });
+
+    keypressListener?.trigger('handler', event);
+
+    // expect focus to wrap to last item in action list
+    expect(document.activeElement).toStrictEqual(
+      actionListButtons[actionListButtons.length - 1].domNode,
+    );
   });
 });

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -145,9 +145,13 @@ function PopoverWithActionListExample() {
       <Popover
         active={popoverActive}
         activator={activator}
+        autofocusTarget="first-node"
         onClose={togglePopoverActive}
       >
-        <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
+        <ActionList
+          actionRole="menuitem"
+          items={[{content: 'Import'}, {content: 'Export'}]}
+        />
       </Popover>
     </div>
   );
@@ -190,6 +194,7 @@ function PopoverContentExample() {
       <Popover
         active={popoverActive}
         activator={activator}
+        autofocusTarget="first-node"
         onClose={togglePopoverActive}
       >
         <Popover.Pane fixed>
@@ -199,6 +204,7 @@ function PopoverContentExample() {
         </Popover.Pane>
         <Popover.Pane>
           <ActionList
+            actionRole="menuitem"
             items={[
               {content: 'Online store'},
               {content: 'Facebook'},
@@ -418,7 +424,9 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 Popovers usually contain an [option list](https://polaris.shopify.com/components/lists-and-tables/option-list) or an [action list](https://polaris.shopify.com/components/actions/action-list), but can also contain other controls or content.
 
-A popover can contain many numerous types of content. Whether it's a menu, grid or something entirely different! When `aria-expanded` is applied to an element, `aria-haspopup` will default to `menu`. To assist screen readers you'll need to pass `ariaHaspopup` to `Popover`.
+To assist screen readers with sending focus to an [action list](https://polaris.shopify.com/components/actions/action-list), pass `autofocusTarget='first-node'` to `Popover`. This will avoid known issues a screen reader may have with keyboard support once focus is moved off the activator.
+
+Web browsers assign a default value of 'menu' to the `aria-haspopup` role. You can use the prop `ariaHaspopup` to specify a value. Screen readers may fail to send focus to the `Popover` content when they expect the content to be adjacent to the element with `aria-haspopup` in the DOM tree. In this scenario, it is recommended not to provide the `ariaHaspopup` prop.
 
 ### Keyboard support
 

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -9,7 +9,8 @@ const FOCUSABLE_SELECTOR =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])';
-
+const MENUITEM_FOCUSABLE_SELECTORS =
+  'a[role="menuitem"],frame[role="menuitem"],iframe[role="menuitem"],input[role="menuitem"]:not([type=hidden]):not(:disabled),select[role="menuitem"]:not(:disabled),textarea[role="menuitem"]:not(:disabled),button[role="menuitem"]:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>
   currentTarget.blur();
 
@@ -124,6 +125,66 @@ export function focusLastKeyboardFocusableNode(
   }
 
   return false;
+}
+
+export function wrapFocusPreviousFocusableMenuItem(
+  parentElement: HTMLElement,
+  currentFocusedElement: HTMLElement,
+) {
+  const allFocusableChildren = getMenuFocusableDescendants(parentElement);
+  const currentItemIdx = getCurrentFocusedElementIndex(
+    allFocusableChildren,
+    currentFocusedElement,
+  );
+  if (currentItemIdx === -1) {
+    allFocusableChildren[0].focus();
+  } else {
+    allFocusableChildren[
+      (currentItemIdx - 1 + allFocusableChildren.length) %
+        allFocusableChildren.length
+    ].focus();
+  }
+}
+
+export function wrapFocusNextFocusableMenuItem(
+  parentElement: HTMLElement,
+  currentFocusedElement: HTMLElement,
+) {
+  const allFocusableChildren = getMenuFocusableDescendants(parentElement);
+  const currentItemIdx = getCurrentFocusedElementIndex(
+    allFocusableChildren,
+    currentFocusedElement,
+  );
+  if (currentItemIdx === -1) {
+    allFocusableChildren[0].focus();
+  } else {
+    allFocusableChildren[
+      (currentItemIdx + 1) % allFocusableChildren.length
+    ].focus();
+  }
+}
+
+function getMenuFocusableDescendants(
+  element: HTMLElement,
+): NodeListOf<HTMLElement> {
+  return element.querySelectorAll(
+    MENUITEM_FOCUSABLE_SELECTORS,
+  ) as NodeListOf<HTMLElement>;
+}
+
+function getCurrentFocusedElementIndex(
+  allFocusableChildren: NodeListOf<HTMLElement>,
+  currentFocusedElement: HTMLElement,
+): number {
+  let currentItemIdx = 0;
+
+  for (const focusableChild of allFocusableChildren) {
+    if (focusableChild === currentFocusedElement) {
+      break;
+    }
+    currentItemIdx++;
+  }
+  return currentItemIdx === allFocusableChildren.length ? -1 : currentItemIdx;
 }
 
 function matches(node: HTMLElement, selector: string) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4419 

The goal of this PR is to address the accessibility issue concerning the `ActionList` component used inside the `Popover` component..  Screen readers are unable to find, navigate into and trigger actions in the revealed content.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

In this proposal, we enhance the `ActionList` to be [WAI-Aria compliant](https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-actions.html).

#### **Navigation**
To do so we start by properly support arrow (⬆️  & ⬇️ ) navigation as well as navigation wrap (which consist of bringing the focus from first to last and last to first action item instead of leaving the content context on arrow navigation).

#### **Role attribution**
We also enhance the `ActionList` component usage of the `actionRole` prop.  If a consumer sets this prop to the value `menuitem`, the component `ActionList`, `Section` and `Item` will automatically set the proper `menu` and `menuitem` roles.

#### **On-open Focus**
In order to have the screen readers properly announce the context to the user, we are adding `tabIndex="-1"` to the root `<ul />` element.  This will ensure that `autoFocusTarget="first-node"` will set the focus to this root `<ul />` element which will in-turn allow the screen reader to properly announce to the user that the context is now on a list.

In the case of **multi-section**, the tabIndex and menu role needs to be assigned on the `<ul />` rendered in the `Actionlist` component. https://github.com/Shopify/polaris-react/blob/c463b45e226fa6ea90e91ddc825a8fc48ecaf352/src/components/ActionList/ActionList.tsx#L96-L106

While also making sure that we assign the `presentation` role to sub-section `<ul />` elements (otherwise screen readers will sub-divise the count for each item instead of having one unified count).
https://github.com/Shopify/polaris-react/blob/c463b45e226fa6ea90e91ddc825a8fc48ecaf352/src/components/ActionList/components/Section/Section.tsx#L67-L76

For more details refer to the following [document](https://docs.google.com/document/d/1pkB83BwEmf_qKU3XM37mL8hQ5FOYkLSk4TwANdQDC0c/edit#)

**NOTE**
In order to keep the size of this PR small, the scope of this PR is only on the `ActionList` implementation and `Popover` documentation.  Once this is approved, we will need to revisit other Polaris components that uses an ActionList inside a Popover (for example `MenuGroup`.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {ActionList, Button, Page, Popover} from '../src';

export function Playground() {
  const [active, setActive] = useState(true);

  const toggleActive = useCallback(() => setActive((active) => !active), []);

  const handleImportedAction = useCallback(
    () => console.log('Imported action'),
    [],
  );

  const handleExportedAction = useCallback(
    () => console.log('Exported action'),
    [],
  );

  const activator = (
    <Button onClick={toggleActive} disclosure>
      More actions
    </Button>
  );

  return (
    <Page>
      <div style={{height: '250px'}}>
        <Popover
          active={active}
          activator={activator}
          autofocusTarget="first-node"
          onClose={toggleActive}
        >
          <ActionList
            actionRole="menuitem"
            items={[
              {
                content: 'Import file',
                onAction: handleImportedAction,
              },
              {
                content: 'Export file',
                onAction: handleExportedAction,
              },
            ]}
          />
        </Popover>
      </div>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
