### PR TITLE
Cache the Next.js site build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             **/.turbo
             node_modules/.cache/turbo
             polaris-react/.loom/cache
+            polaris.shopify.com/.next/cache
           key: ${{ runner.os }}-node${{ matrix.node_version }}-test-v1-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-node${{ matrix.node_version }}-test-v1-


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Looks like we are most-always having a "cache miss" for the website on `yarn build` [in our CI workflow](https://github.com/Shopify/polaris/runs/6397684713?check_suite_focus=true#step:6:64). For now, we can help improve the site build by caching the `.next/cache` folder as [suggested in the Next.js docs](https://nextjs.org/docs/messages/no-cache).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Add the `polaris.shopify.com/.next/cache` to our CI cache.
