### PR TITLE
[ContextualSaveBar] Add `secondaryMenu` prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated mobile behaviour of Navigation to only show one sub-section at a time ([#4902](https://github.com/Shopify/polaris-react/pull/4902))
 - Remove the info icon and external link guidance from FooterHelp ([#4982](https://github.com/Shopify/polaris-react/pull/4982))
 - Normalise spacing around the `Header` within the `Page` ([#4911](https://github.com/Shopify/polaris-react/pull/4911))
+- Added a `secondaryMenu` prop to the `ContextualSaveBar` component ([#5018](https://github.com/Shopify/polaris-react/pull/5018))
 
 ### Bug fixes
 

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -21,6 +21,7 @@ export function ContextualSaveBar({
   discardAction,
   fullWidth,
   contextControl,
+  secondaryMenu,
 }: ContextualSaveBarProps) {
   const i18n = useI18n();
   const {logo} = useTheme();
@@ -121,6 +122,7 @@ export function ContextualSaveBar({
             <h2 className={styles.Message}>{message}</h2>
             <div className={styles.ActionContainer}>
               <Stack spacing="tight" wrap={false}>
+                {secondaryMenu}
                 {discardActionMarkup}
                 {saveActionMarkup}
               </Stack>

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -285,6 +285,15 @@ describe('<ContextualSaveBar />', () => {
     });
   });
 
+  it('renders the secondaryMenu prop', () => {
+    const expectedContent = 'some content';
+    const contextualSaveBar = mountWithApp(
+      <ContextualSaveBar secondaryMenu={<>{expectedContent}</>} />,
+    );
+
+    expect(contextualSaveBar).toContainReactText(expectedContent);
+  });
+
   it('renders a ThemeProvider with inverted theme', () => {
     const contextualSaveBar = mountWithApp(<ContextualSaveBar />);
     expect(contextualSaveBar).toContainReactComponent(ThemeProvider, {

--- a/src/utilities/frame/types.ts
+++ b/src/utilities/frame/types.ts
@@ -34,7 +34,7 @@ export interface ContextualSaveBarProps {
   fullWidth?: boolean;
   /** Accepts a component that is used to help users switch between different contexts */
   contextControl?: React.ReactNode;
-  /** Accepts a node that is rendered before the discard and save actions */
+  /** Accepts a node that is rendered to the left of the discard and save actions */
   secondaryMenu?: React.ReactNode;
 }
 

--- a/src/utilities/frame/types.ts
+++ b/src/utilities/frame/types.ts
@@ -34,6 +34,8 @@ export interface ContextualSaveBarProps {
   fullWidth?: boolean;
   /** Accepts a component that is used to help users switch between different contexts */
   contextControl?: React.ReactNode;
+  /** Accepts a node that is rendered before the discard and save actions */
+  secondaryMenu?: React.ReactNode;
 }
 
 // Toast


### PR DESCRIPTION
### WHAT is this pull request doing?

Ref: Shopify/growth-activation#2363

Adds a new optional `secondaryMenu` prop to the `ContextualSaveBar` component that enables consumers render any valid react node before the save and discard actions. This is particularly needed for the Setup Guide experience (see [this thread](https://shopify.slack.com/archives/C4Y8N30KD/p1643737450254329)).

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Button, ContextualSaveBar} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ContextualSaveBar
        secondaryMenu={<Button>Setup Guide</Button>}
        discardAction={{content: 'Discard'}}
        saveAction={{content: 'Save'}}
      />
    </Page>
  );
}
```

</details>

Confirm that a button that says "Setup Guide" is rendered before the discard and save buttons

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
