### PR TITLE
Root-level linter configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,10 @@
+node_modules
+.loom
+/polaris-react/build
+/polaris-react/build-internal
+/polaris.shopify.com/.next
+
+
+# These folders should pass linting, remove these lines and fix the errors
+/polaris.shopify.com
+/stylelint-polaris

--- a/.eslintrc
+++ b/.eslintrc
@@ -59,10 +59,10 @@
   },
   "overrides": [
     {
-      "files": ["src/**/*.{ts,tsx}"],
+      "files": ["polaris-react/src/**/*.{ts,tsx}"],
       "extends": ["plugin:@shopify/typescript-type-checking"],
       "parserOptions": {
-        "project": "./tsconfig.json"
+        "project": "./polaris-react/tsconfig.json"
       },
       "rules": {
         "@typescript-eslint/prefer-readonly": "off",
@@ -81,7 +81,7 @@
       }
     },
     {
-      "files": ["playground/*.tsx"],
+      "files": ["polaris-react/playground/*.tsx"],
       "rules": {
         "react/prefer-stateless-function": "off",
         "@shopify/jsx-no-hardcoded-content": "off",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn workspace @shopify/polaris run validate-tokens
       - run: yarn workspace @shopify/polaris run type-check && yarn run build
-      - run: yarn workspace @shopify/polaris run lint
+      - run: yarn run lint
       - run: yarn workspace @shopify/polaris run test
 
   accessibility_test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.log
 node_modules
 .DS_Store
+.loom
 .shadowenv.d

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+.loom
+/polaris-react/build
+/polaris-react/build-internal
+/polaris.shopify.com/.next
+
+/polaris-react/package.json

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,7 @@
+node_modules
+.loom
+/polaris-react/build
+/polaris-react/build-internal
+/polaris.shopify.com/.next
+
+/polaris-react/documentation/guides/legacy-polaris-v8-public-api.scss

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  extends: ['@shopify/stylelint-plugin/prettier', './stylelint-polaris'],
+  overrides: [
+    {
+      files: ['polaris-react/**/*.scss'],
+      extends: [
+        '@shopify/stylelint-plugin/prettier',
+        './stylelint-polaris/configs/internal',
+      ],
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -16,11 +16,20 @@
     "build:react": "yarn workspace @shopify/polaris build",
     "dev:site": "yarn workspace polaris-shopify-com dev",
     "start:site": "yarn workspace polaris-shopify-com start",
-    "build:site": "yarn workspace polaris-shopify-com build"
+    "build:site": "yarn workspace polaris-shopify-com build",
+    "lint": "yarn run lint:eslint && yarn run lint:stylelint && yarn run lint:prettier",
+    "lint:eslint": "eslint . --max-warnings 0 --cache --cache-location '.loom/cache/eslint'",
+    "lint:stylelint": "yarn workspace '@shopify/stylelint-polaris' run gen-polaris-vars && stylelint '**/*.scss' --max-warnings 9999",
+    "lint:prettier": "prettier '**/*.{md,json,yaml,yml}' --check"
   },
   "devDependencies": {
+    "@shopify/eslint-plugin": "^41.0.1",
     "@shopify/prettier-config": "^1.1.2",
+    "@shopify/stylelint-plugin": "^11.0.0",
     "@shopify/typescript-configs": "^5.1.0",
+    "eslint": "^8.3.0",
+    "prettier": "^2.5.0",
+    "stylelint": "^14.1.0",
     "typescript": ">=3.0.0"
   },
   "prettier": "@shopify/prettier-config"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:site": "yarn workspace polaris-shopify-com build",
     "lint": "yarn run lint:eslint && yarn run lint:stylelint && yarn run lint:prettier",
     "lint:eslint": "eslint . --max-warnings 0 --cache --cache-location '.loom/cache/eslint'",
-    "lint:stylelint": "yarn workspace '@shopify/stylelint-polaris' run gen-polaris-vars && stylelint '**/*.scss' --max-warnings 9999",
+    "lint:stylelint": "yarn workspace '@shopify/stylelint-polaris' run gen-polaris-vars && stylelint '**/*.scss'",
     "lint:prettier": "prettier '**/*.{md,json,yaml,yml}' --check"
   },
   "devDependencies": {

--- a/polaris-react/.eslintignore
+++ b/polaris-react/.eslintignore
@@ -1,4 +1,0 @@
-node_modules
-/.loom
-/build
-/build-internal

--- a/polaris-react/.gitignore
+++ b/polaris-react/.gitignore
@@ -1,4 +1,3 @@
-.loom
 build
 build-internal
 *.scss.d.ts

--- a/polaris-react/.prettierignore
+++ b/polaris-react/.prettierignore
@@ -1,6 +1,0 @@
-node_modules
-/.loom
-/build
-/build-internal
-
-/package.json

--- a/polaris-react/.stylelintignore
+++ b/polaris-react/.stylelintignore
@@ -1,5 +1,0 @@
-node_modules
-/.loom
-/build
-/build-internal
-/documentation/guides/legacy-polaris-v8-public-api.scss

--- a/polaris-react/loom.config.ts
+++ b/polaris-react/loom.config.ts
@@ -9,8 +9,6 @@ import {
   buildLibraryWorkspace,
   rollupPlugins,
 } from '@shopify/loom-plugin-build-library';
-import {eslint} from '@shopify/loom-plugin-eslint';
-import {prettier} from '@shopify/loom-plugin-prettier';
 import replace from '@rollup/plugin-replace';
 import image from '@rollup/plugin-image';
 import json from '@rollup/plugin-json';
@@ -36,8 +34,6 @@ export default createPackage((pkg) => {
       esnext: true,
     }),
     buildLibraryWorkspace(),
-    eslint(),
-    prettier({files: '**/*.{md,json,yaml,yml}'}),
     rollupAdjustPluginsPlugin(),
     rollupAdjustOutputPlugin(),
     jestAdjustmentsPlugin(),

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -45,10 +45,6 @@
     }
   },
   "scripts": {
-    "lint": "yarn run lint:loom && yarn run lint:styles",
-    "lint:loom": "loom lint",
-    "lint:styles": "stylelint '**/*.scss'",
-    "format": "loom lint --fix",
     "type-check": "loom type-check",
     "a11y-check": "node ./scripts/accessibility-check.js",
     "test": "loom test",
@@ -91,20 +87,13 @@
     "@rollup/pluginutils": "^3.1.0",
     "@shopify/babel-preset": "^24.1.2",
     "@shopify/browserslist-config": "^3.0.0",
-    "@shopify/eslint-plugin": "^41.0.1",
     "@shopify/jest-dom-mocks": "^3.0.5",
     "@shopify/loom": "^1.0.0",
     "@shopify/loom-cli": "^1.0.0",
     "@shopify/loom-plugin-build-library": "^1.0.0",
-    "@shopify/loom-plugin-eslint": "^2.0.0",
-    "@shopify/loom-plugin-prettier": "^2.0.0",
-    "@shopify/loom-plugin-stylelint": "^2.0.0",
     "@shopify/postcss-plugin": "^5.0.1",
-    "@shopify/prettier-config": "^1.1.2",
     "@shopify/react-testing": "^3.2.4",
     "@shopify/storybook-a11y-test": "0.4.3",
-    "@shopify/stylelint-plugin": "^11.0.0",
-    "@shopify/typescript-configs": "^5.0.0",
     "@size-limit/preset-small-lib": "^5.0.3",
     "@storybook/addon-a11y": "^6.4.19",
     "@storybook/addon-console": "^1.2.3",
@@ -123,7 +112,6 @@
     "core-js": "^3.6.5",
     "create-file-webpack": "^1.0.2",
     "downlevel-dts": "^0.6.0",
-    "eslint": "^8.3.0",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.4",
     "gray-matter": "^4.0.2",
@@ -136,7 +124,6 @@
     "postcss-loader": "^4.2.0",
     "postcss-modules": "^4.2.2",
     "postcss-pxtorem": "^5.1.1",
-    "prettier": "^2.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
@@ -147,7 +134,6 @@
     "shelljs": "^0.8.3",
     "shx": "^0.3.2",
     "size-limit": "^5.0.3",
-    "stylelint": "^14.1.0",
     "svgo": "^1.3.0",
     "typescript": "~4.3.5",
     "webpack": "5"
@@ -163,12 +149,6 @@
     "ios >= 13.4"
   ],
   "prettier": "@shopify/prettier-config",
-  "stylelint": {
-    "extends": [
-      "@shopify/stylelint-plugin/prettier",
-      "../stylelint-polaris/configs/internal"
-    ]
-  },
   "size-limit": [
     {
       "name": "cjs",

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -148,7 +148,6 @@
     "last 1 firefoxandroid versions",
     "ios >= 13.4"
   ],
-  "prettier": "@shopify/prettier-config",
   "size-limit": [
     {
       "name": "cjs",

--- a/polaris.shopify.com/next.config.js
+++ b/polaris.shopify.com/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2051,13 +2051,6 @@
     common-ancestor-path "^1.0.1"
     rollup-plugin-node-externals "^2.2.0"
 
-"@shopify/loom-plugin-eslint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/loom-plugin-eslint/-/loom-plugin-eslint-2.0.0.tgz#135a30fded12d6e7f325529dfeba5e09d08ff272"
-  integrity sha512-8Uf3pyS1iGIMEh4xjQOBlwVAnV+0FOUPvlLEe2dITCqi1zO0VzfRj0pT1lsQwkwyhUebqNXEPho2ARsybwCp7Q==
-  dependencies:
-    "@shopify/loom" "^1.0.1"
-
 "@shopify/loom-plugin-jest@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@shopify/loom-plugin-jest/-/loom-plugin-jest-1.0.0.tgz#58b0b003ff50d0fa79420ae878dee02577358989"
@@ -2068,13 +2061,6 @@
     jest "^27.2.4"
     jest-watch-typeahead "^1.0.0"
 
-"@shopify/loom-plugin-prettier@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/loom-plugin-prettier/-/loom-plugin-prettier-2.0.0.tgz#fc13bdd6b5c69735517f9fac3fa132516bc9ef2f"
-  integrity sha512-zs+bShodNV9Qx8IyVPLbMtvO3uXhh8ARWGGbAQQQX51Brp4q5SgtUQ1hZWVfsUiMjh++YMMiFtt0+Xcx/Rp41g==
-  dependencies:
-    "@shopify/loom" "^1.0.1"
-
 "@shopify/loom-plugin-rollup@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@shopify/loom-plugin-rollup/-/loom-plugin-rollup-1.0.0.tgz#25cce3f102514530272d008682374ec37861149e"
@@ -2082,13 +2068,6 @@
   dependencies:
     "@shopify/loom" "^1.0.0"
     rollup "^2.48.0"
-
-"@shopify/loom-plugin-stylelint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/loom-plugin-stylelint/-/loom-plugin-stylelint-2.0.0.tgz#8716daca516473ef3ee965d64b6afba9a013493c"
-  integrity sha512-LSaIlZAM8hucqt5B6Q559Myq0wuWkOmTNvFr0ESrWTQcEXNHbxfJx99QwqZitNB1XyVpR8BJsDOw3VAlFm2uzA==
-  dependencies:
-    "@shopify/loom" "^1.0.1"
 
 "@shopify/loom-plugin-typescript@^1.0.0":
   version "1.0.0"
@@ -2098,7 +2077,7 @@
     "@shopify/loom" "^1.0.0"
     typescript "^4.3.5"
 
-"@shopify/loom@^1.0.0", "@shopify/loom@^1.0.1":
+"@shopify/loom@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@shopify/loom/-/loom-1.0.1.tgz#d56a50570f3e445ac40ad1962a6f0a5a67b28a12"
   integrity sha512-FpL77FrqlYYXUbx04ELQQmXWN4+hZ9aYwmxCVWcH0CR9bOuLSizYiiAjNhp1/fB6IJjOGctofT+NJ6xEQ/DYlQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,11 +2162,6 @@
     stylelint-prettier "^2.0.0"
     stylelint-scss "^4.0.0"
 
-"@shopify/typescript-configs@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/typescript-configs/-/typescript-configs-5.0.0.tgz#4cd1339a6a5ab34e7f7d852d155d2c82b731c152"
-  integrity sha512-1TV9pr3UBr1AlGC//4bdeKiQ2qwDuaqCZGfxO2OtIg/EN3luDdf49UNNm/BL9ZiApHcz7kg9Wklc09vhzD24hw==
-
 "@shopify/typescript-configs@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@shopify/typescript-configs/-/typescript-configs-5.1.0.tgz#f6e8fdd3291bf0a406578b2c6eb21f8c542d3c0a"


### PR DESCRIPTION
### WHY are these changes introduced?

The majority of the code in the monorepo should adhere to a single set of linting rules. Packages that diverge are free to do so but they would be the exception rather than the rule. Currently linting is package-specific which means new packages need to bring their own linting rules.

This PR pulls the eslint, stylelint and prettier configs up to the top of the repository where they can apply to all packages and adds a new `yarn run lint` command can be used to lint the entire codebase in one go.

### WHAT is this pull request doing?

- Moves eslint stylelint and prettier configs from inside polaris-react to the root of the repository
- Removes the lint plugins from loom in the polaris-react project (eventually we might want a workspace loom config where linting is ran by loom at the root of the repo, but that can be follow-up work)
- Add a `yarn run lint` command at the root of the repo, this is ran as part of CI

Currently the `stylelint-polaris` and `polaris.shopify.com` folders are excluded from eslint as they currently fail. A follow-up PR should fix linting issues in those packages.

### How to 🎩

Run `yarn run lint` and see that linting occurs 