### PR TITLE
[ActionList] Fix base padding when there are multiple sections

### DIFF
--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -209,6 +209,7 @@ import {
   SearchMinor,
   MinusMinor,
   ViewMinor,
+  EditMinor,
 } from '@shopify/polaris-icons';
 
 export default {

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -8,6 +8,7 @@ $titleVerticalSpacing: spacing(tight) * 1.5;
 .ActionList {
   list-style: none;
   margin: 0;
+  padding: 0;
 }
 
 .Section-withoutTitle:not(:first-child) {

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -222,6 +222,13 @@ function SectionedActionListExample() {
                 {content: 'Export file', icon: ExportMinor},
               ],
             },
+            {
+              title: 'Bulk actions',
+              items: [
+                {content: 'Edit', icon: EditMinor},
+                {content: 'Delete', icon: DeleteMinor},
+              ],
+            },
           ]}
         />
       </Popover>


### PR DESCRIPTION
### WHY are these changes introduced?

This fixes the default browser `ul` padding from not being overwritten when using an `ActionList` with multiple sections.

### WHAT is this pull request doing?

It adds `padding: 0` to the main `ActionList` element. I also added the sectioned example to have multiple sections so we catch this in the future.

#### Before

<img width="208" alt="Screen Shot 2021-11-10 at 11 38 24 AM" src="https://user-images.githubusercontent.com/478990/141155063-abf88967-13f0-491a-a44a-cedc4de34a7d.png">

#### After

<img width="184" alt="Screen Shot 2021-11-10 at 11 39 05 AM" src="https://user-images.githubusercontent.com/478990/141155077-1472bfd7-3135-4db5-b9bc-49c3a8d5ad6b.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
