### PR TITLE
Add spacing to migration guide

### DIFF
--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -207,6 +207,19 @@ We replaced a few of the following filter function instances with color tokens i
 | `shadow(layer)`              | `--p-shadow-layer`       |
 | `shadow(transparent)`        | `--p-shadow-transparent` |
 
+#### `spacing()`
+
+| Function               | Replacement Value/Token |
+| ---------------------- | ----------------------- |
+| `spacing()`            | `--p-space-4`           |
+| `spacing(none)`        | `--p-space-0`           |
+| `spacing(extra-tight)` | `--p-space-1`           |
+| `spacing(tight)`       | `--p-space-2`           |
+| `spacing(base-tight)`  | `--p-space-3`           |
+| `spacing(base)`        | `--p-space-4`           |
+| `spacing(loose)`       | `--p-space-5`           |
+| `spacing(extra-loose)` | `--p-space-8`           |
+
 #### `unstyled-link()`
 
 Replace any instances of `@include unstyled-link` with the following code block.

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -209,15 +209,15 @@ We replaced a few of the following filter function instances with color tokens i
 
 #### `spacing()`
 
-| Function               | Replacement Value/Token |
-| ---------------------- | ----------------------- |
-| `spacing()`<br>`spacing(base)`            | `--p-space-4`           |
-| `spacing(none)`        | `--p-space-0`           |
-| `spacing(extra-tight)` | `--p-space-1`           |
-| `spacing(tight)`       | `--p-space-2`           |
-| `spacing(base-tight)`  | `--p-space-3`           |
-| `spacing(loose)`       | `--p-space-5`           |
-| `spacing(extra-loose)` | `--p-space-8`           |
+| Function                       | Replacement Value/Token |
+| ------------------------------ | ----------------------- |
+| `spacing(none)`                | `--p-space-0`           |
+| `spacing(extra-tight)`         | `--p-space-1`           |
+| `spacing(tight)`               | `--p-space-2`           |
+| `spacing(base-tight)`          | `--p-space-3`           |
+| `spacing()`<br>`spacing(base)` | `--p-space-4`           |
+| `spacing(loose)`               | `--p-space-5`           |
+| `spacing(extra-loose)`         | `--p-space-8`           |
 
 #### `unstyled-link()`
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -216,7 +216,6 @@ We replaced a few of the following filter function instances with color tokens i
 | `spacing(extra-tight)` | `--p-space-1`           |
 | `spacing(tight)`       | `--p-space-2`           |
 | `spacing(base-tight)`  | `--p-space-3`           |
-| `spacing(base)`        | `--p-space-4`           |
 | `spacing(loose)`       | `--p-space-5`           |
 | `spacing(extra-loose)` | `--p-space-8`           |
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -211,7 +211,7 @@ We replaced a few of the following filter function instances with color tokens i
 
 | Function               | Replacement Value/Token |
 | ---------------------- | ----------------------- |
-| `spacing()`            | `--p-space-4`           |
+| `spacing()`<br>`spacing(base)`            | `--p-space-4`           |
 | `spacing(none)`        | `--p-space-0`           |
 | `spacing(extra-tight)` | `--p-space-1`           |
 | `spacing(tight)`       | `--p-space-2`           |


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5029

### WHAT is this pull request doing?

Adds migration guidance for deprecated `spacing()` scss function