### PR TITLE
Vsc build updates

### DIFF
--- a/polaris-for-vscode/.vscodeignore
+++ b/polaris-for-vscode/.vscodeignore
@@ -5,8 +5,6 @@
 **/*.ts
 *.vsix
 CONTRIBUTING.md
-docs
-!docs/polaris-icon.png
 scripts
 src
 node_modules

--- a/polaris-for-vscode/.vscodeignore
+++ b/polaris-for-vscode/.vscodeignore
@@ -1,9 +1,12 @@
+.turbo
+../**
 **/tsconfig.json
 **/*.map
 **/*.ts
 *.vsix
 CONTRIBUTING.md
 docs
+!docs/polaris-icon.png
 scripts
 src
 node_modules

--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [these versioning and changelog guidelines](/documentatio
 
 ---
 
-## `v0.2.0` - 2022-05-13
+## `v0.2.0` - 2022-05-16
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
 - Added token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))

--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [these versioning and changelog guidelines](/documentatio
 
 ---
 
-## `v0.2.0` 2022-05-12
+## `v0.2.0` - 2022-05-13
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
 - Added token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))
 
-## `v0.1.0` 2022-04-12
+## `v0.1.0` - 2022-04-12
 
 - Initial release

--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [these versioning and changelog guidelines](/documentatio
 ## `v0.2.0` 2022-05-12
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
-- Add token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))
+- Added token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))
 
 ## `v0.1.0` 2022-04-12
 

--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [these versioning and changelog guidelines](/documentatio
 
 ---
 
-## `v0.2.0` 2022-04-12
+## `v0.2.0` 2022-05-12
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
 - Add token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))

--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [these versioning and changelog guidelines](/documentatio
 ## `v0.2.0` 2022-04-12
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
+- Add token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))
 
 ## `v0.1.0` 2022-04-12
 

--- a/polaris-for-vscode/package.json
+++ b/polaris-for-vscode/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/Shopify/polaris/issues"
   },
-  "version": "0.1.1",
+  "version": "0.2.0",
   "keywords": [
     "polaris",
     "shopify"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

* The entire monorepo was getting packaged up with the extension on `vsce package`
* Get ready for v0.2.0
* Bring up to speed with main

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
* updating the `.vscodeignore` to exclude everything outside of `polaris-for-vscode` and `.turbo`
* bump the version to `v0.2.0`
* merge `main`
