### PR TITLE
[ActionList] Remove icon recolor when pressed

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,9 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Documentation
 
+- Removed `examples` dir and all references ([#5207](https://github.com/Shopify/polaris-react/pull/5207))
+- Removed `recolor-icon()` from ActionList ([#5273](https://github.com/Shopify/polaris-react/pull/5273))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -65,7 +65,6 @@
   }
 
   &:active {
-    @include recolor-icon(var(--p-interactive));
     background-color: var(--p-surface-pressed);
   }
 
@@ -79,7 +78,6 @@
   }
 
   &.active {
-    @include recolor-icon(var(--p-interactive));
     background-color: var(--p-surface-selected);
 
     &::before {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes Shopify/shopify/issues/322272.

### WHAT is this pull request doing?

On the pressed state, the icon is no longer blue. 

**Before**

https://user-images.githubusercontent.com/42760127/157991519-28c90121-d914-4cdb-9813-5198c0ad1c00.mov




**After**

https://user-images.githubusercontent.com/42760127/157991550-b3144704-5579-4e16-aac2-06e8bb651344.mov




### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
