### PR TITLE
stylelint use monorepo package

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['@shopify/stylelint-plugin/prettier', './stylelint-polaris'],
+  extends: ['@shopify/stylelint-plugin/prettier', '@shopify/stylelint-polaris'],
   // Disabling @shopify/stylelint-plugin/configs/core no-unknown-animations as styelint
   // is not aware of global Polaris keyframes
   // TODO: create custom plugin to ensure animation-names match Polaris keyframe names
@@ -12,7 +12,7 @@ module.exports = {
       files: ['polaris-react/**/*.scss'],
       extends: [
         '@shopify/stylelint-plugin/prettier',
-        './stylelint-polaris/configs/internal',
+        '@shopify/stylelint-polaris/configs/internal',
       ],
     },
   ],

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@shopify/eslint-plugin": "^41.0.1",
     "@shopify/prettier-config": "^1.1.2",
     "@shopify/stylelint-plugin": "^11.0.0",
+    "@shopify/stylelint-polaris": "*",
     "@shopify/typescript-configs": "^5.1.0",
     "eslint": "^8.3.0",
     "jest": "^27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,6 +2759,13 @@
     stylelint-prettier "^2.0.0"
     stylelint-scss "^4.0.0"
 
+"@shopify/stylelint-polaris@*":
+  version "0.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@shopify/stylelint-polaris/-/stylelint-polaris-0.0.0-alpha.6.tgz#177bf4a6ed45fd0e3cb46f619a37a5696ab2ca9e"
+  integrity sha512-KE84eR3vCB5sDQG/o3rQetqVF9152/SaBjWsg/c3fKI3IkfCnPymkaKVtPuTS5lXLiUUrCWXMgo1fnBW9192zQ==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
 "@shopify/typescript-configs@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@shopify/typescript-configs/-/typescript-configs-5.1.0.tgz#f6e8fdd3291bf0a406578b2c6eb21f8c542d3c0a"


### PR DESCRIPTION
I don't know if this worked correctly. Testing the plugin everything worked as intended.

The intention of this PR is to use the `package.json` format for built packages to include `stylelint-polaris`. When running `yarn` after this change I had to specify a version and the `yarn.lock` has it there. Unsure if version bumps and edits would flow through as I intended.

```
Couldn’t find any versions for “@shopify/stylelint-polaris” that matches “*”.
Please choose a version of “@shopify/stylelint-polaris” from this list:
- 0.0.0-alpha.6
```