### PR TITLE
feat: Update experimental XL breakpoint value

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -8,7 +8,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Ported internal breakpoint and layout functions to SCSS variables ([#5722](https://github.com/Shopify/polaris/pull/5722))
 - Added `extraSmall` to the available sizes of the `Thumbnail` and `SkeletonThumbnail` ([#5770](https://github.com/Shopify/polaris/pull/5770))
-- Updated experimental breakpoint values ([#5804](https://github.com/Shopify/polaris/pull/5804))
+- Updated experimental breakpoint values ([#5804](https://github.com/Shopify/polaris/pull/5804), [#5830](https://github.com/Shopify/polaris/pull/5830))
 - Added support for tooltips on Navigation items ([#5750](https://github.com/Shopify/polaris/pull/5750))
 - Change types for DataTable `totalsName` prop to allow for ReactNode ([#5454](https://github.com/Shopify/polaris/pull/5365/))
 - Implemented accessibility role and attributes in `SettingToggle` ([#5470](https://github.com/Shopify/polaris/pull/5470))

--- a/polaris-react/src/components/TopBar/TopBar.scss
+++ b/polaris-react/src/components/TopBar/TopBar.scss
@@ -53,7 +53,7 @@ $page-left-alignment-breakpoint-max: 1238px;
     display: block;
   }
 
-  @media #{$p-breakpoints-xl-up} {
+  @media (min-width: 1400px) {
     width: $layout-width-nav-base;
   }
 }

--- a/polaris-react/src/components/TopBar/TopBar.scss
+++ b/polaris-react/src/components/TopBar/TopBar.scss
@@ -53,7 +53,7 @@ $page-left-alignment-breakpoint-max: 1238px;
     display: block;
   }
 
-  @media (min-width: 1400px) {
+  @media #{$p-breakpoints-xl-up} {
     width: $layout-width-nav-base;
   }
 }

--- a/polaris-react/src/tokens/token-groups/breakpoints.json
+++ b/polaris-react/src/tokens/token-groups/breakpoints.json
@@ -3,5 +3,5 @@
   "breakpoints-sm": "490px",
   "breakpoints-md": "768px",
   "breakpoints-lg": "1040px",
-  "breakpoints-xl": "1400px"
+  "breakpoints-xl": "1440px"
 }

--- a/polaris-tokens/src/token-groups/breakpoints.ts
+++ b/polaris-tokens/src/token-groups/breakpoints.ts
@@ -12,6 +12,6 @@ export const breakpoints = {
     value: '1040px',
   },
   'breakpoints-xl': {
-    value: '1400px',
+    value: '1440px',
   },
 };


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR updates the `xl` breakpoint value to `1440px` to enable equal widths for our `12` column grid:

Before:
`((1400 - (32*2)) - (11 * 16)) / 12`
`96.67px` each column

After:
`((1440 - (32*2)) - (11 * 16)) / 12`
`100px` each column

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
