### PR TITLE
px to em in media queries

### DIFF
--- a/config/postcss-plugins.js
+++ b/config/postcss-plugins.js
@@ -1,11 +1,13 @@
 const postcssShopify = require('@shopify/postcss-plugin');
-const pxtorem = require('postcss-pxtorem');
+const pxToRem = require('postcss-pxtorem');
+const pxToEmMediaQuery = require('postcss-em-media-query');
 
 module.exports = [
   postcssShopify,
-  pxtorem({
+  pxToRem({
     rootValue: 16,
     replace: true,
     propList: ['*'],
   }),
+  pxToEmMediaQuery(),
 ];

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "postcss-modules": "^4.2.2",
     "postcss-pxtorem": "^5.1.1",
     "postcss-value-parser": "^4.2.0",
+    "postcss-em-media-query": "^4.1.0",
     "prettier": "^2.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -1,6 +1,6 @@
 @import '../../../../styles/common';
 
-$breakpoint: em(640px);
+$breakpoint: 640px;
 $Backdrop-opacity: 0.88;
 
 .Toast {

--- a/src/components/ResourceList/ResourceList.scss
+++ b/src/components/ResourceList/ResourceList.scss
@@ -187,7 +187,7 @@ $item-wrapper-loading-height: 64px;
   padding-top: var(--p-space-8);
   padding-bottom: var(--p-space-8);
 
-  @media (min-height: em(600px)) {
+  @media (min-height: 600px) {
     padding-top: calc(var(--p-space-8) * 2);
     padding-bottom: calc(var(--p-space-8) * 2);
   }

--- a/src/styles/foundation/_typography.scss
+++ b/src/styles/foundation/_typography.scss
@@ -1,4 +1,4 @@
-$typography-condensed: em(640px);
+$typography-condensed: 640px;
 
 $font-family-data: (
   base: #{-apple-system,

--- a/src/styles/foundation/_utilities.scss
+++ b/src/styles/foundation/_utilities.scss
@@ -1,28 +1,4 @@
-$default-browser-font-size: 16px;
-$base-font-size: 10px;
-
-/// Returns the value in ems for a given pixel value. Note that this
-/// only works for elements that have had no font-size changes.
-/// @param {Number} $value - The pixel value to be converted.
-/// @return {Number} The converted value in ems.
-
-@function em($value) {
-  $unit: unit($value);
-
-  @if $value == 0 {
-    @return 0;
-  } @else if $unit == 'em' {
-    @return $value;
-  } @else if $unit == 'rem' {
-    @return $value / 1rem * 1em * ($base-font-size / $default-browser-font-size);
-  } @else if $unit == 'px' {
-    @return $value / $default-browser-font-size * 1em;
-  } @else {
-    @error 'Value must be in px, rem, or em.';
-  }
-}
-
-/// Returns the list of available names in a given map.
+// Returns the list of available names in a given map.
 /// @param {Map} $map - The map of data to list the names from.
 /// @param {Number} $map - The level of depth to get names from.
 /// @return {String} The list of names in the map.

--- a/src/styles/shared/_breakpoints.scss
+++ b/src/styles/shared/_breakpoints.scss
@@ -2,38 +2,23 @@ $page-max-width: layout-width(primary, max) + layout-width(secondary, max) +
   layout-width(inner-spacing);
 $frame-with-nav-max-width: layout-width(nav) + $page-max-width;
 
-$stacked-content: em(
-  layout-width(primary, min) + layout-width(secondary, min) +
-    layout-width(inner-spacing)
-);
-$not-condensed-content: em(layout-width(page-content, not-condensed));
-$partially-condensed-content: em(
-  layout-width(page-content, partially-condensed)
-);
+$stacked-content: layout-width(primary, min) + layout-width(secondary, min) +
+  layout-width(inner-spacing);
+$not-condensed-content: layout-width(page-content, not-condensed);
+$partially-condensed-content: layout-width(page-content, partially-condensed);
 
-$not-condensed-outer-spacing: em(2 * layout-width(outer-spacing, max));
-$partially-condensed-outer-spacing: em(2 * layout-width(outer-spacing, min));
+$not-condensed-outer-spacing: 2 * layout-width(outer-spacing, max);
+$partially-condensed-outer-spacing: 2 * layout-width(outer-spacing, min);
 
 $not-condensed-min-page: $not-condensed-content + $not-condensed-outer-spacing;
 $partially-condensed-min-page: $partially-condensed-content +
   $partially-condensed-outer-spacing;
 
-$nav-size: em(layout-width(nav));
-$nav-min-window: em(layout-width(page-with-nav));
+$nav-size: layout-width(nav);
+$nav-min-window: layout-width(page-with-nav);
 
 @function breakpoint($value, $adjustment: 0) {
-  $adjusted-value: em($adjustment);
-
-  // Reduces chances to have a style void
-  // between two media queries
-  // See https://github.com/sass-mq/sass-mq/issues/6
-  @if $adjustment == -1px {
-    $adjusted-value: -0.01em;
-  } @else if $adjustment == 1px {
-    $adjusted-value: 0.01em;
-  }
-
-  @return em($value) + $adjusted-value;
+  @return $value + $adjustment;
 }
 
 @mixin page-content-breakpoint-before($size) {

--- a/src/styles/shared/_typography.scss
+++ b/src/styles/shared/_typography.scss
@@ -1,4 +1,4 @@
-$typography-condensed: em(640px);
+$typography-condensed: 640px;
 
 @mixin when-typography-not-condensed {
   @include breakpoint-after($typography-condensed) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6321,6 +6321,14 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+em-media-query@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/em-media-query/-/em-media-query-2.0.0.tgz#058cc2ac47a227d46ff2c7d909a930169637daea"
+  integrity sha512-00WaHd1seQTAlWFKjmSNQx1NVflBdC4YWIEhDA08P7gv2JdRrMEdx5do3j4xOcJgQlrUuvE1Yx0FaYoPl5Ql8w==
+  dependencies:
+    lodash.round "^4.0.4"
+    postcss-value-parser "^4.1.0"
+
 emittery@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
@@ -9839,6 +9847,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.round@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.round/-/lodash.round-4.0.4.tgz#101b6ba5c6cecc998f2abbe80b6029affd25d262"
+  integrity sha1-EBtrpcbOzJmPKrvoC2Apr/0l0mI=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -11504,6 +11517,13 @@ postcss-discard-overridden@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz#454b41f707300b98109a75005ca4ab0ff2743ac6"
   integrity sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==
+
+postcss-em-media-query@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-em-media-query/-/postcss-em-media-query-4.1.0.tgz#910d71394296f058c2b0aefca66e80bc53289dfc"
+  integrity sha512-BYw6a13M9SGVqK/ORWi1P2oqCNKi4/DHlA5tSM8Do4pIRN3jwMyfaAqxsEyu8xqr2I+dXwdEQPjLJOclgF5MGg==
+  dependencies:
+    em-media-query "^2.0.0"
 
 postcss-flexbugs-fixes@^4.2.1:
   version "4.2.1"


### PR DESCRIPTION
Uses: https://github.com/niksy/postcss-em-media-query

Converts and min/max width, min/max height media queries from px to ems. Not super well known so we may want to fork this plugin and make sure it's solid but for now we can use this branch to experiment with removing the `em()` function @aveline 