### PR TITLE
[MediaCard] Fix border radius to match Card component

### DIFF
--- a/polaris-react/src/components/MediaCard/MediaCard.scss
+++ b/polaris-react/src/components/MediaCard/MediaCard.scss
@@ -19,8 +19,6 @@ $portrait-breakpoint: 804px;
 
 .MediaContainer {
   overflow: hidden;
-  border-top-left-radius: var(--p-border-radius-2);
-  border-top-right-radius: var(--p-border-radius-2);
 
   &:not(.portrait) {
     flex-basis: 40%;
@@ -28,6 +26,11 @@ $portrait-breakpoint: 804px;
     &.sizeSmall {
       flex-basis: 33%;
     }
+  }
+
+  @include page-content-when-not-fully-condensed {
+    border-top-left-radius: var(--p-border-radius-2);
+    border-top-right-radius: var(--p-border-radius-2);
   }
 
   @include breakpoint-after($portrait-breakpoint, inclusive) {


### PR DESCRIPTION
### WHY are these changes introduced?

Previously Card and Image `top-border-radius` would not match at smaller sizes.
[Slack thread](https://shopify.slack.com/archives/C4Y8N30KD/p1652794765994999)

https://user-images.githubusercontent.com/20962833/168885997-bad1b240-69ce-487c-bad6-94c1070f0bbb.mov


### WHAT is this pull request doing?

Before:
<img width="624" alt="Screen Shot 2022-05-17 at 1 29 35 PM" src="https://user-images.githubusercontent.com/20962833/168886545-c351f24b-efad-4626-b45b-cdacfcdb27e8.png">

After:
<img width="624" alt="Screen Shot 2022-05-17 at 1 29 48 PM" src="https://user-images.githubusercontent.com/20962833/168886565-230f56bd-762b-459d-a725-b655e38f7f50.png">


https://user-images.githubusercontent.com/20962833/168886665-31998291-2edd-4374-842f-ceebcc6305bb.mov


### 🎩 checklist

- [X] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)