### PR TITLE
[Listbox] Add `autoSelection` prop

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added the ability to disable specific dates in the `DatePicker`, to go along with date ranges ([#5356](https://github.com/Shopify/polaris/pull/5356))
 
 - Added breakpoint CSS custom properties and SCSS media conditions ([#5558](https://github.com/Shopify/polaris/pull/5558))
+- Added an `autoSelection` prop to `Listbox` to support always defaulting the initial active option to the first option ([#5667](https://github.com/Shopify/polaris/pull/5667))
+- Added `autoSelection` `AutoSelection.First` to `Autocomplete` `Listbox` when `actionBefore` is set ([#5667](https://github.com/Shopify/polaris/pull/5667))
 
 ### Bug fixes
 

--- a/polaris-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/polaris-react/src/components/Autocomplete/Autocomplete.tsx
@@ -9,7 +9,7 @@ import type {PopoverProps} from '../Popover';
 import {isSection} from '../../utilities/options';
 import {useI18n} from '../../utilities/i18n';
 import {Combobox} from '../Combobox';
-import {Listbox} from '../Listbox';
+import {Listbox, AutoSelection} from '../Listbox';
 
 import {MappedAction, MappedOption} from './components';
 import styles from './Autocomplete.scss';
@@ -170,6 +170,8 @@ export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
     <div role="status">{emptyState}</div>
   );
 
+  const autoSelection = actionBefore ? AutoSelection.First : undefined;
+
   return (
     <Combobox
       activator={textField}
@@ -179,7 +181,7 @@ export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
       willLoadMoreOptions={willLoadMoreResults}
     >
       {actionMarkup || optionsMarkup || loadingMarkup || emptyStateMarkup ? (
-        <Listbox onSelect={updateSelection}>
+        <Listbox autoSelection={autoSelection} onSelect={updateSelection}>
           {actionMarkup}
           {optionsMarkup && (!loading || willLoadMoreResults)
             ? optionsMarkup

--- a/polaris-react/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/polaris-react/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -9,7 +9,7 @@ import {Autocomplete} from '../Autocomplete';
 import {Combobox} from '../../Combobox';
 import type {ComboboxProps} from '../../Combobox';
 import {KeypressListener} from '../../KeypressListener';
-import {Listbox} from '../../Listbox';
+import {AutoSelection, Listbox} from '../../Listbox';
 
 describe('<Autocomplete/>', () => {
   const options = [
@@ -232,6 +232,35 @@ describe('<Autocomplete/>', () => {
           triggerFocus(autocomplete.find(Combobox));
 
           expect(autocomplete).toContainReactComponent(MappedAction);
+        });
+
+        it('sets default active option to first option', () => {
+          const actionBefore = {
+            accessibilityLabel: 'label',
+            helpText: 'help text',
+            image: '',
+            prefix: null,
+            suffix: null,
+            ellipsis: false,
+            active: false,
+            role: 'option',
+            icon: 'icon',
+            disabled: false,
+            destructive: true,
+            badge: {
+              status: 'new' as const,
+              content: 'new',
+            },
+          };
+          const autocomplete = mountWithApp(
+            <Autocomplete {...defaultProps} actionBefore={actionBefore} />,
+          );
+
+          triggerFocus(autocomplete.find(Combobox));
+
+          expect(autocomplete).toContainReactComponent(Listbox, {
+            autoSelection: AutoSelection.First,
+          });
         });
       });
 

--- a/polaris-react/src/components/Listbox/Listbox.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.tsx
@@ -33,9 +33,20 @@ import {
 } from './components';
 import styles from './Listbox.scss';
 
+export enum AutoSelection {
+  /** Default active option is the first selected option. If no options are selected, defaults to first interactive option. */
+  FirstSelected = 'FIRST_SELECTED',
+  /** Default active option is always the first interactive option. */
+  First = 'FIRST',
+}
+
 export interface ListboxProps {
   /** Inner content of the listbox */
   children: ReactNode;
+  /** Indicates the default active option in the list. Patterns that support option creation should default the active option to the first option.
+   * @default AutoSelection.FirstSelected
+   */
+  autoSelection?: AutoSelection;
   /** Explicitly enable keyboard control */
   enableKeyboardControl?: boolean;
   /** Visually hidden text for screen readers */
@@ -55,6 +66,7 @@ const OPTION_FOCUS_ATTRIBUTE = 'data-focused';
 
 export function Listbox({
   children,
+  autoSelection = AutoSelection.FirstSelected,
   enableKeyboardControl,
   accessibilityLabel,
   onSelect,
@@ -118,7 +130,10 @@ export function Listbox({
         const isInteractable = option.getAttribute('aria-disabled') !== 'true';
         let isFirstNavigableOption;
 
-        if (hasSelectedOptions) {
+        if (
+          hasSelectedOptions &&
+          autoSelection === AutoSelection.FirstSelected
+        ) {
           const isSelected = option.getAttribute('aria-selected') === 'true';
           isFirstNavigableOption = isSelected && isInteractable;
         } else {
@@ -134,7 +149,7 @@ export function Listbox({
 
       return {element, index: elementIndex};
     },
-    [],
+    [autoSelection],
   );
 
   const handleScrollIntoView = useCallback((option: NavigableOption) => {

--- a/polaris-react/src/components/Listbox/tests/Listbox.test.tsx
+++ b/polaris-react/src/components/Listbox/tests/Listbox.test.tsx
@@ -10,7 +10,7 @@ import {Key} from '../../../types';
 import {KeypressListener} from '../../KeypressListener';
 import {Scrollable} from '../../Scrollable';
 import {VisuallyHidden} from '../../VisuallyHidden';
-import {Listbox} from '../Listbox';
+import {Listbox, AutoSelection} from '../Listbox';
 import {ListboxContext} from '../../../utilities/listbox';
 
 const MockComponent = ({
@@ -703,6 +703,104 @@ describe('<Listbox>', () => {
       listbox.setProps({enableKeyboardControl: true});
 
       expect(listbox).toContainReactComponent(KeypressListener);
+    });
+  });
+
+  describe('auto-selection', () => {
+    describe('when list has selected options', () => {
+      it('sets the initial active option to the first selected option by default', () => {
+        const selectedListbox = (
+          <Listbox>
+            <Listbox.Option value="one" selected={false}>
+              one
+            </Listbox.Option>
+            <Listbox.Option value="two" selected={false}>
+              two
+            </Listbox.Option>
+            <Listbox.Option value="three" selected>
+              three
+            </Listbox.Option>
+          </Listbox>
+        );
+        const wrapper = mountWithApp(selectedListbox);
+        const listbox = wrapper.find('ul', {role: 'listbox'})!;
+        const options = wrapper.findAll('li', {role: 'option'});
+
+        expect(listbox.domNode?.getAttribute('aria-activedescendant')).toBe(
+          options[2].domNode?.id,
+        );
+      });
+
+      it('sets the initial active option to the first option when autoSelection is AutoSelection.First', () => {
+        const selectedListbox = (
+          <Listbox autoSelection={AutoSelection.First}>
+            <Listbox.Option value="one" selected={false}>
+              one
+            </Listbox.Option>
+            <Listbox.Option value="two" selected={false}>
+              two
+            </Listbox.Option>
+            <Listbox.Option value="three" selected>
+              three
+            </Listbox.Option>
+          </Listbox>
+        );
+        const wrapper = mountWithApp(selectedListbox);
+        const listbox = wrapper.find('ul', {role: 'listbox'})!;
+        const options = wrapper.findAll('li', {role: 'option'});
+
+        expect(listbox.domNode?.getAttribute('aria-activedescendant')).toBe(
+          options[0].domNode?.id,
+        );
+      });
+    });
+
+    describe('when list has no selected options', () => {
+      it('sets the initial active option to the first option by default', () => {
+        const unselectedListbox = (
+          <Listbox>
+            <Listbox.Option value="one" selected={false}>
+              one
+            </Listbox.Option>
+            <Listbox.Option value="two" selected={false}>
+              two
+            </Listbox.Option>
+            <Listbox.Option value="three" selected={false}>
+              three
+            </Listbox.Option>
+          </Listbox>
+        );
+        const wrapper = mountWithApp(unselectedListbox);
+        const listbox = wrapper.find('ul', {role: 'listbox'})!;
+        const options = wrapper.findAll('li', {role: 'option'});
+
+        expect(listbox.domNode?.getAttribute('aria-activedescendant')).toBe(
+          options[0].domNode?.id,
+        );
+      });
+
+      it('sets the initial active option to the first option when autoSelection is AutoSelection.First', () => {
+        const unselectedListbox = (
+          <Listbox autoSelection={AutoSelection.First}>
+            <Listbox.Option value="one" selected={false}>
+              one
+            </Listbox.Option>
+            <Listbox.Option value="two" selected={false}>
+              two
+            </Listbox.Option>
+            <Listbox.Option value="three" selected={false}>
+              three
+            </Listbox.Option>
+          </Listbox>
+        );
+        const wrapper = mountWithApp(unselectedListbox);
+        const listbox = wrapper.find('ul', {role: 'listbox'})!;
+        const options = wrapper.findAll('li', {role: 'option'});
+
+        expect(listbox.domNode?.getAttribute('aria-activedescendant')).toBe(
+          options[0].domNode?.id,
+        );
+      });
     });
   });
 });

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -217,7 +217,7 @@ export type {LinkProps} from './components/Link';
 export {List} from './components/List';
 export type {ListProps} from './components/List';
 
-export {Listbox} from './components/Listbox';
+export {Listbox, AutoSelection} from './components/Listbox';
 export type {ListboxProps} from './components/Listbox';
 
 export {Loading} from './components/Loading';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

**_This PR unblocks https://github.com/Shopify/web/pull/63375 and will be cut by itself into a minor release._**

The auto-selection pattern we introduced to `Listbox` breaks merchant's workflows when options are creatable. For example, if you're trying to create a new tag in the admin's tag multi-select combobox, the `Add` action that displays when the input has a value is not the default active option if there is a search result that is selected. This means that unless merchants manually navigate to the Add action, a keypress of Enter deselects the active selected option instead of adding the new tag.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR adds an `autoSelection` prop to the `Listbox` to enable the expected auto-select behavior of comboboxes and searchable listboxes that support option creation by displaying an listbox action above the options. When `autoSelection` is `AutoSelection.First`, the initial active option is the first option regardless of whether there are options selected or not.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Play with [the Combobox examples in the Chromatic deploy:](https://5d559397bae39100201eedc1-hyojkuqtnz.chromatic.com/?path=/story/all-components-combobox--multi-select-autocomplete-with-vertical-content)
- The Multiselect tag example should always initially set the first option as active
- The others should still initially set the first selected option as active if selected options are present, or otherwise default to making the first option active

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback, useMemo} from 'react';

import {
  Page,
  Stack,
  TextStyle,
  Tag,
  Listbox,
  Combobox,
  AutoSelection,
  EmptySearchResult,
} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <MultiselectTagComboboxExample />
    </Page>
  );
}

function MultiselectTagComboboxExample() {
  const [selectedTags, setSelectedTags] = useState(['Rustic']);
  const [value, setValue] = useState('');
  const [suggestion, setSuggestion] = useState('');

  const handleActiveOptionChange = useCallback(
    (activeOption) => {
      const activeOptionIsAction = activeOption === value;

      if (!activeOptionIsAction && !selectedTags.includes(activeOption)) {
        setSuggestion(activeOption);
      } else {
        setSuggestion('');
      }
    },
    [value, selectedTags],
  );
  const updateSelection = useCallback(
    (selected) => {
      const nextSelectedTags = new Set([...selectedTags]);

      if (nextSelectedTags.has(selected)) {
        nextSelectedTags.delete(selected);
      } else {
        nextSelectedTags.add(selected);
      }
      setSelectedTags([...nextSelectedTags]);
      setValue('');
      setSuggestion('');
    },
    [selectedTags],
  );

  const removeTag = useCallback(
    (tag) => () => {
      updateSelection(tag);
    },
    [updateSelection],
  );

  const getAllTags = useCallback(() => {
    const savedTags = ['Rustic', 'Antique', 'Vinyl', 'Vintage', 'Refurbished'];
    return [...new Set([...savedTags, ...selectedTags].sort())];
  }, [selectedTags]);

  const formatOptionText = useCallback(
    (option) => {
      const trimValue = value.trim().toLocaleLowerCase();
      const matchIndex = option.toLocaleLowerCase().indexOf(trimValue);

      if (!value || matchIndex === -1) return option;

      const start = option.slice(0, matchIndex);
      const highlight = option.slice(matchIndex, matchIndex + trimValue.length);
      const end = option.slice(matchIndex + trimValue.length, option.length);

      return (
        <p>
          {start}
          <TextStyle variation="strong">{highlight}</TextStyle>
          {end}
        </p>
      );
    },
    [value],
  );

  const options = useMemo(() => {
    let list;
    const allTags = getAllTags();
    const filterRegex = new RegExp(value, 'i');

    if (value) {
      list = allTags.filter((tag) => tag.match(filterRegex));
    } else {
      list = allTags;
    }

    return [...list];
  }, [value, getAllTags]);

  const verticalContentMarkup =
    selectedTags.length > 0 ? (
      <Stack spacing="extraTight" alignment="center">
        {selectedTags.map((tag) => (
          <Tag key={`option-${tag}`} onRemove={removeTag(tag)}>
            {tag}
          </Tag>
        ))}
      </Stack>
    ) : null;

  const optionMarkup =
    options.length > 0
      ? options.map((option) => {
          return (
            <Listbox.Option
              key={option}
              value={option}
              selected={selectedTags.includes(option)}
              accessibilityLabel={option}
            >
              <Listbox.TextOption selected={selectedTags.includes(option)}>
                {formatOptionText(option)}
              </Listbox.TextOption>
            </Listbox.Option>
          );
        })
      : null;

  const actionMarkup =
    value && getAllTags().includes(value) ? (
      <Listbox.Action value={value}>{`Add "${value}"`}</Listbox.Action>
    ) : null;

  const emptyStateMarkup =
    value && !getAllTags().includes(value) ? (
      <EmptySearchResult
        title=""
        description={`No tags found matching "${value}"`}
      />
    ) : null;

  const listboxMarkup =
    optionMarkup || actionMarkup || emptyStateMarkup ? (
      <Listbox
        autoSelection={AutoSelection.First}
        onSelect={updateSelection}
        onActiveOptionChange={handleActiveOptionChange}
      >
        {actionMarkup}
        {optionMarkup}
      </Listbox>
    ) : null;

  return (
    <div style={{height: '225px'}}>
      <Combobox
        allowMultiple
        activator={
          <Combobox.TextField
            autoComplete="off"
            label="Search tags"
            labelHidden
            value={value}
            suggestion={suggestion}
            placeholder="Search tags"
            verticalContent={verticalContentMarkup}
            onChange={setValue}
          />
        }
      >
        {listboxMarkup}
      </Combobox>
    </div>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
