### PR TITLE
Reduce the types of absolute imports that are considered valid

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Development workflow
 
+- Removed `baseUrl` from `tsconfig.json`. Attempting to do an absolute import from `src/BLAH` now results in a error when type-checking. ([#4643](https://github.com/Shopify/polaris-react/pull/4643))
+
 ### Dependency upgrades
 
 ### Code quality

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Development workflow
 
-- Removed `baseUrl` from `tsconfig.json`. Attempting to do an absolute import from `src/BLAH` now results in a error when type-checking. ([#4643](https://github.com/Shopify/polaris-react/pull/4643))
+- Tightened up what absolute imports are allowed. Removed `baseUrl` from `tsconfig.json`. Attempting to do an absolute import from `src/X` or `components/X` now results in a error when type-checking. ([#4643](https://github.com/Shopify/polaris-react/pull/4643))
 
 ### Dependency upgrades
 

--- a/loom.config.ts
+++ b/loom.config.ts
@@ -55,7 +55,7 @@ function jestAdjustmentsPlugin() {
         configuration.jestModuleNameMapper?.hook((moduleNameMapper) => ({
           ...moduleNameMapper,
           '^tests/(.*)': '<rootDir>/tests/$1',
-          '^components($|/.*)': '<rootDir>/src/components$1',
+          '^components$': '<rootDir>/src/components',
         }));
 
         // Ignore tests in the examples folder

--- a/loom.config.ts
+++ b/loom.config.ts
@@ -50,13 +50,13 @@ function jestAdjustmentsPlugin() {
     test.hook(({hooks}) => {
       hooks.configure.hook((configuration) => {
         // Aliases for root-level imports, which are used in test files
-        // These do not work in rollup builds, so perhaps we shouldn't configure
-        // them to work in jest tests either
-        configuration.jestModuleNameMapper?.hook((moduleMapper) => {
-          moduleMapper['^tests(.*)'] = '<rootDir>/tests$1';
-          moduleMapper['^(components)(.*)'] = '<rootDir>/src/$1$2';
-          return moduleMapper;
-        });
+        // `tests/*` as an alias for test-only utilities is acceptable, but
+        // avoid others as paths working in jest but not in rollup is confusing
+        configuration.jestModuleNameMapper?.hook((moduleNameMapper) => ({
+          ...moduleNameMapper,
+          '^tests/(.*)': '<rootDir>/tests/$1',
+          '^components($|/.*)': '<rootDir>/src/components$1',
+        }));
 
         // Ignore tests in the examples folder
         configuration.jestConfig?.hook((config) => ({

--- a/src/components/AccountConnection/tests/AccountConnection.test.tsx
+++ b/src/components/AccountConnection/tests/AccountConnection.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 import {Avatar} from 'components';
-import {Button} from 'components/Button';
 
+import {Button} from '../../Button';
 import {AccountConnection} from '../AccountConnection';
 
 describe('<AccountConnection />', () => {

--- a/src/components/AppProvider/tests/AppProvider.test.tsx
+++ b/src/components/AppProvider/tests/AppProvider.test.tsx
@@ -1,11 +1,11 @@
 import React, {useContext} from 'react';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
-import {MediaQueryProvider} from 'components/MediaQueryProvider';
 
 import {LinkContext} from '../../../utilities/link';
-import {AppProvider} from '../AppProvider';
 import {FocusManager} from '../../FocusManager';
+import {MediaQueryProvider} from '../../MediaQueryProvider';
+import {AppProvider} from '../AppProvider';
 
 describe('<AppProvider />', () => {
   beforeEach(() => {

--- a/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Sticky} from 'components/Sticky';
-import {EventListener} from 'components/EventListener';
 
 import {getTableHeadingsBySelector} from '../utilities';
 import {EmptySearchResult} from '../../EmptySearchResult';
+import {EventListener} from '../../EventListener';
 import {Spinner} from '../../Spinner';
+import {Sticky} from '../../Sticky';
 import {Button} from '../../Button';
 import {Checkbox} from '../../Checkbox';
 import {Badge} from '../../Badge';

--- a/src/components/Labelled/tests/Labelled.test.tsx
+++ b/src/components/Labelled/tests/Labelled.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {InlineError, Label, Labelled} from 'components';
 import {mountWithApp} from 'tests/utilities';
-import {Button} from 'components/Button';
+
+import {Button} from '../../Button';
 
 describe('<Labelled />', () => {
   it('passes relevant props along to the label', () => {

--- a/src/components/Layout/tests/Layout.test.tsx
+++ b/src/components/Layout/tests/Layout.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {TextContainer} from 'components/TextContainer';
-import {Heading} from 'components/Heading';
 
+import {Heading} from '../../Heading';
+import {TextContainer} from '../../TextContainer';
 import {Section} from '../components';
 import {Layout} from '../Layout';
 import styles from '../Layout.scss';

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 import type {CustomRoot} from '@shopify/react-testing';
 import {Tooltip, TextField} from 'components';
-import {TextStyle} from 'components/TextStyle';
 
 import {Key} from '../../../types';
 import {Pagination} from '../Pagination';
 import {Button} from '../../Button';
 import {ButtonGroup} from '../../ButtonGroup';
+import {TextStyle} from '../../TextStyle';
 import en from '../../../../locales/en.json';
 
 interface HandlerMap {

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -1,8 +1,8 @@
 import React, {useCallback, useRef, useState} from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {PositionedOverlay} from 'components/PositionedOverlay';
 import {Portal} from 'components';
 
+import {PositionedOverlay} from '../../PositionedOverlay';
 import {Popover} from '../Popover';
 import type {PopoverPublicAPI} from '../Popover';
 import {PopoverOverlay} from '../components';

--- a/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
@@ -1,7 +1,7 @@
-import {InlineError} from 'components/InlineError';
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
+import {InlineError} from '../../../../InlineError';
 import {SingleThumb} from '../SingleThumb';
 
 const mockProps = {

--- a/src/components/SettingToggle/tests/SettingToggle.test.tsx
+++ b/src/components/SettingToggle/tests/SettingToggle.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {SettingAction} from 'components/SettingAction';
 
+import {SettingAction} from '../../SettingAction';
 import {SettingToggle} from '../SettingToggle';
 
 describe('<SettingToggle />', () => {

--- a/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {ViewMinor} from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
-import {Avatar} from 'components/Avatar';
 
+import {Avatar} from '../../../../Avatar';
 import {UserMenu} from '../UserMenu';
 import {Menu} from '../../Menu';
 

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {UnstyledLink} from 'components/UnstyledLink';
+
+import {UnstyledLink} from '../UnstyledLink';
 
 describe('<UnstyledLink />', () => {
   describe('custom link component', () => {

--- a/src/utilities/index-table/tests/hooks-useContainerScroll.test.tsx
+++ b/src/utilities/index-table/tests/hooks-useContainerScroll.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 import {IndexTable, IndexTableProps} from 'components';
-import {ScrollContainer} from 'components/IndexTable';
 
+// eslint-disable-next-line @shopify/strict-component-boundaries
+import {ScrollContainer} from '../../../components/IndexTable';
 import {useContainerScroll} from '../hooks';
 
 function Component({condensed}: {condensed?: boolean}) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "strictFunctionTypes": false,
     "paths": {
       "components": ["./src/components"],
-      "components/*": ["./src/components/*"],
       "tests/*": ["./tests/*"]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@shopify/typescript-configs/library",
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "./",
     "noEmit": false,
     "emitDeclarationOnly": true,
@@ -12,8 +11,9 @@
     "importsNotUsedAsValues": "error",
     "strictFunctionTypes": false,
     "paths": {
-      "components": ["src/components"],
-      "components/*": ["src/components/*"]
+      "components": ["./src/components"],
+      "components/*": ["./src/components/*"],
+      "tests/*": ["./tests/*"]
     }
   },
   "include": ["./config/typescript", "./src", "./tests", "./playground"]


### PR DESCRIPTION
### WHY are these changes introduced?

A follow up to #4561. I realised a better fix for aiming to shrink the
number of absolute paths.

By removing `baseUrl` we remove support for all files being able to be
arbitrarily accessed (e.g. `src/components/BLAH`).
Now only paths mentioned in the paths object can be accessed absolutely.

After this PR is merged the only valid absolute imports are `tests/SOMETHING` and `components`. `src/FOO`, `tests` and `components/FOO` are all considered invalid.

### WHAT is this pull request doing?

- Removes `baseUrl` from tsconfig.json, meaning arbitrary absolute paths like "src/components/BLAH` are no longer possible - the only usable absolute paths are those specified in the paths object
- Adds a path aliases for `tests/*` that point to the `tests` folder. In reality this will only be used for the `tests/utilities` folder.
- Replaces all usage of importing `components/X` with a relative import
- Remove path alias form `components/X` from tsconfig and jest module mapper.

### How to 🎩

- Tests and type check passes
- Try importing something from `src/components` and note that it fails.