### PR TITLE
Remove opinionated layout from listbox option

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed empty children being wrapped with `Item` in `Stack` ([#4487](https://github.com/Shopify/polaris-react/pull/4487))
+- Fixed a bug where `Listbox.Option`'s children wouldn't stretch to fit their container ([#4530](https://github.com/Shopify/polaris-react/pull/4530))
 
 ### Documentation
 

--- a/src/components/Listbox/components/Action/Action.scss
+++ b/src/components/Listbox/components/Action/Action.scss
@@ -2,7 +2,6 @@
 
 .Action {
   display: flex;
-  flex: 1;
 }
 
 .Icon {

--- a/src/components/Listbox/components/Option/Option.scss
+++ b/src/components/Listbox/components/Option/Option.scss
@@ -1,7 +1,6 @@
 @import '../../../../styles/common';
 
 .Option {
-  display: flex;
   margin: 0;
   padding: 0;
 

--- a/src/components/Listbox/components/TextOption/TextOption.scss
+++ b/src/components/Listbox/components/TextOption/TextOption.scss
@@ -2,7 +2,6 @@
 
 .TextOption {
   margin: spacing(extra-tight) spacing(tight) 0;
-  flex: 1;
   border-radius: var(--p-border-radius-base);
   padding: spacing(tight) spacing(tight);
   cursor: pointer;

--- a/src/components/Listbox/components/TextOption/TextOption.scss
+++ b/src/components/Listbox/components/TextOption/TextOption.scss
@@ -5,7 +5,6 @@
   border-radius: var(--p-border-radius-base);
   padding: spacing(tight) spacing(tight);
   cursor: pointer;
-  display: flex;
   @include focus-ring;
 
   &.allowMultiple {
@@ -62,9 +61,4 @@
 
 [data-focused]:not(:focus) .TextOption {
   @include focus-ring($style: 'focused');
-}
-
-.Content {
-  flex: 1 1 auto;
-  display: flex;
 }

--- a/src/components/Listbox/components/TextOption/TextOption.tsx
+++ b/src/components/Listbox/components/TextOption/TextOption.tsx
@@ -31,13 +31,11 @@ export const TextOption = memo(function TextOption({
   );
   return (
     <div className={textOptionClassName}>
-      <div className={styles.Content}>
-        {allowMultiple ? (
-          <Checkbox checked={selected} label={children} />
-        ) : (
-          children
-        )}
-      </div>
+      {allowMultiple ? (
+        <Checkbox checked={selected} label={children} />
+      ) : (
+        children
+      )}
     </div>
   );
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://github.com/Shopify/web/pull/51269#issuecomment-947807663

![image](https://camo.githubusercontent.com/eb154e01def876c3313dfc6bed359c6adeef9ac5d8597eb3ac267238d39b2233/68747470733a2f2f73637265656e73686f742e636c69636b2f53686f705f315f5f4372656174655f6f726465725f5f53686f706966795f323032312d31302d32305f31312d35362d31332e706e67)

### WHAT is this pull request doing?

Removes the opinionated display property from Listbox > Option. Do we know for sure if this should be a flex layout? IMO we should only have opinions on this when we can also control the components direct child.

Note: The issue above can be fixed in web so I'm not sure this PR is the right way to go just yet, but my gut tells me it is. Please let me know if I'm wrong @voiid !

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
