### PR TITLE
Stop errors when running a repository after yarn install without yarn build

### DIFF
--- a/.github/workflows/ci-a11y-vrt.yml
+++ b/.github/workflows/ci-a11y-vrt.yml
@@ -36,11 +36,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-accessibility-test-v1-
 
-      - name: Install dependencies
+      - name: Install dependencies and build packages
         run: yarn --frozen-lockfile
-
-      - name: Build packages
-        run: yarn turbo run build --filter=@shopify/polaris
 
       - name: Build Storybook
         run: yarn workspace @shopify/polaris run storybook:build --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node${{ matrix.node_version }}-test-v1-
 
-      - name: Install dependencies
+      - name: Install dependencies and build packages
         run: yarn --frozen-lockfile
-
-      - name: Build packages
-        run: yarn build
 
       - name: Lint
         run: yarn lint

--- a/README.md
+++ b/README.md
@@ -30,19 +30,13 @@ polaris/
 
 ## Commands
 
-**1. Install dependencies**
+**1. Install dependencies and build packages**
 
 ```sh
 yarn
 ```
 
-**2. Build the packages**
-
-```sh
-yarn build
-```
-
-**3. Start a local development environment**
+**2. Start a local development environment**
 
 Start a **storybook** server for the polaris-react components
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier . --write",
     "type-check": "tsc --build",
+    "postinstall": "yarn build",
     "preversion": "echo \"Error: do not run yarn version from root\" && exit 1"
   },
   "devDependencies": {


### PR DESCRIPTION
Every now and then someone runs `yarn install` or `dev up` then starts a project for it to have multiple errors as a build has not been ran. This change would remove the need to remember to run `yarn build` after install.

This is very strict and forces a build after every install. This might not be the right long term solution. Happy for any other ideas.