### PR TITLE
[Badge] 🐛 makes `new` and `info` Pip colors the same as in `Badge`

### DIFF
--- a/.changeset/unlucky-baboons-breathe.md
+++ b/.changeset/unlucky-baboons-breathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Badge` and `Pip` having different background colors for `new` and `info` status ([#5840](https://github.com/Shopify/polaris/pull/5840))

--- a/polaris-react/src/components/Badge/components/Pip/Pip.scss
+++ b/polaris-react/src/components/Badge/components/Pip/Pip.scss
@@ -11,7 +11,7 @@
 }
 
 .statusInfo {
-  --pc-pip-color: var(--p-icon);
+  --pc-pip-color: var(--p-icon-highlight);
 }
 
 .statusSuccess {
@@ -19,7 +19,7 @@
 }
 
 .statusNew {
-  --pc-pip-color: var(--p-icon-highlight);
+  --pc-pip-color: var(--p-icon);
 }
 
 .statusAttention {


### PR DESCRIPTION
## !Important
This PR was previously reverted https://github.com/Shopify/polaris/pull/5798#issuecomment-1130313111 as it introduced breaking changes 😔

## What is the problem
The background color hue for `<Badge status ='new  />` and `<Badge status ='info'  />`  are different than the ones rendered as `<Badge.Pip status ='...' />`.  The colors should match independent of the component.

## Example of the problem 
### When Badge `status='info'` 
#### Current
|  `<Badge status='info' ... />`|  `<Badge.Pip status='info' ... />`    |
|---	|---	|
|  <img width="173" alt="image" src="https://user-images.githubusercontent.com/1577809/168819843-c4610543-e452-4a7f-82e8-a5ac225cd8ec.png"> |   <img width="176" alt="image" src="https://user-images.githubusercontent.com/1577809/168819681-04553198-371f-4cae-8362-8c7700afcc60.png"> |

#### Expected
|  `<Badge status='info' ... />`|  `<Badge.Pip status='info'  ... />`    |
|---	|---	|
|  <img width="176" alt="image" src="https://user-images.githubusercontent.com/1577809/168821136-f1994467-7f3d-4452-9c6c-7ac246858e07.png"> |  <img width="177" alt="image" src="https://user-images.githubusercontent.com/1577809/168820960-601a3324-8046-4bcc-89f8-93cf9b6448ae.png"> |


### When Badge `status='new'` 
#### Current
|  `<Badge status='new' ... />`|  `<Badge.Pip status='new' ... `/>`    |
|---	|---	|
|  <img width="178" alt="image" src="https://user-images.githubusercontent.com/1577809/168820184-7dfdaee7-0d70-4ab4-977e-d407ce241b0f.png"> | <img width="181" alt="image" src="https://user-images.githubusercontent.com/1577809/168820031-b41e142e-f779-48fa-8ba5-66a29f5af7c3.png">  |

#### Expected
|  `<Badge status='new' ... />`|  `<Badge.Pip status='new' ... />`    |
|---	|---	|
|  <img width="185" alt="image" src="https://user-images.githubusercontent.com/1577809/168821280-75ba709d-3d09-40d4-bf40-e265909ad387.png"> | <img width="186" alt="image" src="https://user-images.githubusercontent.com/1577809/168820713-93001cf5-2fb9-468f-94c1-b26419b4d662.png"> |


## Why the error happens
Checking [Badge.scss](https://github.com/Shopify/polaris/blob/5a01bbdba2c7178a3ff3363e57436f5802921168/polaris-react/src/components/Badge/Badge.scss#L29) we see that the colors for badge and pip are inverted. 

So part of the solution is to use the same colors Badge.scss uses for `info` and `new` status in Pip.scss

## How to tophat
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Stack, Badge} from '../src';

export function Playground() {
  return (
    <>
      <Page title="Pip">
        <Stack>
          <div>
            <Badge.Pip progress="incomplete" status="new" /> Incomplete & new
            <br />
            <Badge.Pip progress="incomplete" status="info" /> Incomplete & info
            <br />
            <Badge.Pip /> Default
          </div>
        </Stack>
      </Page>
      <Page title="Badges">
        <Stack>
          <Badge progress="incomplete" status="new">
            Incomplete & new
          </Badge>
          <Badge progress="incomplete" status="info">
            Incomplete & info
          </Badge>
          <Badge progress="complete">Default</Badge>
        </Stack>
      </Page>
    </>
  );
}

```
</details>

It should render the following
<img width="565" alt="image" src="https://user-images.githubusercontent.com/1577809/170948181-e8cb142a-1ebe-486c-8bbc-d9a3f3fa2ce9.png">


