### PR TITLE
[Tag] Fix styling for removable tag with link

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -13,6 +13,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
+- Fixed focus and hover style for removable tag with link ([#5567](https://github.com/Shopify/polaris/pull/5567))
+
 ### Documentation
 
 ### Development workflow

--- a/polaris-react/src/components/Tag/README.md
+++ b/polaris-react/src/components/Tag/README.md
@@ -103,6 +103,38 @@ Use when a tag needs to be visually distinguished from others, like when it's ad
 </Tag>
 ```
 
+### Removable tag with link
+
+A removable attribute to an object that allows merchants to navigate to a resource.
+
+```jsx
+function RemovableTagWithLinkExample() {
+  const [selectedTags, setSelectedTags] = useState([
+    'Rustic',
+    'Antique',
+    'Vinyl',
+    'Refurbished',
+  ]);
+
+  const removeTag = useCallback(
+    (tag) => () => {
+      setSelectedTags((previousTags) =>
+        previousTags.filter((previousTag) => previousTag !== tag),
+      );
+    },
+    [],
+  );
+
+  const tagMarkup = selectedTags.map((option) => (
+    <Tag key={option} onRemove={removeTag(option)} url="/collections/wholesale">
+      {option}
+    </Tag>
+  ));
+
+  return <Stack spacing="tight">{tagMarkup}</Stack>;
+}
+```
+
 <!-- content-for: android -->
 
 ![Tag for Android](/public_images/components/Tag/android/default@2x.png)

--- a/polaris-react/src/components/Tag/Tag.scss
+++ b/polaris-react/src/components/Tag/Tag.scss
@@ -120,11 +120,6 @@ $breakpoint: 490px;
 
   &.segmented {
     margin-left: calc(-1 * var(--p-space-1));
-
-    &::after {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    }
   }
 }
 
@@ -164,13 +159,12 @@ $breakpoint: 490px;
   }
 
   &.segmented {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    &:hover {
+      background: none;
+    }
 
     &::after {
       margin-right: var(--p-space-1);
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5563, #5549.

We have a `segmented` class for a tag that has `onRemove` and `url` (i.e., Collections) that had inconsistent focus styling with the new tag density changes.

### WHAT is this pull request doing?

Fixes tag styling for removable tag with url to have focus styling consistent with regular removable tag.
Modifies hover state on removable tag with url.
Adds a new story for this type of tag.
    <details>
      <summary>Removable tag with url — before</summary>
      <img src="https://user-images.githubusercontent.com/26749317/164287776-28c1263b-302a-4080-b142-f87f2e17bf12.gif" alt="Removable tag with url — before">
    </details>
    <details>
      <summary>Removable tag with url — after</summary>
      <img src="https://user-images.githubusercontent.com/26749317/164287774-2f4eb847-0cf2-420a-a0f7-ef1874ce84bf.gif" alt="Removable tag with url — after">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, ping @ sarahill to update the Polaris UI kit