### PR TITLE
[Popover] Motion improvements

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added helper hooks `useIndexTableRowHovered`, `useIndexTableRowSelected`, and `useIndexTableContainerScroll` to `IndexTable` ([#4286](https://github.com/Shopify/polaris-react/pull/4286))
 - Added token for slim border radius ([#4573](https://github.com/Shopify/polaris-react/pull/4573))
+- Improves `Popover` component and its animation ([#4580](https://github.com/Shopify/polaris-react/pull/4580))
+- Improves `base` easing curve ([#4580](https://github.com/Shopify/polaris-react/pull/4580))
 
 ### Bug fixes
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -4,8 +4,7 @@ $arrow-size: rem(14px);
 $visible-portion-of-arrow: rem(5px);
 $content-max-height: rem(500px);
 $content-max-width: rem(400px);
-$vertical-motion-offset: rem(-20px);
-$motion-duration: 150ms;
+$vertical-motion-offset: rem(-5px);
 
 .Popover {
   max-width: calc(100vw - #{2 * spacing()});
@@ -18,8 +17,7 @@ $motion-duration: 150ms;
 .PopoverOverlay {
   will-change: opacity, transform;
   opacity: 0;
-  transition: opacity $motion-duration easing(),
-    transform $motion-duration easing();
+  transition: opacity duration(fast) easing(), transform duration(fast) easing();
   transform: translateY($vertical-motion-offset);
 }
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -2,8 +2,10 @@
 
 $arrow-size: rem(14px);
 $visible-portion-of-arrow: rem(5px);
-$content-max-height: rem(295px);
+$content-max-height: rem(500px);
 $content-max-width: rem(400px);
+$vertical-motion-offset: rem(-20px);
+$motion-duration: 150ms;
 
 .Popover {
   max-width: calc(100vw - #{2 * spacing()});
@@ -14,26 +16,32 @@ $content-max-width: rem(400px);
 }
 
 .PopoverOverlay {
-  will-change: opacity;
+  will-change: opacity, transform;
   opacity: 0;
-  transition: opacity duration() easing(in);
+  transition: opacity $motion-duration easing(),
+    transform $motion-duration easing();
+  transform: translateY($vertical-motion-offset);
 }
 
 .PopoverOverlay-entering {
   opacity: 1;
+  transform: translateY(0);
 }
 
 .PopoverOverlay-open {
   opacity: 1;
+  transform: translateY(0);
 }
 
 .PopoverOverlay-exiting {
-  opacity: 0;
-  transition-timing-function: easing(out);
+  opacity: 1;
+  transform: translateY(0);
+  transition-duration: 0ms;
 }
 
 .measuring:not(.PopoverOverlay-exiting) {
   opacity: 0;
+  transform: translateY($vertical-motion-offset);
 }
 
 .fullWidth {

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -15,7 +15,6 @@ $vertical-motion-offset: rem(-5px);
 }
 
 .PopoverOverlay {
-  will-change: opacity, transform;
   opacity: 0;
   transition: opacity duration(fast) easing(), transform duration(fast) easing();
   transform: translateY($vertical-motion-offset);

--- a/src/components/Popover/components/Pane/Pane.tsx
+++ b/src/components/Popover/components/Pane/Pane.tsx
@@ -32,7 +32,6 @@ export function Pane({
     <div className={className}>{content}</div>
   ) : (
     <Scrollable
-      hint
       shadow
       className={className}
       onScrolledToBottom={onScrolledToBottom}

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -102,7 +102,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         this.clearTransitionTimeout();
         this.enteringTimer = window.setTimeout(() => {
           this.setState({transitionStatus: TransitionStatus.Entered});
-        }, durationBase);
+        }, 150);
       });
     }
 
@@ -111,7 +111,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         this.clearTransitionTimeout();
         this.exitingTimer = window.setTimeout(() => {
           this.setState({transitionStatus: TransitionStatus.Exited});
-        }, durationBase);
+        }, 150);
       });
     }
   }

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -1,4 +1,5 @@
 import React, {PureComponent, Children, createRef} from 'react';
+import {durationFast} from '@shopify/polaris-tokens';
 
 import {findFirstFocusableNode} from '../../../../utilities/focus';
 import {ThemeProvider, ThemeProviderProps} from '../../../ThemeProvider';
@@ -101,7 +102,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         this.clearTransitionTimeout();
         this.enteringTimer = window.setTimeout(() => {
           this.setState({transitionStatus: TransitionStatus.Entered});
-        }, 150);
+        }, durationFast);
       });
     }
 
@@ -110,7 +111,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         this.clearTransitionTimeout();
         this.exitingTimer = window.setTimeout(() => {
           this.setState({transitionStatus: TransitionStatus.Exited});
-        }, 150);
+        }, 0);
       });
     }
   }

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -1,5 +1,4 @@
 import React, {PureComponent, Children, createRef} from 'react';
-import {durationBase} from '@shopify/polaris-tokens';
 
 import {findFirstFocusableNode} from '../../../../utilities/focus';
 import {ThemeProvider, ThemeProviderProps} from '../../../ThemeProvider';

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -4,7 +4,7 @@ import {classNames} from '../../utilities/css';
 import {getRectForNode, Rect} from '../../utilities/geometry';
 import {EventListener} from '../EventListener';
 import {Scrollable} from '../Scrollable';
-import {layer} from '../shared';
+import {layer, dataPolarisTopBar} from '../shared';
 
 import {
   PreferredPosition,
@@ -239,6 +239,14 @@ export class PositionedOverlay extends PureComponent<
           scrollableContainerRect.height = document.body.scrollHeight;
         }
 
+        let topBarOffset = 0;
+        const topBarElement = scrollableElement.querySelector(
+          `${dataPolarisTopBar.selector}`,
+        );
+        if (topBarElement) {
+          topBarOffset = topBarElement.clientHeight;
+        }
+
         const overlayMargins =
           this.overlay.firstElementChild &&
           this.overlay.firstChild instanceof HTMLElement
@@ -257,6 +265,7 @@ export class PositionedOverlay extends PureComponent<
           containerRect,
           preferredPosition,
           fixed,
+          topBarOffset,
         );
         const horizontalPosition = calculateHorizontalPosition(
           activatorRect,

--- a/src/components/PositionedOverlay/utilities/math.ts
+++ b/src/components/PositionedOverlay/utilities/math.ts
@@ -18,10 +18,11 @@ export function calculateVerticalPosition(
   containerRect: Rect,
   preferredPosition: PreferredPosition,
   fixed: boolean | undefined,
+  topBarOffset = 0,
 ) {
   const activatorTop = activatorRect.top;
   const activatorBottom = activatorTop + activatorRect.height;
-  const spaceAbove = activatorRect.top;
+  const spaceAbove = activatorRect.top - topBarOffset;
   const spaceBelow =
     containerRect.height - activatorRect.top - activatorRect.height;
 

--- a/src/styles/foundation/_easing.scss
+++ b/src/styles/foundation/_easing.scss
@@ -1,5 +1,5 @@
 $easing-data: (
-  base: cubic-bezier(0.64, 0, 0.35, 1),
+  base: cubic-bezier(0.25, 0.1, 0.25, 1),
   in: cubic-bezier(0.36, 0, 1, 1),
   out: cubic-bezier(0, 0, 0.42, 1),
   excite: cubic-bezier(0.18, 0.67, 0.6, 1.22),


### PR DESCRIPTION
### WHY are these changes introduced?

This PR makes a few improvements to the `Popover` component including some foundational changes in things that it uses.

### WHAT is this pull request doing?

1. It improves the animation to feel snappier. It has been updated to use the `fast` duration and an updated `base` easing curve woking with @johanstromqvist. It also removed the animation on close to make it get out of the users way immediately.

#### Before

https://user-images.githubusercontent.com/478990/140956276-d9b92832-cbb5-467d-9c7a-d4ab9dd1d278.mov

#### After

https://user-images.githubusercontent.com/478990/140956239-b0554506-9a11-4162-b2d1-953afae4b940.mov

2. Bumps our default `max-height` for popovers to avoid forcing users to scroll the popover when they shouldn't need to.

#### Before

<img width="227" alt="Screen Shot 2021-11-09 at 11 01 40 AM" src="https://user-images.githubusercontent.com/478990/140959616-82e3a08f-1964-492d-8215-9ffe2cba88d0.png">


#### After

<img width="212" alt="Screen Shot 2021-11-09 at 11 01 28 AM" src="https://user-images.githubusercontent.com/478990/140959656-1fbb1a0e-319c-4156-ab32-0017a1e075a5.png">

3. Remove the scroll hint by default on popover panes. Currently we animate any scrollable popover on open, which can be disorienting. By increasing the max-height this happens less often, but we also removed this as the default option.

#### Before

https://user-images.githubusercontent.com/478990/140959678-327109b7-b1e5-45c5-a47d-476de7e18197.mov


#### After

https://user-images.githubusercontent.com/478990/140959700-0a3eda14-ef96-4480-b583-b29d86ec9245.mov


4. Fixes a bug where popover or tooltip contents could be hidden behind the top bar if set to `preferredPosition="above"`.

#### Before

<img width="870" alt="Screen Shot 2021-11-09 at 10 51 34 AM" src="https://user-images.githubusercontent.com/478990/140957827-6b2025cf-cdb0-4db1-85d8-1ba42531e625.png">

#### After

<img width="908" alt="Screen Shot 2021-11-09 at 10 51 13 AM" src="https://user-images.githubusercontent.com/478990/140957859-7409d4fd-3679-46d9-af88-9fe7758f1b61.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
