### PR TITLE
Migration guide for skeleton mixins

### DIFF
--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -363,6 +363,44 @@ align-items: center;
 
 #### `skeleton-shimmer()`
 
+We completely removed motion from our skeleton components for a better user experience but if you want to keep the functionality of this mixin you can reference the table below for replacement values.
+
+<table>
+<tr>
+<th>Deprecated Mixin</th>
+<th>Replacement Value</th>
+</tr>
+<tr>
+<td>
+
+`@include skeleton-shimmer`
+
+</td>
+<td>
+
+```scss
+animation: shimmer 800ms linear infinite alternate;
+will-change: opacity;
+
+@keyframes shimmer {
+  0% {
+    opacity: 0.45;
+  }
+
+  100% {
+    opacity: 0.9;
+  }
+}
+
+@media (prefers-reduced-motion) {
+  animation: none;
+}
+```
+
+</td>
+</tr>
+</table>
+
 #### `spacing()`
 
 | Function                       | Replacement Value/Token |

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -336,6 +336,31 @@ This function has been deprecated, but the definition can be copied and used loc
 
 #### `skeleton-page-secondary-actions-layout()`
 
+<table>
+<tr>
+<th>Deprecated Mixin</th>
+<th>Replacement Value</th>
+</tr>
+<tr>
+<td>
+
+`@include skeleton-page-secondary-actions-layout`
+
+</td>
+<td>
+
+```scss
+margin-top: var(--p-space-2);
+display: flex;
+flex-direction: row-reverse;
+justify-content: flex-end;
+align-items: center;
+```
+
+</td>
+</tr>
+</table>
+
 #### `skeleton-shimmer()`
 
 #### `spacing()`

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -330,9 +330,9 @@ This function has been deprecated, but the definition can be copied and used loc
 
 #### `skeleton-page-header-layout()`
 
-| Deprecated Mixin                       | Replacement Value                   |
-| -------------------------------------- | ----------------------------------- |
-| `@include skeleton-page-header-layout` | `padding-bottom: var(--p-space-2);` |
+| Deprecated Mixin                       | Replacement Value                  |
+| -------------------------------------- | ---------------------------------- |
+| `@include skeleton-page-header-layout` | `padding-bottom: var(--p-space-2)` |
 
 #### `skeleton-page-secondary-actions-layout()`
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -328,6 +328,16 @@ This function has been deprecated, but the definition can be copied and used loc
 | `shadow(layer)`              | `--p-shadow-layer`       |
 | `shadow(transparent)`        | `--p-shadow-transparent` |
 
+#### `skeleton-page-header-layout()`
+
+| Deprecated Mixin                       | Replacement Value                   |
+| -------------------------------------- | ----------------------------------- |
+| `@include skeleton-page-header-layout` | `padding-bottom: var(--p-space-2);` |
+
+#### `skeleton-page-secondary-actions-layout()`
+
+#### `skeleton-shimmer()`
+
 #### `spacing()`
 
 | Function                       | Replacement Value/Token |


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5039, #5040, and #5037

### WHAT is this pull request doing?

- Adding documentation for the`skeleton-page-header-layout()` mixin to our migration guide
- Adding documentation for the`skeleton-page-secondary-actions-layout()` mixin to our migration guide
- Adding documentation for the`skeleton-shimmer()` mixin to our migration guide

<hr>

### Helpful References

- #4462
- #4991
- [polaris-react/src/components/AppProvider/AppProvider.scss](https://github.com/Shopify/polaris-react/blob/b07102c14a09aed8013a24d4fb5fd79ec9606164/src/components/AppProvider/AppProvider.scss)