### PR TITLE
[Page] Add ReactNode as an accepted secondaryActions prop value for customizability

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
+- Added `ReactNode` as an accepted prop type to `secondaryActions` on the `Page` component ([#5258](https://github.com/Shopify/polaris-react/pull/5258))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -4,6 +4,7 @@ import {classNames} from '../../utilities/css';
 
 import {Header, HeaderProps} from './components';
 import styles from './Page.scss';
+import {isInterface, isReactElement} from './utilities';
 
 export interface PageProps extends HeaderProps {
   /** The contents of the page */
@@ -32,7 +33,10 @@ export function Page({
   const hasHeaderContent =
     (rest.title != null && rest.title !== '') ||
     rest.primaryAction != null ||
-    (rest.secondaryActions != null && rest.secondaryActions.length > 0) ||
+    (rest.secondaryActions != null &&
+      ((isInterface(rest.secondaryActions) &&
+        rest.secondaryActions.length > 0) ||
+        isReactElement(rest.secondaryActions))) ||
     (rest.actionGroups != null && rest.actionGroups.length > 0) ||
     (rest.breadcrumbs != null && rest.breadcrumbs.length > 0);
 

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -270,6 +270,30 @@ Used to visually indicate that the secondary page action is destructive.
 </Page>
 ```
 
+### Page with custom secondary action
+
+<!-- example-for: web -->
+
+Use to create a custom secondary action.
+
+```jsx
+<Page
+  title="General"
+  secondaryActions={
+    <Button
+      connectedDisclosure={{
+        accessibilityLabel: 'Other save actions',
+        actions: [{content: 'Save as new'}],
+      }}
+    >
+      Save
+    </Button>
+  }
+>
+  <p>Page content</p>
+</Page>
+```
+
 ### Page with subtitle
 
 <!-- example-for: web -->

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -8,7 +8,7 @@ import {Breadcrumbs} from '../../../../Breadcrumbs';
 import {Button} from '../../../../Button';
 import {ButtonGroup} from '../../../../ButtonGroup';
 import {Pagination} from '../../../../Pagination';
-import type {LinkAction} from '../../../../../types';
+import type {LinkAction, MenuActionDescriptor} from '../../../../../types';
 import {Header, HeaderProps} from '../Header';
 
 describe('<Header />', () => {
@@ -125,18 +125,18 @@ describe('<Header />', () => {
   });
 
   describe('actionGroups', () => {
-    const mockSecondaryActions: HeaderProps['secondaryActions'] = [
+    const mockActionGroupsActions: MenuActionDescriptor[] = [
       {content: 'mock content 1'},
       {content: 'mock content 2'},
     ];
     const mockActionGroups: HeaderProps['actionGroups'] = [
       {
         title: 'First group',
-        actions: mockSecondaryActions,
+        actions: mockActionGroupsActions,
       },
       {
         title: 'Second group',
-        actions: mockSecondaryActions,
+        actions: mockActionGroupsActions,
       },
     ];
 
@@ -163,18 +163,19 @@ describe('<Header />', () => {
     });
   });
 
-  describe('<ActionMenu />', () => {
+  describe('action menu', () => {
     const mockSecondaryActions: HeaderProps['secondaryActions'] = [
       {content: 'mock content 1'},
     ];
+    const CustomSecondaryActions = () => null;
 
-    it('does not render without either `secondaryActions` or `actionGroups`', () => {
+    it('does not render <ActionMenu /> without either `secondaryActions` or `actionGroups`', () => {
       const wrapper = mountWithApp(<Header {...mockProps} />);
 
       expect(wrapper).not.toContainReactComponent(ActionMenu);
     });
 
-    it('does not render if `actionGroups` has no `actions', () => {
+    it('does not render <ActionMenu /> if `actionGroups` has no `actions', () => {
       const mockActionGroups: HeaderProps['actionGroups'] = [
         {
           title: 'mock title',
@@ -188,7 +189,15 @@ describe('<Header />', () => {
       expect(wrapper).not.toContainReactComponent(ActionMenu);
     });
 
-    it('renders with at least valid `secondaryActions`', () => {
+    it('does not render <ActionMenu /> if `ReactNode` is provided as `secondaryActions`', () => {
+      const wrapper = mountWithApp(
+        <Header secondaryActions={<CustomSecondaryActions />} />,
+      );
+
+      expect(wrapper).not.toContainReactComponent(ActionMenu);
+    });
+
+    it('renders <ActionMenu /> with at least valid `secondaryActions`', () => {
       const mockSecondaryActions: HeaderProps['secondaryActions'] = [
         {content: 'mock content'},
       ];
@@ -199,7 +208,7 @@ describe('<Header />', () => {
       expect(wrapper).toContainReactComponent(ActionMenu);
     });
 
-    it('renders with at least valid `actionGroups`', () => {
+    it('renders <ActionMenu /> with at least valid `actionGroups`', () => {
       const mockActionGroups: HeaderProps['actionGroups'] = [
         {
           title: 'mock title',
@@ -213,7 +222,7 @@ describe('<Header />', () => {
       expect(wrapper).toContainReactComponent(ActionMenu);
     });
 
-    it('renders with `rollup` as `false` when on desktop', () => {
+    it('renders <ActionMenu /> with `rollup` as `false` when on desktop', () => {
       const wrapper = mountWithApp(
         <Header {...mockProps} secondaryActions={mockSecondaryActions} />,
       );
@@ -223,7 +232,7 @@ describe('<Header />', () => {
       });
     });
 
-    it('renders with `rollup` as `true` when on mobile', () => {
+    it('renders <ActionMenu /> with `rollup` as `true` when on mobile', () => {
       const wrapper = mountWithApp(
         <Header {...mockProps} secondaryActions={mockSecondaryActions} />,
         {mediaQuery: {isNavigationCollapsed: true}},
@@ -232,6 +241,14 @@ describe('<Header />', () => {
       expect(wrapper).toContainReactComponent(ActionMenu, {
         rollup: true,
       });
+    });
+
+    it('renders <CustomSecondaryActions /> if `ReactNode` is provided as `secondaryActions`', () => {
+      const wrapper = mountWithApp(
+        <Header secondaryActions={<CustomSecondaryActions />} />,
+      );
+
+      expect(wrapper).toContainReactComponent(CustomSecondaryActions);
     });
   });
 

--- a/src/components/Page/utilities.ts
+++ b/src/components/Page/utilities.ts
@@ -1,0 +1,9 @@
+import {isValidElement} from 'react';
+
+export function isInterface<T>(x: T | React.ReactNode): x is T {
+  return !isValidElement(x) && x !== undefined;
+}
+
+export function isReactElement<T>(x: T): x is T {
+  return isValidElement(x) && x !== undefined;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

The current `secondaryActions` on `Page` only allows for passing props as `MenuActionDescriptor[]` which doesn't allow for flexibility and may cause accessibility issues in some cases.

[Currently](https://user-images.githubusercontent.com/15054990/157740503-4bf1e454-71c8-400e-b47e-a359472385f1.png), `Export` secondary action in Discounts opens a modal. Ideally we should be able to move focus back to the button that opened it after the modal is closed to support keyboard users, whether it'd be through passing entire modal as secondary action to leverage modal's built-in focus management or through passing a custom button that'd able to have a `ref` to receive the focus. To make either of these and other secondary actions customizations possible, Page's secondaryActions has a need for `React.ReactNode` as another type. 



[Slack thread](https://shopify.slack.com/archives/C4Y8N30KD/p1646765805356699)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR maintains the existing `secondaryActions` prop, while adding the option to pass a `ReactNode` instead for customizability.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Button, Modal, Page, TextContainer} from '../src';

export function Playground() {
  return (
    <Page title="Playground" secondaryActions={<ModalExample />}>
      <p>Page content</p>
    </Page>
  );
}

function ModalExample() {
  const [active, setActive] = useState(true);

  const handleChange = useCallback(() => setActive(!active), [active]);

  const activator = <Button onClick={handleChange}>Open</Button>;

  return (
    <Modal
      activator={activator}
      open={active}
      onClose={handleChange}
      title="Reach more shoppers with Instagram product tags"
      primaryAction={{
        content: 'Add Instagram',
        onAction: handleChange,
      }}
      secondaryActions={[
        {
          content: 'Learn more',
          onAction: handleChange,
        },
      ]}
    >
      <Modal.Section>
        <TextContainer>
          <p>
            Use Instagram posts to share your products with millions of people.
            Let shoppers buy from your store without leaving Instagram.
          </p>
        </TextContainer>
      </Modal.Section>
    </Modal>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
