### PR TITLE
Enable CORS for the token API

### DIFF
--- a/polaris.shopify.com/next.config.js
+++ b/polaris.shopify.com/next.config.js
@@ -1,8 +1,30 @@
+/* eslint-disable require-await */
 /** @type {import('next').NextConfig} */
+
 const nextConfig = {
   reactStrictMode: true,
   eslint: {
     ignoreDuringBuilds: true,
+  },
+  async headers() {
+    return [
+      {
+        source: '/api/v0/tokens/:path*',
+        headers: [
+          {key: 'Access-Control-Allow-Credentials', value: 'true'},
+          {key: 'Access-Control-Allow-Origin', value: '*'},
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET,OPTIONS',
+          },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value:
+              'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
+          },
+        ],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The tokens API can't be accessed from other origins (see [example CodeSandbox](https://codesandbox.io/s/jolly-paper-q8xuoj?file=/src/index.js)).

This change will allow the tokens API to to be used by [origins](https://developer.mozilla.org/en-US/docs/Glossary/Origin) (domain, scheme, or port) other than its own.

Followed the suggestion from the Vercel documentation on [enabling CORS for a Next.js application](https://vercel.com/support/articles/how-to-enable-cors#enabling-cors-in-a-next.js-app).

<img width="755" alt="cors" src="https://user-images.githubusercontent.com/11774595/163460449-9d9c26aa-b9e7-4e30-946f-a052e9145848.png">

