### PR TITLE
[Button] Clean up Button styling and $button-filled mixin

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,4 +30,6 @@ Bump polaris-icons to v4.10.0 ([#4569](https://github.com/Shopify/polaris-react/
 
 ### Code quality
 
+Clean up Button styling and $button-filled mixin([#4635](https://github.com/Shopify/polaris-react/pull/4635))
+
 ### Deprecations

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -111,21 +111,29 @@ $stacking-order: (
   margin-left: -($spinner-size / 2);
 }
 
+.primary,
+.destructive {
+  @include button-filled();
+
+  &.disabled {
+    @include recolor-icon(var(--p-icon-disabled));
+    color: var(--p-text-disabled);
+    box-shadow: none;
+    border-color: transparent;
+  }
+}
+
 .primary {
   --p-button-color: var(--p-action-primary);
   --p-button-text: var(--p-text-on-primary);
   --p-button-color-hover: var(--p-action-primary-hovered);
   --p-button-color-active: var(--p-action-primary-pressed);
   --p-button-color-depressed: var(--p-action-primary-depressed);
-  @include button-filled(color('indigo'), color('indigo', 'dark'));
+  @include button-filled();
   @include recolor-icon(var(--p-icon-on-primary));
 
   &.disabled {
-    @include recolor-icon(var(--p-icon-disabled));
     background: var(--p-action-primary-disabled);
-    color: var(--p-text-disabled);
-    border-color: transparent;
-    box-shadow: none;
   }
 }
 
@@ -135,15 +143,11 @@ $stacking-order: (
   --p-button-color-hover: var(--p-action-critical-hovered);
   --p-button-color-active: var(--p-action-critical-pressed);
   --p-button-color-depressed: var(--p-action-critical-depressed);
-  @include button-filled(color('red'), color('red', 'dark'));
+  @include button-filled();
   @include recolor-icon(var(--p-icon-on-critical));
 
   &.disabled {
-    @include recolor-icon(var(--p-icon-disabled));
     background: var(--p-action-critical-disabled);
-    color: var(--p-text-disabled);
-    box-shadow: none;
-    border-color: transparent;
   }
 }
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -113,7 +113,7 @@ $stacking-order: (
 
 .primary,
 .destructive {
-  @include button-filled();
+  @include button-filled;
 
   &.disabled {
     @include recolor-icon(var(--p-icon-disabled));
@@ -129,7 +129,6 @@ $stacking-order: (
   --p-button-color-hover: var(--p-action-primary-hovered);
   --p-button-color-active: var(--p-action-primary-pressed);
   --p-button-color-depressed: var(--p-action-primary-depressed);
-  @include button-filled();
   @include recolor-icon(var(--p-icon-on-primary));
 
   &.disabled {
@@ -143,7 +142,6 @@ $stacking-order: (
   --p-button-color-hover: var(--p-action-critical-hovered);
   --p-button-color-active: var(--p-action-critical-pressed);
   --p-button-color-depressed: var(--p-action-critical-depressed);
-  @include button-filled();
   @include recolor-icon(var(--p-icon-on-critical));
 
   &.disabled {

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -76,10 +76,8 @@
   color: var(--p-text-disabled);
 }
 
-@mixin button-filled($button-color, $focus-color, $outline-color: null) {
+@mixin button-filled() {
   @include focus-ring($border-width: 0);
-  $border-color: darken($button-color, 10%);
-  $active-color: darken($button-color, 15%);
   background: var(--p-button-color);
   border-width: 0;
   border-color: transparent;


### PR DESCRIPTION
## Description

While working through #4592 I found the `$button-filled` mixin had some parameters that weren't being used. Decided to clean up the mixin and simplify the `Button` style by creating a joint `.primary, .destructive` style.

co-authored with @alex-page 
<!--
  Context about the problem that’s being addressed.
-->

