### PR TITLE
[Navigation] Move alt tag to img instead of UnstyledLink

### DIFF
--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -39,11 +39,10 @@ export const Navigation: React.FunctionComponent<NavigationProps> & {
         url={logo.url || ''}
         className={styles.LogoLink}
         style={{width}}
-        alt={logo.accessibilityLabel || ''}
       >
         <Image
           source={logo.topBarSource || ''}
-          alt=""
+          alt={logo.accessibilityLabel || ''}
           className={styles.Logo}
           style={{width}}
         />


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4702

### WHAT is this pull request doing?

Moves alt to img tag