### PR TITLE
[ActionList] remove vertical padding from wrapping div

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added token for slim border radius ([#4573](https://github.com/Shopify/polaris-react/pull/4573))
 - Improves `Popover` component and its animation ([#4580](https://github.com/Shopify/polaris-react/pull/4580))
 - Improves `base` easing curve ([#4580](https://github.com/Shopify/polaris-react/pull/4580))
+- Remove vertical padding from wrapping div of `ActionList` ([#4571](https://github.com/Shopify/polaris-react/pull/4571))
 
 ### Bug fixes
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -8,7 +8,6 @@ $titleVerticalSpacing: spacing(tight) * 1.5;
 .ActionList {
   list-style: none;
   margin: 0;
-  padding: spacing(tight) 0;
 }
 
 .Section-withoutTitle:not(:first-child) {


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses: https://github.com/Shopify/polaris-react/issues/4570

Removes the vertical padding of the `<ActionList />` to provide a more compact aesthetic.

### WHAT is this pull request doing?

Removes padding attribute from the top-level element of `<ActionList />`. 

Horizontal padding was set to 0 and only the vertical padding was set. So, I removed the padding attribute, so we have no padding set.

**Before**
<img width="187" alt="action-list-before" src="https://user-images.githubusercontent.com/86790511/140254422-21a69ae5-3a3c-44a2-b02a-acf508622cfc.png">

**After**
<img width="185" alt="action-list-after" src="https://user-images.githubusercontent.com/86790511/140254429-4c2b76ea-78a9-479f-9b92-ec8f05256ffa.png">