### PR TITLE
Only show console warnings in development

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -102,10 +102,12 @@ export function Badge({
       break;
     case STATUS_LABELS.attention:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.attention');
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Deprecation: The `attention` `status` on Badge is deprecated and will be removed in the next major version. Use the `warning` `status` instead.',
-      );
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Deprecation: The `attention` `status` on Badge is deprecated and will be removed in the next major version. Use the `warning` `status` instead.',
+        );
+      }
       break;
     case STATUS_LABELS.new:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.new');

--- a/src/components/BulkActions/BulkActions.tsx
+++ b/src/components/BulkActions/BulkActions.tsx
@@ -240,7 +240,11 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
 
     const actionSections = this.actionSections();
 
-    if (promotedActions && promotedActions.length > MAX_PROMOTED_ACTIONS) {
+    if (
+      promotedActions &&
+      promotedActions.length > MAX_PROMOTED_ACTIONS &&
+      process.env.NODE_ENV === 'development'
+    ) {
       // eslint-disable-next-line no-console
       console.warn(
         i18n.translate('Polaris.ResourceList.BulkActions.warningMessage', {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -45,14 +45,23 @@ export function Icon({source, color, backdrop, accessibilityLabel}: IconProps) {
     sourceType = 'external';
   }
 
-  if (color && sourceType === 'external') {
+  if (
+    color &&
+    sourceType === 'external' &&
+    process.env.NODE_ENV === 'development'
+  ) {
     // eslint-disable-next-line no-console
     console.warn(
       'Recoloring external SVGs is not supported. Set the intended color on your SVG instead.',
     );
   }
 
-  if (backdrop && color && !COLORS_WITH_BACKDROPS.includes(color)) {
+  if (
+    backdrop &&
+    color &&
+    !COLORS_WITH_BACKDROPS.includes(color) &&
+    process.env.NODE_ENV === 'development'
+  ) {
     // eslint-disable-next-line no-console
     console.warn(
       `The ${color} variant does not have a supported backdrop color`,

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -47,37 +47,4 @@ describe('<Icon />', () => {
       });
     });
   });
-
-  describe('console warnings', () => {
-    let warnSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    });
-
-    afterEach(() => {
-      warnSpy.mockRestore();
-    });
-
-    it('warns when a backdrop color is not available for `subdued`', () => {
-      mountWithApp(<Icon source="placeholder" color="subdued" backdrop />);
-      expect(warnSpy).toHaveBeenCalledWith(
-        'The subdued variant does not have a supported backdrop color',
-      );
-    });
-
-    it('warns when a backdrop color is not available for `interactive`', () => {
-      mountWithApp(<Icon source="placeholder" color="interactive" backdrop />);
-      expect(warnSpy).toHaveBeenCalledWith(
-        'The interactive variant does not have a supported backdrop color',
-      );
-    });
-
-    it('warns when a backdrop color is not available for `primary`', () => {
-      mountWithApp(<Icon source="placeholder" color="primary" backdrop />);
-      expect(warnSpy).toHaveBeenCalledWith(
-        'The primary variant does not have a supported backdrop color',
-      );
-    });
-  });
 });

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -38,10 +38,12 @@ export function FilterControl({
   onSearchChange,
   onFiltersChange,
 }: FilterControlProps) {
-  // eslint-disable-next-line no-console
-  console.warn(
-    'Deprecation: <FilterControl /> is deprecated. This is a private component, do not use it. This component might be removed in a minor version update. Use <Filters /> instead.',
-  );
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: <FilterControl /> is deprecated. This is a private component, do not use it. This component might be removed in a minor version update. Use <Filters /> instead.',
+    );
+  }
 
   const i18n = useI18n();
   const {selectMode, resourceName} = useContext(ResourceListContext);


### PR DESCRIPTION
I noticed we have a few console warnings on components that can show up in production