### PR TITLE
Only add min-height to .Row:first-child

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Fixed `segmented` `ButtonGroup` misaligning icon only buttons when grouped with text only buttons ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
 - Added missing styles for `destructive` `Page` `secondaryActions` ([#4647](https://github.com/Shopify/polaris-react/pull/4647))
+- Removed `min-height` from `Page` `additionalNavigation` ([#4952](https://github.com/Shopify/polaris-react/pull/4952))
 
 ### Documentation
 

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -144,7 +144,10 @@ $action-menu-rollup-computed-width: rem(40px);
 .Row {
   display: flex;
   justify-content: space-between;
-  min-height: 36px;
+
+  &:first-child {
+    min-height: 36px;
+  }
 
   + .Row {
     margin-top: spacing(extra-tight);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes spacing issue on multiple pages in `shopify/web` with a quick hack.
![screen_shot_2022-01-21_at_10 49 19_am](https://user-images.githubusercontent.com/19199063/150881402-fa7290ce-a780-4302-a659-ad4206625da5.png)

### WHAT is this pull request doing?

With https://github.com/Shopify/polaris-react/pull/4779 shipped all rows get a `min-height`. However some issues exist when users return components that return `null`. To resolve this temporarily I am moving the `min-height` to the first row only.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card} from '../src';

export function Playground() {
  return (
    <>
      {/* Incorrect spacing when using <NullComponent /> */}
      <Page
        title="<NullComponent/>"
        subtitle="Come back <Card/> I miss you!"
        compactTitle
        primaryAction={{content: 'Save'}}
        additionalNavigation={<NullComponent />}
      >
        <Card title="Hello world">
          <Card.Section>
            <p>Boop</p>
          </Card.Section>
        </Card>
      </Page>
      {/* Correct spacing when using null */}
      <Page
        title="null"
        subtitle="I am beatifully spaced"
        compactTitle
        primaryAction={{content: 'Save'}}
        additionalNavigation={null}
      >
        <Card title="Hello world">
          <Card.Section>
            <p>Boop</p>
          </Card.Section>
        </Card>
      </Page>
    </>
  );
}

const NullComponent = () => null;
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
