### PR TITLE
Replace `768px` breakpoint Sass variables with tokens

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -11,7 +11,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Replaced any hardcoded `outline-width` with `border-width` ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Added the ability to disable specific dates in the `DatePicker`, to go along with date ranges ([#5356](https://github.com/Shopify/polaris/pull/5356))
 - Added breakpoint CSS custom properties and SCSS media conditions ([#5558](https://github.com/Shopify/polaris/pull/5558))
-- Replaced `768px` breakpoint Sass variables with tokens ([#5629](https://github.com/Shopify/polaris/pull/5629))
+- Replaced `768px` breakpoint mixins and variables with custom media conditions ([#5629](https://github.com/Shopify/polaris/pull/5629))
 
 ### Bug fixes
 

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,8 +10,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added `border-width-4` and `border-width-5` tokens and replaced hardcoded values ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Replaced any hardcoded `outline-width` with `border-width` ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Added the ability to disable specific dates in the `DatePicker`, to go along with date ranges ([#5356](https://github.com/Shopify/polaris/pull/5356))
-
 - Added breakpoint CSS custom properties and SCSS media conditions ([#5558](https://github.com/Shopify/polaris/pull/5558))
+- Replaced `768px` breakpoint Sass variables with tokens ([#5629](https://github.com/Shopify/polaris/pull/5629))
 
 ### Bug fixes
 

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -1,6 +1,5 @@
 @import '../../../../styles/common';
-
-$breakpoint: 768px;
+@import '../../../../styles/media-queries';
 
 .SecondaryAction {
   --pc-secondary-action-button-spacing: var(--p-space-3);
@@ -22,7 +21,7 @@ $breakpoint: 768px;
       background: var(--p-background-pressed) !important;
     }
 
-    @include breakpoint-after($breakpoint) {
+    @media #{$p-breakpoints-md-up} {
       border: none !important;
       @include focus-ring($border-width: 0);
     }

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -1,5 +1,4 @@
 @import '../../../../styles/common';
-@import '../../../../styles/media-queries';
 
 .SecondaryAction {
   --pc-secondary-action-button-spacing: var(--p-space-3);

--- a/polaris-react/src/components/DataTable/DataTable.scss
+++ b/polaris-react/src/components/DataTable/DataTable.scss
@@ -1,6 +1,5 @@
 @import '../../styles/common';
-
-$breakpoint: 768px;
+@import '../../styles/media-queries';
 
 .DataTable {
   --pc-data-table-first-column-width: 145px;
@@ -16,7 +15,7 @@ $breakpoint: 768px;
     width: 100%;
     padding: var(--p-space-4) var(--p-space-2);
 
-    @include breakpoint-after($breakpoint, inclusive) {
+    @media #{$p-breakpoints-md-up} {
       justify-content: flex-end;
     }
   }
@@ -58,7 +57,7 @@ $breakpoint: 768px;
 
 .hoverable {
   &:hover .Cell {
-    @include breakpoint-after($breakpoint) {
+    @media #{$p-breakpoints-md-up} {
       background: var(--p-surface-hovered);
     }
   }

--- a/polaris-react/src/components/DataTable/DataTable.scss
+++ b/polaris-react/src/components/DataTable/DataTable.scss
@@ -1,5 +1,4 @@
 @import '../../styles/common';
-@import '../../styles/media-queries';
 
 .DataTable {
   --pc-data-table-first-column-width: 145px;

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -1,5 +1,4 @@
 @import '../../../../styles/common';
-@import '../../../../styles/media-queries';
 
 $mobile-layout: 468px;
 $medium-layout: 860px;

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -1,7 +1,7 @@
 @import '../../../../styles/common';
+@import '../../../../styles/media-queries';
 
 $mobile-layout: 468px;
-$button-style-breakpoint: 768px;
 $medium-layout: 860px;
 $desktop-layout: 1080px;
 $action-menu-rollup-computed-width: 40px;
@@ -123,7 +123,7 @@ $action-menu-rollup-computed-width: 40px;
   margin-top: 0;
   margin-left: var(--p-space-1);
 
-  @include breakpoint-after($button-style-breakpoint) {
+  @media #{$p-breakpoints-md-up} {
     margin-left: var(--p-space-4);
   }
 

--- a/polaris-react/src/styles/_common.scss
+++ b/polaris-react/src/styles/_common.scss
@@ -18,3 +18,5 @@
 @import './shared/typography';
 @import './shared/skeleton';
 @import './shared/interaction-state';
+
+@import './media-queries';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Beginning of work to consolidate and standardize all of our breakpoint values across `polaris` and `web`.

Related to #5620 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Replacing any `768px` Sass breakpoint variables in Polaris' components with the new `p-breakpoints-md` token.
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->