### PR TITLE
Fix Popover bug with fixed positioned children

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
 - Fixed an issue with `TextField` where date and time were uneditable on click ([#4671](https://github.com/Shopify/polaris-react/pull/4671))
+- Fixed an issue with `Popover` where the transform property interfered with descendants positioning ([#4685](https://github.com/Shopify/polaris-react/pull/4685))
 
 ### Documentation
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -27,7 +27,7 @@ $vertical-motion-offset: rem(-5px);
 
 .PopoverOverlay-open {
   opacity: 1;
-  transform: translateY(0);
+  transform: none;
 }
 
 .PopoverOverlay-exiting {


### PR DESCRIPTION
### WHY are these changes introduced?

Because transformed elements create a containing block for all its positioned descendants, [a recent change](https://github.com/Shopify/polaris-react/pull/4580) to the Popover breaks `react-draggable-hoc`.


### WHAT is this pull request doing?

removes the transform on the popover-overlay when it's opened 

**Current:**
https://user-images.githubusercontent.com/1229901/142909448-a6880dc9-2d4c-48f7-ac3f-89602dd28cf1.mov


**Fixed:**
https://user-images.githubusercontent.com/1229901/142909436-fd697dd9-fe91-4453-9011-3a1b781962ef.mov


### How to 🎩

In storybook ensure this didn't break the animation on the popover.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
