### PR TITLE
Update `Combobox` read.me documentation

### DIFF
--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -34,42 +34,16 @@ A combobox is made up of the following:
 
 The `Combobox` component should:
 
-- Be clearly labeled so it’s noticeable to the merchant what type of options will be available
+- Be clearly labeled so the merchant knows what type of options will be available
 - Not be used within a popover
 - Indicate a loading state to the merchant while option data is being populated
+- Order items in an intentional way so it’s easy for the merchant to find a specific value
 
 ---
 
 ## Content guidelines
 
 The input field for `Combobox` should follow the [content guidelines](https://polaris.shopify.com/components/forms/text-field) for text fields.
-
----
-
-## Sorting and filtering
-
-### Sorting
-
-Item order should be intentional. Order them so it’s easy for the merchant to find a specific value. Some ways you can do this:
-
-- Sort options in alphabetical order
-- Display options based on how frequently the merchant selects an option
-
-If multiple options can be selected, move selected items to the top of the list. If this doesn’t work for your context, you can override this behavior.
-
-### Filtering
-
-- By default, menu items are filtered based on whether or not they match the value of the textfield.
-- Filters are **not** case-sensitive by default.
-- You can apply custom filtering logic if the default behavior doesn’t make sense for your use case.
-
----
-
-## Patterns
-
-### Tags autocomplete
-
-The tag multiselect allows merchants to select, create and browse from a long list of options.
 
 ---
 

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -13,7 +13,7 @@ keywords:
 
 # Combobox
 
-Combobox uses an enahnced text field that allows merchants to filter through a list of options to pick one or more values. The list of options is displayed when a merchant focuses on the field.
+Combobox uses an enhanced text field that allows merchants to filter through a list of options to pick one or more values. The list of options is displayed when a merchant focuses on the field.
 
 ---
 

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -70,7 +70,7 @@ If multiple options can be selected, move selected items to the top of the list.
 
 ### Tags autocomplete
 
-The tag multiselect allows merchants to select, create and browse from a long list of options.
+The tag multiselect allows merchants to select, create, and browse from a long list of options.
 
 ---
 

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -47,6 +47,33 @@ The input field for `Combobox` should follow the [content guidelines](https://po
 
 ---
 
+## Sorting and filtering
+
+### Sorting
+
+Item order should be intentional. Order them so it’s easy for the merchant to find a specific value. Some ways you can do this:
+
+- Sort options in alphabetical order
+- Display options based on how frequently the merchant selects an option
+
+If multiple options can be selected, move selected items to the top of the list. If this doesn’t work for your context, you can override this behavior.
+
+### Filtering
+
+- By default, menu items are filtered based on whether or not they match the value of the textfield.
+- Filters are **not** case-sensitive by default.
+- You can apply custom filtering logic if the default behavior doesn’t make sense for your use case.
+
+---
+
+## Patterns
+
+### Tags autocomplete
+
+The tag multiselect allows merchants to select, create and browse from a long list of options.
+
+---
+
 ## Examples
 
 ### Single select autocomplete

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -13,7 +13,20 @@ keywords:
 
 # Combobox
 
-The `Combobox` component implements part of the [Aria 1.2 combobox](https://www.w3.org/TR/wai-aria-practices-1.2/#combobox) specs on a TextField and a popover containing a Listbox. Like `Autocomplete`, `Combobox` allows merchants to quickly search through and select from large collections of options.
+Combobox uses an enahnced text field that allows merchants to filter through a list of options to pick one or more values. The list of options is displayed when a merchant focuses on the field.
+
+---
+
+## Anatomy
+
+![A diagram of the Combobox component showing the smaller primitive components it is composed of.](/public_images/components/Combobox/combobox-anatomy.png)
+
+A combobox is made up of the following:
+
+1. **Text field**: The field people click in to activate the popover and filter through the options they can choose from. Once selected, the option will be shown in the text input.
+2. **Popover**: Renders to contain the Listbox.
+3. **Listbox**: Contains the list of all selectable items.
+4. **Listbox** options: The individual options that merchants can select. For context on ways the Listbox can be composed with various content, check out the [listbox documentation](https://polaris.shopify.com/components/forms/listbox).
 
 ---
 
@@ -33,11 +46,38 @@ The input field for `Combobox` should follow the [content guidelines](https://po
 
 ---
 
+## Sorting and filtering
+
+### Sorting
+
+Item order should be intentional. Order them so it’s easy for the merchant to find a specific value. Some ways you can do this:
+
+- Sort options in alphabetical order
+- Display options based on how frequently the merchant selects an option
+
+If multiple options can be selected, move selected items to the top of the list. If this doesn’t work for your context, you can override this behavior.
+
+### Filtering
+
+- By default, menu items are filtered based on whether or not they match the value of the textfield.
+- Filters are **not** case-sensitive by default.
+- You can apply custom filtering logic if the default behavior doesn’t make sense for your use case.
+
+---
+
+## Patterns
+
+### Tags autocomplete
+
+The tag multiselect allows merchants to select, create and browse from a long list of options.
+
+---
+
 ## Examples
 
 ### Single select autocomplete
 
-Use to help merchants complete text input quickly from a list of options.
+Allows merchants to select from a predefined list of options. It’s typically used when there are a large number of options to choose from.
 
 ```jsx
 function ComboboxExample() {
@@ -129,7 +169,7 @@ function ComboboxExample() {
 
 ### Multi-select autocomplete
 
-Use to help merchants select multiple options from a list curated by the text input.
+Allows the merchant to select multiple options from a pre-defined list of options.
 
 ```jsx
 function MultiComboboxExample() {
@@ -369,7 +409,6 @@ function LoadingAutocompleteExample() {
 
 - For an input field without suggested options, [use the text field component](https://polaris.shopify.com/components/forms/text-field)
 - For a list of selectable options not linked to an input field, [use the list box component](https://polaris.shopify.com/components/lists-and-tables/listbox)
-- [Autocomplete](https://polaris.shopify.com/components/forms/autocomplete) can be used as a convenience wrapper in lieu of `Combobox` and `Listbox`.
 
 ---
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris/issues/5322

Updating comobobox documentation for the style guide.

Changes:
- Updated description
- Added Anatomy section
- Updated Best practices


Before | After
--- | ---
<img width="943" alt="image" src="https://user-images.githubusercontent.com/8629173/160022882-6d885228-24de-42ea-b7aa-c5cc9f9b7cf3.png"> | <img width="1129" alt="image" src="https://user-images.githubusercontent.com/8629173/160022717-21723f88-020f-41cc-bd24-fe7eca65c72d.png"> removed the specific accessibility info from the description but it is still available in the "Accessibility" section
n/a | <img width="822" alt="image" src="https://user-images.githubusercontent.com/8629173/160022964-fdb7f482-681c-4434-aa7c-5ca1035cba06.png">
<img width="775" alt="image" src="https://user-images.githubusercontent.com/8629173/160023188-122e1bf7-b530-4d95-9742-a8875728255d.png"> | <img width="749" alt="image" src="https://user-images.githubusercontent.com/8629173/160023101-8fd6bc1b-da92-4260-bf33-6e081c5ba9c2.png">