### PR TITLE
[ContextualSaveBar] Register `secondaryMenu` prop in frame context

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
+- [ContextualSaveBar] Register `secondaryMenu` prop in frame context ([#5116](https://github.com/Shopify/polaris-react/pull/5116))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -18,6 +18,7 @@ export const ContextualSaveBar = memo(function ContextualSaveBar({
   alignContentFlush,
   fullWidth,
   contextControl,
+  secondaryMenu,
 }: ContextualSaveBarProps) {
   const {setContextualSaveBar, removeContextualSaveBar} = useFrame();
 
@@ -29,6 +30,7 @@ export const ContextualSaveBar = memo(function ContextualSaveBar({
       alignContentFlush,
       fullWidth,
       contextControl,
+      secondaryMenu,
     });
   }, [
     message,
@@ -38,6 +40,7 @@ export const ContextualSaveBar = memo(function ContextualSaveBar({
     setContextualSaveBar,
     fullWidth,
     contextControl,
+    secondaryMenu,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
### WHAT is this pull request doing?

Ref: Shopify/growth-activation#2363

An optional `secondaryMenu` prop was added to the `ContextualSaveBar` component in #5018 but wasn't registered in the frame context which prevented content passed to it from being rendered. This PR is simply an hotfix for that. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Button, ContextualSaveBar, Frame} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Frame>
        <ContextualSaveBar
          secondaryMenu={<Button>Setup Guide</Button>}
          discardAction={{content: 'Discard'}}
          saveAction={{content: 'Save'}}
        />
      </Frame>
    </Page>
  );
}
```

</details>

Confirm that a button that says "Setup Guide" is rendered before the discard and save buttons

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
