### PR TITLE
Performance Benchmarking with the User Timing API

### DIFF
--- a/polaris-react/.storybook/preview.js
+++ b/polaris-react/.storybook/preview.js
@@ -20,7 +20,10 @@ function AppProviderDecorator(Story, context) {
   if (context.args.omitAppProvider) return <Story {...context} />;
 
   return (
-    <AppProvider i18n={enTranslations}>
+    <AppProvider
+      i18n={enTranslations}
+      features={{enablePerformanceBenchmarking: true}}
+    >
       <Story {...context} />
     </AppProvider>
   );

--- a/polaris-react/src/components/AccountConnection/AccountConnection.tsx
+++ b/polaris-react/src/components/AccountConnection/AccountConnection.tsx
@@ -7,6 +7,7 @@ import {Card} from '../Card';
 import {Stack} from '../Stack';
 import {TextStyle} from '../TextStyle';
 import {SettingAction} from '../SettingAction';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './AccountConnection.scss';
 
@@ -36,6 +37,7 @@ export function AccountConnection({
   details,
   termsOfService,
 }: AccountConnectionProps) {
+  usePerformanceBenchmark('AccountConnection');
   const initials = accountName
     ? accountName
         .split(/\s+/)

--- a/polaris-react/src/components/ActionList/ActionList.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.tsx
@@ -7,6 +7,7 @@ import {
 import {KeypressListener} from '../KeypressListener';
 import {ActionListItemDescriptor, ActionListSection, Key} from '../../types';
 import {classNames} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Section} from './components';
 import styles from './ActionList.scss';
@@ -28,6 +29,7 @@ export function ActionList({
   actionRole,
   onActionAnyItem,
 }: ActionListProps) {
+  usePerformanceBenchmark('ActionList');
   let finalSections: readonly ActionListSection[] = [];
   const actionListRef = useRef<HTMLDivElement & HTMLUListElement>(null);
 

--- a/polaris-react/src/components/ActionMenu/ActionMenu.tsx
+++ b/polaris-react/src/components/ActionMenu/ActionMenu.tsx
@@ -6,6 +6,7 @@ import type {
   MenuActionDescriptor,
   MenuGroupDescriptor,
 } from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Actions, RollupActions} from './components';
 import styles from './ActionMenu.scss';
@@ -27,6 +28,7 @@ export function ActionMenu({
   rollup,
   rollupActionsLabel,
 }: ActionMenuProps) {
+  usePerformanceBenchmark('ActionMenu');
   if (actions.length === 0 && groups.length === 0) {
     return null;
   }

--- a/polaris-react/src/components/AfterInitialMount/AfterInitialMount.tsx
+++ b/polaris-react/src/components/AfterInitialMount/AfterInitialMount.tsx
@@ -1,6 +1,7 @@
 import React, {ReactNode} from 'react';
 
 import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 interface Props {
   children?: ReactNode;
@@ -8,6 +9,7 @@ interface Props {
 }
 
 export function AfterInitialMount({children, fallback = null}: Props) {
+  usePerformanceBenchmark('AfterInitialMount');
   const isMounted = useIsAfterInitialMount();
   const content = isMounted ? children : fallback;
 

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -24,7 +24,7 @@ import {
   UniqueIdFactoryContext,
   globalIdGeneratorFactory,
 } from '../../utilities/unique-id';
-
+import {PerformanceBenchmark} from '../PerformanceBenchmark';
 import './AppProvider.scss';
 
 interface State {
@@ -111,23 +111,25 @@ export class AppProvider extends Component<AppProviderProps, State> {
 
     return (
       <FeaturesContext.Provider value={features}>
-        <I18nContext.Provider value={intl}>
-          <ScrollLockManagerContext.Provider value={this.scrollLockManager}>
-            <StickyManagerContext.Provider value={this.stickyManager}>
-              <UniqueIdFactoryContext.Provider value={this.uniqueIdFactory}>
-                <LinkContext.Provider value={link}>
-                  <CustomProperties colorScheme={colorScheme}>
-                    <MediaQueryProvider>
-                      <PortalsManager>
-                        <FocusManager>{children}</FocusManager>
-                      </PortalsManager>
-                    </MediaQueryProvider>
-                  </CustomProperties>
-                </LinkContext.Provider>
-              </UniqueIdFactoryContext.Provider>
-            </StickyManagerContext.Provider>
-          </ScrollLockManagerContext.Provider>
-        </I18nContext.Provider>
+        <PerformanceBenchmark name="AppProvider">
+          <I18nContext.Provider value={intl}>
+            <ScrollLockManagerContext.Provider value={this.scrollLockManager}>
+              <StickyManagerContext.Provider value={this.stickyManager}>
+                <UniqueIdFactoryContext.Provider value={this.uniqueIdFactory}>
+                  <LinkContext.Provider value={link}>
+                    <CustomProperties colorScheme={colorScheme}>
+                      <MediaQueryProvider>
+                        <PortalsManager>
+                          <FocusManager>{children}</FocusManager>
+                        </PortalsManager>
+                      </MediaQueryProvider>
+                    </CustomProperties>
+                  </LinkContext.Provider>
+                </UniqueIdFactoryContext.Provider>
+              </StickyManagerContext.Provider>
+            </ScrollLockManagerContext.Provider>
+          </I18nContext.Provider>
+        </PerformanceBenchmark>
       </FeaturesContext.Provider>
     );
   }

--- a/polaris-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/polaris-react/src/components/Autocomplete/Autocomplete.tsx
@@ -10,6 +10,7 @@ import {isSection} from '../../utilities/options';
 import {useI18n} from '../../utilities/i18n';
 import {Combobox} from '../Combobox';
 import {Listbox, AutoSelection} from '../Listbox';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {MappedAction, MappedOption} from './components';
 import styles from './Autocomplete.scss';
@@ -67,6 +68,7 @@ export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
   onSelect,
   onLoadMoreResults,
 }: AutocompleteProps) {
+  usePerformanceBenchmark('Autocomplete');
   const i18n = useI18n();
 
   const buildMappedOptionFromOption = useCallback(

--- a/polaris-react/src/components/Avatar/Avatar.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.tsx
@@ -3,6 +3,7 @@ import React, {useState, useCallback, useEffect} from 'react';
 import {classNames, variationName} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 import {Image} from '../Image';
 
 import styles from './Avatar.scss';
@@ -46,6 +47,7 @@ export function Avatar({
   size = 'medium',
   accessibilityLabel,
 }: AvatarProps) {
+  usePerformanceBenchmark('Avatar');
   const i18n = useI18n();
   const isAfterInitialMount = useIsAfterInitialMount();
 

--- a/polaris-react/src/components/Backdrop/Backdrop.tsx
+++ b/polaris-react/src/components/Backdrop/Backdrop.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 import {ScrollLock} from '../ScrollLock';
 
 import styles from './Backdrop.scss';
@@ -13,6 +14,7 @@ export interface BackdropProps {
 }
 
 export function Backdrop(props: BackdropProps) {
+  usePerformanceBenchmark('Backdrop');
   const {onClick, onTouchStart, belowNavigation, transparent} = props;
 
   const className = classNames(

--- a/polaris-react/src/components/Badge/Badge.tsx
+++ b/polaris-react/src/components/Badge/Badge.tsx
@@ -6,6 +6,7 @@ import {WithinFilterContext} from '../../utilities/within-filter-context';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {Icon} from '../Icon';
 import type {IconSource} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Badge.scss';
 import type {Progress, Size, Status} from './types';
@@ -45,6 +46,7 @@ export function Badge({
   size = DEFAULT_SIZE,
   statusAndProgressLabelOverride,
 }: BadgeProps) {
+  usePerformanceBenchmark('Badge');
   const i18n = useI18n();
   const withinFilter = useContext(WithinFilterContext);
 

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -26,6 +26,7 @@ import {UnstyledLink} from '../UnstyledLink';
 import {Spinner} from '../Spinner';
 import {Icon, IconProps} from '../Icon';
 import {WithinContentContext} from '../../utilities/within-content-context';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Banner.scss';
 
@@ -63,6 +64,7 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
   }: BannerProps,
   bannerRef,
 ) {
+  usePerformanceBenchmark('Banner');
   const withinContentContainer = useContext(WithinContentContext);
   const id = useUniqueId('Banner');
   const i18n = useI18n();

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,6 +6,7 @@ import {UnstyledLink} from '../UnstyledLink';
 import type {CallbackAction, LinkAction} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {VisuallyHidden} from '../VisuallyHidden';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Breadcrumbs.scss';
 
@@ -15,6 +16,7 @@ export interface BreadcrumbsProps {
 }
 
 export function Breadcrumbs({breadcrumbs}: BreadcrumbsProps) {
+  usePerformanceBenchmark('Breadcrumbs');
   const breadcrumb = breadcrumbs[breadcrumbs.length - 1];
   if (breadcrumb == null) {
     return null;

--- a/polaris-react/src/components/BulkActions/BulkActions.tsx
+++ b/polaris-react/src/components/BulkActions/BulkActions.tsx
@@ -20,6 +20,7 @@ import {ButtonGroup} from '../ButtonGroup';
 import {CheckableButton} from '../CheckableButton';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
+import {PerformanceBenchmark} from '../PerformanceBenchmark';
 
 import {BulkActionButton, BulkActionMenu} from './components';
 import styles from './BulkActions.scss';
@@ -492,10 +493,12 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
     );
 
     return (
-      <div ref={this.setContainerNode}>
-        {smallScreenGroup}
-        {largeScreenGroup}
-      </div>
+      <PerformanceBenchmark name="BulkActions">
+        <div ref={this.setContainerNode}>
+          {smallScreenGroup}
+          {largeScreenGroup}
+        </div>
+      </PerformanceBenchmark>
     );
   }
 

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -17,6 +17,7 @@ import {Spinner} from '../Spinner';
 import {Popover} from '../Popover';
 import {ActionList} from '../ActionList';
 import {UnstyledButton, UnstyledButtonProps} from '../UnstyledButton';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Button.scss';
 
@@ -126,6 +127,7 @@ export function Button({
   fullWidth,
   connectedDisclosure,
 }: ButtonProps) {
+  usePerformanceBenchmark('Button');
   const i18n = useI18n();
 
   const isDisabled = disabled || loading;

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {classNames} from '../../utilities/css';
 import {elementChildren} from '../../utilities/components';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Item} from './components';
 import styles from './ButtonGroup.scss';
@@ -28,6 +29,7 @@ export function ButtonGroup({
   fullWidth,
   connectedTop,
 }: ButtonGroupProps) {
+  usePerformanceBenchmark('ButtonGroup');
   const className = classNames(
     styles.ButtonGroup,
     spacing && styles[spacing],

--- a/polaris-react/src/components/CalloutCard/CalloutCard.tsx
+++ b/polaris-react/src/components/CalloutCard/CalloutCard.tsx
@@ -9,6 +9,7 @@ import {ButtonGroup} from '../ButtonGroup';
 import {Button, buttonFrom} from '../Button';
 import {Heading} from '../Heading';
 import {Image} from '../Image';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './CalloutCard.scss';
 
@@ -35,6 +36,7 @@ export function CalloutCard({
   secondaryAction,
   onDismiss,
 }: CalloutCardProps) {
+  usePerformanceBenchmark('CalloutCard');
   const primaryActionMarkup = buttonFrom(primaryAction);
   const secondaryActionMarkup = secondaryAction
     ? buttonFrom(secondaryAction, {plain: true})

--- a/polaris-react/src/components/Caption/Caption.tsx
+++ b/polaris-react/src/components/Caption/Caption.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import styles from './Caption.scss';
 
 export interface CaptionProps {
@@ -8,5 +10,6 @@ export interface CaptionProps {
 }
 
 export function Caption({children}: CaptionProps) {
+  usePerformanceBenchmark('Caption');
   return <p className={styles.Caption}>{children}</p>;
 }

--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -9,6 +9,7 @@ import type {DisableableAction, ComplexAction} from '../../types';
 import {ActionList} from '../ActionList';
 import {Button, buttonFrom} from '../Button';
 import {Popover} from '../Popover';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Header, Section, Subsection} from './components';
 import styles from './Card.scss';
@@ -63,6 +64,7 @@ export const Card: React.FunctionComponent<CardProps> & {
   secondaryFooterActionsDisclosureText,
   footerActionAlignment = 'right',
 }: CardProps) {
+  usePerformanceBenchmark('Card');
   const i18n = useI18n();
   const {
     value: secondaryActionsPopoverOpen,

--- a/polaris-react/src/components/CheckableButton/CheckableButton.tsx
+++ b/polaris-react/src/components/CheckableButton/CheckableButton.tsx
@@ -7,6 +7,7 @@ import {
   ResourceListContext,
   CheckableButtonKey,
 } from '../../utilities/resource-list';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './CheckableButton.scss';
 
@@ -33,6 +34,7 @@ export function CheckableButton({
   disabled,
   smallScreen,
 }: CheckableButtonProps) {
+  usePerformanceBenchmark('CheckableButton');
   const checkBoxRef = useRef<CheckboxHandles>(null);
 
   const {registerCheckableButtons} = useContext(ResourceListContext);

--- a/polaris-react/src/components/Checkbox/Checkbox.tsx
+++ b/polaris-react/src/components/Checkbox/Checkbox.tsx
@@ -15,6 +15,7 @@ import {errorTextID} from '../InlineError';
 import {Icon} from '../Icon';
 import {Error, CheckboxHandles, Key} from '../../types';
 import {WithinListboxContext} from '../../utilities/listbox/context';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Checkbox.scss';
 
@@ -69,6 +70,7 @@ export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
     }: CheckboxProps,
     ref,
   ) {
+    usePerformanceBenchmark('Checkbox');
     const inputNode = useRef<HTMLInputElement>(null);
     const id = useUniqueId('Checkbox', idProp);
     const {

--- a/polaris-react/src/components/Choice/Choice.tsx
+++ b/polaris-react/src/components/Choice/Choice.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {classNames} from '../../utilities/css';
 import type {Error} from '../../types';
 import {InlineError} from '../InlineError';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Choice.scss';
 
@@ -41,6 +42,7 @@ export function Choice({
   onMouseOut,
   onMouseOver,
 }: ChoiceProps) {
+  usePerformanceBenchmark('Choice');
   const className = classNames(
     styles.Choice,
     labelHidden && styles.labelHidden,

--- a/polaris-react/src/components/ChoiceList/ChoiceList.tsx
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.tsx
@@ -6,6 +6,7 @@ import type {Error} from '../../types';
 import {Checkbox} from '../Checkbox';
 import {RadioButton} from '../RadioButton';
 import {InlineError, errorTextID} from '../InlineError';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './ChoiceList.scss';
 
@@ -56,6 +57,7 @@ export function ChoiceList({
   disabled = false,
   name: nameProp,
 }: ChoiceListProps) {
+  usePerformanceBenchmark('ChoiceList');
   // Type asserting to any is required for TS3.2 but can be removed when we update to 3.3
   // see https://github.com/Microsoft/TypeScript/issues/28768
   const ControlComponent: any = allowMultiple ? Checkbox : RadioButton;

--- a/polaris-react/src/components/Collapsible/Collapsible.tsx
+++ b/polaris-react/src/components/Collapsible/Collapsible.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useRef, useEffect, useCallback} from 'react';
 
 import {classNames} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Collapsible.scss';
 
@@ -33,6 +34,7 @@ export function Collapsible({
   transition,
   children,
 }: CollapsibleProps) {
+  usePerformanceBenchmark('Collapsible');
   const [height, setHeight] = useState(0);
   const [isOpen, setIsOpen] = useState(open);
   const [animationState, setAnimationState] = useState<AnimationState>('idle');

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -7,6 +7,7 @@ import {hsbToRgb} from '../../utilities/color-transformers';
 import type {HSBColor, HSBAColor} from '../../utilities/color-types';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
+import {PerformanceBenchmark} from '../PerformanceBenchmark';
 
 import {AlphaPicker, HuePicker, Slidable, SlidableProps} from './components';
 import styles from './ColorPicker.scss';
@@ -120,22 +121,24 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
     );
 
     return (
-      <div className={className} id={id} onMouseDown={this.handlePickerDrag}>
-        <div ref={this.setColorNode} className={styles.MainColor}>
-          <div
-            className={styles.ColorLayer}
-            style={{backgroundColor: colorString}}
-          />
-          <Slidable
-            onChange={this.handleDraggerMove}
-            draggerX={draggerX}
-            draggerY={draggerY}
-          />
+      <PerformanceBenchmark name="ColorPicker">
+        <div className={className} id={id} onMouseDown={this.handlePickerDrag}>
+          <div ref={this.setColorNode} className={styles.MainColor}>
+            <div
+              className={styles.ColorLayer}
+              style={{backgroundColor: colorString}}
+            />
+            <Slidable
+              onChange={this.handleDraggerMove}
+              draggerX={draggerX}
+              draggerY={draggerY}
+            />
+          </div>
+          <HuePicker hue={hue} onChange={this.handleHueChange} />
+          {alphaSliderMarkup}
+          <EventListener event="resize" handler={this.handleResize} />
         </div>
-        <HuePicker hue={hue} onChange={this.handleHueChange} />
-        {alphaSliderMarkup}
-        <EventListener event="resize" handler={this.handleResize} />
-      </div>
+      </PerformanceBenchmark>
     );
   }
 

--- a/polaris-react/src/components/Combobox/Combobox.tsx
+++ b/polaris-react/src/components/Combobox/Combobox.tsx
@@ -12,6 +12,7 @@ import {
   ComboboxListboxOptionType,
   ComboboxListboxOptionContext,
 } from '../../utilities/combobox';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Combobox.scss';
 import {TextField} from './components';
@@ -45,6 +46,7 @@ export function Combobox({
   onScrolledToBottom,
   onClose,
 }: ComboboxProps) {
+  usePerformanceBenchmark('Combobox');
   const [popoverActive, setPopoverActive] = useState(false);
   const [activeOptionId, setActiveOptionId] = useState<string>();
   const [textFieldLabelId, setTextFieldLabelId] = useState<string>();

--- a/polaris-react/src/components/Connected/Connected.tsx
+++ b/polaris-react/src/components/Connected/Connected.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import {Item} from './components';
 import styles from './Connected.scss';
 
@@ -13,6 +15,7 @@ export interface ConnectedProps {
 }
 
 export function Connected({children, left, right}: ConnectedProps) {
+  usePerformanceBenchmark('Connected');
   const leftConnectionMarkup = left ? (
     <Item position="left">{left}</Item>
   ) : null;

--- a/polaris-react/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/polaris-react/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -4,6 +4,7 @@ import {
   ContextualSaveBarProps as ContextualSaveBarProps1,
   useFrame,
 } from '../../utilities/frame';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 // The script in the styleguide that generates the Props Explorer data expects
 // that the interface defining the props is defined in this file, not imported
@@ -20,6 +21,7 @@ export const ContextualSaveBar = memo(function ContextualSaveBar({
   contextControl,
   secondaryMenu,
 }: ContextualSaveBarProps) {
+  usePerformanceBenchmark('ContextualSaveBar');
   const {setContextualSaveBar, removeContextualSaveBar} = useFrame();
 
   useEffect(() => {

--- a/polaris-react/src/components/CustomProperties/CustomProperties.tsx
+++ b/polaris-react/src/components/CustomProperties/CustomProperties.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import type {ColorScheme} from '../../tokens';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {styles} from './styles';
 
@@ -20,6 +21,7 @@ export interface CustomPropertiesProps {
 }
 
 export function CustomProperties(props: CustomPropertiesProps) {
+  usePerformanceBenchmark('CustomProperties');
   const {
     as: Component = 'div',
     children,

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -9,6 +9,7 @@ import {headerCell} from '../shared';
 import {EventListener} from '../EventListener';
 import {AfterInitialMount} from '../AfterInitialMount';
 import {Sticky} from '../Sticky';
+import {PerformanceBenchmark} from '../PerformanceBenchmark';
 
 import {Cell, CellProps, Navigation} from './components';
 import {measureColumn, getPrevAndCurrentColumns} from './utilities';
@@ -293,30 +294,32 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     ) : null;
 
     return (
-      <div className={wrapperClassName}>
-        {navigationMarkup}
-        <div className={className} ref={this.dataTable}>
-          {stickyHeaderMarkup}
-          <div className={styles.ScrollContainer} ref={this.scrollContainer}>
-            <EventListener event="resize" handler={this.handleResize} />
-            <EventListener
-              capture
-              passive
-              event="scroll"
-              handler={this.scrollListener}
-            />
-            <table className={styles.Table} ref={this.table}>
-              <thead>
-                {headingMarkup}
-                {headerTotalsMarkup}
-              </thead>
-              <tbody>{bodyMarkup}</tbody>
-              {footerTotalsMarkup}
-            </table>
+      <PerformanceBenchmark name="DataTable">
+        <div className={wrapperClassName}>
+          {navigationMarkup}
+          <div className={className} ref={this.dataTable}>
+            {stickyHeaderMarkup}
+            <div className={styles.ScrollContainer} ref={this.scrollContainer}>
+              <EventListener event="resize" handler={this.handleResize} />
+              <EventListener
+                capture
+                passive
+                event="scroll"
+                handler={this.scrollListener}
+              />
+              <table className={styles.Table} ref={this.table}>
+                <thead>
+                  {headingMarkup}
+                  {headerTotalsMarkup}
+                </thead>
+                <tbody>{bodyMarkup}</tbody>
+                {footerTotalsMarkup}
+              </table>
+            </div>
+            {footerMarkup}
           </div>
-          {footerMarkup}
         </div>
-      </div>
+      </PerformanceBenchmark>
     );
   }
 

--- a/polaris-react/src/components/DatePicker/DatePicker.tsx
+++ b/polaris-react/src/components/DatePicker/DatePicker.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../utilities/dates';
 import type {Range} from '../../utilities/dates';
 import {useI18n} from '../../utilities/i18n';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {monthName} from './utilities';
 import {Month} from './components';
@@ -68,6 +69,7 @@ export function DatePicker({
   onMonthChange,
   onChange = noop,
 }: DatePickerProps) {
+  usePerformanceBenchmark('DatePicker');
   const i18n = useI18n();
   const [hoverDate, setHoverDate] = useState<Date | undefined>(undefined);
   const [focusDate, setFocusDate] = useState<Date | undefined>(undefined);

--- a/polaris-react/src/components/DescriptionList/DescriptionList.tsx
+++ b/polaris-react/src/components/DescriptionList/DescriptionList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './DescriptionList.scss';
 
@@ -22,6 +23,7 @@ export function DescriptionList({
   items,
   spacing = 'loose',
 }: DescriptionListProps) {
+  usePerformanceBenchmark('DescriptionList');
   // There's no good key to give React so using the index is a last resport.
   // we can't use the term/description value as it may be a react component
   // which can't be stringified

--- a/polaris-react/src/components/DisplayText/DisplayText.tsx
+++ b/polaris-react/src/components/DisplayText/DisplayText.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
 import type {HeadingTagName} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './DisplayText.scss';
 
@@ -27,6 +28,7 @@ export function DisplayText({
   children,
   size = 'medium',
 }: DisplayTextProps) {
+  usePerformanceBenchmark('DisplayText');
   const className = classNames(
     styles.DisplayText,
     size && styles[variationName('size', size)],

--- a/polaris-react/src/components/DropZone/DropZone.tsx
+++ b/polaris-react/src/components/DropZone/DropZone.tsx
@@ -24,6 +24,7 @@ import {isServer} from '../../utilities/target';
 import {useUniqueId} from '../../utilities/unique-id';
 import {useComponentDidMount} from '../../utilities/use-component-did-mount';
 import {useToggle} from '../../utilities/use-toggle';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {FileUpload} from './components';
 import {DropZoneContext} from './context';
@@ -142,6 +143,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
   onDragOver,
   onDragLeave,
 }: DropZoneProps) {
+  usePerformanceBenchmark('DropZone');
   const node = useRef<HTMLDivElement>(null);
   const dragTargets = useRef<EventTarget[]>([]);
 

--- a/polaris-react/src/components/EmptySearchResult/EmptySearchResult.tsx
+++ b/polaris-react/src/components/EmptySearchResult/EmptySearchResult.tsx
@@ -5,6 +5,7 @@ import {DisplayText} from '../DisplayText';
 import {TextStyle} from '../TextStyle';
 import {Image} from '../Image';
 import {Stack} from '../Stack';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {emptySearch} from './illustrations';
 
@@ -19,6 +20,7 @@ export function EmptySearchResult({
   description,
   withIllustration,
 }: EmptySearchResultProps) {
+  usePerformanceBenchmark('EmptySearchResult');
   const i18n = useI18n();
   const altText = i18n.translate('Polaris.EmptySearchResult.altText');
 

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -8,6 +8,7 @@ import {buttonFrom} from '../Button';
 import {Stack} from '../Stack';
 import {TextContainer} from '../TextContainer';
 import {DisplayText} from '../DisplayText';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './EmptyState.scss';
 
@@ -46,6 +47,7 @@ export function EmptyState({
   secondaryAction,
   footerContent,
 }: EmptyStateProps) {
+  usePerformanceBenchmark('EmptyState');
   const withinContentContainer = useContext(WithinContentContext);
   const className = classNames(
     styles.EmptyState,

--- a/polaris-react/src/components/ExceptionList/ExceptionList.tsx
+++ b/polaris-react/src/components/ExceptionList/ExceptionList.tsx
@@ -1,6 +1,7 @@
 import React, {Fragment} from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 import {Icon, IconProps} from '../Icon';
 import {Truncate} from '../Truncate';
 
@@ -30,6 +31,7 @@ export interface ExceptionListProps {
 }
 
 export function ExceptionList({items: itemsList}: ExceptionListProps) {
+  usePerformanceBenchmark('ExceptionList');
   const items = itemsList.map((item, index) => {
     const {status, icon, title, description, truncate = false} = item;
 

--- a/polaris-react/src/components/Filters/Filters.tsx
+++ b/polaris-react/src/components/Filters/Filters.tsx
@@ -28,6 +28,7 @@ import {Sheet} from '../Sheet';
 import {Stack} from '../Stack';
 import {Key} from '../../types';
 import {KeypressListener} from '../KeypressListener';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {
   ConnectedFilterControl,
@@ -601,6 +602,7 @@ function getShortcutFilters(filters: FilterInterface[]) {
 }
 
 export function Filters(props: FiltersProps) {
+  usePerformanceBenchmark('Filters');
   const i18n = useI18n();
   const mediaQuery = useMediaQuery();
 

--- a/polaris-react/src/components/Focus/Focus.tsx
+++ b/polaris-react/src/components/Focus/Focus.tsx
@@ -1,6 +1,7 @@
 import React, {memo, useEffect} from 'react';
 
 import {focusFirstFocusableNode} from '../../utilities/focus';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export interface FocusProps {
   children?: React.ReactNode;
@@ -13,6 +14,7 @@ export const Focus = memo(function Focus({
   disabled,
   root,
 }: FocusProps) {
+  usePerformanceBenchmark('Focus');
   useEffect(() => {
     if (disabled || !root) {
       return;

--- a/polaris-react/src/components/FocusManager/FocusManager.tsx
+++ b/polaris-react/src/components/FocusManager/FocusManager.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo, useState, useCallback, ContextType} from 'react';
 
 import {FocusManagerContext} from '../../utilities/focus-manager';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 interface Props {
   children?: React.ReactNode;
@@ -9,6 +10,7 @@ interface Props {
 type Context = NonNullable<ContextType<typeof FocusManagerContext>>;
 
 export function FocusManager({children}: Props) {
+  usePerformanceBenchmark('FocusManager');
   const [trapFocusList, setTrapFocusList] = useState<string[]>([]);
 
   const add = useCallback<Context['add']>((id) => {

--- a/polaris-react/src/components/FooterHelp/FooterHelp.tsx
+++ b/polaris-react/src/components/FooterHelp/FooterHelp.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import styles from './FooterHelp.scss';
 
 export interface FooterHelpProps {
@@ -8,6 +10,7 @@ export interface FooterHelpProps {
 }
 
 export function FooterHelp({children}: FooterHelpProps) {
+  usePerformanceBenchmark('FooterHelp');
   return (
     <div className={styles.FooterHelp}>
       <div className={styles.Text}>{children}</div>

--- a/polaris-react/src/components/Form/Form.tsx
+++ b/polaris-react/src/components/Form/Form.tsx
@@ -2,6 +2,7 @@ import React, {useCallback} from 'react';
 
 import {VisuallyHidden} from '../VisuallyHidden';
 import {useI18n} from '../../utilities/i18n';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 type Enctype =
   | 'application/x-www-form-urlencoded'
@@ -53,6 +54,7 @@ export function Form({
   target,
   onSubmit,
 }: FormProps) {
+  usePerformanceBenchmark('Form');
   const i18n = useI18n();
 
   const handleSubmit = useCallback(

--- a/polaris-react/src/components/FormLayout/FormLayout.tsx
+++ b/polaris-react/src/components/FormLayout/FormLayout.tsx
@@ -1,6 +1,7 @@
 import React, {memo, Children, NamedExoticComponent} from 'react';
 
 import {wrapWithComponent, isElementOfType} from '../../utilities/components';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Group, Item} from './components';
 import styles from './FormLayout.scss';
@@ -13,6 +14,7 @@ export interface FormLayoutProps {
 export const FormLayout = memo(function FormLayout({
   children,
 }: FormLayoutProps) {
+  usePerformanceBenchmark('FormLayout');
   return (
     <div className={styles.FormLayout}>
       {Children.map(children, wrapChildren)}

--- a/polaris-react/src/components/Frame/Frame.tsx
+++ b/polaris-react/src/components/Frame/Frame.tsx
@@ -20,6 +20,7 @@ import {
   ToastID,
   ToastPropsWithID,
 } from '../../utilities/frame';
+import {PerformanceBenchmark} from '../PerformanceBenchmark';
 
 import {
   ToastManager,
@@ -263,30 +264,32 @@ class FrameInner extends PureComponent<CombinedProps, State> {
     };
 
     return (
-      <FrameContext.Provider value={context}>
-        <div
-          className={frameClassName}
-          {...layer.props}
-          {...navigationAttributes}
-        >
-          {skipMarkup}
-          {topBarMarkup}
-          {navigationMarkup}
-          {contextualSaveBarMarkup}
-          {loadingMarkup}
-          {navigationOverlayMarkup}
-          <main
-            className={styles.Main}
-            id={APP_FRAME_MAIN}
-            data-has-global-ribbon={Boolean(globalRibbon)}
+      <PerformanceBenchmark name="Frame">
+        <FrameContext.Provider value={context}>
+          <div
+            className={frameClassName}
+            {...layer.props}
+            {...navigationAttributes}
           >
-            <div className={styles.Content}>{children}</div>
-          </main>
-          <ToastManager toastMessages={toastMessages} />
-          {globalRibbonMarkup}
-          <EventListener event="resize" handler={this.handleResize} />
-        </div>
-      </FrameContext.Provider>
+            {skipMarkup}
+            {topBarMarkup}
+            {navigationMarkup}
+            {contextualSaveBarMarkup}
+            {loadingMarkup}
+            {navigationOverlayMarkup}
+            <main
+              className={styles.Main}
+              id={APP_FRAME_MAIN}
+              data-has-global-ribbon={Boolean(globalRibbon)}
+            >
+              <div className={styles.Content}>{children}</div>
+            </main>
+            <ToastManager toastMessages={toastMessages} />
+            {globalRibbonMarkup}
+            <EventListener event="resize" handler={this.handleResize} />
+          </div>
+        </FrameContext.Provider>
+      </PerformanceBenchmark>
     );
   }
 

--- a/polaris-react/src/components/Heading/Heading.tsx
+++ b/polaris-react/src/components/Heading/Heading.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import type {HeadingTagName} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Heading.scss';
 
@@ -17,6 +18,7 @@ export interface HeadingProps {
 }
 
 export function Heading({element: Element = 'h2', children, id}: HeadingProps) {
+  usePerformanceBenchmark('Heading');
   return (
     <Element className={styles.Heading} id={id}>
       {children}

--- a/polaris-react/src/components/Icon/Icon.tsx
+++ b/polaris-react/src/components/Icon/Icon.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {classNames, variationName} from '../../utilities/css';
 import type {IconSource} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Icon.scss';
 
@@ -36,6 +37,7 @@ export interface IconProps {
 }
 
 export function Icon({source, color, backdrop, accessibilityLabel}: IconProps) {
+  usePerformanceBenchmark('Icon');
   let sourceType: 'function' | 'placeholder' | 'external';
   if (typeof source === 'function') {
     sourceType = 'function';

--- a/polaris-react/src/components/Image/Image.tsx
+++ b/polaris-react/src/components/Image/Image.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 interface SourceSet {
   source: string;
   descriptor?: string;
@@ -17,6 +19,7 @@ export interface ImageProps extends React.HTMLProps<HTMLImageElement> {
 }
 
 export function Image({sourceSet, source, crossOrigin, ...rest}: ImageProps) {
+  usePerformanceBenchmark('Image');
   const finalSourceSet = sourceSet
     ? sourceSet
         .map(({source: subSource, descriptor}) => `${subSource} ${descriptor}`)

--- a/polaris-react/src/components/IndexProvider/IndexProvider.tsx
+++ b/polaris-react/src/components/IndexProvider/IndexProvider.tsx
@@ -8,6 +8,7 @@ import {
   useBulkSelectionData,
   useHandleBulkSelection,
 } from '../../utilities/index-provider';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export function IndexProvider({
   children,
@@ -20,6 +21,7 @@ export function IndexProvider({
   condensed,
   selectable: isSelectableIndex = true,
 }: IndexProviderProps) {
+  usePerformanceBenchmark('IndexProvider');
   const {
     paginatedSelectAllText,
     bulkActionsLabel,

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -28,6 +28,7 @@ import {
 import {AfterInitialMount} from '../AfterInitialMount';
 import {IndexProvider} from '../IndexProvider';
 import type {NonEmptyArray} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {getTableHeadingsBySelector} from './utilities';
 import {ScrollContainer, Cell, Row} from './components';
@@ -796,6 +797,7 @@ export function IndexTable({
   onSelectionChange,
   ...indexTableBaseProps
 }: IndexTableProps) {
+  usePerformanceBenchmark('IndexTable');
   return (
     <IndexProvider
       selectable={selectable}

--- a/polaris-react/src/components/Indicator/Indicator.tsx
+++ b/polaris-react/src/components/Indicator/Indicator.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Indicator.scss';
 
@@ -9,6 +10,7 @@ export interface IndicatorProps {
 }
 
 export function Indicator({pulse = true}: IndicatorProps) {
+  usePerformanceBenchmark('Indicator');
   const className = classNames(
     styles.Indicator,
     pulse && styles.pulseIndicator,

--- a/polaris-react/src/components/InlineError/InlineError.tsx
+++ b/polaris-react/src/components/InlineError/InlineError.tsx
@@ -3,6 +3,7 @@ import {AlertMinor} from '@shopify/polaris-icons';
 
 import {Icon} from '../Icon';
 import type {Error} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './InlineError.scss';
 
@@ -14,6 +15,7 @@ export interface InlineErrorProps {
 }
 
 export function InlineError({message, fieldID}: InlineErrorProps) {
+  usePerformanceBenchmark('InlineError');
   if (!message) {
     return null;
   }

--- a/polaris-react/src/components/KeyboardKey/KeyboardKey.tsx
+++ b/polaris-react/src/components/KeyboardKey/KeyboardKey.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import styles from './KeyboardKey.scss';
 
 export interface KeyboardKeyProps {
@@ -8,6 +10,7 @@ export interface KeyboardKeyProps {
 }
 
 export function KeyboardKey({children}: KeyboardKeyProps) {
+  usePerformanceBenchmark('KeyboardKey');
   let key = children || '';
   key = key.length > 1 ? key.toLowerCase() : key.toUpperCase();
 

--- a/polaris-react/src/components/KeypressListener/KeypressListener.tsx
+++ b/polaris-react/src/components/KeypressListener/KeypressListener.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useRef} from 'react';
 
 import {useIsomorphicLayoutEffect} from '../../utilities/use-isomorphic-layout-effect';
 import type {Key} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export interface NonMutuallyExclusiveProps {
   keyCode: Key;
@@ -24,6 +25,7 @@ export function KeypressListener({
   options,
   useCapture,
 }: KeypressListenerProps) {
+  usePerformanceBenchmark('KeypressListener');
   const tracked = useRef({handler, keyCode});
 
   useIsomorphicLayoutEffect(() => {

--- a/polaris-react/src/components/KonamiCode/KonamiCode.tsx
+++ b/polaris-react/src/components/KonamiCode/KonamiCode.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
 
 import {Key} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export interface KonamiCodeProps {
   handler(event: KeyboardEvent): void;
@@ -20,6 +21,7 @@ export const KONAMI_CODE = [
 ];
 
 export function KonamiCode({handler}: KonamiCodeProps) {
+  usePerformanceBenchmark('KonamiCode');
   const keyEvent = 'keydown';
   const [position, setPosition] = useState(0);
 

--- a/polaris-react/src/components/Label/Label.tsx
+++ b/polaris-react/src/components/Label/Label.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Label.scss';
 
@@ -20,6 +21,7 @@ export function labelID(id: string) {
 }
 
 export function Label({children, id, hidden, requiredIndicator}: LabelProps) {
+  usePerformanceBenchmark('Label');
   const className = classNames(styles.Label, hidden && styles.hidden);
 
   return (

--- a/polaris-react/src/components/Labelled/Labelled.tsx
+++ b/polaris-react/src/components/Labelled/Labelled.tsx
@@ -5,6 +5,7 @@ import type {Action, Error} from '../../types';
 import {buttonFrom} from '../Button';
 import {Label, LabelProps, labelID} from '../Label';
 import {InlineError} from '../InlineError';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Labelled.scss';
 
@@ -40,6 +41,7 @@ export function Labelled({
   requiredIndicator,
   ...rest
 }: LabelledProps) {
+  usePerformanceBenchmark('Labelled');
   const className = classNames(labelHidden && styles.hidden);
 
   const actionMarkup = action ? (

--- a/polaris-react/src/components/Layout/Layout.tsx
+++ b/polaris-react/src/components/Layout/Layout.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import {AnnotatedSection, Section} from './components';
 import styles from './Layout.scss';
 
@@ -14,6 +16,7 @@ export const Layout: React.FunctionComponent<LayoutProps> & {
   AnnotatedSection: typeof AnnotatedSection;
   Section: typeof Section;
 } = function Layout({sectioned, children}: LayoutProps) {
+  usePerformanceBenchmark('Layout');
   const content = sectioned ? <Section>{children}</Section> : children;
   return <div className={styles.Layout}>{content}</div>;
 };

--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -6,6 +6,7 @@ import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {UnstyledLink} from '../UnstyledLink';
 import {Icon} from '../Icon';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Link.scss';
 
@@ -38,6 +39,7 @@ export function Link({
   removeUnderline,
   accessibilityLabel,
 }: LinkProps) {
+  usePerformanceBenchmark('Link');
   const i18n = useI18n();
   let childrenMarkup = children;
 

--- a/polaris-react/src/components/List/List.tsx
+++ b/polaris-react/src/components/List/List.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Item} from './components';
 import styles from './List.scss';
@@ -20,6 +21,7 @@ export interface ListProps {
 export const List: React.FunctionComponent<ListProps> & {
   Item: typeof Item;
 } = function List({children, type = 'bullet'}: ListProps) {
+  usePerformanceBenchmark('List');
   const className = classNames(
     styles.List,
     type && styles[variationName('type', type)],

--- a/polaris-react/src/components/Listbox/Listbox.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.tsx
@@ -22,6 +22,7 @@ import {Key} from '../../types';
 import {KeypressListener} from '../KeypressListener';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {scrollable} from '../shared';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {
   Option,
@@ -75,6 +76,7 @@ export function Listbox({
   onSelect,
   onActiveOptionChange,
 }: ListboxProps) {
+  usePerformanceBenchmark('Listbox');
   const [loading, setLoading] = useState<string>();
   const [activeOption, setActiveOption] = useState<NavigableOption>();
   const [lazyLoading, setLazyLoading] = useState(false);

--- a/polaris-react/src/components/Loading/Loading.tsx
+++ b/polaris-react/src/components/Loading/Loading.tsx
@@ -1,10 +1,12 @@
 import {memo, useEffect} from 'react';
 
 import {useFrame} from '../../utilities/frame';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export interface LoadingProps {}
 
 export const Loading = memo(function Loading() {
+  usePerformanceBenchmark('Loading');
   const {startLoading, stopLoading} = useFrame();
 
   useEffect(() => {

--- a/polaris-react/src/components/MediaCard/MediaCard.tsx
+++ b/polaris-react/src/components/MediaCard/MediaCard.tsx
@@ -12,6 +12,7 @@ import {Popover} from '../Popover';
 import {ActionList} from '../ActionList';
 import {ButtonGroup} from '../ButtonGroup';
 import {Stack} from '../Stack';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './MediaCard.scss';
 
@@ -50,6 +51,7 @@ export function MediaCard({
   portrait = false,
   size = 'medium',
 }: MediaCardProps) {
+  usePerformanceBenchmark('MediaCard');
   const i18n = useI18n();
   const {value: popoverActive, toggle: togglePopoverActive} = useToggle(false);
 

--- a/polaris-react/src/components/MediaQueryProvider/MediaQueryProvider.tsx
+++ b/polaris-react/src/components/MediaQueryProvider/MediaQueryProvider.tsx
@@ -5,6 +5,7 @@ import {MediaQueryContext} from '../../utilities/media-query';
 import {navigationBarCollapsed} from '../../utilities/breakpoints';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 interface Props {
   children?: React.ReactNode;
@@ -13,6 +14,7 @@ interface Props {
 export const MediaQueryProvider = function MediaQueryProvider({
   children,
 }: Props) {
+  usePerformanceBenchmark('MediaQueryProvider');
   const [isNavigationCollapsed, setIsNavigationCollapsed] = useState(
     navigationBarCollapsed().matches,
   );

--- a/polaris-react/src/components/MessageIndicator/MessageIndicator.tsx
+++ b/polaris-react/src/components/MessageIndicator/MessageIndicator.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import styles from './MessageIndicator.scss';
 
 export interface MessageIndicatorProps {
@@ -8,6 +10,7 @@ export interface MessageIndicatorProps {
 }
 
 export function MessageIndicator({children, active}: MessageIndicatorProps) {
+  usePerformanceBenchmark('MessageIndicator');
   const indicatorMarkup = active && <div className={styles.MessageIndicator} />;
 
   return (

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -10,6 +10,7 @@ import {Backdrop} from '../Backdrop';
 import {Scrollable} from '../Scrollable';
 import {Spinner} from '../Spinner';
 import {Portal} from '../Portal';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Dialog, Footer, FooterProps, Header, Section} from './components';
 import styles from './Modal.scss';
@@ -86,6 +87,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   onTransitionEnd,
   noScroll,
 }: ModalProps) {
+  usePerformanceBenchmark('Modal');
   const [iframeHeight, setIframeHeight] = useState(IFRAME_LOADING_HEIGHT);
 
   const headerId = useUniqueId('modal-header');

--- a/polaris-react/src/components/Navigation/Navigation.tsx
+++ b/polaris-react/src/components/Navigation/Navigation.tsx
@@ -6,6 +6,7 @@ import {Image} from '../Image';
 import {UnstyledLink} from '../UnstyledLink';
 import {getWidth} from '../../utilities/get-width';
 import {useFrame} from '../../utilities/frame';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {NavigationContext} from './context';
 import {Section, Item} from './components';
@@ -30,6 +31,7 @@ export const Navigation: React.FunctionComponent<NavigationProps> & {
   onDismiss,
   ariaLabelledBy,
 }: NavigationProps) {
+  usePerformanceBenchmark('Navigation');
   const {logo} = useFrame();
   const width = getWidth(logo, 104);
 

--- a/polaris-react/src/components/OptionList/OptionList.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.tsx
@@ -9,6 +9,7 @@ import {isSection} from '../../utilities/options';
 import {arraysAreEqual} from '../../utilities/arrays';
 import {useUniqueId} from '../../utilities/unique-id';
 import {useDeepEffect} from '../../utilities/use-deep-effect';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Option} from './components';
 import styles from './OptionList.scss';
@@ -50,6 +51,7 @@ export function OptionList({
   onChange,
   id: idProp,
 }: OptionListProps) {
+  usePerformanceBenchmark('OptionList');
   const [normalizedOptions, setNormalizedOptions] = useState(
     createNormalizedOptions(options, sections, title),
   );

--- a/polaris-react/src/components/Page/Page.tsx
+++ b/polaris-react/src/components/Page/Page.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {classNames} from '../../utilities/css';
 import {isInterface} from '../../utilities/is-interface';
 import {isReactElement} from '../../utilities/is-react-element';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Header, HeaderProps} from './components';
 import styles from './Page.scss';
@@ -25,6 +26,7 @@ export function Page({
   divider,
   ...rest
 }: PageProps) {
+  usePerformanceBenchmark('Page');
   const pageClassName = classNames(
     styles.Page,
     fullWidth && styles.fullWidth,

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -10,6 +10,7 @@ import {ButtonGroup} from '../ButtonGroup';
 import {buttonsFrom} from '../Button';
 import {isInterface} from '../../utilities/is-interface';
 import {isReactElement} from '../../utilities/is-react-element';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './PageActions.scss';
 
@@ -26,6 +27,7 @@ export function PageActions({
   primaryAction,
   secondaryActions,
 }: PageActionsProps) {
+  usePerformanceBenchmark('PageActions');
   const primaryActionMarkup = primaryAction
     ? buttonsFrom(primaryAction, {primary: true})
     : null;

--- a/polaris-react/src/components/Pagination/Pagination.tsx
+++ b/polaris-react/src/components/Pagination/Pagination.tsx
@@ -4,6 +4,7 @@ import React, {createRef} from 'react';
 import type {Key} from '../../types';
 import {useI18n} from '../../utilities/i18n';
 import {isInputFocused} from '../../utilities/is-input-focused';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 import {Button} from '../Button';
 import {ButtonGroup} from '../ButtonGroup';
 import {KeypressListener} from '../KeypressListener';
@@ -59,6 +60,7 @@ export function Pagination({
   accessibilityLabels,
   label,
 }: PaginationProps) {
+  usePerformanceBenchmark('Pagination');
   const i18n = useI18n();
 
   const node: React.RefObject<HTMLElement> = createRef();

--- a/polaris-react/src/components/PerformanceBenchmark/PerformanceBenchmark.tsx
+++ b/polaris-react/src/components/PerformanceBenchmark/PerformanceBenchmark.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import React, {PropsWithChildren, useEffect} from 'react';
+
+import {useFeatures} from '../../utilities/features';
+import {useIsMountedRef} from '../../utilities/use-is-mounted-ref';
+import {Mark, PolarisEmoji} from '../../utilities/use-performance-benchmark';
+
+interface PerformanceBenchmarkProps {
+  name: string;
+}
+
+export function PerformanceBenchmark({
+  name,
+  children,
+}: PropsWithChildren<PerformanceBenchmarkProps>) {
+  const {enablePerformanceBenchmarking} = useFeatures();
+  if (!enablePerformanceBenchmarking) {
+    return <>{children}</>;
+  }
+
+  const {current: isMounted} = useIsMountedRef();
+
+  if (!isMounted) {
+    window.performance.mark(`${name}${Mark.MountStart}`);
+  } else {
+    window.performance.mark(`${name}${Mark.UpdateStart}`);
+  }
+
+  useEffect(() => {
+    if (!isMounted) {
+      window.performance.mark(`${name}${Mark.MountEnd}`);
+      window.performance.measure(
+        `${PolarisEmoji} ${name}`,
+        `${name}${Mark.MountStart}`,
+        `${name}${Mark.MountEnd}`,
+      );
+    } else {
+      window.performance.mark(`${name}UpdateEnd`);
+      window.performance.measure(
+        `${PolarisEmoji} ${name} (${Mark.Update})`,
+        `${name}${Mark.UpdateStart}`,
+        `${name}${Mark.UpdateEnd}`,
+      );
+    }
+  });
+
+  return <>{children}</>;
+}

--- a/polaris-react/src/components/PerformanceBenchmark/PerformanceBenchmark.tsx
+++ b/polaris-react/src/components/PerformanceBenchmark/PerformanceBenchmark.tsx
@@ -1,48 +1,12 @@
-/* eslint-disable react-hooks/rules-of-hooks */
-import React, {PropsWithChildren, useEffect} from 'react';
+import React, {PropsWithChildren} from 'react';
 
-import {useFeatures} from '../../utilities/features';
-import {useIsMountedRef} from '../../utilities/use-is-mounted-ref';
-import {Mark, PolarisEmoji} from '../../utilities/use-performance-benchmark';
-
-interface PerformanceBenchmarkProps {
-  name: string;
-}
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export function PerformanceBenchmark({
   name,
   children,
-}: PropsWithChildren<PerformanceBenchmarkProps>) {
-  const {enablePerformanceBenchmarking} = useFeatures();
-  if (!enablePerformanceBenchmarking) {
-    return <>{children}</>;
-  }
-
-  const {current: isMounted} = useIsMountedRef();
-
-  if (!isMounted) {
-    window.performance.mark(`${name}${Mark.MountStart}`);
-  } else {
-    window.performance.mark(`${name}${Mark.UpdateStart}`);
-  }
-
-  useEffect(() => {
-    if (!isMounted) {
-      window.performance.mark(`${name}${Mark.MountEnd}`);
-      window.performance.measure(
-        `${PolarisEmoji} ${name}`,
-        `${name}${Mark.MountStart}`,
-        `${name}${Mark.MountEnd}`,
-      );
-    } else {
-      window.performance.mark(`${name}UpdateEnd`);
-      window.performance.measure(
-        `${PolarisEmoji} ${name} (${Mark.Update})`,
-        `${name}${Mark.UpdateStart}`,
-        `${name}${Mark.UpdateEnd}`,
-      );
-    }
-  });
+}: PropsWithChildren<{name: string}>) {
+  usePerformanceBenchmark(name);
 
   return <>{children}</>;
 }

--- a/polaris-react/src/components/PerformanceBenchmark/index.ts
+++ b/polaris-react/src/components/PerformanceBenchmark/index.ts
@@ -1,0 +1,1 @@
+export {PerformanceBenchmark} from './PerformanceBenchmark';

--- a/polaris-react/src/components/Popover/Popover.tsx
+++ b/polaris-react/src/components/Popover/Popover.tsx
@@ -16,6 +16,7 @@ import {
 import {Portal} from '../Portal';
 import {portal} from '../shared';
 import {useUniqueId} from '../../utilities/unique-id';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {
   PopoverCloseSource,
@@ -107,6 +108,7 @@ const PopoverComponent = forwardRef<PopoverPublicAPI, PopoverProps>(
     },
     ref,
   ) {
+    usePerformanceBenchmark('Popover');
     const [activatorNode, setActivatorNode] = useState<HTMLElement>();
 
     const overlayRef = useRef<PopoverOverlay>(null);

--- a/polaris-react/src/components/Portal/Portal.tsx
+++ b/polaris-react/src/components/Portal/Portal.tsx
@@ -3,6 +3,7 @@ import {createPortal} from 'react-dom';
 
 import {usePortalsManager} from '../../utilities/portals';
 import {useUniqueId} from '../../utilities/unique-id';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export interface PortalProps {
   children?: React.ReactNode;
@@ -15,6 +16,7 @@ export function Portal({
   idPrefix = '',
   onPortalCreated = noop,
 }: PortalProps) {
+  usePerformanceBenchmark('Portal');
   const {container} = usePortalsManager();
 
   const uniqueId = useUniqueId('portal');

--- a/polaris-react/src/components/PortalsManager/PortalsManager.tsx
+++ b/polaris-react/src/components/PortalsManager/PortalsManager.tsx
@@ -4,6 +4,7 @@ import {
   PortalsManagerContext,
   PortalsContainerElement,
 } from '../../utilities/portals';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {PortalsContainer} from './components';
 
@@ -13,6 +14,7 @@ export interface PortalsManagerProps {
 }
 
 export function PortalsManager({children, container}: PortalsManagerProps) {
+  usePerformanceBenchmark('PortalsManager');
   const [portalContainerElement, setPortalContainerElement] =
     useState<PortalsContainerElement>(null);
 

--- a/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -6,6 +6,7 @@ import {getRectForNode, Rect} from '../../utilities/geometry';
 import {EventListener} from '../EventListener';
 import {Scrollable} from '../Scrollable';
 import {layer, dataPolarisTopBar} from '../shared';
+import {PerformanceBenchmark} from '../PerformanceBenchmark';
 
 import {
   PreferredPosition,
@@ -153,10 +154,12 @@ export class PositionedOverlay extends PureComponent<
     );
 
     return (
-      <div className={className} style={style} ref={this.setOverlay}>
-        <EventListener event="resize" handler={this.handleMeasurement} />
-        {render(this.overlayDetails())}
-      </div>
+      <PerformanceBenchmark name="PositionedOverlay">
+        <div className={className} style={style} ref={this.setOverlay}>
+          <EventListener event="resize" handler={this.handleMeasurement} />
+          {render(this.overlayDetails())}
+        </div>
+      </PerformanceBenchmark>
     );
   }
 

--- a/polaris-react/src/components/ProgressBar/ProgressBar.tsx
+++ b/polaris-react/src/components/ProgressBar/ProgressBar.tsx
@@ -4,6 +4,7 @@ import {CSSTransition} from 'react-transition-group';
 import {classNames, variationName} from '../../utilities/css';
 import {tokens} from '../../tokens';
 import {useI18n} from '../../utilities/i18n';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './ProgressBar.scss';
 
@@ -39,6 +40,7 @@ export function ProgressBar({
   color = 'highlight',
   animated: hasAppearAnimation = true,
 }: ProgressBarProps) {
+  usePerformanceBenchmark('ProgressBar');
   const i18n = useI18n();
 
   const className = classNames(

--- a/polaris-react/src/components/RadioButton/RadioButton.tsx
+++ b/polaris-react/src/components/RadioButton/RadioButton.tsx
@@ -4,6 +4,7 @@ import {useUniqueId} from '../../utilities/unique-id';
 import {useToggle} from '../../utilities/use-toggle';
 import {classNames} from '../../utilities/css';
 import {Choice, helpTextID} from '../Choice';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './RadioButton.scss';
 
@@ -48,6 +49,7 @@ export function RadioButton({
   name: nameProp,
   value,
 }: RadioButtonProps) {
+  usePerformanceBenchmark('RadioButton');
   const id = useUniqueId('RadioButton', idProp);
   const name = nameProp || id;
   const inputNode = useRef<HTMLInputElement>(null);

--- a/polaris-react/src/components/RangeSlider/RangeSlider.tsx
+++ b/polaris-react/src/components/RangeSlider/RangeSlider.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {useUniqueId} from '../../utilities/unique-id';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import type {RangeSliderProps, RangeSliderValue, DualValue} from './types';
 import {SingleThumb, DualThumb} from './components';
@@ -20,6 +21,7 @@ export function RangeSlider({
   value,
   ...rest
 }: Props) {
+  usePerformanceBenchmark('RangeSlider');
   const id = useUniqueId('RangeSlider');
 
   const sharedProps = {

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -19,6 +19,7 @@ import {
   ResourceListSelectedItems,
 } from '../../utilities/resource-list';
 import {globalIdGeneratorFactory} from '../../utilities/unique-id';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './ResourceItem.scss';
 
@@ -459,6 +460,7 @@ function isSelected(id: string, selectedItems?: ResourceListSelectedItems) {
 }
 
 export function ResourceItem(props: ResourceItemProps) {
+  usePerformanceBenchmark('ResourceItem');
   return (
     <BaseResourceItem
       {...props}

--- a/polaris-react/src/components/ResourceList/ResourceList.tsx
+++ b/polaris-react/src/components/ResourceList/ResourceList.tsx
@@ -32,6 +32,7 @@ import {ResourceItem} from '../ResourceItem';
 import {useLazyRef} from '../../utilities/use-lazy-ref';
 import {BulkActions, BulkActionsProps} from '../BulkActions';
 import {CheckableButton} from '../CheckableButton';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './ResourceList.scss';
 
@@ -144,6 +145,7 @@ export const ResourceList: ResourceListType = function ResourceList<TItemType>({
   idForItem = defaultIdForItem,
   resolveItemId,
 }: ResourceListProps<TItemType>) {
+  usePerformanceBenchmark('ResourceList');
   const i18n = useI18n();
   const [selectMode, setSelectMode] = useState(
     Boolean(selectedItems && selectedItems.length > 0),

--- a/polaris-react/src/components/Scrollable/Scrollable.tsx
+++ b/polaris-react/src/components/Scrollable/Scrollable.tsx
@@ -7,6 +7,7 @@ import {
   StickyManagerContext,
 } from '../../utilities/sticky-manager';
 import {scrollable} from '../shared';
+import {PerformanceBenchmark} from '../PerformanceBenchmark';
 
 import {ScrollTo} from './components';
 import {ScrollableContext} from './context';
@@ -127,20 +128,22 @@ export class Scrollable extends Component<ScrollableProps, State> {
     );
 
     return (
-      <ScrollableContext.Provider value={this.scrollToPosition}>
-        <StickyManagerContext.Provider value={this.stickyManager}>
-          <div
-            className={finalClassName}
-            {...scrollable.props}
-            {...rest}
-            ref={this.setScrollArea}
-            // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-            tabIndex={focusable ? 0 : undefined}
-          >
-            {children}
-          </div>
-        </StickyManagerContext.Provider>
-      </ScrollableContext.Provider>
+      <PerformanceBenchmark name="Scrollable">
+        <ScrollableContext.Provider value={this.scrollToPosition}>
+          <StickyManagerContext.Provider value={this.stickyManager}>
+            <div
+              className={finalClassName}
+              {...scrollable.props}
+              {...rest}
+              ref={this.setScrollArea}
+              // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+              tabIndex={focusable ? 0 : undefined}
+            >
+              {children}
+            </div>
+          </StickyManagerContext.Provider>
+        </ScrollableContext.Provider>
+      </PerformanceBenchmark>
     );
   }
 

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -6,6 +6,7 @@ import {useUniqueId} from '../../utilities/unique-id';
 import {Labelled, LabelledProps, helpTextID} from '../Labelled';
 import {Icon} from '../Icon';
 import type {Error} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Select.scss';
 
@@ -93,6 +94,7 @@ export function Select({
   onBlur,
   requiredIndicator,
 }: SelectProps) {
+  usePerformanceBenchmark('Select');
   const id = useUniqueId('Select', idProp);
   const labelHidden = labelInline ? true : labelHiddenProp;
 

--- a/polaris-react/src/components/SettingAction/SettingAction.tsx
+++ b/polaris-react/src/components/SettingAction/SettingAction.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import styles from './SettingAction.scss';
 
 export interface SettingActionProps {
@@ -8,6 +10,7 @@ export interface SettingActionProps {
 }
 
 export function SettingAction({action, children}: SettingActionProps) {
+  usePerformanceBenchmark('SettingAction');
   return (
     <div className={styles.SettingAction}>
       <div className={styles.Setting}>{children}</div>

--- a/polaris-react/src/components/SettingToggle/SettingToggle.tsx
+++ b/polaris-react/src/components/SettingToggle/SettingToggle.tsx
@@ -5,6 +5,7 @@ import {SettingAction} from '../SettingAction';
 import {buttonFrom} from '../Button';
 import {Card} from '../Card';
 import {globalIdGeneratorFactory} from '../../utilities/unique-id';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export interface SettingToggleProps {
   /** Inner content of the card */
@@ -18,6 +19,7 @@ export interface SettingToggleProps {
 const getUniqueSettingToggleId = globalIdGeneratorFactory('SettingToggle');
 
 export function SettingToggle({enabled, action, children}: SettingToggleProps) {
+  usePerformanceBenchmark('SettingToggle');
   const id = useMemo(getUniqueSettingToggleId, []);
 
   const actionMarkup = action

--- a/polaris-react/src/components/Sheet/Sheet.tsx
+++ b/polaris-react/src/components/Sheet/Sheet.tsx
@@ -11,6 +11,7 @@ import {Backdrop} from '../Backdrop';
 import {TrapFocus} from '../TrapFocus';
 import {Portal} from '../Portal';
 import {KeypressListener} from '../KeypressListener';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Sheet.scss';
 
@@ -55,6 +56,7 @@ export function Sheet({
   accessibilityLabel,
   activator,
 }: SheetProps) {
+  usePerformanceBenchmark('Sheet');
   const {isNavigationCollapsed} = useMediaQuery();
   const container = useRef<HTMLDivElement>(null);
   const activatorRef = useRef<HTMLDivElement>(null);

--- a/polaris-react/src/components/SkeletonBodyText/SkeletonBodyText.tsx
+++ b/polaris-react/src/components/SkeletonBodyText/SkeletonBodyText.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import styles from './SkeletonBodyText.scss';
 
 export interface SkeletonBodyTextProps {
@@ -11,6 +13,7 @@ export interface SkeletonBodyTextProps {
 }
 
 export function SkeletonBodyText({lines = 3}: SkeletonBodyTextProps) {
+  usePerformanceBenchmark('SkeletonBodyText');
   const bodyTextLines = [];
 
   for (let i = 0; i < lines; i++) {

--- a/polaris-react/src/components/SkeletonDisplayText/SkeletonDisplayText.tsx
+++ b/polaris-react/src/components/SkeletonDisplayText/SkeletonDisplayText.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './SkeletonDisplayText.scss';
 
@@ -17,6 +18,7 @@ export interface SkeletonDisplayTextProps {
 export function SkeletonDisplayText({
   size = 'medium',
 }: SkeletonDisplayTextProps) {
+  usePerformanceBenchmark('SkeletonDisplayText');
   const className = classNames(
     styles.DisplayText,
     size && styles[variationName('size', size)],

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -4,6 +4,7 @@ import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {SkeletonDisplayText} from '../SkeletonDisplayText';
 import {SkeletonBodyText} from '../SkeletonBodyText';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './SkeletonPage.scss';
 
@@ -30,6 +31,7 @@ export function SkeletonPage({
   title = '',
   breadcrumbs,
 }: SkeletonPageProps) {
+  usePerformanceBenchmark('SkeletonPage');
   const i18n = useI18n();
   const className = classNames(
     styles.Page,

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.tsx
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 import {SkeletonBodyText} from '../SkeletonBodyText';
 
 import styles from './SkeletonTabs.scss';
@@ -10,6 +11,7 @@ export interface Props {
 }
 
 export function SkeletonTabs({count = 2}: Props) {
+  usePerformanceBenchmark('SkeletonTabs');
   return (
     <div className={styles.Tabs}>
       {[...Array(count).keys()].map((key) => {

--- a/polaris-react/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx
+++ b/polaris-react/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './SkeletonThumbnail.scss';
 
@@ -15,6 +16,7 @@ export interface SkeletonThumbnailProps {
 }
 
 export function SkeletonThumbnail({size = 'medium'}: SkeletonThumbnailProps) {
+  usePerformanceBenchmark('SkeletonThumbnail');
   const className = classNames(
     styles.SkeletonThumbnail,
     size && styles[variationName('size', size)],

--- a/polaris-react/src/components/Spinner/Spinner.tsx
+++ b/polaris-react/src/components/Spinner/Spinner.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {classNames, variationName} from '../../utilities/css';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Spinner.scss';
 
@@ -25,6 +26,7 @@ export function Spinner({
   accessibilityLabel,
   hasFocusableParent,
 }: SpinnerProps) {
+  usePerformanceBenchmark('Spinner');
   const isAfterInitialMount = useIsAfterInitialMount();
 
   const className = classNames(

--- a/polaris-react/src/components/Stack/Stack.tsx
+++ b/polaris-react/src/components/Stack/Stack.tsx
@@ -2,6 +2,7 @@ import React, {memo, NamedExoticComponent} from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
 import {elementChildren, wrapWithComponent} from '../../utilities/components';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Item} from './components';
 import styles from './Stack.scss';
@@ -47,6 +48,7 @@ export const Stack = memo(function Stack({
   alignment,
   wrap,
 }: StackProps) {
+  usePerformanceBenchmark('Stack');
   const className = classNames(
     styles.Stack,
     vertical && styles.vertical,

--- a/polaris-react/src/components/Sticky/Sticky.tsx
+++ b/polaris-react/src/components/Sticky/Sticky.tsx
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 
 import {getRectForNode} from '../../utilities/geometry';
 import {useStickyManager} from '../../utilities/sticky-manager';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 interface State {
   isSticky: boolean;
@@ -139,6 +140,7 @@ function isFunction(arg: any): arg is Function {
 }
 
 export function Sticky(props: StickyProps) {
+  usePerformanceBenchmark('Sticky');
   const stickyManager = useStickyManager();
 
   return <StickyInner {...props} stickyManager={stickyManager} />;

--- a/polaris-react/src/components/Subheading/Subheading.tsx
+++ b/polaris-react/src/components/Subheading/Subheading.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import type {HeadingTagName} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Subheading.scss';
 
@@ -18,6 +19,7 @@ export function Subheading({
   element: Element = 'h3',
   children,
 }: SubheadingProps) {
+  usePerformanceBenchmark('Subheading');
   const ariaLabel = typeof children === 'string' ? children : undefined;
   return (
     <Element aria-label={ariaLabel} className={styles.Subheading}>

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -5,6 +5,7 @@ import {classNames} from '../../utilities/css';
 import {Icon} from '../Icon';
 import {Popover} from '../Popover';
 import {useI18n} from '../../utilities/i18n';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import type {TabDescriptor} from './types';
 import {getVisibleAndHiddenTabIndices} from './utilities';
@@ -378,6 +379,7 @@ function handleKeyDown(event: React.KeyboardEvent<HTMLElement>) {
 }
 
 export function Tabs(props: TabsProps) {
+  usePerformanceBenchmark('Tabs');
   const i18n = useI18n();
 
   return <TabsInner {...props} i18n={i18n} />;

--- a/polaris-react/src/components/Tag/Tag.tsx
+++ b/polaris-react/src/components/Tag/Tag.tsx
@@ -5,6 +5,7 @@ import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {Icon} from '../Icon';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Tag.scss';
 
@@ -37,6 +38,7 @@ export function Tag({
   accessibilityLabel,
   url,
 }: TagProps) {
+  usePerformanceBenchmark('Tag');
   const i18n = useI18n();
 
   const segmented = onRemove && url;

--- a/polaris-react/src/components/TextContainer/TextContainer.tsx
+++ b/polaris-react/src/components/TextContainer/TextContainer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './TextContainer.scss';
 
@@ -14,6 +15,7 @@ export interface TextContainerProps {
 }
 
 export function TextContainer({spacing, children}: TextContainerProps) {
+  usePerformanceBenchmark('TextContainer');
   const className = classNames(
     styles.TextContainer,
     spacing && styles[variationName('spacing', spacing)],

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -16,6 +16,7 @@ import {Labelled, LabelledProps, helpTextID, labelID} from '../Labelled';
 import {Connected} from '../Connected';
 import {Error, Key} from '../../types';
 import {Icon} from '../Icon';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {Resizer, Spinner, SpinnerProps} from './components';
 import styles from './TextField.scss';
@@ -226,6 +227,7 @@ export function TextField({
   onFocus,
   onBlur,
 }: TextFieldProps) {
+  usePerformanceBenchmark('TextField');
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
   const [focus, setFocus] = useState(Boolean(focused));

--- a/polaris-react/src/components/TextStyle/TextStyle.tsx
+++ b/polaris-react/src/components/TextStyle/TextStyle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './TextStyle.scss';
 
@@ -29,6 +30,7 @@ export interface TextStyleProps {
 }
 
 export function TextStyle({variation, children}: TextStyleProps) {
+  usePerformanceBenchmark('TextStyle');
   const className = classNames(
     variation && styles[variationName('variation', variation)],
     variation === VariationValue.Code && styles.code,

--- a/polaris-react/src/components/Thumbnail/Thumbnail.tsx
+++ b/polaris-react/src/components/Thumbnail/Thumbnail.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {classNames, variationName} from '../../utilities/css';
 import {Image} from '../Image';
 import {Icon} from '../Icon';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import styles from './Thumbnail.scss';
 
@@ -28,6 +29,7 @@ export function Thumbnail({
   size = 'medium',
   transparent,
 }: ThumbnailProps) {
+  usePerformanceBenchmark('Thumbnail');
   const className = classNames(
     styles.Thumbnail,
     size && styles[variationName('size', size)],

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -5,6 +5,7 @@ import {findFirstFocusableNode} from '../../utilities/focus';
 import {useUniqueId} from '../../utilities/unique-id';
 import {useToggle} from '../../utilities/use-toggle';
 import {Key} from '../../types';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {TooltipOverlay, TooltipOverlayProps} from './components';
 
@@ -40,6 +41,7 @@ export function Tooltip({
   activatorWrapper = 'span',
   accessibilityLabel,
 }: TooltipProps) {
+  usePerformanceBenchmark('Tooltip');
   const WrapperComponent: any = activatorWrapper;
   const {
     value: active,

--- a/polaris-react/src/components/TopBar/TopBar.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.tsx
@@ -9,6 +9,7 @@ import {useFrame} from '../../utilities/frame';
 import {Icon} from '../Icon';
 import {Image} from '../Image';
 import {UnstyledLink} from '../UnstyledLink';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {SearchField, UserMenu, Search, Menu} from './components';
 import type {SearchFieldProps, UserMenuProps, SearchProps} from './components';
@@ -60,6 +61,7 @@ export const TopBar: React.FunctionComponent<TopBarProps> & {
   onSearchResultsDismiss,
   contextControl,
 }: TopBarProps) {
+  usePerformanceBenchmark('TopBar');
   const i18n = useI18n();
   const {logo} = useFrame();
 

--- a/polaris-react/src/components/TrapFocus/TrapFocus.tsx
+++ b/polaris-react/src/components/TrapFocus/TrapFocus.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../utilities/focus';
 import {useFocusManager} from '../../utilities/focus-manager';
 import {portal} from '../shared';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 export interface TrapFocusProps {
   trapping?: boolean;
@@ -21,6 +22,7 @@ export interface TrapFocusProps {
 }
 
 export function TrapFocus({trapping = true, children}: TrapFocusProps) {
+  usePerformanceBenchmark('TrapFocus');
   const {canSafelyFocus} = useFocusManager({trapping});
   const focusTrapWrapper = useRef<HTMLDivElement>(null);
   const [disableFocus, setDisableFocus] = useState(true);

--- a/polaris-react/src/components/Truncate/Truncate.tsx
+++ b/polaris-react/src/components/Truncate/Truncate.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import styles from './Truncate.scss';
 
 export interface TruncateProps {
@@ -7,5 +9,6 @@ export interface TruncateProps {
 }
 
 export function Truncate({children}: TruncateProps) {
+  usePerformanceBenchmark('Truncate');
   return <span className={styles.Truncate}>{children}</span>;
 }

--- a/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type {BaseButton} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 import {UnstyledLink} from '../UnstyledLink';
 
 export interface UnstyledButtonProps extends BaseButton {
@@ -39,6 +40,7 @@ export function UnstyledButton({
   onTouchStart,
   ...rest
 }: UnstyledButtonProps) {
+  usePerformanceBenchmark('UnstyledButton');
   let buttonMarkup;
 
   const commonProps = {

--- a/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
@@ -2,6 +2,7 @@ import React, {memo, forwardRef} from 'react';
 
 import {unstyled} from '../shared';
 import {useLink, LinkLikeComponentProps} from '../../utilities/link';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 // The script in the styleguide that generates the Props Explorer data expects
 // that the interface defining the props is defined in this file, not imported
@@ -15,6 +16,7 @@ export interface UnstyledLinkProps extends LinkLikeComponentProps {}
 // eslint-disable-next-line react/display-name
 export const UnstyledLink = memo(
   forwardRef<unknown, UnstyledLinkProps>(function UnstyledLink(props, _ref) {
+    usePerformanceBenchmark('UnstyledLink');
     const LinkComponent = useLink();
     if (LinkComponent) {
       return <LinkComponent {...unstyled.props} {...props} />;

--- a/polaris-react/src/components/VideoThumbnail/VideoThumbnail.tsx
+++ b/polaris-react/src/components/VideoThumbnail/VideoThumbnail.tsx
@@ -7,6 +7,7 @@ import {
   secondsToTimestamp,
   secondsToDurationTranslationKey,
 } from '../../utilities/duration';
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
 
 import {PlayIcon} from './illustrations';
 import styles from './VideoThumbnail.scss';
@@ -48,6 +49,7 @@ export function VideoThumbnail({
   onClick,
   onBeforeStartPlaying,
 }: VideoThumbnailProps) {
+  usePerformanceBenchmark('VideoThumbnail');
   const i18n = useI18n();
   let buttonLabel;
 

--- a/polaris-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/polaris-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {usePerformanceBenchmark} from '../../utilities/use-performance-benchmark';
+
 import styles from './VisuallyHidden.scss';
 
 export interface VisuallyHiddenProps {
@@ -8,5 +10,6 @@ export interface VisuallyHiddenProps {
 }
 
 export function VisuallyHidden({children}: VisuallyHiddenProps) {
+  usePerformanceBenchmark('VisuallyHidden');
   return <span className={styles.VisuallyHidden}>{children}</span>;
 }

--- a/polaris-react/src/utilities/features/types.ts
+++ b/polaris-react/src/utilities/features/types.ts
@@ -2,4 +2,6 @@ export interface FeaturesConfig {
   [key: string]: boolean;
 }
 
-export interface Features {}
+export interface Features {
+  enablePerformanceBenchmarking?: boolean;
+}

--- a/polaris-react/src/utilities/use-performance-benchmark.ts
+++ b/polaris-react/src/utilities/use-performance-benchmark.ts
@@ -3,6 +3,7 @@ import {useEffect} from 'react';
 
 import {useIsMountedRef} from './use-is-mounted-ref';
 import {useFeatures} from './features';
+import {isServer} from './target';
 
 export enum Mark {
   MountStart = 'MountStart',
@@ -16,7 +17,7 @@ export const PolarisEmoji = '🌌';
 
 export function usePerformanceBenchmark(name: string) {
   const {enablePerformanceBenchmarking} = useFeatures();
-  if (!enablePerformanceBenchmarking) {
+  if (isServer || !enablePerformanceBenchmarking) {
     return;
   }
 

--- a/polaris-react/src/utilities/use-performance-benchmark.ts
+++ b/polaris-react/src/utilities/use-performance-benchmark.ts
@@ -1,0 +1,48 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import {useEffect} from 'react';
+
+import {useIsMountedRef} from './use-is-mounted-ref';
+import {useFeatures} from './features';
+
+export enum Mark {
+  MountStart = 'MountStart',
+  MountEnd = 'MountEnd',
+  Update = 'Update',
+  UpdateStart = 'UpdateStart',
+  UpdateEnd = 'UpdateEnd',
+}
+
+export const PolarisEmoji = '🌌';
+
+export function usePerformanceBenchmark(name: string) {
+  const {enablePerformanceBenchmarking} = useFeatures();
+  if (!enablePerformanceBenchmarking) {
+    return;
+  }
+
+  const {current: isMounted} = useIsMountedRef();
+
+  if (!isMounted) {
+    window.performance.mark(`${name}${Mark.MountStart}`);
+  } else {
+    window.performance.mark(`${name}${Mark.UpdateStart}`);
+  }
+
+  useEffect(() => {
+    if (!isMounted) {
+      window.performance.mark(`${name}${Mark.MountEnd}`);
+      window.performance.measure(
+        `${PolarisEmoji} ${name}`,
+        `${name}${Mark.MountStart}`,
+        `${name}${Mark.MountEnd}`,
+      );
+    } else {
+      window.performance.mark(`${name}UpdateEnd`);
+      window.performance.measure(
+        `${PolarisEmoji} ${name} (${Mark.Update})`,
+        `${name}${Mark.UpdateStart}`,
+        `${name}${Mark.UpdateEnd}`,
+      );
+    }
+  });
+}


### PR DESCRIPTION
WIP/Exploration

The end goal is to measure Polaris component performance in production with as close to zero overhead as possible. The User Timing API gives a way to benchmark component performance, access the data with `window.performance.getEntriesByType('measure');`, and post to an endpoint. This can also be helpful with ad hoc performance profiling.

### Custom timings visualized in the performance tools
<img width="1920" alt="Screen Shot 2022-05-19 at 12 49 37 PM" src="https://user-images.githubusercontent.com/344839/169404616-a5ed0f5c-b7bc-4f7b-ad34-babe041ca0a8.png">

### Output of performance markings which can be sent to an endpoint for custom visualization and performance over time
<img width="1044" alt="Screen Shot 2022-05-19 at 12 50 36 PM" src="https://user-images.githubusercontent.com/344839/169405124-c778ef81-e4bf-4dd9-89b2-a378f3e306c8.png">


