### PR TITLE
[Listbox.Action] Fix rendering of the action when used outside an Autocomplete

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,6 +24,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Fixed an issue where the `MutationObserver` of the `PositionedOverlay` was calling setState on an unmounted component ([#4869](https://github.com/Shopify/polaris-react/pull/4869));
 - Fixed a color contrast issue in `FileUpload` ([#4875](https://github.com/Shopify/polaris-react/pull/4875))
 - Fixed a bug where a checkbox showed on an `Autocomplete` action when `allowMultiple` is true ([#4886](https://github.com/Shopify/polaris-react/pull/4886))
+- Fixed a bug where the `Listbox.Action` was not treated like an action when used outside `Autocomplete` ([#4893](https://github.com/Shopify/polaris-react/pull/4893))
 
 ### Documentation
 

--- a/src/components/Autocomplete/components/MappedAction/MappedAction.scss
+++ b/src/components/Autocomplete/components/MappedAction/MappedAction.scss
@@ -25,9 +25,6 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   min-height: $item-min-height;
   text-align: left;
   cursor: pointer;
-  padding: $item-vertical-padding spacing(tight);
-  border-radius: var(--p-border-radius-base);
-  border-top: 1px solid var(--p-surface); // 1px gap between elements
 
   &:hover {
     background-color: var(--p-surface-hovered);

--- a/src/components/Autocomplete/components/MappedAction/MappedAction.tsx
+++ b/src/components/Autocomplete/components/MappedAction/MappedAction.tsx
@@ -86,7 +86,6 @@ export function MappedAction({
       external,
       onAction,
       destructive,
-      isAction: true,
     }),
     [role, url, external, onAction, destructive],
   );

--- a/src/components/Autocomplete/components/MappedAction/tests/MappedAction.test.tsx
+++ b/src/components/Autocomplete/components/MappedAction/tests/MappedAction.test.tsx
@@ -61,7 +61,6 @@ describe('MappedAction', () => {
     expect(mappedAction).toContainReactComponent(MappedActionContext.Provider, {
       value: {
         ...props,
-        isAction: true,
       },
     });
   });
@@ -174,7 +173,9 @@ describe('MappedAction', () => {
       );
 
       expect(mappedAction).toContainReactComponent(MockComponent);
-      expect(mappedAction).not.toContainReactComponent(Icon, {source});
+      expect(mappedAction).not.toContainReactComponent(Icon, {
+        source,
+      });
     });
   });
 });

--- a/src/components/Listbox/components/Action/Action.scss
+++ b/src/components/Listbox/components/Action/Action.scss
@@ -5,6 +5,10 @@
   flex: 1;
 }
 
+.ActionDivider {
+  margin-bottom: spacing(extra-tight);
+}
+
 .Icon {
   padding-right: spacing(tight);
 }

--- a/src/components/Listbox/components/Action/Action.tsx
+++ b/src/components/Listbox/components/Action/Action.tsx
@@ -4,6 +4,8 @@ import {Icon} from '../../../Icon';
 import type {IconProps} from '../../../Icon';
 import {Option, OptionProps} from '../Option';
 import {TextOption} from '../TextOption';
+import {classNames} from '../../../../utilities/css';
+import {ActionContext} from '../../../../utilities/listbox/context';
 
 import styles from './Action.scss';
 
@@ -12,7 +14,7 @@ interface ActionProps extends OptionProps {
 }
 
 export function Action(props: ActionProps) {
-  const {selected, disabled, children, icon} = props;
+  const {selected, disabled, children, icon, divider} = props;
 
   const iconMarkup = icon && (
     <div className={styles.Icon}>
@@ -20,14 +22,18 @@ export function Action(props: ActionProps) {
     </div>
   );
 
+  const className = classNames(styles.Action, divider && styles.ActionDivider);
+
   return (
     <Option {...props}>
-      <TextOption selected={selected} disabled={disabled}>
-        <div className={styles.Action}>
-          {iconMarkup}
-          {children}
+      <ActionContext.Provider value>
+        <div className={className}>
+          <TextOption selected={selected} disabled={disabled}>
+            {iconMarkup}
+            {children}
+          </TextOption>
         </div>
-      </TextOption>
+      </ActionContext.Provider>
     </Option>
   );
 }

--- a/src/components/Listbox/components/Option/Option.tsx
+++ b/src/components/Listbox/components/Option/Option.tsx
@@ -34,8 +34,9 @@ export const Option = memo(function Option({
   divider,
 }: OptionProps) {
   const {onOptionSelect} = useListbox();
-  const {role, url, external, onAction, destructive, isAction} =
+  const {role, url, external, onAction, destructive} =
     useContext(MappedActionContext);
+
   const listItemRef = useRef<HTMLLIElement>(null);
   const domId = useUniqueId('ListboxOption');
   const sectionId = useSection();
@@ -45,7 +46,7 @@ export const Option = memo(function Option({
     (evt: React.MouseEvent) => {
       evt.preventDefault();
       onAction && onAction();
-      if (listItemRef.current && !isAction) {
+      if (listItemRef.current && !onAction) {
         onOptionSelect({
           domId,
           value,
@@ -54,7 +55,7 @@ export const Option = memo(function Option({
         });
       }
     },
-    [domId, onOptionSelect, value, disabled, onAction, isAction],
+    [domId, onOptionSelect, value, disabled, onAction],
   );
 
   // prevents lost of focus on Textfield

--- a/src/components/Listbox/components/Option/tests/Option.test.tsx
+++ b/src/components/Listbox/components/Option/tests/Option.test.tsx
@@ -249,7 +249,6 @@ describe('Option', () => {
       const option = mountWithListboxProvider(
         <MappedActionContext.Provider
           value={{
-            isAction: true,
             role,
           }}
         >
@@ -269,7 +268,6 @@ describe('Option', () => {
       const option = mountWithListboxProvider(
         <MappedActionContext.Provider
           value={{
-            isAction: true,
             url: 'google.com',
           }}
         >
@@ -287,7 +285,6 @@ describe('Option', () => {
       const option = mountWithListboxProvider(
         <MappedActionContext.Provider
           value={{
-            isAction: true,
             url: 'google.com',
             external: true,
           }}
@@ -307,7 +304,6 @@ describe('Option', () => {
       const option = mountWithListboxProvider(
         <MappedActionContext.Provider
           value={{
-            isAction: true,
             onAction: onActionSpy,
           }}
         >
@@ -332,7 +328,7 @@ describe('Option', () => {
       const option = mountWithListboxProvider(
         <MappedActionContext.Provider
           value={{
-            isAction: true,
+            onAction: () => {},
           }}
         >
           <Option {...defaultProps} />

--- a/src/components/Listbox/components/TextOption/TextOption.scss
+++ b/src/components/Listbox/components/TextOption/TextOption.scss
@@ -15,8 +15,8 @@
   }
 
   &.isAction {
-    padding: 0;
     margin-top: 0;
+    padding: spacing(tight) spacing(tight);
   }
 
   &:hover {
@@ -54,6 +54,10 @@
     border-bottom-right-radius: var(--p-border-radius-base);
     transform: translateX(-100%);
   }
+}
+
+li:first-of-type > .TextOption {
+  margin-top: 0;
 }
 
 [data-focused] .TextOption {

--- a/src/components/Listbox/components/TextOption/TextOption.tsx
+++ b/src/components/Listbox/components/TextOption/TextOption.tsx
@@ -3,7 +3,7 @@ import React, {memo, useContext} from 'react';
 import {Checkbox} from '../../../Checkbox';
 import {classNames} from '../../../../utilities/css';
 import {ComboboxListboxOptionContext} from '../../../../utilities/combobox/context';
-import {MappedActionContext} from '../../../../utilities/autocomplete';
+import {ActionContext} from '../../../../utilities/listbox/context';
 
 import styles from './TextOption.scss';
 
@@ -21,7 +21,8 @@ export const TextOption = memo(function TextOption({
   disabled,
 }: TextOptionProps) {
   const {allowMultiple} = useContext(ComboboxListboxOptionContext);
-  const {isAction} = useContext(MappedActionContext);
+  const isAction = useContext(ActionContext);
+
   const textOptionClassName = classNames(
     styles.TextOption,
     selected && !allowMultiple && styles.selected,
@@ -29,6 +30,7 @@ export const TextOption = memo(function TextOption({
     allowMultiple && styles.allowMultiple,
     isAction && styles.isAction,
   );
+
   return (
     <div className={textOptionClassName}>
       <div className={styles.Content}>

--- a/src/components/Listbox/components/TextOption/tests/TextOption.test.tsx
+++ b/src/components/Listbox/components/TextOption/tests/TextOption.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import {mount, mountWithApp} from 'tests/utilities';
 
 import {TextOption} from '../TextOption';
+import {Listbox} from '../../..';
 import {Checkbox} from '../../../../Checkbox';
 import {ComboboxListboxOptionContext} from '../../../../../utilities/combobox/context';
-import {MappedActionContext} from '../../../../../utilities/autocomplete/context';
 
 describe('TextOption', () => {
   it('renders children', () => {
@@ -40,12 +40,24 @@ describe('TextOption', () => {
     expect(textOption).toContainReactComponent(Checkbox);
   });
 
-  it('does not render visual checkbox when allowMultiple is provided and isAction is true', () => {
+  it('does not render visual checkbox when allowMultiple is false', () => {
+    const textOption = mountWithApp(
+      <ComboboxListboxOptionContext.Provider value={{allowMultiple: false}}>
+        <TextOption>child</TextOption>
+      </ComboboxListboxOptionContext.Provider>,
+    );
+
+    expect(textOption).not.toContainReactComponent(Checkbox);
+  });
+
+  it('does not render visual checkbox wrapped in a ListBox.Action', () => {
     const textOption = mountWithApp(
       <ComboboxListboxOptionContext.Provider value={{allowMultiple: true}}>
-        <MappedActionContext.Provider value={{isAction: true}}>
-          <TextOption>child</TextOption>
-        </MappedActionContext.Provider>
+        <Listbox accessibilityLabel="Listbox with Action example">
+          <Listbox.Action value="action">
+            <TextOption>child</TextOption>
+          </Listbox.Action>
+        </Listbox>
       </ComboboxListboxOptionContext.Provider>,
     );
 

--- a/src/utilities/autocomplete/context.ts
+++ b/src/utilities/autocomplete/context.ts
@@ -6,9 +6,6 @@ interface MappedActionContextType {
   external?: boolean;
   onAction?(): void;
   destructive?: boolean;
-  isAction: boolean;
 }
 
-export const MappedActionContext = createContext<MappedActionContextType>({
-  isAction: false,
-});
+export const MappedActionContext = createContext<MappedActionContextType>({});

--- a/src/utilities/listbox/context.ts
+++ b/src/utilities/listbox/context.ts
@@ -12,3 +12,5 @@ export const ListboxContext = createContext<ListboxContextType | undefined>(
 );
 
 export const WithinListboxContext = createContext(false);
+
+export const ActionContext = createContext<boolean>(false);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4884

The Autocomplete context was providing the Listbox.Action with the boolean context identifying the Action as an Action which was responsible for the CSS. In the issue reported the Action was being used inside a Comboxbox as oppose to Autocomplete therefor the context was missing.

### WHAT is this pull request doing?

I moved the context to the Listbox.Action. I also fixed a few styling issues. 

https://user-images.githubusercontent.com/1229901/149540299-cbb96d49-e56a-4724-843b-41f7fc35b9dc.mov

<img width="583" alt="Screen Shot 2022-01-14 at 9 30 00 AM" src="https://user-images.githubusercontent.com/1229901/149540305-b5d1386f-dcb5-4e3e-9647-cf1844b10b8c.png">

https://user-images.githubusercontent.com/1229901/149540307-a4e028fd-4443-4475-b18a-d053543d1733.mov

**before:**
<img width="294" alt="Screen Shot 2022-01-14 at 1 02 58 PM" src="https://user-images.githubusercontent.com/1229901/149563570-7d089159-c110-4c62-8daf-17661c4448eb.png">

**after:**
<img width="300" alt="Screen Shot 2022-01-14 at 1 03 15 PM" src="https://user-images.githubusercontent.com/1229901/149563568-10ecea13-28e1-437a-ae2c-d2b22b7ff364.png">



### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {CirclePlusMinor, SearchMinor} from '@shopify/polaris-icons';

import {Page, Combobox, Listbox, Icon} from '../src';

export function Playground() {
  const listAction = (
    <Listbox.Action icon={CirclePlusMinor} value="testAction" divider>
      Test action
    </Listbox.Action>
  );

  const listOptions = (
    <>
      <Listbox.Option key="1" value="1">
        My first option
      </Listbox.Option>
      <Listbox.Option key="2" value="2">
        My second option
      </Listbox.Option>
    </>
  );

  const listBox = (
    <Listbox onSelect={() => {}}>
      {listAction}
      {listOptions}
    </Listbox>
  );
  return (
    <Page title="Playground">
      <Combobox
        allowMultiple
        activator={
          <Combobox.TextField
            autoComplete="off"
            prefix={<Icon source={SearchMinor} color="base" />}
            label="search"
            labelHidden
            onChange={() => {}}
          />
        }
      >
        {listBox}
      </Combobox>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
