### PR TITLE
Style cleanup and translations

### DIFF
--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -44,7 +44,9 @@
       "clear": "Clear",
       "close": "Close",
       "submit": "Submit",
-      "more": "More"
+      "more": "More",
+      "back": "Back",
+      "next": "Next"
     },
     "ContextualSaveBar": {
       "save": "Save",
@@ -156,7 +158,9 @@
       "clearLabel": "Clear {filterName}"
     },
     "InContextLearning": {
-      "accessibilityLabel": "Close {tutorialName} tutorial"
+      "accessibilityLabel": "Close {tutorialName} tutorial",
+      "gotIt": "Got it",
+      "multipleSteps": "{currentStep} of {totalSteps}"
     },
     "IndexProvider": {
       "defaultItemSingular": "Item",

--- a/polaris-react/src/components/InContextLearning/InContextLearning.scss
+++ b/polaris-react/src/components/InContextLearning/InContextLearning.scss
@@ -9,29 +9,28 @@
 
   &.above {
     margin-bottom: var(--p-space-3);
+
+    &:after {
+      bottom: calc(-1 * var(--p-space-4));
+      border-color: var(--p-surface) transparent transparent;
+    }
   }
 
   &.below {
     margin-top: var(--p-space-3);
-  }
-}
 
-.Arrow {
-  position: absolute;
-  left: calc(25% - var(--p-space-4));
-  border-width: var(--p-space-2);
-  border-style: solid;
-
-  &.above {
-    margin-bottom: var(--p-space-3);
-    bottom: calc(-1 * var(--p-space-4));
-    border-color: var(--p-surface) transparent transparent;
+    &:after {
+      top: calc(-1 * var(--p-space-4));
+      border-color: transparent transparent var(--p-surface);
+    }
   }
 
-  &.below {
-    margin-top: var(--p-space-3);
-    top: calc(-1 * var(--p-space-4));
-    border-color: transparent transparent var(--p-surface);
+  &:after {
+    content: '';
+    position: absolute;
+    left: var(--p-space-12);
+    border-width: var(--p-space-2);
+    border-style: solid;
   }
 }
 

--- a/polaris-react/src/components/InContextLearning/InContextLearning.scss
+++ b/polaris-react/src/components/InContextLearning/InContextLearning.scss
@@ -6,10 +6,39 @@
   background-color: var(--p-surface);
   filter: drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.1))
     drop-shadow(0px 4px 20px rgba(0, 0, 0, 0.15));
+
+  &.above {
+    margin-bottom: var(--p-space-3);
+  }
+
+  &.below {
+    margin-top: var(--p-space-3);
+  }
 }
+
+.Arrow {
+  position: absolute;
+  left: calc(25% - var(--p-space-4));
+  border-width: var(--p-space-2);
+  border-style: solid;
+
+  &.above {
+    margin-bottom: var(--p-space-3);
+    bottom: calc(-1 * var(--p-space-4));
+    border-color: var(--p-surface) transparent transparent;
+  }
+
+  &.below {
+    margin-top: var(--p-space-3);
+    top: calc(-1 * var(--p-space-4));
+    border-color: transparent transparent var(--p-surface);
+  }
+}
+
 .TutorialContent {
   margin: var(--p-space-3) 0;
 }
+
 .TutorialFooter {
   margin-top: var(--p-space-3);
 }

--- a/polaris-react/src/components/InContextLearning/InContextLearning.tsx
+++ b/polaris-react/src/components/InContextLearning/InContextLearning.tsx
@@ -1,16 +1,17 @@
 import React, {useContext, useEffect, useState} from 'react';
 
-import {useI18n} from '../../utilities/i18n';
 import {Header, InContextLearningContext} from './components';
+import {Button} from '../Button';
+import {KeypressListener} from '../KeypressListener';
 import {Portal} from '../Portal';
 import {PositionedOverlay} from '../PositionedOverlay';
-import {KeypressListener} from '../KeypressListener';
-import {Key} from '../../types';
-import {TextStyle} from '../TextStyle';
 import {Stack} from '../Stack';
+import {TextStyle} from '../TextStyle';
+import {useI18n} from '../../utilities/i18n';
+import {classNames} from '../../utilities/css';
+import {Key} from '../../types';
 import {Step} from './components';
 import styles from './InContextLearning.scss';
-import {Button} from '../Button';
 interface Props {
   onDismiss(): void;
   title?: string;
@@ -38,27 +39,15 @@ export function InContextLearning({onDismiss, title}: Props) {
 
   const handleNext = () => {
     setCurrentStep((currentStep) => currentStep + 1);
-    console.warn('Next clicked');
   };
 
   const handleBack = () => {
     setCurrentStep((currentStep) => currentStep - 1);
-    console.warn('Back clicked');
   };
 
   const handleClose = () => {
-    console.warn('Close popover');
     onDismiss?.();
   };
-
-  const showArrow = steps[currentStep].direction != 'none';
-
-  const counterMarkup = hasMultipleSteps ? (
-    <p style={{textAlign: 'center'}}>
-      {currentStep + 1}
-      <TextStyle variation="subdued">/{totalSteps}</TextStyle>
-    </p>
-  ) : null;
 
   if (!currentActivator) {
     return null;
@@ -70,22 +59,18 @@ export function InContextLearning({onDismiss, title}: Props) {
         active={true}
         activator={currentActivator}
         render={(state) => {
-          const isAbove = state.positioning === 'above';
-          const verticalMargin = isAbove
-            ? {marginBottom: '.75rem'}
-            : {marginTop: '.75rem'};
-          const arrowStyles = isAbove
-            ? {bottom: '-1rem', borderColor: '#fff transparent transparent'}
-            : {top: '-1rem', borderColor: 'transparent transparent #fff'};
+          const containerClassName = classNames(
+            styles.InContextLearning,
+            state.positioning === 'above' ? styles.above : styles.below,
+          );
+          const arrowClassName = classNames(
+            styles.Arrow,
+            state.positioning === 'above' ? styles.above : styles.below,
+          );
 
           return (
             <>
-              <div
-                className={styles.InContextLearning}
-                style={{
-                  ...verticalMargin,
-                }}
-              >
+              <div className={containerClassName}>
                 <KeypressListener keyCode={Key.Escape} handler={onDismiss} />
                 <Header title={title} onDismiss={onDismiss} />
                 <div className={styles.TutorialContent}>
@@ -100,7 +85,10 @@ export function InContextLearning({onDismiss, title}: Props) {
                     <Stack.Item>
                       {hasMultipleSteps && (
                         <TextStyle variation="subdued">
-                          {currentStep + 1} of {totalSteps}
+                          {i18n.translate(
+                            'Polaris.InContextLearning.multipleSteps',
+                            {currentStep: currentStep + 1, totalSteps},
+                          )}
                         </TextStyle>
                       )}
                     </Stack.Item>
@@ -111,15 +99,19 @@ export function InContextLearning({onDismiss, title}: Props) {
                         spacing="tight"
                         distribution="trailing"
                       >
-                        {showBack && <Button onClick={handleBack}>Back</Button>}
+                        {showBack && (
+                          <Button onClick={handleBack}>
+                            {i18n.translate('Polaris.Common.back')}
+                          </Button>
+                        )}
                         {showNext && (
                           <Button primary onClick={handleNext}>
-                            Next
+                            {i18n.translate('Polaris.Common.next')}
                           </Button>
                         )}
                         {showClose && (
                           <Button primary onClick={handleClose}>
-                            Got it
+                            {i18n.translate('Polaris.InContextLearning.gotIt')}
                           </Button>
                         )}
                       </Stack>
@@ -127,18 +119,7 @@ export function InContextLearning({onDismiss, title}: Props) {
                   </Stack>
                 </div>
               </div>
-              {showArrow && (
-                <div
-                  style={{
-                    position: 'absolute',
-                    left: 'calc(25% - 1rem)',
-                    borderWidth: '.5rem',
-                    borderStyle: 'solid',
-                    ...verticalMargin,
-                    ...arrowStyles,
-                  }}
-                />
-              )}
+              <div className={arrowClassName} />
             </>
           );
         }}

--- a/polaris-react/src/components/InContextLearning/InContextLearning.tsx
+++ b/polaris-react/src/components/InContextLearning/InContextLearning.tsx
@@ -63,10 +63,6 @@ export function InContextLearning({onDismiss, title}: Props) {
             styles.InContextLearning,
             state.positioning === 'above' ? styles.above : styles.below,
           );
-          const arrowClassName = classNames(
-            styles.Arrow,
-            state.positioning === 'above' ? styles.above : styles.below,
-          );
 
           return (
             <>
@@ -119,7 +115,6 @@ export function InContextLearning({onDismiss, title}: Props) {
                   </Stack>
                 </div>
               </div>
-              <div className={arrowClassName} />
             </>
           );
         }}

--- a/polaris-react/src/components/InContextLearning/components/InContextLearningContext.tsx
+++ b/polaris-react/src/components/InContextLearning/components/InContextLearningContext.tsx
@@ -1,20 +1,8 @@
-import React, { useState } from 'react';
-
-export type DirectionType = 
-  | 'top-left'
-  | 'top-right'
-  | 'right-top'
-  | 'right-bottom'
-  | 'bottom-right'
-  | 'bottom-left'
-  | 'left-top'
-  | 'left-bottom'
-  | 'none';
+import React, {useState} from 'react';
 
 export interface InContextLearningContextProviderStepType {
   component: React.ReactNode;
-  direction?: DirectionType,
-  ref:HTMLElement | null;
+  ref: HTMLElement | null;
 }
 
 export interface InContextLearningContextProviderPropsType {
@@ -22,31 +10,41 @@ export interface InContextLearningContextProviderPropsType {
   stepComponents: React.ReactNode[];
 }
 
-export type registerStepType = (stepIndex: number, ref: HTMLElement | null, direction?: DirectionType) => void;
+export type registerStepType = (
+  stepIndex: number,
+  ref: HTMLElement | null,
+) => void;
 
 export interface InContextLearningContextType {
   registerStep: registerStepType;
   steps: InContextLearningContextProviderStepType[];
 }
 
-export const InContextLearningContext = React.createContext<InContextLearningContextType>({
-  registerStep: ()=> {},
-  steps: [],
-});
+export const InContextLearningContext =
+  React.createContext<InContextLearningContextType>({
+    registerStep: () => {},
+    steps: [],
+  });
 
 export function InContextLearningContextProvider({
   children,
-  stepComponents
+  stepComponents,
 }: InContextLearningContextProviderPropsType) {
-  const [steps, setSteps] = useState(stepComponents.map((component):InContextLearningContextProviderStepType => ({ component, ref: null })));
+  const [steps, setSteps] = useState(
+    stepComponents.map(
+      (component): InContextLearningContextProviderStepType => ({
+        component,
+        ref: null,
+      }),
+    ),
+  );
 
-  const registerStep:registerStepType = (stepIndex, ref, direction) => {
+  const registerStep: registerStepType = (stepIndex, ref) => {
     steps[stepIndex] = {
       ...steps[stepIndex],
-      direction,
-      ref
+      ref,
     };
-    
+
     setSteps([...steps]);
   };
 

--- a/polaris-react/src/components/InContextLearning/components/Step.tsx
+++ b/polaris-react/src/components/InContextLearning/components/Step.tsx
@@ -1,36 +1,18 @@
 import React, {useContext, useEffect, useRef} from 'react';
-import { InContextLearningContext } from './InContextLearningContext';
+import {InContextLearningContext} from './InContextLearningContext';
 
 interface Props {
-  children?:React.ReactNode;
-  direction?:
-    | 'top-left'
-    | 'top-right'
-    | 'right-top'
-    | 'right-bottom'
-    | 'bottom-right'
-    | 'bottom-left'
-    | 'left-top'
-    | 'left-bottom'
-    | 'none';
+  children?: React.ReactNode;
   stepIndex: number;
 }
 
-export function Step({
-  children,
-  direction,
-  stepIndex
-}: Props) {
+export function Step({children, stepIndex}: Props) {
   const stepRef = useRef(null);
-  const {registerStep} = useContext(InContextLearningContext); 
-  
+  const {registerStep} = useContext(InContextLearningContext);
+
   useEffect(() => {
-    registerStep(stepIndex, stepRef.current, direction);
+    registerStep(stepIndex, stepRef.current);
   }, []);
 
-  return (
-    <span ref={stepRef}>
-      {children}
-    </span>
-  );
+  return <span ref={stepRef}>{children}</span>;
 }


### PR DESCRIPTION
1. Move hardcoded text to translation file
2. Move all arrow styling / inline styles to sass file
3. Remove console.warn and some other unused code
4. Remove any direction props (we are using `PositionedOverlay` for above/below positioning and will not be including the other directions in MVP)