### PR TITLE
Deprecate <Page addtionalNavigation>

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,3 +21,5 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Code quality
 
 ### Deprecations
+
+- Deprecated `additionalNavigation` in `<Page>` component

--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -522,7 +522,6 @@ export function DetailsPage() {
       breadcrumbs={[{content: 'Products', url: '/products/31'}]}
       title="The North Face Ventrix Active Trail Hybrid Hoodie - Men's"
       titleMetadata={<Badge status="success">Success badge</Badge>}
-      additionalNavigation={<Avatar initials="JD" />}
       primaryAction={{
         content: 'Save this page',
         // eslint-disable-next-line no-console

--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -14,7 +14,6 @@ import {
 
 import {
   ActionList,
-  Avatar,
   Badge,
   Caption,
   Card,

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -173,7 +173,6 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
     hasPrevious: true,
     hasNext: true,
   }}
-  additionalNavigation={<Avatar size="small" initials="CD" customer={false} />}
 >
   <Card title="Credit card" sectioned>
     <p>Credit card information</p>

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -48,7 +48,7 @@ export interface HeaderProps extends TitleProps {
   secondaryActions?: MenuActionDescriptor[];
   /** Collection of page-level groups of secondary actions */
   actionGroups?: MenuGroupDescriptor[];
-  /** Additional navigation markup */
+  /** @deprecated Additional navigation markup */
   additionalNavigation?: React.ReactNode;
   // Additional meta data
   additionalMetadata?: React.ReactNode | string;

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -81,6 +81,14 @@ export function Header({
 }: HeaderProps) {
   const i18n = useI18n();
   const {isNavigationCollapsed} = useMediaQuery();
+
+  if (additionalNavigation && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: The `additionalNavigation` on Page is deprecated and will be removed in the next major version.',
+    );
+  }
+
   const isSingleRow =
     !primaryAction &&
     !pagination &&


### PR DESCRIPTION
### WHY are these changes introduced?

This was built for realtime avatars. This functionality is no longer needed.

### WHAT is this pull request doing?

Deprecate the use of additionalNavigation

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
