### PR TITLE
[DataTable] Fix table row border bottom

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Fixed `segmented` `ButtonGroup` misaligning icon only buttons when grouped with text only buttons ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
 - Added missing styles for `destructive` `Page` `secondaryActions` ([#4647](https://github.com/Shopify/polaris-react/pull/4647))
 - Removed `min-height` from `Page` `additionalNavigation` ([#4952](https://github.com/Shopify/polaris-react/pull/4952))
+- Fixed overly dark `bottom-border` on `DataTable` header cell and total cell. ([#4975])(https://github.com/Shopify/polaris-react/pull/4975)
 
 ### Documentation
 

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -92,7 +92,7 @@ $breakpoint: 768px;
 
 .Cell-header {
   @include text-emphasis-normal;
-  border-bottom: border(dark);
+  border-bottom: border('divider');
   border-top: 0;
 }
 
@@ -165,7 +165,7 @@ $breakpoint: 768px;
 .Cell-total {
   @include text-emphasis-strong;
   background: var(--p-surface-subdued);
-  border-bottom: border();
+  border-bottom: border('divider');
 }
 
 .Cell-total-footer {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4972.

DataTable headers had a border bottom color that was inconsistent with the way other tables looked.

### WHAT is this pull request doing?

Sets the bottom border to `divider`.
    <details>
      <summary>Data table border before</summary>
      <img src="https://user-images.githubusercontent.com/26749317/151436694-dce112fb-bdbe-425c-8de3-aba658922360.png" alt="Before picture of darker bottom border">
    </details>
    <details>
      <summary>Data table border after</summary>
      <img src="https://user-images.githubusercontent.com/26749317/151436693-588bc0ed-5a4e-429e-8795-6479a7c4c7cd.png" alt="After picture of consistent bottom border">
    </details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
