### PR TITLE
[Tag] Adds support for url prop

### DIFF
--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -210,6 +210,7 @@ import {
   MinusMinor,
   ViewMinor,
   EditMinor,
+  WandMinor,
 } from '@shopify/polaris-icons';
 
 export default {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -28,6 +28,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Dependency upgrades
 
+Bump polaris-icons to v4.11.0 ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
+
 ### Code quality
 
 ### Deprecations

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated the styling of `DropZone.FileUpload` ([#4813](https://github.com/Shopify/polaris-react/pull/4813))
 - Added a minimum height to `Page` component `Header` ([#4770](https://github.com/Shopify/polaris-react/pull/4779))
 - Added a `verticalAlign` prop to `OptionList`. ([#4800](https://github.com/Shopify/polaris-react/pull/4800))
+- Added suppport for a `url` prop in the `Tag` component ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
+- Added support for `children` to take elements other than strings in the `Tag` component ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
 
 ### Bug fixes
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "postcolordocs": "yarn run format"
   },
   "dependencies": {
-    "@shopify/polaris-icons": "^4.10.0",
+    "@shopify/polaris-icons": "^4.11.0",
     "@shopify/polaris-tokens": "^3.0.0",
     "@types/react": "^17.0.19",
     "@types/react-dom": "^17.0.9",

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -123,6 +123,58 @@ function URLTagExample() {
 }
 ```
 
+### Tag with custom content
+
+Use to allow merchants to generate special custom content for a tag.
+
+```jsx
+<Stack>
+  <Tag>
+    <Stack alignment="center" spacing="extraTight" title="Order #123">
+      <Icon source={SearchMinor} />
+      <span>Order #123</span>
+      <Badge status="attention" progress="partiallyComplete">
+        In Progress
+      </Badge>
+    </Stack>
+  </Tag>
+
+  <Tag onClick={() => console.log('Clicked')} title="Order #123">
+    <Stack alignment="center" spacing="extraTight">
+      <Icon source={SearchMinor} />
+      <span>Order #123</span>
+      <Badge status="attention" progress="partiallyComplete">
+        In Progress
+      </Badge>
+    </Stack>
+  </Tag>
+
+  <Tag onRemove={() => console.log('Removed')} title="Order #123">
+    <Stack alignment="center" spacing="extraTight">
+      <Icon source={SearchMinor} />
+      <span>Order #123</span>
+      <Badge status="attention" progress="partiallyComplete">
+        In Progress
+      </Badge>
+    </Stack>
+  </Tag>
+
+  <Tag
+    url="https://www.shopify.com/"
+    onRemove={() => console.log('Removed')}
+    title="Order #123"
+  >
+    <Stack alignment="center" spacing="extraTight">
+      <Icon source={SearchMinor} />
+      <span>Order #123</span>
+      <Badge status="attention" progress="partiallyComplete">
+        In Progress
+      </Badge>
+    </Stack>
+  </Tag>
+</Stack>
+```
+
 <!-- content-for: android -->
 
 ![Tag for Android](/public_images/components/Tag/android/default@2x.png)

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -80,99 +80,27 @@ Use to allow merchants to add attributes to an object.
 <Tag onClick={() => console.log('Clicked')}>Wholesale</Tag>
 ```
 
-### Tagss with links
+### Tag with link
 
-Use to allow merchants to navigate to an entity.
+Use to allow merchants to navigate to a resource. For example a customer segment or a smart collection
 
 ```jsx
 function URLTagExample() {
-  return (
-    <Stack spacing="tight">
-      <Tag url="https://www.shopify.com/">Wholesale</Tag>
-      <Tag url="https://www.shopify.com/">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at
-        ipsum quam. Aliquam fermentum bibendum vestibulum. Vestibulum
-        condimentum luctus metus, sed sagittis magna pellentesque eget. Duis
-        dapibus pretium nisi, et venenatis tortor dignissim ut. Quisque eget
-        lacus ac ex eleifend ultrices. Phasellus facilisis ex sit amet leo
-        elementum condimentum. Ut vel maximus felis. Etiam eget diam eu eros
-        blandit interdum. Sed eu metus sed justo aliquam iaculis ac sit amet ex.
-        Curabitur justo magna, porttitor non pulvinar eu, malesuada at leo. Cras
-        mollis consectetur eros, quis maximus lorem dignissim at. Proin in
-        rhoncus massa. Vivamus lectus nunc, fringilla euismod risus commodo,
-        mattis blandit nulla
-      </Tag>
-      <Tag url="https://www.shopify.com/" onRemove={() => {}}>
-        Wholesale
-      </Tag>
-      <Tag url="https://www.shopify.com/" onRemove={() => {}}>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at
-        ipsum quam. Aliquam fermentum bibendum vestibulum. Vestibulum
-        condimentum luctus metus, sed sagittis magna pellentesque eget. Duis
-        dapibus pretium nisi, et venenatis tortor dignissim ut. Quisque eget
-        lacus ac ex eleifend ultrices. Phasellus facilisis ex sit amet leo
-        elementum condimentum. Ut vel maximus felis. Etiam eget diam eu eros
-        blandit interdum. Sed eu metus sed justo aliquam iaculis ac sit amet ex.
-        Curabitur justo magna, porttitor non pulvinar eu, malesuada at leo. Cras
-        mollis consectetur eros, quis maximus lorem dignissim at. Proin in
-        rhoncus massa. Vivamus lectus nunc, fringilla euismod risus commodo,
-        mattis blandit nulla
-      </Tag>
-    </Stack>
-  );
+  return <Tag url="/collections/wholesale">Wholesale</Tag>;
 }
 ```
 
 ### Tag with custom content
 
-Use to allow merchants to generate special custom content for a tag.
+Use when a tag needs to be visually distinguished from others, like when it's added automatically.
 
 ```jsx
-<Stack>
-  <Tag>
-    <Stack alignment="center" spacing="extraTight" title="Order #123">
-      <Icon source={SearchMinor} />
-      <span>Order #123</span>
-      <Badge status="attention" progress="partiallyComplete">
-        In Progress
-      </Badge>
-    </Stack>
-  </Tag>
-
-  <Tag onClick={() => console.log('Clicked')} title="Order #123">
-    <Stack alignment="center" spacing="extraTight">
-      <Icon source={SearchMinor} />
-      <span>Order #123</span>
-      <Badge status="attention" progress="partiallyComplete">
-        In Progress
-      </Badge>
-    </Stack>
-  </Tag>
-
-  <Tag onRemove={() => console.log('Removed')} title="Order #123">
-    <Stack alignment="center" spacing="extraTight">
-      <Icon source={SearchMinor} />
-      <span>Order #123</span>
-      <Badge status="attention" progress="partiallyComplete">
-        In Progress
-      </Badge>
-    </Stack>
-  </Tag>
-
-  <Tag
-    url="https://www.shopify.com/"
-    onRemove={() => console.log('Removed')}
-    title="Order #123"
-  >
-    <Stack alignment="center" spacing="extraTight">
-      <Icon source={SearchMinor} />
-      <span>Order #123</span>
-      <Badge status="attention" progress="partiallyComplete">
-        In Progress
-      </Badge>
-    </Stack>
-  </Tag>
-</Stack>
+<Tag url="/customers?tag=VIP">
+  <Stack spacing="extraTight">
+    <Icon source={SearchMinor} />
+    <span>VIP</span>
+  </Stack>
+</Tag>
 ```
 
 <!-- content-for: android -->

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -80,6 +80,49 @@ Use to allow merchants to add attributes to an object.
 <Tag onClick={() => console.log('Clicked')}>Wholesale</Tag>
 ```
 
+### Tagss with links
+
+Use to allow merchants to navigate to an entity.
+
+```jsx
+function URLTagExample() {
+  return (
+    <Stack spacing="tight">
+      <Tag url="https://www.shopify.com/">Wholesale</Tag>
+      <Tag url="https://www.shopify.com/">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at
+        ipsum quam. Aliquam fermentum bibendum vestibulum. Vestibulum
+        condimentum luctus metus, sed sagittis magna pellentesque eget. Duis
+        dapibus pretium nisi, et venenatis tortor dignissim ut. Quisque eget
+        lacus ac ex eleifend ultrices. Phasellus facilisis ex sit amet leo
+        elementum condimentum. Ut vel maximus felis. Etiam eget diam eu eros
+        blandit interdum. Sed eu metus sed justo aliquam iaculis ac sit amet ex.
+        Curabitur justo magna, porttitor non pulvinar eu, malesuada at leo. Cras
+        mollis consectetur eros, quis maximus lorem dignissim at. Proin in
+        rhoncus massa. Vivamus lectus nunc, fringilla euismod risus commodo,
+        mattis blandit nulla
+      </Tag>
+      <Tag url="https://www.shopify.com/" onRemove={() => {}}>
+        Wholesale
+      </Tag>
+      <Tag url="https://www.shopify.com/" onRemove={() => {}}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at
+        ipsum quam. Aliquam fermentum bibendum vestibulum. Vestibulum
+        condimentum luctus metus, sed sagittis magna pellentesque eget. Duis
+        dapibus pretium nisi, et venenatis tortor dignissim ut. Quisque eget
+        lacus ac ex eleifend ultrices. Phasellus facilisis ex sit amet leo
+        elementum condimentum. Ut vel maximus felis. Etiam eget diam eu eros
+        blandit interdum. Sed eu metus sed justo aliquam iaculis ac sit amet ex.
+        Curabitur justo magna, porttitor non pulvinar eu, malesuada at leo. Cras
+        mollis consectetur eros, quis maximus lorem dignissim at. Proin in
+        rhoncus massa. Vivamus lectus nunc, fringilla euismod risus commodo,
+        mattis blandit nulla
+      </Tag>
+    </Stack>
+  );
+}
+```
+
 <!-- content-for: android -->
 
 ![Tag for Android](/public_images/components/Tag/android/default@2x.png)

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -95,10 +95,10 @@ function URLTagExample() {
 Use when a tag needs to be visually distinguished from others, like when it's added automatically.
 
 ```jsx
-<Tag url="/customers?tag=VIP">
+<Tag url="/collections/wholesale">
   <Stack spacing="extraTight">
-    <Icon source={SearchMinor} />
-    <span>VIP</span>
+    <Icon source={WandMinor} />
+    <span>Wholesale</span>
   </Stack>
 </Tag>
 ```

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -127,10 +127,12 @@ $icon-size: rem(16px);
 
   &:focus:not(:active) {
     @include focus-ring($style: 'focused');
+    text-decoration: underline;
   }
 
   &:hover {
     background: var(--p-surface-neutral-hovered);
+    text-decoration: underline;
   }
 
   &.segmented::after {

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -54,7 +54,6 @@ $icon-size: rem(16px);
   }
 
   &.linkable {
-    align-items: stretch;
     padding: 0;
   }
 
@@ -118,9 +117,7 @@ $icon-size: rem(16px);
   padding: spacing(extra-tight) spacing(tight);
 
   .LinkText {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    @include truncate;
   }
 
   @include focus-ring;
@@ -135,9 +132,14 @@ $icon-size: rem(16px);
     text-decoration: underline;
   }
 
-  &.segmented::after {
-    margin-right: spacing(extra-tight);
+  &.segmented {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+
+    &::after {
+      margin-right: spacing(extra-tight);
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 }

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -20,10 +20,6 @@ $icon-size: rem(16px);
     color: var(--p-text-disabled);
   }
 
-  &.removable {
-    padding-right: 0;
-  }
-
   &.clickable {
     @include unstyled-button;
     cursor: pointer;
@@ -52,6 +48,15 @@ $icon-size: rem(16px);
     }
   }
 
+  &.removable {
+    padding-right: 0;
+  }
+
+  &.linkable {
+    align-items: stretch;
+    padding: 0;
+  }
+
   @include high-contrast-outline;
 }
 
@@ -71,14 +76,11 @@ $icon-size: rem(16px);
   width: $height;
   margin-left: spacing(extra-tight);
   border-radius: 0 border-radius() border-radius() 0;
+  background-color: var(--p-surface-neutral);
 
   &:hover {
     background: var(--p-surface-neutral-hovered);
     @include high-contrast-outline;
-  }
-
-  &:focus {
-    background-color: transparent;
   }
 
   @include focus-ring;
@@ -95,5 +97,45 @@ $icon-size: rem(16px);
     @include recolor-icon(var(--p-icon-disabled));
     cursor: default;
     pointer-events: none;
+  }
+
+  &.segmented {
+    margin-left: -1 * spacing(extra-tight);
+
+    &::after {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+}
+
+.Link {
+  display: inline-grid;
+  color: var(--p-text);
+  outline: none;
+  border-radius: var(--p-border-radius-base);
+  text-decoration: none;
+  padding: spacing(extra-tight) spacing(tight);
+
+  .LinkText {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  @include focus-ring;
+
+  &:focus:not(:active) {
+    @include focus-ring($style: 'focused');
+  }
+
+  &:hover {
+    background: var(--p-surface-neutral-hovered);
+  }
+
+  &.segmented::after {
+    margin-right: spacing(extra-tight);
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
   }
 }

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -45,6 +45,7 @@ $icon-size: rem(16px);
       background: var(--p-surface-neutral-disabled);
       cursor: default;
       pointer-events: none;
+      color: var(--p-text-disabled);
     }
   }
 
@@ -76,7 +77,6 @@ $icon-size: rem(16px);
   width: $height;
   margin-left: spacing(extra-tight);
   border-radius: 0 border-radius() border-radius() 0;
-  background-color: var(--p-surface-neutral);
 
   &:hover {
     background: var(--p-surface-neutral-hovered);

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -45,7 +45,7 @@ export function Tag({
     disabled && styles.disabled,
     onClick && styles.clickable,
     onRemove && styles.removable,
-    url && styles.linkable,
+    url && !disabled && styles.linkable,
     segmented && styles.segmented,
   );
 
@@ -85,20 +85,21 @@ export function Tag({
     </button>
   ) : null;
 
-  const tagContent = url ? (
-    <a
-      className={classNames(styles.Link, segmented && styles.segmented)}
-      href={url}
-    >
-      <span title={tagTitle} className={styles.LinkText}>
+  const tagContent =
+    url && !disabled ? (
+      <a
+        className={classNames(styles.Link, segmented && styles.segmented)}
+        href={url}
+      >
+        <span title={tagTitle} className={styles.LinkText}>
+          {children}
+        </span>
+      </a>
+    ) : (
+      <span title={tagTitle} className={styles.TagText}>
         {children}
       </span>
-    </a>
-  ) : (
-    <span title={tagTitle} className={styles.TagText}>
-      {children}
-    </span>
-  );
+    );
 
   return (
     <span className={className}>

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -13,27 +13,51 @@ export interface NonMutuallyExclusiveProps {
   children?: string;
   /** Disables the tag  */
   disabled?: boolean;
-  /** Callback when tag is clicked or keypressed. Renders without remove button when set. */
+  /** Callback when tag is clicked or keypressed. Renders without remove button or url when set. */
   onClick?(): void;
   /** Callback when remove button is clicked or keypressed. */
   onRemove?(): void;
+  /** Url to navigate to when tag is clicked or keypressed. */
+  url?: string;
 }
 
 export type TagProps = NonMutuallyExclusiveProps &
   (
-    | {onClick?(): void; onRemove?: undefined}
-    | {onClick?: undefined; onRemove?(): void}
+    | {onClick?(): void; onRemove?: undefined; url?: undefined}
+    | {onClick?: undefined; onRemove?(): void; url?: string}
   );
 
-export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
+export function Tag({
+  children,
+  disabled = false,
+  onClick,
+  onRemove,
+  url,
+}: TagProps) {
   const i18n = useI18n();
 
+  const segmented = onRemove && url;
   const className = classNames(
     styles.Tag,
     disabled && styles.disabled,
     onClick && styles.clickable,
     onRemove && styles.removable,
+    url && styles.linkable,
+    segmented && styles.segmented,
   );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        className={className}
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    );
+  }
 
   const ariaLabel = i18n.translate('Polaris.Tag.ariaLabel', {
     children: children || '',
@@ -43,7 +67,7 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
     <button
       type="button"
       aria-label={ariaLabel}
-      className={styles.Button}
+      className={classNames(styles.Button, segmented && styles.segmented)}
       onClick={onRemove}
       onMouseUp={handleMouseUpByBlurring}
       disabled={disabled}
@@ -52,22 +76,25 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
     </button>
   ) : null;
 
-  const tagMarkup = onClick ? (
-    <button
-      type="button"
-      disabled={disabled}
-      className={className}
-      onClick={onClick}
+  const tagContent = url ? (
+    <a
+      className={classNames(styles.Link, segmented && styles.segmented)}
+      href={url}
     >
-      {children}
-    </button>
-  ) : (
-    <span className={className}>
-      <span title={children} className={styles.TagText}>
+      <span title={children} className={styles.LinkText}>
         {children}
       </span>
+    </a>
+  ) : (
+    <span title={children} className={styles.TagText}>
+      {children}
+    </span>
+  );
+
+  return (
+    <span className={className}>
+      {tagContent}
       {removeButton}
     </span>
   );
-  return tagMarkup;
 }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -10,7 +10,7 @@ import styles from './Tag.scss';
 
 export interface NonMutuallyExclusiveProps {
   /** Content to display in the tag */
-  children?: string | React.ReactElement;
+  children?: React.ReactNode;
   /** Disables the tag  */
   disabled?: boolean;
   /** Callback when tag is clicked or keypressed. Renders without remove button or url when set. */
@@ -18,7 +18,7 @@ export interface NonMutuallyExclusiveProps {
   /** Callback when remove button is clicked or keypressed. */
   onRemove?(): void;
   /** A string to use when tag has more than textual content */
-  title?: string;
+  accessibilityLabel?: string;
   /** Url to navigate to when tag is clicked or keypressed. */
   url?: string;
 }
@@ -34,7 +34,7 @@ export function Tag({
   disabled = false,
   onClick,
   onRemove,
-  title = '',
+  accessibilityLabel = '',
   url,
 }: TagProps) {
   const i18n = useI18n();
@@ -62,7 +62,7 @@ export function Tag({
     );
   }
 
-  let tagTitle = title;
+  let tagTitle = accessibilityLabel;
 
   if (!tagTitle) {
     tagTitle = typeof children === 'string' ? children : '';

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -34,7 +34,7 @@ export function Tag({
   disabled = false,
   onClick,
   onRemove,
-  accessibilityLabel = '',
+  accessibilityLabel,
   url,
 }: TagProps) {
   const i18n = useI18n();
@@ -65,11 +65,11 @@ export function Tag({
   let tagTitle = accessibilityLabel;
 
   if (!tagTitle) {
-    tagTitle = typeof children === 'string' ? children : '';
+    tagTitle = typeof children === 'string' ? children : undefined;
   }
 
   const ariaLabel = i18n.translate('Polaris.Tag.ariaLabel', {
-    children: tagTitle,
+    children: tagTitle || '',
   });
 
   const removeButton = onRemove ? (

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -10,13 +10,15 @@ import styles from './Tag.scss';
 
 export interface NonMutuallyExclusiveProps {
   /** Content to display in the tag */
-  children?: string;
+  children?: string | React.ReactElement;
   /** Disables the tag  */
   disabled?: boolean;
   /** Callback when tag is clicked or keypressed. Renders without remove button or url when set. */
   onClick?(): void;
   /** Callback when remove button is clicked or keypressed. */
   onRemove?(): void;
+  /** A string to use when tag has more than textual content */
+  title?: string;
   /** Url to navigate to when tag is clicked or keypressed. */
   url?: string;
 }
@@ -32,6 +34,7 @@ export function Tag({
   disabled = false,
   onClick,
   onRemove,
+  title = '',
   url,
 }: TagProps) {
   const i18n = useI18n();
@@ -59,8 +62,14 @@ export function Tag({
     );
   }
 
+  let tagTitle = title;
+
+  if (!tagTitle) {
+    tagTitle = typeof children === 'string' ? children : '';
+  }
+
   const ariaLabel = i18n.translate('Polaris.Tag.ariaLabel', {
-    children: children || '',
+    children: tagTitle,
   });
 
   const removeButton = onRemove ? (
@@ -81,12 +90,12 @@ export function Tag({
       className={classNames(styles.Link, segmented && styles.segmented)}
       href={url}
     >
-      <span title={children} className={styles.LinkText}>
+      <span title={tagTitle} className={styles.LinkText}>
         {children}
       </span>
     </a>
   ) : (
-    <span title={children} className={styles.TagText}>
+    <span title={tagTitle} className={styles.TagText}>
       {children}
     </span>
   );

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
+import {SearchMinor} from '@shopify/polaris-icons';
+import {Icon} from '../../Icon';
 
 import {Tag} from '../Tag';
 
@@ -48,6 +50,65 @@ describe('<Tag />', () => {
       tag.find('button')!.domNode!.click();
       expect(spy).toHaveBeenCalled();
       expect(tag).toContainReactComponent('a', {href: '#'});
+    });
+  });
+
+  describe('children', () => {
+    it('accepts simple strings as children', () => {
+      const tag = mountWithApp(<Tag>children</Tag>);
+      expect(tag).toContainReactComponent('span', {
+        children: 'children',
+        title: 'children',
+      });
+    });
+
+    it('accepts React components as children', () => {
+      const tag = mountWithApp(
+        <Tag>
+          <Icon source={SearchMinor} />
+        </Tag>,
+      );
+      expect(tag).toContainReactComponent(Icon, {source: SearchMinor});
+    });
+  });
+
+  describe('title', () => {
+    it('uses children to render title if no title prop is provided', () => {
+      const tag = mountWithApp(<Tag>children</Tag>);
+      expect(tag).toContainReactComponent('span', {
+        children: 'children',
+        title: 'children',
+      });
+    });
+
+    it('uses the title prop to render title when a string is received as children', () => {
+      const tag = mountWithApp(<Tag title="customTitle">children</Tag>);
+      expect(tag).toContainReactComponent('span', {
+        children: 'children',
+        title: 'customTitle',
+      });
+    });
+
+    it('uses the title prop to render title when a component is received as children and url prop is passed', () => {
+      const tag = mountWithApp(
+        <Tag title="customTitle" url="#">
+          <Icon source={SearchMinor} />
+        </Tag>,
+      );
+      expect(tag).toContainReactComponent('span', {
+        title: 'customTitle',
+      });
+    });
+
+    it('renders an empty title if no title prop when a component is received as children and url prop is passed', () => {
+      const tag = mountWithApp(
+        <Tag url="#">
+          <Icon source={SearchMinor} />
+        </Tag>,
+      );
+      expect(tag).toContainReactComponent('span', {
+        title: '',
+      });
     });
   });
 });

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -53,8 +53,13 @@ describe('<Tag />', () => {
     });
 
     it('renders plain text when the tag is disabled', () => {
-      const tag = mountWithApp(<Tag url="#" disabled />);
+      const tag = mountWithApp(
+        <Tag url="#" disabled>
+          #
+        </Tag>,
+      );
       expect(tag).not.toContainReactComponent('a', {href: '#'});
+      expect(tag).toContainReactComponent('span', {children: '#'});
     });
   });
 
@@ -78,7 +83,7 @@ describe('<Tag />', () => {
   });
 
   describe('accessibilityLabel', () => {
-    it('uses children to render title if no title prop is provided', () => {
+    it('uses children to render title if no accessibilityLabel prop is provided', () => {
       const tag = mountWithApp(<Tag>children</Tag>);
       expect(tag).toContainReactComponent('span', {
         children: 'children',
@@ -107,14 +112,17 @@ describe('<Tag />', () => {
       });
     });
 
-    it('renders an empty title if no title prop when a component is received as children and url prop is passed', () => {
+    it('does not render the title attribute if accessibilityLabel is `undefined` when a component is received as children and url prop is passed', () => {
       const tag = mountWithApp(
         <Tag url="#">
           <Icon source={SearchMinor} />
         </Tag>,
       );
-      expect(tag).toContainReactComponent('span', {
+      expect(tag).not.toContainReactComponent('span', {
         title: '',
+      });
+      expect(tag).toContainReactComponent('span', {
+        title: undefined,
       });
     });
   });

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -40,7 +40,7 @@ describe('<Tag />', () => {
 
   describe('url', () => {
     it('renders an anchor tag when url is provided', () => {
-      const tag = mountWithApp(<Tag url="#" disabled />);
+      const tag = mountWithApp(<Tag url="#" />);
       expect(tag).toContainReactComponent('a', {href: '#'});
     });
 
@@ -50,6 +50,11 @@ describe('<Tag />', () => {
       tag.find('button')!.domNode!.click();
       expect(spy).toHaveBeenCalled();
       expect(tag).toContainReactComponent('a', {href: '#'});
+    });
+
+    it('renders plain text when the tag is disabled', () => {
+      const tag = mountWithApp(<Tag url="#" disabled />);
+      expect(tag).not.toContainReactComponent('a', {href: '#'});
     });
   });
 

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -35,4 +35,19 @@ describe('<Tag />', () => {
       expect(spy).not.toHaveBeenCalled();
     });
   });
+
+  describe('url', () => {
+    it('renders an anchor tag when url is provided', () => {
+      const tag = mountWithApp(<Tag url="#" disabled />);
+      expect(tag).toContainReactComponent('a', {href: '#'});
+    });
+
+    it('allows url and onRemove props at the same time', () => {
+      const spy = jest.fn();
+      const tag = mountWithApp(<Tag onRemove={spy} url="#" />);
+      tag.find('button')!.domNode!.click();
+      expect(spy).toHaveBeenCalled();
+      expect(tag).toContainReactComponent('a', {href: '#'});
+    });
+  });
 });

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 import {SearchMinor} from '@shopify/polaris-icons';
-import {Icon} from '../../Icon';
 
+import {Icon} from '../../Icon';
 import {Tag} from '../Tag';
 
 describe('<Tag />', () => {
@@ -72,7 +72,7 @@ describe('<Tag />', () => {
     });
   });
 
-  describe('title', () => {
+  describe('accessibilityLabel', () => {
     it('uses children to render title if no title prop is provided', () => {
       const tag = mountWithApp(<Tag>children</Tag>);
       expect(tag).toContainReactComponent('span', {
@@ -81,17 +81,19 @@ describe('<Tag />', () => {
       });
     });
 
-    it('uses the title prop to render title when a string is received as children', () => {
-      const tag = mountWithApp(<Tag title="customTitle">children</Tag>);
+    it('uses the accessibilityLabel prop to render title when a string is received as children', () => {
+      const tag = mountWithApp(
+        <Tag accessibilityLabel="customTitle">children</Tag>,
+      );
       expect(tag).toContainReactComponent('span', {
         children: 'children',
         title: 'customTitle',
       });
     });
 
-    it('uses the title prop to render title when a component is received as children and url prop is passed', () => {
+    it('uses the accessibilityLabel prop to render title when a component is received as children and url prop is passed', () => {
       const tag = mountWithApp(
-        <Tag title="customTitle" url="#">
+        <Tag accessibilityLabel="customTitle" url="#">
           <Icon source={SearchMinor} />
         </Tag>,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,10 +1993,10 @@
     fs-extra "^9.0.0"
     glob "^7.1.6"
 
-"@shopify/polaris-icons@^4.10.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-4.10.0.tgz#fbfc0628c7da0786a6cbe9069ee007070762a4ac"
-  integrity sha512-TxOJeLd4qXNl8bhEtJ3bQrjMgdOTzw3xDfKhqWTinBMcjDsW0+Rb8ynSsxzS9ut821L3qXJK9AnJZwoR/Yd8nw==
+"@shopify/polaris-icons@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-4.11.0.tgz#8b1ebf7f07077300f8281e12824588835f108b23"
+  integrity sha512-vq37+I6oDlFzQXqkuDI0DO4AXz36AiyGOMkSstnBWTI6UR/eHAuI2aALqbPMxYbD6877Pi1kk+bAfWIFf3D4LA==
 
 "@shopify/polaris-tokens@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
This is a spin off of [[WIP] [Tag] Allow arbitrary content and allow onClick and onRemove at the same time](https://github.com/Shopify/polaris-react/pull/4830). I'm opening it early as a Draft so I can get feedback while I start working on tests and final cleanup 🙏 

This PR adds a `url` prop to the `Tag` component that works in the following way:
- You can either pass `onClick` or `url` but not both (this is enforced in the type system)
- You can pass both `url` and `onRemove`
- When `url` is received, an anchor tag is used to render the tag content
- When both `url` and `onRemove` are provided, a `segmented` variant of the tag is created and a `ButtonGroup` is used to render both items

### WHY are these changes introduced?

This is a partial approach to solve the problem presented in [[Tag] Allow arbitrary children](https://github.com/Shopify/polaris-react/issues/4819) by focusing on some part of the specific need that triggered that request (navigation in a removable tag).

I've limited this PR to just the interaction, since arbitrary children sounds like a less controversial topic and switched gears based on @dleroux [comment](https://github.com/Shopify/polaris-react/pull/4830#issuecomment-993916486):

> What do you think about leaving the onClick and onRemove as is, but adding a url prop?

### WHAT is this pull request doing?

Adds the following options that can be explored in the Storybook `URL Tag` section:

```jsx
// Tags with links
<Tag url="https://www.shopify.com/">Wholesale</Tag>
<Tag url="https://www.shopify.com/">Long text that causes ellipsis</Tag>
<Tag url="https://www.shopify.com/" onRemove={() => {}}>Wholesale</Tag>
<Tag url="https://www.shopify.com/" onRemove={() => {}}>Long text that causes ellipsis</Tag>

// Tags with custom content
<Tag>
  <Stack alignment="center" spacing="extraTight" title="Order #123">
    <Icon source={SearchMinor} />
    <span>Order #123</span>
    <Badge status="attention" progress="partiallyComplete">
      In Progress
    </Badge>
  </Stack>
</Tag>
```

https://user-images.githubusercontent.com/905006/146237385-a5ec3609-7365-4b3b-a725-c1bd3326fc14.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Look into the Storybook `URL Tag` section:

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit
