### PR TITLE
[Page] Remove thumbnail prop

### DIFF
--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -137,12 +137,6 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
   title="3/4 inch Leather pet collar"
   titleMetadata={<Badge status="success">Paid</Badge>}
   subtitle="Perfect for any pet"
-  thumbnail={
-    <Thumbnail
-      source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-      alt="Black leather pet collar"
-    />
-  }
   compactTitle
   primaryAction={{content: 'Save', disabled: true}}
   secondaryActions={[
@@ -275,52 +269,6 @@ Use when the page title benefits from secondary content.
 </Page>
 ```
 
-### Page with title thumbnail
-
-<!-- example-for: web -->
-
-Use when an image will help merchants identify the purpose of the page.
-
-```jsx
-<Page
-  breadcrumbs={[{content: 'Products', url: '/products/31'}]}
-  title="3/4 inch Leather pet collar"
-  titleMetadata={<Badge status="success">Paid</Badge>}
-  thumbnail={
-    <Thumbnail
-      source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-      alt="Black leather pet collar"
-    />
-  }
-  secondaryActions={[
-    {
-      content: 'Duplicate',
-      icon: DuplicateMinor,
-    },
-    {
-      content: 'View',
-      icon: ViewMinor,
-    },
-  ]}
-  actionGroups={[
-    {
-      title: 'Promote',
-      actions: [{content: 'Share on Facebook'}],
-    },
-    {
-      title: 'More actions',
-      actions: [{content: 'Embed on a website'}],
-    },
-  ]}
-  pagination={{
-    hasPrevious: true,
-    hasNext: true,
-  }}
->
-  <p>Page content</p>
-</Page>
-```
-
 ### Page with external link
 
 <!-- example-for: web -->
@@ -336,7 +284,8 @@ Use when a secondary action links to another website. Actions marked external op
       content: 'Promote',
       external: true,
       icon: ExternalMinor,
-      url: 'https://www.facebook.com/business/learn/facebook-page-build-audience',
+      url:
+        'https://www.facebook.com/business/learn/facebook-page-build-audience',
     },
   ]}
 >

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -284,8 +284,7 @@ Use when a secondary action links to another website. Actions marked external op
       content: 'Promote',
       external: true,
       icon: ExternalMinor,
-      url:
-        'https://www.facebook.com/business/learn/facebook-page-build-audience',
+      url: 'https://www.facebook.com/business/learn/facebook-page-build-audience',
     },
   ]}
 >

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -69,7 +69,6 @@ export function Header({
   subtitle,
   titleMetadata,
   additionalMetadata,
-  thumbnail,
   titleHidden = false,
   primaryAction,
   pagination,
@@ -122,7 +121,6 @@ export function Header({
         title={title}
         subtitle={subtitle}
         titleMetadata={titleMetadata}
-        thumbnail={thumbnail}
         compactTitle={compactTitle}
       />
     </div>

--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -19,18 +19,6 @@
   }
 }
 
-.hasThumbnail {
-  display: grid;
-  grid-gap: spacing();
-  grid-template-columns: auto 1fr;
-
-  .TitleAndSubtitleWrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
-}
-
 .TitleWithMetadataWrapper {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -48,9 +48,9 @@ export function Title({
   ) : null;
 
   return (
-    <div>
+    <>
       {wrappedTitleMarkup}
       {subtitleMarkup}
-    </div>
+    </>
   );
 }

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import type {AvatarProps} from '../../../../../Avatar';
-import type {ThumbnailProps} from '../../../../../Thumbnail';
 import {classNames} from '../../../../../../utilities/css';
 
 import styles from './Title.scss';
@@ -13,10 +11,6 @@ export interface TitleProps {
   subtitle?: string;
   /** Important and non-interactive status information shown immediately after the title. */
   titleMetadata?: React.ReactNode;
-  /** @deprecated thumbnail that precedes the title */
-  thumbnail?:
-    | React.ReactElement<AvatarProps | ThumbnailProps>
-    | React.SFC<React.SVGProps<SVGSVGElement>>;
   /** Removes spacing between title and subtitle */
   compactTitle?: boolean;
 }
@@ -25,14 +19,8 @@ export function Title({
   title,
   subtitle,
   titleMetadata,
-  thumbnail,
   compactTitle,
 }: TitleProps) {
-  if (process.env.NODE_ENV === 'development' && thumbnail != null) {
-    // eslint-disable-next-line no-console
-    console.warn('The thumbnail prop from Page has been deprecated');
-  }
-
   const titleMarkup = title ? <h1 className={styles.Title}>{title}</h1> : null;
 
   const titleMetadataMarkup = titleMetadata ? (
@@ -59,17 +47,10 @@ export function Title({
     </div>
   ) : null;
 
-  const thumbnailMarkup = thumbnail ? <div>{thumbnail}</div> : null;
-
-  const pageTitleClassName = thumbnail ? styles.hasThumbnail : undefined;
-
   return (
-    <div className={pageTitleClassName}>
-      {thumbnailMarkup}
-      <div className={styles.TitleAndSubtitleWrapper}>
-        {wrappedTitleMarkup}
-        {subtitleMarkup}
-      </div>
+    <div>
+      {wrappedTitleMarkup}
+      {subtitleMarkup}
     </div>
   );
 }

--- a/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
+++ b/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
@@ -3,7 +3,6 @@ import {mountWithApp} from 'tests/utilities';
 
 import {Badge} from '../../../../../../Badge';
 import {DisplayText} from '../../../../../../DisplayText';
-import {Avatar} from '../../../../../../Avatar';
 import {Title} from '../Title';
 
 describe('<Title />', () => {
@@ -61,18 +60,6 @@ describe('<Title />', () => {
     it('renders the titleMetadata when defined', () => {
       const pageTitle = mountWithApp(<Title {...propsWithMetadata} />);
       expect(pageTitle).toContainReactComponent(Badge);
-    });
-  });
-
-  describe('thumbail', () => {
-    const propsWithThumbail = {
-      ...mockProps,
-      thumbnail: <Avatar customer />,
-    };
-
-    it('renders the thumbnail when defined', () => {
-      const pageTitle = mountWithApp(<Title {...propsWithThumbail} />);
-      expect(pageTitle).toContainReactComponent(Avatar);
     });
   });
 });

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
 
-import {Avatar} from '../../../../Avatar';
 import {ActionMenu} from '../../../../ActionMenu';
 import {Badge} from '../../../../Badge';
 import {Breadcrumbs} from '../../../../Breadcrumbs';
@@ -22,7 +21,6 @@ describe('<Header />', () => {
       title: 'title',
       subtitle: 'subtitle',
       titleMetadata: <Badge>Sold</Badge>,
-      thumbnail: <Avatar customer />,
     };
 
     it('sets the title on the Header', () => {
@@ -36,13 +34,6 @@ describe('<Header />', () => {
       const header = mountWithApp(<Header {...mockProps} />);
       expect(header).toHaveReactProps({
         subtitle: mockProps.subtitle,
-      });
-    });
-
-    it('sets the thumbnail on the Header', () => {
-      const header = mountWithApp(<Header {...mockProps} />);
-      expect(header).toHaveReactProps({
-        thumbnail: mockProps.thumbnail,
       });
     });
 

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useState} from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
 
-import {Avatar} from '../../Avatar';
 import type {ActionMenuProps} from '../../ActionMenu';
 import {Badge} from '../../Badge';
 import {Card} from '../../Card';
@@ -74,16 +73,6 @@ describe('<Page />', () => {
       );
       expect(page).toContainReactComponent(Header, {
         titleMetadata,
-      });
-    });
-  });
-
-  describe('thumbnail', () => {
-    it('gets passed into the <Header />', () => {
-      const thumbnail = <Avatar customer />;
-      const page = mountWithApp(<Page {...mockProps} thumbnail={thumbnail} />);
-      expect(page).toContainReactComponent(Header, {
-        thumbnail,
       });
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Clean up for v8.0.0

### WHAT is this pull request doing?

Removes deprecated property thumbnail and the related styles, examples and tests.