### PR TITLE
[DropZone] Updating FileUpload styles

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Keyboard arrow navigation support added in `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
 - Menu role attribute value support added in `ActionList/Section` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+- Updated the styling of `DropZone.FileUpload` ([#4813](https://github.com/Shopify/polaris-react/pull/4813))
 
 ### Bug fixes
 

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -62,7 +62,7 @@ $dropzone-stacking-order: (
   padding: border-width();
 
   &::after {
-    border-color: var(--p-border);
+    border-color: var(--p-border-neutral-subdued);
   }
 
   &:not(.isDisabled) {
@@ -81,7 +81,7 @@ $dropzone-stacking-order: (
     &::after {
       @include reset-after;
       @include set-border-radius;
-      border-color: var(--p-border);
+      border-color: var(--p-border-neutral-subdued);
     }
   }
 }

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -68,7 +68,7 @@ $dropzone-stacking-order: (
   &:not(.isDisabled) {
     &:hover {
       cursor: pointer;
-      background-color: var(--p-surface-selected-hovered);
+      background-color: var(--p-surface-subdued);
 
       // stylelint-disable-next-line selector-max-specificity
       &::after {

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -2,7 +2,7 @@
 
 $dropzone-padding: rem(15px);
 $dropzone-border-style: dashed;
-$dropzone-min-height-large: rem(100px);
+$dropzone-min-height-large: rem(120px);
 $dropzone-min-height-medium: rem(100px);
 $dropzone-min-height-small: rem(50px);
 

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -463,7 +463,7 @@ Use for cases with tight space constraints, such as variant thumbnails on the Pr
 </div>
 ```
 
-### Drop zone with variable size
+### Drop zone with custom FileUpload text
 
 Use for cases where you want the child contents of the dropzone to determine its height.
 
@@ -480,15 +480,9 @@ function DropZoneExample() {
   const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
 
   const fileUpload = !files.length && (
-    <div style={{padding: '1rem'}}>
-      <Stack distribution="center">
-        <Stack vertical>
-          <Button>Add files</Button>
-          <TextStyle variation="subdued">or drop to upload</TextStyle>
-        </Stack>
-      </Stack>
-    </div>
+    <DropZone.FileUpload actionHint="Accepts .gif, .jpg, and .png" />
   );
+
   const uploadedFiles = files.length > 0 && (
     <Stack vertical>
       {files.map((file, index) => (

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -279,25 +279,7 @@ function DropZoneWithDropOnPageExample() {
     </Stack>
   );
 
-  const uploadMessage = !uploadedFiles && (
-    <div
-      style={{
-        height: '100%',
-        width: '100%',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <Caption>
-        <TextStyle variation="strong">
-          <TextStyle variation="subdued">
-            Drop or <Link>browse files</Link>
-          </TextStyle>
-        </TextStyle>
-      </Caption>
-    </div>
-  );
+  const uploadMessage = !uploadedFiles && <DropZone.FileUpload />;
 
   return (
     <Page

--- a/src/components/DropZone/components/FileUpload/FileUpload.scss
+++ b/src/components/DropZone/components/FileUpload/FileUpload.scss
@@ -43,7 +43,7 @@ $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
   text-align: center;
   appearance: none;
 
-  &:focus {
+  &.focused {
     outline: 0;
     box-shadow: none;
     @include focus-ring($style: 'focused');

--- a/src/components/DropZone/components/FileUpload/FileUpload.scss
+++ b/src/components/DropZone/components/FileUpload/FileUpload.scss
@@ -27,7 +27,8 @@ $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
 
 .Button {
   @include focus-ring;
-
+  display: inline-flex;
+  flex: 0 0 auto;
   border: none;
   border-radius: var(--p-border-radius-base);
   padding: rem(4px) rem(6px);

--- a/src/components/DropZone/components/FileUpload/FileUpload.scss
+++ b/src/components/DropZone/components/FileUpload/FileUpload.scss
@@ -25,7 +25,7 @@ $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
   vertical-align: bottom;
 }
 
-.Button {
+.Action {
   @include focus-ring;
   display: inline-flex;
   flex: 0 0 auto;
@@ -42,12 +42,6 @@ $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
   cursor: pointer;
   text-align: center;
   appearance: none;
-
-  &.focused {
-    outline: 0;
-    box-shadow: none;
-    @include focus-ring($style: 'focused');
-  }
 
   &:hover {
     color: var(--p-interactive-hovered);

--- a/src/components/DropZone/components/FileUpload/FileUpload.scss
+++ b/src/components/DropZone/components/FileUpload/FileUpload.scss
@@ -26,26 +26,36 @@ $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
 }
 
 .Button {
-  @include button-base;
   @include focus-ring;
+
+  border: none;
+  border-radius: var(--p-border-radius-base);
+  padding: rem(4px) rem(6px);
+  margin: 0;
+  text-decoration: none;
+  background: var(--p-surface-selected-pressed);
+  color: var(--p-interactive);
+  font-size: rem(12px);
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  text-align: center;
+  appearance: none;
+
+  &:focus {
+    outline: 0;
+    box-shadow: none;
+    @include focus-ring($style: 'focused');
+  }
+
+  &:hover {
+    color: var(--p-interactive-hovered);
+  }
 
   &.disabled {
     @include base-button-disabled;
     cursor: not-allowed;
     box-shadow: none;
-  }
-
-  &.focused {
-    outline: 0;
-    box-shadow: none;
-
-    @include focus-ring($style: 'focused');
-    @include high-contrast-button-outline;
-  }
-
-  .sizeSlim {
-    min-height: $slim-min-height;
-    padding: $slim-vertical-padding spacing(base-tight);
   }
 }
 

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -32,13 +32,13 @@ export function FileUpload(props: FileUploadProps) {
     actionHint,
   } = props;
 
-  const buttonStyles = classNames(
+  const actionClassNames = classNames(
     styles.Button,
     focused && styles.focused,
     disabled && styles.disabled,
   );
 
-  const buttonMarkup = <div className={buttonStyles}>{actionTitle}</div>;
+  const actionMarkup = <div className={actionClassNames}>{actionTitle}</div>;
 
   const fileUploadClassName = classNames(
     styles.FileUpload,
@@ -58,7 +58,7 @@ export function FileUpload(props: FileUploadProps) {
     case 'large':
       viewMarkup = (
         <Stack vertical spacing="tight">
-          {buttonMarkup}
+          {actionMarkup}
           {actionHintMarkup}
         </Stack>
       );
@@ -66,7 +66,7 @@ export function FileUpload(props: FileUploadProps) {
     case 'medium':
       viewMarkup = (
         <Stack vertical spacing="tight">
-          {buttonMarkup}
+          {actionMarkup}
           {actionHintMarkup}
         </Stack>
       );

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -19,7 +19,7 @@ export interface FileUploadProps {
 
 export function FileUpload(props: FileUploadProps) {
   const i18n = useI18n();
-  const {size, measuring, type, focused, disabled, allowMultiple} =
+  const {size, measuring, type, disabled, allowMultiple} =
     useContext(DropZoneContext);
 
   const typeSuffix = capitalize(type);
@@ -33,8 +33,7 @@ export function FileUpload(props: FileUploadProps) {
   } = props;
 
   const actionClassNames = classNames(
-    styles.Button,
-    focused && styles.focused,
+    styles.Action,
     disabled && styles.disabled,
   );
 

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -29,32 +29,16 @@ export function FileUpload(props: FileUploadProps) {
     actionTitle = i18n.translate(
       `Polaris.DropZone.${allowMultipleKey}.actionTitle${typeSuffix}`,
     ),
-    actionHint = i18n.translate(
-      `Polaris.DropZone.${allowMultipleKey}.actionHint${typeSuffix}`,
-    ),
+    actionHint,
   } = props;
 
   const buttonStyles = classNames(
     styles.Button,
-    styles.slim,
     focused && styles.focused,
     disabled && styles.disabled,
   );
 
-  const buttonMarkup =
-    size === 'large' && buttonStyles ? (
-      <div className={buttonStyles}>{actionTitle}</div>
-    ) : null;
-
-  const actionTitleClassName = classNames(
-    styles.ActionTitle,
-    focused && !disabled && styles['ActionTitle-focused'],
-    disabled && styles['ActionTitle-disabled'],
-  );
-
-  const actionTitleMarkup = (
-    <div className={actionTitleClassName}>{actionTitle}</div>
-  );
+  const buttonMarkup = <div className={buttonStyles}>{actionTitle}</div>;
 
   const fileUploadClassName = classNames(
     styles.FileUpload,
@@ -63,26 +47,27 @@ export function FileUpload(props: FileUploadProps) {
     size === 'small' && styles.small,
   );
 
+  const actionHintMarkup = actionHint && (
+    <Caption>
+      <TextStyle variation="subdued">{actionHint}</TextStyle>
+    </Caption>
+  );
+
   let viewMarkup;
   switch (size) {
     case 'large':
       viewMarkup = (
         <Stack vertical spacing="tight">
-          <img width="40" src={uploadArrow} alt="" />
           {buttonMarkup}
-          <Caption>
-            <TextStyle variation="subdued">{actionHint}</TextStyle>
-          </Caption>
+          {actionHintMarkup}
         </Stack>
       );
       break;
     case 'medium':
       viewMarkup = (
         <Stack vertical spacing="tight">
-          {actionTitleMarkup}
-          <Caption>
-            <TextStyle variation="subdued">{actionHint}</TextStyle>
-          </Caption>
+          {buttonMarkup}
+          {actionHintMarkup}
         </Stack>
       );
       break;

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -54,7 +54,7 @@ describe('<FileUpload />', () => {
       expect(fileUpload).not.toContainReactComponent(TextStyle);
 
       expect(fileUpload).toContainReactComponent('div', {
-        className: 'Button',
+        className: 'Action',
       });
     });
   });
@@ -75,7 +75,7 @@ describe('<FileUpload />', () => {
     expect(fileUpload).not.toContainReactComponent(TextStyle);
 
     expect(fileUpload).toContainReactComponent('div', {
-      className: 'Button',
+      className: 'Action',
     });
   });
 
@@ -129,7 +129,7 @@ describe('<FileUpload />', () => {
     [true, 'file', 'Add files'],
   ])(
     'renders texts when allowMultiple is %s and type is %s',
-    (allowMultiple, type, expectedButtonText) => {
+    (allowMultiple, type, expectedActionText) => {
       const fileUpload = mountWithApp(
         <DropZoneContext.Provider
           value={{size: 'large', ...defaultStates, allowMultiple, type}}
@@ -139,7 +139,7 @@ describe('<FileUpload />', () => {
       );
 
       expect(fileUpload).toContainReactComponent('div', {
-        children: expectedButtonText,
+        children: expectedActionText,
       });
     },
   );

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -47,14 +47,14 @@ describe('<FileUpload />', () => {
         </DropZoneContext.Provider>,
       );
 
-      expect(fileUpload).toContainReactComponent('img', {
+      expect(fileUpload).not.toContainReactComponent('img', {
         src: uploadArrowImage,
       });
-      expect(fileUpload).toContainReactComponent(Caption);
-      expect(fileUpload).toContainReactComponent(TextStyle);
+      expect(fileUpload).not.toContainReactComponent(Caption);
+      expect(fileUpload).not.toContainReactComponent(TextStyle);
 
       expect(fileUpload).toContainReactComponent('div', {
-        className: 'Button slim',
+        className: 'Button',
       });
     });
   });
@@ -68,10 +68,15 @@ describe('<FileUpload />', () => {
       </DropZoneContext.Provider>,
     );
 
-    expect(fileUpload).toContainReactComponent('div', {
-      className: 'ActionTitle',
+    expect(fileUpload).not.toContainReactComponent('img', {
+      src: uploadArrowImage,
     });
-    expect(fileUpload).toContainReactComponentTimes(Caption, 1);
+    expect(fileUpload).not.toContainReactComponent(Caption);
+    expect(fileUpload).not.toContainReactComponent(TextStyle);
+
+    expect(fileUpload).toContainReactComponent('div', {
+      className: 'Button',
+    });
   });
 
   it('renders small view', () => {
@@ -82,6 +87,9 @@ describe('<FileUpload />', () => {
         <FileUpload />
       </DropZoneContext.Provider>,
     );
+
+    expect(fileUpload).not.toContainReactComponent(Caption);
+    expect(fileUpload).not.toContainReactComponent(TextStyle);
 
     expect(fileUpload).toContainReactComponentTimes('img', 1);
   });
@@ -100,7 +108,7 @@ describe('<FileUpload />', () => {
     expect(fileUpload).toContainReactText('Add files');
   });
 
-  it('sets a default actionHint if the prop is provided then removed', () => {
+  it('renders a custom actionHint if the prop is provided', () => {
     const fileUpload = mountWithApp(
       <DropZoneContext.Provider
         value={{size: 'large', type: 'file', ...defaultStates}}
@@ -109,18 +117,19 @@ describe('<FileUpload />', () => {
       </DropZoneContext.Provider>,
     );
 
-    fileUpload.setProps({children: <FileUpload />});
-    expect(fileUpload).toContainReactText('or drop files to upload');
+    expect(fileUpload).toContainReactComponent(Caption);
+    expect(fileUpload).toContainReactComponent(TextStyle);
+    expect(fileUpload).toContainReactText('Hint');
   });
 
   it.each([
-    [false, 'image', 'Add image', 'or drop image to upload'],
-    [true, 'image', 'Add images', 'or drop images to upload'],
-    [false, 'file', 'Add file', 'or drop file to upload'],
-    [true, 'file', 'Add files', 'or drop files to upload'],
+    [false, 'image', 'Add image'],
+    [true, 'image', 'Add images'],
+    [false, 'file', 'Add file'],
+    [true, 'file', 'Add files'],
   ])(
     'renders texts when allowMultiple is %s and type is %s',
-    (allowMultiple, type, expectedButtonText, expectedTextStyleText) => {
+    (allowMultiple, type, expectedButtonText) => {
       const fileUpload = mountWithApp(
         <DropZoneContext.Provider
           value={{size: 'large', ...defaultStates, allowMultiple, type}}
@@ -131,9 +140,6 @@ describe('<FileUpload />', () => {
 
       expect(fileUpload).toContainReactComponent('div', {
         children: expectedButtonText,
-      });
-      expect(fileUpload).toContainReactComponent(TextStyle, {
-        children: expectedTextStyleText,
       });
     },
   );


### PR DESCRIPTION
### WHY are these changes introduced?

This updates the styles used by `DropZone` the the `FileUpload` component.

### WHAT is this pull request doing?

It changes the `FileUpload` button styles, removes the icon at larger sizes, updates the hover style on `DropZone`, and removes the `actionHint` unless a custom one is passed in.

This is what it looks like now:

<img width="405" alt="Screen Shot 2021-12-09 at 10 56 33 AM" src="https://user-images.githubusercontent.com/478990/145432038-3f1fee43-7095-4a97-8fea-f1aef0ba9349.png">
<img width="135" alt="Screen Shot 2021-12-09 at 10 56 06 AM" src="https://user-images.githubusercontent.com/478990/145432039-30c7cc0e-e677-497b-9426-41b0ffbb51d7.png">
<img width="69" alt="Screen Shot 2021-12-09 at 11 06 25 AM" src="https://user-images.githubusercontent.com/478990/145432572-0b0187fe-f76e-4e89-ae49-eea234b4e023.png">
<img width="399" alt="Screen Shot 2021-12-09 at 11 08 01 AM" src="https://user-images.githubusercontent.com/478990/145432597-d0ca22f9-05f2-403a-ba43-545b6e692936.png">

FYI @ouellettejordan is going to sync up with @sarahill about potentially making this a button variation that is shared.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Take a look around at the `DropZone` stories.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
