### PR TITLE
Clean up recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,8 @@
 {
   "recommendations": [
-    "christian-kohler.npm-intellisense",
-    "christian-kohler.path-intellisense",
-    "codezombiech.gitignore",
     "dbaeumer.vscode-eslint",
     "EditorConfig.editorconfig",
     "esbenp.prettier-vscode",
-    "mrmlnc.vscode-scss",
-    "orta.vscode-jest",
     "Shopify.polaris-for-vscode"
   ]
 }


### PR DESCRIPTION
This PR removes a bunch of plugins that I see as optional or things that VSCode already supports. This leaves recommendations for extensions we strongly recommend using when developing in `shopify/polaris`.

Let me know your thoughts.