### PR TITLE
Migration guidance for `px()`

### DIFF
--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -154,7 +154,7 @@ A list of functions/mixins and their value equivalents or new token values.
 This function has been deprecated, but the definition can be copied and used locally.
 | Function | Source |
 | -------- | -------------------- |
-| `em()` | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss#L333) |
+| `em()` | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss#L333-L352) |
 
 #### `easing()`
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -190,6 +190,10 @@ We replaced a few of the following filter function instances with color tokens i
 | `ms-high-contrast-color('button-text-background')`   | `buttonFace`            |
 | `ms-high-contrast-color('background')`               | `window`                |
 
+#### `px()`
+
+All `px` values are now automatically converted to `rem` through our postcss config with the `postcss-pxtorem` plugin.
+
 #### `shadow()`
 
 | Function                     | Replacement Value/Token  |

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -273,15 +273,15 @@ For `<border-width>` instances that are hard coded values, see if you can replac
 This function has been deprecated, but the definition can be copied and used locally.
 | Function | Source |
 | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `px()` | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss#L313) |
+| `px()` | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss##L313-L331) |
 
 #### `rem()`
 
 This function has been deprecated, but the definition can be copied and used locally.
 
-| Function | Source                                                                                                                                                           |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `rem()`  | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss#L293) |
+| Function | Source                                                                                                                                                                |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rem()`  | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss#L293-L311) |
 
 #### `shadow()`
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -192,7 +192,9 @@ We replaced a few of the following filter function instances with color tokens i
 
 #### `px()`
 
-All `px` values are now automatically converted to `rem` through our postcss config with the `postcss-pxtorem` plugin.
+| Function | Source to copy       |
+| -------- | -------------------- |
+| `px()`   | [link to function]() |
 
 #### `shadow()`
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -231,9 +231,10 @@ We replaced a few of the following filter function instances with color tokens i
 
 #### `px()`
 
-| Function | Source to copy       |
-| -------- | -------------------- |
-| `px()`   | [link to function]() |
+This function has been deprecated, but the definition can be copied and used locally.
+| Function | Source |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `px()` | [definition](https://github.com/Shopify/polaris-react/blob/a75c305d2cc4b72808d6d9f7302d479c68178706/documentation/guides/legacy-polaris-v8-public-api.scss#L317) |
 
 #### `shadow()`
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -232,9 +232,10 @@ We replaced a few of the following filter function instances with color tokens i
 #### `px()`
 
 This function has been deprecated, but the definition can be copied and used locally.
-| Function | Source |
-| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `px()` | [definition](https://github.com/Shopify/polaris-react/blob/a75c305d2cc4b72808d6d9f7302d479c68178706/documentation/guides/legacy-polaris-v8-public-api.scss#L317) |
+
+| Function | Source                                                                                                                                                           |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `px()`   | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss#L313) |
 
 #### `shadow()`
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5021 

### WHAT is this pull request doing?
Add migration guidance around the deprecation of `px()`
