### PR TITLE
[a11y][Filters] Improve focus handling based on accessibility feedback

### DIFF
--- a/polaris-react/src/components/Filters/Filters.tsx
+++ b/polaris-react/src/components/Filters/Filters.tsx
@@ -1,4 +1,4 @@
-import React, {Component, createRef} from 'react';
+import React, {Component, createRef, RefObject} from 'react';
 import {
   SearchMinor,
   ChevronUpMinor,
@@ -22,7 +22,6 @@ import {TextField} from '../TextField';
 import {Tag} from '../Tag';
 import {TextStyle} from '../TextStyle';
 import {Badge} from '../Badge';
-import {Focus} from '../Focus';
 // eslint-disable-next-line import/no-deprecated
 import {Sheet} from '../Sheet';
 import {Stack} from '../Stack';
@@ -145,7 +144,7 @@ class FiltersInner extends Component<CombinedProps, State> {
       mediaQuery: {isNavigationCollapsed},
     } = this.props;
     const {resourceName} = this.context;
-    const {open, readyForFocus} = this.state;
+    const {open} = this.state;
 
     const backdropMarkup = open ? (
       <>
@@ -177,6 +176,8 @@ class FiltersInner extends Component<CombinedProps, State> {
 
       const buttonClassName = classNames(styles.FilterTrigger);
 
+      const filterToggleRef = createRef<HTMLButtonElement>();
+
       return (
         <div key={filter.key} className={className}>
           <button
@@ -186,6 +187,7 @@ class FiltersInner extends Component<CombinedProps, State> {
             type="button"
             aria-controls={collapsibleID}
             aria-expanded={filterIsOpen}
+            ref={filterToggleRef}
           >
             <div className={styles.FilterTriggerLabelContainer}>
               <h3 className={styles.FilterTriggerTitle}>
@@ -207,12 +209,7 @@ class FiltersInner extends Component<CombinedProps, State> {
           </button>
           <Collapsible id={collapsibleID} open={filterIsOpen}>
             <div className={styles.FilterNodeContainer}>
-              <Focus
-                disabled={!filterIsOpen || !readyForFocus || !open}
-                root={this.focusNode}
-              >
-                {this.generateFilterMarkup(filter)}
-              </Focus>
+              {this.generateFilterMarkup(filter, filterToggleRef)}
             </div>
           </Collapsible>
         </div>
@@ -549,7 +546,10 @@ class FiltersInner extends Component<CombinedProps, State> {
     return transformedActions;
   }
 
-  private generateFilterMarkup(filter: FilterInterface) {
+  private generateFilterMarkup(
+    filter: FilterInterface,
+    collapsibleButtonRef?: RefObject<HTMLButtonElement>,
+  ) {
     const i18n = this.props.i18n;
     const removeCallback = this.getAppliedFilterRemoveHandler(filter.key);
     const removeHandler =
@@ -557,6 +557,9 @@ class FiltersInner extends Component<CombinedProps, State> {
         ? undefined
         : () => {
             removeCallback(filter.key);
+
+            collapsibleButtonRef?.current &&
+              focusFirstFocusableNode(collapsibleButtonRef.current, false);
           };
 
     const clearButtonMarkup = !filter.hideClearButton && (

--- a/polaris-react/src/components/Filters/tests/Filters.test.tsx
+++ b/polaris-react/src/components/Filters/tests/Filters.test.tsx
@@ -430,6 +430,37 @@ describe('<Filters />', () => {
       expect(spy).toHaveBeenCalledWith('filterOne');
     });
 
+    it('focuses filter toggle when clear button is clicked', () => {
+      const spy = jest.fn();
+      const appliedFilters = [{key: 'filterOne', label: 'foo', onRemove: spy}];
+
+      const resourceFilters = mountWithApp(
+        <Filters {...mockProps} appliedFilters={appliedFilters} />,
+      );
+
+      resourceFilters
+        .find(Button, {children: 'More filters'})!
+        .trigger('onClick');
+
+      resourceFilters
+        .find('button', {id: 'filterOneToggleButton'})!
+        .trigger('onClick');
+
+      const collapsible = resourceFilters.find(Collapsible, {
+        id: 'filterOneCollapsible',
+      });
+      const buttons = collapsible!.findAll(Button);
+
+      // last button
+      const clearButton = buttons.at(-1);
+
+      clearButton!.trigger('onClick');
+
+      expect(document.activeElement).toBe(
+        resourceFilters.find('button', {id: 'filterOneToggleButton'})!.domNode,
+      );
+    });
+
     it('renders a clear button when clearButton is not provided', () => {
       const filters = [
         {key: 'filterOne', label: 'foo', onRemove: () => {}, filter: null},


### PR DESCRIPTION
### WHY are these changes introduced?

When using "More Filters" there were some cases where focus was lost or was set in an unexpected way. After getting feedback in accessibility office hours, https://github.com/Shopify/temp-project-mover-Archetypically-20250411125603/issues/305 was created to improve focus handling.

### WHAT is this pull request doing?

The `Focus` component wrapping `{this.generateFilterMarkup(filter)}` is removed for a few reasons:
- When we expand / collapse the `Collapsible` containing filter options, we want focus to stay on the `Collapsible` rather than jumping to its contents
- When the `Focus` component is present and a `Collapsible` is already expanded when opening "More Filters" for a second time, focus would get pulled to the contents of that `Collapsible` rather than starting at the top of "More Filters"

A ref to the `button` that toggles a `Collapsible` is passed to `generateFilterMarkup` so that focus can be set back to it when filter options are cleared.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
