### PR TITLE
[PageActions] Add ReactNode as an accepted secondaryActions prop value for customizability 

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Added `icon` prop to the `Badge` component ([#5292](https://github.com/Shopify/polaris/pull/5292))
 
+- Added support for setting a `ReactNode` on the `PageActions` `secondaryActions` prop ([#5495](https://github.com/Shopify/polaris/pull/5495))
+
 ### Bug fixes
 
 ### Documentation

--- a/polaris-react/src/components/Page/Page.tsx
+++ b/polaris-react/src/components/Page/Page.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
+import {isInterface} from '../../utilities/is-interface';
+import {isReactElement} from '../../utilities/is-react-element';
 
 import {Header, HeaderProps} from './components';
 import styles from './Page.scss';
-import {isInterface, isReactElement} from './utilities';
 
 export interface PageProps extends HeaderProps {
   /** The contents of the page */

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -20,7 +20,8 @@ import type {
 import {Breadcrumbs, BreadcrumbsProps} from '../../../Breadcrumbs';
 import {Pagination, PaginationProps} from '../../../Pagination';
 import {ActionMenu, hasGroupsWithActions} from '../../../ActionMenu';
-import {isInterface, isReactElement} from '../../utilities';
+import {isInterface} from '../../../../utilities/is-interface';
+import {isReactElement} from '../../../../utilities/is-react-element';
 
 import {Title, TitleProps} from './components';
 import styles from './Header.scss';

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -8,6 +8,8 @@ import type {
 import {Stack} from '../Stack';
 import {ButtonGroup} from '../ButtonGroup';
 import {buttonsFrom} from '../Button';
+import {isInterface} from '../../utilities/is-interface';
+import {isReactElement} from '../../utilities/is-react-element';
 
 import styles from './PageActions.scss';
 
@@ -15,8 +17,10 @@ export interface PageActionsProps {
   /** The primary action for the page */
   primaryAction?: DisableableAction & LoadableAction;
   /** The secondary actions for the page */
-  secondaryActions?: ComplexAction[];
+  secondaryActions?: ComplexAction[] | React.ReactNode;
 }
+
+type MaybeJSX = JSX.Element | null;
 
 export function PageActions({
   primaryAction,
@@ -26,9 +30,14 @@ export function PageActions({
     ? buttonsFrom(primaryAction, {primary: true})
     : null;
 
-  const secondaryActionsMarkup = secondaryActions ? (
-    <ButtonGroup>{buttonsFrom(secondaryActions)}</ButtonGroup>
-  ) : null;
+  let secondaryActionsMarkup: MaybeJSX = null;
+  if (isInterface(secondaryActions) && secondaryActions.length > 0) {
+    secondaryActionsMarkup = (
+      <ButtonGroup>{buttonsFrom(secondaryActions)}</ButtonGroup>
+    );
+  } else if (isReactElement(secondaryActions)) {
+    secondaryActionsMarkup = <>{secondaryActions}</>;
+  }
 
   const distribution = secondaryActionsMarkup ? 'equalSpacing' : 'trailing';
 

--- a/polaris-react/src/components/PageActions/README.md
+++ b/polaris-react/src/components/PageActions/README.md
@@ -114,6 +114,28 @@ Not all page actions require a secondary action.
 />
 ```
 
+### Page actions with custom secondary action
+
+Use to create a custom secondary action.
+
+```jsx
+<PageActions
+  primaryAction={{
+    content: 'Save',
+  }}
+  secondaryActions={
+    <Button
+      connectedDisclosure={{
+        accessibilityLabel: 'Other save actions',
+        actions: [{content: 'Save as draft'}],
+      }}
+    >
+      Save
+    </Button>
+  }
+/>
+```
+
 ---
 
 ## Related components

--- a/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
+++ b/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
@@ -87,5 +87,14 @@ describe('<PageActions />', () => {
       const pageActions = mountWithApp(<PageActions />);
       expect(pageActions.findAll(ButtonGroup)).toHaveLength(0);
     });
+
+    it('renders <CustomSecondaryActions /> if `ReactNode` is provided as `secondaryActions`', () => {
+      const CustomSecondaryActions = () => null;
+      const pageActions = mountWithApp(
+        <PageActions secondaryActions={<CustomSecondaryActions />} />,
+      );
+
+      expect(pageActions).toContainReactComponent(CustomSecondaryActions);
+    });
   });
 });

--- a/polaris-react/src/utilities/is-interface.ts
+++ b/polaris-react/src/utilities/is-interface.ts
@@ -1,0 +1,5 @@
+import {isValidElement} from 'react';
+
+export function isInterface<T>(x: T | React.ReactNode): x is T {
+  return !isValidElement(x) && x !== undefined;
+}

--- a/polaris-react/src/utilities/is-react-element.ts
+++ b/polaris-react/src/utilities/is-react-element.ts
@@ -1,9 +1,5 @@
 import {isValidElement} from 'react';
 
-export function isInterface<T>(x: T | React.ReactNode): x is T {
-  return !isValidElement(x) && x !== undefined;
-}
-
 export function isReactElement<T>(x: T): x is T {
   return isValidElement(x) && x !== undefined;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This PR is [related to a similar recent change](https://github.com/Shopify/polaris/pull/5258) to `secondaryActions` on `Page`.

Currently `secondaryActions` on `PageActions` only allows for passing props as `ComplexAction[]` which doesn't allow for flexibility and results in accessibility issues in some cases.

In cases where secondary actions open a modal we are unable to move focus back to the button that opened it after the modal is closed. With this change to accept `React.ReactNode` we are better able to support keyboard users through passing an entire modal as secondary action to leverage modal's built-in focus management, or through passing a custom button that'd able to have a `ref` to receive the focus. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR maintains the existing `secondaryActions` prop, while adding the option to pass a `ReactNode` instead for customizability.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Button, Modal, Page, PageActions, TextContainer} from '../src';

export function Playground() {
  return (
    <Page>
      <PageActions 
        primaryAction={{
          content: 'Save',
        }} 
        secondaryActions={<ModalExample />}
      />
    </Page>
  );
}

function ModalExample() {
  const [active, setActive] = useState(true);

  const handleChange = useCallback(() => setActive(!active), [active]);

  const activator = <Button onClick={handleChange}>Open</Button>;

  return (
    <Modal
      activator={activator}
      open={active}
      onClose={handleChange}
      title="Reach more shoppers with Instagram product tags"
      primaryAction={{
        content: 'Add Instagram',
        onAction: handleChange,
      }}
      secondaryActions={[
        {
          content: 'Learn more',
          onAction: handleChange,
        },
      ]}
    >
      <Modal.Section>
        <TextContainer>
          <p>
            Use Instagram posts to share your products with millions of people.
            Let shoppers buy from your store without leaving Instagram.
          </p>
        </TextContainer>
      </Modal.Section>
    </Modal>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
