### PR TITLE
SkeletonPage polish

### DIFF
--- a/polaris-react/playground/DetailsPage.scss
+++ b/polaris-react/playground/DetailsPage.scss
@@ -1,4 +1,3 @@
-$nav-collapsed: 769px;
 $top-bar-height: 56px;
 
 .ContextControl {
@@ -13,8 +12,4 @@ $top-bar-height: 56px;
   font-weight: var(--p-font-weight-semibold);
   font-size: var(--p-font-size-3);
   color: var(--p-text);
-
-  @media only screen and (min-width: $nav-collapsed) {
-    color: var(--p-text);
-  }
 }

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -34,10 +34,6 @@ $skeleton-display-text-max-width: 120px;
 
 .TitleAndPrimaryAction {
   display: flex;
-
-  @include page-content-when-partially-condensed {
-    display: block;
-  }
 }
 
 .TitleWrapper {
@@ -66,24 +62,6 @@ $skeleton-display-text-max-width: 120px;
   > * {
     height: $primary-action-button-height;
     min-width: $primary-action-button-width;
-  }
-
-  @include page-content-when-layout-stacked {
-    margin-top: var(--p-space-4);
-    margin-bottom: calc(-1 * var(--p-space-2));
-  }
-
-  @include page-content-when-not-fully-condensed {
-    margin-top: $actions-vertical-spacing;
-    margin-bottom: calc(-1 * var(--p-space-2));
-  }
-
-  @include page-content-when-not-partially-condensed {
-    margin-top: 0;
-  }
-
-  @include page-content-when-layout-not-stacked {
-    margin-top: 0;
   }
 }
 

--- a/polaris-react/src/styles/shared/_page.scss
+++ b/polaris-react/src/styles/shared/_page.scss
@@ -23,10 +23,10 @@ $actions-vertical-spacing: var(--p-space-2);
 }
 
 @mixin page-content-layout {
-  margin: var(--p-space-2) 0;
+  margin: var(--p-space-3) 0;
 
   @include page-content-when-not-partially-condensed {
-    margin-top: var(--p-space-5);
+    margin-top: var(--p-space-0);
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Playground below 👇 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {
  HomeMinor,
  OrdersMinor,
  ProductsMinor,
  CustomersMinor,
  AnalyticsMinor,
  MarketingMinor,
  DiscountsMinor,
  SettingsMinor,
} from '@shopify/polaris-icons';

import {
  Card,
  Frame,
  Layout,
  Navigation,
  Page,
  SkeletonBodyText,
  SkeletonDisplayText,
  SkeletonPage,
  TextContainer,
  TopBar,
} from '../src';

export function Playground() {
  const [skelly, setSkelly] = React.useState(true);

  const styles = {
    Branding: {
      display: 'flex',
      alignItems: 'center',
      padding: '0 12px',
      height: '56px',
    },

    svg: {
      opacity: '0.5',
    },

    ShopName: {
      marginLeft: 'var(--p-space-2)',
      fontWeight: 'var(--p-font-weight-semibold)' as unknown as number,
      fontSize: 'var(--p-font-size-3)',
      color: 'var(--p-text)',
      width: '70%',
    },

    SearchField: {
      height: '36px',
      maxWidth: '578px',
      backgroundColor: 'var(--p-surface-neutral)',
      borderRadius: 'var(--p-border-radius-1)',
      marginLeft: 'var(--p-space-4)',
    },

    UserMenu: {
      minWidth: '100px',
      display: 'flex',
      alignItems: 'center',
      marginRight: 'var(--p-space-4)',
    },

    Avatar: {
      width: '40px',
      height: '40px',
      borderRadius: '50%',
      flexShrink: 0,
      marginRight: 'var(--p-space-1)',
      backgroundColor: 'var(--p-surface-neutral)',
    },

    User: {
      width: '100%',
      height: '20px',
      borderRadius: 'var(--p-border-radius-1)',
      backgroundColor: 'var(--p-surface-neutral)',
    },
  };

  return (
    <Frame
      topBar={
        <TopBar
          searchField={<div style={styles.SearchField} />}
          userMenu={
            <div style={styles.UserMenu}>
              <div style={styles.Avatar} />
              <div style={styles.User} />
            </div>
          }
          contextControl={
            <div style={styles.Branding}>
              <svg
                width="36"
                height="36"
                viewBox="0 0 36 36"
                fill="none"
                xmlns="http://www.w3.org/2000/svg"
              >
                <path
                  d="M26.8956 8.39159C26.876 8.25021 26.751 8.17175 26.6473 8.16321C26.5443 8.15466 24.5277 8.12436 24.5277 8.12436C24.5277 8.12436 22.8411 6.50548 22.6745 6.3408C22.5079 6.17611 22.1825 6.22583 22.056 6.26312C22.0544 6.26389 21.7392 6.36022 21.2087 6.52257C21.1199 6.23826 20.9895 5.88869 20.8032 5.53757C20.2028 4.40498 19.3233 3.80605 18.2608 3.8045C18.2592 3.8045 18.2584 3.8045 18.2568 3.8045C18.183 3.8045 18.1099 3.81149 18.036 3.8177C18.0046 3.78042 17.9731 3.74391 17.9401 3.70817C17.4772 3.21878 16.8838 2.9803 16.1726 3.00127C14.8004 3.04011 13.4337 4.01968 12.3255 5.75974C11.5459 6.984 10.9525 8.52209 10.7843 9.71295C9.20858 10.1954 8.10673 10.5325 8.08237 10.5403C7.28702 10.7873 7.26187 10.8114 7.15813 11.5524C7.08111 12.1125 5 28.0186 5 28.0186L22.4403 31L29.9992 29.1426C29.9992 29.1426 26.9153 8.53297 26.8956 8.39159ZM20.3356 6.7898C19.934 6.91253 19.4774 7.05236 18.9822 7.20384C18.972 6.51714 18.8895 5.56165 18.5657 4.7359C19.607 4.93088 20.1195 6.09532 20.3356 6.7898ZM18.0698 7.48349C17.1558 7.76315 16.1584 8.06843 15.158 8.3745C15.4393 7.30949 15.973 6.24913 16.6284 5.55388C16.8721 5.29521 17.2131 5.00701 17.6171 4.84232C17.9967 5.62535 18.0792 6.73387 18.0698 7.48349ZM16.2001 3.90393C16.5223 3.89694 16.7935 3.96685 17.0253 4.11755C16.6544 4.30787 16.296 4.58131 15.9596 4.93787C15.088 5.86228 14.42 7.29706 14.1536 8.68134C13.3229 8.93536 12.5102 9.18472 11.762 9.4131C12.2344 7.23414 14.0821 3.96452 16.2001 3.90393Z"
                  fill="#95BF47"
                />
                <path
                  d="M26.6482 8.16418C26.5452 8.15564 24.5286 8.12534 24.5286 8.12534C24.5286 8.12534 22.842 6.50646 22.6754 6.34178C22.6133 6.28041 22.5292 6.24856 22.4412 6.23535L22.4419 30.9994L30.0001 29.1428C30.0001 29.1428 26.9162 8.53395 26.8965 8.39257C26.8769 8.25119 26.7511 8.17273 26.6482 8.16418Z"
                  fill="#5E8E3E"
                />
                <path
                  d="M18.2512 12.0055L17.3734 15.2518C17.3734 15.2518 16.3941 14.8113 15.2333 14.8836C13.531 14.99 13.5129 16.0511 13.5302 16.3176C13.623 17.7695 17.4873 18.0864 17.7042 21.4873C17.8748 24.1626 16.2684 25.9928 13.9538 26.1373C11.1756 26.3105 9.64624 24.6909 9.64624 24.6909L10.2349 22.2159C10.2349 22.2159 11.7745 23.3641 13.0068 23.2872C13.8116 23.2367 14.0992 22.5896 14.0702 22.132C13.9491 20.2382 10.8023 20.35 10.6035 17.2381C10.4361 14.6195 12.1761 11.9659 16.0153 11.7266C17.4944 11.6326 18.2512 12.0055 18.2512 12.0055Z"
                  fill="white"
                />
              </svg>
              <div style={styles.ShopName}>
                <SkeletonBodyText lines={1} />
              </div>
            </div>
          }
        />
      }
      navigation={
        <Navigation location="/">
          <Navigation.Section
            items={[
              {icon: HomeMinor, label: 'Home', disabled: true},
              {icon: OrdersMinor, label: 'Orders', disabled: true},
              {icon: ProductsMinor, label: 'Products', disabled: true},
              {icon: CustomersMinor, label: 'Customers', disabled: true},
              {icon: AnalyticsMinor, label: 'Analytics', disabled: true},
              {icon: MarketingMinor, label: 'Marketing', disabled: true},
              {icon: DiscountsMinor, label: 'Discounts', disabled: true},
            ]}
            fill
          />
          <Navigation.Section
            items={[{icon: SettingsMinor, label: 'Settings', disabled: true}]}
          />
        </Navigation>
      }
    >
      {skelly ? (
        <SkeletonPage primaryAction>
          <Layout>
            <Layout.Section>
              <Card sectioned>
                <SkeletonBodyText />
              </Card>
              <Card sectioned>
                <TextContainer>
                  <SkeletonDisplayText size="small" />
                  <SkeletonBodyText />
                </TextContainer>
              </Card>
              <Card sectioned>
                <TextContainer>
                  <SkeletonDisplayText size="small" />
                  <SkeletonBodyText />
                </TextContainer>
              </Card>
            </Layout.Section>
          </Layout>
        </SkeletonPage>
      ) : (
        <Page
          title="Orders"
          compactTitle
          primaryAction={{content: 'New order'}}
        >
          <Layout>
            <Layout.Section>
              <Card sectioned>
                <SkeletonBodyText />
              </Card>
              <Card sectioned>
                <TextContainer>
                  <SkeletonDisplayText size="small" />
                  <SkeletonBodyText />
                </TextContainer>
              </Card>
              <Card sectioned>
                <TextContainer>
                  <SkeletonDisplayText size="small" />
                  <SkeletonBodyText />
                </TextContainer>
              </Card>
            </Layout.Section>
          </Layout>
        </Page>
      )}
      <button
        style={{
          position: 'absolute',
          left: '8px',
          bottom: '8px',
          padding: '8px 12px',
        }}
        onClick={() => setSkelly((skelly) => !skelly)}
      >
        Toggle skeleton
      </button>
    </Frame>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
