### PR TITLE
Add non-committable GitHub Action check

### DIFF
--- a/.github/workflows/non-committable.yml
+++ b/.github/workflows/non-committable.yml
@@ -1,0 +1,24 @@
+name: Check for non committable changes
+
+on:
+  pull_request:
+    paths:
+      - 'polaris-react/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            playground:
+              - 'polaris-react/playground/Playground.tsx'
+
+      - name: Check for changes to Playground.tsx
+        if: steps.filter.outputs.playground == 'true'
+        run: |
+          echo "Please remove changes from Playground.tsx before committing"
+          exit 1


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #5582 <!-- link to issue if one exists -->

The previous method of checking for changes to non-committable files was not working as we need. This is due to how the GitHub workflows [built-in path filters](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) only work on a level of individual jobs or steps. This was causing unexpected issues when trying to create a new RC for the `polaris-tokens` package.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Add back the GitHub Action for checking for non-committable changes.