### PR TITLE
Remove root level control height

### DIFF
--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -53,7 +53,7 @@
   --pc-banner-rgb-text: 33, 43, 54;
   --pc-banner-secondary-action-horizontal-padding: var(--p-space-3);
   --pc-banner-secondary-action-vertical-padding: calc(
-    0.5 * (var(--pc-control-height) - var(--p-line-height-2))
+    0.5 * (var(--p-line-height-6) - var(--p-line-height-2))
   );
   position: relative;
   display: flex;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -1,11 +1,10 @@
 @import '../../styles/common';
 
 .Button {
-  --pc-button-min-height: var(--pc-control-height);
   --pc-button-slim-min-height: var(--p-line-height-4);
   --pc-button-large-min-height: var(--p-line-height-7);
   --pc-button-vertical-padding: calc(
-    (var(--pc-button-min-height) - var(--p-line-height-2) - 2px) / 2
+    (var(--p-line-height-6) - var(--p-line-height-2) - 2px) / 2
   );
   --pc-button-slim-vertical-padding: calc(
     (var(--pc-button-slim-min-height) - var(--p-line-height-2) - 2px) / 2
@@ -291,7 +290,7 @@
 
   &.iconOnly {
     @include recolor-icon(var(--p-icon));
-    margin: calc(-0.5 * (var(--pc-button-min-height) - #{icon-size()}));
+    margin: calc(-0.5 * (var(--p-line-height-6) - #{icon-size()}));
 
     &:hover {
       @include recolor-icon(var(--p-icon-hovered));

--- a/src/styles/shared/_controls.scss
+++ b/src/styles/shared/_controls.scss
@@ -2,17 +2,13 @@
   @return 36px;
 }
 
-:root {
-  --pc-control-height: var(--p-line-height-6);
-}
-
 @function control-slim-height() {
   @return 28px;
 }
 
 @function control-vertical-padding() {
   @return calc(
-    (var(--pc-control-height) - var(--p-line-height-3) - var(--p-space-05)) / 2
+    (var(--p-line-height-6) - var(--p-line-height-3) - var(--p-space-05)) / 2
   );
 }
 


### PR DESCRIPTION
Just noticed some weirdness where `--pc-control-height` was being defined in may css files. 

[Screencast](https://screenshot.click/22-09-huwnj-e8hy3.mp4)

[Many definitions](https://screenshot.click/22-10-kjhc5-uk1xn.mp4) which could lead to a minor performance issue. This fixes that up by using the line-height var directly