### PR TITLE
[TextStyle] Add warning color variation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added suppport for a `url` prop in the `Tag` component ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
 - Added support for `children` to take elements other than strings in the `Tag` component ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
 - Bumped the `@shopify/storybook-a11y-test` package to the latest version `0.3.0` ([#4870](https://github.com/Shopify/polaris-react/pull/4870))
+- Added a `warning` variation to `TextStyle` ([#4880](https://github.com/Shopify/polaris-react/pull/4880))
 
 ### Bug fixes
 

--- a/src/components/TextStyle/README.md
+++ b/src/components/TextStyle/README.md
@@ -11,6 +11,7 @@ keywords:
   - subdued
   - strong
   - negative
+  - warning
   - positive
   - cues
   - enhancements
@@ -37,6 +38,7 @@ Text style should be:
 
 - Used when enhancing the text to help merchants understand its meaning
 - Subdued if the text is less important than its surrounding text
+- Warning if the text denotes something that needs attention, or that merchants need to take action on.
 - Strong for input fields, or for a row total in a price table
 - Paired with symbols, like an arrow or dollar sign, when using positive or negative styles
 
@@ -123,6 +125,14 @@ Use in combination with a symbol showing a decreasing value to indicate a downwa
 ![Negative text style](/public_images/components/TextStyle/ios/negative@2x.png)
 
 <!-- /content-for -->
+
+### Warning text style
+
+Use to denote something that needs attention, or that merchants need to take action on.
+
+```jsx
+<TextStyle variation="warning">Scheduled maintenance</TextStyle>
+```
 
 ### Code text style
 

--- a/src/components/TextStyle/TextStyle.scss
+++ b/src/components/TextStyle/TextStyle.scss
@@ -11,6 +11,10 @@ $code-font-size: 1.15em;
   color: var(--p-text-critical);
 }
 
+.variationWarning {
+  color: var(--p-text-warning);
+}
+
 .variationCode {
   position: relative;
   padding: $code-padding;

--- a/src/components/TextStyle/TextStyle.tsx
+++ b/src/components/TextStyle/TextStyle.tsx
@@ -4,11 +4,18 @@ import {classNames, variationName} from '../../utilities/css';
 
 import styles from './TextStyle.scss';
 
-type Variation = 'positive' | 'negative' | 'strong' | 'subdued' | 'code';
+type Variation =
+  | 'positive'
+  | 'negative'
+  | 'warning'
+  | 'strong'
+  | 'subdued'
+  | 'code';
 
 enum VariationValue {
   Positive = 'positive',
   Negative = 'negative',
+  Warning = 'warning',
   Strong = 'strong',
   Subdued = 'subdued',
   Code = 'code',

--- a/src/components/TextStyle/tests/TextStyle.test.tsx
+++ b/src/components/TextStyle/tests/TextStyle.test.tsx
@@ -33,6 +33,13 @@ describe('<TextStyle />', () => {
     expect(textStyle).toContainReactComponent('span');
   });
 
+  it('renders a span when the variant warning is provided', () => {
+    const textStyle = mountWithApp(
+      <TextStyle variation="warning">Hello Polaris</TextStyle>,
+    );
+    expect(textStyle).toContainReactComponent('span');
+  });
+
   it('renders a span when the variant subdued is provided', () => {
     const textStyle = mountWithApp(
       <TextStyle variation="subdued">Hello Polaris</TextStyle>,


### PR DESCRIPTION
### WHY are these changes introduced?

Add the warning color as an option to TextStyle component to allow people to easily create warning text. Sometimes warnings need to be displayed inline that are neither positive or negative but should stand out amongst other text.

### WHAT is this pull request doing?

Adding an extra font color variation to the TextStyle component.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
