### PR TITLE
Replace scss `easing()` with custom property

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
+- Fixed sheet animation by replacing deprecated `easing()` with css custom property ([5251](https://github.com/Shopify/polaris-react/pull/5251))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Sheet/Sheet.scss
+++ b/src/components/Sheet/Sheet.scss
@@ -40,7 +40,7 @@ $sheet-desktop-width: 380px;
 
 .Bottom {
   will-change: transform;
-  transition: transform var(--p-duration-300) easing('base');
+  transition: transform var(--p-duration-300) var(--p-ease);
   transform-origin: bottom;
 }
 
@@ -62,7 +62,7 @@ $sheet-desktop-width: 380px;
 
 .Right {
   will-change: transform;
-  transition: transform var(--p-duration-300) easing('base');
+  transition: transform var(--p-duration-300) var(--p-ease);
   transform-origin: right;
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a bug in the sheet component animation

### WHAT is this pull request doing?

Replace a couple of straggling instances of the scss `easing()` function which was removed as part of the v9

