### PR TITLE
Consolidate keyframe tokens

### DIFF
--- a/polaris-react/scripts/utilities/getCustomPropertyNames.js
+++ b/polaris-react/scripts/utilities/getCustomPropertyNames.js
@@ -13,11 +13,14 @@ const getCustomPropertyNames = () => {
     new Set(
       fs
         .readdirSync(tokenGroupsDir)
-        .filter((file) => !file.includes('keyframes'))
         .map((file) => {
           const tokenGroup = require(path.join(tokenGroupsDir, file));
 
-          return Object.keys(tokenGroup).map((token) => `--p-${token}`);
+          return Object.keys(tokenGroup).map((token) =>
+            token.startsWith('keyframes')
+              ? `--p-${token}-name`
+              : `--p-${token}`,
+          );
         })
         .flat(),
     ),

--- a/polaris-react/scripts/utilities/getCustomPropertyNames.js
+++ b/polaris-react/scripts/utilities/getCustomPropertyNames.js
@@ -16,11 +16,7 @@ const getCustomPropertyNames = () => {
         .map((file) => {
           const tokenGroup = require(path.join(tokenGroupsDir, file));
 
-          return Object.keys(tokenGroup).map((token) =>
-            token.startsWith('keyframes')
-              ? `--p-${token}-name`
-              : `--p-${token}`,
-          );
+          return Object.keys(tokenGroup).map((token) => `--p-${token}`);
         })
         .flat(),
     ),

--- a/polaris-react/scripts/utilities/getKeyframeNames.js
+++ b/polaris-react/scripts/utilities/getKeyframeNames.js
@@ -8,8 +8,8 @@ const tokenGroupsDir = path.join(__dirname, '../../src/tokens/token-groups');
  * Result: ['p-keyframes-fade-in', 'p-keyframes-spin', etc...]
  */
 const getKeyframeNames = () =>
-  Object.keys(require(path.join(tokenGroupsDir, 'keyframes'))).map(
-    (name) => `p-${name}`,
-  );
+  Object.keys(require(path.join(tokenGroupsDir, 'motion')))
+    .map((name) => (name.startsWith('keyframes') ? `p-${name}` : null))
+    .filter(Boolean);
 
 module.exports = getKeyframeNames;

--- a/polaris-react/src/components/Backdrop/Backdrop.scss
+++ b/polaris-react/src/components/Backdrop/Backdrop.scss
@@ -7,7 +7,7 @@
   left: 0;
   display: block;
   background-color: var(--p-backdrop);
-  animation: var(--p-animation-name-fade-in) var(--p-duration-200) 1 forwards;
+  animation: var(--p-keyframes-fade-in-name) var(--p-duration-200) 1 forwards;
   opacity: 0;
   will-change: opacity;
 }

--- a/polaris-react/src/components/Backdrop/Backdrop.scss
+++ b/polaris-react/src/components/Backdrop/Backdrop.scss
@@ -7,7 +7,7 @@
   left: 0;
   display: block;
   background-color: var(--p-backdrop);
-  animation: var(--p-keyframes-fade-in-name) var(--p-duration-200) 1 forwards;
+  animation: var(--p-keyframes-fade-in) var(--p-duration-200) 1 forwards;
   opacity: 0;
   will-change: opacity;
 }

--- a/polaris-react/src/components/CustomProperties/styles.ts
+++ b/polaris-react/src/components/CustomProperties/styles.ts
@@ -73,7 +73,7 @@ export function getCustomProperties(tokens: TokenGroup) {
   return Object.entries(tokens)
     .map(([token, value]) =>
       token.startsWith('keyframes')
-        ? `--p-${token}-name:${token}`
+        ? `--p-${token}:p-${token};`
         : `--p-${token}:${value};`,
     )
     .join('');

--- a/polaris-react/src/components/CustomProperties/styles.ts
+++ b/polaris-react/src/components/CustomProperties/styles.ts
@@ -47,10 +47,7 @@ export function getColorSchemeRules(
  */
 export function getStaticCustomProperties(tokens: Tokens) {
   return Object.entries(tokens)
-    .filter(
-      ([tokenGroup]) =>
-        !(tokenGroup === 'colorSchemes' || tokenGroup === 'keyframes'),
-    )
+    .filter(([tokenGroup]) => tokenGroup !== 'colorSchemes')
     .map(([_, tokens]) => getCustomProperties(tokens))
     .join('');
 }
@@ -74,16 +71,21 @@ export function getColorSchemeDeclarations(
  */
 export function getCustomProperties(tokens: TokenGroup) {
   return Object.entries(tokens)
-    .map(([name, value]) => `--p-${name}:${value};`)
+    .map(([token, value]) =>
+      token.startsWith('keyframes')
+        ? `--p-${token}-name:${token}`
+        : `--p-${token}:${value};`,
+    )
     .join('');
 }
 
 /**
  * Concatenates the `keyframes` token-group into a single string.
  */
-export function getKeyframes(keyframes: TokenGroup) {
-  return Object.entries(keyframes)
-    .map(([name, value]) => `@keyframes p-${name}${value}`)
+export function getKeyframes(motion: TokenGroup) {
+  return Object.entries(motion)
+    .filter(([token]) => token.startsWith('keyframes'))
+    .map(([token, value]) => `@keyframes p-${token}${value}`)
     .join('');
 }
 
@@ -93,5 +95,5 @@ export function getKeyframes(keyframes: TokenGroup) {
 export const styles = `
   :root{${defaultDeclarations}}
   ${getColorSchemeRules(tokens, osColorSchemes)}
-  ${getKeyframes(tokens.keyframes)}
+  ${getKeyframes(tokens.motion)}
 `;

--- a/polaris-react/src/components/Indicator/Indicator.scss
+++ b/polaris-react/src/components/Indicator/Indicator.scss
@@ -18,11 +18,11 @@
 
 .pulseIndicator::before {
   z-index: 1;
-  animation: var(--p-animation-name-bounce) var(--p-duration-5000) ease infinite;
+  animation: var(--p-keyframes-bounce-name) var(--p-duration-5000) ease infinite;
 }
 
 .pulseIndicator::after {
   right: var(--pc-indicator-base-position);
   top: var(--pc-indicator-base-position);
-  animation: var(--p-animation-name-pulse) var(--p-duration-5000) ease infinite;
+  animation: var(--p-keyframes-pulse-name) var(--p-duration-5000) ease infinite;
 }

--- a/polaris-react/src/components/Indicator/Indicator.scss
+++ b/polaris-react/src/components/Indicator/Indicator.scss
@@ -18,11 +18,11 @@
 
 .pulseIndicator::before {
   z-index: 1;
-  animation: var(--p-keyframes-bounce-name) var(--p-duration-5000) ease infinite;
+  animation: var(--p-keyframes-bounce) var(--p-duration-5000) ease infinite;
 }
 
 .pulseIndicator::after {
   right: var(--pc-indicator-base-position);
   top: var(--pc-indicator-base-position);
-  animation: var(--p-keyframes-pulse-name) var(--p-duration-5000) ease infinite;
+  animation: var(--p-keyframes-pulse) var(--p-duration-5000) ease infinite;
 }

--- a/polaris-react/src/components/ProgressBar/ProgressBar.scss
+++ b/polaris-react/src/components/ProgressBar/ProgressBar.scss
@@ -66,7 +66,7 @@
 
 .Animated {
   will-change: width;
-  animation: var(--p-animation-name-fill-up) var(--p-duration-500) var(--p-ease);
+  animation: var(--p-keyframes-fill-up-name) var(--p-duration-500) var(--p-ease);
   transition: width var(--p-duration-500) var(--p-ease);
 }
 

--- a/polaris-react/src/components/ProgressBar/ProgressBar.scss
+++ b/polaris-react/src/components/ProgressBar/ProgressBar.scss
@@ -66,7 +66,7 @@
 
 .Animated {
   will-change: width;
-  animation: var(--p-keyframes-fill-up-name) var(--p-duration-500) var(--p-ease);
+  animation: var(--p-keyframes-fill-up) var(--p-duration-500) var(--p-ease);
   transition: width var(--p-duration-500) var(--p-ease);
 }
 

--- a/polaris-react/src/components/Spinner/Spinner.scss
+++ b/polaris-react/src/components/Spinner/Spinner.scss
@@ -7,7 +7,7 @@ $large-size: 44px;
 }
 
 .Spinner svg {
-  animation: var(--p-keyframes-spin-name) var(--p-duration-500) linear infinite;
+  animation: var(--p-keyframes-spin) var(--p-duration-500) linear infinite;
   fill: var(--p-border-highlight);
 }
 

--- a/polaris-react/src/components/Spinner/Spinner.scss
+++ b/polaris-react/src/components/Spinner/Spinner.scss
@@ -7,7 +7,7 @@ $large-size: 44px;
 }
 
 .Spinner svg {
-  animation: var(--p-animation-name-spin) var(--p-duration-500) linear infinite;
+  animation: var(--p-keyframes-spin-name) var(--p-duration-500) linear infinite;
   fill: var(--p-border-highlight);
 }
 

--- a/polaris-react/src/tokens/token-groups/beta-tokens.json
+++ b/polaris-react/src/tokens/token-groups/beta-tokens.json
@@ -1,7 +1,0 @@
-{
-  "animation-name-bounce": "p-keyframes-bounce",
-  "animation-name-fade-in": "p-keyframes-fade-in",
-  "animation-name-fill-up": "p-keyframes-fill-up",
-  "animation-name-pulse": "p-keyframes-pulse",
-  "animation-name-spin": "p-keyframes-spin"
-}

--- a/polaris-react/src/tokens/token-groups/keyframes.json
+++ b/polaris-react/src/tokens/token-groups/keyframes.json
@@ -1,7 +1,0 @@
-{
-  "keyframes-bounce": "{ from, 65%, 85% { transform: scale(1) } 75% { transform: scale(0.85) } 82.5% { transform: scale(1.05) } }",
-  "keyframes-fade-in": "{ to { opacity: 1 } }",
-  "keyframes-fill-up": "{ 0% { width: 0 } }",
-  "keyframes-pulse": "{ from, 75% { transform: scale(0.85); opacity: 1; } to { transform: scale(2.5); opacity: 0; } }",
-  "keyframes-spin": "{ to { transform: rotate(1turn) } }"
-}

--- a/polaris-react/src/tokens/token-groups/motion.json
+++ b/polaris-react/src/tokens/token-groups/motion.json
@@ -15,5 +15,10 @@
   "ease-in": "cubic-bezier(0.42, 0, 1, 1)",
   "ease-out": "cubic-bezier(0, 0, 0.58, 1)",
   "ease-in-out": "cubic-bezier(0.42, 0, 0.58, 1)",
-  "linear": "cubic-bezier(0, 0, 1, 1)"
+  "linear": "cubic-bezier(0, 0, 1, 1)",
+  "keyframes-bounce": "{ from, 65%, 85% { transform: scale(1) } 75% { transform: scale(0.85) } 82.5% { transform: scale(1.05) } }",
+  "keyframes-fade-in": "{ to { opacity: 1 } }",
+  "keyframes-fill-up": "{ 0% { width: 0 } }",
+  "keyframes-pulse": "{ from, 75% { transform: scale(0.85); opacity: 1; } to { transform: scale(2.5); opacity: 0; } }",
+  "keyframes-spin": "{ to { transform: rotate(1turn) } }"
 }

--- a/polaris-react/src/tokens/tokens.ts
+++ b/polaris-react/src/tokens/tokens.ts
@@ -1,7 +1,5 @@
-import betaTokens from './token-groups/beta-tokens.json';
 import darkColorScheme from './token-groups/color.dark.json';
 import depth from './token-groups/depth.json';
-import keyframes from './token-groups/keyframes.json';
 import legacyTokens from './token-groups/legacy-tokens.json';
 import lightColorScheme from './token-groups/color.light.json';
 import motion from './token-groups/motion.json';
@@ -49,10 +47,8 @@ const colorSchemes: ColorSchemes = {
 };
 
 export interface Tokens {
-  betaTokens: TokenGroup;
   colorSchemes: ColorSchemes;
   depth: TokenGroup;
-  keyframes: TokenGroup;
   legacyTokens: TokenGroup;
   motion: TokenGroup;
   shape: TokenGroup;
@@ -62,10 +58,8 @@ export interface Tokens {
 }
 
 export const tokens: Tokens = {
-  betaTokens,
   colorSchemes,
   depth,
-  keyframes,
   legacyTokens: tokensToRems(legacyTokens),
   motion,
   shape: tokensToRems(shape),


### PR DESCRIPTION
- Moved `keyframes.json` tokens to `motion.json`
- Removed `keyframes.json` and `beta-tokens.json` token groups
- `keyframes-*` tokens are the source of truth and the `style.ts` utils generate the associated CSS custom property
- Updated `animation:` usages to use the new `--p-keyframes-*` custom properties

TODO:
- Update `CustomProperties.test.tsx` - Feel free to merge before the tests are updated (That can be addressed in the `keyframes-custom-properties` branch)