### PR TITLE
Run CI on all PRs and add caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
           path: |
             .loom
             polaris-react/.loom
-            polaris-react/build/ts
-            polaris-react/build/*.tsbuildinfo
+            polaris-react/build/ts/latest
+            polaris.shopify.com/.next/cache
           key: ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-
@@ -74,6 +74,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
+
+      - uses: actions/cache@v2
+        name: Restore build cache
+        with:
+          path: |
+            polaris-react/build-internal/cache
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-visual-regression-test-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-node${{ matrix.node-version }}-visual-regression-test-v1-
 
       - run: yarn --frozen-lockfile
       - run: yarn workspace @shopify/polaris run storybook:build --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,10 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'polaris-react/**'
   pull_request:
-    paths:
-      - 'polaris-react/**'
+    branches: ['**']
+  push:
+    branches: [main, polaris-release]
 
 jobs:
   test:
@@ -24,9 +20,21 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
+      - uses: actions/cache@v2
+        name: Restore build cache
+        with:
+          path: |
+            .loom
+            polaris-react/.loom
+            polaris-react/build/ts
+            polaris-react/build/*.tsbuildinfo
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-
+
       - run: yarn --frozen-lockfile
       - run: yarn workspace @shopify/polaris run validate-tokens
-      - run: yarn workspace @shopify/polaris run type-check && yarn run build
+      - run: yarn run build
       - run: yarn run lint
       - run: yarn workspace @shopify/polaris run test
 
@@ -39,6 +47,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
+
+      - uses: actions/cache@v2
+        name: Restore build cache
+        with:
+          path: |
+            polaris-react/build-internal/cache
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-accessibility-test-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-node${{ matrix.node-version }}-accessibility-test-v1-
 
       - run: yarn --frozen-lockfile
       - run: yarn workspace @shopify/polaris run storybook:build --quiet


### PR DESCRIPTION
### WHY are these changes introduced?

Part of #5424

CI should run on all commits, and PRs, and we should use caching to make subsequent builds faster.

Related issues: #5424

### WHAT is this pull request doing?

Run CI on all commits, and PRs and add caching