### PR TITLE
[Badge] 🐛 matches `new` and `info` Pip colors with the ones in `Badge`

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -12,12 +12,15 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added support for tooltips on Navigation items ([#5750](https://github.com/Shopify/polaris/pull/5750))
 - Change types for DataTable `totalsName` prop to allow for ReactNode ([#5454](https://github.com/Shopify/polaris/pull/5365/))
 - Implemented accessibility role and attributes in `SettingToggle` ([#5470](https://github.com/Shopify/polaris/pull/5470))
+- Removed `info` status as default prop value for `Badge.Pip`. The default color is `--p-icon` ([#5798](https://github.com/Shopify/polaris/pull/5798))
 
 ### Bug fixes
 
 - Fixed vertical scroll on small screens in `EmptyState` ([#5779](https://github.com/Shopify/polaris/pull/5779))
 - Fixed broken links in documentation ([#5824](https://github.com/Shopify/polaris/pull/5824))
 - Fixed key prop error introduced in [sticky header](https://github.com/Shopify/polaris/pull/5494) ([#5826](https://github.com/Shopify/polaris/pull/5826))
+
+- Fixed `Badge` and `Pip` having different background colors for `new` and `info` status ([#5798](https://github.com/Shopify/polaris/pull/5798))
 
 ### Documentation
 

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -4,6 +4,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Breaking changes
 
+- Removed `info` status as default prop value for `Badge.Pip`. The default color is `--p-icon` ([#5798](https://github.com/Shopify/polaris/pull/5798))
+
 ### Enhancements
 
 - Ported internal breakpoint and layout functions to SCSS variables ([#5722](https://github.com/Shopify/polaris/pull/5722))
@@ -12,14 +14,12 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added support for tooltips on Navigation items ([#5750](https://github.com/Shopify/polaris/pull/5750))
 - Change types for DataTable `totalsName` prop to allow for ReactNode ([#5454](https://github.com/Shopify/polaris/pull/5365/))
 - Implemented accessibility role and attributes in `SettingToggle` ([#5470](https://github.com/Shopify/polaris/pull/5470))
-- Removed `info` status as default prop value for `Badge.Pip`. The default color is `--p-icon` ([#5798](https://github.com/Shopify/polaris/pull/5798))
 
 ### Bug fixes
 
 - Fixed vertical scroll on small screens in `EmptyState` ([#5779](https://github.com/Shopify/polaris/pull/5779))
 - Fixed broken links in documentation ([#5824](https://github.com/Shopify/polaris/pull/5824))
 - Fixed key prop error introduced in [sticky header](https://github.com/Shopify/polaris/pull/5494) ([#5826](https://github.com/Shopify/polaris/pull/5826))
-
 - Fixed `Badge` and `Pip` having different background colors for `new` and `info` status ([#5798](https://github.com/Shopify/polaris/pull/5798))
 
 ### Documentation

--- a/polaris-react/src/components/Badge/components/Pip/Pip.scss
+++ b/polaris-react/src/components/Badge/components/Pip/Pip.scss
@@ -11,7 +11,7 @@
 }
 
 .statusInfo {
-  --pc-pip-color: var(--p-icon);
+  --pc-pip-color: var(--p-icon-highlight);
 }
 
 .statusSuccess {
@@ -19,7 +19,7 @@
 }
 
 .statusNew {
-  --pc-pip-color: var(--p-icon-highlight);
+  --pc-pip-color: var(--p-icon);
 }
 
 .statusAttention {

--- a/polaris-react/src/components/Badge/components/Pip/Pip.tsx
+++ b/polaris-react/src/components/Badge/components/Pip/Pip.tsx
@@ -15,7 +15,7 @@ export interface PipProps {
 }
 
 export function Pip({
-  status = 'info',
+  status,
   progress = 'complete',
   accessibilityLabelOverride,
 }: PipProps) {

--- a/polaris-react/src/components/Badge/tests/Badge.test.tsx
+++ b/polaris-react/src/components/Badge/tests/Badge.test.tsx
@@ -44,7 +44,7 @@ describe('<Badge />', () => {
     const badge = mountWithApp(<Badge progress="incomplete" />);
 
     expect(badge).toContainReactComponent('span', {
-      className: 'Pip statusInfo progressIncomplete',
+      className: 'Pip progressIncomplete',
     });
   });
 
@@ -147,7 +147,7 @@ describe('<Badge.Pip />', () => {
     badge = mountWithApp(<Badge.Pip progress="partiallyComplete" />);
 
     expect(badge).toContainReactComponent(VisuallyHidden, {
-      children: 'Info Partially complete',
+      children: ' Partially complete',
     });
 
     badge = mountWithApp(<Badge.Pip status="attention" />);
@@ -159,7 +159,7 @@ describe('<Badge.Pip />', () => {
     badge = mountWithApp(<Badge.Pip />);
 
     expect(badge).toContainReactComponent(VisuallyHidden, {
-      children: 'Info Complete',
+      children: ' Complete',
     });
   });
 });


### PR DESCRIPTION
## What is the problem
The background color hue for `<Badge  />` with status  `info` and `new`  is different of when it is rendered as `<Badge.Pip />` 

## Example of the problem when...
#### status `info` 

|  `<Badge status='info' />`|  `<Badge.Pip status='info' />`    |
|---	|---	|
|  <img width="173" alt="image" src="https://user-images.githubusercontent.com/1577809/168819843-c4610543-e452-4a7f-82e8-a5ac225cd8ec.png"> |   <img width="176" alt="image" src="https://user-images.githubusercontent.com/1577809/168819681-04553198-371f-4cae-8362-8c7700afcc60.png"> |

#### status `new` 

|  `<Badge status='new' />`|  `<Badge.Pip status='new' />`    |
|---	|---	|
|  <img width="178" alt="image" src="https://user-images.githubusercontent.com/1577809/168820184-7dfdaee7-0d70-4ab4-977e-d407ce241b0f.png"> | <img width="181" alt="image" src="https://user-images.githubusercontent.com/1577809/168820031-b41e142e-f779-48fa-8ba5-66a29f5af7c3.png">  |

## How it should be
#### When status `info` 

|  `<Badge status='info' />`|  `<Badge.Pip status='info' />`    |
|---	|---	|
|  <img width="176" alt="image" src="https://user-images.githubusercontent.com/1577809/168821136-f1994467-7f3d-4452-9c6c-7ac246858e07.png"> |  <img width="177" alt="image" src="https://user-images.githubusercontent.com/1577809/168820960-601a3324-8046-4bcc-89f8-93cf9b6448ae.png"> |

#### When status `new` 

|  `<Badge status='new' />`|  `<Badge.Pip status='new' />`    |
|---	|---	|
|  <img width="185" alt="image" src="https://user-images.githubusercontent.com/1577809/168821280-75ba709d-3d09-40d4-bf40-e265909ad387.png"> | <img width="186" alt="image" src="https://user-images.githubusercontent.com/1577809/168820713-93001cf5-2fb9-468f-94c1-b26419b4d662.png"> |

## Why it happens
Checking [Badge.scss](https://github.com/Shopify/polaris/blob/5a01bbdba2c7178a3ff3363e57436f5802921168/polaris-react/src/components/Badge/Badge.scss#L29) we see that the colors for badge and pip are inverted. 

The solution is to use the same colors Badge.scss uses for `info` and `new` status in Pip.scss

## How to tophat
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Stack, Badge} from '../src';

export function Playground() {
  return (
    <Page title="Pip">
      <Stack>
        <div>
          <Badge.Pip progress="incomplete" status="new" /> Incomplete & new
          <Badge.Pip progress="incomplete" status="info" /> Incomplete & info
        </div>
      </Stack>

      <Page title="Badges">
        <Stack>
          <Badge progress="incomplete" status="new">
            Incomplete & new
          </Badge>
          <Badge progress="incomplete" status="info">
            Incomplete & info
          </Badge>
        </Stack>
      </Page>
    </Page>
  );
}

```
</details>

It should render the following
<img width="476" alt="image" src="https://user-images.githubusercontent.com/1577809/168822199-d5aac307-5cca-4b42-8a1d-9cae9f0fd48a.png">
