### PR TITLE
Stack: optionally flatten React.Fragment children

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Replaced hard coded `font-size` and `line-height` values with tokens ([5355](https://github.com/Shopify/polaris/pull/5355/))
 - Replaced hard coded spacing values with tokens ([5364](https://github.com/Shopify/polaris/pull/5364/))
 - Simplified usage of color tokens ([5360](https://github.com/Shopify/polaris/pull/5360/))
+- Added `flattedReactFragments` as an optional prop to `Stack` to allow conditional rendering of multiple child elements wrapped in a `React.Fragment` ([#5293](https://github.com/Shopify/polaris-react/pull/5293))
 
 ### Bug fixes
 

--- a/polaris-react/src/components/Stack/tests/Stack.test.tsx
+++ b/polaris-react/src/components/Stack/tests/Stack.test.tsx
@@ -11,4 +11,24 @@ describe('<Stack />', () => {
 
     expect(stack).toContainReactComponentTimes(Stack.Item, 2);
   });
+
+  it('flattens one depth of React.Fragment with "flattenReactFragments"', () => {
+    const stack = mountWithApp(
+      <Stack flattenReactFragments>
+        <>
+          <p>One</p>
+          <p>Two</p>
+          <p>
+            Three
+            <>
+              <p>This should not be flattened</p>
+            </>
+          </p>
+        </>
+        <p>Four</p>
+      </Stack>,
+    );
+
+    expect(stack).toContainReactComponentTimes(Stack.Item, 4);
+  });
 });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

In scenarios when you need to conditionally render a collection of `Stack.Item`s  it should be handled with a `React.Fragment`.  Currently `Stack` is handling `React.Fragment` as single element to be rendered and wrapping it with a single `Stack.Item`, which translates into an additional host node and incorrect layout.

A user should explicitly add a host node if this was their desired behaviour.

This change aligns `Stack`'s handling of `React.Fragment` to be more inline with how React internally handles fragments; that is to not translate it to a host node (i.e. `div`).

Note this is a _non-breaking change_ as we only apply this logic when passing in the `flattenReactFragments`. Personally, I think this to should be the default behavior, but it's likely to break a lot of layouts for developers who have developed around this nuance.


![image](https://user-images.githubusercontent.com/7349258/158596671-cd9b2ec9-f4c1-4c45-9aca-6453cdd72ebe.png)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Adds an optional prop to `Stack` to flatten `React.Fragment`'s 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Stack} from '../src';

export function Playground() {
  const someCondition = true;
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}

      <h2>Unflattened (normal)</h2>
      <p>you should see 2 Stack.Items in dev tools</p>
      <Stack>
        {someCondition && (
          <>
            <p>One</p>
            <p>Two</p>
            <p>Three</p>
          </>
        )}
        <p>Four</p>
      </Stack>

      <hr style={{margin: '50px 0'}} />

      <h2>Flattened</h2>
      <p>you should see 4 Stack.Items in dev tools</p>

      <Stack flattenReactFragments>
        {someCondition && (
          <>
            <p>One</p>
            <p>Two</p>
            <p>Three</p>
          </>
        )}
        <p>Four</p>
      </Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
