### PR TITLE
Add migration guidance for rem()

### DIFF
--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -229,6 +229,14 @@ We replaced a few of the following filter function instances with color tokens i
 | `ms-high-contrast-color('button-text-background')`   | `buttonFace`            |
 | `ms-high-contrast-color('background')`               | `window`                |
 
+#### `rem()`
+
+This function has been deprecated, but the definition can be copied and used locally.
+
+| Function | Source                                                                                                                                                           |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rem()`  | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss#L293) |
+
 #### `shadow()`
 
 | Function                     | Replacement Value/Token  |


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5023

### WHAT is this pull request doing?

Adds link to definition of deprecated `rem()` scss function