### PR TITLE
[ActionList] Wrap MenuItem Focus Arrow Navigation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -36,6 +36,29 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Properly support `selected` prop for `Navigation.Item` when `url` prop is not specified ([#4375](https://github.com/Shopify/polaris-react/pull/4375))
 - Fixed an accessibility bug in `Icon` where `aria-label` was used incorrectly ([#4414](https://github.com/Shopify/polaris-react/pull/4414))
 - Fixed a bug in `Option` where the label would cause scrollbars to appear instead of wrapping ([#4411](https://github.com/Shopify/polaris-react/pull/4411))
+- Keyboard arrow navigation support added in `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+- Menu role attribute value support added in `ActionList/Section` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+
+### Bug fixes
+
+- Properly support JAWS screen reader for `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+- Keyboard arrow navigation support added in `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+- Keyboard wrapping support added in `ActionList` ([#4644](https://github.com/Shopify/polaris-react/pull/4644))
+- Menu role attribute value support added in `ActionList/Section` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+
+- Fixed a bug in `Banner` where loading state wasn't getting passed to `primaryAction` ([#4338](https://github.com/Shopify/polaris-react/pull/4338))
+- Fixed `Popover` not correctly positioning itself ([#4357](https://github.com/Shopify/polaris-react/pull/4357))
+- Fixed a bug `TextField` where Safari would render the incorrect text color ([#4344](https://github.com/Shopify/polaris-react/pull/4344))
+- Fixed screen readers reading out the clear button in `TextField` when there is no input ([#4369](https://github.com/Shopify/polaris-react/pull/4369))
+- Fix bug in Safari where `Button` text is gray instead of white after changing state from disabled to enabled ([#4270](https://github.com/Shopify/polaris-react/pull/4270))
+- Bring back borders on the `IndexTable` sticky cells ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
+- Adjust `IndexTable` sticky z-index to avoid collisions with focused `TextField` ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
+- Adjust `IndexTable` rows to have a grey hover state when unselected ([#4359](https://github.com/Shopify/polaris-react/pull/4359))
+- Properly support `selected` prop for `Navigation.Item` when `url` prop is not specified ([#4375](https://github.com/Shopify/polaris-react/pull/4375))
+- Fixed an accessibility bug in `Icon` where `aria-label` was used incorrectly ([#4414](https://github.com/Shopify/polaris-react/pull/4414))
+- Fixed a bug in `Option` where the label would cause scrollbars to appear instead of wrapping ([#4411](https://github.com/Shopify/polaris-react/pull/4411))
+
+### Documentation
 
 ### Documentation
 

--- a/src/components/ActionList/ActionList.tsx
+++ b/src/components/ActionList/ActionList.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, {useRef} from 'react';
 
-import type {ActionListItemDescriptor, ActionListSection} from '../../types';
+import {
+  wrapFocusNextFocusableMenuItem,
+  wrapFocusPreviousFocusableMenuItem,
+} from '../../utilities/focus';
+import {KeypressListener} from '../KeypressListener';
+import {ActionListItemDescriptor, ActionListSection, Key} from '../../types';
 import {classNames} from '../../utilities/css';
 
 import {Section} from './components';
@@ -24,6 +29,7 @@ export function ActionList({
   onActionAnyItem,
 }: ActionListProps) {
   let finalSections: ActionListSection[] = [];
+  const actionListRef = useRef<HTMLDivElement & HTMLUListElement>(null);
 
   if (items) {
     finalSections = [{items}, ...sections];
@@ -48,5 +54,46 @@ export function ActionList({
     ) : null;
   });
 
-  return <Element className={className}>{sectionMarkup}</Element>;
+  const handleFocusPreviousItem = (evt: KeyboardEvent) => {
+    evt.preventDefault();
+    if (actionListRef.current && evt.target) {
+      wrapFocusPreviousFocusableMenuItem(
+        actionListRef.current,
+        evt.target as HTMLElement,
+      );
+    }
+  };
+
+  const handleFocusNextItem = (evt: KeyboardEvent) => {
+    evt.preventDefault();
+    if (actionListRef.current && evt.target) {
+      wrapFocusNextFocusableMenuItem(
+        actionListRef?.current,
+        evt.target as HTMLElement,
+      );
+    }
+  };
+
+  const listeners =
+    actionRole === 'menuitem' ? (
+      <>
+        <KeypressListener
+          keyEvent="keydown"
+          keyCode={Key.DownArrow}
+          handler={handleFocusNextItem}
+        />
+        <KeypressListener
+          keyEvent="keydown"
+          keyCode={Key.UpArrow}
+          handler={handleFocusPreviousItem}
+        />
+      </>
+    ) : null;
+
+  return (
+    <Element ref={actionListRef} className={className}>
+      {listeners}
+      {sectionMarkup}
+    </Element>
+  );
 }

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -110,6 +110,7 @@ function ActionListInPopoverExample() {
     <div style={{height: '250px'}}>
       <Popover active={active} activator={activator} onClose={toggleActive}>
         <ActionList
+          actionRole="menuitem"
           items={[
             {
               content: 'Import file',
@@ -147,6 +148,7 @@ function ActionListWithMediaExample() {
     <div style={{height: '200px'}}>
       <Popover active={active} activator={activator} onClose={toggleActive}>
         <ActionList
+          actionRole="menuitem"
           items={[
             {content: 'Import file', icon: ImportMinor},
             {content: 'Export file', icon: ExportMinor},
@@ -178,6 +180,7 @@ function ActionListWithSuffixExample() {
     <div style={{height: '200px'}}>
       <Popover active={active} activator={activator} onClose={toggleActive}>
         <ActionList
+          actionRole="menuitem"
           items={[
             {
               content: 'Import file',
@@ -214,6 +217,7 @@ function SectionedActionListExample() {
     <div style={{height: '250px'}}>
       <Popover active={active} activator={activator} onClose={toggleActive}>
         <ActionList
+          actionRole="menuitem"
           sections={[
             {
               title: 'File options',
@@ -250,6 +254,7 @@ function ActionListWithDestructiveItemExample() {
     <div style={{height: '250px'}}>
       <Popover active={active} activator={activator} onClose={toggleActive}>
         <ActionList
+          actionRole="menuitem"
           sections={[
             {
               title: 'File options',
@@ -291,6 +296,7 @@ function ActionListWithHelpTextExample() {
     <div style={{height: '250px'}}>
       <Popover active={active} activator={activator} onClose={toggleActive}>
         <ActionList
+          actionRole="menuitem"
           sections={[
             {
               items: [
@@ -321,6 +327,7 @@ function ActionListWithPrefixSuffixExample() {
   return (
     <div style={{height: '250px', maxWidth: '350px'}}>
       <ActionList
+        actionRole="menuitem"
         items={[
           {
             content: 'Go here',

--- a/src/components/ActionList/components/Section/Section.tsx
+++ b/src/components/ActionList/components/Section/Section.tsx
@@ -63,7 +63,18 @@ export function Section({
     <p className={titleClassName}>{section.title}</p>
   ) : null;
 
-  const sectionRole = actionRole === 'option' ? 'presentation' : undefined;
+  let sectionRole;
+  switch (actionRole) {
+    case 'option':
+      sectionRole = 'presentation';
+      break;
+    case 'menuitem':
+      sectionRole = 'menu';
+      break;
+    default:
+      sectionRole = undefined;
+      break;
+  }
 
   const sectionMarkup = (
     <div className={className}>
@@ -75,7 +86,9 @@ export function Section({
   );
 
   return hasMultipleSections ? (
-    <li className={styles.Section}>{sectionMarkup}</li>
+    <li className={styles.Section} role="presentation">
+      {sectionMarkup}
+    </li>
   ) : (
     sectionMarkup
   );

--- a/src/components/ActionList/tests/ActionList.test.tsx
+++ b/src/components/ActionList/tests/ActionList.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {ImportMinor, ExportMinor} from '@shopify/polaris-icons';
+import {KeypressListener} from 'components';
 import {mountWithApp} from 'test-utilities';
 
 import {ActionList} from '../ActionList';
 import {Badge} from '../../Badge';
 import {Item, Section} from '../components';
+import {Key} from '../../../types';
 
 describe('<ActionList />', () => {
   let mockOnActionAnyItem: jest.Mock;
@@ -176,5 +178,96 @@ describe('<ActionList />', () => {
       children: 'badge',
       status: 'new',
     });
+  });
+  it('wraps focus to first item in action list after keydown event on last element', () => {
+    const actionList = mountWithApp(
+      <ActionList
+        sections={[
+          {
+            title: 'One',
+            items: [
+              {content: 'First section'},
+              {content: 'First section second item'},
+            ],
+          },
+          {
+            title: 'Two',
+            items: [
+              {content: 'Second section'},
+              {content: 'Second section second item'},
+            ],
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="menuitem"
+      />,
+    );
+
+    const actionListButtons = actionList.findAll('button');
+    const keypressListener = actionList.find(KeypressListener, {
+      keyCode: Key.DownArrow,
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      keyCode: Key.DownArrow,
+    });
+
+    Object.defineProperty(event, 'target', {
+      writable: false,
+      // set target to last focusable item in list
+      value: actionListButtons[actionListButtons.length - 1].domNode,
+    });
+
+    keypressListener?.trigger('handler', event);
+
+    // expect focus to wrap back to first item in action list
+    expect(document.activeElement).toStrictEqual(actionListButtons[0].domNode);
+  });
+
+  it('wraps focus to last item in action list after keyup event on first element', () => {
+    const actionList = mountWithApp(
+      <ActionList
+        sections={[
+          {
+            title: 'One',
+            items: [
+              {content: 'First section'},
+              {content: 'First section second item'},
+            ],
+          },
+          {
+            title: 'Two',
+            items: [
+              {content: 'Second section'},
+              {content: 'Second section second item'},
+            ],
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="menuitem"
+      />,
+    );
+
+    const actionListButtons = actionList.findAll('button');
+    const keypressListener = actionList.find(KeypressListener, {
+      keyCode: Key.UpArrow,
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      keyCode: Key.UpArrow,
+    });
+
+    Object.defineProperty(event, 'target', {
+      writable: false,
+      // set target to first focusable item in list
+      value: actionListButtons[0].domNode,
+    });
+
+    keypressListener?.trigger('handler', event);
+
+    // expect focus to wrap to last item in action list
+    expect(document.activeElement).toStrictEqual(
+      actionListButtons[actionListButtons.length - 1].domNode,
+    );
   });
 });

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -147,7 +147,10 @@ function PopoverWithActionListExample() {
         activator={activator}
         onClose={togglePopoverActive}
       >
-        <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
+        <ActionList
+          actionRole="menuitem"
+          items={[{content: 'Import'}, {content: 'Export'}]}
+        />
       </Popover>
     </div>
   );
@@ -199,6 +202,7 @@ function PopoverContentExample() {
         </Popover.Pane>
         <Popover.Pane>
           <ActionList
+            actionRole="menuitem"
             items={[
               {content: 'Online store'},
               {content: 'Facebook'},

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -9,7 +9,8 @@ const FOCUSABLE_SELECTOR =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])';
-
+const MENUITEM_FOCUSABLE_SELECTORS =
+  'a[role="menuitem"],frame[role="menuitem"],iframe[role="menuitem"],input[role="menuitem"]:not([type=hidden]):not(:disabled),select[role="menuitem"]:not(:disabled),textarea[role="menuitem"]:not(:disabled),button[role="menuitem"]:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>
   currentTarget.blur();
 
@@ -124,6 +125,61 @@ export function focusLastKeyboardFocusableNode(
   }
 
   return false;
+}
+
+function getMenuFocusableDescendants(element: HTMLElement) {
+  return element.querySelectorAll(
+    MENUITEM_FOCUSABLE_SELECTORS,
+  ) as NodeListOf<HTMLElement>;
+}
+
+function getCurrentFocusedElementIndex(
+  allFocusableChildren: NodeListOf<HTMLElement>,
+  currentFocusedElement: HTMLElement,
+) {
+  let currentItemIdx = 0;
+
+  for (const focusableChild of allFocusableChildren) {
+    if (focusableChild === currentFocusedElement) {
+      break;
+    }
+    currentItemIdx++;
+  }
+  return currentItemIdx;
+}
+
+export function wrapFocusPreviousFocusableMenuItem(
+  parentElement: HTMLElement,
+  currentFocusedElement: HTMLElement,
+) {
+  const allFocusableChildren = getMenuFocusableDescendants(parentElement);
+  const currentItemIdx = getCurrentFocusedElementIndex(
+    allFocusableChildren,
+    currentFocusedElement,
+  );
+
+  if (currentItemIdx === 0) {
+    allFocusableChildren[allFocusableChildren.length - 1].focus();
+  } else {
+    allFocusableChildren[currentItemIdx - 1].focus();
+  }
+}
+
+export function wrapFocusNextFocusableMenuItem(
+  parentElement: HTMLElement,
+  currentFocusedElement: HTMLElement,
+) {
+  const allFocusableChildren = getMenuFocusableDescendants(parentElement);
+  const currentItemIdx = getCurrentFocusedElementIndex(
+    allFocusableChildren,
+    currentFocusedElement,
+  );
+
+  if (currentItemIdx === allFocusableChildren.length - 1) {
+    allFocusableChildren[0].focus();
+  } else {
+    allFocusableChildren[currentItemIdx + 1].focus();
+  }
 }
 
 function matches(node: HTMLElement, selector: string) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Works towards  #4419

The goal of this PR is to wrap Focus For menuitems in an actionlist. 

### WHAT is this pull request doing?
Focus wrap is done by adding a few new functions to `focus.ts`:
1. `getMenuFocusableDescendants` --> finds all focusable children of an element with the role `menuitem`
2. `getCurrentFocusedElementIndex` --> of a list of focusable elements, find the index of the currently focused item (important for knowing when at top or bottom of list in order to wrap)
3. `wrapFocusPreviousFocusableMenuItem` --> move focus to previous node or if at the top, wrap to the bottom element in the list
4. `wrapFocusNextFocusableMenuItem` --> move focus to next node or if at the bottom, wrap to the top element.

I also added a line of code in Section where if the sectionRole is menu, we will default to each action having a role of `menuitem`. The reason for this is because I think it would be good for this change to make all actionlists be keyboard accessible with as little changes as possible. This way only the actionlist would need the `menu` role instead of actionlist needing the `menu` as well as each item requiring `menuitem` as well.

There is an issue that Patrick and I determined would be out of scope for this particular PR. If there is an active item, `ScrollTo` is called so that the active element is scrolled to. It does this by adding an anchor element. There are two issues here:
1. If the first element is active, when the popover autofocus is set to `first-node`, the first focusable node it finds is the anchor element that was scrolled to, breaking focus wrapping
2. Although the scroll to scrolls to the active element, focus is still controlled by the popover and focus will be set to the first node in the list if the popover has autofocus set to `first-node`, not to the active element like it should


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
