### PR TITLE
Remove whitespace from CustomProperties

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -8,9 +8,9 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Added `icon` prop to the `Badge` component ([#5292](https://github.com/Shopify/polaris/pull/5292))
 - Added support for setting a `ReactNode` on the `PageActions` `secondaryActions` prop ([#5495](https://github.com/Shopify/polaris/pull/5495))
-
 - Added support for NodeJS v14 ([#5551](https://github.com/Shopify/polaris/pull/5551))
 - Add `video` as DropZoneFileType option on the `DropZone` component ([#5349](https://github.com/Shopify/polaris/pull/5349))
+- Removed whitespace from CustomProperties output ([#5570](https://github.com/Shopify/polaris/pull/5570))
 
 ### Bug fixes
 

--- a/polaris-react/src/components/CustomProperties/styles.ts
+++ b/polaris-react/src/components/CustomProperties/styles.ts
@@ -7,10 +7,10 @@ import {
   OSColorSchemes,
 } from '../../tokens';
 
-const tokenValues = getStaticCustomProperties(tokens);
-const declaration = getColorSchemeDeclarations('light', tokens, osColorSchemes);
+const staticCustomProperties = getStaticCustomProperties(tokens);
+const colorSchemeDeclarations = getColorSchemeDeclarations('light', tokens, osColorSchemes);
 
-const defaultDeclarations = `${declaration}${tokenValues}`;
+const defaultDeclarations = `${colorSchemeDeclarations}${staticCustomProperties}`;
 
 /**
  * Creates CSS Rules for each color-scheme.

--- a/polaris-react/src/components/CustomProperties/styles.ts
+++ b/polaris-react/src/components/CustomProperties/styles.ts
@@ -7,10 +7,10 @@ import {
   OSColorSchemes,
 } from '../../tokens';
 
-const defaultDeclarations = `
-  ${getColorSchemeDeclarations('light', tokens, osColorSchemes)}
-  ${getStaticCustomProperties(tokens)}
-`;
+const tokenValues = getStaticCustomProperties(tokens);
+const declaration = getColorSchemeDeclarations('light', tokens, osColorSchemes);
+
+const defaultDeclarations = `${declaration}${tokenValues}`;
 
 /**
  * Creates CSS Rules for each color-scheme.
@@ -34,9 +34,11 @@ export function getColorSchemeRules(
         osColorSchemes,
       );
 
-      return `${selector}{${colorCustomProperties}${getStaticCustomProperties(
+      const tokenString = `${selector}{${colorCustomProperties}${getStaticCustomProperties(
         tokens,
       )}}`;
+
+      return tokenString;
     })
     .join('');
 }

--- a/polaris-react/src/components/CustomProperties/styles.ts
+++ b/polaris-react/src/components/CustomProperties/styles.ts
@@ -8,7 +8,11 @@ import {
 } from '../../tokens';
 
 const staticCustomProperties = getStaticCustomProperties(tokens);
-const colorSchemeDeclarations = getColorSchemeDeclarations('light', tokens, osColorSchemes);
+const colorSchemeDeclarations = getColorSchemeDeclarations(
+  'light',
+  tokens,
+  osColorSchemes,
+);
 
 const defaultDeclarations = `${colorSchemeDeclarations}${staticCustomProperties}`;
 

--- a/polaris-react/src/components/CustomProperties/styles.ts
+++ b/polaris-react/src/components/CustomProperties/styles.ts
@@ -34,11 +34,9 @@ export function getColorSchemeRules(
         osColorSchemes,
       );
 
-      const tokenString = `${selector}{${colorCustomProperties}${getStaticCustomProperties(
+      return `${selector}{${colorCustomProperties}${getStaticCustomProperties(
         tokens,
       )}}`;
-
-      return tokenString;
     })
     .join('');
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When doing releases for `polaris-styleguide` the [Demo.test.tsx](https://github.com/Shopify/polaris-styleguide/blob/e96d88c3a029915ad1d6e8092164bfab0aa03a63/web/styleguide-demo/Demo/test/Demo.test.tsx#L54-L58) checks the output of custom properties. The whitespace is making it difficult to use variables for this data as it's changing with whitespace.

### WHAT is this pull request doing?

- [x] Removing whitespace from the declaration