### PR TITLE
Migrate from PIPA to shopify-build dynamic container builder

### DIFF
--- a/.shopify-build/polaris-react-production-builder.yml
+++ b/.shopify-build/polaris-react-production-builder.yml
@@ -1,0 +1,8 @@
+containers:
+  production:
+    environment: production
+    build:
+      from: ubuntu-latest
+
+steps:
+  - build: production


### PR DESCRIPTION

This PR attempts to get you started in migrating this app to use the **dynamic container builder**.
_Caveat: changes may not be perfect or even correct, so it may not be immediately shippable._

Please use the checklist below and our [migration guide](https://shopify-build.docs.shopify.io/migrating_to_the_dynamic_builder/migration_guide/) to verify the changes.

### Checklist
I read through the migration guide and checked that…
- [ ] ([Step 1 and 2](https://shopify-build.docs.shopify.io/migrating_to_the_dynamic_builder/migration_guide/#step-1-set-ruby-and-node-versions-in-devyml)) Intended ruby and node versions are defined in `dev.yml`.
- [ ] ([Step 3 and 4](https://shopify-build.docs.shopify.io/migrating_to_the_dynamic_builder/migration_guide/#step-3-use-a-dynamic-container-for-ci)) The CI pipeline is using the dynamic builder.
- [ ] ([Step 5](https://shopify-build.docs.shopify.io/migrating_to_the_dynamic_builder/migration_guide/#step-5-use-dynamic-containers-for-production)) The production (+ staging if applicable) builder pipeline is using the dynamic builder.
- [ ] All checks are passing! If checks are not passing, check out the [troubleshooting section](https://shopify-build.docs.shopify.io/migrating_to_the_dynamic_builder/troubleshooting/) of the migration guide or join us in #proj-kill-pipa and we’ll be happy to help.

If a pipeline is not used anymore, you can archive it with [@spy build archive-pipeline $NAME](https://spy-v2.docs.shopify.io/commands/build.html#build-archive-pipeline---route).

Please merge this PR before 15. April 2022 or archive the pipeline.

## I have questions/concerns about this
Please contact the test-infra team using #proj-kill-pipa.
 

Tracker: https://github.com/Shopify/test-infra/issues/1331


