### PR TITLE
[Autocomplete] Fixed bug where `Listbox` would "snap" to items in scrollable list when clicked

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Fixed `segmented` `ButtonGroup` misaligning icon only buttons when grouped with text only buttons ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
 - Added missing styles for `destructive` `Page` `secondaryActions` ([#4647](https://github.com/Shopify/polaris-react/pull/4647))
+- Fixed a bug where `Listbox` would "snap" to items in scrollable list when clicked ([#4961](https://github.com/Shopify/polaris-react/pull/4961))
 
 ### Documentation
 

--- a/src/components/Listbox/Listbox.tsx
+++ b/src/components/Listbox/Listbox.tsx
@@ -112,7 +112,7 @@ export function Listbox({
   );
 
   const handleChangeActiveOption = useCallback(
-    (nextOption?: NavigableOption) => {
+    (nextOption?: NavigableOption, isKeyboardChange?: boolean) => {
       setCurrentActiveOption((currentActiveOption) => {
         if (currentActiveOption) {
           currentActiveOption.element.removeAttribute(DATA_ATTRIBUTE);
@@ -120,7 +120,7 @@ export function Listbox({
 
         if (nextOption) {
           nextOption.element.setAttribute(DATA_ATTRIBUTE, 'true');
-          if (scrollableRef.current) {
+          if (scrollableRef.current && isKeyboardChange) {
             const first =
               getNavigableOptions().findIndex(
                 (element) => element.id === nextOption.element.id,
@@ -224,7 +224,7 @@ export function Listbox({
       disabled: nextValidElement.getAttribute('aria-disabled') === 'true',
     };
 
-    handleChangeActiveOption(nextOption);
+    handleChangeActiveOption(nextOption, true);
   }
 
   function handleDownArrow(evt: KeyboardEvent) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4957

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This PR adds a small change to only `scroll into view` on keyboard navigation, not mouse clicks. With this fix you can click on items in the list without them jumping or "snapping" to the option, making it easy to track where you are in the list.

![autocomplete-snapping-fixed](https://user-images.githubusercontent.com/90475364/151027329-29ad0e10-cdee-43de-ae0d-221e5777a2b0.gif)


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
- Click on the `Autocomplete` and select / deselect options in the scrollable list
- When clicking an option it should remain in the same position and not jump or "snap" to the top of the scroll list
- Try using keyboard actions like the up / down arrow to navigate through the list of options and ensure this behaviour is the same as was (it should still scroll the option into view when navigating with keyboard)

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, { useCallback, useState } from 'react';

import {Stack, Tag, TextContainer} from '../src';
import { Autocomplete } from '../src';

export function Playground() {

    const deselectedOptions = [
      {value: 'option1', label: 'Option1'},
      {value: 'option2', label: 'Option2'},
      {value: 'option3', label: 'Option3'},
      {value: 'option4', label: 'Option4'},
      {value: 'option5', label: 'Option5'},
      {value: 'option6', label: 'Option6'},
      {value: 'option7', label: 'Option7'},
      {value: 'option8', label: 'Option8'},
      {value: 'option9', label: 'Option9'},
      {value: 'option10', label: 'Option10'},
      {value: 'option11', label: 'Option11'},
      {value: 'option12', label: 'Option12'},
      {value: 'option13', label: 'Option13'},
      {value: 'option14', label: 'Option14'},
      {value: 'option15', label: 'Option15'},
      {value: 'option16', label: 'Option16'},
      {value: 'option17', label: 'Option17'},
    ];
    const [selectedOptions, setSelectedOptions] = useState([]);
    const [inputValue, setInputValue] = useState('');
    const [options, setOptions] = useState(deselectedOptions);
  
    const updateText = useCallback(
      (value) => {
        setInputValue(value);
  
        if (value === '') {
          setOptions(deselectedOptions);
          return;
        }
  
        const filterRegex = new RegExp(value, 'i');
        const resultOptions = deselectedOptions.filter((option) =>
          option.label.match(filterRegex),
        );
        let endIndex = resultOptions.length - 1;
        if (resultOptions.length === 0) {
          endIndex = 0;
        }
        setOptions(resultOptions);
      },
      [deselectedOptions],
    );
  
    const removeTag = useCallback(
      (tag) => () => {
        const options = [...selectedOptions];
        options.splice(options.indexOf(tag), 1);
        setSelectedOptions(options);
      },
      [selectedOptions],
    );
  
    const tagsMarkup = selectedOptions.map((option) => {
      let tagLabel = '';
      tagLabel = option.replace('_', ' ');
      tagLabel = titleCase(tagLabel);
      return (
        <Tag key={`option${option}`} onRemove={removeTag(option)}>
          {tagLabel}
        </Tag>
      );
    });
  
    const textField = (
      <Autocomplete.TextField
        onChange={updateText}
        label="Tags"
        value={inputValue}
        placeholder="Vintage, cotton, summer"
      />
    );
  
    return (
      <div style={{height: '325px'}}>
        <TextContainer>
          <Stack>{tagsMarkup}</Stack>
        </TextContainer>
        <br />
        <Autocomplete
          allowMultiple
          options={options}
          selected={selectedOptions}
          textField={textField}
          onSelect={setSelectedOptions}
          listTitle="Suggested Tags"
        />
      </div>
    );
  
    function titleCase(string) {
      return string
        .toLowerCase()
        .split(' ')
        .map((word) => word.replace(word[0], word[0].toUpperCase()))
        .join('');
    }
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
