### PR TITLE
Refactor visually hidden

### DIFF
--- a/src/components/AppProvider/AppProvider.scss
+++ b/src/components/AppProvider/AppProvider.scss
@@ -3,6 +3,7 @@
 // components then this css shall always be present.
 
 @import '../../styles/common';
+@import '../../styles/utilities.scss';
 
 :root {
   --polaris-version-number: '{{POLARIS_VERSION}}';

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -7,8 +7,6 @@
 
 // stylelint-disable selector-max-specificity, selector-max-class
 .Input {
-  @include visually-hidden;
-
   &.keyFocused {
     + .Backdrop {
       @include focus-ring($style: 'focused');

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -143,6 +143,7 @@ export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
       styles.Input,
       isIndeterminate && styles['Input-indeterminate'],
       keyFocused && styles.keyFocused,
+      'polaris-visually-hidden',
     );
 
     return (

--- a/src/components/Checkbox/README.md
+++ b/src/components/Checkbox/README.md
@@ -134,6 +134,24 @@ function CheckboxExample() {
 
 <!-- /content-for -->
 
+### Checkbox with label hidden
+
+```jsx
+function CheckboxExample() {
+  const [checked, setChecked] = useState(false);
+  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+
+  return (
+    <Checkbox
+      label="Basic checkbox"
+      checked={checked}
+      onChange={handleChange}
+      labelHidden={true}
+    />
+  );
+}
+```
+
 ---
 
 ## Related components

--- a/src/components/Choice/Choice.scss
+++ b/src/components/Choice/Choice.scss
@@ -10,10 +10,6 @@
 .labelHidden {
   padding: 0;
 
-  > .Label {
-    @include visually-hidden;
-  }
-
   .Control {
     margin-top: 0;
     margin-right: 0;

--- a/src/components/Choice/Choice.tsx
+++ b/src/components/Choice/Choice.tsx
@@ -56,7 +56,14 @@ export function Choice({
       onMouseOut={onMouseOut}
     >
       <span className={styles.Control}>{children}</span>
-      <span className={styles.Label}>{label}</span>
+      <span
+        className={classNames(
+          styles.Label,
+          labelHidden && 'polaris-visually-hidden',
+        )}
+      >
+        {label}
+      </span>
     </label>
   );
 

--- a/src/components/VisuallyHidden/VisuallyHidden.scss
+++ b/src/components/VisuallyHidden/VisuallyHidden.scss
@@ -1,5 +1,14 @@
-@import '../../styles/common';
-
 .VisuallyHidden {
-  @include visually-hidden;
+  // Need to make sure we override any existing styles.
+  // stylelint-disable declaration-no-important
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important;
+  // stylelint-enable declaration-no-important
 }

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -1,0 +1,14 @@
+:global(.polaris-visually-hidden) {
+  // Need to make sure we override any existing styles.
+  // stylelint-disable declaration-no-important
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important;
+  // stylelint-enable declaration-no-important
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4922

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Creates a `polaris-visually-hidden` global utility class
- Remove `visually-hidden` sass mixin
- Refactors components with usage of `visually-hidden` sass mixin to use global utillity class or `VisuallyHidden` component

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
