### PR TITLE
[ResourceItem] Fix: adjust ResourceItem media height to match its content height

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Fixed a bug where remove button could shrink in the `Tag` component ([#4816](https://github.com/Shopify/polaris-react/issues/4816))
 - Fixed incorrect `Popover` position in `Combobox` when an element is conditionally rendered before the `Combobox` ([#4825](https://github.com/Shopify/polaris-react/pull/4825))
 - Reverted the deprecation of the "attention" `status` in `Badge` ([#4840](https://github.com/Shopify/polaris-react/pull/4840))
+- Adjust ResourceItem media wrapper height to match children height
 
 ### Documentation
 

--- a/src/components/ResourceItem/ResourceItem.scss
+++ b/src/components/ResourceItem/ResourceItem.scss
@@ -177,6 +177,7 @@ $resource-list-item-variables: (
   margin-right: spacing(loose);
   color: inherit;
   text-decoration: none;
+  line-height: 0;
 }
 
 // Item content


### PR DESCRIPTION
### WHY are these changes introduced?

While developing my custom Shopify app, I saw that the media wrapper of the ResourceItem component adds more space at the bottom than at the top of the media item.

Red color ist the background color for the image
Green color is the actual media wrapper background.

Before:
![polaris bug](https://user-images.githubusercontent.com/14923786/147467367-da520888-2ae4-48c7-9e56-10512f9a4723.jpg)

### WHAT is this pull request doing?

Remove the unnecessary extra space around the media component of ResourceItem by setting the line height of the media container to zero.

After:
![polaris bug with fix](https://user-images.githubusercontent.com/14923786/147467417-d31a366d-e485-47af-895b-f0aec9190bc5.jpg)
