### PR TITLE
Fix `border-divider` token

### DIFF
--- a/src/tokens/token-groups/shape.json
+++ b/src/tokens/token-groups/shape.json
@@ -15,5 +15,5 @@
   "border-base": "var(--p-border-width-1) solid var(--p-border-subdued)",
   "border-dark": "var(--p-border-width-1) solid var(--p-border)",
   "border-transparent": "var(--p-border-width-1) solid transparent",
-  "border-divider": "var(--p-border-width-1) solid var(--p-border-divider)"
+  "border-divider": "var(--p-border-width-1) solid var(--p-divider)"
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Part of #5003 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- fixes `border-divider` token

This is a small one line fix, but it resolves a bunch of Chromatic diffs (down to 31 from 105) so I think it's worth merging in as is.