### PR TITLE
feat: Update experimental breakpoint values

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added `customListId` prop to `Listbox` ([5627](https://github.com/Shopify/polaris/pull/5627))
 - Pass `domId` as an argument to `onActiveOptionChange` prop on `Listbox` ([5627](https://github.com/Shopify/polaris/pull/5627))
 - Adjusted a hardcoded `padding` value for `FileUpload` and replaced it with a spacing token ([#5675](https://github.com/Shopify/polaris/pull/5675))
+- Updated experimental breakpoint values ([#5736](https://github.com/Shopify/polaris/pull/5736))
 
 ### Bug fixes
 

--- a/polaris-react/src/tokens/token-groups/breakpoints.json
+++ b/polaris-react/src/tokens/token-groups/breakpoints.json
@@ -1,7 +1,7 @@
 {
   "breakpoints-xs": "0px",
-  "breakpoints-sm": "560px",
+  "breakpoints-sm": "490px",
   "breakpoints-md": "768px",
-  "breakpoints-lg": "1008px",
-  "breakpoints-xl": "1776px"
+  "breakpoints-lg": "1040px",
+  "breakpoints-xl": "1400px"
 }

--- a/polaris-tokens/src/token-groups/breakpoints.ts
+++ b/polaris-tokens/src/token-groups/breakpoints.ts
@@ -3,15 +3,15 @@ export const breakpoints = {
     value: '0px',
   },
   'breakpoints-sm': {
-    value: '560px',
+    value: '490px',
   },
   'breakpoints-md': {
     value: '768px',
   },
   'breakpoints-lg': {
-    value: '1008px',
+    value: '1040px',
   },
   'breakpoints-xl': {
-    value: '1776px',
+    value: '1400px',
   },
 };


### PR DESCRIPTION
Closes #5514

### WHAT is this pull request doing?

This PR updates the experimental breakpoint values based on [new data](https://github.com/Shopify/polaris/issues/5514#issuecomment-1119112045) captured in the `Audit breakpoints` issue #5514 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
