### PR TITLE
Fix build-consumer.js script

### DIFF
--- a/polaris-react/LICENSE.md
+++ b/polaris-react/LICENSE.md
@@ -1,0 +1,27 @@
+Copyright (c) 2017-present Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The rights granted above may only be exercised to develop and distribute
+applications that integrate or interoperate with Shopify software or services,
+and in the case of external, stand-alone applications that do not embed
+directly inside Shopify, the rights granted above may only be exercised to
+develop and distribute applications that are dissimilar and visually distinct
+from Shopify products and services (including the internal administration page
+of a Shopify merchant store), as determined by Shopify in its sole discretion.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/polaris-react/scripts/build-consumer.js
+++ b/polaris-react/scripts/build-consumer.js
@@ -6,7 +6,7 @@ const {config, cp, mkdir, rm} = require('shelljs');
 
 const packageJSON = require('../package.json');
 
-const root = resolve(__dirname, '..');
+const root = resolve(__dirname, '../../');
 const projectDir = process.argv[2];
 
 config.fatal = true;


### PR DESCRIPTION
After the monorepo changes were shipped, the `build-consumer.js` script wasn't running properly when you tried `yarn run build-consumer [PROJECT_DIR]` from the `polaris-react` dir. It's blocking the ability to tophat a PR to update Combobox documentation.

There are two issues:
1. ~`LICENSE.md` doesn't exist in the `polaris/polaris-react` dir~. Updated this to add in a new `LICENSE.md` to the `polaris-react` dir.
>Copying build to node_modules...
/Users/lokim/src/github.com/Shopify/polaris/node_modules/shelljs/src/common.js:401
      if (config.fatal) throw e;
                        ^
Error: cp: no such file or directory: LICENSE.md

2. Changes to files weren't being picked up

To tophat:
```
// in polaris root dir 
$ git checkout lo/fix-build-consumer-script
$ cd polaris-react
$ yarn run build-consumer polaris-styleguide

// in polaris-styleguide root dir
$ dev up && dev run
// press CTRL + T from same terminal window to open local server for styleguide
// Search Combobox
// see Best practices--TESTING on side nav to reflect latest component readme changes
```
Changes successfully picked up after running the above:
<img width="264" alt="example" src="https://user-images.githubusercontent.com/26749317/159374971-53e3d29f-14e7-48b6-83bb-4d27d92ca995.png">
