### PR TITLE
Only convert `px` units greater than `4` to `rem`

### DIFF
--- a/config/postcss-plugins.js
+++ b/config/postcss-plugins.js
@@ -7,5 +7,6 @@ module.exports = [
     rootValue: 16,
     replace: true,
     propList: ['*'],
+    minPixelValue: 4,
   }),
 ];


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4776

### WHAT is this pull request doing?

`pxtorem` will now only convert `px` values greater than `4px`

<img width="382" alt="Screen Shot 2022-01-12 at 9 13 27 AM" src="https://user-images.githubusercontent.com/3474483/149212241-88d663ce-2cc6-441f-b378-749c3328df86.png">|<img width="343" alt="Screen Shot 2022-01-12 at 11 48 28 AM" src="https://user-images.githubusercontent.com/3474483/149212263-e76dd916-dda4-43c6-8084-751f1c845bdb.png">
:----:|:----:
Before|After
