### PR TITLE
[Page] Update the subtitle prop type from a string to a React node

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
-- Changed the `Page` prop `subtitle` type from a string to a React node ([#](https://github.com/Shopify/polaris-react/pull/))
+- Changed the `Page` prop `subtitle` type from a string to a React node ([#4638](https://github.com/Shopify/polaris-react/pull/4638))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
+- Changed the `Page` prop `subtitle` type from a string to a React node ([#](https://github.com/Shopify/polaris-react/pull/))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -10,7 +10,7 @@ export interface TitleProps {
   /** Page title, in large type */
   title?: string;
   /** Page subtitle, in regular type*/
-  subtitle?: string;
+  subtitle?: React.ReactNode;
   /** Important and non-interactive status information shown immediately after the title. */
   titleMetadata?: React.ReactNode;
   /** thumbnail that precedes the title */

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -67,6 +67,14 @@ describe('<Page />', () => {
         subtitle,
       });
     });
+
+    it('gets passed into the <Header /> as an html element', () => {
+      const subtitle = <div>Subtitle</div>;
+      const page = mountWithApp(<Page {...mockProps} subtitle={subtitle} />);
+      expect(page).toContainReactComponent(Header, {
+        subtitle,
+      });
+    });
   });
 
   describe('titleMetadata', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Inventory history is looking to use the subtitle prop as a link to the product variant:

<kbd><img width="757" alt="Screen Shot 2021-11-12 at 3 02 41 PM" src="https://user-images.githubusercontent.com/22782157/141527833-54cb887d-337c-48c0-acef-292f44ae4c2c.png"></kbd>


### WHAT is this pull request doing?

This PR updates the page subtitle prop from a `string` to a `ReactNode` in order to pass in a link.

I couldn't find any documentation or direct reason not to make this change, but if this is something we don't want to ship then feel free to decline these changes and we can try to find an alternative approach for inventory 😄.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
