### PR TITLE
[DNM] Experiment with constraining main colour picker to a Polaris theme

### DIFF
--- a/polaris-react/src/components/ColorPicker/ColorPicker.scss
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.scss
@@ -13,6 +13,7 @@
   --pc-color-picker-dragger-size: 18px;
   --pc-color-picker-z-index: 10;
   --pc-color-picker-adjustments: 20;
+  --pc-color-picker-gamut: 25;
   --pc-color-picker-dragger: 30;
   --pc-color-picker-inner-shadow: inset 0 0 2px 0 var(--p-shadow-color-picker);
   --pc-color-picker-dragger-shadow: inset 0 1px 2px 0
@@ -74,6 +75,18 @@
   @media (-ms-high-contrast: active) {
     outline: var(--p-border-width-1) solid windowText;
   }
+}
+
+.Gamut {
+  position: absolute;
+  z-index: var(--pc-color-picker-gamut);
+  top: 0;
+  left: 0;
+  display: block;
+  height: 100%;
+  width: 100%;
+  pointer-events: none;
+  border-radius: var(--p-border-radius-1);
 }
 
 .Dragger {


### PR DESCRIPTION
### WHY are these changes introduced?

Just experimenting with an idea. And the result points to a failure.

After seeing the new Polaris VS Code extension in action, I thought about augmenting the colour (token) dropdown with an optional colour picker that is locked to Polaris colours. i.e. for a given hue, instead of rendering the entire saturation x brightness gradient, rendering only the Polaris (light/dark theme) colours that are the closest by the Pythagorean distance of the HSB components. In the best case it looks something like this:

<img width="481" alt="image" src="https://user-images.githubusercontent.com/50832/167318614-157fb560-9116-41f1-a867-441342695cf1.png">

But in majority of cases, it is a boring flat-colour rectangle:

<img width="222" alt="image" src="https://user-images.githubusercontent.com/50832/167318640-05d3e209-7bb4-463f-9781-81f4ce3acb7b.png">

Neither interesting, nor intuitive.

If we had lots of more colour, this idea would have potential. I think the Photoshop colour picker does / used to optionally show only the RGB colours that would fit a CMYK gamut with a similar technique.

Instead of directly trying to build this out in the VS Code extension, I YOLO messed around with the ColorPicker component, just as an experiment. The intention wasn't to extend the ColourPicker component.

Also, this current implementation is slow as hell. Even though I'm directly writing into an RGBA buffer, the 160 x 160 = 25,600 pixel iteration kills the CPU. This would be better implemented with GLSL on a 3D context.
Just briefly opening the PR to show the result of the experiment. We can nuke the PR + branch later.