### PR TITLE
Fix division bugs and Prepare for dart-sass interoperability

### DIFF
--- a/UNRELEASED-v8.md
+++ b/UNRELEASED-v8.md
@@ -57,5 +57,6 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Replaced font-weight values with tokens ([#4599](https://github.com/Shopify/polaris-react/issues/4599))
 - Replaced hardcoded spacing values with spacing tokens ([#4775](https://github.com/Shopify/polaris-react/pull/4775))
+- Avoid some usage of `/` for division in preparation for dart-sass support [#4933](https://github.com/Shopify/polaris-react/pull/4933))
 
 ### Deprecations

--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -13,7 +13,7 @@
   color: var(--p-text-subdued);
   text-decoration: none;
   margin: 0;
-  padding: var(--p-space-1) / 2;
+  padding: var(--p-space-1) * 0.5;
   border-radius: var(--p-border-radius-1);
   border: 1px solid var(--p-border-neutral-subdued);
   @include focus-ring($border-width: 1px);

--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -13,7 +13,7 @@
   color: var(--p-text-subdued);
   text-decoration: none;
   margin: 0;
-  padding: var(--p-space-1) * 0.5;
+  padding: calc(var(--p-space-1) * 0.5);
   border-radius: var(--p-border-radius-1);
   border: 1px solid var(--p-border-neutral-subdued);
   @include focus-ring($border-width: 1px);

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -134,7 +134,7 @@ $action-menu-rollup-computed-width: 40px;
 
   // stylelint-disable-next-line selector-max-class
   .mobileView.hasNavigation & {
-    top: control-height() / 2;
+    top: control-height() * 0.5;
   }
 
   @include print-hidden;

--- a/src/components/ProgressBar/ProgressBar.scss
+++ b/src/components/ProgressBar/ProgressBar.scss
@@ -3,7 +3,7 @@
 @function progress-bar-height($height: base) {
   $base: 16px;
   $data: (
-    small: $base / 2,
+    small: $base * 0.5,
     base: $base,
     large: $base * 2,
   );

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -166,7 +166,7 @@ $range-output-spacing: 16px;
     transform: translateY(-$range-output-spacing);
 
     @include page-content-when-not-partially-condensed {
-      transform: translateY(-($range-output-spacing / 2));
+      transform: translateY(-($range-output-spacing * 0.5));
     }
   }
   // stylelint-enable selector-max-specificity, selector-max-combinators, selector-max-class

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -109,13 +109,13 @@
 
   &::-ms-thumb {
     margin-top: 0;
-    transform: translateY(var(--pc-range-slider-thumb-size) / 5) scale(0.4);
+    transform: translateY(var(--pc-range-slider-thumb-size) * 0.2) scale(0.4);
   }
 
   &::-webkit-slider-thumb {
     margin-top: -(
         var(--pc-range-slider-thumb-size) - var(--pc-range-slider-track-height)
-      ) / 2;
+      ) * 0.5;
   }
 
   &:active {
@@ -209,7 +209,7 @@ $range-output-spacing: 16px;
     transform: translateY(-$range-output-spacing);
 
     @include page-content-when-not-partially-condensed {
-      transform: translateY(-($range-output-spacing / 2));
+      transform: translateY(-($range-output-spacing * 0.5));
     }
   }
   @include high-contrast-outline;

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -109,13 +109,15 @@
 
   &::-ms-thumb {
     margin-top: 0;
-    transform: translateY(var(--pc-range-slider-thumb-size) * 0.2) scale(0.4);
+    transform: translateY(calc(var(--pc-range-slider-thumb-size) * 0.2))
+      scale(0.4);
   }
 
   &::-webkit-slider-thumb {
-    margin-top: -(
-        var(--pc-range-slider-thumb-size) - var(--pc-range-slider-track-height)
-      ) * 0.5;
+    margin-top: calc(
+      (var(--pc-range-slider-thumb-size) - var(--pc-range-slider-track-height)) *
+        -0.5
+    );
   }
 
   &:active {

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -2,7 +2,7 @@
 
 $item-min-height: 16px;
 $item-min-width: 50px;
-$item-vertical-padding: $item-min-height / 2;
+$item-vertical-padding: $item-min-height * 0.5;
 $underline-height: var(--p-border-width-3);
 $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 

--- a/src/components/VideoThumbnail/VideoThumbnail.scss
+++ b/src/components/VideoThumbnail/VideoThumbnail.scss
@@ -53,8 +53,8 @@ $progress-bar-height: 6px;
   left: 50%;
   width: $start-button-size;
   height: $start-button-size;
-  margin-top: -$start-button-size / 2;
-  margin-left: -$start-button-size / 2;
+  margin-top: -$start-button-size * 0.5;
+  margin-left: -$start-button-size * 0.5;
 }
 
 .Timestamp {

--- a/src/styles/_public-api.scss
+++ b/src/styles/_public-api.scss
@@ -18,11 +18,9 @@
 
 @import './foundation/utilities';
 @import './foundation/colors';
-@import './foundation/spacing';
 @import './foundation/borders';
 @import './foundation/layout';
 @import './foundation/typography';
-@import './foundation/z-index';
 @import './foundation/focus-ring';
 
 @import './shared/accessibility';


### PR DESCRIPTION
### WHY are these changes introduced?

Part of #4725.

Using `/` for division is deprecated in dart-sass. Simple cases can be replaced with
multiplying by the reciprocal number, which works in both node-sass and
dart-sass. e.g. `10 / 2` becomes `10 * 0.5`.

In order to prepare for an eventual migration from node-sass to dart-sass, this PR clears up this low-hanging fruit.

Along they way this also identified a pair of issues in the v9 branch:

- `_public-api.scss` imported a pair of files that no longer exist.
- `src/components/Breadcrumbs/Breadcrumbs.scss` and `src/components/RangeSlider/components/SingleThumb/SingleThumb.scss` contained cases where migration to css tokens was done incorrectly and resulted in incorrect style output. 

### WHAT is this pull request doing?

This PR runs `npx sass-migrator division 'src/**/*.scss' --dry-run  --migrate-deps --load-path=.` and commits the subset of changes that use this simple modification.

It also removes two lines in `_public-api.scss` that tried to import files that have been deleted as part of v9 scss api refactoring work.

It fixes two cases where the migrated division caused build errors, because the division was incorrectly located outside of  a `calc()`. These errors were surfaced because `padding: var(--p-space-1) / 2` is considered parsable CSS, but `padding: var(--p-space-1) * 0.5` is an error.