### PR TITLE
Fixed border radius on resource list bulk actions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Bug fixes
 
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
+- Fixed the round corners on the `BulkActions` wrapper of `ResourceList` ([#4666](https://github.com/Shopify/polaris-react/pull/4666))
 
 ### Documentation
 

--- a/src/components/ResourceList/ResourceList.scss
+++ b/src/components/ResourceList/ResourceList.scss
@@ -32,6 +32,9 @@ $item-wrapper-loading-height: rem(64px);
   position: relative;
   background-color: var(--p-surface);
   z-index: resource-list(header-outer-wrapper-stacking-order);
+  overflow: hidden;
+  border-top-left-radius: var(--p-border-radius-wide, border-radius(large));
+  border-top-right-radius: var(--p-border-radius-wide, border-radius(large));
 
   + .ResourceList {
     border-top: border('divider');


### PR DESCRIPTION

### WHY are these changes introduced?

While tophatting a PR I noticed the round corder on the bulk action on resource list were square:

<img width="335" alt="Screen Shot 2021-11-17 at 4 37 36 PM" src="https://user-images.githubusercontent.com/1229901/142286606-70e662b7-7b37-4653-9e52-e96edb015849.png">

So I fixed it.
<img width="309" alt="Screen Shot 2021-11-17 at 4 35 52 PM" src="https://user-images.githubusercontent.com/1229901/142286608-462a40fc-79b5-4e65-97cc-7d4771de5075.png">



### How to 🎩

In story book look at the resource list example and ensure the corners are round.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
