### PR TITLE
[Badge] Reduce pip size and spacing

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,7 +10,6 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated `VisuallyHidden` styles to not use `top` or `clip` ([#4641](https://github.com/Shopify/polaris-react/pull/4641))
 - Added `PlainAction` type to `ComplexAction`. ([#4489](https://github.com/Shopify/polaris-react/pull/4489))
 - Updated timeout of `Popover` exit to `durationFast`. ([#4651](https://github.com/Shopify/polaris-react/pull/4651))
-- Reduced the size of the font and `progress` pip in `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 - Reduced the size of the `progress` pip in `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 
 ### Bug fixes
@@ -37,3 +36,5 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Removed custom and unnecessary font weight properties ([#4648](https://github.com/Shopify/polaris-react/pull/4648))
 
 ### Deprecations
+
+- Deprecated passing `attention` to the `status` prop on `Badge` in favor of `warning` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated `VisuallyHidden` styles to not use `top` or `clip` ([#4641](https://github.com/Shopify/polaris-react/pull/4641))
 - Added `PlainAction` type to `ComplexAction`. ([#4489](https://github.com/Shopify/polaris-react/pull/4489))
 - Updated timeout of `Popover` exit to `durationFast`. ([#4651](https://github.com/Shopify/polaris-react/pull/4651))
+- Reduced the size of the font and `progress` pip in `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
+- Reduced the size of the `progress` pip in `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Documentation
 
+- Added an example for the `small` `size` variant of `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
+
 ### Development workflow
 
 - Tightened up what absolute imports are allowed. Removed `baseUrl` from `tsconfig.json`. Attempting to do an absolute import from `src/X` or `components/X` now results in a error when type-checking. ([#4643](https://github.com/Shopify/polaris-react/pull/4643))

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -1,13 +1,9 @@
 @import '../../styles/common';
-
-$height: rem(20px);
-$small-height: rem(18px);
-$extra-small-height: rem(16px);
 $horizontal-padding: spacing(tight);
-$vertical-padding: rem(3px);
+$vertical-padding: calc(#{spacing(extra-tight)} - #{rem(2px)});
 
-$pip-size: rem(10px);
-$pip-spacing: ($height - $pip-size) / 2;
+$pip-size: spacing(tight);
+$pip-spacing: calc(#{$pip-size} / 2);
 
 .Badge {
   --p-component-badge-pip-color: var(--p-icon);
@@ -15,21 +11,19 @@ $pip-spacing: ($height - $pip-size) / 2;
   align-items: center;
   padding: $vertical-padding $horizontal-padding;
   background-color: var(--p-surface-neutral);
-  border-radius: $height;
-  font-size: rem(13px);
-  line-height: $extra-small-height;
+  border-radius: spacing(loose);
+  font-size: font-size(caption);
+  line-height: line-height(caption, large-screen);
   color: var(--p-text);
   font-weight: 400;
 
   @media print {
     border: solid rem(0.1px) var(--p-border);
-    border-radius: $height;
   }
 }
 
 .sizeSmall {
   font-size: font-size(caption, large-screen);
-  line-height: $small-height;
 }
 
 .statusSuccess {
@@ -73,7 +67,8 @@ $pip-spacing: ($height - $pip-size) / 2;
   color: var(--p-component-badge-pip-color);
   height: $pip-size;
   width: $pip-size;
-  margin: 0 spacing(extra-tight) 0 ($pip-spacing - $horizontal-padding);
+  margin-right: $pip-spacing;
+  margin-left: calc(#{$vertical-padding} - #{$pip-spacing});
   border: border-width(thick) solid currentColor;
   border-radius: 50%;
   flex-shrink: 0;
@@ -98,9 +93,9 @@ $pip-spacing: ($height - $pip-size) / 2;
   @media print {
     background: none;
     // 100px is an arbitrarily large number so that you can't see the curvature
-    // of the box shadow. y-offset is 3px larger than the spread to make it look
-    // like it is half-way down the pip (which is 6px tall)
-    box-shadow: 0 -103px 0 -100px currentColor inset;
+    // of the box shadow. y-offset is 2px larger than the spread to make it look
+    // like it is half-way down the pip (which is 4px tall)
+    box-shadow: 0 -102px 0 -100px currentColor inset;
   }
 }
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -7,14 +7,21 @@ import {VisuallyHidden} from '../VisuallyHidden';
 
 import styles from './Badge.scss';
 
-type Status = 'success' | 'info' | 'attention' | 'critical' | 'warning' | 'new';
+type StatusDeprecated = 'attention';
+type Status =
+  | 'success'
+  | 'info'
+  | 'critical'
+  | 'warning'
+  | 'new'
+  | StatusDeprecated;
 type Progress = 'incomplete' | 'partiallyComplete' | 'complete';
 type Size = 'small' | 'medium';
 
 export interface BadgeProps {
   /** The content to display inside the badge. */
   children?: string;
-  /** Set the color of the badge for the given status. */
+  /** Colors and labels the badge with the given status. */
   status?: Status;
   /** Render a pip showing the progress of a given task. */
   progress?: Progress;
@@ -95,6 +102,10 @@ export function Badge({
       break;
     case STATUS_LABELS.attention:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.attention');
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Deprecation: The `attention` `status` on Badge is deprecated and will be removed in the next major version. Use the `warning` `status` instead.',
+      );
       break;
     case STATUS_LABELS.new:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.new');

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -19,7 +19,7 @@ export interface BadgeProps {
   /** Render a pip showing the progress of a given task. */
   progress?: Progress;
   /**
-   * Medium or small size. Use `small` only in the main navigation of an app frame.
+   * Medium or small size.
    * @default 'medium'
    */
   size?: Size;

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -27,6 +27,12 @@ Badges are used to inform merchants of the status of an object or of an action t
 
 ---
 
+## Deprecation rationale
+
+- As of v7.4.0, the `attention` `status` is deprecated. Use `warning` status instead. Support for the `attention` `status` will be removed in v8.0.0. The new design language that shipped in v6.0.0 replaced the 12 color spectrum with a [semantic color system](https://polaris.shopify.com/design/colors#section-color-roles). Since there is no attention color role in the semantic color system, `attention` `status` now uses warning color role tokens and is redundant to the `warning` status.
+
+---
+
 ## Best practices
 
 Badges benefit merchants by:

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -99,6 +99,14 @@ Use to give a non-critical status update on a piece of information or action.
 
 <!-- /content-for -->
 
+### Small badge
+
+Use in layouts with minimal space, like inside of an `IndexTable` cell.
+
+```jsx
+<Badge size="small">Fulfilled</Badge>
+```
+
 ### Informational badge
 
 Use to call out an object or action as having an important attribute. For example, marking an option as “Recommended” or marking a theme as “Published”.


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/web/issues/52577 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

[Figma spec](https://www.figma.com/file/TQX4JBfDgAKUIlNvmWCdQv/Density-improvements?node-id=164%3A45566)

Initially the density changes included a reduced font-size, but since there is a `small` `size` variant that already supports the desired font-size, we'll opt to use the `small` `Badge` variation on list views to achieve the results we want.

- Reduces the`progress` pip size from `10px` to `8px`
- Reduces the left and right spacing from `3px` to `2px`
- Deprecates the `attention` `status` since it's redundant to the `warning` `status` and there's no semantic color role token equivalent 
- Adds an example for the `small` `size`  variant

|Badge density changes|  Before | After  |
|---|---|---|
|web|<img width="428" alt="Screen Shot 2021-11-17 at 12 50 29 PM" src="https://user-images.githubusercontent.com/18447883/142255161-b452bbe2-afb0-475f-b127-06534ac01d8d.png">|<img width="424" alt="Screen Shot 2021-11-17 at 1 37 49 PM" src="https://user-images.githubusercontent.com/18447883/142261999-55a88f33-5e30-4f72-9bc2-82b633de5d9f.png">|
|print|<img width="499" alt="Screen Shot 2021-11-17 at 12 50 48 PM" src="https://user-images.githubusercontent.com/18447883/142255334-ee5a7415-d10e-49d1-90ab-e0a8ce583316.png">|<img width="489" alt="Screen Shot 2021-11-17 at 1 38 15 PM" src="https://user-images.githubusercontent.com/18447883/142261962-cdcd106c-35f8-4cd7-9756-ed2a14ad7816.png">|

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- Check out the `Badge` [Storybook examples](https://5d559397bae39100201eedc1-xpgqlgfbgj.chromatic.com/?path=/story/all-components-badge--partially-complete-badge) 
- Approve and deny changes in [the visual regression testing results](https://www.chromatic.com/build?appId=5d559397bae39100201eedc1&number=8972)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Stack, Badge} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Stack>
        <Badge size="small" progress="complete">Fulfilled</Badge>
        <Badge size="small" status="attention" progress="incomplete">
          Unpaid
        </Badge>
        <Badge size="small" progress="partiallyComplete">Partially fulfilled</Badge>
        <Badge size="small" status="success">Completed</Badge>
      </Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
