### PR TITLE
[WIP] [Tag] Allow arbitrary content and allow onClick and onRemove at the same time (#4819)

### DIFF
--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -85,7 +85,58 @@ Use to allow merchants to add attributes to an object.
 Use to allow merchants to add attributes to an object.
 
 ```jsx
-<Tag onClick={() => console.log('Clicked')} onRemove={() => console.log('Removed')}>Wholesale</Tag>
+<Tag
+  onClick={() => console.log('Clicked')}
+  onRemove={() => console.log('Removed')}
+>
+  Wholesale
+</Tag>
+```
+
+### Custom content tag
+
+Use to allow merchants to add attributes to an object.
+
+```jsx
+<>
+  <Tag>
+    <Stack alignment="center" spacing="extraTight" title="Farrah Fawcett">
+      <Icon source={SearchMinor} color="inkLighter" />
+      <TextContainer>Farrah Fawcett</TextContainer>
+    </Stack>
+  </Tag>
+
+  <hr />
+
+  <Tag onClick={() => console.log('Clicked')} title="Farrah Fawcett">
+    <Stack alignment="center" spacing="extraTight">
+      <Icon source={SearchMinor} color="inkLighter" />
+      <TextContainer>Farrah Fawcett</TextContainer>
+    </Stack>
+  </Tag>
+
+  <hr />
+
+  <Tag onRemove={() => console.log('Removed')} title="Farrah Fawcett">
+    <Stack alignment="center" spacing="extraTight">
+      <Icon source={SearchMinor} color="inkLighter" />
+      <TextContainer>Farrah Fawcett</TextContainer>
+    </Stack>
+  </Tag>
+
+  <hr />
+
+  <Tag
+    onClick={() => console.log('Clicked')}
+    onRemove={() => console.log('Removed')}
+    title="Farrah Fawcett"
+  >
+    <Stack alignment="center" spacing="extraTight">
+      <Icon source={SearchMinor} color="inkLighter" />
+      <TextContainer>Farrah Fawcett</TextContainer>
+    </Stack>
+  </Tag>
+</>
 ```
 
 <!-- content-for: android -->

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -80,6 +80,14 @@ Use to allow merchants to add attributes to an object.
 <Tag onClick={() => console.log('Clicked')}>Wholesale</Tag>
 ```
 
+### Clickable and removable tag
+
+Use to allow merchants to add attributes to an object.
+
+```jsx
+<Tag onClick={() => console.log('Clicked')} onRemove={() => console.log('Removed')}>Wholesale</Tag>
+```
+
 <!-- content-for: android -->
 
 ![Tag for Android](/public_images/components/Tag/android/default@2x.png)

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -52,6 +52,11 @@ $icon-size: rem(16px);
     }
   }
 
+  &.segmented {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+  }
+
   @include high-contrast-outline;
 }
 
@@ -95,5 +100,25 @@ $icon-size: rem(16px);
     @include recolor-icon(var(--p-icon-disabled));
     cursor: default;
     pointer-events: none;
+  }
+
+  &.segmented {
+    cursor: pointer;
+    background-color: var(--p-surface-neutral);
+    margin-left: 0;
+
+    &:hover {
+      background: var(--p-surface-neutral-hovered);
+    }
+
+    @include focus-ring;
+
+    &:focus:not(:active) {
+      @include focus-ring($style: 'focused');
+    }
+
+    &:active {
+      background: var(--p-surface-neutral-pressed);
+    }
   }
 }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {ButtonGroup} from '../ButtonGroup';
 import {CancelSmallMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../utilities/css';
@@ -8,7 +9,7 @@ import {handleMouseUpByBlurring} from '../../utilities/focus';
 
 import styles from './Tag.scss';
 
-export interface NonMutuallyExclusiveProps {
+export interface TagProps {
   /** Content to display in the tag */
   children?: string;
   /** Disables the tag  */
@@ -19,20 +20,21 @@ export interface NonMutuallyExclusiveProps {
   onRemove?(): void;
 }
 
-export type TagProps = NonMutuallyExclusiveProps &
-  (
-    | {onClick?(): void; onRemove?: undefined}
-    | {onClick?: undefined; onRemove?(): void}
-  );
-
 export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
   const i18n = useI18n();
 
-  const className = classNames(
+  const tagClassName = classNames(
     styles.Tag,
     disabled && styles.disabled,
     onClick && styles.clickable,
     onRemove && styles.removable,
+    onClick && onRemove && styles.segmented,
+  );
+
+  const removeClassName = classNames(
+    styles.Button,
+    styles.clickable,
+    onClick && onRemove && styles.segmented,
   );
 
   const ariaLabel = i18n.translate('Polaris.Tag.ariaLabel', {
@@ -43,7 +45,7 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
     <button
       type="button"
       aria-label={ariaLabel}
-      className={styles.Button}
+      className={removeClassName}
       onClick={onRemove}
       onMouseUp={handleMouseUpByBlurring}
       disabled={disabled}
@@ -52,22 +54,30 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
     </button>
   ) : null;
 
-  const tagMarkup = onClick ? (
+  const tagButton = onClick ? (
     <button
       type="button"
       disabled={disabled}
-      className={className}
+      className={tagClassName}
       onClick={onClick}
     >
       {children}
     </button>
   ) : (
-    <span className={className}>
+    <span className={tagClassName}>
       <span title={children} className={styles.TagText}>
         {children}
       </span>
       {removeButton}
     </span>
   );
-  return tagMarkup;
+
+  if (onClick && onRemove) {
+    return <ButtonGroup segmented>
+      {tagButton}
+      {removeButton}
+    </ButtonGroup>
+  }
+
+  return tagButton;
 }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {ButtonGroup} from '../ButtonGroup';
 import {CancelSmallMinor} from '@shopify/polaris-icons';
 
+import {ButtonGroup} from '../ButtonGroup';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {Icon} from '../Icon';
@@ -11,16 +11,24 @@ import styles from './Tag.scss';
 
 export interface TagProps {
   /** Content to display in the tag */
-  children?: string;
+  children?: string | React.ReactElement;
   /** Disables the tag  */
   disabled?: boolean;
   /** Callback when tag is clicked or keypressed. Renders without remove button when set. */
   onClick?(): void;
   /** Callback when remove button is clicked or keypressed. */
   onRemove?(): void;
+  /** A string to use when tag has more than textual content */
+  title?: string;
 }
 
-export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
+export function Tag({
+  children,
+  disabled = false,
+  onClick,
+  onRemove,
+  title = '',
+}: TagProps) {
   const i18n = useI18n();
 
   const tagClassName = classNames(
@@ -37,8 +45,10 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
     onClick && onRemove && styles.segmented,
   );
 
+  const tagTitle = typeof children === 'string' ? children : title;
+
   const ariaLabel = i18n.translate('Polaris.Tag.ariaLabel', {
-    children: children || '',
+    children: tagTitle,
   });
 
   const removeButton = onRemove ? (
@@ -65,7 +75,7 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
     </button>
   ) : (
     <span className={tagClassName}>
-      <span title={children} className={styles.TagText}>
+      <span title={tagTitle} className={styles.TagText}>
         {children}
       </span>
       {removeButton}
@@ -73,10 +83,12 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
   );
 
   if (onClick && onRemove) {
-    return <ButtonGroup segmented>
-      {tagButton}
-      {removeButton}
-    </ButtonGroup>
+    return (
+      <ButtonGroup segmented>
+        {tagButton}
+        {removeButton}
+      </ButtonGroup>
+    );
   }
 
   return tagButton;

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
+import {Button} from '../../Button';
 import {Tag} from '../Tag';
 
 describe('<Tag />', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

This is POC to attempt to address the needs described in [[Tag] Allow arbitrary children #4819](https://github.com/Shopify/polaris-react/issues/4819)

**TL;DR**

We want to be able to use the `Tag` component in a way that:
- We can have `removable` tags that also have a main faction (navigate to the thing the tag describes)
- We can add richer content other than just text

### WHAT is this pull request doing?

#### [[Tag] Accepts ReactElement to be passed as children](https://github.com/Shopify/polaris-react/commit/3a43ce11a0cd01ab78f1141ee3f411f54af6a9b0)

This commit allows for arbitrary markup/components to be passed down as the `Tag` `children` prop.

Since **we can't infer reasonable `aria-label` or `title` attribute from an arbitrary prop**, this commit also **adds an additional `title` prop that overrides the default** generation logic for them. This could be useful in itself regardless of being able to pass arbitrary markup.

![Screenshot 2021-12-13 at 12 49 59](https://user-images.githubusercontent.com/905006/145815562-594d4bfe-5be6-483f-ac8b-4d8e0f7d6efb.png)

(Using a `Stack` here breaks the new segmented markdown (1px difference), so that's definitely something we'd need to figure out 😂 )

#### [[Tag] Removes restriction for passing both an onClick and onRemove prop](https://github.com/Shopify/polaris-react/commit/e07aedd769c9750d1125bf1a185eac40a8008085)

This commit is removes the restriction for passing both an `onClick` prop at the same time of an `onRemove` prop and slightly refactors the component to generate markup for that case by creating a `segmented` variant so we can show both buttons together using a `ButtonGroup`.

![Screenshot 2021-12-13 at 12 49 52](https://user-images.githubusercontent.com/905006/145817055-3e51ed92-7dfd-45fe-8e0d-ff6913b762e8.png)

I'm obviously hardly sure this is the right markup or approach, so just take this as a way to start the conversation. 

Initially (for our case), we wouldn't need this if we could pass any markup we wanted (like a `Link`). However, by doing that, we need to restyle the link and likely rebuild the tag interaction (hover, down, focus...). By adding this option, we can pass simpler markup to the tag and handle the navigation via JS.

It would probably still be better if the navigation was handled natively using an anchor tag for accessibility and other reasons, but that would mean adding some type of `url` prop to the `Tag` component for something that's currently just a one-off, so I'd say this is a good compromise. If this pattern ever becomes common enough, we could add better support for it here.

### How to 🎩

I've added some samples in the `Tag` page in Storybook

### 🎩 checklist

Haven't 🎩 ed, just looking open the conversation and figure out what direction to take :)

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

/cc @dleroux 