### PR TITLE
[PositionnedOverlay] Fix the MutationObserver call to setState when the componentWillUnmount

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Fixed a bug where remove button could shrink in the `Tag` component ([#4816](https://github.com/Shopify/polaris-react/issues/4816))
 - Fixed incorrect `Popover` position in `Combobox` when an element is conditionally rendered before the `Combobox` ([#4825](https://github.com/Shopify/polaris-react/pull/4825))
 - Reverted the deprecation of the "attention" `status` in `Badge` ([#4840](https://github.com/Shopify/polaris-react/pull/4840))
+- Fixed an issue where the `MutationObserver` of the `PositionedOverlay` was calling setState on an unmounted component ([#4869](https://github.com/Shopify/polaris-react/pull/4869));
 
 ### Documentation
 

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -103,6 +103,7 @@ export class PositionedOverlay extends PureComponent<
   }
 
   componentWillUnmount() {
+    this.observer.disconnect();
     if (this.scrollableContainer && !this.props.fixed) {
       this.scrollableContainer.removeEventListener(
         'scroll',
@@ -202,6 +203,7 @@ export class PositionedOverlay extends PureComponent<
         if (this.overlay == null || this.scrollableContainer == null) {
           return;
         }
+
         const {
           activator,
           preferredPosition = 'below',

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -25,19 +25,25 @@ describe('<PositionedOverlay />', () => {
 
   describe('mutation observer', () => {
     let mutationObserverObserveSpy: jest.SpyInstance;
+    let mutationObserverDisconnectSpy: jest.SpyInstance;
 
     beforeEach(() => {
       mutationObserverObserveSpy = jest.spyOn(
         MutationObserver.prototype,
         'observe',
       );
+      mutationObserverDisconnectSpy = jest.spyOn(
+        MutationObserver.prototype,
+        'disconnect',
+      );
     });
 
     afterEach(() => {
       mutationObserverObserveSpy.mockRestore();
+      mutationObserverDisconnectSpy.mockRestore();
     });
 
-    it('observers the activator', () => {
+    it('observes the activator', () => {
       const activator = document.createElement('button');
       mountWithApp(
         <PositionedOverlay
@@ -52,6 +58,21 @@ describe('<PositionedOverlay />', () => {
         childList: true,
         subtree: true,
       });
+    });
+
+    it('disconnects the observer when componentWillUnMount', () => {
+      const activator = document.createElement('button');
+      const overlay = mountWithApp(
+        <PositionedOverlay
+          {...mockProps}
+          activator={activator}
+          preferredPosition="above"
+        />,
+      );
+
+      overlay.unmount();
+
+      expect(mutationObserverDisconnectSpy).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4652 

When changing the suffix/prefix on a TextField activator of a Popover, the component re-renders but the MutationObserver still called `handleMeasurements` on the unmounted component.

This happened when opening the popover a 3rd time.

### WHAT is this pull request doing?

On `componentWillUnmount` I simply disconnected the observer

https://user-images.githubusercontent.com/1229901/148389046-f51d07a1-24ea-44b1-bd68-293259b09714.mov


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';
import {WandMajor, PlusMinor, SelectMinor} from '@shopify/polaris-icons';

import {Page, TextField, Icon, Button, Popover} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <PopoverWithActionListExample />
    </Page>
  );
}
function PopoverWithActionListExample() {
  const [value, setValue] = useState('Jaded Pixel');
  const [popoverActive, setPopoverActive] = useState(false);

  const togglePopoverActive = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );

  const activator = (
    <TextField
      label="Store name"
      value={value}
      onChange={setValue}
      autoComplete="off"
      suffix={
        popoverActive ? (
          <Icon source={WandMajor} />
        ) : (
          <Icon source={PlusMinor} />
        )
      }
      connectedRight={
        <Button icon={SelectMinor} onClick={togglePopoverActive} />
      }
    />
  );

  return (
    <div style={{height: '250px'}}>
      <Popover
        active={popoverActive}
        activator={activator}
        onClose={togglePopoverActive}
      >
        <p>test</p>
      </Popover>
    </div>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
