### PR TITLE
Update `changelog` and bump version number to v0.2.0

### DIFF
--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [these versioning and changelog guidelines](/documentatio
 ## `v0.2.0` 2022-05-12
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
-- Add token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))
+- Added token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))
 
 ## `v0.1.0` 2022-04-12
 

--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [these versioning and changelog guidelines](/documentatio
 
 ---
 
-## `v0.2.0` 2022-04-12
+## `v0.2.0` 2022-05-12
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
 - Add token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))

--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [these versioning and changelog guidelines](/documentatio
 ## `v0.2.0` 2022-04-12
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
+- Add token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))
 
 ## `v0.1.0` 2022-04-12
 

--- a/polaris-for-vscode/package.json
+++ b/polaris-for-vscode/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/Shopify/polaris/issues"
   },
-  "version": "0.1.1",
+  "version": "0.2.0",
   "keywords": [
     "polaris",
     "shopify"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
To release version v0.2.0

After this gets merged I'll manually publish and upload this version of the vscode plugin to the marketplace as we're still working on [porting our automated process over to turborepo](https://github.com/Shopify/polaris/pull/5720/files#diff-aae63a3776b5367b3b8e30e46003f227cc5431c6e67448596de757272c586abb)