### PR TITLE
fix: Remove postinstall script from stylelint-polaris

### DIFF
--- a/stylelint-polaris/README.md
+++ b/stylelint-polaris/README.md
@@ -68,3 +68,25 @@ module.exports = {
   },
 };
 ```
+
+## Local development - Polaris react
+
+> Open your terminal to the root of the `polaris` monorepo:
+
+1. Install and symlink dependencies
+
+```sh
+yarn install
+```
+
+2. Generate Polaris custom property names
+
+```sh
+yarn workspace @shopify/stylelint-polaris gen-polaris-var
+```
+
+3. Run `stylelint` on `polaris-react`
+
+```sh
+yarn workspace @shopify/polaris-react lint:styles
+```

--- a/stylelint-polaris/README.md
+++ b/stylelint-polaris/README.md
@@ -88,5 +88,5 @@ yarn workspace @shopify/stylelint-polaris gen-polaris-var
 3. Run `stylelint` on `polaris-react`
 
 ```sh
-yarn workspace @shopify/polaris-react lint:styles
+yarn workspace @shopify/polaris lint:styles
 ```

--- a/stylelint-polaris/package.json
+++ b/stylelint-polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/stylelint-polaris",
   "description": "Polaris Design System Stylelint tooling",
-  "version": "0.0.0-alpha.2",
+  "version": "0.0.0-alpha.3",
   "private": false,
   "license": "MIT",
   "author": "Shopify <dev@shopify.com>",
@@ -31,7 +31,6 @@
   },
   "scripts": {
     "gen-polaris-vars": "node ./scripts/gen-polaris-vars.js",
-    "postinstall": "yarn gen-polaris-vars",
     "build": "echo '@shopify/stylelint-polaris does not have a build script.'",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "prepublishOnly": "yarn gen-polaris-vars && yarn type-check"


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR removes the `postinstall` script from `stylelint-polaris` and adds local development instructions to the README.

We do not include the `gen-polaris-vars` script in the distributed package which was causing `yarn add @shopify/stylelint-polaris` failures.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
