### PR TITLE
Remove legacy tokens from .storybook/manager.js

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -9,9 +9,5 @@ addons.setConfig({
     brandUrl: '/',
     brandImage: null,
     appBorderRadius: 0,
-    // TODO investigate removing these values
-    appBg: '#f4f6f8',
-    contentBg: '#f4f6f8',
-    textColor: '#212b36',
   }),
 });

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,6 +1,5 @@
 import {addons} from '@storybook/addons';
 import {create} from '@storybook/theming';
-import {colorSkyLight, colorInk} from '@shopify/polaris-tokens';
 
 addons.setConfig({
   panelPosition: 'bottom',
@@ -10,10 +9,9 @@ addons.setConfig({
     brandUrl: '/',
     brandImage: null,
     appBorderRadius: 0,
-    appBg: colorSkyLight,
-    contentBg: colorSkyLight,
-    textColor: colorInk,
-    // TODO more pretty brand colors?
-    // SEE https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/theming/index.md
+    // TODO investigate removing these values
+    appBg: '#f4f6f8',
+    contentBg: '#f4f6f8',
+    textColor: '#212b36',
   }),
 });

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -43,7 +43,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Cleaned up Button styling and $button-filled mixin([#4635](https://github.com/Shopify/polaris-react/pull/4635))
 - Removed `rem()` function from `tokens.ts` ([#4695](https://github.com/Shopify/polaris-react/pull/4695))
 - Remove unnecessary import of `Tokens` in `Collapsible` test ([#4722](https://github.com/Shopify/polaris-react/pull/4722))
-- Hard code legacy tokens in `.storybook/manager.js` ([#](https://github.com/Shopify/polaris-react/pull/))
+- Remove legacy tokens and use default theme for `.storybook/manager.js` ([#4729](https://github.com/Shopify/polaris-react/pull/4729))
 
 ### Deprecations
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -43,6 +43,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Cleaned up Button styling and $button-filled mixin([#4635](https://github.com/Shopify/polaris-react/pull/4635))
 - Removed `rem()` function from `tokens.ts` ([#4695](https://github.com/Shopify/polaris-react/pull/4695))
 - Remove unnecessary import of `Tokens` in `Collapsible` test ([#4722](https://github.com/Shopify/polaris-react/pull/4722))
+- Hard code legacy tokens in `.storybook/manager.js` ([#](https://github.com/Shopify/polaris-react/pull/))
 
 ### Deprecations
 


### PR DESCRIPTION
### WHY are these changes introduced?

When removing legacy tokens in v8 I noticed this existing.

### WHAT is this pull request doing?

Uses default styles for storybook UI