### PR TITLE
[TextField] Added a class to hide the clear button instead of removing it from the DOM

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added support for `children` to take elements other than strings in the `Tag` component ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
 - Bumped the `@shopify/storybook-a11y-test` package to the latest version `0.3.0` ([#4870](https://github.com/Shopify/polaris-react/pull/4870))
 - Added a `warning` variation to `TextStyle` ([#4880](https://github.com/Shopify/polaris-react/pull/4880))
+- Added the click event to the `onClearButtonClick` callback in the `TextField` component ([#4897](https://github.com/Shopify/polaris-react/pull/4897))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,7 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added support for `children` to take elements other than strings in the `Tag` component ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
 - Bumped the `@shopify/storybook-a11y-test` package to the latest version `0.3.0` ([#4870](https://github.com/Shopify/polaris-react/pull/4870))
 - Added a `warning` variation to `TextStyle` ([#4880](https://github.com/Shopify/polaris-react/pull/4880))
-- Added the click event to the `onClearButtonClick` callback in the `TextField` component ([#4897](https://github.com/Shopify/polaris-react/pull/4897))
+- Added a class to hide the clear button in the `TextField` component instead of removing it from the DOM ([#4897](https://github.com/Shopify/polaris-react/pull/4897))
 
 ### Bug fixes
 

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -232,6 +232,10 @@ $stacking-order: (
   }
 }
 
+.Hidden {
+  visibility: hidden;
+}
+
 .Spinner {
   --p-text-field-spinner-offset-large: calc(
     var(--p-text-field-spinner-offset) + #{border-width()}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -125,10 +125,7 @@ interface NonMutuallyExclusiveProps {
   /** Determines the alignment of the text in the input */
   align?: Alignment;
   /** Callback when clear button is clicked */
-  onClearButtonClick?(
-    id: string,
-    event: React.MouseEvent | React.TouchEvent,
-  ): void;
+  onClearButtonClick?(id: string): void;
   /** Callback when value is changed */
   onChange?(value: string, id: string): void;
   /** Callback when input is focused */
@@ -281,20 +278,22 @@ export function TextField({
 
   const clearButtonVisible = normalizedValue !== '';
 
-  const clearButtonMarkup =
-    clearButtonVisible && clearButton ? (
-      <button
-        type="button"
-        className={styles.ClearButton}
-        onClick={handleClearButtonPress}
-        disabled={disabled}
-      >
-        <VisuallyHidden>
-          {i18n.translate('Polaris.Common.clear')}
-        </VisuallyHidden>
-        <Icon source={CircleCancelMinor} color="base" />
-      </button>
-    ) : null;
+  const clearButtonClassNames = classNames(
+    styles.ClearButton,
+    !clearButtonVisible && styles.Hidden,
+  );
+
+  const clearButtonMarkup = clearButton ? (
+    <button
+      type="button"
+      className={clearButtonClassNames}
+      onClick={handleClearButtonPress}
+      disabled={disabled}
+    >
+      <VisuallyHidden>{i18n.translate('Polaris.Common.clear')}</VisuallyHidden>
+      <Icon source={CircleCancelMinor} color="base" />
+    </button>
+  ) : null;
 
   const handleNumberChange = useCallback(
     (steps: number) => {
@@ -481,8 +480,8 @@ export function TextField({
     </Labelled>
   );
 
-  function handleClearButtonPress(event: React.MouseEvent | React.TouchEvent) {
-    onClearButtonClick && onClearButtonClick(id, event);
+  function handleClearButtonPress() {
+    onClearButtonClick && onClearButtonClick(id);
   }
 
   function handleKeyPress(event: React.KeyboardEvent) {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -125,7 +125,10 @@ interface NonMutuallyExclusiveProps {
   /** Determines the alignment of the text in the input */
   align?: Alignment;
   /** Callback when clear button is clicked */
-  onClearButtonClick?(id: string): void;
+  onClearButtonClick?(
+    id: string,
+    event: React.MouseEvent | React.TouchEvent,
+  ): void;
   /** Callback when value is changed */
   onChange?(value: string, id: string): void;
   /** Callback when input is focused */
@@ -478,8 +481,8 @@ export function TextField({
     </Labelled>
   );
 
-  function handleClearButtonPress() {
-    onClearButtonClick && onClearButtonClick(id);
+  function handleClearButtonPress(event: React.MouseEvent | React.TouchEvent) {
+    onClearButtonClick && onClearButtonClick(id, event);
   }
 
   function handleKeyPress(event: React.KeyboardEvent) {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1336,7 +1336,7 @@ describe('<TextField />', () => {
 
       textField.find('button', {className: 'ClearButton'})!.trigger('onClick');
 
-      expect(spy).toHaveBeenCalledWith('MyTextField', undefined);
+      expect(spy).toHaveBeenCalledWith('MyTextField');
     });
 
     it('does not render a clear button by default', () => {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1336,7 +1336,7 @@ describe('<TextField />', () => {
 
       textField.find('button', {className: 'ClearButton'})!.trigger('onClick');
 
-      expect(spy).toHaveBeenCalledWith('MyTextField');
+      expect(spy).toHaveBeenCalledWith('MyTextField', undefined);
     });
 
     it('does not render a clear button by default', () => {


### PR DESCRIPTION
### WHY are these changes introduced?
I found this issue when I was trying to add a clearable textfield to a `<Popover />`. The popover doesn't usually close when a button within it is pressed but since the `clearButton` on the `TextField` is removed from the DOM before the popover events are handled, it doesn't register it as a child of the popover. 

BEFORE
![ezgif-3-deae442bf7](https://user-images.githubusercontent.com/20652326/149596890-8cffd60e-a186-4989-b657-12b12a56f672.gif)

### WHAT is this pull request doing?
The easiest thing to do is to call `event.stopPropagation` on the click event, but the event is not currently accessible from the `onClearButtonClick` for the text field. This PR adds the event to the callback. I could've called `stopPropagation` directly in the `TextField` component, but that felt risky considering all the other events from the component bubble.

AFTER
![ezgif-3-8df119b0bf](https://user-images.githubusercontent.com/20652326/149597229-b4fd3920-cd49-4b44-9137-a38e83a7b8df.gif)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import {SearchMinor} from '@shopify/polaris-icons';
import React, {useState} from 'react';

import {Button, Icon, Popover, TextField} from '../src';

export function Playground() {
  const [popoverActive, setPopoverActive] = useState(true);
  const [queryValue, setQueryValue] = useState<string | undefined>(undefined);

  const togglePopoverActive = () =>
    setPopoverActive((popoverActive) => !popoverActive);

  const activator = (
    <Button onClick={togglePopoverActive} disclosure>
      open
    </Button>
  );

  return (
    <Popover
      sectioned
      active={popoverActive}
      activator={activator}
      onClose={togglePopoverActive}
      ariaHaspopup={false}
    >
      <TextField
        placeholder="type here"
        onChange={setQueryValue}
        value={queryValue}
        label="type here"
        labelHidden
        prefix={<Icon source={SearchMinor} />}
        clearButton
        onClearButtonClick={(_id, event) => {
          setQueryValue(undefined);
          event.stopPropagation();
        }}
        autoComplete="off"
      />
    </Popover>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

Closes https://github.com/Shopify/web/issues/55738