### PR TITLE
[IndexTable] do not force resourceName lower case

### DIFF
--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -415,7 +415,7 @@ function IndexTableBase({
             {i18n.translate(
               'Polaris.IndexTable.resourceLoadingAccessibilityLabel',
               {
-                resourceNamePlural: resourceName.plural.toLocaleLowerCase(),
+                resourceNamePlural: resourceName.plural,
               },
             )}
           </span>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5708

Forcing text into lower case on the code side is prone to cause problems in internationalization, because capitalization rules and word order are different between languages. More details in the linked issue above but a quick example: all German nouns are supposed to be capitalized, so this forced lower case breaks German grammar rules.

### WHAT is this pull request doing?

This PR removes the code that forces lower case.

### How to 🎩


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
