### PR TITLE
[Page] Fixes alignment of right-hand side of Header

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Fixed accessibility issues on focus and option create in `Combobox` and `Listbox` ([#5298](https://github.com/Shopify/polaris-react/pull/5298))
 - Fixed accessibility issues and logic to set active descendant in `Listbox` ([#5297](https://github.com/Shopify/polaris-react/pull/5297))
+- Fixed alignment of right-hand side of `Header` in `Page` ([#5390](https://github.com/Shopify/polaris/pull/5390))
 
 ### Documentation
 

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -191,7 +191,8 @@ $action-menu-rollup-computed-width: 40px;
   display: flex;
   align-content: flex-end;
   flex: 1 1 auto;
-  align-items: baseline;
+  align-items: center;
+  align-self: flex-start;
   justify-content: flex-end;
   margin-left: var(--p-space-4);
   // Necessary for flex to realize this container doesn't want to wrap

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -191,7 +191,7 @@ $action-menu-rollup-computed-width: 40px;
   display: flex;
   align-content: flex-end;
   flex: 1 1 auto;
-  align-items: flex-start;
+  align-items: baseline;
   justify-content: flex-end;
   margin-left: var(--p-space-4);
   // Necessary for flex to realize this container doesn't want to wrap


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5383

When the only actions in the secondary action area of a `Page`'s `Header` are `plain` buttons or links, using `align-items: flex-start` displays those plain actions too high. The text of the plain actions should line up with the text of the primary action.

### WHAT is this pull request doing?

On the container for the right-hand elements: sets `align-items: center` to line up the elements correctly and then `align-self: flex-start` to keep the elements aligned along the top of the container when the left-hand side wraps over multiple lines.

Before this change:

![Plain link sits too high compared to the other header elements.](https://user-images.githubusercontent.com/7571219/160882535-ffcbb6bf-5b9b-44d5-a779-15367de13b93.png)

After this change:

![Plain link appears lined up with the other header elements.](https://user-images.githubusercontent.com/7571219/160882773-43fba040-74ac-491d-a38c-73687f420a1f.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>polaris-react/playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Badge, Card} from '../src';

export function Playground() {
  return (
    <Page
      breadcrumbs={[{content: 'Products', url: '/products'}]}
      title="3/4 inch Leather pet collar"
      titleMetadata={<Badge status="success">Paid</Badge>}
      subtitle="Perfect for any pet"
      compactTitle
      primaryAction={{content: 'Save', disabled: true}}
      secondaryActions={[
        {
          content: 'Duplicate',
          plain: true,
          onAction: () => alert('Duplicate action'),
        },
        {
          content: 'View',
          url: 'https://shopify.com',
          external: true,
          plain: true,
        },
      ]}
      pagination={{
        hasPrevious: true,
        hasNext: true,
      }}
    >
      <Card title="Credit card" sectioned>
        <p>Credit card information</p>
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
