### PR TITLE
[Page] fix destructive secondary action not visible

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Bug fixes
 
 - Fixed `segmented` `ButtonGroup` misaligning icon only buttons when grouped with text only buttons ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
+- Added missing styles for `destructive` `Page` `secondaryActions` ([#4647](https://github.com/Shopify/polaris-react/pull/4647))
 
 ### Documentation
 

--- a/playground/Playground.tsx
+++ b/playground/Playground.tsx
@@ -4,17 +4,8 @@ import {Page} from '../src';
 
 export function Playground() {
   return (
-    // <Page title="Playground">
-    //   {/* Add the code you want to test in here */}
-    // </Page>
-    <Page
-      title="My Page"
-      primaryAction={{content: 'Edit', url: '#Edit'}}
-      secondaryActions={[
-        {content: 'Delete', destructive: true, url: '#Delete'},
-      ]}
-    >
-      Some page content
+    <Page title="Playground">
+      {/* Add the code you want to test in here */}
     </Page>
   );
 }

--- a/playground/Playground.tsx
+++ b/playground/Playground.tsx
@@ -4,8 +4,17 @@ import {Page} from '../src';
 
 export function Playground() {
   return (
-    <Page title="Playground">
-      {/* Add the code you want to test in here */}
+    // <Page title="Playground">
+    //   {/* Add the code you want to test in here */}
+    // </Page>
+    <Page
+      title="My Page"
+      primaryAction={{content: 'Edit', url: '#Edit'}}
+      secondaryActions={[
+        {content: 'Delete', destructive: true, url: '#Delete'},
+      ]}
+    >
+      Some page content
     </Page>
   );
 }

--- a/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -26,5 +26,10 @@ $button-spacing: rem(12px);
       border: none !important;
       @include focus-ring($border-width: rem(0));
     }
+
+    &.destructive {
+      // --p-button-color: var(--p-action-critical);
+      background: var(--p-text-on-critical);
+    }
   }
 }

--- a/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -26,10 +26,12 @@ $button-spacing: rem(12px);
       border: none !important;
       @include focus-ring($border-width: rem(0));
     }
+  }
 
-    &.destructive {
-      // --p-button-color: var(--p-action-critical);
-      background: var(--p-text-on-critical);
+  &.destructive {
+    a,
+    button {
+      color: var(--p-text-critical);
     }
   }
 }

--- a/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -31,7 +31,18 @@ $button-spacing: rem(12px);
   &.destructive {
     a,
     button {
-      color: var(--p-text-critical);
+      @include recolor-icon(var(--p-icon-critical));
+      color: var(--p-interactive-critical);
+
+      // stylelint-disable-next-line selector-max-specificity
+      &:hover {
+        background-color: var(--p-surface-critical-subdued-hovered) !important;
+      }
+
+      // stylelint-disable selector-max-specificity
+      &:active {
+        background-color: var(--p-surface-critical-subdued-pressed) !important;
+      }
     }
   }
 }

--- a/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect, useRef} from 'react';
 
+import {classNames} from '../../../../utilities/css';
 import {Button} from '../../../Button';
 import type {ButtonProps} from '../../../Button';
 
@@ -25,7 +26,13 @@ export function SecondaryAction({
   }, [getOffsetWidth]);
 
   return (
-    <span className={styles.SecondaryAction} ref={secondaryActionsRef}>
+    <span
+      className={classNames(
+        styles.SecondaryAction,
+        rest?.destructive && styles.destructive,
+      )}
+      ref={secondaryActionsRef}
+    >
       <Button onClick={onAction} {...rest}>
         {children}
       </Button>

--- a/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -13,6 +13,7 @@ interface SecondaryAction extends ButtonProps {
 
 export function SecondaryAction({
   children,
+  destructive,
   onAction,
   getOffsetWidth,
   ...rest
@@ -29,7 +30,7 @@ export function SecondaryAction({
     <span
       className={classNames(
         styles.SecondaryAction,
-        rest?.destructive && styles.destructive,
+        destructive && styles.destructive,
       )}
       ref={secondaryActionsRef}
     >

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -258,6 +258,21 @@ Use when a primary action functions better as part of the page content instead o
 </Page>
 ```
 
+### Page with destructive secondary action
+
+<!-- example-for: web -->
+
+Used to visually indicate that the secondary page action is destructive.
+
+```jsx
+<Page
+  title="General"
+  secondaryActions={[{content: 'Delete', destructive: true}]}
+>
+  <p>Page content</p>
+</Page>
+```
+
 ### Page with subtitle
 
 <!-- example-for: web -->


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4510 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fixes the text and hover interaction colors for `destructive` `Page` `secondaryActions`. CC: @sarahill 

|Page destructive secondary action|Before|After|
|---|---|---|
|No interaction|<img width="958" alt="Screen Shot 2022-01-24 at 11 33 16 AM" src="https://user-images.githubusercontent.com/18447883/150825242-54d4be6d-16a9-4f8a-9f49-bbd426c7916a.png">|<img width="955" alt="Screen Shot 2022-01-24 at 11 30 57 AM" src="https://user-images.githubusercontent.com/18447883/150825152-4182108b-a495-43c0-bf90-bb4618185acf.png">|
|Hovered|<img width="960" alt="Screen Shot 2022-01-24 at 11 33 25 AM" src="https://user-images.githubusercontent.com/18447883/150825198-5b559d50-b75f-40aa-aa92-cf1c61c0d034.png">|<img width="957" alt="Screen Shot 2022-01-24 at 11 31 07 AM" src="https://user-images.githubusercontent.com/18447883/150825299-d5bb2e37-f3f8-48f4-b542-ccc32f7ecee6.png">|

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page
      title="My Page"
      primaryAction={{content: 'Edit', url: '#Edit'}}
      secondaryActions={[
        {content: 'Delete', destructive: true, url: '#Delete'},
      ]}
    >
      Some page content
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
