### PR TITLE
Clean `tsbuildinfo` and add common scripts to `polaris-for-figma`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,6 +70,12 @@
   },
   "overrides": [
     {
+      "files": ["polaris-for-figma/src/**/*.{ts,tsx}"],
+      "rules": {
+        "@shopify/jsx-no-hardcoded-content": "off"
+      }
+    },
+    {
       "files": ["polaris-react/src/**/*.{ts,tsx}"],
       "extends": ["plugin:@shopify/typescript-type-checking"],
       "parserOptions": {

--- a/polaris-for-figma/package.json
+++ b/polaris-for-figma/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "scripts": {
     "build": "webpack --mode=production",
-    "dev": "webpack --mode=development --watch"
+    "dev": "webpack --mode=development --watch",
+    "lint": "TIMING=1 eslint --cache .",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",

--- a/polaris-for-figma/src/tokens/tokenScript.js
+++ b/polaris-for-figma/src/tokens/tokenScript.js
@@ -21,6 +21,7 @@ function addPaintStyleIDtoTokens() {
     JSON.stringify(apiColorTokens),
     (err) => {
       if (err) throw err;
+      // eslint-disable-next-line no-console
       console.log('Data written to file');
     },
   );

--- a/polaris-for-vscode/package.json
+++ b/polaris-for-vscode/package.json
@@ -33,7 +33,7 @@
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "lint": "TIMING=1 eslint --cache .",
-    "clean": "rm -rf .turbo node_modules dist"
+    "clean": "rm -rf .turbo node_modules dist *.tsbuildinfo"
   },
   "dependencies": {
     "@shopify/polaris-tokens": "*",

--- a/polaris-tokens/package.json
+++ b/polaris-tokens/package.json
@@ -23,7 +23,7 @@
     "dev": "rollup -c -w",
     "lint": "TIMING=1 eslint --cache .",
     "test": "jest",
-    "clean": "rm -rf .turbo node_modules dist"
+    "clean": "rm -rf .turbo node_modules dist *.tsbuildinfo"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.1",

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "start": "next start ",
     "lint": "TIMING=1 eslint --cache .",
-    "clean": "rm -rf .turbo node_modules .next",
+    "clean": "rm -rf .turbo node_modules .next *.tsbuildinfo",
     "create-component": "generact --root src/components src/components/Template/Template.tsx",
     "parse-components": "node src/scripts/parseComponents.mjs",
     "parse-guidelines": "node src/scripts/parseGuidelines.mjs"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

- The `tsbuildinfo` output should be cleared when cleaning the repo of build output (`yarn clean`)
- There are missing common tasks for the `polaris-for-figma` package (clean and lint)
 
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Add the `*.tsbuildinfo` files to the `clean` task where relevant
- Add lint and clean scripts to `polaris-for-figma`

Post-build | Post-clean 
--- | ---
<img width="727" alt="before" src="https://user-images.githubusercontent.com/11774595/168441927-4b8f0438-8eca-4538-af6c-ae3192a317a0.png"> | <img width="727" alt="after" src="https://user-images.githubusercontent.com/11774595/168441942-1cc679a9-896e-487c-a7d8-50950ce1abf3.png">

