### PR TITLE
[DropZone] Updating outline and overlay text size

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added `PlainAction` type to `ComplexAction`. ([#4489](https://github.com/Shopify/polaris-react/pull/4489))
 - Updated timeout of `Popover` exit to `durationFast`. ([#4651](https://github.com/Shopify/polaris-react/pull/4651))
 - Reduced the size of the `progress` pip in `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
+- Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
 
 ### Bug fixes
 

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -2,8 +2,7 @@
 
 $dropzone-padding: rem(15px);
 $dropzone-border-style: dashed;
-$dropzone-min-height-extra-large: rem(205px);
-$dropzone-min-height-large: rem(160px);
+$dropzone-min-height-large: rem(100px);
 $dropzone-min-height-medium: rem(100px);
 $dropzone-min-height-small: rem(50px);
 
@@ -97,10 +96,6 @@ $dropzone-stacking-order: (
   &::after {
     border-color: var(--p-border-disabled);
   }
-}
-
-.sizeExtraLarge {
-  min-height: $dropzone-min-height-extra-large;
 }
 
 .sizeLarge {

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -69,7 +69,11 @@ $dropzone-stacking-order: (
   &:not(.isDisabled) {
     &:hover {
       cursor: pointer;
-      background-color: var(--p-surface-hovered);
+      background-color: var(--p-surface-selected-hovered);
+
+      &::after {
+        border-color: var(--p-interactive-hovered);
+      }
     }
   }
 

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -19,12 +19,12 @@ $dropzone-stacking-order: (
   bottom: 0;
   opacity: 1;
   transform: scale(1);
-  border: border-width(thick) $dropzone-border-style transparent;
+  border: border-width() $dropzone-border-style transparent;
 }
 
 @mixin set-border-radius {
   border-radius: calc(
-    var(--p-border-radius-base) + #{border-width(thick)} + #{rem(1px)}
+    var(--p-border-radius-base) + #{border-width()} + #{rem(1px)}
   );
 }
 
@@ -43,7 +43,7 @@ $dropzone-stacking-order: (
     right: 0;
     bottom: 0;
     left: 0;
-    border: border-width(thick) $dropzone-border-style transparent;
+    border: border-width() $dropzone-border-style transparent;
     border-radius: var(--p-border-radius-base);
     pointer-events: none;
   }
@@ -61,7 +61,7 @@ $dropzone-stacking-order: (
 }
 
 .hasOutline {
-  padding: border-width(thick);
+  padding: border-width();
 
   &::after {
     border-color: var(--p-border);
@@ -124,7 +124,7 @@ $dropzone-stacking-order: (
 }
 
 .Container {
-  @include focus-ring($border-width: border-width(thick));
+  @include focus-ring($border-width: border-width());
   flex: 1;
 }
 
@@ -140,7 +140,7 @@ $dropzone-stacking-order: (
   justify-content: center;
   align-items: center;
   padding: $dropzone-padding;
-  border: border-width(thick) $dropzone-border-style var(--p-interactive);
+  border: border-width() $dropzone-border-style var(--p-interactive);
   text-align: center;
   color: var(--p-interactive);
   background-color: var(--p-surface-selected);

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -71,6 +71,7 @@ $dropzone-stacking-order: (
       cursor: pointer;
       background-color: var(--p-surface-selected-hovered);
 
+      // stylelint-disable-next-line selector-max-specificity
       &::after {
         border-color: var(--p-interactive-hovered);
       }

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -425,10 +425,11 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
       <div className={styles.Overlay}>
         <Stack vertical spacing="tight">
           {size === 'small' && <Icon source={icon} color={color} />}
-          {size === 'extraLarge' && (
-            <TextStyle variation="strong">{text}</TextStyle>
+          {(size === 'extraLarge' || size === 'medium' || size === 'large') && (
+            <Caption>
+              <TextStyle variation="strong">{text}</TextStyle>
+            </Caption>
           )}
-          {(size === 'medium' || size === 'large') && <Caption>{text}</Caption>}
         </Stack>
       </div>
     );

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -157,15 +157,13 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
           return;
         }
 
-        let size = 'extraLarge';
+        let size = 'large';
         const width = node.current.getBoundingClientRect().width;
 
         if (width < 100) {
           size = 'small';
         } else if (width < 160) {
           size = 'medium';
-        } else if (width < 300) {
-          size = 'large';
         }
 
         setSize(size);
@@ -184,7 +182,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
     setTrue: handleFocus,
     setFalse: handleBlur,
   } = useToggle(false);
-  const [size, setSize] = useState('extraLarge');
+  const [size, setSize] = useState('large');
   const [measuring, setMeasuring] = useState(true);
 
   const i18n = useI18n();
@@ -425,7 +423,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
       <div className={styles.Overlay}>
         <Stack vertical spacing="tight">
           {size === 'small' && <Icon source={icon} color={color} />}
-          {(size === 'extraLarge' || size === 'medium' || size === 'large') && (
+          {(size === 'medium' || size === 'large') && (
             <Caption>
               <TextStyle variation="strong">{text}</TextStyle>
             </Caption>

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -16,7 +16,7 @@ import {capitalize} from '../../utilities/capitalize';
 import {Icon} from '../Icon';
 import {Stack} from '../Stack';
 import {Caption} from '../Caption';
-import {DisplayText} from '../DisplayText';
+import {TextStyle} from '../TextStyle';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {Labelled, LabelledProps} from '../Labelled';
 import {useI18n} from '../../utilities/i18n';
@@ -426,9 +426,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
         <Stack vertical spacing="tight">
           {size === 'small' && <Icon source={icon} color={color} />}
           {size === 'extraLarge' && (
-            <DisplayText size="small" element="p">
-              {text}
-            </DisplayText>
+            <TextStyle variation="strong">{text}</TextStyle>
           )}
           {(size === 'medium' || size === 'large') && <Caption>{text}</Caption>}
         </Stack>

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -95,9 +95,9 @@ function DropZoneExample() {
 
   const fileUpload = !files.length && <DropZone.FileUpload />;
   const uploadedFiles = files.length > 0 && (
-    <Stack vertical>
-      {files.map((file, index) => (
-        <div style={{padding: '1.6rem'}}>
+    <div style={{padding: '0'}}>
+      <Stack vertical>
+        {files.map((file, index) => (
           <Stack alignment="center" key={index}>
             <Thumbnail
               size="small"
@@ -112,9 +112,9 @@ function DropZoneExample() {
               {file.name} <Caption>{file.size} bytes</Caption>
             </div>
           </Stack>
-        </div>
-      ))}
-    </Stack>
+        ))}
+      </Stack>
+    </div>
   );
 
   return (
@@ -279,6 +279,26 @@ function DropZoneWithDropOnPageExample() {
     </Stack>
   );
 
+  const uploadMessage = !uploadedFiles && (
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Caption>
+        <TextStyle variation="strong">
+          <TextStyle variation="subdued">
+            Drop or <Link>browse files</Link>
+          </TextStyle>
+        </TextStyle>
+      </Caption>
+    </div>
+  );
+
   return (
     <Page
       breadcrumbs={[{content: 'Products'}]}
@@ -295,6 +315,7 @@ function DropZoneWithDropOnPageExample() {
     >
       <DropZone dropOnPage onDrop={handleDropZoneDrop}>
         {uploadedFiles}
+        {uploadMessage}
       </DropZone>
     </Page>
   );

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -97,20 +97,22 @@ function DropZoneExample() {
   const uploadedFiles = files.length > 0 && (
     <Stack vertical>
       {files.map((file, index) => (
-        <Stack alignment="center" key={index}>
-          <Thumbnail
-            size="small"
-            alt={file.name}
-            source={
-              validImageTypes.includes(file.type)
-                ? window.URL.createObjectURL(file)
-                : NoteMinor
-            }
-          />
-          <div>
-            {file.name} <Caption>{file.size} bytes</Caption>
-          </div>
-        </Stack>
+        <div style={{padding: '1.6rem'}}>
+          <Stack alignment="center" key={index}>
+            <Thumbnail
+              size="small"
+              alt={file.name}
+              source={
+                validImageTypes.includes(file.type)
+                  ? window.URL.createObjectURL(file)
+                  : NoteMinor
+              }
+            />
+            <div>
+              {file.name} <Caption>{file.size} bytes</Caption>
+            </div>
+          </Stack>
+        </div>
       ))}
     </Stack>
   );

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 import {clock} from '@shopify/jest-dom-mocks';
-import {Label, Labelled, DisplayText, Caption} from 'components';
+import {Label, Labelled, TextStyle, Caption} from 'components';
 import {mountWithApp} from 'tests/utilities';
 import type {CustomRoot} from '@shopify/react-testing';
 
@@ -217,7 +217,7 @@ describe('<DropZone />', () => {
     [true, 'file', 'Drop files to upload', 'Upload files'],
   ])(
     'renders texts when allowMultiple is %s and type is %s',
-    (allowMultiple, type, expectedDisplayText, expectedLabelText) => {
+    (allowMultiple, type, expectedTextStyle, expectedLabelText) => {
       const dropZone = mountWithApp(
         <DropZone
           overlay
@@ -234,8 +234,8 @@ describe('<DropZone />', () => {
 
       dropZone.forceUpdate();
 
-      expect(dropZone).toContainReactComponent(DisplayText, {
-        children: expectedDisplayText,
+      expect(dropZone).toContainReactComponent(TextStyle, {
+        children: expectedTextStyle,
       });
 
       expect(dropZone).toContainReactComponent(Labelled, {
@@ -317,7 +317,7 @@ describe('<DropZone />', () => {
       setBoundingClientRect('small');
       const dropZone = mountWithApp(<DropZone overlayText={overlayText} />);
       fireEvent({wrapper: dropZone, eventType: 'dragenter'});
-      expect(dropZone).not.toContainReactComponent(DisplayText);
+      expect(dropZone).not.toContainReactComponent(TextStyle);
       expect(dropZone).not.toContainReactComponent(Caption);
     });
 
@@ -337,22 +337,22 @@ describe('<DropZone />', () => {
       expect(captionText).toContainReactText(overlayText);
     });
 
-    it('renders a DisplayText containing the overlayText on extra-large screens', () => {
+    it('renders a TextStyle containing the overlayText on extra-large screens', () => {
       setBoundingClientRect('extraLarge');
       const dropZone = mountWithApp(<DropZone overlayText={overlayText} />);
       fireEvent({wrapper: dropZone, eventType: 'dragenter'});
-      const displayText = dropZone.find(DisplayText);
-      expect(displayText).toContainReactText(overlayText);
+      const textStyle = dropZone.find(TextStyle);
+      expect(textStyle).toContainReactText(overlayText);
     });
 
-    it('renders a DisplayText containing the overlayText on any screen size when variableHeight is true', () => {
+    it('renders a TextStyle containing the overlayText on any screen size when variableHeight is true', () => {
       setBoundingClientRect('small');
       const dropZone = mountWithApp(
         <DropZone overlayText={overlayText} variableHeight />,
       );
       fireEvent({wrapper: dropZone, eventType: 'dragenter'});
-      const displayText = dropZone.find(DisplayText);
-      expect(displayText).toContainReactText(overlayText);
+      const textStyle = dropZone.find(TextStyle);
+      expect(textStyle).toContainReactText(overlayText);
     });
   });
 
@@ -364,7 +364,7 @@ describe('<DropZone />', () => {
         <DropZone errorOverlayText={errorOverlayText} accept="image/gif" />,
       );
       fireEvent({wrapper: dropZone, eventType: 'dragenter'});
-      expect(dropZone).not.toContainReactComponent(DisplayText);
+      expect(dropZone).not.toContainReactComponent(TextStyle);
       expect(dropZone).not.toContainReactComponent(Caption);
     });
 
@@ -389,17 +389,17 @@ describe('<DropZone />', () => {
       expect(captionText).toContainReactText(errorOverlayText);
     });
 
-    it('renders a DisplayText containing the overlayText on extra-large screens', () => {
+    it('renders a TextStyle containing the overlayText on extra-large screens', () => {
       setBoundingClientRect('extraLarge');
       const dropZone = mountWithApp(
         <DropZone errorOverlayText={errorOverlayText} accept="image/gif" />,
       );
       fireEvent({wrapper: dropZone, eventType: 'dragenter'});
-      const displayText = dropZone.find(DisplayText);
-      expect(displayText).toContainReactText(errorOverlayText);
+      const textStyle = dropZone.find(TextStyle);
+      expect(textStyle).toContainReactText(errorOverlayText);
     });
 
-    it('renders a DisplayText containing the overlayText on any screen size when variableHeight is true', () => {
+    it('renders a TextStyle containing the overlayText on any screen size when variableHeight is true', () => {
       setBoundingClientRect('small');
       const dropZone = mountWithApp(
         <DropZone
@@ -409,8 +409,8 @@ describe('<DropZone />', () => {
         />,
       );
       fireEvent({wrapper: dropZone, eventType: 'dragenter'});
-      const displayText = dropZone.find(DisplayText);
-      expect(displayText).toContainReactText(errorOverlayText);
+      const textStyle = dropZone.find(TextStyle);
+      expect(textStyle).toContainReactText(errorOverlayText);
     });
   });
 

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -36,7 +36,6 @@ const widths = {
   small: 99,
   medium: 159,
   large: 299,
-  extraLarge: 1024,
 };
 
 describe('<DropZone />', () => {
@@ -337,14 +336,6 @@ describe('<DropZone />', () => {
       expect(captionText).toContainReactText(overlayText);
     });
 
-    it('renders a TextStyle containing the overlayText on extra-large screens', () => {
-      setBoundingClientRect('extraLarge');
-      const dropZone = mountWithApp(<DropZone overlayText={overlayText} />);
-      fireEvent({wrapper: dropZone, eventType: 'dragenter'});
-      const textStyle = dropZone.find(TextStyle);
-      expect(textStyle).toContainReactText(overlayText);
-    });
-
     it('renders a TextStyle containing the overlayText on any screen size when variableHeight is true', () => {
       setBoundingClientRect('small');
       const dropZone = mountWithApp(
@@ -387,16 +378,6 @@ describe('<DropZone />', () => {
       const captionText = dropZone.find(Caption);
 
       expect(captionText).toContainReactText(errorOverlayText);
-    });
-
-    it('renders a TextStyle containing the overlayText on extra-large screens', () => {
-      setBoundingClientRect('extraLarge');
-      const dropZone = mountWithApp(
-        <DropZone errorOverlayText={errorOverlayText} accept="image/gif" />,
-      );
-      fireEvent({wrapper: dropZone, eventType: 'dragenter'});
-      const textStyle = dropZone.find(TextStyle);
-      expect(textStyle).toContainReactText(errorOverlayText);
     });
 
     it('renders a TextStyle containing the overlayText on any screen size when variableHeight is true', () => {

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -8,6 +8,7 @@
   background: none;
   border: 0;
   font-size: inherit;
+  font-weight: inherit;
   color: var(--p-interactive);
   text-decoration: underline;
   cursor: pointer;


### PR DESCRIPTION
### WHY are these changes introduced?

As part of a larger effort to clean up and polish drop zones and asset uploading, this makes a few small visual tweaks to the component.

### WHAT is this pull request doing?

- Changes the dashed border to use our default border thickness instead of `thick`
- Got rid of the `extraLarge` variation and brought down the `min-height` of the large variation
- It uses `Caption` and `TextStyle` instead of `DisplayText` for the overlay text.

#### Before
<img width="642" alt="Screen Shot 2021-11-17 at 11 46 49 AM" src="https://user-images.githubusercontent.com/478990/142244752-442e0651-6a78-498f-ba8b-7c8753ed5659.png">
<img width="635" alt="Screen Shot 2021-11-17 at 11 47 10 AM" src="https://user-images.githubusercontent.com/478990/142244755-5f921a6c-5be2-42da-b25c-69ffac8117e3.png">
<img width="638" alt="Screen Shot 2021-11-17 at 11 47 25 AM" src="https://user-images.githubusercontent.com/478990/142244756-1d8b402d-b1bf-4e35-ba6b-76d7e9eb5557.png">

#### After
<img width="547" alt="Screen Shot 2021-11-17 at 12 19 14 PM" src="https://user-images.githubusercontent.com/478990/142249969-15064d4f-f0f3-4042-906c-76af3c0ff5b9.png">
<img width="542" alt="Screen Shot 2021-11-17 at 12 19 57 PM" src="https://user-images.githubusercontent.com/478990/142249966-dd180bef-490d-4d17-9f0a-d3b30ff5dd0b.png">
<img width="540" alt="Screen Shot 2021-11-17 at 12 19 39 PM" src="https://user-images.githubusercontent.com/478990/142249967-20016511-ca7d-40c6-8445-2b490dc111a5.png">

I also went ahead and fixed a padding issue on one of the examples.

#### Before
<img width="631" alt="Screen Shot 2021-11-17 at 11 54 10 AM" src="https://user-images.githubusercontent.com/478990/142250037-d92917f6-b8fc-45c5-90ff-ef17ceaf4c1a.png">

#### After

<img width="633" alt="Screen Shot 2021-11-17 at 11 53 36 AM" src="https://user-images.githubusercontent.com/478990/142250048-4ff9ef05-3740-4dfe-8ee7-0fe0b2785049.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
