### PR TITLE
[Navigation] Make selected item prop work even with subNav

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,12 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added missing styles for `destructive` `Page` `secondaryActions` ([#4647](https://github.com/Shopify/polaris-react/pull/4647))
 - Removed `min-height` from `Page` `additionalNavigation` ([#4952](https://github.com/Shopify/polaris-react/pull/4952))
 - Fixed overly dark `bottom-border` on `DataTable` header cell and total cell. ([#4975])(https://github.com/Shopify/polaris-react/pull/4975)
+- Fixed a bug where remove button could shrink in the `Tag` component ([#4816](https://github.com/Shopify/polaris-react/issues/4816))
+- Fixed incorrect `Popover` position in `Combobox` when an element is conditionally rendered before the `Combobox` ([#4825](https://github.com/Shopify/polaris-react/pull/4825))
+- Reverted the deprecation of the "attention" `status` in `Badge` ([#4840](https://github.com/Shopify/polaris-react/pull/4840))
+- Fixed an issue where the `MutationObserver` of the `PositionedOverlay` was calling setState on an unmounted component ([#4869](https://github.com/Shopify/polaris-react/pull/4869));
+- Fixed a color contrast issue in `FileUpload` ([#4875](https://github.com/Shopify/polaris-react/pull/4875))
+- Fixed an issue with selected props in `Navigation` `Item` being ignored if subnav items are present ([#4912](https://github.com/Shopify/polaris-react/pull/4912))
 
 ### Documentation
 


### PR DESCRIPTION
### WHY are these changes introduced?

- Fixes an issue where if a nav item has subNav items, the `selected` prop won't result in the item looking selected.

### WHAT is this pull request doing?

- Ensure the `selected` option for nav items has the highest precedence (even if subnav children are present)
- Doesn't affect any route-matching logic, and could lead to multiple items being selected at once

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
