### PR TITLE
Clarify `build-consumer` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To test the changes on a mobile or virtual machine, you will need to open the so
 yarn run build-consumer polaris-styleguide
 ```
 
-2. In your terminal, open a second tab and run `yarn run dev` from the `polaris-styleguide` repository
+2. In your terminal, open a second tab and run `dev up && dev run` from the `polaris-styleguide` repository (or `yarn install && yarn dev` in your consuming project)
 
 In the example above, the build is copied to `polaris-styleguide/node_modules/@shopify/polaris`. And in this case, a rebuild of `polaris-styleguide` is required after copying the `polaris-react` build, but may not be the case for all consuming projects.
 


### PR DESCRIPTION
The styleguide runs on railgun / dev so `yarn run dev` can't work there. Updated the doc to help clarify