### PR TITLE
[Combobox] Add height to loading example

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -17,6 +17,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Documentation
 
+- Added wrapper with height on `Combobox` example for autocomplete with loading ([#5624](https://github.com/Shopify/polaris/pull/5624))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -489,20 +489,22 @@ function LoadingAutocompleteExample() {
     ) : null;
 
   return (
-    <Combobox
-      activator={
-        <Combobox.TextField
-          prefix={<Icon source={SearchMinor} />}
-          onChange={updateText}
-          label="Search tags"
-          labelHidden
-          value={inputValue}
-          placeholder="Search tags"
-        />
-      }
-    >
-      {listboxMarkup}
-    </Combobox>
+    <div style={{height: '225px'}}>
+      <Combobox
+        activator={
+          <Combobox.TextField
+            prefix={<Icon source={SearchMinor} />}
+            onChange={updateText}
+            label="Search tags"
+            labelHidden
+            value={inputValue}
+            placeholder="Search tags"
+          />
+        }
+      >
+        {listboxMarkup}
+      </Combobox>
+    </div>
   );
 }
 ```


### PR DESCRIPTION
### WHY are these changes introduced?

The `Autocomplete with loading` example didn't have a wrapper with a minimum height and was cutting off content in the styleguide.

### WHAT is this pull request doing?

Adds a wrapper `div` with height set.
    <details>
      <summary>Combobox example — before</summary>
      <img src="https://user-images.githubusercontent.com/26749317/165379053-6e8a7f6e-5a45-45ee-862c-1fb0052c1bfd.png" alt="Combobox example — before">
    </details>
    <details>
      <summary>Combobox example — after</summary>
      <img src="https://user-images.githubusercontent.com/26749317/165379045-28afa946-415b-48bc-b0d1-e80d9c466390.png" alt="Combobox example — after">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
