### PR TITLE
Remove components alias and import components directly in tests

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -32,6 +32,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Tightened up what absolute imports are allowed. Removed `baseUrl` from `tsconfig.json`. Attempting to do an absolute import from `src/X` or `components/X` now results in a error when type-checking. ([#4643](https://github.com/Shopify/polaris-react/pull/4643))
 - Remove analyze custom properties check. ([#4718](https://github.com/Shopify/polaris-react/pull/4718))
+- Removed support for importing from `components` as it slows tests down ([#4735](https://github.com/Shopify/polaris-react/pull/4735))
 
 ### Dependency upgrades
 

--- a/loom.config.ts
+++ b/loom.config.ts
@@ -55,7 +55,6 @@ function jestAdjustmentsPlugin() {
         configuration.jestModuleNameMapper?.hook((moduleNameMapper) => ({
           ...moduleNameMapper,
           '^tests/(.*)': '<rootDir>/tests/$1',
-          '^components$': '<rootDir>/src/components',
         }));
 
         // Ignore tests in the examples folder

--- a/src/components/AccountConnection/tests/AccountConnection.test.tsx
+++ b/src/components/AccountConnection/tests/AccountConnection.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Avatar} from 'components';
 
+import {Avatar} from '../../Avatar';
 import {Button} from '../../Button';
 import {AccountConnection} from '../AccountConnection';
 

--- a/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {UnstyledLink} from 'components';
 
 import {Item} from '../Item';
 import {TextStyle} from '../../../../TextStyle';
+import {UnstyledLink} from '../../../../UnstyledLink';
 
 describe('<Item />', () => {
   it('adds a style property when the image prop is present', () => {

--- a/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Popover, ActionList, Button} from 'components';
 
+import {ActionList} from '../../../../ActionList';
+import {Button} from '../../../../Button';
+import {Popover} from '../../../../Popover';
 import {MenuGroup} from '../MenuGroup';
 
 describe('<MenuGroup />', () => {

--- a/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
+++ b/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
-import {Button, Popover} from 'components';
 
+import {Button} from '../../../../Button';
+import {Popover} from '../../../../Popover';
 // eslint-disable-next-line @shopify/strict-component-boundaries
 import {
   Item as ActionListItem,

--- a/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mountWithApp, ReactTestingElement, CustomRoot} from 'tests/utilities';
-import {KeypressListener} from 'components';
 
 import {TextField} from '../../TextField';
 import {Key, SectionDescriptor} from '../../../types';
@@ -9,6 +8,7 @@ import {ComboboxTextFieldContext} from '../../../utilities/combobox';
 import {Autocomplete} from '../Autocomplete';
 import {Combobox} from '../../Combobox';
 import type {ComboboxProps} from '../../Combobox';
+import {KeypressListener} from '../../KeypressListener';
 import {Listbox} from '../../Listbox';
 
 describe('<Autocomplete/>', () => {

--- a/src/components/Avatar/tests/Avatar-ssr.test.tsx
+++ b/src/components/Avatar/tests/Avatar-ssr.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Avatar, Image} from 'components';
+
+import {Image} from '../../Image';
+import {Avatar} from '../Avatar';
 
 jest.mock('../../../utilities/use-is-after-initial-mount', () => {
   return {

--- a/src/components/Avatar/tests/Avatar.test.tsx
+++ b/src/components/Avatar/tests/Avatar.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Avatar, Image} from 'components';
+
+import {Image} from '../../Image';
+import {Avatar} from '../Avatar';
 
 describe('<Avatar />', () => {
   describe('intials', () => {

--- a/src/components/Badge/tests/Badge.test.tsx
+++ b/src/components/Badge/tests/Badge.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {VisuallyHidden} from 'components';
 
+import {VisuallyHidden} from '../../VisuallyHidden';
 import {Badge} from '../Badge';
 
 describe('<Badge />', () => {

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -7,15 +7,13 @@ import {
   DiamondAlertMajor,
 } from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
-import {
-  Button,
-  Heading,
-  Icon,
-  Spinner,
-  UnstyledButton,
-  UnstyledLink,
-} from 'components';
 
+import {Button} from '../../Button';
+import {Heading} from '../../Heading';
+import {Icon} from '../../Icon';
+import {Spinner} from '../../Spinner';
+import {UnstyledButton} from '../../UnstyledButton';
+import {UnstyledLink} from '../../UnstyledLink';
 import {BannerContext} from '../../../utilities/banner-context';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {Banner, BannerHandles} from '../Banner';

--- a/src/components/BulkActions/components/BulkActionMenu/tests/BulkActionMenu.test.tsx
+++ b/src/components/BulkActions/components/BulkActionMenu/tests/BulkActionMenu.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {Popover, ActionList} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {ActionList} from '../../../../ActionList';
+import {Popover} from '../../../../Popover';
 import {BulkActionMenu, BulkActionsMenuProps, BulkActionButton} from '../..';
 
 const defaultProps: BulkActionsMenuProps = {

--- a/src/components/BulkActions/tests/BulkActions.test.tsx
+++ b/src/components/BulkActions/tests/BulkActions.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {Transition, CSSTransition} from 'react-transition-group';
 import {mountWithApp} from 'tests/utilities';
-import {Popover, ActionList} from 'components';
 
+import {ActionList} from '../../ActionList';
 import {CheckableButton} from '../../CheckableButton';
 import {Button} from '../../Button';
+import {Popover} from '../../Popover';
 import {
   BulkActionButton,
   BulkActionMenu,

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -6,8 +6,12 @@ import {
   SelectMinor,
 } from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
-import {ActionList, Icon, Popover, Spinner, UnstyledButton} from 'components';
 
+import {ActionList} from '../../ActionList';
+import {Icon} from '../../Icon';
+import {Popover} from '../../Popover';
+import {Spinner} from '../../Spinner';
+import {UnstyledButton} from '../../UnstyledButton';
 import {Button} from '../Button';
 import en from '../../../../locales/en.json';
 import styles from '../Button.scss';

--- a/src/components/ButtonGroup/components/Item/tests/Item.test.tsx
+++ b/src/components/ButtonGroup/components/Item/tests/Item.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Button} from 'components';
 
+import {Button} from '../../../../Button';
 import {Item} from '../Item';
 
 describe('<Item />', () => {

--- a/src/components/ButtonGroup/tests/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup/tests/ButtonGroup.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Button} from 'components';
 
+import {Button} from '../../Button';
 import {Item} from '../components';
 import {ButtonGroup} from '../ButtonGroup';
 

--- a/src/components/CalloutCard/tests/CalloutCard.test.tsx
+++ b/src/components/CalloutCard/tests/CalloutCard.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Button, ButtonGroup} from 'components';
 
+import {Button} from '../../Button';
+import {ButtonGroup} from '../../ButtonGroup';
 import {CalloutCard} from '../CalloutCard';
 
 describe('<CalloutCard />', () => {

--- a/src/components/Card/components/Header/tests/Header.test.tsx
+++ b/src/components/Card/components/Header/tests/Header.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {ButtonGroup, Heading, buttonsFrom} from 'components';
 
+import {buttonsFrom} from '../../../../Button';
+import {ButtonGroup} from '../../../../ButtonGroup';
+import {Heading} from '../../../../Heading';
 import {Header} from '../Header';
 
 jest.mock('../../../../Button', () => ({

--- a/src/components/Card/components/Section/tests/Section.test.tsx
+++ b/src/components/Card/components/Section/tests/Section.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Badge, Subheading, ButtonGroup, Button} from 'components';
 
+import {Badge} from '../../../../Badge';
+import {Button} from '../../../../Button';
+import {ButtonGroup} from '../../../../ButtonGroup';
+import {Subheading} from '../../../../Subheading';
 import {Section} from '../Section';
 
 describe('<Card.Section />', () => {

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Card, Badge, Button, Popover, ActionList} from 'components';
 
+import {Badge} from '../../Badge';
+import {Button} from '../../Button';
+import {Popover} from '../../Popover';
+import {ActionList} from '../../ActionList';
 import {WithinContentContext} from '../../../utilities/within-content-context';
+import {Card} from '../Card';
 import {Section} from '../components';
 
 describe('<Card />', () => {

--- a/src/components/CheckableButton/tests/CheckableButton.test.tsx
+++ b/src/components/CheckableButton/tests/CheckableButton.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Checkbox} from 'components';
 
+import {Checkbox} from '../../Checkbox';
 import {CheckableButton} from '../CheckableButton';
 
 const CheckableButtonProps = {

--- a/src/components/Choice/tests/Choice.test.tsx
+++ b/src/components/Choice/tests/Choice.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {InlineError} from 'components';
 
+import {InlineError} from '../../InlineError';
 import {Choice} from '../Choice';
 
 describe('<Choice />', () => {

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {RadioButton, Checkbox, InlineError} from 'components';
 
+import {Checkbox} from '../../Checkbox';
+import {InlineError} from '../../InlineError';
+import {RadioButton} from '../../RadioButton';
 import {ChoiceList, ChoiceListProps} from '../ChoiceList';
 
 describe('<ChoiceList />', () => {

--- a/src/components/DataTable/components/Cell/tests/Cell.test.tsx
+++ b/src/components/DataTable/components/Cell/tests/Cell.test.tsx
@@ -2,7 +2,7 @@ import React, {ReactElement} from 'react';
 import {CaretUpMinor, CaretDownMinor} from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
 
-import {Icon} from '../../../..';
+import {Icon} from '../../../../Icon';
 import {Cell} from '../Cell';
 
 describe('<Cell />', () => {

--- a/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Button} from 'components';
 
+import {Button} from '../../../../Button';
 import {Navigation} from '../Navigation';
 
 describe('<Navigation />', () => {

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {timer} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
-import {Checkbox} from 'components';
 
+import {Checkbox} from '../../Checkbox';
 import {Cell, Navigation} from '../components';
 import {DataTable, DataTableProps} from '../DataTable';
 

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {Caption, TextStyle} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Caption} from '../../../../Caption';
+import {TextStyle} from '../../../../TextStyle';
 import {DropZoneContext} from '../../../context';
 import {FileUpload} from '../FileUpload';
 import {uploadArrow as uploadArrowImage} from '../../../images';

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 import {clock} from '@shopify/jest-dom-mocks';
-import {Label, Labelled, TextStyle, Caption} from 'components';
-import {mountWithApp} from 'tests/utilities';
-import type {CustomRoot} from '@shopify/react-testing';
+import {mountWithApp, CustomRoot} from 'tests/utilities';
 
+import {Caption} from '../../Caption';
+import {Label} from '../../Label';
+import {Labelled} from '../../Labelled';
+import {TextStyle} from '../../TextStyle';
 import {DropZone, DropZoneFileType} from '../DropZone';
 import {DropZoneContext} from '../context';
 

--- a/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
+++ b/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {DisplayText, TextStyle} from 'components';
 
+import {DisplayText} from '../../DisplayText';
+import {TextStyle} from '../../TextStyle';
 import {EmptySearchResult} from '../EmptySearchResult';
 import {emptySearch} from '../illustrations';
 

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {
-  Button,
-  DisplayText,
-  Image,
-  Stack,
-  TextContainer,
-  UnstyledLink,
-} from 'components';
 
+import {Button} from '../../Button';
+import {DisplayText} from '../../DisplayText';
+import {Image} from '../../Image';
+import {Stack} from '../../Stack';
+import {TextContainer} from '../../TextContainer';
+import {UnstyledLink} from '../../UnstyledLink';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {EmptyState} from '../EmptyState';
 

--- a/src/components/ExceptionList/tests/ExceptionList.test.tsx
+++ b/src/components/ExceptionList/tests/ExceptionList.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {CirclePlusMinor, NoteMinor} from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
-import {Icon} from 'components';
 
 import {ExceptionList} from '../ExceptionList';
+import {Icon} from '../../Icon';
 import {Truncate} from '../../Truncate';
 
 describe('<ExceptionList />', () => {

--- a/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {Popover, Button} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Button} from '../../../../Button';
+import {Popover} from '../../../../Popover';
 import styles from '../ConnectedFilterControl.scss';
 import {
   ConnectedFilterControl,

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
 import {matchMedia} from '@shopify/jest-dom-mocks';
-import {
-  Button,
-  Popover,
-  Sheet,
-  Tag,
-  TextField,
-  TextStyle,
-  ButtonProps,
-} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Button, ButtonProps} from '../../Button';
+import {Collapsible} from '../../Collapsible';
+import {Popover} from '../../Popover';
+// eslint-disable-next-line import/no-deprecated
+import {Sheet} from '../../Sheet';
+import {Tag} from '../../Tag';
+import {TextField} from '../../TextField';
+import {TextStyle} from '../../TextStyle';
 import {WithinFilterContext} from '../../../utilities/within-filter-context';
 import {Filters, FiltersProps} from '../Filters';
 import {ConnectedFilterControl, TagsWrapper} from '../components';
-import {Collapsible} from '../../Collapsible';
 import * as focusUtils from '../../../utilities/focus';
 import styles from '../Filters.scss';
 
@@ -101,6 +99,8 @@ describe('<Filters />', () => {
         .find(Button, {children: 'More filters'})!
         .trigger('onClick');
       jest.runAllTimers();
+
+      // eslint-disable-next-line import/no-deprecated
       expect(resourceFilters).toContainReactComponent(Sheet, {open: true});
     });
 
@@ -114,6 +114,7 @@ describe('<Filters />', () => {
         .find(Button, {children: 'More filters'})!
         .trigger('onClick');
 
+      // eslint-disable-next-line import/no-deprecated
       expect(resourceFilters).toContainReactComponent(Sheet, {open: false});
     });
 
@@ -121,6 +122,7 @@ describe('<Filters />', () => {
       it('renders a sheet on desktop size with right origin', () => {
         const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
+        // eslint-disable-next-line import/no-deprecated
         expect(resourceFilters).toContainReactComponent(Sheet);
       });
 
@@ -128,6 +130,7 @@ describe('<Filters />', () => {
         matchMedia.setMedia(() => ({matches: true}));
         const resourceFilters = mountWithApp(<Filters {...mockProps} />);
 
+        // eslint-disable-next-line import/no-deprecated
         expect(resourceFilters).toContainReactComponent(Sheet);
       });
 
@@ -139,6 +142,7 @@ describe('<Filters />', () => {
           .find(Button, {children: 'More filters'})!
           .trigger('onClick');
 
+        // eslint-disable-next-line import/no-deprecated
         expect(resourceFilters).toContainReactComponent(Sheet, {open: true});
       });
 
@@ -153,6 +157,7 @@ describe('<Filters />', () => {
           .find(Button, {children: 'More filters'})!
           .trigger('onClick');
 
+        // eslint-disable-next-line import/no-deprecated
         expect(resourceFilters).toContainReactComponent(Sheet, {open: false});
       });
     });

--- a/src/components/FooterHelp/tests/FooterHelp.test.tsx
+++ b/src/components/FooterHelp/tests/FooterHelp.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {InfoMinor} from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
-import {Icon} from 'components';
 
+import {Icon} from '../../Icon';
 import {FooterHelp} from '../FooterHelp';
 
 describe('<FooterHelp />', () => {

--- a/src/components/FormLayout/components/Group/tests/Group.test.tsx
+++ b/src/components/FormLayout/components/Group/tests/Group.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {TextField} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {TextField} from '../../../../TextField';
 import {Group} from '../Group';
 
 describe('<Group />', () => {

--- a/src/components/FormLayout/components/Item/tests/Item.test.tsx
+++ b/src/components/FormLayout/components/Item/tests/Item.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {TextField} from 'components';
 
+import {TextField} from '../../../../TextField';
 import {Item} from '../Item';
 
 describe('<Item />', () => {

--- a/src/components/FormLayout/tests/FormLayout.test.tsx
+++ b/src/components/FormLayout/tests/FormLayout.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {TextField} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {TextField} from '../../TextField';
 import {FormLayout} from '../FormLayout';
 
 describe('<FormLayout />', () => {

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Modal} from 'components';
 
+import {Modal} from '../../../../../../Modal';
 import {DiscardConfirmationModal} from '../DiscardConfirmationModal';
 
 describe('<DiscardConfirmationModal />', () => {

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import {Button, Image, ThemeProvider} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Button} from '../../../../Button';
+import {Image} from '../../../../Image';
+import {ThemeProvider} from '../../../../ThemeProvider';
 import {ContextualSaveBar} from '../ContextualSaveBar';
 import {DiscardConfirmationModal} from '../components';
 

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -2,12 +2,10 @@ import React, {createRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
 import {animationFrame, dimension} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
-import {
-  ContextualSaveBar as PolarisContextualSavebar,
-  Loading as PolarisLoading,
-  TrapFocus,
-} from 'components';
 
+import {ContextualSaveBar as PolarisContextualSavebar} from '../../ContextualSaveBar';
+import {Loading as PolarisLoading} from '../../Loading';
+import {TrapFocus} from '../../TrapFocus';
 import {Frame} from '../Frame';
 import {
   ContextualSaveBar as FrameContextualSavebar,

--- a/src/components/Labelled/tests/Labelled.test.tsx
+++ b/src/components/Labelled/tests/Labelled.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import {InlineError, Label, Labelled} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
 import {Button} from '../../Button';
+import {InlineError} from '../../InlineError';
+import {Label} from '../../Label';
+import {Labelled} from '..';
 
 describe('<Labelled />', () => {
   it('passes relevant props along to the label', () => {

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Banner, UnstyledLink, Icon} from 'components';
 
+import {Banner} from '../../Banner';
+import {UnstyledLink} from '../../UnstyledLink';
+import {Icon} from '../../Icon';
 import en from '../../../../locales/en.json';
 import {Link} from '../Link';
 

--- a/src/components/Listbox/components/Option/tests/Option.test.tsx
+++ b/src/components/Listbox/components/Option/tests/Option.test.tsx
@@ -8,13 +8,6 @@ import {TextOption} from '../../TextOption';
 import {MappedActionContext} from '../../../../../utilities/autocomplete';
 import {UnstyledLink} from '../../../../UnstyledLink';
 
-jest.mock('components', () => ({
-  ...jest.requireActual('components'),
-  Icon() {
-    return null;
-  },
-}));
-
 const defaultProps = {
   accessibilityLabel: 'label',
   value: 'value',

--- a/src/components/Listbox/components/TextOption/tests/TextOption.test.tsx
+++ b/src/components/Listbox/components/TextOption/tests/TextOption.test.tsx
@@ -5,13 +5,6 @@ import {TextOption} from '../TextOption';
 import {Checkbox} from '../../../../Checkbox';
 import {ComboboxListboxOptionContext} from '../../../../../utilities/combobox/context';
 
-jest.mock('components', () => ({
-  ...jest.requireActual('components'),
-  Icon() {
-    return null;
-  },
-}));
-
 describe('TextOption', () => {
   it('renders children', () => {
     const child = 'child';

--- a/src/components/MediaCard/tests/MediaCard.test.tsx
+++ b/src/components/MediaCard/tests/MediaCard.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import {Heading, Popover, Button, ActionList, Badge} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Heading} from '../../Heading';
+import {Popover} from '../../Popover';
+import {Button} from '../../Button';
+import {ActionList} from '../../ActionList';
+import {Badge} from '../../Badge';
 import {MediaCard} from '../MediaCard';
 import styles from '../MediaCard.scss';
 

--- a/src/components/MediaQueryProvider/tests/MediaQueryProvider.test.tsx
+++ b/src/components/MediaQueryProvider/tests/MediaQueryProvider.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {act} from 'react-dom/test-utils';
 import {mountWithApp} from 'tests/utilities';
-import {EventListener} from 'components';
 
+import {EventListener} from '../../EventListener';
 import {MediaQueryProvider} from '../MediaQueryProvider';
 import {useMediaQuery} from '../../../utilities/media-query';
 

--- a/src/components/Modal/components/Dialog/tests/Dialog.test.tsx
+++ b/src/components/Modal/components/Dialog/tests/Dialog.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
-import {KeypressListener} from 'components';
 
+import {KeypressListener} from '../../../../KeypressListener';
 import {Dialog} from '../Dialog';
 
 describe('<Dialog>', () => {

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -1,8 +1,12 @@
 import React, {useRef} from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
-import {Badge, Button, Spinner, Portal, Scrollable} from 'components';
 
+import {Badge} from '../../Badge';
+import {Button} from '../../Button';
+import {Scrollable} from '../../Scrollable';
+import {Spinner} from '../../Spinner';
+import {Portal} from '../../Portal';
 import {Footer, Dialog, Header} from '../components';
 import {Modal} from '../Modal';
 import {WithinContentContext} from '../../../utilities/within-content-context';

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import {PlusMinor, ExternalMinor} from '@shopify/polaris-icons';
 import {matchMedia} from '@shopify/jest-dom-mocks';
-import {Icon, UnstyledLink, Indicator, Badge} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Badge} from '../../../../Badge';
+import {Icon} from '../../../../Icon';
+import {Indicator} from '../../../../Indicator';
+import {UnstyledLink} from '../../../../UnstyledLink';
 import {NavigationContext} from '../../../context';
 import {Item, ItemProps} from '../Item';
 import {Secondary} from '../components';

--- a/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
+++ b/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Badge, DisplayText, Avatar} from 'components';
 
+import {Badge} from '../../../../../../Badge';
+import {DisplayText} from '../../../../../../DisplayText';
+import {Avatar} from '../../../../../../Avatar';
 import {Title} from '../Title';
 
 describe('<Title />', () => {

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
-import {
-  ActionMenu,
-  Breadcrumbs,
-  Pagination,
-  Badge,
-  Avatar,
-  Button,
-  ButtonGroup,
-} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Avatar} from '../../../../Avatar';
+import {ActionMenu} from '../../../../ActionMenu';
+import {Badge} from '../../../../Badge';
+import {Breadcrumbs} from '../../../../Breadcrumbs';
+import {Button} from '../../../../Button';
+import {ButtonGroup} from '../../../../ButtonGroup';
+import {Pagination} from '../../../../Pagination';
 import type {LinkAction} from '../../../../../types';
 import {Header, HeaderProps} from '../Header';
 

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -1,15 +1,12 @@
 import React, {useCallback, useState} from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
-import {
-  Page,
-  PageProps,
-  Card,
-  Avatar,
-  Badge,
-  ActionMenuProps,
-} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Avatar} from '../../Avatar';
+import type {ActionMenuProps} from '../../ActionMenu';
+import {Badge} from '../../Badge';
+import {Card} from '../../Card';
+import {Page, PageProps} from '../Page';
 import {Header} from '../components';
 
 window.matchMedia =

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 import type {CustomRoot} from '@shopify/react-testing';
-import {Tooltip, TextField} from 'components';
 
 import {Key} from '../../../types';
 import {Pagination} from '../Pagination';
 import {Button} from '../../Button';
 import {ButtonGroup} from '../../ButtonGroup';
+import {TextField} from '../../TextField';
 import {TextStyle} from '../../TextStyle';
+import {Tooltip} from '../../Tooltip';
 import en from '../../../../locales/en.json';
 
 interface HandlerMap {

--- a/src/components/Popover/components/Pane/tests/Pane.test.tsx
+++ b/src/components/Popover/components/Pane/tests/Pane.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {TextContainer, Scrollable} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Scrollable} from '../../../../Scrollable';
+import {TextContainer} from '../../../../TextContainer';
 import {Pane} from '../Pane';
 import {Section} from '../../Section';
 

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -1,8 +1,10 @@
 import React, {useRef} from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {TextContainer, TextField, EventListener} from 'components';
 
 import {Key} from '../../../../../types';
+import {EventListener} from '../../../../EventListener';
+import {TextContainer} from '../../../../TextContainer';
+import {TextField} from '../../../../TextField';
 import {PositionedOverlay} from '../../../../PositionedOverlay';
 import {PopoverOverlay} from '../PopoverOverlay';
 

--- a/src/components/Popover/components/Section/tests/Section.test.tsx
+++ b/src/components/Popover/components/Section/tests/Section.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {TextContainer} from 'components';
 
+import {TextContainer} from '../../../../TextContainer';
 import {Section} from '../Section';
 
 describe('<Section />', () => {

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useRef, useState} from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Portal} from 'components';
 
+import {Portal} from '../../Portal';
 import {PositionedOverlay} from '../../PositionedOverlay';
 import {Popover} from '../Popover';
 import type {PopoverPublicAPI} from '../Popover';

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -1,14 +1,12 @@
 import React, {AllHTMLAttributes} from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {
-  Avatar,
-  ButtonGroup,
-  Checkbox,
-  Thumbnail,
-  UnstyledLink,
-  Button,
-} from 'components';
 
+import {Avatar} from '../../Avatar';
+import {Button} from '../../Button';
+import {ButtonGroup} from '../../ButtonGroup';
+import {Checkbox} from '../../Checkbox';
+import {Thumbnail} from '../../Thumbnail';
+import {UnstyledLink} from '../../UnstyledLink';
 import {ResourceItem} from '../ResourceItem';
 import {ResourceListContext} from '../../../utilities/resource-list';
 import styles from '../ResourceItem.scss';

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import {DatePicker, Select, TextField} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {DatePicker} from '../../../../../../DatePicker';
+import {Select} from '../../../../../../Select';
+import {TextField} from '../../../../../../TextField';
 import {
   DateSelector,
   DateSelectorProps,

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import {mountWithApp} from 'tests/utilities';
-import type {CustomRoot} from '@shopify/react-testing';
-import {Button, Select, Popover, Form} from 'components';
+import {mountWithApp, CustomRoot} from 'tests/utilities';
 
+import {Button} from '../../../../../../Button';
+import {Form} from '../../../../../../Form';
+import {Popover} from '../../../../../../Popover';
+import {Select} from '../../../../../../Select';
 import {FilterCreator, FilterCreatorProps} from '../FilterCreator';
 import {FilterValueSelector} from '../../FilterValueSelector';
 import {FilterType} from '../../../types';

--- a/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Select, TextField} from 'components';
 
+import {Select} from '../../../../../../Select';
+import {TextField} from '../../../../../../TextField';
 import {FilterValueSelector} from '../FilterValueSelector';
 import {DateSelector} from '../../DateSelector';
 import {Filter, FilterType, Operator} from '../../../types';

--- a/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {TextField, Tag, Button} from 'components';
 
+import {Button} from '../../../../Button';
+import {TextField} from '../../../../TextField';
+import {Tag} from '../../../../Tag';
 import {ResourceListContext} from '../../../../../utilities/resource-list';
 import {
   Filter,

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
-import {
-  ResourceList,
-  Select,
-  Spinner,
-  EmptySearchResult,
-  ResourceItem,
-  EventListener,
-  Button,
-  EmptyState,
-} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
-import {SELECT_ALL_ITEMS} from '../../../utilities/resource-list';
 import {BulkActions} from '../../BulkActions';
+import {Button} from '../../Button';
 import {CheckableButton} from '../../CheckableButton';
+import {EmptySearchResult} from '../../EmptySearchResult';
+import {EmptyState} from '../../EmptyState';
+import {EventListener} from '../../EventListener';
+import {Select} from '../../Select';
+import {Spinner} from '../../Spinner';
+import {ResourceItem} from '../../ResourceItem';
+import {SELECT_ALL_ITEMS} from '../../../utilities/resource-list';
+import {ResourceList} from '../ResourceList';
 import styles from '../ResourceList.scss';
 
 const itemsNoID = [{url: 'item 1'}, {url: 'item 2'}];

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import {InlineError, Icon, Labelled} from 'components';
 import {mountWithApp} from 'tests/utilities';
 import {CircleTickOutlineMinor} from '@shopify/polaris-icons';
 
+import {InlineError} from '../../InlineError';
+import {Icon} from '../../Icon';
+import {Labelled} from '../../Labelled';
 import {Select} from '../Select';
 
 describe('<Select />', () => {

--- a/src/components/Sheet/tests/Sheet.test.tsx
+++ b/src/components/Sheet/tests/Sheet.test.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable import/no-deprecated */
 import React, {useRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
-import {Backdrop, Button} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Backdrop} from '../../Backdrop';
+import {Button} from '../../Button';
 import {Sheet} from '../Sheet';
 
 describe('<Sheet />', () => {

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {
-  Layout,
-  Card,
-  SkeletonBodyText,
-  DisplayText,
-  SkeletonDisplayText,
-} from 'components';
 
+import {Card} from '../../Card';
+import {DisplayText} from '../../DisplayText';
+import {Layout} from '../../Layout';
+import {SkeletonBodyText} from '../../SkeletonBodyText';
+import {SkeletonDisplayText} from '../../SkeletonDisplayText';
 import {SkeletonPage} from '../SkeletonPage';
 
 describe('<SkeletonPage />', () => {

--- a/src/components/Subheading/tests/Subheading.test.tsx
+++ b/src/components/Subheading/tests/Subheading.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Button} from 'components';
 
+import {Button} from '../../Button';
 import {Subheading} from '../Subheading';
 
 describe('<Subheading />', () => {

--- a/src/components/Tabs/components/Item/tests/Item.test.tsx
+++ b/src/components/Tabs/components/Item/tests/Item.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {UnstyledLink} from 'components';
 
+import {UnstyledLink} from '../../../../UnstyledLink';
 import {Item} from '../Item';
 
 describe('<Item />', () => {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import {InlineError, Labelled, Connected, Select} from 'components';
 import {mountWithApp} from 'tests/utilities';
 
+import {Connected} from '../../Connected';
+import {InlineError} from '../../InlineError';
+import {Labelled} from '../../Labelled';
+import {Select} from '../../Select';
 import {Resizer, Spinner} from '../components';
 import {TextField} from '../TextField';
 import styles from '../TextField.scss';

--- a/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Link} from 'components';
 
+import {Link} from '../../Link';
 import {Tooltip} from '../Tooltip';
 import {TooltipOverlay} from '../components';
 import {Key} from '../../../types';

--- a/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {ActionList, Popover} from 'components';
 
+import {ActionList} from '../../../../ActionList';
+import {Popover} from '../../../../Popover';
 import {Menu} from '../Menu';
 import {Message} from '../components';
 

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {Image, UnstyledLink} from 'components';
 
+import {Image} from '../../Image';
+import {UnstyledLink} from '../../UnstyledLink';
 import {TopBar} from '../TopBar';
 import {Menu, SearchField, UserMenu, Search} from '../components';
 

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {
-  EventListener,
-  Focus,
-  TextContainer,
-  TextField,
-  Button,
-  Portal,
-} from 'components';
 
+import {Button} from '../../Button';
+import {EventListener} from '../../EventListener';
+import {Focus} from '../../Focus';
+import {TextContainer} from '../../TextContainer';
+import {TextField} from '../../TextField';
+import {Portal} from '../../Portal';
 import * as focusUtils from '../../../utilities/focus';
 import {TrapFocus} from '../TrapFocus';
 import {Key} from '../../../types';

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {UnstyledLink} from 'components';
 
+import {UnstyledLink} from '../../UnstyledLink';
 import {UnstyledButton} from '../UnstyledButton';
 
 describe('<Button />', () => {

--- a/src/utilities/index-table/tests/hooks-useContainerScroll.test.tsx
+++ b/src/utilities/index-table/tests/hooks-useContainerScroll.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {IndexTable, IndexTableProps} from 'components';
 
 // eslint-disable-next-line @shopify/strict-component-boundaries
-import {ScrollContainer} from '../../../components/IndexTable';
+import {
+  IndexTable,
+  IndexTableProps,
+  ScrollContainer,
+} from '../../../components/IndexTable';
 import {useContainerScroll} from '../hooks';
 
 function Component({condensed}: {condensed?: boolean}) {

--- a/src/utilities/index-table/tests/hooks-useRowHovered.test.tsx
+++ b/src/utilities/index-table/tests/hooks-useRowHovered.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
-import {IndexTable, IndexTableProps} from '../../../components';
+// eslint-disable-next-line @shopify/strict-component-boundaries
+import {IndexTable, IndexTableProps} from '../../../components/IndexTable';
 import {useRowHovered} from '../hooks';
 
 function Component() {

--- a/src/utilities/index-table/tests/hooks-useRowSelected.test.tsx
+++ b/src/utilities/index-table/tests/hooks-useRowSelected.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
-import {IndexTable, IndexTableProps} from '../../../components';
+// eslint-disable-next-line @shopify/strict-component-boundaries
+import {IndexTable, IndexTableProps} from '../../../components/IndexTable';
 import {useRowSelected} from '../hooks';
 
 function Component() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "importsNotUsedAsValues": "error",
     "strictFunctionTypes": false,
     "paths": {
-      "components": ["./src/components"],
       "tests/*": ["./tests/*"]
     }
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Hitting two birds with one PR - removing a confusing way of importing files, and a chonky test speed improvement.

`components` is usable as an alias for importing the components in tests. However feel it should be removed as it is usage is not intuitive and has the potential to accidentally break consumers:

- It is possible to use the alias to import a type in source files, and TS will pass but when the package is published consumers will get an error
- Importing concrete values (i.e. not types) fails in source code but works in test files. This is confusing and unintuitive to folks unfamiliar with the codebase.

In addition, using this file to access components means that Jest has to read and parse all components (as that file reexports every component) even if you only use a specific component or two in a given test. This slows tests down as jest is doing lots unneeded work. This gets particularly pathological when you're trying to run a single test or when you're running tests with a cold cache (i.e on CI).

In order to ensure that even relative path imports to the components index never reappear we should remove the components index file, per the recommendations and investigations in this [web decision doc](https://github.com/Shopify/web/blob/master/documentation/decisions/09%20-%20Explicit%20root%20components%20imports.md) that spurned the investigation in this PR

### WHAT is this pull request doing?

This PR replaces all instances of `import {BLAH} from 'components'` with `import {BLAH} from '../../BLAH'` or whatever is the correct relative path to that component is.

`loom.config.ts` and `tsconfig.json` have been updated to remove the ability to use `'components'` as an importable path


### How to 🎩

Tests / type-check passes


### Stats!

I mentioned this improves performance on cold-cache test runs on CI.

Running 3 ci-style cold test runs `rm -rf .loom && CI=1 yarn test` on main takes: 50.01s, 50.30s, 49.04s.
Running 3 the same on this branch takes:  32.57s 32.39s 33.74s

So I've our tests are now almost twice as fast :D
