### PR TITLE
Remove color function

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
 - Fixed an issue with `TextField` where date and time were uneditable on click ([#4671](https://github.com/Shopify/polaris-react/pull/4671))
+- Fixed an issue with `Popover` where the transform property interfered with descendants positioning ([#4685](https://github.com/Shopify/polaris-react/pull/4685))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
 - Fixed an issue with `TextField` where date and time were uneditable on click ([#4671](https://github.com/Shopify/polaris-react/pull/4671))
+- Fixed an issue with `Popover` where the transform property interfered with descendants positioning ([#4685](https://github.com/Shopify/polaris-react/pull/4685))
 
 ### Documentation
 

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Načítání stránky"
     },
-    "Spinner": {
-      "warningMessage": "Barva ({color}) není určena pro spinnery o velikosti: {size}). Pro velké spinnery jsou k dispozici tyto barvy: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Více karet"
     },

--- a/locales/de.json
+++ b/locales/de.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Seite wird geladen"
     },
-    "Spinner": {
-      "warningMessage": "Die Farbe {color} sollte nicht für {size} Spinner verwendet werden. Die für große Spinner verfügbaren Farben sind: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Weitere Registerkarten"
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Cargando página"
     },
-    "Spinner": {
-      "warningMessage": "El color {color} no está concebido para ser utilizado en spinners {size} Los colores disponibles en los spinners grandes son: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Más pestañas"
     },

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Sivu latautuu"
     },
-    "Spinner": {
-      "warningMessage": "Väriä {color} ei ole tarkoitus käyttää koon {size} spinnereissä. Suurten spinnerien värit ovat: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Lisää välilehtiä"
     },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Chargement de page"
     },
-    "Spinner": {
-      "warningMessage": "La couleur {color} n'est pas destinée à être utilisée sur les boutons fléchés de {size}. Les couleurs disponibles sur les grands boutons fléchés sont : {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Plus d'onglets"
     },

--- a/locales/it.json
+++ b/locales/it.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Caricamento della pagina"
     },
-    "Spinner": {
-      "warningMessage": "Il colore {color} non è pensato per essere usato su spinner {size}. Colori disponibili per grandi spinner: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Altre schede"
     },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "ページの読み込み中"
     },
-    "Spinner": {
-      "warningMessage": "{color}色は{size}のスピナーでは使用されていません。大きなスピナーで利用可能な色は次のとおりです: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "その他のタブ"
     },

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "페이지 로딩"
     },
-    "Spinner": {
-      "warningMessage": "{color} 색상은 {size} 스피너에 사용할 수 없습니다. 대형 스피너에 사용할 수 있는 색상: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "탭 더 보기"
     },

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Siden laster"
     },
-    "Spinner": {
-      "warningMessage": "Fargen {color} er ikke ment å bli brukt på {size} spinnere. Fargene som er tilgjengelige på store spinnere, er: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Flere faner"
     },

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Pagina is aan het laden"
     },
-    "Spinner": {
-      "warningMessage": "De kleur {color} is niet bedoeld voor gebruik op {size} spinners. De beschikbare kleuren op grote spinner zijn: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Meer tabbladen"
     },

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Ładowanie strony"
     },
-    "Spinner": {
-      "warningMessage": "Kolor {color} nie jest przeznaczony do używania na pokrętłach {size}. Kolory dostępne na dużych pokrętłach to: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Więcej kart"
     },

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Página a carregar"
     },
-    "Spinner": {
-      "warningMessage": "A cor {color} não deve ser utilizada em spinners de {size}. As cores disponíveis em spinners grandes são: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Mais separadores"
     },

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Sidan laddar"
     },
-    "Spinner": {
-      "warningMessage": "Färgen {color} är inte tänkt att användas för {size} spinnare. De färger som finns för stora spinnare är: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Fler flikar"
     },

--- a/locales/th.json
+++ b/locales/th.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "กำลังโหลดหน้า"
     },
-    "Spinner": {
-      "warningMessage": "สี {color} ไม่ได้มีไว้เพื่อใช้กับสปินเนอร์ขนาด {size} สีที่มีให้บริการสำหรับสปินเนอร์ขนาดใหญ่คือ: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "แท็บเพิ่มเติม"
     },

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Sayfa yükleniyor"
     },
-    "Spinner": {
-      "warningMessage": "{color} rengi {size} boyutlu çarklarda kullanıma yönelik değildir. Büyük çarklarda kullanılabilen renkler şunlardır: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Daha fazla sekme"
     },

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "Đang tải trang"
     },
-    "Spinner": {
-      "warningMessage": "Màu {color} không nhằm mục đích sử dụng trên con quay {size}. Màu có sẵn trên con quay cỡ lớn là: {colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "Tab khác"
     },

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -236,9 +236,6 @@
     "SkeletonPage": {
       "loadingLabel": "頁面載入中"
     },
-    "Spinner": {
-      "warningMessage": "{color} 這個顏色不能搭配{size}的轉盤。大型轉盤可以使用的顏色為：{colors}"
-    },
     "Tabs": {
       "toggleTabsLabel": "更多索引標籤"
     },

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -150,15 +150,16 @@ $stacking-order: (
 }
 
 .outline {
-  @include button-outline(color('ink', 'lighter'));
+  @include button-outline(var(--p-border));
 
   &.disabled {
-    @include button-outline-disabled(color('ink', 'lighter'));
+    background: transparent;
+    box-shadow: none;
   }
 }
 
 .destructive.outline {
-  @include button-outline(color('red'));
+  @include button-outline(var(--p-border-critical));
 }
 
 .disabled {
@@ -485,9 +486,12 @@ $stacking-order: (
   border-bottom-left-radius: 0;
   height: 100%;
 
-  // Because the outline border color has a 40% opacity, the left border appears darker than the rest of the borders because they are layered over one another. Reducing the opacity to zero for the connected disclosure when not focused gives us the expected border color.
+  // Note 1: Because the outline border color has a 40% opacity, the left border appears darker than the rest of the borders because they are layered over one another. Reducing the opacity to zero for the connected disclosure when not focused gives us the expected border color.
+  // Note 2: hardcoding this value because we can't use custom css properties in sass functions. Will clean up in a follow-up
+  // https://github.com/Shopify/polaris-react/pull/4655#discussion_r750793847
   &.outline:not(:focus) {
-    border-left-color: rgba(color('ink', 'lighter'), 0);
+    /* stylelint-disable color-no-hex */
+    border-left-color: rgba(#d2d5d8, 0);
   }
 
   &:focus,

--- a/src/components/Navigation/_variables.scss
+++ b/src/components/Navigation/_variables.scss
@@ -2,9 +2,6 @@ $item-font-size: rem(16px);
 $item-font-size-small: rem(14px);
 $item-line-height-small: rem(32px);
 $item-line-height-large: rem(36px);
-// This is the only place this color is used.
-// stylelint-disable-next-line color-no-hex
-$item-selected-background: rgba(color('indigo'), 0.12);
 $text-line-height: rem(20px);
 $nav-variables: (
   mobile-spacing: rem(10px),

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -27,7 +27,7 @@ $vertical-motion-offset: rem(-5px);
 
 .PopoverOverlay-open {
   opacity: 1;
-  transform: translateY(0);
+  transform: none;
 }
 
 .PopoverOverlay-exiting {

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -28,7 +28,7 @@ $vertical-motion-offset: rem(-5px);
 
 .PopoverOverlay-open {
   opacity: 1;
-  transform: translateY(0);
+  transform: none;
 }
 
 .PopoverOverlay-exiting {

--- a/src/styles/foundation/_colors.scss
+++ b/src/styles/foundation/_colors.scss
@@ -27,36 +27,6 @@ $color-palette-data: map-extend(
   )
 );
 
-/// Returns the color value for a given color name and group.
-///
-/// @param {String} $hue - The color’s hue.
-/// @param {String} $value - The darkness/lightness of the color. Defaults to
-/// base.
-/// @param {Color} $for-background - The background color on which this color
-/// will appear. Applies a multiply filter to ensure appropriate contrast.
-/// @return {Color} The color value.
-
-@function color($hue, $value: base, $for-background: null) {
-  $fetched-color: map-get(map-get($color-palette-data, $hue), $value);
-
-  @if map-has-key($color-palette-data, $fetched-color) {
-    $fetched-color: map-get(
-      map-get($color-palette-data, $fetched-color),
-      $value
-    );
-  }
-
-  @if $for-background {
-    $fetched-color: color-multiply($fetched-color, $for-background);
-  }
-
-  @if type-of($fetched-color) == color {
-    @return $fetched-color;
-  } @else {
-    @error "Color `#{$hue}, #{$value}` not found.\a Make sure arguments are strings.\a GOOD: `color('yellow')`.\a BAD: `color(yellow)`.\a\a Available options: #{available-names($color-palette-data)}";
-  }
-}
-
 /// Darkens the foreground color by the background color. This is the same as
 /// the "multiply" filter in graphics apps.
 ///

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -197,11 +197,7 @@
 
 @mixin button-outline-disabled($outline-color) {
   background: transparent;
-  // border-color: rgba($outline-color, 0.25);
   box-shadow: none;
-  // color: color('ink', 'lightest');
-
-  // @include recolor-icon(color('ink', 'lightest'));
 }
 
 @mixin button-full-width {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/4656

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Removes the `color()` sass function which has been deprecated and is no longer used

### How to 🎩
Run storybook and check Chromatic for visual regressions
