### PR TITLE
[Navigation] [TopBar] Move a11y text from img alt to UnstyledLink ariaLabel

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,7 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
 - Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
-- Move logo description from `<img alt>` to `<UnstyledLink ariaLabel>` in `TopBar` and `Navigation` ([#4713](https://github.com/Shopify/polaris-react/pull/4713))
+- Moved logo description from `<img alt>` to `<UnstyledLink ariaLabel>` in `TopBar` and `Navigation` ([#4713](https://github.com/Shopify/polaris-react/pull/4713))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
 - Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
+- Move logo description from `<img alt>` to `<UnstyledLink ariaLabel>` in `TopBar` and `Navigation` ([#4713](https://github.com/Shopify/polaris-react/pull/4713))
 
 ### Bug fixes
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -36,13 +36,14 @@ export const Navigation: React.FunctionComponent<NavigationProps> & {
   const logoMarkup = logo ? (
     <div className={styles.LogoContainer}>
       <UnstyledLink
+        ariaLabel={logo.accessibilityLabel || ''}
         url={logo.url || ''}
         className={styles.LogoLink}
         style={{width}}
       >
         <Image
+          alt=""
           source={logo.topBarSource || ''}
-          alt={logo.accessibilityLabel || ''}
           className={styles.Logo}
           style={{width}}
         />

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -105,13 +105,14 @@ export const TopBar: React.FunctionComponent<TopBarProps> & {
     contextMarkup = (
       <div className={className}>
         <UnstyledLink
+          ariaLabel={logo.accessibilityLabel || ''}
           url={logo.url || ''}
           className={styles.LogoLink}
           style={{width}}
         >
           <Image
+            alt=""
             source={logo.topBarSource || ''}
-            alt={logo.accessibilityLabel || ''}
             className={styles.Logo}
             style={{width}}
           />

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -192,8 +192,8 @@ describe('<TopBar />', () => {
           },
         },
       });
-      expect(topBar).toContainReactComponent(Image, {
-        alt: 'Shopify',
+      expect(topBar).toContainReactComponent(UnstyledLink, {
+        ariaLabel: 'Shopify',
       });
     });
 


### PR DESCRIPTION
Closes https://github.com/Shopify/polaris-react/issues/4702

Co-Authored-By: Aaron Casanova <32409546+aaronccasanova@users.noreply.github.com>
