### PR TITLE
Polaris for VS Code Autopublish Follow Up

### DIFF
--- a/.github/workflows/publish-polaris-for-vscode.yml.yml
+++ b/.github/workflows/publish-polaris-for-vscode.yml.yml
@@ -19,8 +19,11 @@ jobs:
           node-version: '16'
           cache: 'yarn'
 
-      - name: 📦 Install dependencies
+      - name: Install dependencies
         run: yarn
+
+      - name: Run Tests
+        run: yarn test
 
       - name: Publish extension in the marketplace
         run: yarn workspace polaris-for-vscode vsce publish --yarn

--- a/polaris-for-vscode/package.json
+++ b/polaris-for-vscode/package.json
@@ -36,7 +36,8 @@
     "compile": "tsc -b",
     "watch": "tsc -b -w",
     "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
-    "lint": "eslint ./client/src ./server/src --ext .ts,.tsx"
+    "lint": "eslint ./client/src ./server/src --ext .ts,.tsx",
+    "test": "yarn lint"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",


### PR DESCRIPTION
Follow up to https://github.com/Shopify/polaris/pull/5542. Renames the action to follow monorepo naming conventions and adds step for tests