### PR TITLE
[polaris-for-vscode] Fix README typo: `automcomplete`->`autocomplete`

### DIFF
--- a/polaris-for-vscode/README.md
+++ b/polaris-for-vscode/README.md
@@ -19,7 +19,7 @@ Get code autocomplete suggestions for the [Polaris Design Tokens](https://polari
 
 Once installed and enabled, the Polaris for VS Code extension will automatically run in any CSS and Sass files.
 
-To trigger tokens automcomplete feature:
+To trigger tokens autocomplete feature:
 
 1. Open a CSS or Sass file from your project
 2. Start typing the CSS property you want to set ex. `color: `


### PR DESCRIPTION
### WHY are these changes introduced?
README contains a simple typo - `automcomplete`

### WHAT is this pull request doing?
Changing `automcomplete` -> `autocomplete`

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit
