### PR TITLE
Revert "[Badge] 🐛 matches `new` and `info` Pip colors with the ones in `Badge`"

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -4,8 +4,6 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Breaking changes
 
-- Removed `info` status as default prop value for `Badge.Pip`. The default color is `--p-icon` ([#5798](https://github.com/Shopify/polaris/pull/5798))
-
 ### Enhancements
 
 - Ported internal breakpoint and layout functions to SCSS variables ([#5722](https://github.com/Shopify/polaris/pull/5722))
@@ -20,7 +18,6 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Fixed vertical scroll on small screens in `EmptyState` ([#5779](https://github.com/Shopify/polaris/pull/5779))
 - Fixed broken links in documentation ([#5824](https://github.com/Shopify/polaris/pull/5824))
 - Fixed key prop error introduced in [sticky header](https://github.com/Shopify/polaris/pull/5494) ([#5826](https://github.com/Shopify/polaris/pull/5826))
-- Fixed `Badge` and `Pip` having different background colors for `new` and `info` status ([#5798](https://github.com/Shopify/polaris/pull/5798))
 
 ### Documentation
 

--- a/polaris-react/src/components/Badge/components/Pip/Pip.scss
+++ b/polaris-react/src/components/Badge/components/Pip/Pip.scss
@@ -11,7 +11,7 @@
 }
 
 .statusInfo {
-  --pc-pip-color: var(--p-icon-highlight);
+  --pc-pip-color: var(--p-icon);
 }
 
 .statusSuccess {
@@ -19,7 +19,7 @@
 }
 
 .statusNew {
-  --pc-pip-color: var(--p-icon);
+  --pc-pip-color: var(--p-icon-highlight);
 }
 
 .statusAttention {

--- a/polaris-react/src/components/Badge/components/Pip/Pip.tsx
+++ b/polaris-react/src/components/Badge/components/Pip/Pip.tsx
@@ -15,7 +15,7 @@ export interface PipProps {
 }
 
 export function Pip({
-  status,
+  status = 'info',
   progress = 'complete',
   accessibilityLabelOverride,
 }: PipProps) {

--- a/polaris-react/src/components/Badge/tests/Badge.test.tsx
+++ b/polaris-react/src/components/Badge/tests/Badge.test.tsx
@@ -44,7 +44,7 @@ describe('<Badge />', () => {
     const badge = mountWithApp(<Badge progress="incomplete" />);
 
     expect(badge).toContainReactComponent('span', {
-      className: 'Pip progressIncomplete',
+      className: 'Pip statusInfo progressIncomplete',
     });
   });
 
@@ -147,7 +147,7 @@ describe('<Badge.Pip />', () => {
     badge = mountWithApp(<Badge.Pip progress="partiallyComplete" />);
 
     expect(badge).toContainReactComponent(VisuallyHidden, {
-      children: ' Partially complete',
+      children: 'Info Partially complete',
     });
 
     badge = mountWithApp(<Badge.Pip status="attention" />);
@@ -159,7 +159,7 @@ describe('<Badge.Pip />', () => {
     badge = mountWithApp(<Badge.Pip />);
 
     expect(badge).toContainReactComponent(VisuallyHidden, {
-      children: ' Complete',
+      children: 'Info Complete',
     });
   });
 });


### PR DESCRIPTION
Reverts Shopify/polaris#5798

This PR unintentionally introduced a breaking change.