### PR TITLE
[TextField]: Add selectAllTextOnFocus boolean prop to allow all `input` / `textarea` field to be selected on focus

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
+- Added the `selectTextOnFocus` prop to `TextField` ([#5216](https://github.com/Shopify/polaris-react/pull/5216))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -789,6 +789,32 @@ function TextFieldWithMonospacedFontExample() {
 }
 ```
 
+### Text field with the ability to select all text on focus
+
+<!-- example-for: web -->
+
+Use to select all text inside TextField on focus.
+
+```jsx
+function TextFieldWithSelectTextOnFocusExample() {
+  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
+
+  const handleTextFieldChange = useCallback(
+    (value) => setTextFieldValue(value),
+    [],
+  );
+
+  return (
+    <TextField
+      label="Store name"
+      value={textFieldValue}
+      onChange={handleTextFieldChange}
+      selectTextOnFocus
+    />
+  );
+}
+```
+
 ---
 
 ## Related components

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -136,6 +136,8 @@ interface NonMutuallyExclusiveProps {
   requiredIndicator?: boolean;
   /** Indicates whether or not a monospaced font should be used */
   monospaced?: boolean;
+  /** Indicates whether or not the entire input/text area text should be selected on focus */
+  selectTextOnFocus?: boolean;
 }
 
 export type TextFieldProps = NonMutuallyExclusiveProps &
@@ -190,6 +192,7 @@ export function TextField({
   onBlur,
   requiredIndicator,
   monospaced,
+  selectTextOnFocus,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -198,7 +201,7 @@ export function TextField({
 
   const id = useUniqueId('TextField', idProp);
 
-  const inputRef = useRef<HTMLElement>(null);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   const prefixRef = useRef<HTMLDivElement>(null);
   const suffixRef = useRef<HTMLDivElement>(null);
   const buttonPressTimer = useRef<number>();
@@ -406,6 +409,15 @@ export function TextField({
     monospaced && styles.monospaced,
   );
 
+  const handleOnFocus = () => {
+    if (selectTextOnFocus) {
+      inputRef.current?.select();
+    }
+    if (onFocus) {
+      onFocus();
+    }
+  };
+
   const input = createElement(multiline ? 'textarea' : 'input', {
     name,
     id,
@@ -415,7 +427,7 @@ export function TextField({
     autoFocus,
     value: normalizedValue,
     placeholder,
-    onFocus,
+    onFocus: handleOnFocus,
     onBlur,
     onKeyPress: handleKeyPress,
     style,

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1390,20 +1390,6 @@ describe('<TextField />', () => {
   });
 
   describe('monospaced', () => {
-    it('passes monospaced prop to TextField', () => {
-      const element = mountWithApp(
-        <TextField
-          label="TextField"
-          onChange={noop}
-          monospaced
-          autoComplete="off"
-        />,
-      );
-      expect(element).toHaveReactProps({
-        monospaced: true,
-      });
-    });
-
     it('applies the monospaced style', () => {
       const input = mountWithApp(
         <TextField
@@ -1417,6 +1403,63 @@ describe('<TextField />', () => {
       expect(input).toContainReactComponent('input', {
         className: expect.stringContaining('monospaced'),
       });
+    });
+  });
+
+  describe('selectTextOnFocus', () => {
+    it('selects entire input onFocus', () => {
+      const value = 'test';
+      const selection = {start: 0, end: value.length};
+
+      const element = mountWithApp(
+        <TextField
+          value={value}
+          label="TextField"
+          onChange={noop}
+          selectTextOnFocus
+          autoComplete="off"
+        />,
+      );
+
+      element?.find('input')!.trigger('onFocus');
+
+      const textareaDOMNode = element.find('input')!
+        .domNode as HTMLInputElement;
+
+      const currentSelection = {
+        start: textareaDOMNode.selectionStart,
+        end: textareaDOMNode.selectionEnd,
+      };
+
+      expect(currentSelection).toStrictEqual(selection);
+    });
+
+    it('selects entire textarea onFocus', () => {
+      const value = 'multiline';
+      const selection = {start: 0, end: value.length};
+
+      const element = mountWithApp(
+        <TextField
+          value={value}
+          label="TextField"
+          onChange={noop}
+          selectTextOnFocus
+          autoComplete="off"
+          multiline
+        />,
+      );
+
+      element?.find('textarea')!.trigger('onFocus');
+
+      const textareaDOMNode = element.find('textarea')!
+        .domNode as HTMLTextAreaElement;
+
+      const currentSelection = {
+        start: textareaDOMNode.selectionStart,
+        end: textareaDOMNode.selectionEnd,
+      };
+
+      expect(currentSelection).toStrictEqual(selection);
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5192
Part of https://github.com/Shopify/inventory-states-ux/issues/392

Adds a `selectTextOnFocus` boolean prop that allows all TextField text to be entirely selected! (see issues for video behaviour) 

### WHAT is this pull request doing?

<details>
<summary>Summary of your gif(s)</summary>

https://user-images.githubusercontent.com/43223543/155763293-32dd76cf-b466-48ec-8e1b-a77410117537.mov

</details>


### How to 🎩

See the copy-paste code below! 💌 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Page, TextField} from '../src';

export function Playground() {
  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');

  const handleTextFieldChange = useCallback(
    (value) => setTextFieldValue(value),
    [],
  );

  return (
    <Page title="Playground">
      <TextField
        label="Store name"
        value={textFieldValue}
        onChange={handleTextFieldChange}
        selectAllTextOnFocus
        autoComplete="off"
      />
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

