### PR TITLE
[DropZone] Adjusting FileUpload padding

### DIFF
--- a/src/components/DropZone/components/FileUpload/FileUpload.scss
+++ b/src/components/DropZone/components/FileUpload/FileUpload.scss
@@ -13,7 +13,11 @@ $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
   height: 100%;
 }
 
-.FileUploadSmallView {
+.large {
+  padding: rem(32px);
+}
+
+.small {
   padding: 1.25rem;
 }
 

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -35,18 +35,15 @@ export function FileUpload(props: FileUploadProps) {
     ),
   } = props;
 
-  const buttonStyles =
-    size === 'extraLarge' || size === 'large'
-      ? classNames(
-          styles.Button,
-          size && size !== 'extraLarge' && styles.slim,
-          focused && styles.focused,
-          disabled && styles.disabled,
-        )
-      : null;
+  const buttonStyles = classNames(
+    styles.Button,
+    styles.slim,
+    focused && styles.focused,
+    disabled && styles.disabled,
+  );
 
   const buttonMarkup =
-    (size === 'extraLarge' || size === 'large') && buttonStyles ? (
+    size === 'large' && buttonStyles ? (
       <div className={buttonStyles}>{actionTitle}</div>
     ) : null;
 
@@ -63,20 +60,12 @@ export function FileUpload(props: FileUploadProps) {
   const fileUploadClassName = classNames(
     styles.FileUpload,
     measuring && styles.measuring,
-    size === 'small' && styles.FileUploadSmallView,
+    size === 'large' && styles.large,
+    size === 'small' && styles.small,
   );
 
   let viewMarkup;
   switch (size) {
-    case 'extraLarge':
-      viewMarkup = (
-        <Stack vertical>
-          <img width="40" src={uploadArrow} alt="" />
-          {buttonMarkup}
-          <TextStyle variation="subdued">{actionHint}</TextStyle>
-        </Stack>
-      );
-      break;
     case 'large':
       viewMarkup = (
         <Stack vertical spacing="tight">

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -19,7 +19,7 @@ describe('<FileUpload />', () => {
       const fileUpload = mountWithApp(
         <DropZoneContext.Provider
           value={{
-            size: 'extraLarge',
+            size: 'large',
             type: 'file',
             ...defaultStates,
             measuring: true,
@@ -32,45 +32,6 @@ describe('<FileUpload />', () => {
       expect(fileUpload).toContainReactComponent('div', {
         className: expect.stringContaining('measuring'),
       });
-    });
-  });
-
-  describe('extraLarge', () => {
-    it('renders extra large view for type file', () => {
-      const fileUpload = mountWithApp(
-        <DropZoneContext.Provider
-          value={{
-            size: 'extraLarge',
-            type: 'file',
-            ...defaultStates,
-          }}
-        >
-          <FileUpload />
-        </DropZoneContext.Provider>,
-      );
-
-      expect(fileUpload).toContainReactComponent('img', {
-        src: uploadArrowImage,
-      });
-      expect(fileUpload).toContainReactComponent(TextStyle);
-      expect(fileUpload).toContainReactComponent('div', {
-        className: 'Button',
-      });
-    });
-
-    it('renders extra large view for type image', () => {
-      const fileUpload = mountWithApp(
-        <DropZoneContext.Provider
-          value={{size: 'extraLarge', type: 'image', ...defaultStates}}
-        >
-          <FileUpload />
-        </DropZoneContext.Provider>,
-      );
-
-      expect(fileUpload).toContainReactComponent('div', {
-        className: 'Button',
-      });
-      expect(fileUpload).toContainReactComponent(TextStyle);
     });
   });
 

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -45,6 +45,9 @@ describe('<FileUpload />', () => {
         </DropZoneContext.Provider>,
       );
 
+      expect(fileUpload).toContainReactComponent('img', {
+        src: uploadArrowImage,
+      });
       expect(fileUpload).toContainReactComponent(Caption);
       expect(fileUpload).toContainReactComponent(TextStyle);
 


### PR DESCRIPTION
### WHY are these changes introduced?

After #4662 the large size of `FileUpload` looks a little tight.

### WHAT is this pull request doing?

This gives it a bit more padding for spacing. I also cleaned up some remaining references to size `extraLarge` in `FileUpload`

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [NA] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [NA] Updated the component's `README.md` with documentation changes
- [NA] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [NA] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
