### PR TITLE
feat: Remove prefers-color-scheme dark

### DIFF
--- a/src/components/CustomProperties/styles.ts
+++ b/src/components/CustomProperties/styles.ts
@@ -14,13 +14,6 @@ const lightDeclarations = getColorSchemeDeclarations(
   osColorSchemes,
 );
 
-/** Default dark color-scheme declarations.  */
-const darkDeclarations = getColorSchemeDeclarations(
-  'dark',
-  tokens,
-  osColorSchemes,
-);
-
 /**
  * Creates CSS Rules for each color-scheme.
  * @example:
@@ -89,12 +82,6 @@ export const styles = /* css */ `
 :root {
   ${lightDeclarations}
   ${getStaticCustomProperties(tokens)}
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    ${darkDeclarations}
-  }
 }
 
 ${getColorSchemeRules(tokens, osColorSchemes)}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4710 

### WHAT is this pull request doing?

Removes the `prefers-color-scheme` media query as we don't officially support dark mode.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
