### PR TITLE
Add bicolour SortIcon component for table headers

### DIFF
--- a/.changeset/silent-games-poke.md
+++ b/.changeset/silent-games-poke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added `SortIcon` component for use in table headers and used it in `Datatable`

--- a/polaris-react/src/components/DataTable/DataTable.scss
+++ b/polaris-react/src/components/DataTable/DataTable.scss
@@ -174,7 +174,8 @@
   @include focus-ring;
   position: relative;
   display: inline-flex;
-  align-items: center;
+  justify-content: flex-end;
+  align-items: baseline;
   color: var(--p-text);
   transition: color var(--p-duration-200) var(--p-ease);
   cursor: pointer;

--- a/polaris-react/src/components/DataTable/DataTable.scss
+++ b/polaris-react/src/components/DataTable/DataTable.scss
@@ -174,9 +174,7 @@
   @include focus-ring;
   position: relative;
   display: inline-flex;
-  justify-content: flex-end;
-  align-items: baseline;
-  @include recolor-icon(var(--p-icon));
+  align-items: center;
   color: var(--p-text);
   transition: color var(--p-duration-200) var(--p-ease);
   cursor: pointer;
@@ -200,15 +198,8 @@
   }
 
   &:hover {
-    @include recolor-icon(var(--p-interactive-hovered));
-    color: var(--p-interactive-hovered);
-
     .Icon {
       opacity: 1;
-
-      svg {
-        fill: var(--p-icon-disabled);
-      }
     }
   }
 
@@ -217,10 +208,6 @@
 
     .Icon {
       opacity: 1;
-
-      svg {
-        fill: var(--p-icon-disabled);
-      }
     }
   }
 }
@@ -233,12 +220,6 @@
 .Cell-sorted {
   .Icon {
     opacity: 1;
-  }
-
-  .Heading:focus:not(:active) {
-    svg {
-      fill: var(--p-icon);
-    }
   }
 }
 

--- a/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
+++ b/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
@@ -83,7 +83,10 @@ export function Cell({
 
   const iconMarkup = (
     <span className={iconClassName}>
-      <SortIcon sortDirection={sortDirection} />
+      <SortIcon
+        sortDirection={sortDirection}
+        accessibilityLabel={sortAccessibilityLabel}
+      />
     </span>
   );
 

--- a/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
+++ b/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
@@ -7,6 +7,7 @@ import {headerCell} from '../../../shared';
 import {Icon} from '../../../Icon';
 import type {SortDirection, VerticalAlign} from '../../types';
 import styles from '../../DataTable.scss';
+import {SortIcon} from '../../../SortIcon';
 
 export interface CellProps {
   content?: React.ReactNode;
@@ -82,7 +83,7 @@ export function Cell({
 
   const iconMarkup = (
     <span className={iconClassName}>
-      <Icon source={source} accessibilityLabel={sortAccessibilityLabel} />
+      <SortIcon sortDirection={sortDirection} />
     </span>
   );
 

--- a/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
+++ b/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import {CaretUpMinor, CaretDownMinor} from '@shopify/polaris-icons';
 
 import {classNames, variationName} from '../../../../utilities/css';
 import {useI18n} from '../../../../utilities/i18n';
 import {headerCell} from '../../../shared';
-import {Icon} from '../../../Icon';
 import type {SortDirection, VerticalAlign} from '../../types';
 import styles from '../../DataTable.scss';
 import {SortIcon} from '../../../SortIcon';
@@ -72,7 +70,6 @@ export function Cell({
   const iconClassName = classNames(sortable && styles.Icon);
   const direction =
     sorted && sortDirection ? sortDirection : defaultSortDirection;
-  const source = direction === 'descending' ? CaretDownMinor : CaretUpMinor;
   const oppositeDirection =
     sortDirection === 'ascending' ? 'descending' : 'ascending';
 
@@ -84,7 +81,7 @@ export function Cell({
   const iconMarkup = (
     <span className={iconClassName}>
       <SortIcon
-        sortDirection={sortDirection}
+        sortDirection={sortDirection ? sortDirection : 'none'}
         accessibilityLabel={sortAccessibilityLabel}
       />
     </span>

--- a/polaris-react/src/components/DataTable/components/Cell/tests/Cell.test.tsx
+++ b/polaris-react/src/components/DataTable/components/Cell/tests/Cell.test.tsx
@@ -4,6 +4,7 @@ import {mountWithApp} from 'tests/utilities';
 
 import {Icon} from '../../../../Icon';
 import {Cell} from '../Cell';
+import {SortIcon} from '../../../../SortIcon';
 
 describe('<Cell />', () => {
   describe('content', () => {
@@ -126,29 +127,29 @@ describe('<Cell />', () => {
     });
 
     describe('when set to ascending', () => {
-      it('renders an up caret Icon when table is currently sorted by that column', () => {
+      it('renders a SortIcon with ascending direction indicated when table is currently sorted by that column', () => {
         const cell = mountWithTable(
           <Cell header firstColumn sortable sorted sortDirection="ascending" />,
         );
 
-        expect(cell).toContainReactComponent(Icon, {
-          source: CaretUpMinor,
+        expect(cell).toContainReactComponent(SortIcon, {
+          sortDirection: 'ascending',
         });
       });
 
-      it('renders an Icon with an accessibility label indicating the next sort direction is descending', () => {
+      it('renders a SortIcon with an accessibility label indicating the next sort direction is descending', () => {
         const cell = mountWithTable(
           <Cell header firstColumn sortable sorted sortDirection="ascending" />,
         );
 
-        expect(cell).toContainReactComponent(Icon, {
+        expect(cell).toContainReactComponent(SortIcon, {
           accessibilityLabel: 'sort descending by',
         });
       });
     });
 
     describe('when set to descending', () => {
-      it('renders a down caret Icon when table is currently sorted by that column', () => {
+      it('renders SortIcon with descending direction indicated when table is currently sorted by that column', () => {
         const cell = mountWithTable(
           <Cell
             header
@@ -159,8 +160,8 @@ describe('<Cell />', () => {
           />,
         );
 
-        expect(cell).toContainReactComponent(Icon, {
-          source: CaretDownMinor,
+        expect(cell).toContainReactComponent(SortIcon, {
+          sortDirection: 'descending',
         });
       });
 
@@ -175,7 +176,7 @@ describe('<Cell />', () => {
           />,
         );
 
-        expect(cell).toContainReactComponent(Icon, {
+        expect(cell).toContainReactComponent(SortIcon, {
           accessibilityLabel: 'sort ascending by',
         });
       });
@@ -184,7 +185,7 @@ describe('<Cell />', () => {
 
   describe('defaultSortDirection', () => {
     describe('when set to none', () => {
-      it('renders an up caret Icon when table is not currently sorted by that column', () => {
+      it('renders a SortIcon with no direction indicated when table is not currently sorted by that column', () => {
         const cell = mountWithTable(
           <Cell
             header
@@ -196,14 +197,14 @@ describe('<Cell />', () => {
           />,
         );
 
-        expect(cell).toContainReactComponent(Icon, {
-          source: CaretUpMinor,
+        expect(cell).toContainReactComponent(SortIcon, {
+          sortDirection: 'none',
         });
       });
     });
 
     describe('when set to ascending', () => {
-      it('renders an up caret Icon when table is not currently sorted by that column', () => {
+      it('renders a SortIcon with no direction indicated when table is not currently sorted by that column', () => {
         const cell = mountWithTable(
           <Cell
             header
@@ -214,14 +215,14 @@ describe('<Cell />', () => {
           />,
         );
 
-        expect(cell).toContainReactComponent(Icon, {
-          source: CaretUpMinor,
+        expect(cell).toContainReactComponent(SortIcon, {
+          sortDirection: 'none',
         });
       });
     });
 
     describe('when set to descending', () => {
-      it('renders a down caret Icon when table is not currently sorted by that column', () => {
+      it('renders a SortIcon with no direction indicated when table is not currently sorted by that column', () => {
         const cell = mountWithTable(
           <Cell
             header
@@ -232,8 +233,8 @@ describe('<Cell />', () => {
           />,
         );
 
-        expect(cell).toContainReactComponent(Icon, {
-          source: CaretDownMinor,
+        expect(cell).toContainReactComponent(SortIcon, {
+          sortDirection: 'none',
         });
       });
     });

--- a/polaris-react/src/components/SortIcon/SortIcon.scss
+++ b/polaris-react/src/components/SortIcon/SortIcon.scss
@@ -4,19 +4,27 @@
   height: var(--p-space-5);
   width: var(--p-space-5);
 }
+
 .Icon {
+  /* stylelint-disable-next-line property-disallowed-list */
   position: relative;
   pointer-events: none;
+
   svg {
     fill: var(--p-icon-subdued);
   }
 }
+
 .Up {
+  /* stylelint-disable-next-line unit-disallowed-list, declaration-property-value-disallowed-list */
   top: -3.5px;
 }
+
 .Down {
+  /* stylelint-disable-next-line unit-disallowed-list, declaration-property-value-disallowed-list */
   top: -16.5px;
 }
+
 .Active {
   svg {
     fill: var(--p-icon);

--- a/polaris-react/src/components/SortIcon/SortIcon.scss
+++ b/polaris-react/src/components/SortIcon/SortIcon.scss
@@ -1,11 +1,15 @@
 @import '../../styles/common';
 
 .SortIcon {
-  height: 20px;
+  height: var(--p-space-5);
+  width: var(--p-space-5);
 }
 .Icon {
-  @include recolor-icon(var(--p-icon-subdued));
   position: relative;
+  pointer-events: none;
+  svg {
+    fill: var(--p-icon-subdued);
+  }
   &:first-of-type {
     top: -3.5px;
   }
@@ -14,5 +18,7 @@
   }
 }
 .Active {
-  @include recolor-icon(var(--p-icon));
+  svg {
+    fill: var(--p-icon);
+  }
 }

--- a/polaris-react/src/components/SortIcon/SortIcon.scss
+++ b/polaris-react/src/components/SortIcon/SortIcon.scss
@@ -1,0 +1,18 @@
+@import '../../styles/common';
+
+.SortIcon {
+  height: 20px;
+}
+.Icon {
+  @include recolor-icon(var(--p-icon-subdued));
+  position: relative;
+  &:first-of-type {
+    top: -3.5px;
+  }
+  &:last-of-type {
+    top: -16.5px;
+  }
+}
+.Active {
+  @include recolor-icon(var(--p-icon));
+}

--- a/polaris-react/src/components/SortIcon/SortIcon.scss
+++ b/polaris-react/src/components/SortIcon/SortIcon.scss
@@ -10,12 +10,12 @@
   svg {
     fill: var(--p-icon-subdued);
   }
-  &:first-of-type {
-    top: -3.5px;
-  }
-  &:last-of-type {
-    top: -16.5px;
-  }
+}
+.Up {
+  top: -3.5px;
+}
+.Down {
+  top: -16.5px;
 }
 .Active {
   svg {

--- a/polaris-react/src/components/SortIcon/SortIcon.tsx
+++ b/polaris-react/src/components/SortIcon/SortIcon.tsx
@@ -15,24 +15,26 @@ interface SortIconProps {
 
 export function SortIcon({sortDirection, accessibilityLabel}: SortIconProps) {
   return (
-    <div className={styles.SortIcon}>
+    <span className={styles.SortIcon}>
       <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
-      <div
+      <span
         className={classNames(
           styles.Icon,
+          styles.Up,
           sortDirection === 'ascending' && styles.Active,
         )}
       >
         <Icon source={CaretUpMinor} />
-      </div>
-      <div
+      </span>
+      <span
         className={classNames(
           styles.Icon,
+          styles.Down,
           sortDirection === 'descending' && styles.Active,
         )}
       >
         <Icon source={CaretDownMinor} />
-      </div>
-    </div>
+      </span>
+    </span>
   );
 }

--- a/polaris-react/src/components/SortIcon/SortIcon.tsx
+++ b/polaris-react/src/components/SortIcon/SortIcon.tsx
@@ -1,0 +1,35 @@
+import {CaretDownMinor, CaretUpMinor} from '@shopify/polaris-icons';
+import React from 'react';
+
+import {classNames} from '../../utilities/css';
+import type {SortDirection} from '../DataTable';
+import {Icon} from '../Icon';
+
+import styles from './SortIcon.scss';
+
+interface SortIconProps {
+  sortDirection: SortDirection | undefined;
+}
+
+export function SortIcon({sortDirection}: SortIconProps) {
+  return (
+    <div className={styles.SortIcon}>
+      <div
+        className={classNames(
+          styles.Icon,
+          sortDirection === 'ascending' && styles.Active,
+        )}
+      >
+        <Icon source={CaretUpMinor} />
+      </div>
+      <div
+        className={classNames(
+          styles.Icon,
+          sortDirection === 'descending' && styles.Active,
+        )}
+      >
+        <Icon source={CaretDownMinor} />
+      </div>
+    </div>
+  );
+}

--- a/polaris-react/src/components/SortIcon/SortIcon.tsx
+++ b/polaris-react/src/components/SortIcon/SortIcon.tsx
@@ -4,24 +4,26 @@ import React from 'react';
 import {classNames} from '../../utilities/css';
 import type {SortDirection} from '../DataTable';
 import {Icon} from '../Icon';
+import {VisuallyHidden} from '../VisuallyHidden';
 
 import styles from './SortIcon.scss';
 
 interface SortIconProps {
-  sortDirection: SortDirection | undefined;
+  sortDirection: SortDirection;
   accessibilityLabel: string;
 }
 
 export function SortIcon({sortDirection, accessibilityLabel}: SortIconProps) {
   return (
     <div className={styles.SortIcon}>
+      <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
       <div
         className={classNames(
           styles.Icon,
           sortDirection === 'ascending' && styles.Active,
         )}
       >
-        <Icon source={CaretUpMinor} accessibilityLabel={accessibilityLabel} />
+        <Icon source={CaretUpMinor} />
       </div>
       <div
         className={classNames(

--- a/polaris-react/src/components/SortIcon/SortIcon.tsx
+++ b/polaris-react/src/components/SortIcon/SortIcon.tsx
@@ -9,9 +9,10 @@ import styles from './SortIcon.scss';
 
 interface SortIconProps {
   sortDirection: SortDirection | undefined;
+  accessibilityLabel: string;
 }
 
-export function SortIcon({sortDirection}: SortIconProps) {
+export function SortIcon({sortDirection, accessibilityLabel}: SortIconProps) {
   return (
     <div className={styles.SortIcon}>
       <div
@@ -20,7 +21,7 @@ export function SortIcon({sortDirection}: SortIconProps) {
           sortDirection === 'ascending' && styles.Active,
         )}
       >
-        <Icon source={CaretUpMinor} />
+        <Icon source={CaretUpMinor} accessibilityLabel={accessibilityLabel} />
       </div>
       <div
         className={classNames(

--- a/polaris-react/src/components/SortIcon/index.ts
+++ b/polaris-react/src/components/SortIcon/index.ts
@@ -1,0 +1,1 @@
+export * from './SortIcon';

--- a/polaris-react/src/components/SortIcon/tests/SortIcon.test.tsx
+++ b/polaris-react/src/components/SortIcon/tests/SortIcon.test.tsx
@@ -21,13 +21,13 @@ describe('<SortIcon/>', () => {
       <SortIcon sortDirection="ascending" accessibilityLabel="test" />,
     );
 
-    const iconWrapper = icon.find('div');
+    const iconWrapper = icon.find('span');
 
-    const firstIconWrapper = iconWrapper?.findAll('div')[0];
-    const secondIconWrapper = iconWrapper?.findAll('div')[1];
+    const firstIconWrapper = iconWrapper?.findAll('span')[1];
+    const secondIconWrapper = iconWrapper?.findAll('span')[4];
 
-    expect(firstIconWrapper).toHaveReactProps({className: 'Icon Active'});
-    expect(secondIconWrapper).not.toHaveReactProps({className: 'Icon Active'});
+    expect(firstIconWrapper).toHaveReactProps({className: 'Icon Up Active'});
+    expect(secondIconWrapper).toHaveReactProps({className: 'Icon Down'});
   });
 
   it('sets the active class on the down icon when the sortDirection is set to descending', () => {
@@ -35,15 +35,15 @@ describe('<SortIcon/>', () => {
       <SortIcon sortDirection="descending" accessibilityLabel="test" />,
     );
 
-    const iconWrapper = icon.find('div');
+    const iconWrapper = icon.find('span', {className: 'SortIcon'});
 
-    const firstIconWrapper = iconWrapper?.findAll('div')[0];
-    const secondIconWrapper = iconWrapper?.findAll('div')[1];
+    const firstIconWrapper = iconWrapper?.findAll('span')[1];
+    const secondIconWrapper = iconWrapper?.findAll('span')[4];
 
-    expect(firstIconWrapper).not.toHaveReactProps({
-      className: 'Icon Active',
+    expect(firstIconWrapper).toHaveReactProps({
+      className: 'Icon Up',
     });
-    expect(secondIconWrapper).toHaveReactProps({className: 'Icon Active'});
+    expect(secondIconWrapper).toHaveReactProps({className: 'Icon Down Active'});
   });
 
   it('sets no active class on the down icon when the sortDirection is set to none', () => {
@@ -51,14 +51,16 @@ describe('<SortIcon/>', () => {
       <SortIcon sortDirection="none" accessibilityLabel="test" />,
     );
 
-    const iconWrapper = icon.find('div');
+    const iconWrapper = icon.find('span');
 
-    const firstIconWrapper = iconWrapper?.findAll('div')[0];
-    const secondIconWrapper = iconWrapper?.findAll('div')[1];
+    const firstIconWrapper = iconWrapper?.findAll('span')[1];
+    const secondIconWrapper = iconWrapper?.findAll('span')[4];
 
-    expect(firstIconWrapper).not.toHaveReactProps({
-      className: 'Icon Active',
+    expect(firstIconWrapper).toHaveReactProps({
+      className: 'Icon Up',
     });
-    expect(secondIconWrapper).not.toHaveReactProps({className: 'Icon Active'});
+    expect(secondIconWrapper).toHaveReactProps({
+      className: 'Icon Down',
+    });
   });
 });

--- a/polaris-react/src/components/SortIcon/tests/SortIcon.test.tsx
+++ b/polaris-react/src/components/SortIcon/tests/SortIcon.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {SortIcon} from '../SortIcon';
+
+describe('<SortIcon/>', () => {
+  it('renders with an accessibility label', () => {
+    const iconWrapper = mountWithApp(
+      <div>
+        <SortIcon sortDirection="none" accessibilityLabel="label test" />,
+      </div>,
+    );
+
+    expect(iconWrapper).toContainReactComponent(SortIcon, {
+      accessibilityLabel: 'label test',
+    });
+  });
+
+  it('sets the active class on the up icon when the sortDirection is set to ascending', () => {
+    const icon = mountWithApp(
+      <SortIcon sortDirection="ascending" accessibilityLabel="test" />,
+    );
+
+    const iconWrapper = icon.find('div');
+
+    const firstIconWrapper = iconWrapper?.findAll('div')[0];
+    const secondIconWrapper = iconWrapper?.findAll('div')[1];
+
+    expect(firstIconWrapper).toHaveReactProps({className: 'Icon Active'});
+    expect(secondIconWrapper).not.toHaveReactProps({className: 'Icon Active'});
+  });
+
+  it('sets the active class on the down icon when the sortDirection is set to descending', () => {
+    const icon = mountWithApp(
+      <SortIcon sortDirection="descending" accessibilityLabel="test" />,
+    );
+
+    const iconWrapper = icon.find('div');
+
+    const firstIconWrapper = iconWrapper?.findAll('div')[0];
+    const secondIconWrapper = iconWrapper?.findAll('div')[1];
+
+    expect(firstIconWrapper).not.toHaveReactProps({
+      className: 'Icon Active',
+    });
+    expect(secondIconWrapper).toHaveReactProps({className: 'Icon Active'});
+  });
+
+  it('sets no active class on the down icon when the sortDirection is set to none', () => {
+    const icon = mountWithApp(
+      <SortIcon sortDirection="none" accessibilityLabel="test" />,
+    );
+
+    const iconWrapper = icon.find('div');
+
+    const firstIconWrapper = iconWrapper?.findAll('div')[0];
+    const secondIconWrapper = iconWrapper?.findAll('div')[1];
+
+    expect(firstIconWrapper).not.toHaveReactProps({
+      className: 'Icon Active',
+    });
+    expect(secondIconWrapper).not.toHaveReactProps({className: 'Icon Active'});
+  });
+});


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The latest UX patterns in the admin call for a new icon for clickable headers in the `Datatable` and `Indextable` that use colour to indicate the sort direction. 

This PR creates a `SortIcon` component that can be used on both components, or anywhere else it should be needed.

Fixes #0000 <!-- link to issue if one exists -->



<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

The new `SortIcon` component makes use of the `CaretUpMinor` and `CaretDownMinor` icons and uses CSS to position them within a wrapper div.

It accepts a `direction` prop which colours the appropriate caret and  an `accessibilityLabel` prop.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Card, DataTable, Page} from '../src';

export function Playground() {
  const [sortedRows, setSortedRows] = useState(null);

  const initiallySortedRows = [
    [
      'May21-May-27 2012',
      'Formalwear',
      "Jill's formal",
      10,
      '$875.00',
      124689,
      140,
      '$426.00',
      '$122,500.00',
    ],
    [
      'Mauve Cashmere Scarf',
      'Accessories',
      "Jack's Accessories and Wonderful clothes",
      253,
      '$230.00',
      124533,
      83,
      '$620.00',
      '$19,090.00',
    ],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      'Ensembles',
      'Avocado Fashions',
      23,
      '$445.00',
      124518,
      32,
      '$353.00',
      '$14,240.00',
    ],
    [
      'Socks',
      'Category',
      'Avocado Fashions',
      465,
      '$4.00',
      124518,
      32,
      '$3.00',
      '$140.00',
    ],
    [
      'May21-May-27 2012',
      'Formalwear',
      "Jill's formal",
      10,
      '$875.00',
      124689,
      140,
      '$426.00',
      '$122,500.00',
    ],
    [
      'Mauve Cashmere Scarf',
      'Accessories',
      "Jack's Accessories and Wonderful clothes",
      253,
      '$230.00',
      124533,
      83,
      '$620.00',
      '$19,090.00',
    ],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      'Ensembles',
      'Avocado Fashions',
      23,
      '$445.00',
      124518,
      32,
      '$353.00',
      '$14,240.00',
    ],
    [
      'Socks',
      'Essentials',
      'Avocado Fashions',
      465,
      '$4.00',
      124518,
      32,
      '$3.00',
      '$140.00',
    ],
    [
      'May21-May-27 2012',
      'Formalwear',
      "Jill's formal",
      10,
      '$875.00',
      124689,
      140,
      '$426.00',
      '$122,500.00',
    ],
    [
      'Mauve Cashmere Scarf',
      'Accessories',
      "Jack's Accessories and Wonderful clothes",
      253,
      '$230.00',
      124533,
      83,
      '$620.00',
      '$19,090.00',
    ],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      'Ensembles',
      'Avocado Fashions',
      23,
      '$445.00',
      124518,
      32,
      '$353.00',
      '$14,240.00',
    ],
    [
      'Socks',
      'Essentials',
      'Avocado Fashions',
      465,
      '$4.00',
      124518,
      32,
      '$3.00',
      '$140.00',
    ],
    [
      'May21-May-27 2012',
      'Formalwear',
      "Jill's formal",
      10,
      '$875.00',
      124689,
      140,
      '$426.00',
      '$122,500.00',
    ],
    [
      'Mauve Cashmere Scarf',
      'Accessories',
      "Jack's Accessories and Wonderful clothes",
      253,
      '$230.00',
      124533,
      83,
      '$620.00',
      '$19,090.00',
    ],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      'Ensembles',
      'Avocado Fashions',
      23,
      '$445.00',
      124518,
      32,
      '$353.00',
      '$14,240.00',
    ],
    [
      'Socks',
      'Essentials',
      'Avocado Fashions',
      465,
      '$4.00',
      124518,
      32,
      '$3.00',
      '$140.00',
    ],
    [
      'May21-May-27 2012',
      'Formalwear',
      "Jill's formal",
      10,
      '$875.00',
      124689,
      140,
      '$426.00',
      '$122,500.00',
    ],
    [
      'Mauve Cashmere Scarf',
      'Accessories',
      "Jack's Accessories and Wonderful clothes",
      253,
      '$230.00',
      124533,
      83,
      '$620.00',
      '$19,090.00',
    ],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      'Ensembles',
      'Avocado Fashions',
      23,
      '$445.00',
      124518,
      32,
      '$353.00',
      '$14,240.00',
    ],
    [
      'Socks',
      'Category',
      'Avocado Fashions',
      465,
      '$4.00',
      124518,
      32,
      '$3.00',
      '$140.00',
    ],
    [
      'May21-May-27 2012',
      'Formalwear',
      "Jill's formal",
      10,
      '$875.00',
      124689,
      140,
      '$426.00',
      '$122,500.00',
    ],
    [
      'Mauve Cashmere Scarf',
      'Accessories',
      "Jack's Accessories and Wonderful clothes",
      253,
      '$230.00',
      124533,
      83,
      '$620.00',
      '$19,090.00',
    ],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      'Ensembles',
      'Avocado Fashions',
      23,
      '$445.00',
      124518,
      32,
      '$353.00',
      '$14,240.00',
    ],
    [
      'Socks',
      'Essentials',
      'Avocado Fashions',
      465,
      '$4.00',
      124518,
      32,
      '$3.00',
      '$140.00',
    ],
  ];
  const rows = sortedRows ? sortedRows : initiallySortedRows;

  const handleSort = useCallback(
    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
    [rows],
  );

  return (
    <Page title="Sales by product">
      <Card>
        <DataTable
          columnContentTypes={[
            'text',
            'text',
            'text',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
          ]}
          headings={[
            'Product',
            'Category',
            'Vendor',
            'Orders',
            'Price',
            'SKU Number',
            'Net quantity',
            'Shipping',
            'Net sales',
          ]}
          rows={rows}
          totals={['', '', '', '', '', '', 255, '$1399', '$155,830.00']}
          sortable={[false, true, true, true, false, true, true, true, true]}
          defaultSortDirection="descending"
          initialSortColumnIndex={4}
          onSort={handleSort}
          hasFixedFirstColumn
          truncate
          stickyHeader
          // firstColumnMinWidth="249.6px"
          // increasedTableDensity
        />
      </Card>
    </Page>
  );

  function sortRows(rows, index, direction) {
    return [...rows].sort((rowA, rowB) => {
      let type;
      if (rowA[index].length > 1) {
        type = !isNaN(parseFloat(rowA[index]))
          ? 'number'
          : !isNaN(parseFloat(rowA[index].substring(1)))
          ? 'currency'
          : 'string';
      } else {
        type = !isNaN(parseFloat(rowA[index])) ? 'number' : 'string';
      }

      const itemA =
        type === 'number'
          ? parseInt(rowA[index])
          : type === 'currency'
          ? parseFloat(rowA[index].substring(1))
          : rowA[index];
      const itemB =
        type === 'number'
          ? parseInt(rowB[index])
          : type === 'currency'
          ? parseFloat(rowB[index].substring(1))
          : rowB[index];

      if (type === 'string') {
        const result = itemA > itemB ? 1 : itemB > itemA ? -1 : 0;
        return direction === 'descending' ? result * -1 : result;
      }

      return direction === 'descending' ? itemB - itemA : itemA - itemB;
    });
  }
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
