### PR TITLE
[Listbox] Fix: preserve scroll position when lazy-loading additional items

### DIFF
--- a/.changeset/curvy-rockets-provide.md
+++ b/.changeset/curvy-rockets-provide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fixed Listbox to preserve scroll position when lazy-loading additional items

--- a/.changeset/curvy-rockets-provide.md
+++ b/.changeset/curvy-rockets-provide.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris': minor
+'@shopify/polaris': patch
 ---
 
-Fixed Listbox to preserve scroll position when lazy-loading additional items
+Fixed `Listbox` to preserve scroll position when lazy-loading additional items

--- a/polaris-react/src/components/Listbox/Listbox.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.tsx
@@ -238,19 +238,30 @@ export function Listbox({
       option.getAttribute(OPTION_VALUE_ATTRIBUTE),
     );
 
-    const listIsUnchangedOrAppended =
+    const listIsUnchanged =
+      nextValues.length === currentValues.length &&
+      nextValues.every((value, index) => {
+        return currentValues[index] === value;
+      });
+
+    const listIsAppended =
       currentValues.length !== 0 &&
-      nextValues.length >= currentValues.length &&
+      nextValues.length > currentValues.length &&
       currentValues.every((value, index) => {
         return nextValues[index] === value;
       });
 
-    if (listIsUnchangedOrAppended) {
+    if (listIsUnchanged) {
       if (optionIsAlreadyActive && actionContentHasUpdated) {
         setCurrentOptions(nextOptions);
         handleChangeActiveOption(nextOption);
       }
 
+      return;
+    }
+
+    if (listIsAppended) {
+      setCurrentOptions(nextOptions);
       return;
     }
 

--- a/polaris-react/src/components/Listbox/Listbox.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.tsx
@@ -238,13 +238,14 @@ export function Listbox({
       option.getAttribute(OPTION_VALUE_ATTRIBUTE),
     );
 
-    const listIsUnchanged =
-      nextValues.length === currentValues.length &&
-      nextValues.every((value, index) => {
-        return currentValues[index] === value;
+    const listIsUnchangedOrAppended =
+      currentValues.length !== 0 &&
+      nextValues.length >= currentValues.length &&
+      currentValues.every((value, index) => {
+        return nextValues[index] === value;
       });
 
-    if (listIsUnchanged) {
+    if (listIsUnchangedOrAppended) {
       if (optionIsAlreadyActive && actionContentHasUpdated) {
         setCurrentOptions(nextOptions);
         handleChangeActiveOption(nextOption);


### PR DESCRIPTION
This fixes a regression in `@shopify/polaris` at version `9.4.0-rc.1`. Previously, appending additional items to a Listbox would preserve the current scroll position. Additional focus management was added (I believe in #5303) that may not have accounted for this case.

### WHY are these changes introduced?

Fixes #5809 (see issue for details from @gcrevell)

### WHAT is this pull request doing?

It Listbox from being scrolled to the top via `scrollIntoViewIfNeeded` when items are appended to the current list of items. The focus behaviour for changing or removing items is unchanged.

#### Before:

https://user-images.githubusercontent.com/105127/168404342-befd7766-ee7c-4a36-81a1-76cc013e215f.mov

#### After:

https://user-images.githubusercontent.com/105127/168404393-65a1c3db-85dc-477b-abfc-8ff96c861709.mov

