### PR TITLE
[Stack] Revert not empty item css

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Removed extraneous space in `MediaCard` when card has no actions ([#4538](https://github.com/Shopify/polaris-react/pull/4538))
+- Fixed a bug in `Stack` where vertical spacing was off ([#4572](https://github.com/Shopify/polaris-react/pull/4572))
 
 ### Documentation
 

--- a/src/components/Stack/Stack.scss
+++ b/src/components/Stack/Stack.scss
@@ -7,7 +7,7 @@
   margin-top: -1 * spacing($spacing);
   margin-left: -1 * spacing($spacing);
 
-  > .Item:not(:empty) {
+  > .Item {
     margin-top: spacing($spacing);
     margin-left: spacing($spacing);
     max-width: 100%;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4560

Reverts the change added here: https://github.com/Shopify/polaris-react/pull/4556/files#diff-12888031b1f0e16bf9d7ee02978c37cbdfd6b64f8912ad164ab1cc51410fd538R10

We've decided to ditch this effort for now and rely on consumers to render `Stack.Items` only if their content is not null in the same way we do with `Cards` and `Layout.Sections`
