### PR TITLE
[`Button`] Prevent the `loading` spinner from overlapping a `monochrome` `outline` `Button`’s text

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,7 +10,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
-- [ContextualSaveBar] Register `secondaryMenu` prop in frame context ([#5116](https://github.com/Shopify/polaris-react/pull/5116))
+- Fixed `ContextualSaveBar` not registering the `secondaryMenu` in the `Frame` context ([#5116](https://github.com/Shopify/polaris-react/pull/5116))
+- Fixed `monochrome` `outline` `Button` `children` being visible when `loading` ([#5145](https://github.com/Shopify/polaris-react/pull/5145))
 
 ### Documentation
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -392,6 +392,11 @@ $stacking-order: (
       opacity: 0.4;
     }
 
+    // Prevents the loading spinner from overlapping the button’s text, while retaining its width.
+    &.loading .Text {
+      visibility: hidden;
+    }
+
     &.iconOnly {
       @include recolor-icon(currentColor);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/5078.

### WHAT is this pull request doing?

#### Before

https://user-images.githubusercontent.com/9154236/153588033-d06e5eeb-c5e7-4896-8e27-d22d2a132608.mov

#### After

https://user-images.githubusercontent.com/9154236/153587826-2d558d26-634e-4bd7-b5ce-e1633b44bec0.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Button} from '../src';

export function Playground() {
  const [isLoading, setLoading] = useState(false)

  return (
    <Button
      outline
      monochrome
      loading={isLoading}
      onClick={() => setLoading(isLoading => !isLoading)}
    >
      Lorem ipsum
    </Button>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit