### PR TITLE
[VisuallyHidden] Reintroduce VisuallyHidden top position

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
+- Reintroduced `top: 0` to `VisuallyHidden` CSS to prevent unexpected scrolling when using a `Sheet` ([#5208](https://github.com/Shopify/polaris-react/pull/5208))
 - Fixed `Form` > `VisuallyHidden` markup causing excessive vertical whitespace ([#5181](https://github.com/Shopify/polaris-react/pull/5181))
 
 ### Documentation

--- a/src/styles/shared/_accessibility.scss
+++ b/src/styles/shared/_accessibility.scss
@@ -7,6 +7,7 @@
   // Need to make sure we override any existing styles.
   // stylelint-disable declaration-no-important
   position: absolute !important;
+  top: 0;
   width: 1px !important;
   height: 1px !important;
   margin: 0 !important;

--- a/src/styles/shared/_accessibility.scss
+++ b/src/styles/shared/_accessibility.scss
@@ -7,6 +7,9 @@
   // Need to make sure we override any existing styles.
   // stylelint-disable declaration-no-important
   position: absolute !important;
+  // Top position is required to prevent unexpected
+  // scrolling with Sheet component
+  // https://github.com/Shopify/polaris-react/pull/5208
   top: 0;
   width: 1px !important;
   height: 1px !important;


### PR DESCRIPTION
### WHY are these changes introduced?

`top:0` was removed from [`VisuallyHidden` in Polaris v7.4.0](https://github.com/Shopify/polaris-react/pull/4641/files). Unfortunately, this change does not play well with Sheets using Popovers. 

Prior to the `top:0` change, when a `Sheet` was opened, the underlying content would not scroll. After the `top:0` was removed, the `VisuallyHidden` elements, presumably by nature of them being `position: absolute` and outside the underlying page DOM flow, stretch the height of the underlying page when data-scroll-lock sets the body height to `100%`.  This causes the underlying page to scroll, which introduces strange Popover behaviour.

In https://github.com/Shopify/online-store-web, there are 2 impacted `Sheet` components. The first, we were able to solve by[ reordering the markup](https://github.com/Shopify/polaris-react/pull/5181). The 2nd is harder - there are a lot of `VisuallyHidden` elements on the underlying page, and overriding the CSS of each element would be a lot of hacky code. 

`Sheet` is deprecated, but until we have UX/dev resources to move away from the pattern, it would be really helpful to reintroduce `top:0`. 

**Before**:

https://user-images.githubusercontent.com/17032120/154578108-05890a91-9cd9-46e6-b4c1-132b6389be64.mov

After:

(running fix on v8 Polaris)


https://user-images.githubusercontent.com/17032120/155311171-93ee179e-7be8-4eda-9ab2-d940c272d143.mov



### Deployment 🌶️ 

If possible, it would amazing to cut a v8 hotfix with this change. Please let me know your thoughts 🙏 

### Other approaches considered

We could keep the a11y gains of removing `top:0`, and see if there's an adjustment to be made in `Sheet`. However, I don't know if it's worth sinking the time into a deprecated component. Again, would love to hear people's thoughts 🙏 

### How to 🎩

- In the Admin, navigate to `Online Store` > `Themes`
- Add themes to your theme library. You need enough themes that the Theme Library is extended below the fold
- Scroll a little from the top of the page. 
- `Add Theme` > `Connect to GitHub` 
- When the `Sheet` opens, the underlying page should not scroll. 


</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](MacOS: safari, firefox, chrome)



