### PR TITLE
[ColorPicker] Add an inset box-shadow to make it easier to see the draggers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
-### Enhancements
+- [ColorPicker] Add an inset box-shadow to make it easier to see the draggers ([#4948](https://github.com/Shopify/polaris-react/pull/4948))
 
 ### Bug fixes
 

--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -27,6 +27,7 @@ $stacking-order: (
 
 .MainColor {
   @include checkers;
+  @include high-contrast-outline;
   position: relative;
   overflow: hidden;
   height: $picker-size;
@@ -99,6 +100,7 @@ $vertical-picker-border-radius: $picker-size * 0.5;
 
 .HuePicker,
 .AlphaPicker {
+  @include high-contrast-outline;
   position: relative;
   overflow: hidden;
   height: $picker-size;

--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -3,6 +3,8 @@
 $picker-size: rem(160px);
 $dragger-size: rem(18px);
 $inner-shadow: inset 0 0 2px 0 rgba(0, 0, 0, 0.5);
+$dragger-shadow: inset 0 0.5px 2px 0 rgba(0, 0, 0, 0.4),
+  0 0.5px 3px 0 rgba(0, 0, 0, 0.4);
 
 $stacking-order: (
   color: 10,
@@ -42,6 +44,7 @@ $stacking-order: (
   .Dragger {
     right: 0.5 * $dragger-size;
     margin: 0;
+    box-shadow: $dragger-shadow;
   }
 
   .ColorLayer {
@@ -68,6 +71,7 @@ $stacking-order: (
 
   &::after {
     background-image: linear-gradient(to top, black, transparent);
+    box-shadow: $inner-shadow;
   }
 }
 
@@ -84,12 +88,14 @@ $stacking-order: (
   border: var(--p-border-radius-base) solid var(--p-surface);
   border-radius: 50%;
   pointer-events: none;
+  box-shadow: $dragger-shadow;
 }
 
 $green: rgb(0, 255, 0);
 $purple: rgb(255, 0, 255);
 $huepicker-padding: $dragger-size;
 $huepicker-bottom-padding-start: $picker-size - $dragger-size;
+$vertical-picker-border-radius: $picker-size * 0.5;
 
 .HuePicker,
 .AlphaPicker {
@@ -99,7 +105,21 @@ $huepicker-bottom-padding-start: $picker-size - $dragger-size;
   width: rem(24px);
   margin-left: spacing(tight);
   border-width: var(--p-border-radius-base);
-  border-radius: $picker-size * 0.5;
+  border-radius: $vertical-picker-border-radius;
+
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: z-index(adjustments, $stacking-order);
+    top: 0;
+    left: 0;
+    display: block;
+    height: 100%;
+    width: 100%;
+    pointer-events: none;
+    border-radius: $vertical-picker-border-radius;
+    box-shadow: $inner-shadow;
+  }
 }
 
 .HuePicker {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4517

When the color picker box or the draggers are on a white background they can be difficult to discern because they are white as well.

### WHAT is this pull request doing?

* Add a visual inset box-shadow around the main color picker, the vertical pickers for hue and opacity and the draggers
* Add an outline for users using High Contrast Mode (HCM)

| Before this PR | After this PR |
|-|-|
| No outline around the color pickers <img width="285" alt="" src="https://user-images.githubusercontent.com/22640631/150803272-28df0803-6f23-4319-8fc0-777a236b56c5.png"> | Outline around the color pickers and draggers <img width="289" alt="Screenshot 2022-01-24 at 17 33 19" src="https://user-images.githubusercontent.com/22640631/150824811-2e5fa47b-87e0-4488-9c66-b5d43f9a9ac7.png">






## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {ColorPicker, Heading, Page} from '../src';

export function Playground() {
  const [color, setColor] = useState({
    hue: 120,
    brightness: 1,
    saturation: 1,
    alpha: 0.5,
  });

  return (
    <Page title="Playground">
      <div style={{backgroundColor: "white", padding: "30px"}}>
        <Heading>White background</Heading>
        <ColorPicker onChange={setColor} color={color} allowAlpha />
      </div>
      <div style={{backgroundColor: "rgb(246, 246, 247)", padding: "30px"}}>
        <Heading>Grey background</Heading>
        <ColorPicker onChange={setColor} color={color} allowAlpha />
      </div>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
