### PR TITLE
Multiselect Prototype (latest): Combobox with typeahead and auto-selection

### DIFF
--- a/playground/Playground.tsx
+++ b/playground/Playground.tsx
@@ -1,11 +1,186 @@
-import React from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
 
-import {Page} from '../src';
+import {Page, Combobox, Listbox, Stack, Icon, TextStyle} from '../src';
+import {CirclePlusMinor} from '@shopify/polaris-icons';
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+const tags = [
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+  'thirteen',
+  'fourteen',
+  'fifteen',
+];
+
+const formattedTags = tags.map((tag) => ({label: tag, value: tag}));
 
 export function Playground() {
+  const [inputValue, setInputValue] = useState<string>('');
+
+  const [options, setOptions] = useState<Option[]>(formattedTags);
+  const [selectedOptions, setSelectedOptions] = useState<Option[]>(
+    formattedTags.slice(0, 7),
+  );
+  const [filteredOptions, setFilteredOptions] = useState<Option[]>(
+    formattedTags.slice(0, 7),
+  );
+  const [selection, setSelection] = useState({start: 0, end: 0});
+  const [autofillValue, setAutofillValue] = useState<string>('');
+
+  const label = 'Tags';
+
+  const updateSelection = useCallback(
+    (selected) => {
+      debugger;
+      const selectedValues = selectedOptions.map((opt) => opt.value);
+      if (selectedValues.includes(selected)) {
+        setSelectedOptions(
+          selectedOptions.filter((option) => option.value !== selected),
+        );
+      } else {
+        setSelectedOptions([
+          ...selectedOptions,
+          {label: selected, value: selected},
+        ]);
+
+        setFilteredOptions([
+          ...filteredOptions,
+          {label: selected, value: selected},
+        ]);
+      }
+    },
+    [options, selectedOptions],
+  );
+
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
+      setAutofillValue(value);
+
+      if (value === '') {
+        setFilteredOptions(selectedOptions);
+        return;
+      }
+
+      // fetch with query
+      const filterRegex = new RegExp(value, 'i');
+      const resultOptions = options.filter((option) =>
+        option.label.match(filterRegex),
+      );
+
+      setFilteredOptions(resultOptions);
+
+      if (Boolean(resultOptions.length)) {
+        const firstMatch = resultOptions[0].value.slice(value.length);
+        setInputValue(value);
+        setAutofillValue(`${value}${firstMatch}`);
+        setSelection({
+          start: value.length,
+          end: firstMatch.length + 1,
+        });
+      }
+    },
+    [options, filteredOptions],
+  );
+
+  const handleOptionChange = useCallback(
+    (value) => {
+      if (!autofillValue) return;
+
+      if (filteredOptions.length === 0) {
+        setAutofillValue(inputValue);
+        return;
+      }
+
+      if (autofillValue !== value) {
+        setAutofillValue(value);
+        setSelection({
+          start: value.length,
+          end: value.length,
+        });
+        return;
+      }
+    },
+    [inputValue, autofillValue],
+  );
+
+  const activator = (
+    <Combobox.TextField
+      disabled={false}
+      label="Tags"
+      value={autofillValue}
+      onChange={updateText}
+      labelHidden
+      type="text"
+      autoComplete="on"
+      ariaAutocomplete="list"
+      selection={selection}
+    />
+  );
+
+  const optionMarkup =
+    filteredOptions.length > 0 ? (
+      filteredOptions.map((option) => {
+        const {label, value} = option;
+        const selected = selectedOptions
+          .map((opt) => opt.value)
+          .includes(value);
+
+        return (
+          <Listbox.Option
+            accessibilityLabel={label}
+            key={`${value}`}
+            value={value}
+            selected={selected}
+          >
+            {label}
+          </Listbox.Option>
+        );
+      })
+    ) : (
+      <Listbox.Option
+        accessibilityLabel={`Add: ${inputValue}`}
+        key={`Add: ${inputValue}`}
+        value={`Add: ${inputValue}`}
+        selected={false}
+      >
+        <Stack spacing="tight" wrap={false}>
+          <Icon source={CirclePlusMinor} color="interactive" />
+          <p>
+            <TextStyle variation="strong">Add: </TextStyle>
+            {inputValue}
+          </p>
+        </Stack>
+      </Listbox.Option>
+    );
+
   return (
     <Page title="Playground">
       {/* Add the code you want to test in here */}
+      <Combobox activator={activator} allowMultiple>
+        <Listbox
+          accessibilityLabel={label}
+          onSelect={updateSelection}
+          onActiveOptionChange={handleOptionChange}
+          enableKeyboardControl
+        >
+          {optionMarkup}
+        </Listbox>
+      </Combobox>
     </Page>
   );
 }

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -121,7 +121,7 @@ export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
         ? buildMappedOptionFromOption(conditionalOptions)
         : null;
 
-    if (listTitle) {
+    if (listTitle && optionList) {
       return (
         <Listbox.Section
           divider={false}
@@ -178,7 +178,7 @@ export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
       preferredPosition={preferredPosition}
     >
       {actionMarkup || optionsMarkup || loadingMarkup || emptyStateMarkup ? (
-        <Listbox onSelect={updateSelection}>
+        <Listbox enableKeyboardControl onSelect={updateSelection}>
           {actionMarkup}
           {optionsMarkup && (!loading || willLoadMoreResults)
             ? optionsMarkup

--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -137,10 +137,7 @@ function MultiAutocompleteExample() {
       const resultOptions = deselectedOptions.filter((option) =>
         option.label.match(filterRegex),
       );
-      let endIndex = resultOptions.length - 1;
-      if (resultOptions.length === 0) {
-        endIndex = 0;
-      }
+
       setOptions(resultOptions);
     },
     [deselectedOptions],

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -33,7 +33,6 @@ export function Combobox({
 }: ComboboxProps) {
   const [popoverActive, setPopoverActive] = useState(false);
   const [activeOptionId, setActiveOptionId] = useState<string>();
-  const [activeOptionValue, setActiveOptionValue] = useState<string>();
   const [textFieldLabelId, setTextFieldLabelId] = useState<string>();
   const [listboxId, setListboxId] = useState<string>();
   const [textFieldFocused, setTextFieldFocused] = useState<boolean>(false);
@@ -80,7 +79,6 @@ export function Combobox({
 
   const textFieldContextValue: ComboboxTextFieldType = useMemo(
     () => ({
-      activeOptionValue,
       activeOptionId,
       expanded: popoverActive,
       listboxId,
@@ -91,7 +89,6 @@ export function Combobox({
       onTextFieldBlur: handleBlur,
     }),
     [
-      activeOptionValue,
       activeOptionId,
       popoverActive,
       listboxId,
@@ -112,24 +109,20 @@ export function Combobox({
 
   const listboxContextValue: ComboboxListboxType = useMemo(
     () => ({
-      activeOptionValue,
       listboxId,
       textFieldLabelId,
       textFieldFocused,
       setActiveOptionId,
       setListboxId,
-      setActiveOptionValue,
       onOptionSelected,
       onKeyToBottom: onScrolledToBottom,
     }),
     [
-      activeOptionValue,
       listboxId,
       textFieldLabelId,
       textFieldFocused,
       setActiveOptionId,
       setListboxId,
-      setActiveOptionValue,
       onOptionSelected,
       onScrolledToBottom,
     ],

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -33,6 +33,7 @@ export function Combobox({
 }: ComboboxProps) {
   const [popoverActive, setPopoverActive] = useState(false);
   const [activeOptionId, setActiveOptionId] = useState<string>();
+  const [activeOptionValue, setActiveOptionValue] = useState<string>();
   const [textFieldLabelId, setTextFieldLabelId] = useState<string>();
   const [listboxId, setListboxId] = useState<string>();
   const [textFieldFocused, setTextFieldFocused] = useState<boolean>(false);
@@ -77,8 +78,16 @@ export function Combobox({
     }
   }, [popoverActive, handleClose]);
 
+  const handleNavigateList = useCallback(
+    (activeOptionValue: string) => {
+      setActiveOptionValue(activeOptionValue);
+    },
+    [setActiveOptionValue],
+  );
+
   const textFieldContextValue: ComboboxTextFieldType = useMemo(
     () => ({
+      activeOptionValue,
       activeOptionId,
       expanded: popoverActive,
       listboxId,
@@ -89,6 +98,7 @@ export function Combobox({
       onTextFieldBlur: handleBlur,
     }),
     [
+      activeOptionValue,
       activeOptionId,
       popoverActive,
       listboxId,
@@ -115,6 +125,7 @@ export function Combobox({
       setActiveOptionId,
       setListboxId,
       onOptionSelected,
+      onActiveOptionChange: handleNavigateList,
       onKeyToBottom: onScrolledToBottom,
     }),
     [
@@ -125,6 +136,7 @@ export function Combobox({
       setListboxId,
       onOptionSelected,
       onScrolledToBottom,
+      handleNavigateList,
     ],
   );
 

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -78,13 +78,6 @@ export function Combobox({
     }
   }, [popoverActive, handleClose]);
 
-  const handleNavigateList = useCallback(
-    (activeOptionValue: string) => {
-      setActiveOptionValue(activeOptionValue);
-    },
-    [setActiveOptionValue],
-  );
-
   const textFieldContextValue: ComboboxTextFieldType = useMemo(
     () => ({
       activeOptionValue,
@@ -119,24 +112,26 @@ export function Combobox({
 
   const listboxContextValue: ComboboxListboxType = useMemo(
     () => ({
+      activeOptionValue,
       listboxId,
       textFieldLabelId,
       textFieldFocused,
       setActiveOptionId,
       setListboxId,
+      setActiveOptionValue,
       onOptionSelected,
-      onActiveOptionChange: handleNavigateList,
       onKeyToBottom: onScrolledToBottom,
     }),
     [
+      activeOptionValue,
       listboxId,
       textFieldLabelId,
       textFieldFocused,
       setActiveOptionId,
       setListboxId,
+      setActiveOptionValue,
       onOptionSelected,
       onScrolledToBottom,
-      handleNavigateList,
     ],
   );
 

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -20,16 +20,16 @@ export interface ComboboxProps {
   children?: React.ReactElement<ListboxProps> | null;
   activator: React.ReactElement<TextFieldProps>;
   allowMultiple?: boolean;
-  onScrolledToBottom?(): void;
   preferredPosition?: PopoverProps['preferredPosition'];
+  onScrolledToBottom?(): void;
 }
 
 export function Combobox({
   children,
   activator,
   allowMultiple,
-  onScrolledToBottom,
   preferredPosition = 'below',
+  onScrolledToBottom,
 }: ComboboxProps) {
   const [popoverActive, setPopoverActive] = useState(false);
   const [activeOptionId, setActiveOptionId] = useState<string>();
@@ -39,38 +39,43 @@ export function Combobox({
   const shouldOpen = Boolean(!popoverActive && Children.count(children) > 0);
   const ref = useRef<PopoverPublicAPI | null>(null);
 
-  const onOptionSelected = useCallback(() => {
-    if (!allowMultiple) {
-      setPopoverActive(false);
-      setActiveOptionId(undefined);
-      return;
-    }
-    ref.current?.forceUpdatePosition();
-  }, [allowMultiple]);
-
   const handleClose = useCallback(() => {
     setPopoverActive(false);
     setActiveOptionId(undefined);
   }, []);
 
+  const handleOpen = useCallback(() => {
+    setPopoverActive(true);
+    setActiveOptionId(undefined);
+  }, []);
+
+  const onOptionSelected = useCallback(() => {
+    if (!allowMultiple) {
+      handleClose();
+      return;
+    } else {
+      setActiveOptionId(undefined);
+    }
+    ref.current?.forceUpdatePosition();
+  }, [allowMultiple, handleClose]);
+
   const handleFocus = useCallback(() => {
     if (shouldOpen) {
-      setPopoverActive(true);
+      handleOpen();
     }
-  }, [shouldOpen]);
+  }, [shouldOpen, handleOpen]);
 
   const handleChange = useCallback(() => {
     if (shouldOpen) {
-      setPopoverActive(true);
+      handleOpen();
     }
-  }, [shouldOpen]);
+  }, [shouldOpen, handleOpen]);
 
   const handleBlur = useCallback(() => {
     if (popoverActive) {
-      setPopoverActive(false);
-      setActiveOptionId(undefined);
+      handleClose();
     }
-  }, [popoverActive]);
+  }, [popoverActive, handleClose]);
 
   const textFieldContextValue: ComboboxTextFieldType = useMemo(
     () => ({
@@ -104,21 +109,21 @@ export function Combobox({
 
   const listboxContextValue: ComboboxListboxType = useMemo(
     () => ({
-      setActiveOptionId,
-      setListboxId,
       listboxId,
       textFieldLabelId,
-      onOptionSelected,
       textFieldFocused,
+      setActiveOptionId,
+      setListboxId,
+      onOptionSelected,
       onKeyToBottom: onScrolledToBottom,
     }),
     [
-      setActiveOptionId,
-      setListboxId,
       listboxId,
       textFieldLabelId,
-      onOptionSelected,
       textFieldFocused,
+      setActiveOptionId,
+      setListboxId,
+      onOptionSelected,
       onScrolledToBottom,
     ],
   );

--- a/src/components/Combobox/README.md
+++ b/src/components/Combobox/README.md
@@ -176,7 +176,7 @@ function MultiComboboxExample() {
         setSelectedOptions([...selectedOptions, selected]);
       }
 
-      setInputValue(('');
+      setInputValue('');
     },
     [options, selectedOptions],
   );

--- a/src/components/Combobox/README.md
+++ b/src/components/Combobox/README.md
@@ -35,7 +35,7 @@ The input field for `Combobox` should follow the [content guidelines](https://po
 
 ## Examples
 
-### Basic autocomplete
+### Single select autocomplete
 
 Use to help merchants complete text input quickly from a list of options.
 
@@ -127,7 +127,7 @@ function ComboboxExample() {
 }
 ```
 
-### Multiple tags autocomplete
+### Multiselect autocomplete
 
 Use to help merchants select multiple options from a list curated by the text input.
 
@@ -176,10 +176,7 @@ function MultiComboboxExample() {
         setSelectedOptions([...selectedOptions, selected]);
       }
 
-      const matchedOption = options.find((option) => {
-        return option.value.match(selected);
-      });
-      setInputValue((matchedOption && matchedOption.label) || '');
+      setInputValue(('');
     },
     [options, selectedOptions],
   );

--- a/src/components/Combobox/components/TextField/TextField.tsx
+++ b/src/components/Combobox/components/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useCallback, useEffect, useState} from 'react';
+import React, {useMemo, useCallback, useEffect} from 'react';
 
 import {labelID} from '../../../Label';
 import {useUniqueId} from '../../../../utilities/unique-id';
@@ -15,13 +15,9 @@ export function TextField({
   onChange,
   ...rest
 }: TextFieldProps) {
-  const [inlineAutocomplete, setInlineAutocomplete] = useState('');
-  const [selection, setSelection] = useState<TextFieldProps['selection']>();
-
   const comboboxTextFieldContext = useComboboxTextField();
 
   const {
-    activeOptionValue,
     activeOptionId,
     listboxId,
     expanded,
@@ -44,33 +40,6 @@ export function TextField({
     if (setTextFieldLabelId) setTextFieldLabelId(labelId);
   }, [labelId, setTextFieldLabelId]);
 
-  useEffect(() => {
-    if (
-      ariaAutocomplete === 'both' &&
-      value !== undefined &&
-      activeOptionValue !== undefined &&
-      activeOptionValue.startsWith(value)
-    ) {
-      const nextInlineAutocomplete = activeOptionValue;
-      const start = value.length;
-      const end = activeOptionValue.length;
-      const selection: TextFieldProps['selection'] = {
-        start,
-        end,
-        direction: 'backward',
-      };
-
-      setInlineAutocomplete(`${value}${nextInlineAutocomplete}`);
-      setSelection(selection);
-    }
-  }, [
-    value,
-    ariaAutocomplete,
-    activeOptionValue,
-    setInlineAutocomplete,
-    setSelection,
-  ]);
-
   const handleFocus = useCallback(() => {
     if (onFocus) onFocus();
     if (onTextFieldFocus) onTextFieldFocus();
@@ -91,14 +60,11 @@ export function TextField({
     [onChange, onTextFieldChange],
   );
 
-  const inputValue = inlineAutocomplete ? inlineAutocomplete : value;
-
   return (
     <PolarisTextField
       {...rest}
-      value={inputValue}
+      value={value}
       id={textFieldId}
-      selection={selection}
       ariaAutocomplete={ariaAutocomplete}
       aria-haspopup="listbox"
       ariaActiveDescendant={activeOptionId}

--- a/src/components/Combobox/components/TextField/TextField.tsx
+++ b/src/components/Combobox/components/TextField/TextField.tsx
@@ -7,6 +7,8 @@ import type {TextFieldProps} from '../../../TextField';
 import {useComboboxTextField} from '../../../../utilities/combobox';
 
 export function TextField({
+  type = 'text',
+  selection,
   value,
   id: idProp,
   ariaAutocomplete = 'list',
@@ -63,6 +65,7 @@ export function TextField({
   return (
     <PolarisTextField
       {...rest}
+      selection={selection}
       value={value}
       id={textFieldId}
       ariaAutocomplete={ariaAutocomplete}
@@ -70,6 +73,7 @@ export function TextField({
       ariaActiveDescendant={activeOptionId}
       ariaControls={listboxId}
       role="combobox"
+      type={type}
       ariaExpanded={expanded}
       onFocus={handleFocus}
       onBlur={handleBlur}

--- a/src/components/Listbox/Listbox.tsx
+++ b/src/components/Listbox/Listbox.tsx
@@ -83,6 +83,7 @@ export function Listbox({
     setActiveOptionId,
     setListboxId,
     onOptionSelected,
+    onActiveOptionChange,
     onKeyToBottom,
   } = useComboboxListbox();
 
@@ -233,8 +234,14 @@ export function Listbox({
         onOptionSelected();
       }
       if (onSelect) onSelect(option.value);
+      if (onActiveOptionChange) onActiveOptionChange(option.value);
     },
-    [handleChangeActiveOption, onSelect, onOptionSelected],
+    [
+      onActiveOptionChange,
+      handleChangeActiveOption,
+      onSelect,
+      onOptionSelected,
+    ],
   );
 
   const listboxContext = useMemo(

--- a/src/components/Listbox/Listbox.tsx
+++ b/src/components/Listbox/Listbox.tsx
@@ -62,7 +62,6 @@ export function Listbox({
 }: ListboxProps) {
   const [loading, setLoading] = useState<string>();
   const [activeOption, setActiveOption] = useState<NavigableOption>();
-  const [navItems, setNavItems] = useState(getNavigableOptions());
   const [listLength, setListLength] = useState(0);
   const [reset, setReset] = useState(false);
 
@@ -94,6 +93,20 @@ export function Listbox({
       setListboxId(listId);
     }
   }, [setListboxId, listboxId, listId]);
+
+  function getNavigableOptions() {
+    if (!listboxRef.current) {
+      return [];
+    }
+
+    return [
+      ...new Set(
+        listboxRef.current.querySelectorAll<HTMLElement>(
+          LISTBOX_OPTION_SELECTOR,
+        ),
+      ),
+    ];
+  }
 
   const getFirstNavigableOption = useCallback(() => {
     const navItems = getNavigableOptions();
@@ -251,8 +264,6 @@ export function Listbox({
   const getNextValidOption = useCallback(
     (key: ArrowKeys) => {
       const navItems = getNavigableOptions();
-      setNavItems(navItems);
-
       const lastIndex = navItems.length - 1;
       const currentIndex = activeOption?.index ? activeOption.index : 0;
       let nextIndex = 0;
@@ -390,16 +401,6 @@ export function Listbox({
       </ListboxContext.Provider>
     </>
   );
-
-  function getNavigableOptions() {
-    return [
-      ...new Set(
-        listboxRef.current?.querySelectorAll<HTMLElement>(
-          LISTBOX_OPTION_SELECTOR,
-        ),
-      ),
-    ];
-  }
 }
 
 Listbox.Option = Option;

--- a/src/components/Listbox/Listbox.tsx
+++ b/src/components/Listbox/Listbox.tsx
@@ -83,7 +83,6 @@ export function Listbox({
     setActiveOptionId,
     setListboxId,
     onOptionSelected,
-    setActiveOptionValue,
     onKeyToBottom,
   } = useComboboxListbox();
 
@@ -234,14 +233,8 @@ export function Listbox({
         onOptionSelected();
       }
       if (onSelect) onSelect(option.value);
-      if (setActiveOptionValue) setActiveOptionValue(option.value);
     },
-    [
-      setActiveOptionValue,
-      handleChangeActiveOption,
-      onSelect,
-      onOptionSelected,
-    ],
+    [handleChangeActiveOption, onSelect, onOptionSelected],
   );
 
   const listboxContext = useMemo(

--- a/src/components/Listbox/Listbox.tsx
+++ b/src/components/Listbox/Listbox.tsx
@@ -83,7 +83,7 @@ export function Listbox({
     setActiveOptionId,
     setListboxId,
     onOptionSelected,
-    onActiveOptionChange,
+    setActiveOptionValue,
     onKeyToBottom,
   } = useComboboxListbox();
 
@@ -234,10 +234,10 @@ export function Listbox({
         onOptionSelected();
       }
       if (onSelect) onSelect(option.value);
-      if (onActiveOptionChange) onActiveOptionChange(option.value);
+      if (setActiveOptionValue) setActiveOptionValue(option.value);
     },
     [
-      onActiveOptionChange,
+      setActiveOptionValue,
       handleChangeActiveOption,
       onSelect,
       onOptionSelected,
@@ -363,8 +363,6 @@ export function Listbox({
         />
       </>
     ) : null;
-
-  console.log('Active descendant', activeOption?.domId);
 
   return (
     <>

--- a/src/components/Listbox/Listbox.tsx
+++ b/src/components/Listbox/Listbox.tsx
@@ -62,6 +62,7 @@ export function Listbox({
 }: ListboxProps) {
   const [loading, setLoading] = useState<string>();
   const [activeOption, setActiveOption] = useState<NavigableOption>();
+  const [navItems, setNavItems] = useState(getNavigableOptions());
   const [listLength, setListLength] = useState(0);
   const [reset, setReset] = useState(false);
 
@@ -75,7 +76,6 @@ export function Listbox({
 
   const scrollableRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement>(null);
-
   const {
     listboxId,
     textFieldLabelId,
@@ -114,7 +114,10 @@ export function Listbox({
 
     if (!element) return;
 
-    return {element, index: navItems.indexOf(element)};
+    const index = navItems.indexOf(element);
+    console.log('First navigable option: ', index);
+
+    return {element, index};
   }, []);
 
   const handleScrollIntoView = useCallback(
@@ -248,9 +251,10 @@ export function Listbox({
   const getNextValidOption = useCallback(
     (key: ArrowKeys) => {
       const navItems = getNavigableOptions();
+      setNavItems(navItems);
+
       const lastIndex = navItems.length - 1;
       const currentIndex = activeOption?.index ? activeOption.index : 0;
-
       let nextIndex = 0;
       let element = activeOption?.element;
       let count = -1;

--- a/src/components/Listbox/components/Option/Option.tsx
+++ b/src/components/Listbox/components/Option/Option.tsx
@@ -42,9 +42,9 @@ export const Option = memo(function Option({
   const sectionId = useSection();
   const isWithinSection = Boolean(sectionId);
 
-  const handleOptionClick = useCallback(
-    (evt: React.MouseEvent) => {
-      evt.preventDefault();
+  const handleOptionSelect = useCallback(
+    (event: React.MouseEvent | React.KeyboardEvent) => {
+      event.preventDefault();
       onAction && onAction();
       if (listItemRef.current && !onAction) {
         onOptionSelect({
@@ -59,8 +59,8 @@ export const Option = memo(function Option({
   );
 
   // prevents lost of focus on Textfield
-  const handleMouseDown = (evt: React.MouseEvent) => {
-    evt.preventDefault();
+  const handleMouseDown = (event: React.MouseEvent) => {
+    event.preventDefault();
   };
 
   const content =
@@ -89,20 +89,21 @@ export const Option = memo(function Option({
   return (
     <li
       {...sectionAttributes}
-      data-within-section={isWithinSection}
+      data-listbox-option
       data-listbox-option-value={value}
       data-listbox-option-destructive={destructive}
+      data-within-section={isWithinSection}
       className={classNames(styles.Option, divider && styles.divider)}
       id={domId}
       ref={listItemRef}
       tabIndex={-1}
-      onMouseDown={handleMouseDown}
-      aria-disabled={disabled}
-      onClick={disabled ? undefined : handleOptionClick}
       role={legacyRoleSupport}
       aria-label={accessibilityLabel}
       aria-selected={selected}
-      data-listbox-option
+      aria-disabled={disabled}
+      onClick={disabled ? undefined : handleOptionSelect}
+      onKeyPress={disabled ? undefined : handleOptionSelect}
+      onMouseDown={handleMouseDown}
     >
       {contentMarkup}
     </li>

--- a/src/components/Listbox/tests/Listbox.test.tsx
+++ b/src/components/Listbox/tests/Listbox.test.tsx
@@ -74,6 +74,20 @@ describe('<Listbox>', () => {
   });
 
   describe('ul', () => {
+    it('renders children', () => {
+      const wrapper = mountWithApp(<MockComponent />);
+
+      expect(wrapper).toContainReactComponent(Listbox.Option);
+    });
+
+    it('does not render a ul when children are null', () => {
+      const listbox = mountWithApp(
+        <Listbox enableKeyboardControl>{null}</Listbox>,
+      );
+
+      expect(listbox).not.toContainReactComponent('ul');
+    });
+
     it('renders with tab index in order', () => {
       const listbox = mountWithApp(<Listbox>Child</Listbox>);
 
@@ -131,7 +145,7 @@ describe('<Listbox>', () => {
       });
     });
 
-    it('renders with aria activedescendant with an id when an option is active', () => {
+    it('renders with aria-activedescendant with an id when an option is active', () => {
       const listbox = mountWithApp(
         <Listbox enableKeyboardControl>
           <Listbox.Option {...defaultOptionProps}>Option 1</Listbox.Option>
@@ -285,46 +299,10 @@ describe('<Listbox>', () => {
     expect(setListboxIdSpy).toHaveBeenCalledWith(expect.any(String));
   });
 
-  it('passes `accessibilityLabel` to the lists aria-label attribute', () => {
+  it("passes `accessibilityLabel` to the list's aria-label attribute", () => {
     const wrapper = mountWithApp(<MockComponent accessibilityLabel="test" />);
 
     expect(wrapper).toContainReactComponent('ul', {'aria-label': 'test'});
-  });
-
-  it('renders children', () => {
-    const wrapper = mountWithApp(<MockComponent />);
-
-    expect(wrapper).toContainReactComponent(Listbox.Option);
-  });
-
-  it('does not render a ul when children are null', () => {
-    const listbox = mountWithApp(
-      <Listbox enableKeyboardControl>{null}</Listbox>,
-    );
-
-    expect(listbox).not.toContainReactComponent('ul');
-  });
-
-  it('scrolls selected option into view when outside scrollable view', () => {
-    animationFrame.mock();
-    const scrollBySpy = jest.fn();
-    const wrapper = mountWithApp(<MockComponent />);
-    const option3 = wrapper.findAll(Listbox.Option)[2]!;
-
-    const scrollable = option3.domNode?.closest('[data-polaris-scrollable]')!;
-    scrollable.scrollBy = scrollBySpy;
-
-    triggerUp(wrapper);
-
-    expect(option3.domNode!.getAttribute('data-focused')).toBe('true');
-
-    timer.runAllTimers();
-
-    animationFrame.runFrame();
-
-    expect(scrollBySpy).toHaveBeenCalled();
-
-    animationFrame.restore();
   });
 
   describe('KeypressListenner', () => {
@@ -428,33 +406,10 @@ describe('<Listbox>', () => {
 
   describe('Keyboard control', () => {
     describe('down arrow', () => {
-      it('move the data-focused attribute to true of the selected list item', () => {
-        const wrapper = mountWithApp(<MockComponent />);
-
-        const options = wrapper.findAll(Listbox.Option);
-
-        expect(options[0].domNode!.getAttribute('data-focused')).toBeNull();
-
-        triggerDown(wrapper);
-
-        expect(options[0].domNode!.getAttribute('data-focused')).toBe('true');
-
-        triggerDown(wrapper);
-
-        expect(options[0].domNode!.getAttribute('data-focused')).toBeNull();
-        expect(options[1].domNode!.getAttribute('data-focused')).toBe('true');
-      });
-
-      it('set the active-descendant attribute of the list to the id of the focused element', () => {
+      it('sets the aria-activedescendant attribute to the id of the active option', () => {
         const wrapper = mountWithApp(<MockComponent />);
         const listbox = wrapper.find('ul', {role: 'listbox'})!;
         const options = wrapper.findAll(Listbox.Option);
-
-        expect(
-          listbox.domNode!.getAttribute('aria-activedescendant'),
-        ).toBeNull();
-
-        triggerDown(wrapper);
 
         expect(listbox.domNode!.getAttribute('aria-activedescendant')).toBe(
           options[0].domNode!.id,
@@ -467,15 +422,33 @@ describe('<Listbox>', () => {
         );
       });
 
-      it('move the focus back to the first option when the bottom of the list is reached', () => {
+      it('moves the data-focused attribute to true on the active option', () => {
+        const wrapper = mountWithApp(<MockComponent />);
+
+        const options = wrapper.findAll(Listbox.Option);
+
+        expect(options[0].domNode!.getAttribute('data-focused')).toBe('true');
+
+        triggerDown(wrapper);
+
+        expect(options[0].domNode!.getAttribute('data-focused')).toBeNull();
+        expect(options[1].domNode!.getAttribute('data-focused')).toBe('true');
+      });
+
+      it('moves the focus back to the first option when the bottom of the list is reached', () => {
         const wrapper = mountWithApp(<MockComponent />);
         const options = wrapper.findAll(Listbox.Option);
 
-        expect(options[0].domNode!.getAttribute('data-focused')).toBeNull();
+        expect(options[0].domNode!.getAttribute('data-focused')).toBe('true');
 
         triggerDown(wrapper);
+
+        expect(options[1].domNode!.getAttribute('data-focused')).toBe('true');
+
         triggerDown(wrapper);
-        triggerDown(wrapper);
+
+        expect(options[2].domNode!.getAttribute('data-focused')).toBe('true');
+
         triggerDown(wrapper);
 
         expect(options[0].domNode!.getAttribute('data-focused')).toBe('true');
@@ -516,7 +489,31 @@ describe('<Listbox>', () => {
     });
 
     describe('up arrow', () => {
-      it('move the data-focused attribute to true of the selected list item', () => {
+      it('scrolls selected option into view when outside scrollable view', () => {
+        animationFrame.mock();
+        const scrollBySpy = jest.fn();
+        const wrapper = mountWithApp(<MockComponent />);
+        const option3 = wrapper.findAll(Listbox.Option)[2]!;
+
+        const scrollable = option3.domNode?.closest(
+          '[data-polaris-scrollable]',
+        )!;
+        scrollable.scrollBy = scrollBySpy;
+
+        triggerUp(wrapper);
+
+        expect(option3.domNode!.getAttribute('data-focused')).toBe('true');
+
+        timer.runAllTimers();
+
+        animationFrame.runFrame();
+
+        expect(scrollBySpy).toHaveBeenCalled();
+
+        animationFrame.restore();
+      });
+
+      it('moves the data-focused attribute to true of the selected list item', () => {
         const wrapper = mountWithApp(<MockComponent />);
 
         const options = wrapper.findAll(Listbox.Option);
@@ -533,7 +530,7 @@ describe('<Listbox>', () => {
         expect(options[1].domNode!.getAttribute('data-focused')).toBe('true');
       });
 
-      it('set the active-descendant attribute of the list to the id of the focused element', () => {
+      it('sets the aria-activedescendant attribute to the id of the focused element', () => {
         const wrapper = mountWithApp(<MockComponent />);
         const listbox = wrapper.find('ul', {role: 'listbox'})!;
         const options = wrapper.findAll(Listbox.Option);
@@ -555,7 +552,7 @@ describe('<Listbox>', () => {
         );
       });
 
-      it('move the focus back to the last option when the top of the list is reached', () => {
+      it('moves the focus back to the last option when the top of the list is reached', () => {
         const wrapper = mountWithApp(<MockComponent />);
         const options = wrapper.findAll(Listbox.Option);
 
@@ -590,13 +587,13 @@ describe('<Listbox>', () => {
       it('calls onOptionSelect with the data-listbox-option-value when enter is pressed', () => {
         const onSelect = jest.fn();
         const wrapper = mountWithApp(<MockComponent onSelect={onSelect} />);
-        const option = wrapper.find(Listbox.Option);
+        const options = wrapper.findAll(Listbox.Option);
         triggerDown(wrapper);
 
         triggerEnter(wrapper);
 
         expect(onSelect).toHaveBeenCalledWith(
-          option!.domNode!.getAttribute('data-listbox-option-value'),
+          options[1]!.domNode!.getAttribute('data-listbox-option-value'),
         );
       });
     });

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -137,6 +137,13 @@ $prefix-horizontal-spacing: var(--p-space-2);
   &:-webkit-autofill {
     border-radius: var(--p-border-radius-1);
   }
+
+  &.typeahead {
+    &::selection {
+      color: hotpink;
+      background: transparent;
+    }
+  }
 }
 
 .Input-hasClearButton {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -68,12 +68,16 @@ interface NonMutuallyExclusiveProps {
   disabled?: boolean;
   /** Show a clear text button in the input */
   clearButton?: boolean;
-  /* Text to render after the cursor to visually indicate pending autocompletion */
+  /** Indicates whether or not the entire value should be selected on focus. */
+  selectTextOnFocus?: boolean;
+  /* Range of characters to select. */
   selection?: {
     start: number;
     end: number;
     direction?: 'forward' | 'backward' | 'none';
   };
+  /** Whether or not the input implements inline autocompletion. When true, the characters within the `selection` range will be subdued. */
+  typeahead?: boolean;
   /** Disable editing of the input */
   readOnly?: boolean;
   /** Automatically focus the input */
@@ -134,8 +138,6 @@ interface NonMutuallyExclusiveProps {
   requiredIndicator?: boolean;
   /** Indicates whether or not a monospaced font should be used */
   monospaced?: boolean;
-  /** Indicates whether or not the entire input/text area text should be selected on focus */
-  selectTextOnFocus?: boolean;
   /** Callback when clear button is clicked */
   onClearButtonClick?(id: string): void;
   /** Callback when value is changed */
@@ -196,6 +198,7 @@ export function TextField({
   monospaced,
   selectTextOnFocus,
   selection,
+  typeahead,
   onClearButtonClick,
   onChange,
   onFocus,
@@ -228,10 +231,11 @@ export function TextField({
       type === 'search' ||
       type === 'url' ||
       type === 'password';
+
     if (!input || !isSupportedInputType || selection === undefined) return;
+
     const {start, end} = selection;
     input.setSelectionRange(start, end);
-    // console.log('set selection: ', selection);
   }, [selection, type]);
 
   // Use a typeof check here as Typescript mostly protects us from non-stringy
@@ -429,6 +433,7 @@ export function TextField({
     suffix && styles['Input-suffixed'],
     clearButton && styles['Input-hasClearButton'],
     monospaced && styles.monospaced,
+    typeahead && styles.typeahead,
   );
 
   const handleOnFocus = (event: React.FocusEvent<HTMLElement>) => {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -68,6 +68,12 @@ interface NonMutuallyExclusiveProps {
   disabled?: boolean;
   /** Show a clear text button in the input */
   clearButton?: boolean;
+  /* Text to render after the cursor to visually indicate pending autocompletion */
+  selection?: {
+    start: number;
+    end: number;
+    direction: 'none' | 'forward' | 'backward';
+  };
   /** Disable editing of the input */
   readOnly?: boolean;
   /** Automatically focus the input */
@@ -124,6 +130,12 @@ interface NonMutuallyExclusiveProps {
   showCharacterCount?: boolean;
   /** Determines the alignment of the text in the input */
   align?: Alignment;
+  /** Visual required indicator, adds an asterisk to label */
+  requiredIndicator?: boolean;
+  /** Indicates whether or not a monospaced font should be used */
+  monospaced?: boolean;
+  /** Indicates whether or not the entire input/text area text should be selected on focus */
+  selectTextOnFocus?: boolean;
   /** Callback when clear button is clicked */
   onClearButtonClick?(id: string): void;
   /** Callback when value is changed */
@@ -132,12 +144,6 @@ interface NonMutuallyExclusiveProps {
   onFocus?: (event?: React.FocusEvent<HTMLElement>) => void;
   /** Callback when focus is removed */
   onBlur?(): void;
-  /** Visual required indicator, adds an asterisk to label */
-  requiredIndicator?: boolean;
-  /** Indicates whether or not a monospaced font should be used */
-  monospaced?: boolean;
-  /** Indicates whether or not the entire input/text area text should be selected on focus */
-  selectTextOnFocus?: boolean;
 }
 
 export type TextFieldProps = NonMutuallyExclusiveProps &
@@ -186,13 +192,14 @@ export function TextField({
   ariaAutocomplete,
   showCharacterCount,
   align,
+  requiredIndicator,
+  monospaced,
+  selectTextOnFocus,
+  selection,
   onClearButtonClick,
   onChange,
   onFocus,
   onBlur,
-  requiredIndicator,
-  monospaced,
-  selectTextOnFocus,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -201,7 +208,8 @@ export function TextField({
 
   const id = useUniqueId('TextField', idProp);
 
-  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const prefixRef = useRef<HTMLDivElement>(null);
   const suffixRef = useRef<HTMLDivElement>(null);
   const buttonPressTimer = useRef<number>();
@@ -211,6 +219,19 @@ export function TextField({
     if (!input || focused === undefined) return;
     focused ? input.focus() : input.blur();
   }, [focused]);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    const isSupportedInputType =
+      type === 'text' ||
+      type === 'tel' ||
+      type === 'search' ||
+      type === 'url' ||
+      type === 'password';
+    if (!input || !isSupportedInputType || selection === undefined) return;
+    const {start, end, direction} = selection;
+    input.setSelectionRange(start, end, direction);
+  }, [selection, type]);
 
   // Use a typeof check here as Typescript mostly protects us from non-stringy
   // values but overzealous usage of `any` in consuming apps means people have
@@ -234,7 +255,7 @@ export function TextField({
   const inputType = type === 'currency' ? 'text' : type;
 
   const prefixMarkup = prefix ? (
-    <div className={styles.Prefix} id={`${id}Prefix`} ref={prefixRef}>
+    <div className={styles.Prefix} id={`${id}-Prefix`} ref={prefixRef}>
       {prefix}
     </div>
   ) : null;
@@ -268,7 +289,7 @@ export function TextField({
 
     characterCountMarkup = (
       <div
-        id={`${id}CharacterCounter`}
+        id={`${id}-CharacterCounter`}
         className={characterCountClassName}
         aria-label={characterCountLabel}
         aria-live={focus ? 'polite' : 'off'}
@@ -434,7 +455,7 @@ export function TextField({
     autoComplete,
     className: inputClassName,
     onChange: handleChange,
-    ref: inputRef,
+    ref: multiline ? textAreaRef : inputRef,
     min,
     max,
     step,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -72,7 +72,7 @@ interface NonMutuallyExclusiveProps {
   selection?: {
     start: number;
     end: number;
-    direction: 'none' | 'forward' | 'backward';
+    direction?: 'forward' | 'backward' | 'none';
   };
   /** Disable editing of the input */
   readOnly?: boolean;
@@ -229,8 +229,9 @@ export function TextField({
       type === 'url' ||
       type === 'password';
     if (!input || !isSupportedInputType || selection === undefined) return;
-    const {start, end, direction} = selection;
-    input.setSelectionRange(start, end, direction);
+    const {start, end} = selection;
+    input.setSelectionRange(start, end);
+    console.log('set selection: ', selection);
   }, [selection, type]);
 
   // Use a typeof check here as Typescript mostly protects us from non-stringy

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -231,7 +231,7 @@ export function TextField({
     if (!input || !isSupportedInputType || selection === undefined) return;
     const {start, end} = selection;
     input.setSelectionRange(start, end);
-    console.log('set selection: ', selection);
+    // console.log('set selection: ', selection);
   }, [selection, type]);
 
   // Use a typeof check here as Typescript mostly protects us from non-stringy
@@ -525,6 +525,7 @@ export function TextField({
     if (type !== 'number' || which === Key.Enter || numbersSpec.test(key)) {
       return;
     }
+
     event.preventDefault();
   }
 

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -6,7 +6,7 @@ import {InlineError} from '../../InlineError';
 import {Labelled} from '../../Labelled';
 import {Select} from '../../Select';
 import {Resizer, Spinner} from '../components';
-import {TextField} from '../TextField';
+import {TextField, TextFieldProps} from '../TextField';
 import styles from '../TextField.scss';
 
 describe('<TextField />', () => {
@@ -616,6 +616,69 @@ describe('<TextField />', () => {
       });
     });
   });
+
+  /* eslint-disable jest/no-commented-out-tests */
+  // describe('selection', () => {
+  //   const selection: TextFieldProps['selection'] = {
+  //     start: 2,
+  //     end: 8,
+  //     direction: 'none',
+  //   };
+
+  //   it('sets the selection on the input when provided', () => {
+  //     const textField = mountWithApp(
+  //       <TextField
+  //         autoComplete = 'off';
+  //         label="TextField"
+  //         type="text"
+  //         value="abcdefghi"
+  //         onChange={noop}
+  //         selection={selection}
+  //       />,
+  //     );
+  //     expect(textField).toContainReactComponent('input', {
+  //       selectionStart,
+  //     });
+  //   });
+
+  //   it('does not set the selection on the input when not provided', () => {
+  //     const textField = mountWithApp(
+  //       <TextField
+  //         autoComplete = 'off';
+  //         label="TextField"
+  //         type="text"
+  //         value="abcdefghi"
+  //         onChange={noop}
+  //       />,
+  //     );
+
+  //     expect(textField).not.toContainReactComponent('input', {
+  //       selectionStart: selection.start,
+  //       selectionEnd: selection.end,
+  //       selctionDirection: selection.direction,
+  //     });
+  //   });
+
+  //   it('does not set the selection on the input when type does not support support', () => {
+  //     const textField = mountWithApp(
+  //       <TextField
+  //         autoComplete = 'off';
+  //         label="TextField"
+  //         type="number"
+  //         value="abcdefghi"
+  //         onChange={noop}
+  //       />,
+  //     );
+
+  //     expect(textField).not.toContainReactComponent('input', {
+  //       selectionStart: selection.start,
+  //       selectionEnd: selection.end,
+  //       selctionDirection: selection.direction,
+  //     });
+  //   });
+  // });
+
+  /* eslint-enable jest/no-commented-out-tests */
 
   describe('type', () => {
     it('sets the type on the input', () => {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -6,7 +6,7 @@ import {InlineError} from '../../InlineError';
 import {Labelled} from '../../Labelled';
 import {Select} from '../../Select';
 import {Resizer, Spinner} from '../components';
-import {TextField, TextFieldProps} from '../TextField';
+import {TextField /* TextFieldProps */} from '../TextField';
 import styles from '../TextField.scss';
 
 describe('<TextField />', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,3 +392,4 @@ export {
   useRowSelected as useIndexTableRowSelected,
   useContainerScroll as useIndexTableContainerScroll,
 } from './utilities/index-table';
+export {useComboboxListbox} from './utilities/combobox';

--- a/src/utilities/combobox/context.tsx
+++ b/src/utilities/combobox/context.tsx
@@ -1,6 +1,8 @@
 import {createContext} from 'react';
 
 export interface ComboboxTextFieldType {
+  // Index of the option set as the aria-activedescendant and visually indicated as active.
+  activeOptionValue?: string;
   // Value for the TextField aria-activedescendant. (also on list context when not in combobox)
   activeOptionId?: string;
   // Value for the Combobox aria-owns and TextField aria-control
@@ -11,12 +13,12 @@ export interface ComboboxTextFieldType {
   setTextFieldLabelId?(id: string): void;
   // Sets a boolean to enable/disable keyboard control for the Listbox
   setTextFieldFocused?(value: boolean): void;
-  // Callback when TextField is focused
+  // Callback fired when TextField is focused
   onTextFieldFocus?(): void;
-  // Callback when TextField is blured
+  // Callback fired when TextField is blured
   onTextFieldBlur?(): void;
-  // Callback when TextField is changed
-  onTextFieldChange?(): void;
+  // Callback fired when TextField value changes
+  onTextFieldChange?(value: string): void;
 }
 
 export interface ComboboxListboxType {
@@ -32,6 +34,8 @@ export interface ComboboxListboxType {
   listboxId?: string;
   // Handler used in Combobox to brings to manage popover state and focus based on multi or single select
   onOptionSelected?(): void;
+  // Callback fired when the active listbox option changes
+  onActiveOptionChange?(activeOptionValue: string): void;
   // Callback to onScrolledToBottom when using keyboard navigation navigates to the last item
   onKeyToBottom?(): void;
 }

--- a/src/utilities/combobox/context.tsx
+++ b/src/utilities/combobox/context.tsx
@@ -35,7 +35,7 @@ export interface ComboboxListboxType {
   // Handler used in Combobox to brings to manage popover state and focus based on multi or single select
   onOptionSelected?(): void;
   // Callback fired when the active listbox option changes
-  onActiveOptionChange?(activeOptionValue: string): void;
+  setActiveOptionValue?(activeOptionValue: string): void;
   // Callback to onScrolledToBottom when using keyboard navigation navigates to the last item
   onKeyToBottom?(): void;
 }

--- a/src/utilities/combobox/context.tsx
+++ b/src/utilities/combobox/context.tsx
@@ -1,8 +1,6 @@
 import {createContext} from 'react';
 
 export interface ComboboxTextFieldType {
-  // Index of the option set as the aria-activedescendant and visually indicated as active.
-  activeOptionValue?: string;
   // Value for the TextField aria-activedescendant. (also on list context when not in combobox)
   activeOptionId?: string;
   // Value for the Combobox aria-owns and TextField aria-control
@@ -26,16 +24,14 @@ export interface ComboboxListboxType {
   textFieldLabelId?: string;
   // Enables/disables keyboard control
   textFieldFocused?: boolean;
+  // Value of listboxId to avoid calling setListboxId
+  listboxId?: string;
   // Sets the value for the TextFields aria-activedescendant.
   setActiveOptionId?(id: string): void;
   // Sets the value of the listboxId use for the Combobox aria-owns and TextField aria-control
   setListboxId?(id: string): void;
-  // Value of listboxId to avoid calling setListboxId
-  listboxId?: string;
   // Handler used in Combobox to brings to manage popover state and focus based on multi or single select
   onOptionSelected?(): void;
-  // Callback fired when the active listbox option changes
-  setActiveOptionValue?(activeOptionValue: string): void;
   // Callback to onScrolledToBottom when using keyboard navigation navigates to the last item
   onKeyToBottom?(): void;
 }

--- a/src/utilities/listbox/types.ts
+++ b/src/utilities/listbox/types.ts
@@ -3,4 +3,5 @@ export interface NavigableOption {
   value: string;
   element: HTMLElement;
   disabled: boolean;
+  index?: number;
 }


### PR DESCRIPTION
## Tl;dr: 
This PR demonstrates the massive improvement to clarity, ease, and speed of multi-selection flows when inline autocompletion with automatic selection is implemented in `Combobox` primitives 🙌🏽 [Check it ouuuut](https://5d559397bae39100201eedc1-mmrewhtcbk.chromatic.com/?path=/story/playground-playground--playground) 👀 

### What is this PR doing?

This PR builds on the prototyping Lo and I have been tag-teaming on. I rebased the [`lo/autpcomplete` branch](https://github.com/Shopify/polaris-react/compare/typeahead-proto...lo/autocomplete?expand=1) over my [`listbox-autoselection` branch](https://github.com/Shopify/polaris-react/pull/5256) and got the typeahead working* and styled (typeahead selection state is pink instead of subdued for clear distinction while developing).  

Next steps I recommend would be to:

- [x] Move the suggestion parsing into `TextField`:
  - [x]  Replace the boolean `typeahead` prop with a  string `suggestion` prop that is mutually exclusive from the `selection` prop**
  - [ ] Remove the need for the `isSupportedInputType` boolean on `line 228` of `TextField.tsx`  by making `selection` a mutually exclusive prop from `type`, only allowing it to be set when `type` is one of the input types supported by the browsers [`setSelectionRange` API](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange)
  - [x] Move the condition on `line 114` of `Playground.tsx` that sets either  the `value` or the `suggestion` (if present) on the `input` value into `TextField`
  - [x] Move the logic for calculating and updating the `selection` range in the Playground as the `suggestion` is set into a `useEffect` hook in `TextField.tsx` that calls `setSelectionRange` directly when the `suggestion` changes
  - [x] Update the conditional in `inputClassName` on `line 436` of `TextField.tsx` from `typeahead` to `suggestion`.
  - [x] Update `line 141` of `TextField.scss` from `.typeahead` to `.suggestion`

Let's branch off of this branch to make those changes, and we'll separate things back out so their easy to review once we're satisfied with the API and feel solid on implementation approach.

### Footnotes

*There's a kink to work out with the create action (it's working inconsistently, but wasn't a main priority this week)

**I think  programmatic `selection` of the `value` should be supported as part of flexibility improvements, but for typeahead selection should be handled internally by `TextField` because the behavior is complex and it doesnt make sense to me to have consumers reimplement that logic in the midst of the complexities of filtering and mutating the list of options for different implementations across Admin.

<!-- Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

