### PR TITLE
Add the underline to removeUnderline on :hover

### DIFF
--- a/.changeset/good-knives-taste.md
+++ b/.changeset/good-knives-taste.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Add underline to Link on hover when removeUnderline property is used
+Added underline to Link on hover when removeUnderline property is used

--- a/.changeset/good-knives-taste.md
+++ b/.changeset/good-knives-taste.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add underline to Link on hover when removeUnderline property is used

--- a/polaris-react/src/components/Link/Link.scss
+++ b/polaris-react/src/components/Link/Link.scss
@@ -76,4 +76,8 @@
 
 .removeUnderline {
   text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris/issues/4377

This gives `<Link removeUnderline />` an underline when hovered so that users do not have to perceive color to use the user interface.