### PR TITLE
[Page] Deprecate thumbnail property

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,7 +15,6 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
 - Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
-- Deprecate thumbnail property for `Page` ([#4733](https://github.com/Shopify/polaris-react/pull/4733))
 
 ### Bug fixes
 
@@ -54,3 +53,4 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Deprecations
 
 - Deprecated passing `attention` to the `status` prop on `Badge` in favor of `warning` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
+- Deprecated `thumbnail` property for `Page` ([#4733](https://github.com/Shopify/polaris-react/pull/4733))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
 - Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
+- Deprecate thumbnail property for `Page` ([#4733](https://github.com/Shopify/polaris-react/pull/4733))
 
 ### Bug fixes
 

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -28,6 +28,11 @@ export function Title({
   thumbnail,
   compactTitle,
 }: TitleProps) {
+  if (process.env.NODE_ENV === 'development' && thumbnail != null) {
+    // eslint-disable-next-line no-console
+    console.warn('The thumbnail prop from Page has been deprecated');
+  }
+
   const titleMarkup = title ? <h1 className={styles.Title}>{title}</h1> : null;
 
   const titleMetadataMarkup = titleMetadata ? (

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -13,7 +13,7 @@ export interface TitleProps {
   subtitle?: string;
   /** Important and non-interactive status information shown immediately after the title. */
   titleMetadata?: React.ReactNode;
-  /** thumbnail that precedes the title */
+  /** @deprecated thumbnail that precedes the title */
   thumbnail?:
     | React.ReactElement<AvatarProps | ThumbnailProps>
     | React.SFC<React.SVGProps<SVGSVGElement>>;


### PR DESCRIPTION
### WHY are these changes introduced?

This functionality is rarely used in our product and should be replaced with layout primitives in the future.

### WHAT is this pull request doing?

Deprecating the thumbnail property

