### PR TITLE
Remove `available-names` scss function

### DIFF
--- a/UNRELEASED-v9.md
+++ b/UNRELEASED-v9.md
@@ -37,6 +37,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Removed the ms-high-contrast-color() function and replaced any instances with values ([#4938](https://github.com/Shopify/polaris-react/pull/4938))
 - Removed the `border()` scss function ([#4934](https://github.com/Shopify/polaris-react/pull/4934))
 - Removed the font-family() function and replaced any instances with tokens ([#4940](https://github.com/Shopify/polaris-react/pull/4940))
+- Removed the `available-names()` scss function ([#4967](https://github.com/Shopify/polaris-react/pull/4967))
 
 ### New components
 

--- a/src/styles/foundation/_layout.scss
+++ b/src/styles/foundation/_layout.scss
@@ -43,36 +43,6 @@ $layout-width-data: (
   ),
 );
 
-/// Returns the list of available layout names.
-/// @param {Number} $map - The level of depth to get names from.
-/// @return {String} The list of names in the map.
-
-@function available-layout-names($level: 1) {
-  $output: '';
-  $newline: '\A ';
-
-  @if $level == 1 {
-    @each $key, $value in $layout-width-data {
-      $output: $output +
-        '#{$newline}- #{$key} #{available-layout-names($value, $level + 1)}';
-    }
-  } @else {
-    $output: '(';
-    $i: 1;
-
-    @each $key, $value in $layout-width-data {
-      $sep: if($i < length($layout-width-data), ', ', '');
-      $output: $output +
-        '#{$key}#{$sep}#{available-layout-names($value, $level + 1)}';
-      $i: $i + 1;
-    }
-
-    $output: $output + ')';
-  }
-
-  @return $output;
-}
-
 /// Returns the widths of the specified column.
 /// @param {String} $name - The column name.
 /// @return {Number} The width for the column.
@@ -83,7 +53,7 @@ $layout-width-data: (
   @if type-of($fetched-value) {
     @return $fetched-value;
   } @else {
-    @error 'Column `#{$name} - #{$value}` not found. Available columns: #{available-layout-names()}';
+    @error 'Column `#{$name} - #{$value}` not found. Available columns:\a       - primary (min, max)\a       - secondary (min, max)\a       - one-half-width (base)\a       - one-third-width (base)\a       - nav (base)\a       - page-with-nav (base)\a       - page-content (not-condensed, partially-condensed)\a       - inner-spacing (base)\a       - outer-spacing (min, max)';
   }
 }
 

--- a/src/styles/foundation/_layout.scss
+++ b/src/styles/foundation/_layout.scss
@@ -43,6 +43,36 @@ $layout-width-data: (
   ),
 );
 
+/// Returns the list of available layout names.
+/// @param {Number} $map - The level of depth to get names from.
+/// @return {String} The list of names in the map.
+
+@function available-layout-names($level: 1) {
+  $output: '';
+  $newline: '\A ';
+
+  @if $level == 1 {
+    @each $key, $value in $layout-width-data {
+      $output: $output +
+        '#{$newline}- #{$key} #{available-layout-names($value, $level + 1)}';
+    }
+  } @else {
+    $output: '(';
+    $i: 1;
+
+    @each $key, $value in $layout-width-data {
+      $sep: if($i < length($layout-width-data), ', ', '');
+      $output: $output +
+        '#{$key}#{$sep}#{available-layout-names($value, $level + 1)}';
+      $i: $i + 1;
+    }
+
+    $output: $output + ')';
+  }
+
+  @return $output;
+}
+
 /// Returns the widths of the specified column.
 /// @param {String} $name - The column name.
 /// @return {Number} The width for the column.
@@ -53,7 +83,7 @@ $layout-width-data: (
   @if type-of($fetched-value) {
     @return $fetched-value;
   } @else {
-    @error 'Column `#{$name} - #{$value}` not found. Available columns: #{available-names($layout-width-data)}';
+    @error 'Column `#{$name} - #{$value}` not found. Available columns: #{available-layout-names()}';
   }
 }
 

--- a/src/styles/foundation/_utilities.scss
+++ b/src/styles/foundation/_utilities.scss
@@ -1,37 +1,3 @@
-/// Returns the list of available names in a given map.
-/// @param {Map} $map - The map of data to list the names from.
-/// @param {Number} $map - The level of depth to get names from.
-/// @return {String} The list of names in the map.
-
-@function available-names($map, $level: 1) {
-  @if type-of($map) != 'map' {
-    @return null;
-  }
-
-  $output: '';
-  $newline: '\A ';
-
-  @if $level == 1 {
-    @each $key, $value in $map {
-      $output: $output +
-        '#{$newline}- #{$key} #{available-names($value, $level + 1)}';
-    }
-  } @else {
-    $output: '(';
-    $i: 1;
-
-    @each $key, $value in $map {
-      $sep: if($i < length($map), ', ', '');
-      $output: $output + '#{$key}#{$sep}#{available-names($value, $level + 1)}';
-      $i: $i + 1;
-    }
-
-    $output: $output + ')';
-  }
-
-  @return $output;
-}
-
 // Merge multiple maps into one.
 // @param {Map} $map - Initial default map.
 // @param {ArgList} $maps - Other maps to merge.


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4920

### WHAT is this pull request doing?

`available-names` is only used by `layout-width` for an error message. This pr removes the `available-names` function and hard codes the error message for `layout-width` as follows:

```
SassError: Column `primary - max` not found. Available columns:
             - primary (min, max)
             - secondary (min, max)
             - one-half-width (base)
             - one-third-width (base)
             - nav (base)
             - page-with-nav (base)
             - page-content (not-condensed, partially-condensed)
             - inner-spacing (base)
             - outer-spacing (min, max)
        on line 56 of src/styles/foundation/_layout.scss, in function `layout-width`
```