### PR TITLE
Fix deadlinks to 'Versioning and changelog' documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [these versioning and changelog guidelines](https://git.io/polaris-changelog-guidelines).
+The format is based on [these versioning and changelog guidelines](/documentation/Versioning%20and%20changelog.md).
 
 <!-- Unreleased changes should go to UNRELEASED.md -->
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,6 @@
 # Unreleased changes
 
-Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to format new entries. 💜
+Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) to format new entries. 💜
 
 ### Breaking changes
 


### PR DESCRIPTION
### WHY are these changes introduced?

The problem: There are 2 `git.io` links that are outdated and are now deadlinks to what should be the `Versioning and changelog` documentation file.

### WHAT is this pull request doing?

This PR replaces those dead links with relative links to the intended documentation.