### PR TITLE
[Page] Add minimum height on page header

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Keyboard arrow navigation support added in `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
 - Menu role attribute value support added in `ActionList/Section` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
 - Updated the styling of `DropZone.FileUpload` ([#4813](https://github.com/Shopify/polaris-react/pull/4813))
+- Added a minimum height to `Page` component `Header` ([#4770](https://github.com/Shopify/polaris-react/pull/4779))
 
 ### Bug fixes
 

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -144,6 +144,7 @@ $action-menu-rollup-computed-width: rem(40px);
 .Row {
   display: flex;
   justify-content: space-between;
+  min-height: 36px;
 
   + .Row {
     margin-top: spacing(extra-tight);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #[4773](https://github.com/Shopify/polaris-react/issues/4773).

By not setting a minimum height, the page header height would visibly jump depending on if the `Page` component had actions and/or breadcrumbs or not. 

### WHAT is this pull request doing?

Sets a minimum height keeps the page header spacing consistent.
I didn't use `rem(36px)` in light of changes in the `v8.0.0-major` branch that removes that function.

Additionally, the height remains unaltered on mobile view (meaning page header jumps depending on content). I had an offline discussion with @sarahill about solutions for keeping it consistent but we agreed that would be out of scope and hot-fixes we tried didn't align with our density improvement initiative. 
    <details>
      <summary>Before gif — Inconsistent spacing on page header depending on content</summary>
      <img src="https://user-images.githubusercontent.com/26749317/144307423-c0187f76-61fd-4789-99f6-fa920a7b2c26.gif" alt="Before gif showing inconsistent spacing on page header depending on content">
    </details>
    <details>
      <summary>After gif — Consistent spacing on page header regardless of content</summary>
      <img src="https://user-images.githubusercontent.com/26749317/144307548-237e6bee-463e-4e2b-97fd-1f4ed5687abc.gif" alt="Gif showing consistent spacing on page header regardless of content">
    </details>

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code> :</summary>

```jsx
import React from 'react';

import {Page, Badge, Card} from '../src';

export function Playground() {
  return (
    // Page with actions and breadcrumbs -- uncomment below to test
    // <Page
    //   breadcrumbs={[{content: 'Products', url: '/products'}]}
    //   title="Jar With Lock-Lid"
    //   titleMetadata={<Badge status="attention">Verified</Badge>}
    //   primaryAction={{content: 'Save', disabled: true}}
    //   secondaryActions={[
    //     {content: 'Duplicate'},
    //     {content: 'View on your store'},
    //   ]}
    //   pagination={{
    //     hasPrevious: true,
    //     hasNext: true,
    //   }}
    // >
    //   <Card title="Page content" />
    // </Page>

    // Page with no actions and breadcrumbs -- comment out below if testing above component
    <Page title="Page with no actions/breadcrumbs">
      <Card title="Page content" />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
