### PR TITLE
[ColorPicker] Make draggers easier to discern on light color scheme

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
-### Enhancements
+- [ColorPicker] Add an inset box-shadow to make it easier to see the draggers ([#4948](https://github.com/Shopify/polaris-react/pull/4948))
 
 ### Bug fixes
 

--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -14,16 +14,16 @@
   --pc-color-picker-z-index: 10;
   --pc-color-picker-adjustments: 20;
   --pc-color-picker-dragger: 30;
-  --pc-color-picker-inner-shadow: inset 0 0 2px 0 rgba(0, 0, 0, 0.5);
-  --pc-color-picker-dragger-shadow: inset 0 0.5px 2px 0 rgba(0, 0, 0, 0.4),
-    0 0.5px 3px 0 rgba(0, 0, 0, 0.4);
+  --pc-color-picker-inner-shadow: inset 0 0 2px 0 var(--p-shadow-color-picker);
+  --pc-color-picker-dragger-shadow: inset 0 1px 2px 0
+      var(--p-shadow-color-picker-dragger),
+    0 1px 2px 0 var(--p-shadow-color-picker-dragger);
   user-select: none;
   display: flex;
 }
 
 .MainColor {
   @include checkers;
-  @include high-contrast-outline;
   position: relative;
   overflow: hidden;
   height: var(--pc-color-picker-size);
@@ -98,17 +98,17 @@ $huepicker-padding: var(--pc-color-picker-dragger-size);
 $huepicker-bottom-padding-start: calc(
   var(--pc-color-picker-size) - var(--pc-color-picker-dragger-size)
 );
+$vertical-picker-border-radius: calc(var(--pc-color-picker-size) * 0.5);
 
 .HuePicker,
 .AlphaPicker {
-  @include high-contrast-outline;
   position: relative;
   overflow: hidden;
   height: var(--pc-color-picker-size);
   width: var(--p-space-6);
   margin-left: var(--p-space-2);
   border-width: var(--p-border-radius-1);
-  border-radius: calc(var(--pc-color-picker-size) * 0.5);
+  border-radius: $vertical-picker-border-radius;
 
   &::after {
     content: '';
@@ -120,7 +120,7 @@ $huepicker-bottom-padding-start: calc(
     height: 100%;
     width: 100%;
     pointer-events: none;
-    border-radius: calc(var(--pc-color-picker-size) * 0.5);
+    border-radius: $vertical-picker-border-radius;
     box-shadow: var(--pc-color-picker-inner-shadow);
   }
 

--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -23,6 +23,7 @@
 
 .MainColor {
   @include checkers;
+  @include high-contrast-outline;
   position: relative;
   overflow: hidden;
   height: var(--pc-color-picker-size);
@@ -100,6 +101,7 @@ $huepicker-bottom-padding-start: calc(
 
 .HuePicker,
 .AlphaPicker {
+  @include high-contrast-outline;
   position: relative;
   overflow: hidden;
   height: var(--pc-color-picker-size);

--- a/src/tokens/token-groups/color.dark.json
+++ b/src/tokens/token-groups/color.dark.json
@@ -20,6 +20,8 @@
   "shadow-from-dim-light": "rgba(255, 255, 255, 0.2)",
   "shadow-from-ambient-light": "rgba(23, 24, 24, 0.05)",
   "shadow-from-direct-light": "rgba(255, 255, 255, 0.15)",
+  "shadow-color-picker": "rgba(0, 0, 0, 0)",
+  "shadow-color-picker-dragger": "rgba(0, 0, 0, 0)",
   "hint-from-direct-light": "rgba(185, 185, 185, 0.2)",
   "border": "rgba(80, 83, 86, 1)",
   "border-neutral-subdued": "rgba(130, 135, 139, 1)",

--- a/src/tokens/token-groups/color.light.json
+++ b/src/tokens/token-groups/color.light.json
@@ -20,6 +20,8 @@
   "shadow-from-dim-light": "rgba(0, 0, 0, 0.2)",
   "shadow-from-ambient-light": "rgba(23, 24, 24, 0.05)",
   "shadow-from-direct-light": "rgba(0, 0, 0, 0.15)",
+  "shadow-color-picker": "rgba(0, 0, 0, 0.5)",
+  "shadow-color-picker-dragger": "rgba(33, 43, 54, 0.32)",
   "hint-from-direct-light": "rgba(0, 0, 0, 0.15)",
   "border": "rgba(140, 145, 150, 1)",
   "border-neutral-subdued": "rgba(186, 191, 195, 1)",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4517

When the color picker box or the draggers are on a white background they can be difficult to discern because they are white as well.

This PR is achieving the same goal as this one: https://github.com/Shopify/polaris-react/pull/4948, but only on light color scheme.

### WHAT is this pull request doing?

* Add a visual inset box-shadow around the main color picker, the vertical pickers for hue and opacity and the draggers
* The box-shadow is only added on light color scheme to prevent the draggers to look blurry on dark scheme

| Before this PR | After this PR |
|-|-|
| No outline around the color pickers <img width="285" alt="" src="https://user-images.githubusercontent.com/22640631/150803272-28df0803-6f23-4319-8fc0-777a236b56c5.png"> | Outline around the color pickers and draggers <img width="433" alt="Screenshot 2022-02-11 at 16 34 01" src="https://user-images.githubusercontent.com/22640631/153620750-701e0729-f6bb-4d05-bc80-65159bc3b7a6.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {ColorPicker, CustomProperties, Heading, Page} from '../src';

export function Playground() {
  const [color, setColor] = useState({
    hue: 120,
    brightness: 1,
    saturation: 1,
    alpha: 0.5,
  });

  return (
    <Page title="Playground">
      <div style={{backgroundColor: "white", padding: "30px"}}>
        <Heading>White background</Heading>
        <ColorPicker onChange={setColor} color={color} allowAlpha />
      </div>
      <CustomProperties colorScheme={"dark"}>
        <div style={{padding: "30px", backgroundColor: 'black'}}>
          <Heading>Dark color scheme</Heading>
          <ColorPicker onChange={setColor} color={color} allowAlpha />
        </div>
      </CustomProperties>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
