### PR TITLE
set max commits to false to avoid backlogged warning in PRs

### DIFF
--- a/shipit.stylelint-polaris.yml
+++ b/shipit.stylelint-polaris.yml
@@ -5,3 +5,4 @@ dependencies:
 deploy:
   override:
     - npm publish stylelint-polaris --tag latest
+  max_commits: false


### PR DESCRIPTION
To avoid this:

<img width="437" alt="image" src="https://user-images.githubusercontent.com/344839/162826988-fb913442-b6ce-4522-b7cb-297b7155fe16.png">
