### PR TITLE
[`Badge`] Add `icon` prop

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
+- Added `icon` prop to the `Badge` component ([#5292](https://github.com/Shopify/polaris/pull/5292))
+
 ### Bug fixes
 
 ### Documentation

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -115,3 +115,13 @@
 .withinFilter {
   border-radius: var(--p-border-radius-1);
 }
+
+.Icon {
+  // This compensates for the typical icon used in badges being inset within
+  // its bounding box.
+  margin-left: calc(-1 * (var(--p-space-1)));
+
+  + *:not(.Icon) {
+    margin-left: var(--p-space-1);
+  }
+}

--- a/polaris-react/src/components/Badge/Badge.tsx
+++ b/polaris-react/src/components/Badge/Badge.tsx
@@ -1,9 +1,11 @@
 import React, {useContext} from 'react';
 
+import type {IconSource} from '../../types';
 import {classNames, variationName} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {WithinFilterContext} from '../../utilities/within-filter-context';
 import {VisuallyHidden} from '../VisuallyHidden';
+import {Icon} from '../Icon';
 
 import styles from './Badge.scss';
 
@@ -11,13 +13,15 @@ type Status = 'info' | 'success' | 'attention' | 'warning' | 'critical' | 'new';
 type Progress = 'incomplete' | 'partiallyComplete' | 'complete';
 type Size = 'small' | 'medium';
 
-export interface BadgeProps {
+interface NonMutuallyExclusiveProps {
   /** The content to display inside the badge. */
   children?: string;
   /** Colors and labels the badge with the given status. */
   status?: Status;
   /** Render a pip showing the progress of a given task. */
   progress?: Progress;
+  /** Icon to display to the left of the badge’s content. */
+  icon?: IconSource;
   /**
    * Medium or small size.
    * @default 'medium'
@@ -26,6 +30,12 @@ export interface BadgeProps {
   /** Pass a custom accessibilityLabel */
   statusAndProgressLabelOverride?: string;
 }
+
+export type BadgeProps = NonMutuallyExclusiveProps &
+  (
+    | {progress?: Progress; icon?: undefined}
+    | {icon?: IconSource; progress?: undefined}
+  );
 
 const PROGRESS_LABELS: {[key in Progress]: Progress} = {
   incomplete: 'incomplete',
@@ -48,6 +58,7 @@ export function Badge({
   children,
   status,
   progress,
+  icon,
   size = DEFAULT_SIZE,
   statusAndProgressLabelOverride,
 }: BadgeProps) {
@@ -58,6 +69,7 @@ export function Badge({
     styles.Badge,
     status && styles[variationName('status', status)],
     progress && styles[variationName('progress', progress)],
+    icon && styles.icon,
     size && size !== DEFAULT_SIZE && styles[variationName('size', size)],
     withinFilter && styles.withinFilter,
   );
@@ -115,7 +127,7 @@ export function Badge({
     <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
   );
 
-  if (progressLabel) {
+  if (progressLabel && !icon) {
     accessibilityMarkup = (
       <span className={styles.Pip}>{accessibilityMarkup}</span>
     );
@@ -124,7 +136,12 @@ export function Badge({
   return (
     <span className={className}>
       {accessibilityMarkup}
-      {children}
+      {icon && (
+        <span className={styles.Icon}>
+          <Icon source={icon} />
+        </span>
+      )}
+      {children && <span>{children}</span>}
     </span>
   );
 }

--- a/polaris-react/src/components/Badge/tests/Badge.test.tsx
+++ b/polaris-react/src/components/Badge/tests/Badge.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
+import {GlobeMinor} from '@shopify/polaris-icons';
 
 import {VisuallyHidden} from '../../VisuallyHidden';
+import {Icon} from '../../Icon';
 import {Badge} from '../Badge';
 
 describe('<Badge />', () => {
@@ -42,6 +44,35 @@ describe('<Badge />', () => {
     const badge = mountWithApp(<Badge progress="incomplete" />);
 
     expect(badge).toContainReactComponent('span', {
+      className: 'Pip',
+    });
+  });
+
+  it('does not render an icon when icon is not provided', () => {
+    const badge = mountWithApp(<Badge status="attention" />);
+
+    expect(badge).not.toContainReactComponent(Icon);
+  });
+
+  it('renders an icon when icon is provided', () => {
+    const badge = mountWithApp(<Badge icon={GlobeMinor} />);
+
+    expect(badge).toContainReactComponent(Icon, {
+      source: GlobeMinor,
+    });
+  });
+
+  it('prefers the icon to pip styles when both progress and icon are provided', () => {
+    const badge = mountWithApp(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      <Badge progress="incomplete" icon={GlobeMinor} />,
+    );
+
+    expect(badge).toContainReactComponent(Icon, {
+      source: GlobeMinor,
+    });
+    expect(badge).not.toContainReactComponent('span', {
       className: 'Pip',
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Working on https://github.com/Shopify/web/pull/60263, I’m currently unable to add an icon to the “worldwide” badge because the `children` prop only accepts a `string`. My first idea was to change the type of that prop to accept any kind of `React.ReactNode`, but [Kyle pointed out](https://github.com/Shopify/polaris/pull/5292#pullrequestreview-914473475) that this was a little too permissive, so in the end I went with adding a more restrictive `icon` prop.

### WHAT is this pull request doing?

Adding an `icon` prop like in the same way it’s done for the `Button` component. The `Badge` already renders some sort of icon when passing the `progress` prop, so I made these two props mutually exclusive from each other.

![Screenshot 2022-04-07 at 11 57 39](https://user-images.githubusercontent.com/9154236/162173961-967265e1-369a-45a0-a02f-1f42276800d0.png)

### 🎩 checklist


### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {GlobeMinor} from '@shopify/polaris-icons';

import {Page, Stack, Badge} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Stack>
        <Badge icon={GlobeMinor}>Icon, no status</Badge>

        {/*
          The Icon doesn’t get scaled down because the `Icon` size is hardcoded to 20px…
        */}
        <Badge icon={GlobeMinor} size="small">
          Small Badge with icon
        </Badge>

        <Badge icon={GlobeMinor} status="success">
          Icon, success
        </Badge>

        <Badge progress="complete" icon={GlobeMinor}>
          Progress + icon, prefers icon but TypeScript errors
        </Badge>

        <Badge progress="complete">Progress, unchanged</Badge>

        {/*
          Icon only. This works right now but I don‘t see a reason why `children` would be optional.
          If we want to allow this we need to also allow an alt prop for the icon.
        */}
        <Badge icon={GlobeMinor} />
      </Stack>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, ping @ sarahill to update the Polaris UI kit