### PR TITLE
[ActionList.Item] Deprecate badge, icon and image props

### DIFF
--- a/.changeset/silent-sheep-protect.md
+++ b/.changeset/silent-sheep-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[ActionList.Item] Deprecate badge, icon and image props

--- a/.changeset/silent-sheep-protect.md
+++ b/.changeset/silent-sheep-protect.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-[ActionList.Item] Deprecate badge, icon and image props
+Deprecated `badge`, `icon` and `image` props in ActionList.Item as the `prefix` and `suffix` properties can replace them.

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -169,15 +169,20 @@ export interface PlainAction extends Action {
 }
 
 export interface ActionListItemDescriptor
-  extends IconableAction,
-    DisableableAction,
-    BadgeAction,
+  extends DisableableAction,
     DestructableAction {
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
+  /** @deprecated Badge component */
+  badge?: {
+    status: 'new';
+    content: string;
+  };
   /** Additional hint text to display with item */
   helpText?: string;
-  /** Image source */
+  /** @deprecated Source of the icon */
+  icon?: IconSource;
+  /** @deprecated Image source */
   image?: string;
   /** Prefix source */
   prefix?: React.ReactNode;


### PR DESCRIPTION
### WHY are these changes introduced?

First step to address https://github.com/Shopify/polaris/issues/3350

### WHAT is this pull request doing?

This PR deprecates properties that should be replaced with the `prefix` and `suffix` properties.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
