### PR TITLE
Use loom for linting styles via modified stylelint plugin

### DIFF
--- a/polaris-react/loom.config.ts
+++ b/polaris-react/loom.config.ts
@@ -10,6 +10,7 @@ import {
   rollupPlugins,
 } from '@shopify/loom-plugin-build-library';
 import {eslint} from '@shopify/loom-plugin-eslint';
+import {stylelint} from '@shopify/loom-plugin-stylelint';
 import {prettier} from '@shopify/loom-plugin-prettier';
 import replace from '@rollup/plugin-replace';
 import image from '@rollup/plugin-image';
@@ -37,7 +38,9 @@ export default createPackage((pkg) => {
     }),
     buildLibraryWorkspace(),
     eslint(),
+    stylelint({files: '**/*.scss'}),
     prettier({files: '**/*.{md,json,yaml,yml}'}),
+    stylelintAdjustmentsPlugin(),
     rollupAdjustPluginsPlugin(),
     rollupAdjustOutputPlugin(),
     jestAdjustmentsPlugin(),
@@ -68,6 +71,20 @@ function jestAdjustmentsPlugin() {
           ...transforms,
           '\\.s?css$': require.resolve('./config/jest-transform-style'),
           '\\.svg$': require.resolve('./config/jest-transform-image'),
+        }));
+      });
+    });
+  });
+}
+
+function stylelintAdjustmentsPlugin() {
+  return createWorkspacePlugin('Polaris.Stylelint', ({tasks: {lint}}) => {
+    lint.hook(({hooks}) => {
+      hooks.configure.hook((configure) => {
+        // Modify the maximum number of allowed warnings from the default of 0
+        configure.stylelintFlags?.hook((flags) => ({
+          ...flags,
+          maxWarnings: Infinity,
         }));
       });
     });

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -45,9 +45,7 @@
     }
   },
   "scripts": {
-    "lint": "yarn run lint:loom && yarn run lint:styles",
-    "lint:loom": "loom lint",
-    "lint:styles": "stylelint '**/*.scss'",
+    "lint": "loom lint",
     "format": "loom lint --fix",
     "type-check": "loom type-check",
     "a11y-check": "node ./scripts/accessibility-check.js",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #5362 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This adds back the use of `loom` for linting styles. It leverages the [plugin hooks](https://github.com/Shopify/loom/tree/main/packages/loom-plugin-stylelint#hooks) to adjust the number of `maxWarnings` allowed for `stylelint`. This is needed since the addition of the coverage stylelint rules which are marked as warnings and used to provided coverage insights within the `polaris-react` package.

