### PR TITLE
[Layout] Switch to css grid and align to 4 / 12 column

### DIFF
--- a/polaris-react/.storybook/GridOverlay/GridOverlay.scss
+++ b/polaris-react/.storybook/GridOverlay/GridOverlay.scss
@@ -7,13 +7,14 @@
   bottom: 0;
   right: 0;
   display: grid;
-  gap: var(--p-space-3);
+  gap: var(--p-space-4);
   grid-template-columns: repeat(4, 1fr);
-  padding: 0 var(--p-space-3);
+  padding: 0 var(--p-space-4);
   margin: 0 auto;
   background-color: var(--p-action-critical);
   opacity: 0.25;
   pointer-events: none;
+  z-index: -1;
 
   @media screen and (min-width: 768px) {
     grid-template-columns: repeat(12, 1fr);
@@ -27,6 +28,7 @@
 }
 
 .inFrame {
+  z-index: 0;
   top: var(--pc-top-bar-height);
 
   @media screen and (min-width: 768px) {

--- a/polaris-react/.storybook/GridOverlay/GridOverlay.scss
+++ b/polaris-react/.storybook/GridOverlay/GridOverlay.scss
@@ -1,3 +1,5 @@
+@import '../../src/styles/media-queries';
+
 .GridOverlay {
   --pc-top-bar-height: 56px;
   --pc-nav-width: 240px;
@@ -8,7 +10,7 @@
   right: 0;
   display: grid;
   gap: var(--p-space-4);
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   padding: 0 var(--p-space-4);
   margin: 0 auto;
   background-color: var(--p-action-critical);
@@ -16,9 +18,14 @@
   pointer-events: none;
   z-index: -1;
 
-  @media screen and (min-width: 768px) {
-    grid-template-columns: repeat(12, 1fr);
+  @media #{$p-breakpoints-sm-up} {
+    padding: 0 var(--p-space-4);
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  @media #{$p-breakpoints-md-up} {
     padding: 0 var(--p-space-8);
+    grid-template-columns: repeat(12, 1fr);
   }
 }
 
@@ -31,7 +38,7 @@
   z-index: 0;
   top: var(--pc-top-bar-height);
 
-  @media screen and (min-width: 768px) {
+  @media #{$p-breakpoints-md-up} {
     left: var(--pc-nav-width);
   }
 }

--- a/polaris-react/.storybook/GridOverlay/GridOverlay.tsx
+++ b/polaris-react/.storybook/GridOverlay/GridOverlay.tsx
@@ -1,5 +1,4 @@
-import React, {useEffect, useState} from 'react';
-import debounce from 'lodash/debounce';
+import React, {useCallback, useState} from 'react';
 import {EventListener} from '../../src';
 import {classNames} from '../../src/utilities/css';
 
@@ -22,9 +21,9 @@ export function GridOverlay({inFrame, maxWidth, layer, children}: Props) {
     window.innerWidth < BREAKPOINT ? COLUMNS_SMALL : COLUMNS_LARGE,
   );
 
-  const handleResize = debounce(() => {
+  const handleResize = useCallback(() => {
     setColumns(window.innerWidth < BREAKPOINT ? COLUMNS_SMALL : COLUMNS_LARGE);
-  }, 50);
+  }, []);
 
   const className = classNames(styles.GridOverlay, inFrame && styles.inFrame);
 

--- a/polaris-react/.storybook/GridOverlay/GridOverlay.tsx
+++ b/polaris-react/.storybook/GridOverlay/GridOverlay.tsx
@@ -1,14 +1,16 @@
-import React, {useCallback, useState} from 'react';
+import React, {useState} from 'react';
 import {EventListener} from '../../src';
+import {tokens} from '../../src/tokens';
 import {classNames} from '../../src/utilities/css';
 
 import styles from './GridOverlay.scss';
 
-const COLUMNS_SMALL = 4;
+const COLUMNS_SMALL = 2;
+const COLUMNS_MEDIUM = 4;
 const COLUMNS_LARGE = 12;
-const BREAKPOINT = 768;
 
 type Layer = 'above' | 'below';
+
 interface Props {
   inFrame?: boolean;
   maxWidth?: string;
@@ -17,20 +19,15 @@ interface Props {
 }
 
 export function GridOverlay({inFrame, maxWidth, layer, children}: Props) {
-  const [columns, setColumns] = useState(
-    window.innerWidth < BREAKPOINT ? COLUMNS_SMALL : COLUMNS_LARGE,
-  );
-
-  const handleResize = useCallback(() => {
-    setColumns(window.innerWidth < BREAKPOINT ? COLUMNS_SMALL : COLUMNS_LARGE);
-  }, []);
+  const [columns, setColumns] = useState(getColumns());
+  const handleResize = () => setColumns(getColumns());
 
   const className = classNames(styles.GridOverlay, inFrame && styles.inFrame);
 
   const style = {
     maxWidth,
     zIndex: layer === 'above' || inFrame ? 1 : -1,
-  } as unknown as React.CSSProperties;
+  } as React.CSSProperties;
 
   return (
     <div className={className} style={style}>
@@ -41,4 +38,24 @@ export function GridOverlay({inFrame, maxWidth, layer, children}: Props) {
       <EventListener event="resize" handler={handleResize} />
     </div>
   );
+}
+
+function getColumns() {
+  const medium = window.matchMedia(
+    `(min-width: ${tokens.breakpoints['breakpoints-md']})`,
+  ).matches;
+  const small = window.matchMedia(
+    `(min-width: ${tokens.breakpoints['breakpoints-sm']})`,
+  ).matches;
+
+  switch (true) {
+    case medium:
+      return COLUMNS_LARGE;
+
+    case small:
+      return COLUMNS_MEDIUM;
+
+    default:
+      return COLUMNS_SMALL;
+  }
 }

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,6 +10,10 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added `border-width-4` and `border-width-5` tokens and replaced hardcoded values ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Replaced any hardcoded `outline-width` with `border-width` ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Added the ability to disable specific dates in the `DatePicker`, to go along with date ranges ([#5356](https://github.com/Shopify/polaris/pull/5356))
+- Added `icon` prop to the `Badge` component ([#5292](https://github.com/Shopify/polaris/pull/5292))
+- Added support for setting a `ReactNode` on the `PageActions` `secondaryActions` prop ([#5495](https://github.com/Shopify/polaris/pull/5495))
+- Added support for NodeJS v14 ([#5551](https://github.com/Shopify/polaris/pull/5551))
+- Applied a grid layout to `Layout` ([#5565](https://github.com/Shopify/polaris/pull/5565))
 
 - Added breakpoint CSS custom properties and SCSS media conditions ([#5558](https://github.com/Shopify/polaris/pull/5558))
 

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,9 +10,6 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added `border-width-4` and `border-width-5` tokens and replaced hardcoded values ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Replaced any hardcoded `outline-width` with `border-width` ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Added the ability to disable specific dates in the `DatePicker`, to go along with date ranges ([#5356](https://github.com/Shopify/polaris/pull/5356))
-- Added `icon` prop to the `Badge` component ([#5292](https://github.com/Shopify/polaris/pull/5292))
-- Added support for setting a `ReactNode` on the `PageActions` `secondaryActions` prop ([#5495](https://github.com/Shopify/polaris/pull/5495))
-- Added support for NodeJS v14 ([#5551](https://github.com/Shopify/polaris/pull/5551))
 - Applied a grid layout to `Layout` ([#5565](https://github.com/Shopify/polaris/pull/5565))
 
 - Added breakpoint CSS custom properties and SCSS media conditions ([#5558](https://github.com/Shopify/polaris/pull/5558))

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -567,7 +567,6 @@ export function DetailsPage() {
       }}
     >
       <Layout>
-        {skipToContentTarget}
         <Layout.Section>
           <Card sectioned>
             <FormLayout>
@@ -675,6 +674,7 @@ export function DetailsPage() {
       onNavigationDismiss={toggleMobileNavigationActive}
       skipToContentTarget={skipToContentRef}
     >
+      {skipToContentTarget}
       {contextualSaveBarMarkup}
       {loadingMarkup}
       {pageMarkup}

--- a/polaris-react/src/components/Layout/Layout.scss
+++ b/polaris-react/src/components/Layout/Layout.scss
@@ -1,109 +1,61 @@
 @import '../../styles/common';
 
-$secondary-basis: layout-width(secondary, min);
-$primary-basis: layout-width(primary, min);
-$one-half-basis: layout-width(one-half-width, base);
-$one-third-basis: layout-width(one-third-width, base);
-$relative-size: $primary-basis / $secondary-basis;
-
 .Layout {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: flex-start;
-  margin-top: calc(-1 * var(--p-space-4));
-  margin-left: calc(-1 * var(--p-space-5));
+  display: grid;
+  gap: var(--p-space-4);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-auto-flow: row;
 
-  @media print {
-    body & {
-      font-size: var(--p-font-size-1);
-      line-height: var(--p-line-height-1);
-    }
-
-    a,
-    button {
-      color: var(--p-text);
-    }
+  @include breakpoint-after(768px) {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
   }
 }
 
 .Section {
-  flex: $relative-size $relative-size $primary-basis;
-  min-width: 51%;
+  grid-column-end: span 4;
 
-  @media print {
-    flex: 2 2 360px;
+  @include breakpoint-after(768px) {
+    grid-column-end: span 8;
   }
 }
 
-.Section-secondary {
-  flex: 1 1 $secondary-basis;
-  min-width: 0;
+@for $i from 1 through 4 {
+  .grid-#{$i}-column {
+    grid-column-end: span #{$i};
+  }
 }
 
-.Section-fullWidth {
-  flex: 1 1 100%;
-}
-
-.Section-oneHalf {
-  flex: 1 1 $one-half-basis;
-  min-width: 0;
-}
-
-.Section-oneThird {
-  flex: 1 1 $one-third-basis;
-  min-width: 0;
-}
-
-.AnnotatedSection {
-  min-width: 0;
-  flex: 1 1 100%;
-}
-
-.Section,
-.AnnotatedSection {
-  max-width: calc(100% - var(--p-space-5));
-  margin-top: var(--p-space-4);
-  margin-left: var(--p-space-5);
-
-  + .AnnotatedSection {
-    @include page-content-when-not-fully-condensed {
-      padding-top: var(--p-space-4);
-      border-top: var(--p-border-divider);
+@for $i from 1 through 12 {
+  @include breakpoint-after(768px) {
+    .grid-#{$i}-large-column {
+      grid-column-end: span #{$i};
     }
   }
 }
 
-.AnnotationWrapper {
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: calc(-1 * var(--p-space-4));
-  margin-left: calc(-1 * var(--p-space-5));
+.secondary,
+.oneThird {
+  grid-column-end: span 4;
 }
 
-.AnnotationContent {
-  flex: $relative-size $relative-size $primary-basis;
+.oneHalf {
+  grid-column-end: span 4;
+
+  @include breakpoint-after(768px) {
+    grid-column-end: span 6;
+  }
+}
+
+.fullWidth {
+  grid-column-end: span 4;
+
+  @include breakpoint-after(768px) {
+    grid-column-end: span 12;
+  }
 }
 
 .Annotation {
-  flex: 1 1 $secondary-basis;
-  padding: var(--p-space-4) var(--p-space-5) 0;
-
-  @include page-content-when-not-fully-condensed {
-    padding: var(--p-space-4) 0 0;
-  }
-
-  @include page-content-when-layout-not-stacked {
-    padding: var(--p-space-5) var(--p-space-5) var(--p-space-5) 0;
-  }
-}
-
-.Annotation,
-.AnnotationContent {
-  min-width: 0;
-  max-width: calc(100% - var(--p-space-5));
-  margin-top: var(--p-space-4);
-  margin-left: var(--p-space-5);
+  margin-top: var(--p-space-5);
 }
 
 .AnnotationDescription {

--- a/polaris-react/src/components/Layout/Layout.scss
+++ b/polaris-react/src/components/Layout/Layout.scss
@@ -1,12 +1,12 @@
 @import '../../styles/common';
+@import '../../styles/media-queries';
 
 .Layout {
   display: grid;
   gap: var(--p-space-4);
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-auto-flow: row;
 
-  @include breakpoint-after(768px) {
+  @media #{$p-breakpoints-md-up} {
     grid-template-columns: repeat(12, minmax(0, 1fr));
   }
 }
@@ -14,7 +14,7 @@
 .Section {
   grid-column-end: span 4;
 
-  @include breakpoint-after(768px) {
+  @media #{$p-breakpoints-md-up} {
     grid-column-end: span 8;
   }
 }
@@ -26,7 +26,7 @@
 }
 
 @for $i from 1 through 12 {
-  @include breakpoint-after(768px) {
+  @media #{$p-breakpoints-md-up} {
     .grid-#{$i}-large-column {
       grid-column-end: span #{$i};
     }
@@ -41,7 +41,7 @@
 .oneHalf {
   grid-column-end: span 4;
 
-  @include breakpoint-after(768px) {
+  @media #{$p-breakpoints-md-up} {
     grid-column-end: span 6;
   }
 }
@@ -49,7 +49,7 @@
 .fullWidth {
   grid-column-end: span 4;
 
-  @include breakpoint-after(768px) {
+  @media #{$p-breakpoints-md-up} {
     grid-column-end: span 12;
   }
 }

--- a/polaris-react/src/components/Layout/README.md
+++ b/polaris-react/src/components/Layout/README.md
@@ -70,7 +70,7 @@ Use to have a single section on its own in a full-width container. Use for simpl
 ```jsx
 <Page fullWidth>
   <Layout>
-    <Layout.Section>
+    <Layout.Section fullWidth>
       <Card title="Online store dashboard" sectioned>
         <p>View a summary of your online store’s performance.</p>
       </Card>
@@ -456,7 +456,7 @@ Use for settings pages that need a banner or other content at the top.
 ```jsx
 <Page fullWidth>
   <Layout>
-    <Layout.Section>
+    <Layout.Section fullWidth>
       <Banner title="Order archived" onDismiss={() => {}}>
         <p>This order was archived on March 7, 2017 at 3:12pm EDT.</p>
       </Banner>

--- a/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -3,23 +3,27 @@ import React from 'react';
 import {Heading} from '../../../Heading';
 import {TextContainer} from '../../../TextContainer';
 import styles from '../../Layout.scss';
+import {Section} from '../Section';
 
 export interface AnnotatedSectionProps {
-  children?: React.ReactNode;
+  id?: string;
   title?: React.ReactNode;
   description?: React.ReactNode;
-  id?: string;
+  children?: React.ReactNode;
 }
 
-export function AnnotatedSection(props: AnnotatedSectionProps) {
-  const {children, title, description, id} = props;
-
+export function AnnotatedSection({
+  children,
+  title,
+  description,
+  id,
+}: AnnotatedSectionProps) {
   const descriptionMarkup =
     typeof description === 'string' ? <p>{description}</p> : description;
 
   return (
-    <div className={styles.AnnotatedSection}>
-      <div className={styles.AnnotationWrapper}>
+    <>
+      <Section secondary>
         <div className={styles.Annotation}>
           <TextContainer>
             <Heading id={id}>{title}</Heading>
@@ -30,9 +34,9 @@ export function AnnotatedSection(props: AnnotatedSectionProps) {
             )}
           </TextContainer>
         </div>
+      </Section>
 
-        <div className={styles.AnnotationContent}>{children}</div>
-      </div>
-    </div>
+      <Section>{children}</Section>
+    </>
   );
 }

--- a/polaris-react/src/components/Layout/components/Section/Section.tsx
+++ b/polaris-react/src/components/Layout/components/Section/Section.tsx
@@ -3,27 +3,43 @@ import React from 'react';
 import {classNames} from '../../../../utilities/css';
 import styles from '../../Layout.scss';
 
+interface Columns {
+  /** Number of columns the section should span on small screens */
+  small: 1 | 2 | 3 | 4;
+  /** Number of columns the section should span on large screens */
+  large: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+}
+
 export interface SectionProps {
-  children?: React.ReactNode;
-  secondary?: boolean;
+  /** Spans the full width of the grid */
   fullWidth?: boolean;
+  /** Spans one third of the grid, full width on small screens */
+  secondary?: boolean;
+  /** Spans one half of the grid, full width on small screens */
   oneHalf?: boolean;
+  /** Spans one third of the grid, full width on small screens */
   oneThird?: boolean;
+  /** Number of columns the section should span. Accepts values for small and large screens */
+  columns?: Columns;
+  children?: React.ReactNode;
 }
 
 export function Section({
-  children,
-  secondary,
   fullWidth,
+  secondary,
   oneHalf,
   oneThird,
+  columns,
+  children,
 }: SectionProps) {
   const className = classNames(
     styles.Section,
-    secondary && styles['Section-secondary'],
-    fullWidth && styles['Section-fullWidth'],
-    oneHalf && styles['Section-oneHalf'],
-    oneThird && styles['Section-oneThird'],
+    fullWidth && styles.fullWidth,
+    secondary && styles.secondary,
+    oneHalf && styles.oneHalf,
+    oneThird && styles.oneThird,
+    columns?.small && styles[`grid-${columns?.small}-column`],
+    columns?.large && styles[`grid-${columns?.large}-large-column`],
   );
 
   return <div className={className}>{children}</div>;

--- a/polaris-react/src/styles/shared/_page.scss
+++ b/polaris-react/src/styles/shared/_page.scss
@@ -1,13 +1,15 @@
+@import '../media-queries';
+
 @mixin page-layout {
   margin: 0 auto;
   padding: 0;
   max-width: $page-max-width;
 
-  @include page-content-when-not-fully-condensed {
+  @media #{$p-breakpoints-sm-up} {
     padding: 0 var(--p-space-4);
   }
 
-  @include breakpoint-after(768px) {
+  @media #{$p-breakpoints-md-up} {
     padding: 0 var(--p-space-8);
   }
 }

--- a/polaris-react/src/styles/shared/_page.scss
+++ b/polaris-react/src/styles/shared/_page.scss
@@ -4,7 +4,11 @@
   max-width: $page-max-width;
 
   @include page-content-when-not-fully-condensed {
-    padding: 0 var(--p-space-6);
+    padding: 0 var(--p-space-4);
+  }
+
+  @include breakpoint-after(768px) {
+    padding: 0 var(--p-space-8);
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5553

**This contains a breaking change:** 
The original `Layout.Section` component would either flex the full width if there were no other `Layout.Section`s. We can't really do that with Grid, and need to specify whether the Section will be fullWidth since the default is Primary (3/4).

### WHAT is this pull request doing?

Changes the Layout component to use Grid vs Flex and aligns it to our new 4 and 12 column grid

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Checkout Page and Layout stories, as well as the Details Page. Also this playground👇 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Card, Page, Layout} from '../src';

export function Playground() {
  return (
    <Page title="Playground" fullWidth>
      <Layout>
        <Layout.Section fullWidth>
          <Card sectioned>Full width</Card>
        </Layout.Section>

        <Layout.Section secondary>
          <Card sectioned>Secondary</Card>
          <Card sectioned>Secondary</Card>
          <Card sectioned>Secondary</Card>
        </Layout.Section>

        <Layout.Section>
          <Card sectioned>Default</Card>
          <Card sectioned>Default</Card>
        </Layout.Section>

        <Layout.Section>
          <Card sectioned>Default</Card>
          <Card sectioned>Default</Card>
          <Card sectioned>Default</Card>
        </Layout.Section>

        <Layout.Section secondary>
          <Card sectioned>Secondary</Card>
          <Card sectioned>Secondary</Card>
        </Layout.Section>

        <Layout.Section columns={{small: 2, large: 4}}>
          <Card sectioned>2 col mobile 4 col desk</Card>
        </Layout.Section>

        <Layout.Section columns={{small: 1, large: 8}}>
          <Card sectioned>1 col mobile 8 col desk</Card>
        </Layout.Section>

        <Layout.Section columns={{small: 1, large: 6}}>
          <Card sectioned>1 col mobile 6 col desk</Card>
        </Layout.Section>

        <Layout.Section columns={{small: 2, large: 6}}>
          <Card sectioned>2 col mobile 6 col desk</Card>
        </Layout.Section>
      </Layout>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
