### PR TITLE
Replace divide operation with math.div in legacy Sass API file

### DIFF
--- a/documentation/guides/legacy-polaris-v8-public-api.scss
+++ b/documentation/guides/legacy-polaris-v8-public-api.scss
@@ -314,9 +314,9 @@ $base-font-size: 16px;
   } @else if $unit == 'rem' {
     @return $value;
   } @else if $unit == 'px' {
-    @return $value / $base-font-size * 1rem;
+    @return math.div($value, $base-font-size) * 1rem;
   } @else if $unit == 'em' {
-    @return $unit / 1em * 1rem;
+    @return math.div($unit, 1em) * 1rem;
   } @else {
     @error 'Value must be in px, em, or rem.';
   }
@@ -334,9 +334,9 @@ $base-font-size: 16px;
   } @else if $unit == 'px' {
     @return $value;
   } @else if $unit == 'em' {
-    @return ($value / 1em) * $base-font-size;
+    @return math.div($value, 1em) * $base-font-size;
   } @else if $unit == 'rem' {
-    @return ($value / 1rem) * $base-font-size;
+    @return math.div($value, 1rem) * $base-font-size;
   } @else {
     @error 'Value must be in rem, em, or px.';
   }
@@ -355,9 +355,10 @@ $base-font-size: 16px;
   } @else if $unit == 'em' {
     @return $value;
   } @else if $unit == 'rem' {
-    @return $value / 1rem * 1em * ($base-font-size / $default-browser-font-size);
+    @return math.div($value, 1rem) * 1em *
+      math.div($base-font-size, $default-browser-font-size);
   } @else if $unit == 'px' {
-    @return $value / $default-browser-font-size * 1em;
+    @return math.div($value, $default-browser-font-size) * 1em;
   } @else {
     @error 'Value must be in px, rem, or em.';
   }
@@ -492,9 +493,9 @@ $color-palette-data: map-extend(
     $background: rgb(255, 255, 255);
   }
 
-  $red: red($background) * red($foreground) / 255;
-  $green: green($background) * green($foreground) / 255;
-  $blue: blue($background) * blue($foreground) / 255;
+  $red: red($background) * math.div(red($foreground), 255);
+  $green: green($background) * math.div(green($foreground), 255);
+  $blue: blue($background) * math.div(blue($foreground), 255);
 
   $opacity: opacity($foreground);
   $background-opacity: opacity($background);
@@ -1316,7 +1317,7 @@ $nav-min-window: em(layout-width(page-with-nav));
 
 @mixin button-base {
   $min-height: control-height();
-  $vertical-padding: ($min-height - line-height(body) - rem(2px)) / 2;
+  $vertical-padding: math.div(($min-height - line-height(body) - rem(2px)), 2);
 
   @include recolor-icon(var(--p-icon));
   @include focus-ring($border-width: border-width('base'));
@@ -1550,7 +1551,7 @@ $nav-min-window: em(layout-width(page-with-nav));
 }
 
 @function control-vertical-padding() {
-  @return (control-height() - line-height(input) - rem(2px)) / 2;
+  @return math.div((control-height() - line-height(input) - rem(2px)), 2);
 }
 
 @function control-icon-transition() {

--- a/documentation/guides/legacy-polaris-v8-public-api.scss
+++ b/documentation/guides/legacy-polaris-v8-public-api.scss
@@ -314,9 +314,9 @@ $base-font-size: 16px;
   } @else if $unit == 'rem' {
     @return $value;
   } @else if $unit == 'px' {
-    @return math.div($value, $base-font-size) * 1rem;
+    @return $value / $base-font-size * 1rem;
   } @else if $unit == 'em' {
-    @return math.div($unit, 1em) * 1rem;
+    @return $unit / 1em * 1rem;
   } @else {
     @error 'Value must be in px, em, or rem.';
   }
@@ -334,9 +334,9 @@ $base-font-size: 16px;
   } @else if $unit == 'px' {
     @return $value;
   } @else if $unit == 'em' {
-    @return math.div($value, 1em) * $base-font-size;
+    @return ($value / 1em) * $base-font-size;
   } @else if $unit == 'rem' {
-    @return math.div($value, 1rem) * $base-font-size;
+    @return ($value / 1rem) * $base-font-size;
   } @else {
     @error 'Value must be in rem, em, or px.';
   }
@@ -355,10 +355,9 @@ $base-font-size: 16px;
   } @else if $unit == 'em' {
     @return $value;
   } @else if $unit == 'rem' {
-    @return math.div($value, 1rem) * 1em *
-      math.div($base-font-size, $default-browser-font-size);
+    @return $value / 1rem * 1em * ($base-font-size / $default-browser-font-size);
   } @else if $unit == 'px' {
-    @return math.div($value, $default-browser-font-size) * 1em;
+    @return $value / $default-browser-font-size * 1em;
   } @else {
     @error 'Value must be in px, rem, or em.';
   }
@@ -493,9 +492,9 @@ $color-palette-data: map-extend(
     $background: rgb(255, 255, 255);
   }
 
-  $red: red($background) * math.div(red($foreground), 255);
-  $green: green($background) * math.div(green($foreground), 255);
-  $blue: blue($background) * math.div(blue($foreground), 255);
+  $red: red($background) * red($foreground) / 255;
+  $green: green($background) * green($foreground) / 255;
+  $blue: blue($background) * blue($foreground) / 255;
 
   $opacity: opacity($foreground);
   $background-opacity: opacity($background);
@@ -1317,7 +1316,7 @@ $nav-min-window: em(layout-width(page-with-nav));
 
 @mixin button-base {
   $min-height: control-height();
-  $vertical-padding: math.div(($min-height - line-height(body) - rem(2px)), 2);
+  $vertical-padding: ($min-height - line-height(body) - rem(2px)) / 2;
 
   @include recolor-icon(var(--p-icon));
   @include focus-ring($border-width: border-width('base'));
@@ -1551,7 +1550,7 @@ $nav-min-window: em(layout-width(page-with-nav));
 }
 
 @function control-vertical-padding() {
-  @return math.div((control-height() - line-height(input) - rem(2px)), 2);
+  @return (control-height() - line-height(input) - rem(2px)) / 2;
 }
 
 @function control-icon-transition() {

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -188,6 +188,14 @@ The following CSS custom properties have either been renamed or removed. You wil
 
 The following Sass functions and mixins have been removed. You will need to either add the function or mixin to your repo or replace any instances of them with a CSS custom property or value equivalent.
 
+The [legacy public API file](./legacy-polaris-v8-public-api.scss) is designed to support Node Sass. If you are using [Dart Sass](https://sass-lang.com/dart-sass) in your project, you can convert the legacy public API file to a Dart-friendly version using the [sass-migrator](https://www.npmjs.com/package/sass-migrator) utility.
+
+```sh
+ npx sass-migrator division path/to/legacy-polaris-v8-public-api.scss
+```
+
+Once converted, use the resulting Dart-friendly file in your local project to replace usages of the legacy API.
+
 ### Replacing function and mixin instances with value equivalents
 
 #### `available-names()`


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #5237  <!-- link to issue if one exists -->

See [Sass Breaking Changes: Slash as Division](https://sass-lang.com/documentation/breaking-changes/slash-div)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Replaces the `/` operation with `math.div`. The `/` is deprecated in Dart Sass and causes a console warning in current versions of Node Sass.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
