### PR TITLE
Move Babel config to root level for better monorepo support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  presets: [['@shopify/babel-preset', {typescript: true}]],
+  overrides: [
+    {
+      test: './polaris-react',
+      presets: [['@shopify/babel-preset', {typescript: true, react: true}]],
+    },
+  ],
+};

--- a/polaris-react/babel.config.js
+++ b/polaris-react/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [['@shopify/babel-preset', {typescript: true, react: true}]],
-};


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #5441 <!-- link to issue if one exists -->

Test and verify using `yarn run build` to build all packages (including `polaris-react` which uses Babel).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

* Move `./polaris-react/babel.config.js` to the root level`./babel.config.js`
* Add `overrides` array as a starting point for consolidated babel overrides on a per-project basis

Using the root `babel.config.js` and the [`overrides` key](https://babeljs.io/docs/en/options#overrides) is the [recommended approach](https://babeljs.io/docs/en/config-files#monorepos) for using Babel with monorepos. This is how [Babel itself configures](https://github.com/babel/babel/blob/master/babel.config.js#L113) subdirectories (packages) in the Babel monorepo.