### PR TITLE
Create migration guidance for `easing()` function

### DIFF
--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -91,14 +91,14 @@ A list of functions/mixins and their value equivalents or new token values.
 
 #### `easing()`
 
-| Function                 | Replacement Value/Token              |
-| ------------------------ | ------------------------------------ |
-| easing()<br>easing(base) | var(--p-ease)                        |
-| easing(in)               | var(--p-ease-in)                     |
-| easing(out)              | var(--p-ease-out)                    |
-| easing(excite)           | var(--p-ease-excite)                 |
-| easing(overshoot)        | cubic-bezier(0.07, 0.28, 0.32, 1.22) |
-| easing(anticipate)       | cubic-bezier(0.38, -0.4, 0.88, 0.65) |
+| Function                     | Replacement Value/Token                |
+| ---------------------------- | -------------------------------------- |
+| `easing()`<br>`easing(base)` | `var(--p-ease)`                        |
+| `easing(in)`                 | `var(--p-ease-in)`                     |
+| `easing(out)`                | `var(--p-ease-out)`                    |
+| `easing(excite)`             | `var(--p-ease-excite)`                 |
+| `easing(overshoot)`          | `cubic-bezier(0.07, 0.28, 0.32, 1.22)` |
+| `easing(anticipate)`         | `cubic-bezier(0.38, -0.4, 0.88, 0.65)` |
 
 ## Removal of the public scss api
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -39,6 +39,31 @@ const App = (props) => (
 )
 ```
 
+## Sass functions and mixins
+
+The following sass functions and mixins have been removed. You will either need to add the functions to your repo or replace all function instances with values.
+
+### Adding the functions to your repo
+
+To help you quickly add these functions back to your repo, we've created a css file with all the removed functions.
+
+[✨ Amazing mega file linked here ✨]
+
+### Replacing function instances with values or tokens
+
+To help you replace function instances in your repo, we've provided the following list of functions and their value equivalents or new token values.
+
+#### `easing()`
+
+| Function                 | Replacement Value/Token              |
+| ------------------------ | ------------------------------------ |
+| easing()<br>easing(base) | var(--p-ease)                        |
+| easing(in)               | var(--p-ease-in)                     |
+| easing(out)              | var(--p-ease-out)                    |
+| easing(excite)           | var(--p-ease-excite)                 |
+| easing(overshoot)        | cubic-bezier(0.07, 0.28, 0.32, 1.22) |
+| easing(anticipate)       | cubic-bezier(0.38, -0.4, 0.88, 0.65) |
+
 ## Removal of the public scss api
 
 Any functions that were being consumed from `build/styles/_public-api.scss` have been removed. The functions can be found in the following permalinks.

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -87,7 +87,7 @@ To help you quickly add these functions and mixins back to your repo, we've crea
 
 ### Replacing function and mixin instances with values or tokens
 
-To help you replace function and mixin instances in your repo, we've provided the following list of functions/mixins and their value equivalents or new token values.
+A list of functions/mixins and their value equivalents or new token values.
 
 #### `easing()`
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -43,15 +43,15 @@ const App = (props) => (
 
 The following sass functions and mixins have been removed. You will either need to add the functions to your repo or replace all function instances with values.
 
-### Adding the functions to your repo
+### Adding the functions and mixins to your repo
 
-To help you quickly add these functions back to your repo, we've created a css file with all the removed functions.
+To help you quickly add these functions and mixins back to your repo, we've created a css file with all the removed functions and mixins.
 
 [✨ Amazing mega file linked here ✨]
 
-### Replacing function instances with values or tokens
+### Replacing function and mixin instances with values or tokens
 
-To help you replace function instances in your repo, we've provided the following list of functions and their value equivalents or new token values.
+To help you replace function and mixin instances in your repo, we've provided the following list of functions/mixins and their value equivalents or new token values.
 
 #### `easing()`
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5030  <!-- link to issue if one exists -->


### WHAT is this pull request doing?

- Creating a new _Sass functions and mixins_ section in our migration guide
- Adding documentation for the [removal of the `easing()` function](https://github.com/Shopify/polaris-react/pull/4698/files) to our migration guide