### PR TITLE
Listbox readme updates

### DIFF
--- a/polaris-react/src/components/Listbox/README.md
+++ b/polaris-react/src/components/Listbox/README.md
@@ -10,7 +10,19 @@ keywords:
 
 # Listbox
 
-The `Listbox` component is a list component that implements part of the [Aria 1.2 Listbox specs](https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox). It presents a list of options and allows users to select one or more of them. If you need more structure than the standard component offers, use composition to customize the presentation of these lists by using headers or custom elements.
+A Listbox is a vertical list of interactive options, with room for icons, descriptions, and other elements.
+
+---
+
+## Anatomy
+
+![A diagram of the Listbox component showing the smaller primitive components it can be composed of.](/public_images/components/Listbox/listbox-anatomy.png)
+
+A listbox can be composed of:
+
+1. **Options:** The individual options inside the Listbox that merchants can select or deselect.
+2. **Dividers:** Placed between items and are useful in complex lists when there’s a lot of information for the merchant to parse.
+3. **Section headers:** Used at the begining of a section when it’s necessary to call out the content being displayed. In most cases, the surrounding context should be enough for the merchant to understand the information in the list.
 
 ---
 
@@ -41,6 +53,10 @@ Each item in a `Listbox` should be clear and descriptive.
 - Source
 
 <!-- end -->
+
+## Patterns that use `Listbox`
+
+Location picker
 
 ---
 
@@ -87,11 +103,16 @@ Implementation of a control element used to let merchants take an action
 function ListboxWithActionExample() {
   return (
     <Listbox accessibilityLabel="Listbox with Action example">
-      <Listbox.Action value="ActionValue" divider>
-        <div>Add item</div>
-      </Listbox.Action>
       <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
-      <Listbox.Option value="UniqueValue-2">Item 2</Listbox.Option>
+      <Listbox.Option value="UniqueValue-2" divider>
+        Item 2
+      </Listbox.Option>
+      <Listbox.Action value="ActionValue">
+        <Stack spacing="tight">
+          <Icon source={CirclePlusMinor} color="base" />
+          <div>Add item</div>
+        </Stack>
+      </Listbox.Action>
     </Listbox>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris/issues/5323

Updating listbox documentation for the style guide.

Changes:
- Updated description
- Added Anatomy section
- Updated the Listbox with action example


Before | After
--- | ---
<img width="903" alt="image" src="https://user-images.githubusercontent.com/8629173/160708737-4919dd54-a8f4-4f6b-8346-b24244cb098a.png"> | <img width="874" alt="image" src="https://user-images.githubusercontent.com/8629173/160708682-bbc554ba-4adf-4e18-bde2-77c487a8aa28.png">
<img width="868" alt="image" src="https://user-images.githubusercontent.com/8629173/160709087-4ed9ceec-2e6a-479e-923f-00c1b5600fc9.png"> | <img width="872" alt="image" src="https://user-images.githubusercontent.com/8629173/160709028-c92ec9af-e290-4524-8a9d-67131cc8878d.png">
n/a | <img width="809" alt="Screen Shot 2022-03-29 at 2 12 06 PM" src="https://user-images.githubusercontent.com/8629173/160708786-9dd58d85-65c1-409f-91c0-a0881f7799cf.png"> 