### PR TITLE
Create migration guidance for `duration()` function

### DIFF
--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -93,10 +93,10 @@ A list of functions/mixins and their value equivalents or new token values.
 
 | Function                     | Replacement Value/Token                |
 | ---------------------------- | -------------------------------------- |
-| `easing()`<br>`easing(base)` | `var(--p-ease)`                        |
-| `easing(in)`                 | `var(--p-ease-in)`                     |
-| `easing(out)`                | `var(--p-ease-out)`                    |
-| `easing(excite)`             | `var(--p-ease-excite)`                 |
+| `easing()`<br>`easing(base)` | `--p-ease`                             |
+| `easing(in)`                 | `--p-ease-in`                          |
+| `easing(out)`                | `--p-ease-out`                         |
+| `easing(excite)`             | `--p-ease-excite`                      |
 | `easing(overshoot)`          | `cubic-bezier(0.07, 0.28, 0.32, 1.22)` |
 | `easing(anticipate)`         | `cubic-bezier(0.38, -0.4, 0.88, 0.65)` |
 
@@ -105,11 +105,11 @@ A list of functions/mixins and their value equivalents or new token values.
 | Function                         | Replacement Value/Token |
 | -------------------------------- | ----------------------- |
 | `duration(none)`                 | 0                       |
-| `duration(fast)`                 | `var(--p-duration-100)` |
-| `duration()`<br>`duration(base)` | `var(--p-duration-200)` |
-| `duration(slow)`                 | `var(--p-duration-300)` |
-| `duration(slower)`               | `var(--p-duration-400)` |
-| `duration(slowest)`              | `var(--p-duration-500)` |
+| `duration(fast)`                 | `--p-duration-100`      |
+| `duration()`<br>`duration(base)` | `--p-duration-200`      |
+| `duration(slow)`                 | `--p-duration-300`      |
+| `duration(slower)`               | `--p-duration-400`      |
+| `duration(slowest)`              | `--p-duration-500`      |
 
 ## Removal of the public scss api
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -111,6 +111,15 @@ A list of functions/mixins and their value equivalents or new token values.
 | `duration(slower)`               | `--p-duration-400`      |
 | `duration(slowest)`              | `--p-duration-500`      |
 
+## Tokens
+
+### Duration
+
+| Token                | Replacement Value/Token |
+| -------------------- | ----------------------- |
+| `--p-duration-1-0-0` | `--p-duration-100`      |
+| `--p-duration-1-5-0` | `--p-duration-150`      |
+
 ## Removal of the public scss api
 
 Any functions that were being consumed from `build/styles/_public-api.scss` have been removed. The functions can be found in the following permalinks.

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -100,6 +100,17 @@ A list of functions/mixins and their value equivalents or new token values.
 | `easing(overshoot)`          | `cubic-bezier(0.07, 0.28, 0.32, 1.22)` |
 | `easing(anticipate)`         | `cubic-bezier(0.38, -0.4, 0.88, 0.65)` |
 
+#### `duration()`
+
+| Function                         | Replacement Value/Token |
+| -------------------------------- | ----------------------- |
+| `duration(none)`                 | 0                       |
+| `duration(fast)`                 | `var(--p-duration-100)` |
+| `duration()`<br>`duration(base)` | `var(--p-duration-200)` |
+| `duration(slow)`                 | `var(--p-duration-300)` |
+| `duration(slower)`               | `var(--p-duration-400)` |
+| `duration(slowest)`              | `var(--p-duration-500)` |
+
 ## Removal of the public scss api
 
 Any functions that were being consumed from `build/styles/_public-api.scss` have been removed. The functions can be found in the following permalinks.


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5031 <!-- link to issue if one exists -->


### WHAT is this pull request doing?

- Adding documentation for the`duration()` function to our migration guide

<hr>

### Helpful Reference PRs/Files

- #4699
- [polaris-tokens/dist/duration.map.scss](https://github.com/Shopify/polaris-tokens/blob/main/dist/duration.map.scss)
- [polaris-react/documentation/Color system.md](https://github.com/Shopify/polaris-react/blob/main/documentation/Color%20system.md)