### PR TITLE
Specify node version with size-limit.yml

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: yarn
       - uses: andresz1/size-limit-action@v1.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -13,6 +13,9 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
       - uses: andresz1/size-limit-action@v1.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub changed their default node version which means that our action tried to run with this version and failed. Specifying a version of node means that it will use that verison.