### PR TITLE
[Badge] exposes `Pip` to outside of `Badge` component

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Added support for NodeJS v14 ([#5551](https://github.com/Shopify/polaris/pull/5551))
 
+- Made `Pip` a sub-component of `Badge` and exposed it to outside ([#5520](https://github.com/Shopify/polaris/pull/5520))
+
 ### Bug fixes
 
 ### Documentation

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -1,9 +1,6 @@
 .Badge {
   --pc-badge-horizontal-padding: var(--p-space-2);
   --pc-badge-vertical-padding: var(--p-space-05);
-  --pc-badge-pip-size: var(--p-space-2);
-  --pc-badge-pip-spacing: var(--p-space-1);
-  --pc-badge-component-badge-pip-color: var(--p-icon);
   display: inline-flex;
   align-items: center;
   padding: var(--pc-badge-vertical-padding) var(--pc-badge-horizontal-padding);
@@ -24,92 +21,34 @@
 }
 
 .statusSuccess {
-  --pc-badge-component-badge-pip-color: var(--p-icon-success);
   background-color: var(--p-surface-success);
   color: var(--p-text);
 }
 
 .statusInfo {
-  --pc-badge-component-badge-pip-color: var(--p-icon-highlight);
   background-color: var(--p-surface-highlight);
   color: var(--p-text);
 }
 
 .statusAttention {
-  --pc-badge-component-badge-pip-color: var(--p-icon-attention);
   background-color: var(--p-surface-attention);
   color: var(--p-text);
 }
 
 .statusWarning {
-  --pc-badge-component-badge-pip-color: var(--p-icon-warning);
   background-color: var(--p-surface-warning);
   color: var(--p-text);
 }
 
 .statusCritical {
-  --pc-badge-component-badge-pip-color: var(--p-icon-critical);
   background-color: var(--p-surface-critical);
   color: var(--p-text);
 }
 
 .statusNew {
-  background-color: var(--p-surface-neutral);
   color: var(--p-text);
   font-weight: var(--p-font-weight-medium);
   border: none;
-}
-
-.Pip {
-  color: var(--pc-badge-component-badge-pip-color);
-  height: var(--pc-badge-pip-size);
-  width: var(--pc-badge-pip-size);
-  margin-right: var(--pc-badge-pip-spacing);
-  margin-left: calc(
-    var(--pc-badge-vertical-padding) - var(--pc-badge-pip-spacing)
-  );
-  border: var(--p-border-width-2) solid currentColor;
-  border-radius: var(--p-border-radius-half);
-  flex-shrink: 0;
-}
-
-.progressIncomplete .Pip {
-  background: transparent;
-}
-
-.progressPartiallyComplete .Pip {
-  background: linear-gradient(
-    to top,
-    currentColor,
-    currentColor 50%,
-    transparent 50%,
-    transparent
-  );
-
-  // Background colors may be stripped when printing, but box-shadow is not.
-  // We don't want to use box-shadow as the screen style as it gives a very
-  // slight halo effect
-  @media print {
-    background: none;
-    // 100px is an arbitrarily large number so that you can't see the curvature
-    // of the box shadow. y-offset is 2px larger than the spread to make it look
-    // like it is half-way down the pip (which is 4px tall)
-    box-shadow: 0 -102px 0 -100px currentColor inset;
-  }
-}
-
-.progressComplete .Pip {
-  background: currentColor;
-
-  // Background colors may be stripped when printing, but box-shadow is not.
-  // We don't want to use box-shadow as the screen style as it gives a very
-  // slight halo effect
-  @media print {
-    background: none;
-    // 100px is an arbitrarily large number so that you can't see the curvature
-    // of the box shadow.
-    box-shadow: 0 0 0 100px currentColor inset;
-  }
 }
 
 .withinFilter {
@@ -124,4 +63,11 @@
   + *:not(.Icon) {
     margin-left: var(--p-space-1);
   }
+}
+
+.PipContainer {
+  display: grid;
+  align-items: center;
+  margin-left: calc(-1 * var(--p-space-05));
+  margin-right: var(--p-space-1);
 }

--- a/polaris-react/src/components/Badge/Badge.tsx
+++ b/polaris-react/src/components/Badge/Badge.tsx
@@ -1,18 +1,18 @@
 import React, {useContext} from 'react';
 
-import type {IconSource} from '../../types';
 import {classNames, variationName} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {WithinFilterContext} from '../../utilities/within-filter-context';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {Icon} from '../Icon';
+import type {IconSource} from '../../types';
 
 import styles from './Badge.scss';
+import type {Progress, Size, Status} from './types';
+import {Pip} from './components';
+import {getDefaultAccessibilityLabel} from './utils';
 
-type Status = 'info' | 'success' | 'attention' | 'warning' | 'critical' | 'new';
-type Progress = 'incomplete' | 'partiallyComplete' | 'complete';
-type Size = 'small' | 'medium';
-
+const DEFAULT_SIZE: Size = 'medium';
 interface NonMutuallyExclusiveProps {
   /** The content to display inside the badge. */
   children?: string;
@@ -37,23 +37,6 @@ export type BadgeProps = NonMutuallyExclusiveProps &
     | {icon?: IconSource; progress?: undefined}
   );
 
-const PROGRESS_LABELS: {[key in Progress]: Progress} = {
-  incomplete: 'incomplete',
-  partiallyComplete: 'partiallyComplete',
-  complete: 'complete',
-};
-
-const STATUS_LABELS: {[key in Status]: Status} = {
-  info: 'info',
-  success: 'success',
-  warning: 'warning',
-  critical: 'critical',
-  attention: 'attention',
-  new: 'new',
-};
-
-const DEFAULT_SIZE = 'medium';
-
 export function Badge({
   children,
   status,
@@ -68,68 +51,28 @@ export function Badge({
   const className = classNames(
     styles.Badge,
     status && styles[variationName('status', status)],
-    progress && styles[variationName('progress', progress)],
     icon && styles.icon,
     size && size !== DEFAULT_SIZE && styles[variationName('size', size)],
     withinFilter && styles.withinFilter,
   );
 
-  let progressLabel = '';
-  switch (progress) {
-    case PROGRESS_LABELS.incomplete:
-      progressLabel = i18n.translate(
-        'Polaris.Badge.PROGRESS_LABELS.incomplete',
-      );
-      break;
-    case PROGRESS_LABELS.partiallyComplete:
-      progressLabel = i18n.translate(
-        'Polaris.Badge.PROGRESS_LABELS.partiallyComplete',
-      );
-      break;
-    case PROGRESS_LABELS.complete:
-      progressLabel = i18n.translate('Polaris.Badge.PROGRESS_LABELS.complete');
-      break;
-  }
-
-  let statusLabel = '';
-  switch (status) {
-    case STATUS_LABELS.info:
-      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.info');
-      break;
-    case STATUS_LABELS.success:
-      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.success');
-      break;
-    case STATUS_LABELS.warning:
-      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.warning');
-      break;
-    case STATUS_LABELS.critical:
-      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.critical');
-      break;
-    case STATUS_LABELS.attention:
-      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.attention');
-      break;
-    case STATUS_LABELS.new:
-      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.new');
-      break;
-  }
-
   const accessibilityLabel = statusAndProgressLabelOverride
     ? statusAndProgressLabelOverride
-    : i18n.translate('Polaris.Badge.progressAndStatus', {
-        progressLabel,
-        statusLabel,
-      });
+    : getDefaultAccessibilityLabel(i18n, progress, status);
 
-  const hasAccessibilityLabel =
-    progressLabel || statusLabel || statusAndProgressLabelOverride;
-
-  let accessibilityMarkup = hasAccessibilityLabel && (
+  let accessibilityMarkup = Boolean(accessibilityLabel) && (
     <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
   );
 
-  if (progressLabel && !icon) {
+  if (progress && !icon) {
     accessibilityMarkup = (
-      <span className={styles.Pip}>{accessibilityMarkup}</span>
+      <span className={styles.PipContainer}>
+        <Pip
+          progress={progress}
+          status={status}
+          accessibilityLabelOverride={accessibilityLabel}
+        />
+      </span>
     );
   }
 
@@ -145,3 +88,5 @@ export function Badge({
     </span>
   );
 }
+
+Badge.Pip = Pip;

--- a/polaris-react/src/components/Badge/components/Pip/Pip.scss
+++ b/polaris-react/src/components/Badge/components/Pip/Pip.scss
@@ -1,0 +1,69 @@
+.Pip {
+  --pc-pip-size: var(--p-space-2);
+  --pc-pip-color: var(--p-icon);
+  display: inline-block;
+  color: var(--pc-pip-color);
+  height: var(--pc-pip-size);
+  width: var(--pc-pip-size);
+  border: var(--p-border-width-2) solid var(--pc-pip-color);
+  border-radius: var(--p-border-radius-half);
+  flex-shrink: 0;
+}
+
+.statusSuccess {
+  --pc-pip-color: var(--p-icon-success);
+}
+
+.statusInfo {
+  --pc-pip-color: var(--p-icon-highlight);
+}
+
+.statusAttention {
+  --pc-pip-color: var(--p-icon-attention);
+}
+
+.statusWarning {
+  --pc-pip-color: var(--p-icon-warning);
+}
+
+.statusCritical {
+  --pc-pip-color: var(--p-icon-critical);
+}
+
+.progressIncomplete {
+  background: transparent;
+}
+
+.progressPartiallyComplete {
+  background: linear-gradient(
+    to top,
+    currentColor,
+    currentColor 50%,
+    transparent 50%,
+    transparent
+  );
+
+  // Background colors may be stripped when printing, but box-shadow is not.
+  // We don't want to use box-shadow as the screen style as it gives a very
+  // slight halo effect
+  @media print {
+    background: none;
+    // 100px is an arbitrarily large number so that you can't see the curvature
+    // of the box shadow. y-offset is 2px larger than the spread to make it look
+    // like it is half-way down the pip (which is 4px tall)
+    box-shadow: 0 -102px 0 -100px currentColor inset;
+  }
+}
+
+.progressComplete {
+  background: currentColor;
+  // Background colors may be stripped when printing, but box-shadow is not.
+  // We don't want to use box-shadow as the screen style as it gives a very
+  // slight halo effect
+  @media print {
+    background: none;
+    // 100px is an arbitrarily large number so that you can't see the curvature
+    // of the box shadow.
+    box-shadow: 0 0 0 100px currentColor inset;
+  }
+}

--- a/polaris-react/src/components/Badge/components/Pip/Pip.tsx
+++ b/polaris-react/src/components/Badge/components/Pip/Pip.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import {classNames, variationName} from '../../../../utilities/css';
+import type {Progress, Status} from '../../types';
+import {VisuallyHidden} from '../../../VisuallyHidden';
+import {useI18n} from '../../../../utilities/i18n';
+import {getDefaultAccessibilityLabel} from '../../utils';
+
+import styles from './Pip.scss';
+
+export interface PipProps {
+  status?: Status;
+  progress?: Progress;
+  accessibilityLabelOverride?: string;
+}
+
+export function Pip({
+  status = 'info',
+  progress = 'complete',
+  accessibilityLabelOverride,
+}: PipProps) {
+  const i18n = useI18n();
+  const className = classNames(
+    styles.Pip,
+    status && styles[variationName('status', status)],
+    progress && styles[variationName('progress', progress)],
+  );
+
+  return (
+    <span className={className}>
+      <VisuallyHidden>
+        {accessibilityLabelOverride
+          ? accessibilityLabelOverride
+          : getDefaultAccessibilityLabel(i18n, progress, status)}
+      </VisuallyHidden>
+    </span>
+  );
+}

--- a/polaris-react/src/components/Badge/components/Pip/index.ts
+++ b/polaris-react/src/components/Badge/components/Pip/index.ts
@@ -1,0 +1,1 @@
+export * from './Pip';

--- a/polaris-react/src/components/Badge/components/index.ts
+++ b/polaris-react/src/components/Badge/components/index.ts
@@ -1,0 +1,1 @@
+export * from './Pip';

--- a/polaris-react/src/components/Badge/index.ts
+++ b/polaris-react/src/components/Badge/index.ts
@@ -1,1 +1,2 @@
 export * from './Badge';
+export * from './types';

--- a/polaris-react/src/components/Badge/tests/Badge.test.tsx
+++ b/polaris-react/src/components/Badge/tests/Badge.test.tsx
@@ -44,7 +44,7 @@ describe('<Badge />', () => {
     const badge = mountWithApp(<Badge progress="incomplete" />);
 
     expect(badge).toContainReactComponent('span', {
-      className: 'Pip',
+      className: 'Pip statusInfo progressIncomplete',
     });
   });
 
@@ -104,6 +104,62 @@ describe('<Badge />', () => {
 
     expect(badge).not.toContainReactComponent(VisuallyHidden, {
       children: 'Attention Incomplete',
+    });
+  });
+
+  it('renders default accessibility label when `statusAndProgressLabelOverride` is not provided', () => {
+    let badge = mountWithApp(
+      <Badge status="attention" progress="incomplete" />,
+    );
+
+    expect(badge).toContainReactComponent(VisuallyHidden, {
+      children: 'Attention Incomplete',
+    });
+
+    badge = mountWithApp(<Badge progress="incomplete" />);
+
+    expect(badge).toContainReactComponent(VisuallyHidden, {
+      children: ' Incomplete',
+    });
+
+    badge = mountWithApp(<Badge status="attention" />);
+
+    expect(badge).toContainReactComponent(VisuallyHidden, {
+      children: 'Attention ',
+    });
+
+    badge = mountWithApp(<Badge />);
+
+    expect(badge).not.toContainReactComponent(VisuallyHidden);
+  });
+});
+
+describe('<Badge.Pip />', () => {
+  it('renders default accessibility label when `statusAndProgressLabelOverride` is not provided', () => {
+    let badge = mountWithApp(
+      <Badge.Pip status="attention" progress="incomplete" />,
+    );
+
+    expect(badge).toContainReactComponent(VisuallyHidden, {
+      children: 'Attention Incomplete',
+    });
+
+    badge = mountWithApp(<Badge.Pip progress="partiallyComplete" />);
+
+    expect(badge).toContainReactComponent(VisuallyHidden, {
+      children: 'Info Partially complete',
+    });
+
+    badge = mountWithApp(<Badge.Pip status="attention" />);
+
+    expect(badge).toContainReactComponent(VisuallyHidden, {
+      children: 'Attention Complete',
+    });
+
+    badge = mountWithApp(<Badge.Pip />);
+
+    expect(badge).toContainReactComponent(VisuallyHidden, {
+      children: 'Info Complete',
     });
   });
 });

--- a/polaris-react/src/components/Badge/types.ts
+++ b/polaris-react/src/components/Badge/types.ts
@@ -1,0 +1,17 @@
+export enum StatusValue {
+  Info = 'info',
+  Success = 'success',
+  Warning = 'warning',
+  Critical = 'critical',
+  Attention = 'attention',
+  New = 'new',
+}
+// uses template literal types to get the string representation of the values of the FieldsMap enums
+export type Status = `${StatusValue}`;
+export enum ProgressValue {
+  Incomplete = 'incomplete',
+  PartiallyComplete = 'partiallyComplete',
+  Complete = 'complete',
+}
+export type Progress = `${ProgressValue}`;
+export type Size = 'small' | 'medium';

--- a/polaris-react/src/components/Badge/utils.ts
+++ b/polaris-react/src/components/Badge/utils.ts
@@ -1,0 +1,57 @@
+import type {I18n} from '../../utilities/i18n';
+
+import {Progress, ProgressValue, Status, StatusValue} from './types';
+
+export function getDefaultAccessibilityLabel(
+  i18n: I18n,
+  progress?: Progress,
+  status?: Status,
+): string {
+  let progressLabel = '';
+  let statusLabel = '';
+
+  if (!progress && !status) {
+    return '';
+  }
+  switch (progress) {
+    case ProgressValue.Incomplete:
+      progressLabel = i18n.translate(
+        'Polaris.Badge.PROGRESS_LABELS.incomplete',
+      );
+      break;
+    case ProgressValue.PartiallyComplete:
+      progressLabel = i18n.translate(
+        'Polaris.Badge.PROGRESS_LABELS.partiallyComplete',
+      );
+      break;
+    case ProgressValue.Complete:
+      progressLabel = i18n.translate('Polaris.Badge.PROGRESS_LABELS.complete');
+      break;
+  }
+
+  switch (status) {
+    case StatusValue.Info:
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.info');
+      break;
+    case StatusValue.Success:
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.success');
+      break;
+    case StatusValue.Warning:
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.warning');
+      break;
+    case StatusValue.Critical:
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.critical');
+      break;
+    case StatusValue.Attention:
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.attention');
+      break;
+    case StatusValue.New:
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.new');
+      break;
+  }
+
+  return i18n.translate('Polaris.Badge.progressAndStatus', {
+    progressLabel,
+    statusLabel,
+  });
+}

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -52,7 +52,11 @@ export type {AvatarProps} from './components/Avatar';
 export {Backdrop} from './components/Backdrop';
 export type {BackdropProps} from './components/Backdrop';
 
-export {Badge} from './components/Badge';
+export {
+  Badge,
+  StatusValue as BadgeStatusValue,
+  ProgressValue as BadgeProgressValue,
+} from './components/Badge';
 export type {BadgeProps} from './components/Badge';
 
 export {Banner} from './components/Banner';


### PR DESCRIPTION
## WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5521

<!--
  Context about the problem that’s being addressed.
-->

## WHAT is this pull request doing?

1) Makes `Pip` a sub-component of `Badge`
2) Exposes `Pip` to outside, to be used by other components inside/outside lib
3) Concentrates types and interfaces to `types.ts`
4) Adapts tests

## Media 📽
<img width="541" alt="Screen Shot 2022-04-20 at 10 04 41" src="https://user-images.githubusercontent.com/1577809/164181296-0ca9fd6e-cc09-420b-a0fc-3c41d085f3c4.png">


## How to 🎩
1)  Checkout the branch
````
git checkout berhell/expose-pip-outside-badge
````

<details>
<summary>2) Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {GlobeMinor} from '@shopify/polaris-icons';

import {Page, Stack, Badge} from '../src';

export function Playground() {
  return (
    <Page title="Pip">
      <Stack>
        <div>
          <Badge.Pip progress="incomplete" status="critical" /> Incomplete &
          Critical
        </div>

        <div>
          <Badge.Pip progress="complete" status="attention" /> Complete &
          Attention
        </div>

        <div>
          <Badge.Pip progress="partiallyComplete" status="info" /> Partial &
          Info
        </div>

        <div>
          <Badge.Pip progress="incomplete" status="new" /> Incomplete & New
        </div>

        <div>
          <Badge.Pip progress="complete" status="success" /> Complete & Success
        </div>

        <div>
          <Badge.Pip progress="partiallyComplete" status="warning" /> Partial &
          warning
        </div>
      </Stack>

      <Page title="Badges">
        <Stack>
          <Badge icon={GlobeMinor}>Icon, no status</Badge>
          {/*
          The Icon doesn’t get scaled down because the `Icon` size is hardcoded to 20px…
        */}
          <Badge icon={GlobeMinor} size="small">
            Small Badge with icon
          </Badge>

          <Badge icon={GlobeMinor} status="success">
            Icon, success
          </Badge>

          <Badge progress="complete" icon={GlobeMinor}>
            Progress + icon, prefers icon but TypeScript errors
          </Badge>

          <Badge progress="complete">Progress, unchanged</Badge>

          {/*
          Icon only. This works right now but I don‘t see a reason why `children` would be optional.
          If we want to allow this we need to also allow an alt prop for the icon.
        */}
          <Badge icon={GlobeMinor} />
        </Stack>
      </Page>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
