### PR TITLE
[SkeletonPage] Deprecate secondaryActions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -55,3 +55,4 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Deprecated passing `attention` to the `status` prop on `Badge` in favor of `warning` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 - Deprecated `thumbnail` property for `Page` ([#4733](https://github.com/Shopify/polaris-react/pull/4733))
+- Deprecated `secondaryActions` property for `SkeletonPage` ([#](https://github.com/Shopify/polaris-react/pull/))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -55,4 +55,4 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Deprecated passing `attention` to the `status` prop on `Badge` in favor of `warning` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 - Deprecated `thumbnail` property for `Page` ([#4733](https://github.com/Shopify/polaris-react/pull/4733))
-- Deprecated `secondaryActions` property for `SkeletonPage` ([#](https://github.com/Shopify/polaris-react/pull/))
+- Deprecated `secondaryActions` property for `SkeletonPage` ([#4740](https://github.com/Shopify/polaris-react/pull/4740))

--- a/src/components/SkeletonPage/README.md
+++ b/src/components/SkeletonPage/README.md
@@ -63,7 +63,7 @@ Use placeholder content that will change when the page fully loads. This will co
 Use this component to compose a loading version of a page where the page title and header content are dynamic, meaning, the content changes.
 
 ```jsx
-<SkeletonPage primaryAction secondaryActions={2}>
+<SkeletonPage primaryAction>
   <Layout>
     <Layout.Section>
       <Card sectioned>
@@ -115,7 +115,7 @@ Use this component to compose a loading version of a page where the page title a
 Use this component to compose a loading version of a page where the page title and header content are known and stay the same.
 
 ```jsx
-<SkeletonPage title="Products" primaryAction secondaryActions={2}>
+<SkeletonPage title="Products" primaryAction>
   <Layout>
     <Layout.Section>
       <Card sectioned>

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -16,7 +16,7 @@ export interface SkeletonPageProps {
   narrowWidth?: boolean;
   /** Shows a skeleton over the primary action */
   primaryAction?: boolean;
-  /** Number of secondary page-level actions to display */
+  /** @deprecated Number of secondary page-level actions to display */
   secondaryActions?: number;
   /** Shows a skeleton over the breadcrumb */
   breadcrumbs?: boolean;

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -35,6 +35,13 @@ export function SkeletonPage({
 }: SkeletonPageProps) {
   const i18n = useI18n();
 
+  if (process.env.NODE_ENV === 'development' && secondaryActions != null) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The secondaryActions prop from SkeletonPage has been deprecated',
+    );
+  }
+
   const className = classNames(
     styles.Page,
     fullWidth && styles.fullWidth,


### PR DESCRIPTION
### WHY are these changes introduced?

`Page` component no longer has secondary actions placed where this component renders them. It also adds an unnecessary layer of complexity with random sizes.

### WHAT is this pull request doing?

Deprecates `secondaryActions` and removes the examples.