### PR TITLE
[HD32][InContextLearning]Add onDismiss key event

### DIFF
--- a/polaris-react/src/components/InContextLearning/InContextLearning.tsx
+++ b/polaris-react/src/components/InContextLearning/InContextLearning.tsx
@@ -6,6 +6,9 @@ import {useI18n} from '../../utilities/i18n';
 import {Button} from '../Button';
 import {Step} from './components';
 
+import {KeypressListener} from '../KeypressListener';
+import {Key} from '../../types';
+
 interface InContextLearningStep {
   selector: string;
   content: React.ReactNode;
@@ -72,6 +75,7 @@ export function InContextLearning({children, steps, onDismiss}: Props) {
       }}
       ref={wrapperRef}
     >
+      <KeypressListener keyCode={Key.Escape} handler={onDismiss} />
       {dismissButton}
       {steps[currentStep].content}
       {showPrev && <Button onClick={handlePrev}>Prev</Button>}


### PR DESCRIPTION
### WHY are these changes introduced?

Add key event to exit/close the InContextLearning

When the component has focus and the use presses escape the onDismiss function will be called. 

This is the continuation of https://github.com/pulls?q=is%3Apr+author%3Aannmariedoyle-shopify+archived%3Afalse+is%3Aclosed

### WHAT is this pull request doing?
Extends key board functionality 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
