### PR TITLE
[ButtonGroup] Fix misalignment in segmented items

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,15 +10,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
-- Fixed a bug where remove button could shrink in the `Tag` component ([#4816](https://github.com/Shopify/polaris-react/issues/4816))
-- Fixed incorrect `Popover` position in `Combobox` when an element is conditionally rendered before the `Combobox` ([#4825](https://github.com/Shopify/polaris-react/pull/4825))
-- Reverted the deprecation of the "attention" `status` in `Badge` ([#4840](https://github.com/Shopify/polaris-react/pull/4840))
-- Fixed an issue where the `MutationObserver` of the `PositionedOverlay` was calling setState on an unmounted component ([#4869](https://github.com/Shopify/polaris-react/pull/4869));
-- Fixed a color contrast issue in `FileUpload` ([#4875](https://github.com/Shopify/polaris-react/pull/4875))
-- Fixed a bug where a checkbox showed on an `Autocomplete` action when `allowMultiple` is true ([#4886](https://github.com/Shopify/polaris-react/pull/4886))
-- Fixed a bug where the `Listbox.Action` was not treated like an action when used outside `Autocomplete` ([#4893](https://github.com/Shopify/polaris-react/pull/4893))
-- Fixed a bug where the `Checkbox` in a `Combobox` with `allowMultiple` would steal focus and close the `Popover` when clicked ([#4895](https://github.com/Shopify/polaris-react/pull/4895))
-- Fixed a bug where the `ButtonGroup` is misaligned when segmented with text and Icon items ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
+- Fixed `segmented` `ButtonGroup` misaligning icon only buttons when grouped with text only buttons ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,16 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
+- Fixed a bug where remove button could shrink in the `Tag` component ([#4816](https://github.com/Shopify/polaris-react/issues/4816))
+- Fixed incorrect `Popover` position in `Combobox` when an element is conditionally rendered before the `Combobox` ([#4825](https://github.com/Shopify/polaris-react/pull/4825))
+- Reverted the deprecation of the "attention" `status` in `Badge` ([#4840](https://github.com/Shopify/polaris-react/pull/4840))
+- Fixed an issue where the `MutationObserver` of the `PositionedOverlay` was calling setState on an unmounted component ([#4869](https://github.com/Shopify/polaris-react/pull/4869));
+- Fixed a color contrast issue in `FileUpload` ([#4875](https://github.com/Shopify/polaris-react/pull/4875))
+- Fixed a bug where a checkbox showed on an `Autocomplete` action when `allowMultiple` is true ([#4886](https://github.com/Shopify/polaris-react/pull/4886))
+- Fixed a bug where the `Listbox.Action` was not treated like an action when used outside `Autocomplete` ([#4893](https://github.com/Shopify/polaris-react/pull/4893))
+- Fixed a bug where the `Checkbox` in a `Combobox` with `allowMultiple` would steal focus and close the `Popover` when clicked ([#4895](https://github.com/Shopify/polaris-react/pull/4895))
+- Fixed a bug where the `ButtonGroup` is misaligned when segmented with text and Icon items ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -540,13 +540,6 @@ $stacking-order: (
   > :last-child:first-child .Button::after {
     border-radius: var(--p-border-radius-base);
   }
-
-  // This compensates for when an Icon is used within
-  // a segmented ButtonGroup. Because of the Icon size, it
-  // causes the size of the item to exceed the parent element.
-  .Icon {
-    margin-top: rem(-1px);
-  }
 }
 
 [data-buttongroup-connected-top='true'] {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -540,6 +540,13 @@ $stacking-order: (
   > :last-child:first-child .Button::after {
     border-radius: var(--p-border-radius-base);
   }
+
+  // This compensates for when an Icon is used within
+  // a segmented ButtonGroup. Because of the Icon size, it
+  // causes the size of the item to exceed the parent element.
+  .Icon {
+    margin-top: rem(-1px);
+  }
 }
 
 [data-buttongroup-connected-top='true'] {

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -42,6 +42,7 @@ $item-spacing: spacing(tight);
     z-index: z-index(item, $stacking-order);
     margin-top: 0;
     margin-left: 0;
+    line-height: normal;
 
     &:not(:first-child) {
       margin-left: -1 * border-width();

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -40,9 +40,9 @@ $item-spacing: spacing(tight);
   .Item {
     position: relative;
     z-index: z-index(item, $stacking-order);
-    display: flex;
     margin-top: 0;
     margin-left: 0;
+    line-height: initial;
 
     &:not(:first-child) {
       margin-left: -1 * border-width();

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -40,6 +40,7 @@ $item-spacing: spacing(tight);
   .Item {
     position: relative;
     z-index: z-index(item, $stacking-order);
+    display: flex;
     margin-top: 0;
     margin-left: 0;
 

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -42,7 +42,6 @@ $item-spacing: spacing(tight);
     z-index: z-index(item, $stacking-order);
     margin-top: 0;
     margin-left: 0;
-    line-height: initial;
 
     &:not(:first-child) {
       margin-left: -1 * border-width();


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4079

When you are using the segmented `ButtonGroup` with a mix of `slim` text-only and icon containing `Button`s, it causes the items to be misaligned due to height differences.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
 
This PR adds `line-height: normal;` to `ButtonGroup` `.Item` when `segmented`.

|Before|After|
|---|---|
|<img width="958" alt="Screen Shot 2022-01-24 at 11 59 02 AM" src="https://user-images.githubusercontent.com/18447883/150829256-4bde53b5-7f88-4162-ad77-7f825dfef611.png">|<img width="963" alt="Screen Shot 2022-01-24 at 11 58 12 AM" src="https://user-images.githubusercontent.com/18447883/150829075-460ff2db-2558-483d-9134-efb116d91665.png">|

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {DeleteMinor} from '@shopify/polaris-icons';

import {Page, Layout, Card, Icon, Button, ButtonGroup} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Layout>
        <Layout.Section>
          <Card>
            <Card.Section title="Slim buttons">
              <ButtonGroup segmented>
                <Button size="slim">Remove</Button>
                <Button icon={<Icon source={DeleteMinor} />} size="slim" />
                <Button icon={<Icon source={DeleteMinor} />} size="slim">
                  Remove
                </Button>
                <Button disclosure size="slim">
                  More actions
                </Button>
              </ButtonGroup>
            </Card.Section>

            <Card.Section title="Default buttons">
              <ButtonGroup segmented>
                <Button>Remove</Button>
                <Button icon={<Icon source={DeleteMinor} />} />
                <Button icon={<Icon source={DeleteMinor} />}>Remove</Button>
                <Button disclosure>More actions</Button>
              </ButtonGroup>
            </Card.Section>

            <Card.Section title="Large buttons">
              <ButtonGroup segmented>
                <Button size="large">Remove</Button>
                <Button icon={<Icon source={DeleteMinor} />} size="large" />
                <Button icon={<Icon source={DeleteMinor} />} size="large">
                  Remove
                </Button>
                <Button disclosure size="large">
                  More actions
                </Button>
              </ButtonGroup>
            </Card.Section>

            <Card.Section title="Full width buttons">
              <ButtonGroup fullWidth segmented>
                <Button>Remove</Button>
                <Button icon={<Icon source={DeleteMinor} />} />
                <Button icon={<Icon source={DeleteMinor} />}>Remove</Button>
                <Button disclosure>More actions</Button>
              </ButtonGroup>
            </Card.Section>

            <Card.Section title="Outline buttons">
              <ButtonGroup segmented>
                <Button outline>Remove</Button>
                <Button outline icon={<Icon source={DeleteMinor} />} />
                <Button outline icon={<Icon source={DeleteMinor} />}>
                  Remove
                </Button>
                <Button outline disclosure>
                  More actions
                </Button>
              </ButtonGroup>
            </Card.Section>

            <Card.Section title="Plain buttons">
              <ButtonGroup segmented>
                <Button plain>Remove</Button>
                <Button plain icon={<Icon source={DeleteMinor} />} />
                <Button plain icon={<Icon source={DeleteMinor} />}>
                  Remove
                </Button>
                <Button plain disclosure>
                  More actions
                </Button>
              </ButtonGroup>
            </Card.Section>
          </Card>
        </Layout.Section>
      </Layout>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [🚫] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [🚫] Updated the component's `README.md` with documentation changes
- [🚫] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [🚫] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
