### PR TITLE
Test (16.10.0)

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,11 +1,11 @@
 ci:
   require:
-    - 'Test (12.22.0)'
+    - 'Test (16.10.0)'
     - 'Accessibility test'
 
 merge:
   require:
-    - 'Test (12.22.0)'
+    - 'Test (16.10.0)'
     - 'Accessibility test'
 
 deploy:


### PR DESCRIPTION
We're getting stuck on test 12.22.0 in [shipit](https://shipit.shopify.io/shopify/polaris-react/production) on the release branch. 

I think we'll need to merge this into v8, cut another rc, and remove 12.22 from github settings. I think this will be fine because main doesn't rely on shipit