### PR TITLE
feat: Move @shopify/stylelint-plugin out of @shopify/stylelint-polaris

### DIFF
--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -103,6 +103,7 @@
     "@shopify/prettier-config": "^1.1.2",
     "@shopify/react-testing": "^3.2.4",
     "@shopify/storybook-a11y-test": "0.4.3",
+    "@shopify/stylelint-plugin": "^11.0.0",
     "@shopify/typescript-configs": "^5.0.0",
     "@size-limit/preset-small-lib": "^5.0.3",
     "@storybook/addon-a11y": "^6.4.19",
@@ -164,6 +165,7 @@
   "prettier": "@shopify/prettier-config",
   "stylelint": {
     "extends": [
+      "@shopify/stylelint-plugin/prettier",
       "../stylelint-polaris/configs/internal"
     ]
   },

--- a/stylelint-polaris/configs/shared.js
+++ b/stylelint-polaris/configs/shared.js
@@ -6,5 +6,5 @@
  * @type {import('stylelint').Config}
  */
 module.exports = {
-  extends: ['@shopify/stylelint-plugin/prettier', './coverage'],
+  extends: ['./coverage'],
 };

--- a/stylelint-polaris/package.json
+++ b/stylelint-polaris/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/stylelint-polaris",
   "description": "Polaris Design System Stylelint tooling",
-  "version": "0.0.0-alpha.4",
+  "version": "0.0.0-alpha.5",
   "private": false,
   "license": "MIT",
   "author": "Shopify <dev@shopify.com>",
@@ -36,7 +36,6 @@
     "prepublishOnly": "yarn build && yarn type-check"
   },
   "dependencies": {
-    "@shopify/stylelint-plugin": "^11.0.0",
     "postcss-value-parser": "^4.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR moves the `@shopify/stylelint-plugin` dependency out of `@shopify/stylelint-polaris`. This simplifies the upgrade path for consumers and tightens the scope of `@shopify/stylelint-polaris`.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
