### PR TITLE
[Checkbox] properly support screen readers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
 - Fixed an issue with `TextField` where date and time were uneditable on click ([#4671](https://github.com/Shopify/polaris-react/pull/4671))
 - Fixed an issue with `Popover` where the transform property interfered with descendants positioning ([#4685](https://github.com/Shopify/polaris-react/pull/4685))
+- Fixed screen reader accessibility issue of the `Checkbox` component ([#4631](https://github.com/Shopify/polaris-react/pull/4631))
 
 ### Documentation
 

--- a/src/components/CheckableButton/tests/CheckableButton.test.tsx
+++ b/src/components/CheckableButton/tests/CheckableButton.test.tsx
@@ -3,7 +3,6 @@ import {mountWithApp} from 'tests/utilities';
 import {Checkbox} from 'components';
 
 import {CheckableButton} from '../CheckableButton';
-import {Key} from '../../../types';
 
 const CheckableButtonProps = {
   label: 'Test-Label',
@@ -71,19 +70,6 @@ describe('<CheckableButton />', () => {
         <CheckableButton {...CheckableButtonProps} onToggleAll={spy} />,
       );
       element.find('div')!.trigger('onClick');
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('is called when the CheckableButton pressed with spacebar', () => {
-      const spy = jest.fn();
-      const element = mountWithApp(
-        <CheckableButton {...CheckableButtonProps} onToggleAll={spy} />,
-      );
-
-      element.find(Checkbox)!.find('input')!.trigger('onKeyUp', {
-        keyCode: Key.Space,
-      });
-
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -13,7 +13,7 @@ import {useUniqueId} from '../../utilities/unique-id';
 import {Choice, helpTextID} from '../Choice';
 import {errorTextID} from '../InlineError';
 import {Icon} from '../Icon';
-import {Error, Key, CheckboxHandles} from '../../types';
+import {Error, CheckboxHandles, Key} from '../../types';
 import {WithinListboxContext} from '../../utilities/listbox/context';
 
 import styles from './Checkbox.scss';
@@ -92,20 +92,21 @@ export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
       setKeyFocused(false);
     };
 
-    const handleInput = () => {
+    const handleKeyUp = (event: React.KeyboardEvent) => {
+      const {keyCode} = event;
+
+      if (keyCode === Key.Space || keyCode === Key.Tab) {
+        !keyFocused && setKeyFocused(true);
+      }
+    };
+
+    const handleOnClick = () => {
       if (onChange == null || inputNode.current == null || disabled) {
         return;
       }
-      onChange(!inputNode.current.checked, id);
-      inputNode.current.focus();
-    };
 
-    const handleKeyUp = (event: React.KeyboardEvent) => {
-      const {keyCode} = event;
-      !keyFocused && setKeyFocused(true);
-      if (keyCode === Key.Space) {
-        handleInput();
-      }
+      onChange(inputNode.current.checked, id);
+      inputNode.current.focus();
     };
 
     const describedBy: string[] = [];
@@ -152,13 +153,11 @@ export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
         helpText={helpText}
         error={error}
         disabled={disabled}
-        onClick={handleInput}
         onMouseOver={handleMouseOver}
         onMouseOut={handleMouseOut}
       >
         <span className={wrapperClassName}>
           <input
-            onKeyUp={handleKeyUp}
             ref={inputNode}
             id={id}
             name={name}
@@ -167,17 +166,22 @@ export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
             checked={isChecked}
             disabled={disabled}
             className={inputClassName}
-            onFocus={onFocus}
             onBlur={handleBlur}
-            onClick={stopPropagation}
             onChange={noop}
+            onClick={handleOnClick}
+            onFocus={onFocus}
+            onKeyUp={handleKeyUp}
             aria-invalid={error != null}
             aria-controls={ariaControls}
             aria-describedby={ariaDescribedBy}
             role={isWithinListbox ? 'presentation' : 'checkbox'}
             {...indeterminateAttributes}
           />
-          <span className={backdropClassName} />
+          <span
+            className={backdropClassName}
+            onClick={stopPropagation}
+            onKeyUp={stopPropagation}
+          />
           <span className={styles.Icon}>
             <Icon source={iconSource} />
           </span>
@@ -189,6 +193,8 @@ export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
 
 function noop() {}
 
-function stopPropagation<E>(event: React.MouseEvent<E>) {
+function stopPropagation(
+  event: React.MouseEvent | React.KeyboardEvent | React.FormEvent,
+) {
   event.stopPropagation();
 }

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -2,7 +2,6 @@ import React, {AllHTMLAttributes} from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {Key} from '../../../types';
-import {Choice} from '../../Choice';
 import {Checkbox} from '../Checkbox';
 
 describe('<Checkbox />', () => {
@@ -32,18 +31,6 @@ describe('<Checkbox />', () => {
     });
   });
 
-  it('does not propagate click events from input element', () => {
-    const spy = jest.fn();
-    const element = mountWithApp(
-      <Checkbox id="MyCheckbox" label="Checkbox" onChange={spy} />,
-    );
-
-    element.find('input')!.trigger('onClick', {
-      stopPropagation: () => {},
-    });
-    expect(spy).not.toHaveBeenCalled();
-  });
-
   describe('onChange()', () => {
     it('is called with the updated checked value of the input on click', () => {
       const spy = jest.fn();
@@ -52,55 +39,23 @@ describe('<Checkbox />', () => {
       );
 
       (element.find('input')!.domNode as HTMLInputElement).checked = true;
-      element.find(Choice)?.trigger('onClick');
+      const event = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      });
+      element.find('input')!.domNode?.dispatchEvent(event);
 
       expect(spy).toHaveBeenCalledWith(false, 'MyCheckbox');
-    });
-
-    it('is called when space is pressed', () => {
-      const spy = jest.fn();
-      const element = mountWithApp(
-        <Checkbox id="MyCheckbox" label="Checkbox" onChange={spy} />,
-      );
-
-      element.find('input')!.trigger('onKeyUp', {
-        keyCode: Key.Space,
-      });
-
-      expect(spy).toHaveBeenCalledTimes(1);
-    });
-
-    it('is not from keys other than space', () => {
-      const spy = jest.fn();
-      const element = mountWithApp(
-        <Checkbox id="MyCheckbox" label="Checkbox" onChange={spy} />,
-      );
-
-      element.find('input')!.trigger('onKeyUp', {
-        keyCode: Key.Enter,
-      });
-
-      expect(spy).not.toHaveBeenCalled();
     });
 
     it('sets focus on the input when checkbox is toggled off', () => {
       const checkbox = mountWithApp(
         <Checkbox checked id="checkboxId" label="Checkbox" onChange={noop} />,
       );
-      checkbox.find(Choice)!.trigger('onClick');
+      checkbox.find('input')!.trigger('onClick');
 
       expect(document.activeElement).toBe(checkbox.find('input')!.domNode);
-    });
-
-    it('is not called from keyboard events when disabled', () => {
-      const spy = jest.fn();
-      const checkbox = mountWithApp(
-        <Checkbox label="label" disabled onChange={spy} />,
-      );
-      checkbox.find('input')!.trigger('onKeyUp', {
-        keyCode: Key.Enter,
-      });
-      expect(spy).not.toHaveBeenCalled();
     });
 
     it('is not called from click events when disabled', () => {
@@ -173,22 +128,6 @@ describe('<Checkbox />', () => {
 
       expect(element).toContainReactComponent('input', {
         disabled: false,
-      });
-    });
-
-    it('can change values when disabled', () => {
-      const spy = jest.fn();
-      const checkbox = mountWithApp(
-        <Checkbox label="label" disabled onChange={spy} />,
-      );
-
-      checkbox.find('input')!.trigger('onKeyUp', {
-        keyCode: Key.Enter,
-      });
-      checkbox.setProps({checked: true});
-
-      expect(checkbox).toContainReactComponent('input', {
-        checked: true,
       });
     });
   });

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 import {RadioButton, Checkbox, InlineError} from 'components';
 
-import {Choice} from '../../Choice';
 import {ChoiceList, ChoiceListProps} from '../ChoiceList';
 
 describe('<ChoiceList />', () => {
@@ -314,12 +313,18 @@ describe('<ChoiceList />', () => {
       const getChoiceElement = (index: number) =>
         choiceList.findAll(Checkbox)[index];
 
-      getChoiceElement(1).find(Choice)!.trigger('onClick');
+      const event = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      getChoiceElement(1).find('input')!.domNode?.dispatchEvent(event);
       expect(spy).toHaveBeenLastCalledWith(['one', 'two'], 'MyChoiceList');
 
       choiceList.setProps({selected});
 
-      getChoiceElement(2).find(Choice)!.trigger('onClick');
+      getChoiceElement(2).find('input')!.domNode?.dispatchEvent(event);
       expect(spy).toHaveBeenLastCalledWith(
         ['one', 'two', 'three'],
         'MyChoiceList',
@@ -327,7 +332,7 @@ describe('<ChoiceList />', () => {
 
       choiceList.setProps({selected});
 
-      getChoiceElement(0).find(Choice)!.trigger('onClick');
+      getChoiceElement(0).find('input')!.domNode?.dispatchEvent(event);
       expect(spy).toHaveBeenLastCalledWith(['two', 'three'], 'MyChoiceList');
     });
   });

--- a/src/components/IndexTable/components/Checkbox/Checkbox.tsx
+++ b/src/components/IndexTable/components/Checkbox/Checkbox.tsx
@@ -36,8 +36,7 @@ export const Checkbox = memo(function Checkbox() {
         <div
           className={wrapperClassName}
           onClick={onInteraction}
-          onKeyUp={onInteraction}
-          onChange={stopPropagation}
+          onKeyUp={noop}
         >
           <PolarisCheckbox
             id={itemId}
@@ -92,8 +91,4 @@ export function CheckboxWrapper({children}: CheckboxWrapperProps) {
   );
 }
 
-function stopPropagation(
-  event: React.MouseEvent | React.KeyboardEvent | React.FormEvent,
-) {
-  event.stopPropagation();
-}
+function noop() {}

--- a/src/components/IndexTable/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/IndexTable/components/Checkbox/tests/Checkbox.test.tsx
@@ -55,19 +55,6 @@ describe('<Checkbox />', () => {
     });
   });
 
-  it('prevents onChange propagation', () => {
-    let stopPropagationSpy = false;
-    const checkbox = mountWithTable(<Checkbox />);
-
-    triggerCheckboxEvent(checkbox, 'onChange', {
-      stopPropagation: () => {
-        stopPropagationSpy = true;
-      },
-    });
-
-    expect(stopPropagationSpy).toBe(true);
-  });
-
   it('toggles the checkbox value when clicked', () => {
     const onSelectionChange = jest.fn();
     const checkbox = mountWithTable(<Checkbox />, {
@@ -76,21 +63,6 @@ describe('<Checkbox />', () => {
     });
 
     triggerCheckboxEvent(checkbox, 'onClick', {
-      nativeEvent: {shiftKey: false},
-    });
-
-    expect(onSelectionChange).toHaveBeenCalledWith('single', false, defaultId);
-  });
-
-  it('toggles the checkbox when spacebar is pressed', () => {
-    const onSelectionChange = jest.fn();
-    const checkbox = mountWithTable(<Checkbox />, {
-      indexProps: {onSelectionChange},
-      rowProps: {selected: true},
-    });
-
-    triggerCheckboxEvent(checkbox, 'onKeyUp', {
-      key: ' ',
       nativeEvent: {shiftKey: false},
     });
 

--- a/src/components/IndexTable/components/Row/Row.tsx
+++ b/src/components/IndexTable/components/Row/Row.tsx
@@ -43,6 +43,7 @@ export const Row = memo(function Row({
   const handleInteraction = useCallback(
     (event: React.MouseEvent | React.KeyboardEvent) => {
       event.stopPropagation();
+
       if (('key' in event && event.key !== ' ') || !onSelectionChange) return;
       const selectionType = event.nativeEvent.shiftKey
         ? SelectionType.Multi
@@ -97,7 +98,6 @@ export const Row = memo(function Row({
       if (!tableRowRef.current || isNavigating.current) {
         return;
       }
-
       event.stopPropagation();
       event.preventDefault();
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3973  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->
The goal of this PR is too properly support screen readers on the `Checkbox` component.  Currently, screen reader users must use a combination of `space+enter` key to be able to check/uncheck the checkbox.

### WHAT is this pull request doing?

The current proposal modifies how the component handles the `click` and `keyboard` events.  We now avoid hijacking the events on the `Choice` component.  Instead we listen to the events directly on the `<input />` element.  The reason why we need to do this is due to the fact that screen readers are triggering the events directly on the `<input />` element and this triggered event is not capturable by the `onClick` handler of the wrapping `Choice` component.

I also removed the `onKeyPress` handler of the `<input />`.  According to the HTML spec, triggering the `space` keyboard event will activate (invoke the click event) of an interact-able element. To properly support the focus state, I added the `onFocus` handler on the `<input />` since this was managed inside the `onKeyPress` previously which is a side effect.

For a deep dive please refer to the following document: [Polaris Checkbox (in Draft Orders context)](https://docs.google.com/document/d/1SIOQRb1vNipj9DEeeMINBI_kOl3KV76bx9hR4oh3lK4/edit?usp=sharing)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

To properly 🎩 these changes, one will need to build the repo using `yarn dev`.
The checkbox can be tested through the playbook and is actually used in the following examples
 - [Checkbox](http://localhost:6006/?path=/story/all-components-checkbox--default-checkboxes)
 - [Choice list/Multi-choice list](http://localhost:6006/?path=/story/all-components-choice-list--multi-choice-list)
 - [Option list](http://localhost:6006/?path=/story/all-components-option-list--multiple-option-list)

Step to 🎩 
 - With a storybook example open
 - Tab to focus on the checkbox
 - Hit `space` to check
 - With the mouse, left click the box to uncheck
 - With the mouse, left click the label to check
 - With a screen reader, use the screen readers shortcut to activate the checkbox
     - For mac VoiceOver, the combination is `control+option+space`

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
