### PR TITLE
Update [top bar] description to include "header"

### DIFF
--- a/src/components/TopBar/README.md
+++ b/src/components/TopBar/README.md
@@ -1,11 +1,12 @@
 ---
 name: Top bar
-category: Structure
+category: Navigation
 keywords:
   - global chrome
   - global features
   - topbar
   - top bar
+  - header
   - nav bar
   - bar
   - navbar

--- a/src/components/TopBar/README.md
+++ b/src/components/TopBar/README.md
@@ -19,7 +19,7 @@ omitAppProvider: true
 
 # Top bar
 
-Merchants can use the top bar component to search, access menus, and navigate by clicking on the logo. It’s always visible at the top of interfaces like Shopify or Shopify Plus. Third-party apps that use the top bar can customize the color to match their brand using the [app provider](https://polaris.shopify.com/components/structure/app-provider) component and are required to use their own logo.
+The top bar is a header component that allows merchants to search, access menus, and navigate by clicking on the logo. It’s always visible at the top of interfaces like Shopify or Shopify Plus. Third-party apps that use the top bar can customize the color to match their brand using the [app provider](https://polaris.shopify.com/components/structure/app-provider) component and are required to use their own logo.
 
 ---
 


### PR DESCRIPTION

### WHY are these changes introduced?

@kwringe offered this feedback about the top bar:
>I think that Top Bar should be part of Navigation. I would also advocate that we somehow sneak the word “header” into it’s description so that when you search for the term “header”, that Top Bar appears (I didn’t realize that we used the term Top Bar).

### WHAT is this pull request doing?

Updated top bar component description to include the term "header" and clarify intended usage for this component. Also added `header` as a keyword for this component. 