### PR TITLE
[TextField] Disable click focus for datetime-local

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Bug fixes
 
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
+- Fixed bug with selecting time in `TextField` with `type="datetime-local"` in Safari ([#4669](https://github.com/Shopify/polaris-react/pull/4669))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -515,7 +515,7 @@ export function TextField({
   }
 
   function handleClick({target}: React.MouseEvent) {
-    if (containsAffix(target)) {
+    if (containsAffix(target) || type === 'datetime-local') {
       return;
     }
     inputRef.current && inputRef.current.focus();


### PR DESCRIPTION
### WHY are these changes introduced?

Currently our click handler on `TextField`s that sets focus is conflicting with the `datetime-local` input in Safari.

### WHAT is this pull request doing?

This disables the click handler if the input type is `datetime-local`.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Try a `TextField` component with `datetime-local` set as `type` in Safari and make sure you can click to select the time portion of the input.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [NA] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [NA] Updated the component's `README.md` with documentation changes
- [NA] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [NA] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
