### PR TITLE
fix: adjust Modal close button spacing when title is hidden

### DIFF
--- a/.changeset/modern-rats-divide.md
+++ b/.changeset/modern-rats-divide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fixed the padding of the close button in the `Modal` component when the title is hidden ([#5279](https://github.com/Shopify/polaris-react/pull/5280))

--- a/polaris-react/src/components/Modal/components/Header/Header.scss
+++ b/polaris-react/src/components/Modal/components/Header/Header.scss
@@ -10,8 +10,10 @@
 
 .titleHidden {
   position: absolute;
-  right: var(--p-space-2);
+  right: 0;
   z-index: 1;
+  padding-top: var(--p-space-4);
+  padding-right: var(--p-space-5);
 
   .Title {
     display: none;


### PR DESCRIPTION
Fixes an issue where the close button would lose its top and right spacing when the `titleHidden` prop was passed to the Modal or if the `title` was not set.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #5279

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Adds top and right padding to the modal header in the `.titleHidden` class so that the close button is consistently positioned both with & without a title present.

Before:
![Screen Shot 2022-03-14 at 09 43 34](https://user-images.githubusercontent.com/4888172/158245867-c4758811-fbab-4378-a217-f8b39bf5458a.png)

After:
![Screen Shot 2022-03-14 at 09 41 54](https://user-images.githubusercontent.com/4888172/158245886-1e018088-62ac-40fe-911d-c7bf23662911.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<!--<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>-->

1. Check out this fork and run `yarn && yarn build` locally to install dependencies
2. Start the development server with `yarn dev`
3. View the Modal component in your local development environment (http://localhost:6006/?path=/story/all-components-modal--modal-without-a-title)
4. Switch between the different variations of the Modal component in the playground UI, and confirm that the close button's positioning is the same both with and without a modal title.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
