### PR TITLE
fix: Update opacity coverage rules

### DIFF
--- a/polaris-react/src/components/Select/Select.scss
+++ b/polaris-react/src/components/Select/Select.scss
@@ -84,8 +84,7 @@
   width: 100%;
   height: 100%;
   margin: 0;
-  // ChromeVox may hide content set to opacity: 0
-  opacity: 0.01;
+  opacity: 0;
   appearance: none;
 }
 

--- a/polaris-react/src/components/Select/Select.scss
+++ b/polaris-react/src/components/Select/Select.scss
@@ -85,7 +85,7 @@
   height: 100%;
   margin: 0;
   // ChromeVox may hide content set to opacity: 0
-  opacity: 0.001;
+  opacity: 0.01;
   appearance: none;
 }
 

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -4,7 +4,6 @@ import {SelectMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
 import {useUniqueId} from '../../utilities/unique-id';
 import {Labelled, LabelledProps, helpTextID} from '../Labelled';
-import {VisuallyHidden} from '../VisuallyHidden';
 import {Icon} from '../Icon';
 import type {Error} from '../../types';
 
@@ -164,25 +163,23 @@ export function Select({
       requiredIndicator={requiredIndicator}
     >
       <div className={className}>
-        <VisuallyHidden>
-          <select
-            id={id}
-            name={name}
-            value={value}
-            className={styles.Input}
-            disabled={disabled}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            onChange={handleChange}
-            aria-invalid={Boolean(error)}
-            aria-describedby={
-              describedBy.length ? describedBy.join(' ') : undefined
-            }
-            aria-required={requiredIndicator}
-          >
-            {optionsMarkup}
-          </select>
-        </VisuallyHidden>
+        <select
+          id={id}
+          name={name}
+          value={value}
+          className={styles.Input}
+          disabled={disabled}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onChange={handleChange}
+          aria-invalid={Boolean(error)}
+          aria-describedby={
+            describedBy.length ? describedBy.join(' ') : undefined
+          }
+          aria-required={requiredIndicator}
+        >
+          {optionsMarkup}
+        </select>
         {contentMarkup}
         <div className={styles.Backdrop} />
       </div>

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -4,6 +4,7 @@ import {SelectMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
 import {useUniqueId} from '../../utilities/unique-id';
 import {Labelled, LabelledProps, helpTextID} from '../Labelled';
+import {VisuallyHidden} from '../VisuallyHidden';
 import {Icon} from '../Icon';
 import type {Error} from '../../types';
 
@@ -163,23 +164,25 @@ export function Select({
       requiredIndicator={requiredIndicator}
     >
       <div className={className}>
-        <select
-          id={id}
-          name={name}
-          value={value}
-          className={styles.Input}
-          disabled={disabled}
-          onFocus={onFocus}
-          onBlur={onBlur}
-          onChange={handleChange}
-          aria-invalid={Boolean(error)}
-          aria-describedby={
-            describedBy.length ? describedBy.join(' ') : undefined
-          }
-          aria-required={requiredIndicator}
-        >
-          {optionsMarkup}
-        </select>
+        <VisuallyHidden>
+          <select
+            id={id}
+            name={name}
+            value={value}
+            className={styles.Input}
+            disabled={disabled}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            onChange={handleChange}
+            aria-invalid={Boolean(error)}
+            aria-describedby={
+              describedBy.length ? describedBy.join(' ') : undefined
+            }
+            aria-required={requiredIndicator}
+          >
+            {optionsMarkup}
+          </select>
+        </VisuallyHidden>
         {contentMarkup}
         <div className={styles.Backdrop} />
       </div>

--- a/stylelint-polaris/configs/coverage.js
+++ b/stylelint-polaris/configs/coverage.js
@@ -20,7 +20,9 @@ module.exports = {
         right: [/\$.+/],
         width: [/\$.+/],
         height: [/\$.+/],
-        opacity: [/(?!0|1)\d|[\d.]{2,}/],
+        // Allow `0`, `1`, values between 0 and 1 (limit 2 decimal places), and custom properties
+        // https://regex101.com/r/kIlVrQ/1
+        opacity: [/^(?!0|1)\d$|^\d{2,}|^[1-9]+\.|^\d+\.\d+\.|^0\.\d{3,}/],
         'z-index': [/(\$.*|-?[0-9]+)/],
         'font-weight': [/(\$.*|[0-9]+)/],
       },


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR updates our coverage rules for `opacity` based on feedback in [PR# 5471](https://github.com/Shopify/polaris/pull/5471). The updated rules allow:
- `0` or `1`
- Values between `0` and `1` (limited to `2` decimal places)
- Any `string` which is basically a pass through for custom properties and validated by our `custom-properties-allowed-list` plugin

#### Before / After
![Screen Shot 2022-04-11 at 9 27 05 AM](https://user-images.githubusercontent.com/32409546/162788764-3d034f78-b55c-4135-820c-183182c5c007.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
