### PR TITLE
[Modal] Allow close on `Backdrop` click or tap

### DIFF
--- a/.changeset/lemon-singers-hug.md
+++ b/.changeset/lemon-singers-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed an accessibility bug in modal where clicking or tapping the backdrop would not close the modal

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -200,7 +200,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       </Dialog>
     );
 
-    backdrop = <Backdrop />;
+    backdrop = <Backdrop onClick={onClose} />;
   }
 
   const animated = !instant;

--- a/polaris-react/src/components/Modal/README.md
+++ b/polaris-react/src/components/Modal/README.md
@@ -90,7 +90,7 @@ Use modals for confirmations and conditional changes. They should be thought of 
 Modals should:
 
 - Require that merchants take an action.
-- Close when merchants press the `X` button, the `Cancel` button, or the <kbd>Esc</kbd> key, not when merchants click or tap the area outside the modal.
+- Close when merchants press the `X` button, the `Cancel` button, the <kbd>Esc</kbd> key, or when merchants click or tap the area outside the modal.
 - Not have more than two buttons (primary and secondary) at the bottom. This prevents unclear action hierarchy and crowding on mobile screens. Since modals are for focused tasks, they should have focused actions. In some cases however, a [tertiary action](#tertiary-actions) may be appropriate.
 
 ---

--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -19,10 +19,17 @@ $dangerous-magic-space-16: 64px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  // Allow passthrough of click events to dismiss modal on backdrop click
+  pointer-events: none;
 
   @include breakpoint-after($layout-width-page-with-nav-base) {
     justify-content: center;
   }
+}
+
+.Dialog {
+  // Resume pointer events
+  pointer-events: initial;
 }
 
 .Dialog:focus {

--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -20,6 +20,7 @@ $dangerous-magic-space-16: 64px;
   flex-direction: column;
   justify-content: flex-end;
   // Allow passthrough of click events to dismiss modal on backdrop click
+  // Resume pointer-events on .Modal below
   pointer-events: none;
 
   @include breakpoint-after($layout-width-page-with-nav-base) {
@@ -32,8 +33,6 @@ $dangerous-magic-space-16: 64px;
 }
 
 .Modal {
-  --pc-dialog-horizontal-spacing: var(--p-space-16);
-  // Resume pointer events
   pointer-events: initial;
   position: fixed;
   right: 0;
@@ -72,7 +71,7 @@ $dangerous-magic-space-16: 64px;
 
   &.sizeSmall {
     @include breakpoint-after($layout-width-page-with-nav-base) {
-      max-width: calc(100% - var(--pc-dialog-horizontal-spacing));
+      max-width: calc(100% - var(--p-space-16));
     }
 
     @include breakpoint-after($xsmall-width + $dangerous-magic-space-16) {
@@ -82,7 +81,7 @@ $dangerous-magic-space-16: 64px;
 
   &.sizeLarge {
     @include breakpoint-after($layout-width-page-with-nav-base) {
-      max-width: calc(100% - var(--pc-dialog-horizontal-spacing));
+      max-width: calc(100% - var(--p-space-16));
     }
 
     @include breakpoint-after($large-width + $dangerous-magic-space-16) {

--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -27,17 +27,14 @@ $dangerous-magic-space-16: 64px;
   }
 }
 
-.Dialog {
-  // Resume pointer events
-  pointer-events: initial;
-}
-
 .Dialog:focus {
   outline: 0;
 }
 
 .Modal {
   --pc-dialog-horizontal-spacing: var(--p-space-16);
+  // Resume pointer events
+  pointer-events: initial;
   position: fixed;
   right: 0;
   bottom: 0;

--- a/polaris-react/src/components/Modal/tests/Modal.test.tsx
+++ b/polaris-react/src/components/Modal/tests/Modal.test.tsx
@@ -7,6 +7,7 @@ import {Button} from '../../Button';
 import {Scrollable} from '../../Scrollable';
 import {Spinner} from '../../Spinner';
 import {Portal} from '../../Portal';
+import {Backdrop} from '../../Backdrop';
 import {Footer, Dialog, Header} from '../components';
 import {Modal} from '../Modal';
 import {WithinContentContext} from '../../../utilities/within-content-context';
@@ -262,6 +263,14 @@ describe('<Modal>', () => {
       );
 
       expect(modal).not.toContainReactComponent(Badge);
+    });
+
+    it('closes the modal when backdrop is clicked', () => {
+      const spy = jest.fn();
+      const modal = mountWithApp(<Modal title="foo" open onClose={spy} />);
+
+      modal.find(Backdrop)!.trigger('onClick');
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5834

### WHAT is this pull request doing?

- Passes `onClose` to the `onClick` handler of `Backdrop`
- Allows pointer events through the transparent section of the `Dialog` container
- Recaptures pointer events on `Dialog` content

Alternative approach:
- Refactor so Dialog renders the backdrop
- Pass a new prop to dialog. Something like `onBackdropClick`

Second approach might be more future proof but I'm not sure it's possible or the implications of that change. I'll explore when I have some time

### How to 🎩

Checkout any of the Modal stories in storybook
I also used ngrok to check the tap event on my phone

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
