### PR TITLE
[Layout.AnnotatedSection] Added stacked prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
 - Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
+- Added `stacked` prop to `Layout.AnnotatedSection` to render in stacked layout ([#4755](https://github.com/Shopify/polaris-react/pull/4755))
 
 ### Bug fixes
 

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -74,38 +74,70 @@ $relative-size: $primary-basis / $secondary-basis;
   }
 }
 
-.AnnotationWrapper {
+.AnnotationWrapperBase {
   display: flex;
-  flex-wrap: wrap;
   margin-top: -1 * spacing();
   margin-left: -1 * spacing(loose);
-}
 
-.AnnotationContent {
-  flex: $relative-size $relative-size $primary-basis;
-}
+  .Annotation {
+    padding: spacing() spacing(loose) 0;
 
-.Annotation {
-  flex: 1 1 $secondary-basis;
-  padding: spacing() spacing(loose) 0;
-
-  @include page-content-when-not-fully-condensed {
-    padding: spacing() 0 0;
+    @include page-content-when-not-fully-condensed {
+      padding: spacing() 0 0;
+    }
   }
 
-  @include page-content-when-layout-not-stacked {
-    padding: spacing(loose) spacing(loose) spacing(loose) 0;
+  .Annotation,
+  .AnnotationContent {
+    min-width: 0;
+    max-width: calc(100% - #{spacing(loose)});
+    margin-left: spacing(loose);
+  }
+
+  .AnnotationDescription {
+    @include text-emphasis-subdued;
   }
 }
 
-.Annotation,
-.AnnotationContent {
-  min-width: 0;
-  max-width: calc(100% - #{spacing(loose)});
-  margin-top: spacing();
-  margin-left: spacing(loose);
+.AnnotationWrapper {
+  flex-wrap: wrap;
+
+  .AnnotationContent {
+    flex: $relative-size $relative-size $primary-basis;
+  }
+
+  .Annotation {
+    flex: 1 1 $secondary-basis;
+
+    @include page-content-when-layout-not-stacked {
+      padding: spacing(loose) spacing(loose) spacing(loose) 0;
+    }
+  }
+
+  .Annotation,
+  .AnnotationContent {
+    margin-top: spacing();
+  }
 }
 
-.AnnotationDescription {
-  @include text-emphasis-subdued;
+.StackedAnnotationWrapper {
+  flex-direction: column;
+
+  .AnnotationContent {
+    flex: 1;
+    margin-top: spacing(loose);
+  }
+
+  .Annotation {
+    flex: 1;
+    margin-top: spacing();
+
+    @include page-content-when-layout-not-stacked {
+      padding: spacing() spacing(loose) 0 0;
+    }
+  }
+
+  .AnnotationDescription {
+    margin-top: rem(4px);
+  }
 }

--- a/src/components/Layout/README.md
+++ b/src/components/Layout/README.md
@@ -430,6 +430,33 @@ Use for settings pages. When settings are grouped thematically in annotated sect
 </Layout>
 ```
 
+### Stacked annotated layout
+
+When stacked is true, annotated section is displayed in a stacked layout, where title, description, and children all stack on the same column.
+
+```jsx
+<Layout>
+  <Layout.AnnotatedSection
+    id="storeDetails"
+    title="Store details"
+    description="Shopify and your customers will use this information to contact you."
+    stacked
+  >
+    <Card sectioned>
+      <FormLayout>
+        <TextField label="Store name" onChange={() => {}} autoComplete="off" />
+        <TextField
+          type="email"
+          label="Account email"
+          onChange={() => {}}
+          autoComplete="email"
+        />
+      </FormLayout>
+    </Card>
+  </Layout.AnnotatedSection>
+</Layout>
+```
+
 ### Annotated layout with Banner at the top
 
 Use for settings pages that need a banner or other content at the top.

--- a/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {wrapWithComponent} from '../../../../utilities/components';
+import {classNames} from '../../../../utilities/css';
 import {Heading} from '../../../Heading';
 import {TextContainer} from '../../../TextContainer';
 import styles from '../../Layout.scss';
@@ -9,28 +11,37 @@ export interface AnnotatedSectionProps {
   title?: React.ReactNode;
   description?: React.ReactNode;
   id?: string;
+  stacked?: boolean;
 }
 
 export function AnnotatedSection(props: AnnotatedSectionProps) {
-  const {children, title, description, id} = props;
+  const {children, title, description, id, stacked} = props;
 
   const descriptionMarkup =
     typeof description === 'string' ? <p>{description}</p> : description;
 
+  const annotation = (
+    <>
+      <Heading id={id}>{title}</Heading>
+      {descriptionMarkup && (
+        <div className={styles.AnnotationDescription}>{descriptionMarkup}</div>
+      )}
+    </>
+  );
+
+  const annotationMarkup = stacked
+    ? annotation
+    : wrapWithComponent(annotation, TextContainer, {});
+
+  const annotationWrapperClasses = classNames(
+    styles.AnnotationWrapperBase,
+    stacked ? styles.StackedAnnotationWrapper : styles.AnnotationWrapper,
+  );
+
   return (
     <div className={styles.AnnotatedSection}>
-      <div className={styles.AnnotationWrapper}>
-        <div className={styles.Annotation}>
-          <TextContainer>
-            <Heading id={id}>{title}</Heading>
-            {descriptionMarkup && (
-              <div className={styles.AnnotationDescription}>
-                {descriptionMarkup}
-              </div>
-            )}
-          </TextContainer>
-        </div>
-
+      <div className={annotationWrapperClasses}>
+        <div className={styles.Annotation}>{annotationMarkup}</div>
         <div className={styles.AnnotationContent}>{children}</div>
       </div>
     </div>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4640

Currently, Layout.AnnotatedSection displays its contents in a two-column layout, where the title and the subtitle are on the left, and the children on the right. And on smaller viewports, it adopts one-column layout, where title, subtitle and children all stack on top of each other.

We would like to pass an optional prop (e.g column) to Layout.AnnotatedSection so that it always remains in one-column layout on every viewport size.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR introduces an optional prop `stacked`, and when it is true, it always renders the `Layout.AnnotatedSection` in a  stacked layout regardless of its container size. 

##### Current example

![Current Layout.AnnotatedSection example from Polaris.](https://user-images.githubusercontent.com/84520558/141536784-76572d08-d2f9-417f-85f6-2ca3f301889f.png "Current Layout.AnnotatedSection example from Polaris")

##### Proposed example

![Proposed Layout.AnnotatedSection example with stacked prop.](https://user-images.githubusercontent.com/84520558/141536481-369b389e-740e-41c3-8ec0-48b2ab394249.png "Proposed Layout.AnnotatedSection example with stacked prop.")


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {
  Card,
  DisplayText,
  FormLayout,
  Layout,
  Page,
  Stack,
  TextField,
} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Stack vertical>
        <DisplayText>Current Layout.AnnotatedSection from Polaris</DisplayText>
        <Layout>
          <Layout.AnnotatedSection
            id="storeDetails"
            title="Store details"
            description="Shopify and your customers will use this information to contact you."
          >
            <Card sectioned>
              <FormLayout>
                <TextField
                  label="Store name"
                  onChange={() => {}}
                  autoComplete="off"
                />
                <TextField
                  type="email"
                  label="Account email"
                  onChange={() => {}}
                  autoComplete="email"
                />
              </FormLayout>
            </Card>
          </Layout.AnnotatedSection>
        </Layout>

        <DisplayText>
          Proposed Layout.AnnotatedSection with stacked prop
        </DisplayText>
        <Layout>
          <Layout.AnnotatedSection
            id="storeDetails"
            title="Store details"
            description="Shopify and your customers will use this information to contact you."
            stacked
          >
            <Card sectioned>
              <FormLayout>
                <TextField
                  label="Store name"
                  onChange={() => {}}
                  autoComplete="off"
                />
                <TextField
                  type="email"
                  label="Account email"
                  onChange={() => {}}
                  autoComplete="email"
                />
              </FormLayout>
            </Card>
          </Layout.AnnotatedSection>
        </Layout>
      </Stack>
    </Page>
  );
}


```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
