### PR TITLE
[Tag] Avoid Tag's remove button to shrink (#4815)

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,7 +11,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
-- Remove Button is smaller in `Tag` with ellipsis ([#4815](https://github.com/Shopify/polaris-react/issues/4815))
+- Fixed a bug where remove button could shrink in the `Tag` component ([#4816](https://github.com/Shopify/polaris-react/issues/4816))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
+- Remove Button is smaller in `Tag` with ellipsis ([#4815](https://github.com/Shopify/polaris-react/issues/4815))
+
 ### Documentation
 
 - Added arrow navigation instructions in keyboard support for `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -50,6 +50,7 @@ function RemovableTagExample() {
     'Antique',
     'Vinyl',
     'Refurbished',
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at ipsum quam. Aliquam fermentum bibendum vestibulum. Vestibulum condimentum luctus metus, sed sagittis magna pellentesque eget. Duis dapibus pretium nisi, et venenatis tortor dignissim ut. Quisque eget lacus ac ex eleifend ultrices. Phasellus facilisis ex sit amet leo elementum condimentum. Ut vel maximus felis. Etiam eget diam eu eros blandit interdum. Sed eu metus sed justo aliquam iaculis ac sit amet ex. Curabitur justo magna, porttitor non pulvinar eu, malesuada at leo. Cras mollis consectetur eros, quis maximus lorem dignissim at. Proin in rhoncus massa. Vivamus lectus nunc, fringilla euismod risus commodo, mattis blandit nulla.',
   ]);
 
   const removeTag = useCallback(

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -66,6 +66,7 @@ $icon-size: rem(16px);
   @include recolor-icon(var(--p-icon));
   @include unstyled-button;
   display: block;
+  flex-shrink: 0;
   height: $height;
   width: $height;
   margin-left: spacing(extra-tight);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4815 which causes the `Remove` button within tags with long texts to "shrink"

![Screenshot 2021-12-09 at 21 22 55](https://user-images.githubusercontent.com/905006/145480271-87d78d0c-bf09-428d-a5a1-6a519a45fda7.png)

### WHAT is this pull request doing?

- I think (or that was my intention) that this just adds `flex-shrink: 0` to the button so it won't give way for the text and retain its size.
- I've also added an example in the `Readme` to see this in Storybook, but maybe we don't want to see this in there 🤷 .  I find the ellipsis behaviour interesting to showcase nevertheless.

### How to 🎩

Check the `Tag` section in Storybook

![Screenshot 2021-12-09 at 21 48 56](https://user-images.githubusercontent.com/905006/145481171-63f085de-8cad-45ea-a052-a138f879af69.png)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers): **Chrome, Firefox, Safari**
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, ping @ sarahill to update the Polaris UI kit

Possible visual changes, so cc'ing @sarahill 