### PR TITLE
[Listbox] Add customListId prop to Listbox

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added breakpoint CSS custom properties and SCSS media conditions ([#5558](https://github.com/Shopify/polaris/pull/5558))
 - Replaced `768px` breakpoint mixins and variables with custom media conditions ([#5629](https://github.com/Shopify/polaris/pull/5629))
 - Added `customListId` prop to `Listbox` ([5627](https://github.com/Shopify/polaris/pull/5627))
+- Pass `domId` as an argument to `onActiveOptionChange` prop on `Listbox` ([5627](https://github.com/Shopify/polaris/pull/5627))
 
 ### Bug fixes
 

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added the ability to disable specific dates in the `DatePicker`, to go along with date ranges ([#5356](https://github.com/Shopify/polaris/pull/5356))
 - Added breakpoint CSS custom properties and SCSS media conditions ([#5558](https://github.com/Shopify/polaris/pull/5558))
 - Replaced `768px` breakpoint mixins and variables with custom media conditions ([#5629](https://github.com/Shopify/polaris/pull/5629))
+- Added `customListId` prop to `Listbox` ([5627](https://github.com/Shopify/polaris/pull/5627))
 
 ### Bug fixes
 

--- a/polaris-react/src/components/Listbox/Listbox.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.tsx
@@ -40,6 +40,8 @@ export interface ListboxProps {
   enableKeyboardControl?: boolean;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
+  /** Provide a custom ID for the list element */
+  customListId?: string;
   /** Callback fired when an option is selected */
   onSelect?(value: string): void;
   /** Callback fired when an option becomes active */
@@ -57,6 +59,7 @@ export function Listbox({
   children,
   enableKeyboardControl,
   accessibilityLabel,
+  customListId,
   onSelect,
   onActiveOptionChange,
 }: ListboxProps) {
@@ -71,7 +74,8 @@ export function Listbox({
     setFalse: disableKeyboardEvents,
   } = useToggle(Boolean(enableKeyboardControl));
 
-  const listId = useUniqueId('Listbox');
+  const uniqueId = useUniqueId('Listbox');
+  const listId = customListId || uniqueId;
 
   const scrollableRef = useRef<HTMLElement | null>(null);
   const listboxRef = useRef<HTMLUListElement>(null);

--- a/polaris-react/src/components/Listbox/Listbox.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.tsx
@@ -45,7 +45,7 @@ export interface ListboxProps {
   /** Callback fired when an option is selected */
   onSelect?(value: string): void;
   /** Callback fired when an option becomes active */
-  onActiveOptionChange?(value: string): void;
+  onActiveOptionChange?(value: string, domId: string): void;
 }
 
 export type ArrowKeys = 'up' | 'down';
@@ -167,7 +167,7 @@ export function Listbox({
       handleScrollIntoViewDebounced(nextOption);
       setActiveOption(nextOption);
       setActiveOptionId?.(nextOption.domId);
-      onActiveOptionChange?.(nextOption.value);
+      onActiveOptionChange?.(nextOption.value, nextOption.domId);
     },
     [
       activeOption,

--- a/polaris-react/src/components/Listbox/tests/Listbox.test.tsx
+++ b/polaris-react/src/components/Listbox/tests/Listbox.test.tsx
@@ -164,7 +164,17 @@ describe('<Listbox>', () => {
       });
     });
 
-    it('renders with id', () => {
+    it('renders with passed id', () => {
+      const listbox = mountWithApp(
+        <Listbox customListId="some-custom-id">Child</Listbox>,
+      );
+
+      expect(listbox).toContainReactComponent('ul', {
+        id: 'some-custom-id',
+      });
+    });
+
+    it('renders with fallback id when none is passed', () => {
       const listbox = mountWithApp(<Listbox>Child</Listbox>);
 
       expect(listbox).toContainReactComponent('ul', {

--- a/polaris-react/src/components/Listbox/tests/Listbox.test.tsx
+++ b/polaris-react/src/components/Listbox/tests/Listbox.test.tsx
@@ -503,6 +503,27 @@ describe('<Listbox>', () => {
         expect(options[2].domNode?.getAttribute('data-focused')).toBe('true');
       });
 
+      it('passes value and domId to onActiveOptionChange', async () => {
+        const spy = jest.fn();
+        const wrapper = mountWithApp(
+          <Listbox enableKeyboardControl onActiveOptionChange={spy}>
+            <Listbox.Option value="valueOne" />
+            <Listbox.Option value="valueTwo" />
+            <Listbox.Option value="valueThree" />
+          </Listbox>,
+        );
+
+        const options = wrapper.findAll(Listbox.Option);
+
+        expect(spy).toHaveBeenCalledWith('valueOne', options[0].domNode?.id);
+
+        await wrapper.act(async () => {
+          await Promise.resolve(triggerDown(wrapper));
+        });
+
+        expect(spy).toHaveBeenCalledWith('valueTwo', options[1].domNode?.id);
+      });
+
       it('does not focus any element when all elements are disabled', async () => {
         const setActiveOptionIdSpy = jest.fn();
         const wrapper = mountWithComboboxListContext(
@@ -634,6 +655,27 @@ describe('<Listbox>', () => {
         });
 
         expect(options[1].domNode?.getAttribute('data-focused')).toBeNull();
+      });
+
+      it('passes value and domId to onActiveOptionChange', async () => {
+        const spy = jest.fn();
+        const wrapper = mountWithApp(
+          <Listbox enableKeyboardControl onActiveOptionChange={spy}>
+            <Listbox.Option value="valueOne" />
+            <Listbox.Option value="valueTwo" />
+            <Listbox.Option value="valueThree" />
+          </Listbox>,
+        );
+
+        const options = wrapper.findAll(Listbox.Option);
+
+        expect(spy).toHaveBeenCalledWith('valueOne', options[0].domNode?.id);
+
+        await wrapper.act(async () => {
+          await Promise.resolve(triggerUp(wrapper));
+        });
+
+        expect(spy).toHaveBeenCalledWith('valueThree', options[2].domNode?.id);
       });
     });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

My team is working on implementing the Location Selector outlined in the [Polaris documentation for Locations](https://polaris.shopify.com/patterns/locations): 

<details>
<summary>Screenshot 📸</summary>
<img width="650" alt="Screen Shot 2022-04-26 at 8 27 54 PM" src="https://user-images.githubusercontent.com/14366097/165414426-73ba1114-4602-49ab-8b2c-de1d64d90517.png">
</details>

In order to support assistive technologies we need to mark this up as a combobox, but the Polaris Combobox component does not currently support our UX where the textfield and the listbox are rendered at the same level, both inside the Popover.

To mark this up as a combobox, we need to pass `aria-controls` or `aria-owns` attributes to the Textfield we are rendering. The value needs to be the ID of the `ul` element with `role="listbox"` that is rendered by the `Listbox` component. Currently that ID is generated inside the `Listbox` component, and only made available to the textfield through a React context as part of the `Combobox` component.

<!--
  Context about the problem that’s being addressed.
-->



### WHAT is this pull request doing?

- Adds a `customListId` prop to the `Listbox` component to allow parent components to supply their own ID for the `ul` element with `role="listbox"`
- Passes `domId` to `onActiveOptionChange` prop on `Listbox`. This allows parent components access to the active element which can then be passed to `aria-activedescendant` on another element.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

If you test the playground code below and inspect the page, you should see the `ul` with `role="listbox"` also has `id="some-custom-id"`. You should also be able to see the domId of the active option logged in the console for testing.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Listbox} from '../src';

export function Playground() {
  function logActiveId(_: string, activeId: string) {
    console.log(activeId);
  }

  return (
    <Page title="Playground">
      <Listbox
        accessibilityLabel="Basic Listbox example"
        customListId="some-custom-id"
        onActiveOptionChange={logActiveId}
      >
        <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
        <Listbox.Option value="UniqueValue-2">Item 2</Listbox.Option>
        <Listbox.Option value="UniqueValue-3">Item 3</Listbox.Option>
      </Listbox>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
