### PR TITLE
[Autocomplete] remove min-height on action

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,8 +6,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
-- [ColorPicker] Add an inset box-shadow to make it easier to see the draggers ([#4948](https://github.com/Shopify/polaris-react/pull/4948))
-
+- Add an inset box-shadow to `ColorPicker` to make it easier to see the draggers ([#4948](https://github.com/Shopify/polaris-react/pull/4948))
 - Tightened up the Navigation component UI density. ([#4874](https://github.com/Shopify/polaris-react/pull/4874))
 - Updated the Navigation IA ([#4902](https://github.com/Shopify/polaris-react/pull/4902))
 - Added new `duplicateRootItem` prop to a Navigation Section to support new mobile Navigation IA ([#4902](https://github.com/Shopify/polaris-react/pull/4902))
@@ -18,13 +17,14 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Fixed `segmented` `ButtonGroup` misaligning icon only buttons when grouped with text only buttons ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
 - Added missing styles for `destructive` `Page` `secondaryActions` ([#4647](https://github.com/Shopify/polaris-react/pull/4647))
 - Removed `min-height` from `Page` `additionalNavigation` ([#4952](https://github.com/Shopify/polaris-react/pull/4952))
-- Fixed overly dark `bottom-border` on `DataTable` header cell and total cell. ([#4975])(https://github.com/Shopify/polaris-react/pull/4975)
+- Fixed overly dark `bottom-border` on `DataTable` header cell and total cell ([#4975](https://github.com/Shopify/polaris-react/pull/4975))
+- Removed `min-height` on `Autocomplete` `action` ([#4977](https://github.com/Shopify/polaris-react/pull/4977))
 
 ### Documentation
 
 ### Development workflow
 
-- Improve error logging in the event of sass errors. ([#4954](https://github.com/Shopify/polaris-react/pull/4954))
+- Improve error logging in the event of sass errors ([#4954](https://github.com/Shopify/polaris-react/pull/4954))
 
 ### Dependency upgrades
 

--- a/src/components/Autocomplete/components/MappedAction/MappedAction.scss
+++ b/src/components/Autocomplete/components/MappedAction/MappedAction.scss
@@ -1,8 +1,6 @@
 @import '../../../../styles/common';
 
 $image-size: rem(20px);
-$item-min-height: rem(40px);
-$item-vertical-padding: ($item-min-height - line-height(body)) / 2;
 
 .ActionContainer {
   margin-bottom: spacing(base-tight);
@@ -22,7 +20,6 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   @include focus-ring;
   display: block;
   width: 100%;
-  min-height: $item-min-height;
   text-align: left;
   cursor: pointer;
 


### PR DESCRIPTION

### WHY are these changes introduced?

The MappedAction in the Autocomplete, which wraps the Listbox.Action, had styles that were interfering the listbox actions

**before**
<img width="234" alt="Screen Shot 2022-01-28 at 12 54 41 PM" src="https://user-images.githubusercontent.com/1229901/151604135-f4a883b6-ec53-44bc-94d5-a93cd2e2605e.png">


**after**
<img width="267" alt="Screen Shot 2022-01-28 at 12 51 04 PM" src="https://user-images.githubusercontent.com/1229901/151604137-05f65a41-180f-41de-a617-9ea6e20af857.png">

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
