### PR TITLE
[KeypressListener] Adds support for `useCapture` and `options`

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Enhancements
 
 - Added `ReactNode` as an accepted prop type to `secondaryActions` on the `Page` component ([#5258](https://github.com/Shopify/polaris-react/pull/5258))
+- Added `useCapture` and `options` props in `KeypressListener` to allow passing through those options to the underlying `addEventListener` call ([#5221](https://github.com/Shopify/polaris-react/pull/5221))
 
 ### Bug fixes
 

--- a/src/components/KeypressListener/KeypressListener.tsx
+++ b/src/components/KeypressListener/KeypressListener.tsx
@@ -3,11 +3,17 @@ import {useCallback, useEffect, useRef} from 'react';
 import {useIsomorphicLayoutEffect} from '../../utilities/use-isomorphic-layout-effect';
 import type {Key} from '../../types';
 
-export interface KeypressListenerProps {
+export interface NonMutuallyExclusiveProps {
   keyCode: Key;
   handler(event: KeyboardEvent): void;
   keyEvent?: KeyEvent;
 }
+
+export type KeypressListenerProps = NonMutuallyExclusiveProps &
+  (
+    | {useCapture?: boolean; options?: undefined}
+    | {useCapture?: undefined; options?: AddEventListenerOptions}
+  );
 
 type KeyEvent = 'keydown' | 'keyup';
 
@@ -15,6 +21,8 @@ export function KeypressListener({
   keyCode,
   handler,
   keyEvent = 'keyup',
+  options,
+  useCapture,
 }: KeypressListenerProps) {
   const tracked = useRef({handler, keyCode});
 
@@ -30,11 +38,15 @@ export function KeypressListener({
   }, []);
 
   useEffect(() => {
-    document.addEventListener(keyEvent, handleKeyEvent);
+    document.addEventListener(keyEvent, handleKeyEvent, useCapture || options);
     return () => {
-      document.removeEventListener(keyEvent, handleKeyEvent);
+      document.removeEventListener(
+        keyEvent,
+        handleKeyEvent,
+        useCapture || options,
+      );
     };
-  }, [keyEvent, handleKeyEvent]);
+  }, [keyEvent, handleKeyEvent, useCapture, options]);
 
   return null;
 }

--- a/src/components/KeypressListener/tests/KeypressListener.test.tsx
+++ b/src/components/KeypressListener/tests/KeypressListener.test.tsx
@@ -9,15 +9,21 @@ interface HandlerMap {
 }
 
 const listenerMap: HandlerMap = {};
+const listenerOptionsMap: HandlerMap = {};
 
 describe('<KeypressListener />', () => {
   beforeEach(() => {
-    jest.spyOn(document, 'addEventListener').mockImplementation((event, cb) => {
-      listenerMap[event] = cb;
-    });
+    jest
+      .spyOn(document, 'addEventListener')
+      .mockImplementation((event, cb, options) => {
+        listenerMap[event] = cb;
+        listenerOptionsMap[event] = options;
+      });
 
     jest.spyOn(document, 'removeEventListener').mockImplementation((event) => {
       listenerMap[event] = noop;
+
+      delete listenerOptionsMap[event];
     });
   });
 
@@ -45,6 +51,37 @@ describe('<KeypressListener />', () => {
 
     listenerMap.keyup({keyCode: Key.Escape});
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('allows registering an event in the capture phase using useCapture', () => {
+    const spy = jest.fn();
+
+    mountWithApp(
+      <KeypressListener handler={spy} keyCode={Key.Escape} useCapture />,
+    );
+
+    expect(listenerOptionsMap.keyup).toBe(true);
+  });
+
+  it('passes additional options to the event', () => {
+    const spy = jest.fn();
+
+    const eventOptions = {
+      capture: true,
+      once: true,
+      passive: true,
+      signal: new AbortController().signal,
+    };
+
+    mountWithApp(
+      <KeypressListener
+        handler={spy}
+        keyCode={Key.Escape}
+        options={eventOptions}
+      />,
+    );
+
+    expect(listenerOptionsMap.keyup).toStrictEqual(eventOptions);
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris-react/issues/5244

This allows for users to be more specific about the underlying event mechanism and avoids obfuscating otherwise standard APIs

A case could be made for just allowing `options` since it supports the capture use case as well, but I decided to go with both for better symmetry with the native API

### WHY are these changes introduced?

This should provide support for the workaround needed in https://github.com/Shopify/polaris-react/issues/4253 which in turn would allow us to remove the [KeypressListener fork in shopify/web](https://github.com/Shopify/web/blob/main/packages/%40shopify/polaris-next/components/KeypressListener/KeypressListener.tsx).

As noted in https://github.com/Shopify/polaris-react/issues/4253:

> [...] it would be ideal if this solution wasn't necessary.

Nevertheless, I think it can still be useful to surface this API for a relatively small price considering that `KeypressListener` is a relatively low level abstraction, close enough to the `addEventListener` concept.

### WHAT is this pull request doing?

It allows `useCapture` or `options` **but not both** to be passed as props of `KeypressListener` and be passed through to the `addEventListener` and `removeEventListener` underlying calls.

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Key, KeypressListener, Page} from '../src';

export function Playground() {
  const logKeypress = (event: Event) => {
    console.log({type: event.type, phase: event.eventPhase});
  };
  
  return (
    <Page title="Playground">
      <KeypressListener handler={logKeypress} keyCode={Key.KeyJ} />
      <KeypressListener handler={logKeypress} keyCode={Key.KeyH} options={{once: true}} />
      <KeypressListener handler={logKeypress} keyCode={Key.KeyN} useCapture={true} />
      <KeypressListener handler={logKeypress} keyCode={Key.KeyB} options={{capture: true}} />
    </Page>
  );
}
```

Checking the console output one could check that:
- Pressing `K` outputs logs normally with `eventPhase: 3`
- Pressing `H` only outputs to the log once
- With keys `N` and `B` log `eventPhase: 1`

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
