### PR TITLE
Remove TS project references and type check

### DIFF
--- a/polaris-for-figma/tsconfig.json
+++ b/polaris-for-figma/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "@shopify/typescript-configs/dom"
+  "extends": "@shopify/typescript-configs/dom",
+  "compilerOptions": {
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src", "src/**/*.json"]
 }

--- a/polaris-for-vscode/tsconfig.json
+++ b/polaris-for-vscode/tsconfig.json
@@ -5,7 +5,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "."
   },
   "include": ["src"]
 }

--- a/polaris-react/tsconfig.json
+++ b/polaris-react/tsconfig.json
@@ -5,7 +5,7 @@
     "emitDeclarationOnly": true,
     "importsNotUsedAsValues": "error",
     "outDir": "build/ts/latest",
-    "rootDir": "./",
+    "rootDir": ".",
     "strictFunctionTypes": false,
     "paths": {
       "tests/*": ["./tests/*"]

--- a/polaris-tokens/tsconfig.json
+++ b/polaris-tokens/tsconfig.json
@@ -4,8 +4,8 @@
     "composite": true,
     "declarationDir": "dist/types",
     "emitDeclarationOnly": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "outDir": "dist/types",
+    "rootDir": "."
   },
   "include": ["src"]
 }

--- a/polaris.shopify.com/tsconfig.json
+++ b/polaris.shopify.com/tsconfig.json
@@ -18,7 +18,9 @@
     "jsx": "preserve",
     "composite": true,
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    "outDir": ".next",
+    "rootDir": "."
   },
   "include": [
     "src",

--- a/stylelint-polaris/tsconfig.json
+++ b/stylelint-polaris/tsconfig.json
@@ -6,7 +6,7 @@
     "composite": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
-    "rootDir": "./"
+    "rootDir": "."
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "files": [],
   "references": [
+    {"path": "./polaris-for-figma"},
     {"path": "./polaris-for-vscode"},
     {"path": "./polaris-react"},
     {"path": "./polaris-tokens"},


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #5792 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Remove TS project references for the following reasons:

- the .tsbuildinfo files can't be cached in CI
- running into occasional build issues due to `tsbuildinfo` cache, having to `rm` them manually to get turbo builds to work
- the type check step in CI isn't providing much additional security
- the package builds should fail if TS isn't valid anyway