### PR TITLE
[DropZone] Add video to DropZoneFileType

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,6 +10,16 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added support for setting a `ReactNode` on the `PageActions` `secondaryActions` prop ([#5495](https://github.com/Shopify/polaris/pull/5495))
 
 - Added support for NodeJS v14 ([#5551](https://github.com/Shopify/polaris/pull/5551))
+- Added visual density updates to `Tag` component for mobile view ([#5353](https://github.com/Shopify/polaris/pull/5353))
+- Added visual density updates to `Tag` component and bumped `@shopify/polaris-icons` package ([#5312](https://github.com/Shopify/polaris/pull/5312))
+- Added `ReactNode` as an accepted prop type to `secondaryActions` on the `Page` component ([#5258](https://github.com/Shopify/polaris-react/pull/5258))
+- Added `useCapture` and `options` props in `KeypressListener` to allow passing through those options to the underlying `addEventListener` call ([#5221](https://github.com/Shopify/polaris-react/pull/5221))
+- Add option to make `Thumbnail` component transparent ([#5109](https://github.com/Shopify/polaris-react/pull/5109))
+- Replaced hard coded `transition` values with tokens ([5340](https://github.com/Shopify/polaris/pull/5340/))
+- Replaced hard coded `font-size` and `line-height` values with tokens ([5355](https://github.com/Shopify/polaris/pull/5355/))
+- Replaced hard coded spacing values with tokens ([5364](https://github.com/Shopify/polaris/pull/5364/))
+- Simplified usage of color tokens ([5360](https://github.com/Shopify/polaris/pull/5360/))
+- Add `video` as DropZoneFileType option on the `DropZone` component ([#5349](https://github.com/Shopify/polaris/pull/5349))
 
 ### Bug fixes
 

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -105,25 +105,34 @@
       "single": {
         "overlayTextFile": "Drop file to upload",
         "overlayTextImage": "Drop image to upload",
+        "overlayTextVideo": "Drop video to upload",
         "actionTitleFile": "Add file",
         "actionTitleImage": "Add image",
+        "actionTitleVideo": "Add video",
         "actionHintFile": "or drop file to upload",
         "actionHintImage": "or drop image to upload",
+        "actionHintVideo": "or drop video to upload",
         "labelFile": "Upload file",
-        "labelImage": "Upload image"
+        "labelImage": "Upload image",
+        "labelVideo": "Upload video"
       },
       "allowMultiple": {
         "overlayTextFile": "Drop files to upload",
         "overlayTextImage": "Drop images to upload",
+        "overlayTextVideo": "Drop videos to upload",
         "actionTitleFile": "Add files",
         "actionTitleImage": "Add images",
+        "actionTitleVideo": "Add videos",
         "actionHintFile": "or drop files to upload",
         "actionHintImage": "or drop images to upload",
+        "actionHintVideo": "or drop videos to upload",
         "labelFile": "Upload files",
-        "labelImage": "Upload images"
+        "labelImage": "Upload images",
+        "labelVideo": "Upload videos"
       },
       "errorOverlayTextFile": "File type is not valid",
-      "errorOverlayTextImage": "Image type is not valid"
+      "errorOverlayTextImage": "Image type is not valid",
+      "errorOverlayTextVideo": "Video type is not valid"
     },
     "EmptySearchResult": {
       "altText": "Empty search results"

--- a/polaris-react/src/components/DropZone/DropZone.tsx
+++ b/polaris-react/src/components/DropZone/DropZone.tsx
@@ -35,7 +35,7 @@ import {
 } from './utils';
 import styles from './DropZone.scss';
 
-export type DropZoneFileType = 'file' | 'image';
+export type DropZoneFileType = 'file' | 'image' | 'video';
 
 export interface DropZoneProps {
   /** Label for the file input */
@@ -482,6 +482,7 @@ class DropZoneInput extends Component<DropZoneInputProps, never> {
 
   render() {
     const {openFileDialog, onFileDialogClose, ...inputProps} = this.props;
+
     return (
       <input {...inputProps} ref={this.fileInputNode} autoComplete="off" />
     );

--- a/polaris-react/src/components/DropZone/tests/DropZone.test.tsx
+++ b/polaris-react/src/components/DropZone/tests/DropZone.test.tsx
@@ -216,6 +216,8 @@ describe('<DropZone />', () => {
     [true, 'image', 'Drop images to upload', 'Upload images'],
     [false, 'file', 'Drop file to upload', 'Upload file'],
     [true, 'file', 'Drop files to upload', 'Upload files'],
+    [false, 'video', 'Drop video to upload', 'Upload video'],
+    [true, 'video', 'Drop videos to upload', 'Upload videos'],
   ])(
     'renders texts when allowMultiple is %s and type is %s',
     (allowMultiple, type, expectedTextStyle, expectedLabelText) => {


### PR DESCRIPTION
### WHY are these changes introduced?

For dropzones that only accept video files, we want the copy to be more specific. 

### WHAT is this pull request doing?

Adds `video` to `DropZoneFileType` as well as i18n strings

![image](https://user-images.githubusercontent.com/12047066/160150880-0fe473dd-24e8-4ba2-b719-ef0ef80924b7.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
