### PR TITLE
Enabling custom buttons for page action menu

### DIFF
--- a/polaris-for-vscode/client/src/extension.ts
+++ b/polaris-for-vscode/client/src/extension.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 
 import {workspace, ExtensionContext} from 'vscode';
-
 import {
   LanguageClient,
   LanguageClientOptions,

--- a/polaris-for-vscode/client/src/extension.ts
+++ b/polaris-for-vscode/client/src/extension.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import {workspace, ExtensionContext} from 'vscode';
+
 import {
   LanguageClient,
   LanguageClientOptions,

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added `border-width-4` and `border-width-5` tokens and replaced hardcoded values ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Replaced any hardcoded `outline-width` with `border-width` ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Added the ability to disable specific dates in the `DatePicker`, to go along with date ranges ([#5356](https://github.com/Shopify/polaris/pull/5356))
+- Added custom button (React component) support to `Page` component headers `ActionMenu` ([#5600](https://github.com/Shopify/polaris/pull/5600))
 
 - Added breakpoint CSS custom properties and SCSS media conditions ([#5558](https://github.com/Shopify/polaris/pull/5558))
 

--- a/polaris-react/src/components/ActionMenu/ActionMenu.tsx
+++ b/polaris-react/src/components/ActionMenu/ActionMenu.tsx
@@ -13,6 +13,8 @@ import styles from './ActionMenu.scss';
 export interface ActionMenuProps {
   /** Collection of page-level secondary actions */
   actions?: MenuActionDescriptor[];
+  /** Collection of page-level custom actions */
+  customActions?: React.ReactNode[];
   /** Collection of page-level action groups */
   groups?: MenuGroupDescriptor[];
   /** Roll up all actions into a Popover > ActionList */
@@ -23,6 +25,7 @@ export interface ActionMenuProps {
 
 export function ActionMenu({
   actions = [],
+  customActions = [],
   groups = [],
   rollup,
   rollupActionsLabel,
@@ -40,14 +43,18 @@ export function ActionMenu({
 
   return (
     <div className={actionMenuClassNames}>
-      {rollup ? (
+      <Actions
+        actions={actions}
+        customActions={customActions}
+        groups={groups}
+        rollup={rollup}
+      />
+      {rollup && (
         <RollupActions
           accessibilityLabel={rollupActionsLabel}
           items={actions}
           sections={rollupSections}
         />
-      ) : (
-        <Actions actions={actions} groups={groups} />
       )}
     </div>
   );

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -18,25 +18,39 @@ export function SecondaryAction({
   getOffsetWidth,
   ...rest
 }: SecondaryAction) {
-  const secondaryActionsRef = useRef<HTMLSpanElement>(null);
+  return (
+    <SecondaryActionWrapper
+      destructive={destructive}
+      getOffsetWidth={getOffsetWidth}
+    >
+      <Button onClick={onAction} {...rest}>
+        {children}
+      </Button>
+    </SecondaryActionWrapper>
+  );
+}
+
+export function SecondaryActionWrapper({
+  children,
+  destructive,
+  getOffsetWidth,
+}: any) {
+  const secondaryActionsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!getOffsetWidth || !secondaryActionsRef.current) return;
-
     getOffsetWidth(secondaryActionsRef.current?.offsetWidth);
   }, [getOffsetWidth]);
 
   return (
-    <span
+    <div
       className={classNames(
         styles.SecondaryAction,
         destructive && styles.destructive,
       )}
       ref={secondaryActionsRef}
     >
-      <Button onClick={onAction} {...rest}>
-        {children}
-      </Button>
-    </span>
+      {children}
+    </div>
   );
 }

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -48,6 +48,8 @@ export interface HeaderProps extends TitleProps {
   breadcrumbs?: BreadcrumbsProps['breadcrumbs'];
   /** Collection of secondary page-level actions */
   secondaryActions?: MenuActionDescriptor[] | React.ReactNode;
+  /** Collection of custom page-level actions */
+  customActions?: React.ReactNode[];
   /** Collection of page-level groups of secondary actions */
   actionGroups?: MenuGroupDescriptor[];
   /** @deprecated Additional navigation markup */
@@ -71,6 +73,7 @@ export function Header({
   additionalNavigation,
   breadcrumbs = [],
   secondaryActions = [],
+  customActions = [],
   actionGroups = [],
   compactTitle = false,
 }: HeaderProps) {
@@ -138,11 +141,14 @@ export function Header({
   let actionMenuMarkup: MaybeJSX = null;
   if (
     isInterface(secondaryActions) &&
-    (secondaryActions.length > 0 || hasGroupsWithActions(actionGroups))
+    (secondaryActions.length > 0 ||
+      hasGroupsWithActions(actionGroups) ||
+      customActions.length > 0)
   ) {
     actionMenuMarkup = (
       <ActionMenu
         actions={secondaryActions}
+        customActions={customActions}
         groups={actionGroups}
         rollup={isNavigationCollapsed}
         rollupActionsLabel={

--- a/polaris-react/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/polaris-react/src/components/Page/components/Header/tests/Header.test.tsx
@@ -344,6 +344,6 @@ describe('<Header />', () => {
         mediaQuery: {isNavigationCollapsed: true},
       },
     );
-    expect(header.findAll(ButtonGroup)).toHaveLength(0);
+    expect(header.findAll(ButtonGroup)[0].findAll(Button)).toHaveLength(0);
   });
 });

--- a/polaris-tokens/rollup.config.js
+++ b/polaris-tokens/rollup.config.js
@@ -34,7 +34,7 @@ const rollupOptions = {
     babel({
       extensions,
       include: ['src/**/*'],
-      babelHelpers: 'bundled'
+      babelHelpers: 'bundled',
     }),
   ],
   external: [


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Currently working on [this ticket](https://github.com/Shopify/new-lite-plan/issues/142) and I need to add a popover button with a tooltip and some other features(e.g. show a modal, show notification when the link copied) but the current action interface currently doesn't support such features. 
I would like to build this popover button as a custom react component as I would also use the same component on the product list page.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR enables adding custom buttons to the page header actions, see example code in playground section

Video:

https://user-images.githubusercontent.com/7462532/165338206-520ccfab-f715-4f42-a052-5550260716ae.mp4

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Page, ActionList, Button, Popover, Badge} from '../src';

import {ShareIosMinor} from '@shopify/polaris-icons';

export function Playground() {
  const shareProductMarkup = <ShareProductPopover />;
  return (
    <Page
      breadcrumbs={[{content: 'Products', url: '/products'}]}
      title="3/4 inch Leather pet collar"
      titleMetadata={<Badge status="success">Paid</Badge>}
      subtitle="Perfect for any pet"
      compactTitle
      primaryAction={{content: 'Save', disabled: true}}
      secondaryActions={[
        {
          content: 'Duplicate',
          accessibilityLabel: 'Secondary action label',
          onAction: () => alert('Duplicate action'),
        },
        {
          content: 'View on your store',
          onAction: () => alert('View on your store action'),
        },
      ]}
      actionGroups={[
        {
          title: 'Promote',
          actions: [
            {
              content: 'Share on Facebook',
              accessibilityLabel: 'Individual action label',
              onAction: () => alert('Share on Facebook action'),
            },
          ],
        },
      ]}
      customActions={[shareProductMarkup, shareProductMarkup]}
      pagination={{
        hasPrevious: true,
        hasNext: true,
      }}
    >
    </Page>
  );
}

export function ShareProductPopover() {
  const [active, setActive] = useState(false);

  const toggleActive = useCallback(() => setActive((active) => !active), []);

  const activator = (
    <Button
      icon={ShareIosMinor}
      onClick={toggleActive}
      disclosure
      plain
      monochrome
      removeUnderline
    >
      Share product
    </Button>
  );

  const actionListMarkup = (
    <ActionList
      actionRole="menuitem"
      sections={[
        {
          items: [{content: 'Copy link'}],
        },
        {
          title: 'Share link to',
          items: [
            {content: 'Facebook'},
            {content: 'Twitter'},
            {content: 'Reddit'},
            {content: 'LinkedIn'},
            {content: 'Pinterest'},
          ],
        },
      ]}
    />
  );

  return (
    <Popover
      active={active}
      activator={activator}
      autofocusTarget="first-node"
      onClose={toggleActive}
    >
      {actionListMarkup}
    </Popover>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
