### PR TITLE
Revert removal of misc tokens

### DIFF
--- a/documentation/Color system.md
+++ b/documentation/Color system.md
@@ -268,8 +268,14 @@ Used to decorate elements where color does convey a specific meaning in componen
 | `--p-button-drop-shadow`                  | `0 1px 0 rgba(0, 0, 0, 0.05)`                                                                                |
 | `--p-button-inner-shadow`                 | `inset 0 -1px 0 rgba(0, 0, 0, 0.2)`                                                                          |
 | `--p-button-pressed-inner-shadow`         | `inset 0 1px 0 rgba(0, 0, 0, 0.15)`                                                                          |
+| `--p-override-none`                       | `none`                                                                                                       |
+| `--p-override-transparent`                | `transparent`                                                                                                |
+| `--p-override-one`                        | `1`                                                                                                          |
+| `--p-override-visible`                    | `visible`                                                                                                    |
+| `--p-override-zero`                       | `0`                                                                                                          |
 | `--p-override-loading-z-index`            | `514`                                                                                                        |
 | `--p-button-font-weight`                  | `500`                                                                                                        |
+| `--p-non-null-content`                    | `''`                                                                                                         |
 | `--p-choice-size`                         | `2rem`                                                                                                       |
 | `--p-icon-size`                           | `1rem`                                                                                                       |
 | `--p-choice-margin`                       | `0.1rem`                                                                                                     |
@@ -279,6 +285,7 @@ Used to decorate elements where color does convey a specific meaning in componen
 | `--p-banner-border-highlight`             | `inset 0 0.1rem 0 0 var(--p-border-highlight-subdued), inset 0 0 0 0.1rem var(--p-border-highlight-subdued)` |
 | `--p-banner-border-warning`               | `inset 0 0.1rem 0 0 var(--p-border-warning-subdued), inset 0 0 0 0.1rem var(--p-border-warning-subdued)`     |
 | `--p-banner-border-critical`              | `inset 0 0.1rem 0 0 var(--p-border-critical-subdued), inset 0 0 0 0.1rem var(--p-border-critical-subdued)`   |
+| `--p-badge-mix-blend-mode`                | `luminosity`                                                                                                 |
 | `--p-thin-border-subdued`                 | `0.1rem solid var(--p-border-subdued)`                                                                       |
 | `--p-text-field-spinner-offset`           | `0.2rem`                                                                                                     |
 | `--p-text-field-focus-ring-offset`        | `-0.4rem`                                                                                                    |
@@ -290,4 +297,5 @@ Used to decorate elements where color does convey a specific meaning in componen
 | `--p-ease`                                | `cubic-bezier(0.4, 0.22, 0.28, 1)`                                                                           |
 | `--p-range-slider-thumb-size-base`        | `1.6rem`                                                                                                     |
 | `--p-range-slider-thumb-size-active`      | `2.4rem`                                                                                                     |
+| `--p-range-slider-thumb-scale`            | `1.5`                                                                                                        |
 | `--p-badge-font-weight`                   | `400`                                                                                                        |

--- a/src/utilities/theme/tokens.ts
+++ b/src/utilities/theme/tokens.ts
@@ -18,8 +18,14 @@ export const Tokens = {
   buttonPressedInnerShadow: 'inset 0 1px 0 rgba(0, 0, 0, 0.15)',
 
   // Overrides
+  overrideNone: 'none',
+  overrideTransparent: 'transparent',
+  overrideOne: '1',
+  overrideVisible: 'visible',
+  overrideZero: '0',
   overrideLoadingZIndex: '514',
   buttonFontWeight: '500',
+  nonNullContent: "''",
   choiceSize: rem('20px'),
   iconSize: rem('10px'),
   choiceMargin: rem('1px'),
@@ -29,6 +35,7 @@ export const Tokens = {
   bannerBorderHighlight: buildBannerBorder('--p-border-highlight-subdued'),
   bannerBorderWarning: buildBannerBorder('--p-border-warning-subdued'),
   bannerBorderCritical: buildBannerBorder('--p-border-critical-subdued'),
+  badgeMixBlendMode: 'luminosity',
   thinBorderSubdued: `${rem('1px')} solid var(--p-border-subdued)`,
   textFieldSpinnerOffset: rem('2px'),
   textFieldFocusRingOffset: rem('-4px'),
@@ -40,6 +47,7 @@ export const Tokens = {
   ease: 'cubic-bezier(0.4, 0.22, 0.28, 1)',
   rangeSliderThumbSizeBase: rem('16px'),
   rangeSliderThumbSizeActive: rem('24px'),
+  rangeSliderThumbScale: '1.5',
   badgeFontWeight: '400',
 };
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Reverts the removal of tokens from #4620 because they are a breaking change for web and our consumers. Changes should be released on a major Polaris version—v8.0.0 not v7.4.0.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adds back the following tokens: 

- `overrideNone: 'none'`
- `overrideTransparent: 'transparent'`
- `overrideOne: '1'`
- `overrideVisible: 'visible'`
- `overrideZero: '0'`
- `nonNullContent: "''"`
- `badgeMixBlendMode: 'luminosity'`
- `rangeSliderThumbScale: '1.5'`

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->