### PR TITLE
[IndexTable] Add loading state to Index Table promoted bulk actions

### DIFF
--- a/src/components/BulkActions/BulkActions.tsx
+++ b/src/components/BulkActions/BulkActions.tsx
@@ -12,6 +12,7 @@ import type {
   Action,
   ActionListSection,
   MenuGroupDescriptor,
+  LoadableAction,
 } from '../../types';
 import {ActionList} from '../ActionList';
 import {Popover} from '../Popover';
@@ -23,7 +24,7 @@ import {CheckableButton} from '../CheckableButton';
 import {BulkActionButton, BulkActionMenu} from './components';
 import styles from './BulkActions.scss';
 
-export type BulkAction = DisableableAction & BadgeAction;
+export type BulkAction = DisableableAction & BadgeAction & LoadableAction;
 
 type BulkActionListSection = ActionListSection;
 
@@ -52,6 +53,8 @@ export interface BulkActionsProps {
   paginatedSelectAllAction?: Action;
   /** Disables bulk actions */
   disabled?: boolean;
+  /** Disables bulk actions */
+  loading?: boolean;
   /** Callback when the select all checkbox is clicked */
   onToggleAll?(): void;
   /** Callback when selectable state of list is changed */
@@ -234,6 +237,7 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
       selected,
       smallScreen,
       disabled,
+      loading,
       promotedActions,
       paginatedSelectAllText = null,
       paginatedSelectAllAction,
@@ -263,6 +267,7 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
         onClick={paginatedSelectAllAction.onAction}
         plain
         disabled={disabled}
+        loading={loading}
       >
         {paginatedSelectAllAction.content}
       </Button>

--- a/src/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
+++ b/src/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
@@ -1,6 +1,6 @@
 import React, {useRef} from 'react';
 
-import type {DisableableAction} from '../../../../types';
+import type {DisableableAction, LoadableAction} from '../../../../types';
 import {Button} from '../../../Button';
 import {Indicator} from '../../../Indicator';
 import {useComponentDidMount} from '../../../../utilities/use-component-did-mount';
@@ -10,7 +10,7 @@ export type BulkActionButtonProps = {
   disclosure?: boolean;
   indicator?: boolean;
   handleMeasurement?(width: number): void;
-} & DisableableAction;
+} & DisableableAction & LoadableAction;
 
 export function BulkActionButton({
   handleMeasurement,
@@ -21,6 +21,7 @@ export function BulkActionButton({
   disclosure,
   accessibilityLabel,
   disabled,
+  loading,
   indicator,
 }: BulkActionButtonProps) {
   const bulkActionButton = useRef<HTMLDivElement>(null);
@@ -40,6 +41,7 @@ export function BulkActionButton({
         aria-label={accessibilityLabel}
         onClick={onAction}
         disabled={disabled}
+        loading={loading}
         disclosure={disclosure}
       >
         {content}

--- a/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -404,6 +404,31 @@ describe('<IndexTable>', () => {
         true,
       );
     });
+
+    it('displays a loading spinner on a promoted bulk action when loading is true for that bulk action', () => {
+      const onSelectionChangeSpy = jest.fn();
+      const promotedBulkActions = [{content: 'promoted action', loading: true}];
+      const index = mountWithApp(
+        <IndexTable
+          {...defaultProps}
+          selectable
+          hasMoreItems
+          selectedItemsCount={1}
+          itemCount={2}
+          promotedBulkActions={promotedBulkActions}
+          onSelectionChange={onSelectionChangeSpy}
+        >
+          {mockTableItems.map(mockRenderRow)}
+        </IndexTable>,
+      );
+
+      const button = index.find(BulkActions)!.find(Button);
+
+
+      expect(button).toHaveReactProps(
+        {loading: true},
+      );
+    });
   });
 
   describe('condensed', () => {


### PR DESCRIPTION


### WHY are these changes introduced?

I've seen a few use cases where having an optional loading prop for promoted bulk actions on the IndexTable would be useful. For example, one bulk action I've recently modified requires a few seconds of wait time while a query loads before a modal comes up to confirm the bulk action. I have used the disabled state for now, but I think it would be clearer to the merchant if the bulk action had a loading state.

Fixes #5282 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adding an optional loading state to promoted bulk actions on the Index Table.

Before (only the disabled state could be used):

![image](https://user-images.githubusercontent.com/39162293/159338352-c86b4eb6-f403-4087-950f-02b2497a1158.png)

After (loading state is available to show the merchant that something is happening in the background): 

<img width="995" alt="Screen Shot 2022-03-21 at 2 18 49 PM" src="https://user-images.githubusercontent.com/39162293/159338450-3a727eee-709a-421f-b5db-7c915f07fb69.png">



<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card, IndexTable, useIndexResourceState, TextStyle} from '../src';

export function Playground() {

  const customers = [
    {
      id: '3413',
      url: 'customers/341',
      name: 'Mae Jemison',
      location: 'Decatur, USA',
      orders: 20,
      amountSpent: '$2,400',
    },
    {
      id: '2563',
      url: 'customers/256',
      name: 'Ellen Ochoa',
      location: 'Los Angeles, USA',
      orders: 30,
      amountSpent: '$140',
    },
  ];
  const resourceName = {
    singular: 'customer',
    plural: 'customers',
  };

  const {selectedResources, allResourcesSelected, handleSelectionChange} =
    useIndexResourceState(customers);

  const promotedBulkActions = [
    {
      content: 'Edit customers',
      loading: true,
      onAction: () => console.log('Todo: implement bulk edit'),
    },
  ];
  const bulkActions = [
    {
      content: 'Add tags',
      loading: true,
      onAction: () => console.log('Todo: implement bulk add tags'),
    },
    {
      content: 'Remove tags',
      onAction: () => console.log('Todo: implement bulk remove tags'),
    },
    {
      content: 'Delete customers',
      onAction: () => console.log('Todo: implement bulk delete'),
    },
  ];

  const rowMarkup = customers.map(
    ({id, name, location, orders, amountSpent}, index) => (
      <IndexTable.Row
        id={id}
        key={id}
        selected={selectedResources.includes(id)}
        position={index}
      >
        <IndexTable.Cell>
          <TextStyle variation="strong">{name}</TextStyle>
        </IndexTable.Cell>
        <IndexTable.Cell>{location}</IndexTable.Cell>
        <IndexTable.Cell>{orders}</IndexTable.Cell>
        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
      </IndexTable.Row>
    ),
  );

  return (
    <Page title="Playground">
       <Card>
      <IndexTable
        resourceName={resourceName}
        itemCount={customers.length}
        selectedItemsCount={
          allResourcesSelected ? 'All' : selectedResources.length
        }
        onSelectionChange={handleSelectionChange}
        bulkActions={bulkActions}
        promotedBulkActions={promotedBulkActions}
        headings={[
          {title: 'Name'},
          {title: 'Location'},
          {title: 'Order count'},
          {title: 'Amount spent'},
        ]}
      >
        {rowMarkup}
      </IndexTable>
    </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
