### PR TITLE
add `--p-` prefix to token labels

### DIFF
--- a/polaris-for-vscode/server/src/server.ts
+++ b/polaris-for-vscode/server/src/server.ts
@@ -67,11 +67,13 @@ connection.onInitialize((params: InitializeParams) => {
     const tokensArray = groupedTokens[category];
 
     const completionItems = tokensArray.map((token): CompletionItem => {
+      const tokenName = `--p-${token.label}`;
+
       return {
-        label: token.label,
+        label: tokenName,
         insertText: token.insertText,
         detail: token.value,
-        filterText: `--p-${token.label}`,
+        filterText: tokenName,
         kind:
           category === 'color'
             ? CompletionItemKind.Color


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

I got some feedback that it was hard to distinguish a polaris token from any other code completion option in the project. I had a hunch that this might be a problem when developing, so this bit of feedback helped confirm we need to make a change. There may be a better way to distinguish polaris tokens from other autocomplete items, but this is a quick solution while we dig into other approaches available from the VS Code api.

<img width="698" alt="Screen Shot 2022-04-22 at 10 49 49 AM" src="https://user-images.githubusercontent.com/4642404/164750224-3c16ddac-57f7-4d16-aaaa-d5e0941f45ac.png">
