### PR TITLE
[Autocomplete]Fixed a bug where a checkbox showed on an `Autocomplete` action when `allowMultiple` is true

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Reverted the deprecation of the "attention" `status` in `Badge` ([#4840](https://github.com/Shopify/polaris-react/pull/4840))
 - Fixed an issue where the `MutationObserver` of the `PositionedOverlay` was calling setState on an unmounted component ([#4869](https://github.com/Shopify/polaris-react/pull/4869));
 - Fixed a color contrast issue in `FileUpload` ([#4875](https://github.com/Shopify/polaris-react/pull/4875))
+- Fixed a bug where a checkbox showed on an `Autocomplete` action when `allowMultiple` is true ([#4886](https://github.com/Shopify/polaris-react/pull/4886))
 
 ### Documentation
 

--- a/src/components/Listbox/components/TextOption/TextOption.tsx
+++ b/src/components/Listbox/components/TextOption/TextOption.tsx
@@ -32,7 +32,7 @@ export const TextOption = memo(function TextOption({
   return (
     <div className={textOptionClassName}>
       <div className={styles.Content}>
-        {allowMultiple ? (
+        {allowMultiple && !isAction ? (
           <Checkbox checked={selected} label={children} />
         ) : (
           children

--- a/src/components/Listbox/components/TextOption/tests/TextOption.test.tsx
+++ b/src/components/Listbox/components/TextOption/tests/TextOption.test.tsx
@@ -4,6 +4,7 @@ import {mount, mountWithApp} from 'tests/utilities';
 import {TextOption} from '../TextOption';
 import {Checkbox} from '../../../../Checkbox';
 import {ComboboxListboxOptionContext} from '../../../../../utilities/combobox/context';
+import {MappedActionContext} from '../../../../../utilities/autocomplete/context';
 
 describe('TextOption', () => {
   it('renders children', () => {
@@ -34,11 +35,20 @@ describe('TextOption', () => {
       <ComboboxListboxOptionContext.Provider value={{allowMultiple: true}}>
         <TextOption>child</TextOption>
       </ComboboxListboxOptionContext.Provider>,
-      {
-        features: {newDesignLanguage: true},
-      },
     );
 
     expect(textOption).toContainReactComponent(Checkbox);
+  });
+
+  it('does not render visual checkbox when allowMultiple is provided and isAction is true', () => {
+    const textOption = mountWithApp(
+      <ComboboxListboxOptionContext.Provider value={{allowMultiple: true}}>
+        <MappedActionContext.Provider value={{isAction: true}}>
+          <TextOption>child</TextOption>
+        </MappedActionContext.Provider>
+      </ComboboxListboxOptionContext.Provider>,
+    );
+
+    expect(textOption).not.toContainReactComponent(Checkbox);
   });
 });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4886  <!-- link to issue if one exists -->
Added a check to not display a checkbox when allowMultiple is true and the TextOption is an Action. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

With the fix:
![image](https://user-images.githubusercontent.com/313318/149234243-3a911ae5-0da2-4d97-bc86-5032a9553ae6.png)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
<!--
🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)
-->
You can 🎩 this is my spin env here: http://240.19.236.19:6006/?path=/story/playground-playground--playground
Its a simplified example without the selection handlers.

Or you can use the following Playground code locally :

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import {CirclePlusMinor, SearchMinor} from '@shopify/polaris-icons';
import React, {useState} from 'react';

import {Autocomplete, Card, Icon, Listbox, Page} from '../src';

function AutocompleteActionBeforeExample() {
  const deselectedOptions = [
    {value: 'rustic', label: 'Rustic'},
    {value: 'antique', label: 'Antique'},
    {value: 'vinyl', label: 'Vinyl'},
    {value: 'vintage', label: 'Vintage'},
    {value: 'refurbished', label: 'Refurbished'},
  ];
  const [options, setOptions] = useState(deselectedOptions);

  const textField = (
    <Autocomplete.TextField
      autoComplete="off"
      onChange={() => {}}
      label="Tags"
      value=""
      prefix={<Icon source={SearchMinor} />}
      placeholder="Search"
    />
  );

  return (
    <div style={{height: '225px'}}>
      <Autocomplete
        allowMultiple
        actionBefore={{
          accessibilityLabel: 'Action label',
          badge: {
            status: 'new',
            content: 'New!',
          },
          content: 'Action with long name',
          ellipsis: true,
          helpText: 'Help text',
          icon: CirclePlusMinor,
        }}
        options={options}
        selected={[]}
        onSelect={() => {}}
        listTitle="Suggested tags"
        textField={textField}
      />
    </div>
  );
}

export function Playground() {

  return (
    <Page title="Playground">
      <Card>
        <AutocompleteActionBeforeExample />
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
