### PR TITLE
[Thumbnail] Add extraSmall size to Thumbnail

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Adjusted a hardcoded `padding` value for `FileUpload` and replaced it with a spacing token ([#5675](https://github.com/Shopify/polaris/pull/5675))
 - Added `disable` prop to the action groups title of the Page header ([#5702](https://github.com/Shopify/polaris/pull/5702))
 - Added `onClick` prop to the action groups title of the Page header ([#5751](https://github.com/Shopify/polaris/pull/5751))
+- Added `extraSmall` to the available sizes of the `Thumbnail` ([TODO]())
 
 ### Bug fixes
 

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -18,7 +18,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Adjusted a hardcoded `padding` value for `FileUpload` and replaced it with a spacing token ([#5675](https://github.com/Shopify/polaris/pull/5675))
 - Added `disable` prop to the action groups title of the Page header ([#5702](https://github.com/Shopify/polaris/pull/5702))
 - Added `onClick` prop to the action groups title of the Page header ([#5751](https://github.com/Shopify/polaris/pull/5751))
-- Added `extraSmall` to the available sizes of the `Thumbnail` ([TODO]())
+- Added `extraSmall` to the available sizes of the `Thumbnail` ([#5770](https://github.com/Shopify/polaris/pull/5770))
 
 ### Bug fixes
 

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -18,7 +18,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Adjusted a hardcoded `padding` value for `FileUpload` and replaced it with a spacing token ([#5675](https://github.com/Shopify/polaris/pull/5675))
 - Added `disable` prop to the action groups title of the Page header ([#5702](https://github.com/Shopify/polaris/pull/5702))
 - Added `onClick` prop to the action groups title of the Page header ([#5751](https://github.com/Shopify/polaris/pull/5751))
-- Added `extraSmall` to the available sizes of the `Thumbnail` ([#5770](https://github.com/Shopify/polaris/pull/5770))
+- Added `extraSmall` to the available sizes of the `Thumbnail` and `SkeletonThumbnail` ([#5770](https://github.com/Shopify/polaris/pull/5770))
 
 ### Bug fixes
 

--- a/polaris-react/src/components/SkeletonThumbnail/README.md
+++ b/polaris-react/src/components/SkeletonThumbnail/README.md
@@ -49,6 +49,14 @@ Use this component to represent small thumbnails.
 <SkeletonThumbnail size="small" />
 ```
 
+### Extra small thumbnail
+
+Use this component to represent extra small thumbnails.
+
+```jsx
+<SkeletonThumbnail size="extraSmall" />
+```
+
 ---
 
 ## Related components

--- a/polaris-react/src/components/SkeletonThumbnail/SkeletonThumbnail.scss
+++ b/polaris-react/src/components/SkeletonThumbnail/SkeletonThumbnail.scss
@@ -1,6 +1,10 @@
 @import '../../styles/common';
 
 .SkeletonThumbnail {
+  --pc-skeleton-thumbnail-extra-small-size: 24px;
+  --pc-skeleton-thumbnail-small-size: 40px;
+  --pc-skeleton-thumbnail-medium-size: 60px;
+  --pc-skeleton-thumbnail-large-size: 80px;
   display: flex;
   background-color: var(--p-surface-neutral);
   border-radius: var(--p-border-radius-base);
@@ -10,17 +14,22 @@
   }
 }
 
+.sizeExtraSmall {
+  height: var(--pc-skeleton-thumbnail-extra-small-size);
+  width: var(--pc-skeleton-thumbnail-extra-small-size);
+}
+
 .sizeSmall {
-  height: 40px;
-  width: 40px;
+  height: var(--pc-skeleton-thumbnail-small-size);
+  width: var(--pc-skeleton-thumbnail-small-size);
 }
 
 .sizeMedium {
-  height: 60px;
-  width: 60px;
+  height: var(--pc-skeleton-thumbnail-medium-size);
+  width: var(--pc-skeleton-thumbnail-medium-size);
 }
 
 .sizeLarge {
-  height: 80px;
-  width: 80px;
+  height: var(--pc-skeleton-thumbnail-large-size);
+  width: var(--pc-skeleton-thumbnail-large-size);
 }

--- a/polaris-react/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx
+++ b/polaris-react/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx
@@ -4,7 +4,7 @@ import {classNames, variationName} from '../../utilities/css';
 
 import styles from './SkeletonThumbnail.scss';
 
-type Size = 'small' | 'medium' | 'large';
+type Size = 'extraSmall' | 'small' | 'medium' | 'large';
 
 export interface SkeletonThumbnailProps {
   /**

--- a/polaris-react/src/components/Thumbnail/README.md
+++ b/polaris-react/src/components/Thumbnail/README.md
@@ -27,7 +27,8 @@ Use thumbnails as a visual anchor and identifier for an object. They should be u
 
 On web, thumbnails should:
 
-- Be one of 3 sizes:
+- Be one of 4 sizes:
+  - Extra small (24 x 24 px): use in tightly condensed layouts
   - Small (40 × 40 px): use when the medium size is too large for the layout, or when the thumbnail has less importance.
   - Medium (60 × 60 px): use as the default size.
   - Large (80 × 80 px): use when an thumbnail is a major focal point. Avoid this size in lists of like items.
@@ -77,6 +78,20 @@ Use as the default size.
 ![Default thumbnail](/public_images/components/Thumbnail/ios/default@2x.png)
 
 <!-- /content-for -->
+
+### Extra small thumbnail
+
+<!-- example-for: web -->
+
+Use to present a thumbnail in a condensed layout, such as a data table cell or an action list item.
+
+```jsx
+<Thumbnail
+  source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+  size="extraSmall"
+  alt="Black choker necklace"
+/>
+```
 
 ### Small thumbnail
 

--- a/polaris-react/src/components/Thumbnail/Thumbnail.scss
+++ b/polaris-react/src/components/Thumbnail/Thumbnail.scss
@@ -1,11 +1,15 @@
 @import '../../styles/common';
 
 .Thumbnail {
+  --pc-thumbnail-extra-small-size: 24px;
+  --pc-thumbnail-small-size: 40px;
+  --pc-thumbnail-medium-size: 60px;
+  --pc-thumbnail-large-size: 80px;
   position: relative;
   display: block;
   overflow: hidden;
   background: var(--p-surface);
-  min-width: 40px;
+  min-width: var(--pc-thumbnail-extra-small-size);
   max-width: 100%;
   border-radius: var(--p-border-radius-1);
   border: var(--p-border-divider);
@@ -17,16 +21,20 @@
   }
 }
 
+.sizeExtraSmall {
+  width: var(--pc-thumbnail-extra-small-size);
+}
+
 .sizeSmall {
-  width: 40px;
+  width: var(--pc-thumbnail-small-size);
 }
 
 .sizeMedium {
-  width: 60px;
+  width: var(--pc-thumbnail-medium-size);
 }
 
 .sizeLarge {
-  width: 80px;
+  width: var(--pc-thumbnail-large-size);
 }
 
 .transparent {

--- a/polaris-react/src/components/Thumbnail/Thumbnail.tsx
+++ b/polaris-react/src/components/Thumbnail/Thumbnail.tsx
@@ -6,7 +6,7 @@ import {Icon} from '../Icon';
 
 import styles from './Thumbnail.scss';
 
-type Size = 'small' | 'medium' | 'large';
+type Size = 'extraSmall' | 'small' | 'medium' | 'large';
 
 export interface ThumbnailProps {
   /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5771

A new Thumbnail extra-small size is needed for condensed layouts like bulk editors.

### WHAT is this pull request doing?

Adds a new `extraSmall` size to the `Thumbnail` component (follows the patterns already established for the `Avatar` component). Updates the `SkeletonThumbnail` for consistent sizing with `Thumbnail`.

Thumbnail | SkeletonThumbnail
---------- | --------------------
![image](https://user-images.githubusercontent.com/97745235/167728953-e111d57d-c2c1-44c0-bb62-66fc0c042c6c.png) | ![image](https://user-images.githubusercontent.com/97745235/167891124-3acd2116-329b-4081-bc67-f586fee65cbb.png)


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

1. In a local development environment or Spin instance, checkout this `1387-extrasmall-thumbnail` branch
2. Run `yarn` then `yarn workspace @shopify/polaris dev` to start a local Storybook instance
3. In [Storybook](http://localhost:6006/):
    1. Search for `Thumbnail` and select the "Extra small thumbnail" story to view the new `extraSmall` size
    2. Search for `SkeletonThumbnail` and select the "Extra small thumbnail" story to view the new `extraSmall` size
4. Use the Playground code below to view a comparison of the extra small `Thumbnail` and `SkeletonThumbnail` components

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {ImageMajor} from '@shopify/polaris-icons';

import {Page, Thumbnail, Stack, SkeletonThumbnail} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Stack vertical>
        <Thumbnail
          size="extraSmall"
          alt="Extra small thumbnail with image"
          source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
        />

        <Thumbnail
          size="extraSmall"
          alt="Extra small thumbnail with icon"
          source={ImageMajor}
        />

        <SkeletonThumbnail size="extraSmall" />
      </Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, ping @ sarahill to update the Polaris UI kit
