### PR TITLE
Fix dev up

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -5,4 +5,4 @@ up:
       version: v16.13.0 # to be kept in sync with .nvmrc and .github/workflows/ci.yml
 
 commands:
-  server: yarn dev:react
+  server: yarn workspace @shopify/polaris dev

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   ],
   "scripts": {
     "build": "yarn workspaces run build",
-    "dev:react": "yarn workspace @shopify/polaris dev",
     "format": "prettier . --write",
     "lint": "run-s lint:*",
     "lint:eslint": "eslint . --cache",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "yarn workspaces run build",
+    "dev:react": "yarn workspace @shopify/polaris dev",
     "format": "prettier . --write",
     "lint": "run-s lint:*",
     "lint:eslint": "eslint . --cache",


### PR DESCRIPTION
Fixes an issue where dev fails to start up

`error Command "dev:react" not found`

Looks like this was removed intentionally and there are ways around this but I think if our project uses dev then something should spin up at root with `dev up && dev run`

Stemming from dev.yml https://github.com/Shopify/polaris/blob/main/dev.yml#L8