### PR TITLE
[EmptyState] Fix vertical scroll on small screens

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
+- Fixed vertical scroll on small screens in `EmptyState` ([#5779](https://github.com/Shopify/polaris/pull/5779))
+
 ### Documentation
 
 ### Development workflow

--- a/polaris-react/src/components/EmptyState/EmptyState.scss
+++ b/polaris-react/src/components/EmptyState/EmptyState.scss
@@ -75,10 +75,6 @@ $centered-illustration-width: 226px;
   @include page-content-when-not-partially-condensed {
     flex-basis: 50%;
   }
-
-  @include page-content-when-fully-condensed {
-    overflow-x: hidden;
-  }
 }
 
 .withinContentContainer {


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5662

The `overflow-x: hidden` property on the Details and Images containers doesn't hide any horizontal overflow since these elements are flex items set with `flex: 1 1 auto`. These elements will grow to the width of the content. If you add a large image in without specifying the `largeImage` prop, the overflow-x does nothing and the image causes a horizontal scroll. 

`overflow-x: hidden` also has unintended side effect of adding a vertical scroll because of [how browsers interpret `overflow-y` as default (which is scroll)](https://stackoverflow.com/questions/6179831/setting-overflow-x-hidden-adds-a-vertical-scrollbar) when an overflow-x is set.

The property was added in this [commit](https://github.com/Shopify/polaris/commit/bf4d3d01b58a4d4be46f233dab5cb277e20adce2), but @lgriffee and I both couldn't find the PR/Issue detailing why. In my opinion, with the content of EmptyState being flexed and properties to take care of large images, this style isn't needed and should be removed since it causes a vertical scroll bar on mobile screens.

### WHAT is this pull request doing?

Removes `overflow-x: hidden` from `.Polaris-EmptyState__DetailsContainer` and `.Polaris-EmptyState__ImageContainer` 

Before:
<img width="322" alt="Screen Shot 2022-05-11 at 10 37 53 AM" src="https://user-images.githubusercontent.com/99371685/167912290-9c8c332a-bba4-423c-9527-d1b93947bc4f.png">

After:
<img width="322" alt="Screen Shot 2022-05-11 at 10 39 10 AM" src="https://user-images.githubusercontent.com/99371685/167912439-b7e079a5-403c-4721-9f67-26ac2b690fa1.png">


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
