### PR TITLE
feat: Add Typography component

### DIFF
--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -95,6 +95,7 @@ import {
   FormLayout,
   Frame,
   Heading,
+  Typography,
   Icon,
   Image,
   IndexTable,
@@ -356,7 +357,8 @@ function filterMarkdownForPlatform(markdown, platform) {
     `<!-- content-for: (?:[\\w\\s,]*${platform}[\\w\\s,]*) -->([\\s\\S]+?)<!-- \\/content-for -->`,
     'gu',
   );
-  const deleteRemainingPlatformsRegExp = /<!-- content-for: [\w\s,]+ -->[\s\S]+?<!-- \/content-for -->/gu;
+  const deleteRemainingPlatformsRegExp =
+    /<!-- content-for: [\w\s,]+ -->[\s\S]+?<!-- \/content-for -->/gu;
 
   return (
     markdown

--- a/src/components/Typography/README.md
+++ b/src/components/Typography/README.md
@@ -1,0 +1,76 @@
+---
+name: Typography
+category: Titles and text
+platforms:
+  - android
+  - ios
+  - web
+keywords:
+  - titles
+  - text
+  - microcopy
+  - conversational
+  - typographic
+  - card headings
+  - card titles
+  - section titles
+  - section headings
+  - heading text
+  - heading font
+  - android
+  - ios
+---
+
+# Typography
+
+Generic typography component encapsulating an opinionated collection of design token groups.
+
+---
+
+## Examples
+
+### Typography default
+
+Render the body variant by default with a paragraph tag.
+
+```jsx
+<Typography>The quick brown fox jumps over the lazy dog</Typography>
+```
+
+### Typography heading
+
+Setting a variant will apply a collection of design tokens and a predefined HTML element.
+
+```jsx
+<Typography variant="heading">
+  The quick brown fox jumps over the lazy dog
+</Typography>
+```
+
+### Typography polymorphic
+
+Use the `as` prop to override the default HTML element associated with each variant.
+
+```jsx
+<Typography variant="heading" as="span">
+  The quick brown fox jumps over the lazy dog
+</Typography>
+```
+
+### Typography noWrap
+
+Truncate text with an ellipsis.
+
+```jsx
+<Typography noWrap>The quick brown fox jumps over the lazy dog</Typography>
+```
+
+### Typography color
+
+Convenience prop for applying Polaris design tokens.
+
+```jsx
+<Typography color="action-primary">
+  The quick brown fox jumps over the lazy dog
+</Typography>
+```

--- a/src/components/Typography/Typography.scss
+++ b/src/components/Typography/Typography.scss
@@ -1,0 +1,186 @@
+@import '../../styles/common';
+
+$breakpoints-md: 640px;
+
+.root {
+  margin: 0;
+}
+
+.inherit {
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+  }
+}
+
+.body {
+  font-size: var(--p-font-size-4);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-line-height-2);
+
+  text-transform: initial;
+  letter-spacing: initial;
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-3);
+  }
+}
+
+.caption {
+  font-size: var(--p-font-size-2);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-line-height-2);
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-1);
+    line-height: var(--p-line-height-1);
+  }
+}
+
+.heading {
+  font-size: var(--p-font-size-6);
+  font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-line-height-3);
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-5);
+  }
+}
+
+.subheading {
+  font-size: var(--p-font-size-2);
+  font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-line-height-1);
+  text-transform: uppercase;
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-1);
+  }
+}
+
+.input {
+  font-size: var(--p-font-size-5);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-line-height-3);
+  border: none; // TODO: Investigate why is this is here.
+
+  text-transform: initial;
+  letter-spacing: initial;
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-3);
+  }
+}
+
+.button {
+  font-size: var(--p-font-size-4);
+  font-weight: var(--p-font-weight-medium);
+  line-height: var(--p-line-height-1);
+
+  text-transform: initial;
+  letter-spacing: initial;
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-3);
+  }
+}
+
+.buttonLarge {
+  font-size: var(--p-font-size-6);
+  font-weight: var(--p-font-weight-medium);
+  line-height: var(--p-line-height-2);
+
+  text-transform: initial;
+  letter-spacing: initial;
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-5);
+  }
+}
+
+.displayExtraLarge {
+  font-size: var(--p-font-size-11);
+  font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-line-height-6);
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-13);
+    line-height: var(--p-line-height-7);
+  }
+}
+
+.displayLarge {
+  font-size: var(--p-font-size-9);
+  font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-line-height-4);
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-12);
+    line-height: var(--p-line-height-5);
+  }
+}
+
+.displayMedium {
+  font-size: var(--p-font-size-8);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-line-height-4);
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-10);
+    line-height: var(--p-line-height-5);
+  }
+}
+
+.displaySmall {
+  font-size: var(--p-font-size-5);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-line-height-3);
+
+  @include breakpoint-after($breakpoints-md) {
+    font-size: var(--p-font-size-7);
+    line-height: var(--p-line-height-4);
+  }
+}
+
+.noWrap {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.breakword {
+  word-wrap: break-word;
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+.printHidden {
+  @media print {
+    // stylelint-disable-next-line declaration-no-important
+    display: none !important;
+  }
+}
+
+// TODO: Can we get rid of these?
+
+.emphasis-subdued {
+  color: var(--p-text-subdued);
+}
+
+.emphasis-strong {
+  font-weight: var(--p-font-weight-semibold);
+}
+
+.emphasis-normal {
+  font-weight: var(--p-font-weight-regular);
+  color: var(--p-text);
+}

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+import {classNames} from '../../utilities/css';
+
+import styles from './Typography.scss';
+import type {
+  PolymorphicRef,
+  PolymorphicComponentPropsWithRef,
+} from './polymorphic';
+
+type Variant =
+  | 'inherit'
+  | 'body'
+  | 'caption'
+  | 'heading'
+  | 'subheading'
+  | 'input'
+  | 'button'
+  | 'buttonLarge'
+  | 'displayExtraLarge'
+  | 'displayMedium'
+  | 'displaySmall';
+
+const defaultVariantMapping: {[V in Variant]: string} = {
+  inherit: 'span',
+  body: 'p',
+  caption: 'span',
+  heading: 'h2',
+  subheading: 'h3',
+  input: 'span',
+  button: 'span',
+  buttonLarge: 'span',
+  displayExtraLarge: 'h2',
+  displayMedium: 'h3',
+  displaySmall: 'h4',
+};
+
+interface Props {
+  children: React.ReactNode;
+  color?: string;
+  noWrap?: boolean;
+  breakword?: boolean;
+  printHidden?: boolean;
+  variant?: Variant;
+  emphasis?: 'normal' | 'subdued' | 'strong';
+}
+
+export type TypographyProps<TElement extends React.ElementType> =
+  PolymorphicComponentPropsWithRef<TElement, Props>;
+
+type TypographyComponent = {displayName?: string} & (<
+  TElement extends React.ElementType = 'p',
+>(
+  props: TypographyProps<TElement>,
+) => React.ReactElement | null);
+
+export const Typography: TypographyComponent = React.forwardRef(
+  <TElement extends React.ElementType = 'p'>(
+    {
+      as,
+      color,
+      style,
+      className,
+      emphasis,
+      variant = 'body',
+      noWrap = false,
+      breakword = false,
+      printHidden = false,
+      ...restProps
+    }: TypographyProps<TElement>,
+    ref?: PolymorphicRef<TElement>,
+  ) => {
+    const Component = as || defaultVariantMapping[variant] || 'p';
+
+    return (
+      <Component
+        {...restProps}
+        ref={ref}
+        className={classNames(
+          styles.root,
+          styles[variant],
+          emphasis && styles[`emphasis-${emphasis}`],
+          noWrap && styles.noWrap,
+          breakword && styles.breakword,
+          printHidden && styles.printHidden,
+          className,
+        )}
+        style={{
+          ...style,
+          ...(color && {color: `var(--p-${color})`}),
+        }}
+      />
+    );
+  },
+);
+
+Typography.displayName = 'Typography';

--- a/src/components/Typography/index.ts
+++ b/src/components/Typography/index.ts
@@ -1,0 +1,1 @@
+export * from './Typography';

--- a/src/components/Typography/polymorphic.ts
+++ b/src/components/Typography/polymorphic.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
+// A more precise version of just React.ComponentPropsWithoutRef on its own
+export type PropsOf<
+  TElement extends
+    | keyof JSX.IntrinsicElements
+    | React.JSXElementConstructor<any>,
+> = JSX.LibraryManagedAttributes<
+  TElement,
+  React.ComponentPropsWithoutRef<TElement>
+>;
+
+interface AsProp<TComponent extends React.ElementType> {
+  /**
+   * An override of the default HTML tag.
+   * Can also be another React component.
+   */
+  as?: TComponent;
+}
+
+/**
+ * Allows for extending a set of props (`TExtendedProps`) by an overriding set of props
+ * (`TOverrideProps`), ensuring that any duplicates are overridden by the overriding
+ * set of props.
+ */
+export type ExtendableProps<
+  TExtendedProps = {},
+  TOverrideProps = {},
+> = TOverrideProps & Omit<TExtendedProps, keyof TOverrideProps>;
+
+/**
+ * Allows for inheriting the props from the specified element type so that
+ * props like children, className & style work, as well as element-specific
+ * attributes like aria roles. The component (`TElement`) must be passed in.
+ */
+export type InheritableElementProps<
+  TElement extends React.ElementType,
+  TProps = {},
+> = ExtendableProps<PropsOf<TElement>, TProps>;
+
+/**
+ * A more sophisticated version of `InheritableElementProps` where
+ * the passed in `as` prop will determine which props can be included
+ */
+export type PolymorphicComponentProps<
+  TElement extends React.ElementType,
+  TProps = {},
+> = InheritableElementProps<TElement, TProps & AsProp<TElement>>;
+
+/**
+ * Utility type to extract the `ref` prop from a polymorphic component
+ */
+export type PolymorphicRef<TElement extends React.ElementType> =
+  React.ComponentPropsWithRef<TElement>['ref'];
+/**
+ * A wrapper of `PolymorphicComponentProps` that also includes the `ref`
+ * prop for the polymorphic component
+ */
+export type PolymorphicComponentPropsWithRef<
+  TElement extends React.ElementType,
+  TProps = {},
+> = PolymorphicComponentProps<TElement, TProps> & {
+  ref?: PolymorphicRef<TElement>;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,6 +356,9 @@ export type {TrapFocusProps} from './components/TrapFocus';
 export {Truncate} from './components/Truncate';
 export type {TruncateProps} from './components/Truncate';
 
+export {Typography} from './components/Typography';
+export type {TypographyProps} from './components/Typography';
+
 export {UnstyledButton, unstyledButtonFrom} from './components/UnstyledButton';
 export type {UnstyledButtonProps} from './components/UnstyledButton';
 


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #4932 

### WHAT is this pull request doing?

This PR removes the `shared/_typography.scss` mixins and re-exposes their behavior through a new `Typography` component. There a number of improvements we can make to the `Typography` component (such as: adding/removing variants, removing the emphasis prop, consolidating the existing `Heading` and `TextStyles` components, etc.), but this PR primarily focuses on maintaining backward compatibility with the `shared/_typography.scss` utilities.

TODO:
- [ ] Write tests
- [ ] Refine the README and storybook entries
- [ ] (Optional) Swap out polymorphic utilities with a library (such as: https://www.radix-ui.com/docs/primitives/utilities/polymorphic)

### How to 🎩

To top hat, simply checkout the `feat/typography-component` branch, run `dev up && yarn storybook`, and navigate to the `Typography` storybook entries.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
