### PR TITLE
[DataTable] Tweak styles for increasedTableDensity

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -7,6 +7,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Enhancements
 
 - Added `icon` prop to the `Badge` component ([#5292](https://github.com/Shopify/polaris/pull/5292))
+- Improved styling for the `DataTable` component when the `increaseTableDensity` prop is set to `true` ([#5480]https://github.com/Shopify/polaris/pull/5480)
+
 - Added support for setting a `ReactNode` on the `PageActions` `secondaryActions` prop ([#5495](https://github.com/Shopify/polaris/pull/5495))
 - Added support for NodeJS v14 ([#5551](https://github.com/Shopify/polaris/pull/5551))
 - Add `video` as DropZoneFileType option on the `DropZone` component ([#5349](https://github.com/Shopify/polaris/pull/5349))

--- a/polaris-react/src/components/DataTable/DataTable.scss
+++ b/polaris-react/src/components/DataTable/DataTable.scss
@@ -24,6 +24,10 @@ $breakpoint: 768px;
 
 .Navigation {
   display: none;
+
+  .IncreasedTableDensity & {
+    padding: var(--p-space-2) var(--p-space-2) 0 var(--p-space-2);
+  }
 }
 
 .Pip {
@@ -44,6 +48,7 @@ $breakpoint: 768px;
 .ScrollContainer {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
 }
 
 .Table {
@@ -125,7 +130,20 @@ $breakpoint: 768px;
   padding: 0;
 
   .IncreasedTableDensity & {
-    padding: var(--p-space-2);
+    padding: var(--p-space-2) var(--p-space-3);
+
+    &:first-child {
+      padding-left: var(--p-space-3);
+
+      button {
+        padding-right: 0;
+        padding-left: var(--p-space-1);
+      }
+    }
+
+    &:last-child {
+      padding-right: var(--p-space-3);
+    }
   }
 }
 

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -156,7 +156,6 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
       condensed && styles.condensed,
       totals && styles.ShowTotals,
       showTotalsInFooter && styles.ShowTotalsInFooter,
-      increasedTableDensity && styles.IncreasedTableDensity,
       hasZebraStripingOnData && styles.ZebraStripingOnData,
       hasZebraStripingOnData && rowCountIsEven && styles.RowCountIsEven,
     );
@@ -164,6 +163,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     const wrapperClassName = classNames(
       styles.TableWrapper,
       condensed && styles.condensed,
+      increasedTableDensity && styles.IncreasedTableDensity,
     );
 
     const headingMarkup = <tr>{headings.map(this.renderHeadings)}</tr>;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This PR improves some spacing and alignment issues on the `DataTable` when the `increasedTableDensity` prop is used.

Resolves: https://github.com/Shopify/core-issues/issues/36871

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/90475486/162524190-bc4f362a-fe18-46a0-bd46-7c91c770988f.png" alt="Horizontal indicator before">
<img src="https://user-images.githubusercontent.com/90475486/162524262-45783614-03fc-432d-b4b4-81ce095be4c7.png" alt="Alignment before">
</details>

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Decreases the padding around the horizontal scroll indicators on the DataTable component so that the spacing better matches the spacing in the `<tablebody>` itself when the `increasedTableDensity` prop is set to true.
- Fixes some padding and alignment issues on the `DataTable` when the `increasedTableDensity` prop is set to true.

<details>
  <summary>After</summary>
  <img src="https://user-images.githubusercontent.com/90475486/162524371-b1b2e9a9-e5a4-4f30-8215-e3d681aec1de.png" alt="Horiztonal scroll after"><img src ="https://user-images.githubusercontent.com/90475486/162524439-8dd40d33-c1d7-46ff-b9e7-a79152c2755a.png" alt="Alignment after">
</details>


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->



## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

-[ ]  

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Button, Card, DataTable, Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Card>
        <div
          style={{
            padding: '9px 1rem',
            display: 'flex',
            justifyContent: 'space-between',
            borderBottom: '1px solid rgb(225, 227, 229)',
          }}
        >
          <Button>Do something</Button>
          <Button>Anything</Button>
        </div>
        <DataTable
          columnContentTypes={[
            'text',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
          ]}
          headings={[
            'Things',
            'Product',
            'Orders',
            'Spaceships',
            'All',
            'More Things',
            'Products',
            'Orders again',
            'Rockets',
            'Whence',
          ]}
          rows={[
            ['One', 1, 2, 3, 4, 5, 2034, 460549, 24, 62],
            ['Two', 1, 2, 3, 4, 5, 2034, 460549, 24, 62],
            ['Three', 1, 2, 3, 4, 5, 2034, 460549, 24, 62],
            ['One', 1, 2, 3, 4, 5, 2034, 460549, 24, 62],
            ['Two', 1, 2, 3, 4, 5, 2034, 460549, 24, 62],
            ['Three', 1, 2, 3, 4, 5, 2034, 460549, 24, 62],
            ['Two', 1, 2, 3, 4, 5, 2034, 460549, 24, 62],
            ['Three', 1, 2, 3, 4, 5, 2034, 460549, 24, 62],
          ]}
          increasedTableDensity
          sortable={[
            true,
            true,
            false,
            true,
            true,
            true,
            true,
            true,
            true,
            true,
          ]}
        />
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
