### PR TITLE
Simplify changelog format

### DIFF
--- a/polaris-for-figma/CHANGELOG.md
+++ b/polaris-for-figma/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.0
+
+Initial release

--- a/polaris-for-figma/package.json
+++ b/polaris-for-figma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polaris-for-figma",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "build": "webpack --mode=production",

--- a/polaris-for-vscode/CHANGELOG.md
+++ b/polaris-for-vscode/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [these versioning and changelog guidelines](/.github/CONTRIBUTING.md#changelog).
-
----
-
-## `v0.2.0` - 2022-05-16
+## 0.2.0
 
 - Removed `var()` autocomplete and added `--p-` prefix to completion item label ([#5764](https://github.com/Shopify/polaris/pull/5764))
 - Added token documentation to completion items ([#5789](https://github.com/Shopify/polaris/pull/5789))
 
-## `v0.1.0` - 2022-04-12
+## 0.1.0
 
 - Initial release

--- a/polaris-icons/CHANGELOG.md
+++ b/polaris-icons/CHANGELOG.md
@@ -1,224 +1,152 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+## 4.21.0
 
-## 4.21.0 - 2022-05-19
+- Updated icon `TickSmallMinor` ([#5836](https://github.com/Shopify/polaris-icons/issues/5836))
+- Updated icon `PlusMinor` ([5726](https://github.com/Shopify/polaris/pull/5726))
 
-### Updated icons
-
-- `TickSmallMinor` ([#5836](https://github.com/Shopify/polaris-icons/issues/5836))
-- `PlusMinor` ([5726](https://github.com/Shopify/polaris/pull/5726))
-
-## 4.20.0 - 2022-05-09
-
-### Enhancements
+## 4.20.0
 
 - Added metadata for the icons
-
-### New icons
-
-- `MergeMinor` ([#1476](https://github.com/Shopify/polaris-icons/pull/1477))
-
-### Changed
-
+- New icon `MergeMinor` ([#1476](https://github.com/Shopify/polaris-icons/pull/1477))
 - Types are now React 18 compatible ([#5704](https://github.com/Shopify/polaris/pull/5704))
 
-## 4.19.1 - 2022-05-03
+## 4.19.1
 
-### New icons
+- New icon `MergeMinor` ([#1476](https://github.com/Shopify/polaris-icons/pull/1477))
 
-- `MergeMinor` ([#1476](https://github.com/Shopify/polaris-icons/pull/1477))
+## 4.19.0
 
-## 4.19.0 - 2022-04-12
+- Updated icon `FinancesMinor` ([#1464](https://github.com/Shopify/polaris-icons/issues/1464))
 
-### Updated icons
+## 4.18.4
 
-- `FinancesMinor` ([#1464](https://github.com/Shopify/polaris-icons/issues/1464))
+- New icon `CreditCardCancelMajor` ([#1457](https://github.com/Shopify/polaris-icons/pull/1457) & [#1460](https://github.com/Shopify/polaris-icons/pull/1460))
 
-## 4.18.4 - 2022-04-01
-
-### New icons
-
-- `CreditCardCancelMajor` ([#1457](https://github.com/Shopify/polaris-icons/pull/1457) & [#1460](https://github.com/Shopify/polaris-icons/pull/1460))
-
-## 4.18.3 - 2022-03-28
+## 4.18.3
 
 ### Bug fixes
 
 - Updated SVG optimization process for greater cross-platform compatibility. ([#1447](https://github.com/Shopify/polaris-icons/pull/1447))
 
-## 4.18.2 - 2022-03-22
+## 4.18.2
 
-### New icons
+- Updated icon `CancelSmallMinor` ([#1440](https://github.com/Shopify/polaris-icons/pull/1440))
 
-### Updated icons
+## 4.18.1
 
-- `CancelSmallMinor` ([#1440](https://github.com/Shopify/polaris-icons/pull/1440))
+- New icon `MarketsMajor` ([#1425](https://github.com/Shopify/polaris-icons/pull/1425))
+- Fix path for `ColorsMajor` ([#1424](https://github.com/Shopify/polaris-icons/pull/1424))
+- Fix path for `DraftOrdersMajor` ([#1424](https://github.com/Shopify/polaris-icons/pull/1424))
+- Fix path for `LanguageMinor` ([#1424](https://github.com/Shopify/polaris-icons/pull/1424))
 
-## 4.18.1 - 2022-03-09
+## 4.18.0
 
-### New icons
+- New icon `DomainRedirectMinor` ([#1407](https://github.com/Shopify/polaris-icons/pull/1407))
 
-- `MarketsMajor` ([#1425](https://github.com/Shopify/polaris-icons/pull/1425))
+## 4.17.0
 
-### Bug fixes
+- New icon `AdjustMinor` ([#1370](https://github.com/Shopify/polaris-icons/pull/1370))
 
-- `ColorsMajor` ([#1424](https://github.com/Shopify/polaris-icons/pull/1424))
-- `DraftOrdersMajor` ([#1424](https://github.com/Shopify/polaris-icons/pull/1424))
-- `LanguageMinor` ([#1424](https://github.com/Shopify/polaris-icons/pull/1424))
+## 4.16.0
 
-## 4.18.0 – 2022-03-01
+- Updated icon `AppsMinor` ([#1347](https://github.com/Shopify/polaris-icons/pull/1347))
 
-### New icons
+## 4.15.0
 
-- `DomainRedirectMinor` ([#1407](https://github.com/Shopify/polaris-icons/pull/1407))
+- New icon `AppsMinor` ([#1338](https://github.com/Shopify/polaris-icons/pull/1338))
+- Updated icon `FinancesMinor` ([#1338](https://github.com/Shopify/polaris-icons/pull/1338))
 
-## 4.17.0 – 2022-02-03
+## 4.14.0
 
-### New icons
+- Updated icon `Columns3Minor` ([#1330](https://github.com/Shopify/polaris-icons/pull/1330))
 
-- `AdjustMinor` ([#1370](https://github.com/Shopify/polaris-icons/pull/1370))
+## 4.13.0
 
-## 4.16.0 – 2022-01-25
+- New icon `AnalyticsMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
+- New icon `DiscountsMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
+- New icon `FinancesMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
+- New icon `HomeMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
+- New icon `MarketingMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
+- New icon `OnlineStoreMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
+- New icon `OrdersMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
+- New icon `ProductsMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
+- Updated icon `CustomersMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
 
-### Updated icons
+## 4.12.0
 
-- `AppsMinor` ([#1347](https://github.com/Shopify/polaris-icons/pull/1347))
+- New icon `Columns3Minor` ([#1315](https://github.com/Shopify/polaris-icons/pull/1315))
 
-## 4.15.0 - 2022-01-19
+## 4.11.0
 
-### New icons
-
-- `AppsMinor` ([#1338](https://github.com/Shopify/polaris-icons/pull/1338))
-
-### Updated icons
-
-- `FinancesMinor` ([#1338](https://github.com/Shopify/polaris-icons/pull/1338))
-
-## 4.14.0 - 2022-01-19
-
-### Updated icons
-
-- `Columns3Minor` ([#1330](https://github.com/Shopify/polaris-icons/pull/1330))
-
-## 4.13.0 - 2022-01-17
-
-### New icons
-
-- `AnalyticsMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-- `DiscountsMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-- `FinancesMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-- `HomeMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-- `MarketingMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-- `OnlineStoreMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-- `OrdersMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-- `ProductsMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-
-### Updated icons
-
-- `CustomersMinor` ([#1332](https://github.com/Shopify/polaris-icons/pull/1332))
-
-## 4.12.0 - 2022-01-05
-
-### New icons
-
-- `Columns3Minor` ([#1315](https://github.com/Shopify/polaris-icons/pull/1315))
-
-## 4.11.0 - 2021-12-15
-
-### New icons
-
-- `CircleTickMinor` ([#1243](https://github.com/Shopify/polaris-icons/pull/1243))
-- `FinancesMajor` ([#1271](https://github.com/Shopify/polaris-icons/pull/1271))
-- `WandMinor` ([#1291](https://github.com/Shopify/polaris-icons/pull/1291))
-
-### Other **changes**
-
+- New icon `CircleTickMinor` ([#1243](https://github.com/Shopify/polaris-icons/pull/1243))
+- New icon `FinancesMajor` ([#1271](https://github.com/Shopify/polaris-icons/pull/1271))
+- New icon `WandMinor` ([#1291](https://github.com/Shopify/polaris-icons/pull/1291))
 - Updated icon metadata for various icons, and cleaned up the changelog ([#1241](https://github.com/Shopify/polaris-icons/pull/1241))
 
-## 4.10.0 - 2021-11-03
+## 4.10.0
 
-### Updated icons
+- Updated icon `SelectMinor` ([#1238](https://github.com/Shopify/polaris-icons/pull/1238))
+- Updated icon `CaretDownMinor` ([#1238](https://github.com/Shopify/polaris-icons/pull/1238))
+- Updated icon `CaretUpMinor` ([#1238](https://github.com/Shopify/polaris-icons/pull/1238))
+- Updated icon `DropDownMinor` ([#1238](https://github.com/Shopify/polaris-icons/pull/1238))
 
-- `SelectMinor` ([#1238](https://github.com/Shopify/polaris-icons/pull/1238))
-- `CaretDownMinor` ([#1238](https://github.com/Shopify/polaris-icons/pull/1238))
-- `CaretUpMinor` ([#1238](https://github.com/Shopify/polaris-icons/pull/1238))
-- `DropDownMinor` ([#1238](https://github.com/Shopify/polaris-icons/pull/1238))
+## 4.9.0
 
-## 4.9.0 - 2021-10-29
+- Updated icon `DropdownMinor` ([#1226](https://github.com/Shopify/polaris-icons/pull/1226))
 
-### Updated icons
+## 4.8.0
 
-- `DropdownMinor` ([#1226](https://github.com/Shopify/polaris-icons/pull/1226))
+- New icon `BlockMinor` ([#1125](https://github.com/Shopify/polaris-icons/pull/1125))
+- New icon `ButtonMinor` ([#1125](https://github.com/Shopify/polaris-icons/pull/1125))
+- New icon `TitleMinor` ([#1125](https://github.com/Shopify/polaris-icons/pull/1125))
 
-## 4.8.0 - 2021-08-19
+## 4.7.0
 
-### New icons
+- New icon `QuestionMarkInverseMajor` ([#1050](https://github.com/Shopify/polaris-icons/pull/1050))
+- New icon `QuestionMarkInverseMinor` ([#1050](https://github.com/Shopify/polaris-icons/pull/1050))
 
-- `BlockMinor` ([#1125](https://github.com/Shopify/polaris-icons/pull/1125))
-- `ButtonMinor` ([#1125](https://github.com/Shopify/polaris-icons/pull/1125))
-- `TitleMinor` ([#1125](https://github.com/Shopify/polaris-icons/pull/1125))
-
-## 4.7.0 - 2021-07-15
-
-### New icons
-
-- `QuestionMarkInverseMajor` ([#1050](https://github.com/Shopify/polaris-icons/pull/1050))
-- `QuestionMarkInverseMinor` ([#1050](https://github.com/Shopify/polaris-icons/pull/1050))
-
-## 4.6.2 - 2021-06-29
+## 4.6.2
 
 - Remove deprecated GOOGLE_APPLICATION_CREDENTIALS usage ([#1005](https://github.com/Shopify/polaris-icons/pull/1005))
 
-## 4.6.1 - 2021-06-24
+## 4.6.1
 
 - Fix breakage in svg imports thanks to incorrect React imports by downgrading `@svgr/core` to v4 ([#1001](https://github.com/Shopify/polaris-icons/pull/1001))
 
-## 4.6.0 - 2021-06-23
+## 4.6.0
 
-### New icons
+- New icon `ExitMajor`
 
-- `ExitMajor`
+## 4.5.0
 
-## 4.5.0 - 2021-02-23
+- New icon `StoreMinor`
 
-### New icons
+## 4.4.0
 
-- `StoreMinor`
+- New icon `ButtonCornerSquareMajor`
+- New icon `ButtonCornerPillMajor`
+- New icon `ButtonCornerRoundedMajor`
 
-## 4.4.0 - 2021-02-10
+## 4.3.0
 
-### New icons
+- New icon `TemplateMajor`
 
-- `ButtonCornerSquareMajor`
-- `ButtonCornerPillMajor`
-- `ButtonCornerRoundedMajor`
+## 4.2.0
 
-## 4.3.0 - 2021-02-05
+- New icon `Column1Major`
+- New icon `Columns2Major`
+- New icon `Columns3Major`
 
-### New icons
+## 4.1.0
 
-- `TemplateMajor`
+- New icon `DiamondAlertMajor`
 
-## 4.2.0 - 2021-01-22
-
-### New icons
-
-- `Column1Major`
-- `Columns2Major`
-- `Columns3Major`
-
-## 4.1.0 - 2020-10-26
-
-### New icons
-
-- `DiamondAlertMajor`
-
-## 4.0.0 - 2020-10-02
+## 4.0.0
 
 Polaris Icons v4.0.0 updates icon styles across the board. It replaces monotone, twotone and filled major icon variants with a single style and icons that previously lived in the `@shopify/polaris-icons-internal` package are now part of the public `@shopify/polaris-icons` package.
 
-### Breaking Changes
+### Major Changes
 
 In Polaris Icons v3 Major icons came in three styles `Monotone`, `Twotone` and `Filled` as denoted by a suffix on their import name. In v4 we have removed this distinction and thus the suffix on the import name. You should update icon imports to omit these suffixes. For instance `HomeMajorMonotone` and `HomeMajorTwotone` would both become `HomeMajor`.
 
@@ -270,660 +198,621 @@ import {
 +} from '@shopify/polaris-icons';
 ```
 
-## 3.12.0 - 2020-07-15
+## 3.12.0
 
-### New icons
+- New icon `ComposeMajor`
 
-- `ComposeMajor`
+## 3.11.0
 
-## 3.11.0 - 2020-07-13
+- New icon `ProductReturnsMinor`
 
-### New icons
+## 3.10.0
 
-- `ProductReturnsMinor`
+- New icon `AnalyticsMajorFilled`
+- New icon `AppsMajorFilled`
+- New icon `CustomersMajorFilled`
+- New icon `DiscountsMajorFilled`
+- New icon `HomeMajorFilled`
+- New icon `MarketingMajorFilled`
+- New icon `OnlineStoreMajorFilled`
+- New icon `OrdersMajorFilled`
+- New icon `ProductsMajorFilled`
+- New icon `CircleAlertMajorFilled`
+- New icon `CircleDisabledMajorFilled`
+- New icon `CircleInformationMajorFilled`
+- New icon `CircleTickMajorFilled`
 
-## 3.10.0 - 2020-03-17
-
-### New icons
-
-- `AnalyticsMajorFilled`
-- `AppsMajorFilled`
-- `CustomersMajorFilled`
-- `DiscountsMajorFilled`
-- `HomeMajorFilled`
-- `MarketingMajorFilled`
-- `OnlineStoreMajorFilled`
-- `OrdersMajorFilled`
-- `ProductsMajorFilled`
-- `CircleAlertMajorFilled`
-- `CircleDisabledMajorFilled`
-- `CircleInformationMajorFilled`
-- `CircleTickMajorFilled`
-
-## 3.9.0 - 2020-01-09
+## 3.9.0
 
 ### Enhancements
 
 - Updated build output so icons are individually exported instead of inlined into a single file. This helps improve chunking in consuming projects as it no longer forces a single chunk for all icons used an app, which can result in smaller initial bundle downloads.
 
-## 3.8.0 - 2019-11-20
-
-### Deprecated
+## 3.8.0
 
 - `FavouriteMajor` was renamed to `FavoriteMajor` to match the American spelling
-
-### New icons
-
-- `AutomationMajorMonotone`
-- `AutomationMajorTwotone`
-- `CapitalMajorMonotone` (exports were missing in v3.6.0)
-- `CapitalMajorTwotone` (exports were missing in v3.6.0)
-- `CustomersMinor`
-- `ReferralMajorMonotone`
-- `ReferralMajorTwotone`
-- `ReferralCodeMajorMonotone`
-- `ReferralCodeMajorTwotone`
-
-### Fixed
-
+- New icon `AutomationMajorMonotone`
+- New icon `AutomationMajorTwotone`
+- New icon `CapitalMajorMonotone` (exports were missing in v3.6.0)
+- New icon `CapitalMajorTwotone` (exports were missing in v3.6.0)
+- New icon `CustomersMinor`
+- New icon `ReferralMajorMonotone`
+- New icon `ReferralMajorTwotone`
+- New icon `ReferralCodeMajorMonotone`
+- New icon `ReferralCodeMajorTwotone`
 - Fixed an issue in `FavoriteMajor` where the top branch of the star had a visual artifact
 
-## 3.7.0 - 2019-09-27
+## 3.7.0
 
-### Added
+- Added iOS asset catalog.
+- Added Android drawables.
 
-- iOS asset catalog.
-- Android drawables.
+## 3.6.0
 
-## 3.6.0 - 2019-09-16
+- New icon `CapitalMajorMonotone`
+- New icon `CapitalMajorTwotone`
 
-### New icons
-
-- `CapitalMajorMonotone`
-- `CapitalMajorTwotone`
-
-## 3.5.1 - 2019-08-15
-
-### Fixed
+## 3.5.1
 
 - `StarFilledMinor` and `StarOutlineMinor` - Centred the icons in their viewboxes
 
-## 3.5.0 - 2019-08-08
+## 3.5.0
 
-### New icons
-
-- `TextAlignmentCenterMajorMonotone`
-- `TextAlignmentCenterMajorTwotone`
-- `TextAlignmentLeftMajorMonotone`
-- `TextAlignmentLeftMajorTwotone`
-- `TextAlignmentRightMajorMonotone`
-- `TextAlignmentRightMajorTwotone`
-
+- New icon `TextAlignmentCenterMajorMonotone`
+- New icon `TextAlignmentCenterMajorTwotone`
+- New icon `TextAlignmentLeftMajorMonotone`
+- New icon `TextAlignmentLeftMajorTwotone`
+- New icon `TextAlignmentRightMajorMonotone`
+- New icon `TextAlignmentRightMajorTwotone`
 - Added a test to restrict attributes on `<svg>` to `xmlns` and `viewBox` ([#649](https://github.com/Shopify/polaris-icons/pull/649))
 
-## 3.4.0 - 2019-05-20
-
-### Enhancements
+## 3.4.0
 
 - Added plain SVG files in the `/images` folder for consumers that can't consume React components
 
-## 3.3.0 - 2019-03-28
-
-### Deprecated
+## 3.3.0
 
 - `ArrowUpDownMinor` has been renamed to `SelectMinor` to match the name used in Sketch. `ArrowUpDownMinor` will continue to exist as an alias until v4.0.0.
 - `ColorMajorMonotone` has been renamed to `ColorsMajorMonotone` to match the name used in Sketch. `ColorMajorMonotone` will continue to exist as an alias until v4.0.0.
 - `SidebarMajorMonotone` has been renamed to `SidebarLeftMajorMonotone` to match the name used in Sketch. `SidebarMajorMonotone` will continue to exist as an alias until v4.0.0.
+- Fixed issue with `ImportStoreMajorMonotone`
+- New icon `AbandonedCartMajorMonotone`
+- New icon `AbandonedCartMajorTwotone`
+- New icon `AccessibilityMajorMonotone`
+- New icon `AccessibilityMajorTwotone`
+- New icon `ActivitiesMajorMonotone`
+- New icon `ActivitiesMajorTwotone`
+- New icon `AddCodeMajorMonotone`
+- New icon `AddCodeMajorTwotone`
+- New icon `AddImageMajorMonotone`
+- New icon `AddImageMajorTwotone`
+- New icon `AddMajorTwotone`
+- New icon `AddNoteMajorMonotone`
+- New icon `AddNoteMajorTwotone`
+- New icon `AddProductMajorMonotone`
+- New icon `AddProductMajorTwotone`
+- New icon `AffiliateMajorMonotone`
+- New icon `AffiliateMajorTwotone`
+- New icon `AnalyticsMajorMonotone`
+- New icon `ArchiveMajorMonotone`
+- New icon `ArchiveMajorTwotone`
+- New icon `AttachmentMajorMonotone`
+- New icon `AttachmentMajorTwotone`
+- New icon `BackspaceMajorMonotone`
+- New icon `BackspaceMajorTwotone`
+- New icon `BalanceMajorMonotone`
+- New icon `BalanceMajorTwotone`
+- New icon `BankMajorMonotone`
+- New icon `BankMajorTwotone`
+- New icon `BarcodeMajorMonotone`
+- New icon `BarcodeMajorTwotone`
+- New icon `BehaviorMajorMonotone`
+- New icon `BehaviorMajorTwotone`
+- New icon `BillingStatementDollarMajorMonotone`
+- New icon `BillingStatementDollarMajorTwotone`
+- New icon `BillingStatementEuroMajorMonotone`
+- New icon `BillingStatementEuroMajorTwotone`
+- New icon `BillingStatementPoundMajorMonotone`
+- New icon `BillingStatementPoundMajorTwotone`
+- New icon `BillingStatementRupeeMajorMonotone`
+- New icon `BillingStatementRupeeMajorTwotone`
+- New icon `BillingStatementYenMajorMonotone`
+- New icon `BillingStatementYenMajorTwotone`
+- New icon `BlockquoteMajorTwotone`
+- New icon `BlogMajorMonotone`
+- New icon `BugMajorMonotone`
+- New icon `BugMajorTwotone`
+- New icon `BuyButtonButtonLayoutMajorMonotone`
+- New icon `BuyButtonButtonLayoutMajorTwotone`
+- New icon `BuyButtonHorizontalLayoutMajorMonotone`
+- New icon `BuyButtonHorizontalLayoutMajorTwotone`
+- New icon `BuyButtonMajorMonotone`
+- New icon `BuyButtonMajorTwotone`
+- New icon `BuyButtonVerticalLayoutMajorMonotone`
+- New icon `BuyButtonVerticalLayoutMajorTwotone`
+- New icon `CalendarMajorMonotone`
+- New icon `CalendarTickMajorMonotone`
+- New icon `CalendarTickMajorTwotone`
+- New icon `CameraMajorMonotone`
+- New icon `CameraMajorTwotone`
+- New icon `CardReaderChipMajorMonotone`
+- New icon `CardReaderChipMajorTwotone`
+- New icon `CardReaderMajorMonotone`
+- New icon `CardReaderMajorTwotone`
+- New icon `CardReaderTapMajorMonotone`
+- New icon `CardReaderTapMajorTwotone`
+- New icon `CartDownMajorMonotone`
+- New icon `CartDownMajorTwotone`
+- New icon `CartMajorMonotone`
+- New icon `CartUpMajorMonotone`
+- New icon `CartUpMajorTwotone`
+- New icon `CashDollarMajorTwotone`
+- New icon `CashEuroMajorMonotone`
+- New icon `CashEuroMajorTwotone`
+- New icon `CashPoundMajorMonotone`
+- New icon `CashPoundMajorTwotone`
+- New icon `CashRupeeMajorMonotone`
+- New icon `CashRupeeMajorTwotone`
+- New icon `CashYenMajorMonotone`
+- New icon `CashYenMajorTwotone`
+- New icon `CategoriesMajorMonotone`
+- New icon `CategoriesMajorTwotone`
+- New icon `ChannelsMajorMonotone`
+- New icon `ChannelsMajorTwotone`
+- New icon `ChatMajorMonotone`
+- New icon `ChatMajorTwotone`
+- New icon `ChecklistAlternateMajorMonotone`
+- New icon `ChecklistAlternateMajorTwotone`
+- New icon `ChecklistMajorMonotone`
+- New icon `ChecklistMajorTwotone`
+- New icon `CheckoutMajorMonotone`
+- New icon `CircleCancelMajorMonotone`
+- New icon `CircleCancelMajorTwotone`
+- New icon `CircleDisabledMajorMonotone`
+- New icon `CircleDotsMajorMonotone`
+- New icon `CircleDotsMajorTwotone`
+- New icon `CircleDownMajorMonotone`
+- New icon `CircleDownMajorTwotone`
+- New icon `CircleInformationMajorMonotone`
+- New icon `CircleLeftMajorMonotone`
+- New icon `CircleLeftMajorTwotone`
+- New icon `CircleMinusMajorMonotone`
+- New icon `CircleMinusMajorTwotone`
+- New icon `CirclePlusMajorTwotone`
+- New icon `CircleRightMajorMonotone`
+- New icon `CircleRightMajorTwotone`
+- New icon `CircleUpMajorMonotone`
+- New icon `CircleUpMajorTwotone`
+- New icon `ClockMajorMonotone`
+- New icon `ClockMajorTwotone`
+- New icon `CodeMajorTwotone`
+- New icon `CollectionsMajorMonotone`
+- New icon `ColorsMajorMonotone`
+- New icon `ColorsMajorTwotone`
+- New icon `ColumnImageWithTextMajorMonotone`
+- New icon `ColumnImageWithTextMajorTwotone`
+- New icon `ConfettiMajorMonotone`
+- New icon `ConfettiMajorTwotone`
+- New icon `CreditCardMajorMonotone`
+- New icon `CreditCardMajorTwotone`
+- New icon `CreditCardPercentMajorMonotone`
+- New icon `CreditCardPercentMajorTwotone`
+- New icon `CreditCardSecureMajorMonotone`
+- New icon `CreditCardSecureMajorTwotone`
+- New icon `CustomerMinusMajorMonotone`
+- New icon `CustomerMinusMajorTwotone`
+- New icon `CustomerPlusMajorMonotone`
+- New icon `CustomerPlusMajorTwotone`
+- New icon `CustomersMajorMonotone`
+- New icon `DataVisualizationMajorMonotone`
+- New icon `DataVisualizationMajorTwotone`
+- New icon `DeleteMajorMonotone`
+- New icon `DeleteMajorTwotone`
+- New icon `DesktopMajorMonotone`
+- New icon `DigitalMediaReceiverMajorMonotone`
+- New icon `DigitalMediaReceiverMajorTwotone`
+- New icon `DiscountAutomaticMajorMonotone`
+- New icon `DiscountAutomaticMajorTwotone`
+- New icon `DiscountCodeMajorMonotone`
+- New icon `DiscountCodeMajorTwotone`
+- New icon `DiscountsMajorMonotone`
+- New icon `DnsSettingsMajorMonotone`
+- New icon `DnsSettingsMajorTwotone`
+- New icon `DomainAddMajorMonotone`
+- New icon `DomainAddMajorTwotone`
+- New icon `DomainsMajorTwotone`
+- New icon `DraftOrdersMajorMonotone`
+- New icon `DraftOrdersMajorTwotone`
+- New icon `DragDropMajorTwotone`
+- New icon `EditMajorMonotone`
+- New icon `EditMajorTwotone`
+- New icon `EmailMajorMonotone`
+- New icon `EmailNewsletterMajorMonotone`
+- New icon `EmailNewsletterMajorTwotone`
+- New icon `EnvelopeMajorMonotone`
+- New icon `EnvelopeMajorTwotone`
+- New icon `ExchangeMajorMonotone`
+- New icon `ExchangeMajorTwotone`
+- New icon `ExistingInventoryMajorMonotone`
+- New icon `ExistingInventoryMajorTwotone`
+- New icon `FaviconMajorTwotone`
+- New icon `FavouriteMajorMonotone`
+- New icon `FavouriteMajorTwotone`
+- New icon `FeaturedCollectionMajorTwotone`
+- New icon `FeaturedContentMajorTwotone`
+- New icon `FilterMajorMonotone`
+- New icon `FilterMajorTwotone`
+- New icon `FirstOrderMajorMonotone`
+- New icon `FirstOrderMajorTwotone`
+- New icon `FirstVisitMajorMonotone`
+- New icon `FirstVisitMajorTwotone`
+- New icon `FlagMajorMonotone`
+- New icon `FlipCameraMajorMonotone`
+- New icon `FlipCameraMajorTwotone`
+- New icon `FolderDownMajorMonotone`
+- New icon `FolderDownMajorTwotone`
+- New icon `FolderMajorMonotone`
+- New icon `FolderMajorTwotone`
+- New icon `FolderMinusMajorMonotone`
+- New icon `FolderMinusMajorTwotone`
+- New icon `FolderPlusMajorMonotone`
+- New icon `FolderPlusMajorTwotone`
+- New icon `FolderUpMajorMonotone`
+- New icon `FolderUpMajorTwotone`
+- New icon `FollowUpEmailMajorMonotone`
+- New icon `FollowUpEmailMajorTwotone`
+- New icon `FoodMajorMonotone`
+- New icon `FoodMajorTwotone`
+- New icon `FooterMajorTwotone`
+- New icon `FormsMajorMonotone`
+- New icon `FormsMajorTwotone`
+- New icon `GamesConsoleMajorMonotone`
+- New icon `GamesConsoleMajorTwotone`
+- New icon `GiftCardMajorMonotone`
+- New icon `GlobeMajorMonotone`
+- New icon `GlobeMajorTwotone`
+- New icon `GrammarMajorMonotone`
+- New icon `GrammarMajorTwotone`
+- New icon `HashtagMajorMonotone`
+- New icon `HashtagMajorTwotone`
+- New icon `HeartMajorMonotone`
+- New icon `HeartMajorTwotone`
+- New icon `HideKeyboardMajorMonotone`
+- New icon `HideKeyboardMajorTwotone`
+- New icon `HintMajorTwotone`
+- New icon `IconsMajorMonotone`
+- New icon `IconsMajorTwotone`
+- New icon `IllustrationMajorMonotone`
+- New icon `IllustrationMajorTwotone`
+- New icon `ImageAltMajorTwotone`
+- New icon `ImageMajorMonotone`
+- New icon `ImagesMajorMonotone`
+- New icon `ImagesMajorTwotone`
+- New icon `ImageWithTextMajorTwotone`
+- New icon `ImageWithTextOverlayMajorTwotone`
+- New icon `ImportStoreMajorMonotone`
+- New icon `ImportStoreMajorTwotone`
+- New icon `IncomingMajorMonotone`
+- New icon `IncomingMajorTwotone`
+- New icon `InventoryMajorMonotone`
+- New icon `InventoryMajorTwotone`
+- New icon `IqMajorMonotone`
+- New icon `IqMajorTwotone`
+- New icon `JobsMajorMonotone`
+- New icon `JobsMajorTwotone`
+- New icon `KeyMajorMonotone`
+- New icon `KeyMajorTwotone`
+- New icon `LabelPrinterMajorMonotone`
+- New icon `LabelPrinterMajorTwotone`
+- New icon `LandingPageMajorMonotone`
+- New icon `LandingPageMajorTwotone`
+- New icon `LegalMajorTwotone`
+- New icon `ListMajorMonotone`
+- New icon `ListMajorTwotone`
+- New icon `LiveViewMajorMonotone`
+- New icon `LiveViewMajorTwotone`
+- New icon `LocationMajorMonotone`
+- New icon `LockMajorMonotone`
+- New icon `LockMajorTwotone`
+- New icon `LogoBlockMajorTwotone`
+- New icon `ManagedStoreMajorMonotone`
+- New icon `ManagedStoreMajorTwotone`
+- New icon `MarketingMajorTwotone`
+- New icon `MaximizeMajorMonotone`
+- New icon `MaximizeMajorTwotone`
+- New icon `MentionMajorMonotone`
+- New icon `MentionMajorTwotone`
+- New icon `MicrophoneMajorMonotone`
+- New icon `MicrophoneMajorTwotone`
+- New icon `MinimizeMajorMonotone`
+- New icon `MinimizeMajorTwotone`
+- New icon `MobileAcceptMajorMonotone`
+- New icon `MobileAcceptMajorTwotone`
+- New icon `MobileBackArrowMajorMonotone`
+- New icon `MobileBackArrowMajorTwotone`
+- New icon `MobileCancelMajorTwotone`
+- New icon `MobileChevronMajorMonotone`
+- New icon `MobileChevronMajorTwotone`
+- New icon `MobileHamburgerMajorTwotone`
+- New icon `MobileHorizontalDotsMajorMonotone`
+- New icon `MobileHorizontalDotsMajorTwotone`
+- New icon `MobileMajorMonotone`
+- New icon `MobilePlusMajorMonotone`
+- New icon `MobilePlusMajorTwotone`
+- New icon `MobileVerticalDotsMajorMonotone`
+- New icon `MobileVerticalDotsMajorTwotone`
+- New icon `MonerisMajorMonotone`
+- New icon `MonerisMajorTwotone`
+- New icon `NatureMajorMonotone`
+- New icon `NatureMajorTwotone`
+- New icon `NavigationMajorMonotone`
+- New icon `NoteMajorMonotone`
+- New icon `NoteMajorMonotone`
+- New icon `NoteMajorTwotone`
+- New icon `NoteMajorTwotone`
+- New icon `NotificationMajorTwotone`
+- New icon `OnlineStoreMajorMonotone`
+- New icon `OrdersMajorMonotone`
+- New icon `OutgoingMajorMonotone`
+- New icon `OutgoingMajorTwotone`
+- New icon `PackageMajorMonotone`
+- New icon `PageDownMajorMonotone`
+- New icon `PageDownMajorTwotone`
+- New icon `PageMajorMonotone`
+- New icon `PageMinusMajorMonotone`
+- New icon `PageMinusMajorTwotone`
+- New icon `PagePlusMajorMonotone`
+- New icon `PagePlusMajorTwotone`
+- New icon `PageUpMajorMonotone`
+- New icon `PageUpMajorTwotone`
+- New icon `PaintBrushMajorMonotone`
+- New icon `PauseCircleMajorMonotone`
+- New icon `PauseCircleMajorTwotone`
+- New icon `PauseMajorMonotone`
+- New icon `PauseMajorTwotone`
+- New icon `PaymentsMajorMonotone`
+- New icon `PhoneInMajorMonotone`
+- New icon `PhoneInMajorTwotone`
+- New icon `PhoneMajorMonotone`
+- New icon `PhoneMajorTwotone`
+- New icon `PhoneOutMajorMonotone`
+- New icon `PhoneOutMajorTwotone`
+- New icon `PinMajorMonotone`
+- New icon `PinMajorTwotone`
+- New icon `PlayCircleMajorTwotone`
+- New icon `PlayMajorMonotone`
+- New icon `PlayMajorTwotone`
+- New icon `PointOfSaleMajorMonotone`
+- New icon `PointOfSaleMajorTwotone`
+- New icon `PopularMajorMonotone`
+- New icon `PopularMajorTwotone`
+- New icon `PrintMajorMonotone`
+- New icon `PrintMajorTwotone`
+- New icon `ProductsMajorMonotone`
+- New icon `QuestionMarkMajorMonotone`
+- New icon `QuickSaleMajorMonotone`
+- New icon `QuickSaleMajorTwotone`
+- New icon `ReceiptMajorMonotone`
+- New icon `ReceiptMajorTwotone`
+- New icon `RecentSearchesMajorMonotone`
+- New icon `RecentSearchesMajorTwotone`
+- New icon `RedoMajorTwotone`
+- New icon `RefreshMajorMonotone`
+- New icon `RefreshMajorTwotone`
+- New icon `RefundMajorMonotone`
+- New icon `RefundMajorTwotone`
+- New icon `RemoveProductMajorMonotone`
+- New icon `RemoveProductMajorTwotone`
+- New icon `RepeatOrderMajorMonotone`
+- New icon `RepeatOrderMajorTwotone`
+- New icon `ReplaceMajorTwotone`
+- New icon `ReportsMajorMonotone`
+- New icon `ReportsMajorTwotone`
+- New icon `ResourcesMajorMonotone`
+- New icon `ResourcesMajorTwotone`
+- New icon `RiskMajorMonotone`
+- New icon `RiskMajorTwotone`
+- New icon `SandboxMajorMonotone`
+- New icon `SandboxMajorTwotone`
+- New icon `SearchMajorMonotone`
+- New icon `SearchMajorTwotone`
+- New icon `SectionMajorMonotone`
+- New icon `SecureMajorMonotone`
+- New icon `SecureMajorTwotone`
+- New icon `SendMajorMonotone`
+- New icon `SendMajorTwotone`
+- New icon `SettingsMajorMonotone`
+- New icon `ShipmentMajorTwotone`
+- New icon `ShopcodesMajorMonotone`
+- New icon `ShopcodesMajorTwotone`
+- New icon `SidebarLeftMajorMonotone`
+- New icon `SidebarLeftMajorTwotone`
+- New icon `SidebarRightMajorMonotone`
+- New icon `SidebarRightMajorTwotone`
+- New icon `SlideshowMajorTwotone`
+- New icon `SmileyHappyMajorMonotone`
+- New icon `SmileyHappyMajorTwotone`
+- New icon `SmileyJoyMajorMonotone`
+- New icon `SmileyJoyMajorTwotone`
+- New icon `SmileyNeutralMajorMonotone`
+- New icon `SmileyNeutralMajorTwotone`
+- New icon `SmileySadMajorMonotone`
+- New icon `SmileySadMajorTwotone`
+- New icon `SocialAdMajorTwotone`
+- New icon `SocialPostMajorMonotone`
+- New icon `SocialPostMajorTwotone`
+- New icon `SoftPackMajorTwotone`
+- New icon `SortAscendingMajorMonotone`
+- New icon `SortAscendingMajorTwotone`
+- New icon `SortDescendingMajorMonotone`
+- New icon `SortDescendingMajorTwotone`
+- New icon `SoundMajorMonotone`
+- New icon `SoundMajorTwotone`
+- New icon `StoreMajorMonotone`
+- New icon `StoreMajorTwotone`
+- New icon `StoreStatusMajorMonotone`
+- New icon `StoreStatusMajorTwotone`
+- New icon `TabletMajorMonotone`
+- New icon `TabletMajorTwotone`
+- New icon `TapChipMajorMonotone`
+- New icon `TapChipMajorTwotone`
+- New icon `TaxMajorMonotone`
+- New icon `TaxMajorTwotone`
+- New icon `TeamMajorMonotone`
+- New icon `TeamMajorTwotone`
+- New icon `TextBlockMajorMonotone`
+- New icon `TextMajorMonotone`
+- New icon `TextMajorTwotone`
+- New icon `ThemeEditMajorMonotone`
+- New icon `ThemeEditMajorTwotone`
+- New icon `ThemesMajorTwotone`
+- New icon `ThemeStoreMajorTwotone`
+- New icon `ThumbsDownMajorMonotone`
+- New icon `ThumbsDownMajorTwotone`
+- New icon `ThumbsUpMajorTwotone`
+- New icon `TimelineAttachmentMajorMonotone`
+- New icon `TimelineAttachmentMajorTwotone`
+- New icon `TipsMajorMonotone`
+- New icon `TipsMajorTwotone`
+- New icon `ToolsMajorMonotone`
+- New icon `ToolsMajorTwotone`
+- New icon `TransactionFeeDollarMajorMonotone`
+- New icon `TransactionFeeDollarMajorTwotone`
+- New icon `TransactionFeeEuroMajorMonotone`
+- New icon `TransactionFeeEuroMajorTwotone`
+- New icon `TransactionFeePoundMajorMonotone`
+- New icon `TransactionFeePoundMajorTwotone`
+- New icon `TransactionFeeRupeeMajorMonotone`
+- New icon `TransactionFeeRupeeMajorTwotone`
+- New icon `TransactionFeeYenMajorMonotone`
+- New icon `TransactionFeeYenMajorTwotone`
+- New icon `TransactionMajorMonotone`
+- New icon `TransactionMajorTwotone`
+- New icon `TransferInMajorMonotone`
+- New icon `TransferInMajorTwotone`
+- New icon `TransferMajorMonotone`
+- New icon `TransferMajorTwotone`
+- New icon `TransferOutMajorMonotone`
+- New icon `TransferOutMajorTwotone`
+- New icon `TransferWithinShopifyMajorMonotone`
+- New icon `TransferWithinShopifyMajorTwotone`
+- New icon `TransportMajorMonotone`
+- New icon `TransportMajorTwotone`
+- New icon `TroubleshootMajorMonotone`
+- New icon `TroubleshootMajorTwotone`
+- New icon `TypeMajorTwotone`
+- New icon `UndoMajorTwotone`
+- New icon `UnfulfilledMajorMonotone`
+- New icon `UnfulfilledMajorTwotone`
+- New icon `UnknownDeviceMajorMonotone`
+- New icon `UnknownDeviceMajorTwotone`
+- New icon `UpdateInventoryMajorMonotone`
+- New icon `UpdateInventoryMajorTwotone`
+- New icon `VariantMajorMonotone`
+- New icon `VariantMajorTwotone`
+- New icon `ViewMajorTwotone`
+- New icon `ViewportNarrowMajorMonotone`
+- New icon `ViewportNarrowMajorTwotone`
+- New icon `ViewportWideMajorTwotone`
+- New icon `VocabularyMajorTwotone`
+- New icon `WandMajorMonotone`
+- New icon `WandMajorTwotone`
+- New icon `WearableMajorMonotone`
+- New icon `WearableMajorTwotone`
+- New icon `WholesaleMajorMonotone`
+- New icon `WifiMajorMonotone`
+- New icon `WifiMajorTwotone`
+- New icon `AppExtensionMinor`
+- New icon `ArchiveMinor`
+- New icon `CapturePaymentMinor`
+- New icon `CircleMinusMinor`
+- New icon `CircleMinusOutlineMinor`
+- New icon `CircleTickOutlineMinor`
+- New icon `ClipboardMinor`
+- New icon `ConnectMinor`
+- New icon `DragHandleMinor`
+- New icon `DropdownMinor`
+- New icon `ExternalSmallMinor`
+- New icon `GiftCardMinor`
+- New icon `GlobeMinor`
+- New icon `ImageAltMinor`
+- New icon `InfoMinor`
+- New icon `InstallMinor`
+- New icon `InviteMinor`
+- New icon `LanguageMinor`
+- New icon `LockMinor`
+- New icon `MarkFulfilledMinor`
+- New icon `MarkPaidMinor`
+- New icon `MaximizeMinor`
+- New icon `MinimizeMinor`
+- New icon `NotesMinor`
+- New icon `OrderStatusMinor`
+- New icon `PaginationEndMinor`
+- New icon `PaginationStartMinor`
+- New icon `PauseMinor`
+- New icon `PinMinor`
+- New icon `PlayMinor`
+- New icon `PriceLookupMinor`
+- New icon `PromoteMinor`
+- New icon `QuestionMarkMinor`
+- New icon `ReadTimeMinor`
+- New icon `RefundMinor`
+- New icon `ReplayMinor`
+- New icon `ReportMinor`
+- New icon `ResetMinor`
+- New icon `ReturnMinor`
+- New icon `SettingsMinor`
+- New icon `ShareIosMinor`
+- New icon `ShareMinor`
+- New icon `SortMinor`
+- New icon `ThumbsDownMinor`
+- New icon `ThumbsUpMinor`
+- New icon `TickMinor`
 
-### Fixed
+## 3.2.0
 
-- `ImportStoreMajorMonotone`
+- New icon `CirclePlusMajorMonotone`
+- New icon `RedoMajorMonotone`
+- New icon `ThemeStoreMajorMonotone`
+- New icon `ThemesMajorMonotone`
+- New icon `UndoMajorMonotone`
 
-### New icons
+## 3.1.0
 
-- `AbandonedCartMajorMonotone`
-- `AbandonedCartMajorTwotone`
-- `AccessibilityMajorMonotone`
-- `AccessibilityMajorTwotone`
-- `ActivitiesMajorMonotone`
-- `ActivitiesMajorTwotone`
-- `AddCodeMajorMonotone`
-- `AddCodeMajorTwotone`
-- `AddImageMajorMonotone`
-- `AddImageMajorTwotone`
-- `AddMajorTwotone`
-- `AddNoteMajorMonotone`
-- `AddNoteMajorTwotone`
-- `AddProductMajorMonotone`
-- `AddProductMajorTwotone`
-- `AffiliateMajorMonotone`
-- `AffiliateMajorTwotone`
-- `AnalyticsMajorMonotone`
-- `ArchiveMajorMonotone`
-- `ArchiveMajorTwotone`
-- `AttachmentMajorMonotone`
-- `AttachmentMajorTwotone`
-- `BackspaceMajorMonotone`
-- `BackspaceMajorTwotone`
-- `BalanceMajorMonotone`
-- `BalanceMajorTwotone`
-- `BankMajorMonotone`
-- `BankMajorTwotone`
-- `BarcodeMajorMonotone`
-- `BarcodeMajorTwotone`
-- `BehaviorMajorMonotone`
-- `BehaviorMajorTwotone`
-- `BillingStatementDollarMajorMonotone`
-- `BillingStatementDollarMajorTwotone`
-- `BillingStatementEuroMajorMonotone`
-- `BillingStatementEuroMajorTwotone`
-- `BillingStatementPoundMajorMonotone`
-- `BillingStatementPoundMajorTwotone`
-- `BillingStatementRupeeMajorMonotone`
-- `BillingStatementRupeeMajorTwotone`
-- `BillingStatementYenMajorMonotone`
-- `BillingStatementYenMajorTwotone`
-- `BlockquoteMajorTwotone`
-- `BlogMajorMonotone`
-- `BugMajorMonotone`
-- `BugMajorTwotone`
-- `BuyButtonButtonLayoutMajorMonotone`
-- `BuyButtonButtonLayoutMajorTwotone`
-- `BuyButtonHorizontalLayoutMajorMonotone`
-- `BuyButtonHorizontalLayoutMajorTwotone`
-- `BuyButtonMajorMonotone`
-- `BuyButtonMajorTwotone`
-- `BuyButtonVerticalLayoutMajorMonotone`
-- `BuyButtonVerticalLayoutMajorTwotone`
-- `CalendarMajorMonotone`
-- `CalendarTickMajorMonotone`
-- `CalendarTickMajorTwotone`
-- `CameraMajorMonotone`
-- `CameraMajorTwotone`
-- `CardReaderChipMajorMonotone`
-- `CardReaderChipMajorTwotone`
-- `CardReaderMajorMonotone`
-- `CardReaderMajorTwotone`
-- `CardReaderTapMajorMonotone`
-- `CardReaderTapMajorTwotone`
-- `CartDownMajorMonotone`
-- `CartDownMajorTwotone`
-- `CartMajorMonotone`
-- `CartUpMajorMonotone`
-- `CartUpMajorTwotone`
-- `CashDollarMajorTwotone`
-- `CashEuroMajorMonotone`
-- `CashEuroMajorTwotone`
-- `CashPoundMajorMonotone`
-- `CashPoundMajorTwotone`
-- `CashRupeeMajorMonotone`
-- `CashRupeeMajorTwotone`
-- `CashYenMajorMonotone`
-- `CashYenMajorTwotone`
-- `CategoriesMajorMonotone`
-- `CategoriesMajorTwotone`
-- `ChannelsMajorMonotone`
-- `ChannelsMajorTwotone`
-- `ChatMajorMonotone`
-- `ChatMajorTwotone`
-- `ChecklistAlternateMajorMonotone`
-- `ChecklistAlternateMajorTwotone`
-- `ChecklistMajorMonotone`
-- `ChecklistMajorTwotone`
-- `CheckoutMajorMonotone`
-- `CircleCancelMajorMonotone`
-- `CircleCancelMajorTwotone`
-- `CircleDisabledMajorMonotone`
-- `CircleDotsMajorMonotone`
-- `CircleDotsMajorTwotone`
-- `CircleDownMajorMonotone`
-- `CircleDownMajorTwotone`
-- `CircleInformationMajorMonotone`
-- `CircleLeftMajorMonotone`
-- `CircleLeftMajorTwotone`
-- `CircleMinusMajorMonotone`
-- `CircleMinusMajorTwotone`
-- `CirclePlusMajorTwotone`
-- `CircleRightMajorMonotone`
-- `CircleRightMajorTwotone`
-- `CircleUpMajorMonotone`
-- `CircleUpMajorTwotone`
-- `ClockMajorMonotone`
-- `ClockMajorTwotone`
-- `CodeMajorTwotone`
-- `CollectionsMajorMonotone`
-- `ColorsMajorMonotone`
-- `ColorsMajorTwotone`
-- `ColumnImageWithTextMajorMonotone`
-- `ColumnImageWithTextMajorTwotone`
-- `ConfettiMajorMonotone`
-- `ConfettiMajorTwotone`
-- `CreditCardMajorMonotone`
-- `CreditCardMajorTwotone`
-- `CreditCardPercentMajorMonotone`
-- `CreditCardPercentMajorTwotone`
-- `CreditCardSecureMajorMonotone`
-- `CreditCardSecureMajorTwotone`
-- `CustomerMinusMajorMonotone`
-- `CustomerMinusMajorTwotone`
-- `CustomerPlusMajorMonotone`
-- `CustomerPlusMajorTwotone`
-- `CustomersMajorMonotone`
-- `DataVisualizationMajorMonotone`
-- `DataVisualizationMajorTwotone`
-- `DeleteMajorMonotone`
-- `DeleteMajorTwotone`
-- `DesktopMajorMonotone`
-- `DigitalMediaReceiverMajorMonotone`
-- `DigitalMediaReceiverMajorTwotone`
-- `DiscountAutomaticMajorMonotone`
-- `DiscountAutomaticMajorTwotone`
-- `DiscountCodeMajorMonotone`
-- `DiscountCodeMajorTwotone`
-- `DiscountsMajorMonotone`
-- `DnsSettingsMajorMonotone`
-- `DnsSettingsMajorTwotone`
-- `DomainAddMajorMonotone`
-- `DomainAddMajorTwotone`
-- `DomainsMajorTwotone`
-- `DraftOrdersMajorMonotone`
-- `DraftOrdersMajorTwotone`
-- `DragDropMajorTwotone`
-- `EditMajorMonotone`
-- `EditMajorTwotone`
-- `EmailMajorMonotone`
-- `EmailNewsletterMajorMonotone`
-- `EmailNewsletterMajorTwotone`
-- `EnvelopeMajorMonotone`
-- `EnvelopeMajorTwotone`
-- `ExchangeMajorMonotone`
-- `ExchangeMajorTwotone`
-- `ExistingInventoryMajorMonotone`
-- `ExistingInventoryMajorTwotone`
-- `FaviconMajorTwotone`
-- `FavouriteMajorMonotone`
-- `FavouriteMajorTwotone`
-- `FeaturedCollectionMajorTwotone`
-- `FeaturedContentMajorTwotone`
-- `FilterMajorMonotone`
-- `FilterMajorTwotone`
-- `FirstOrderMajorMonotone`
-- `FirstOrderMajorTwotone`
-- `FirstVisitMajorMonotone`
-- `FirstVisitMajorTwotone`
-- `FlagMajorMonotone`
-- `FlipCameraMajorMonotone`
-- `FlipCameraMajorTwotone`
-- `FolderDownMajorMonotone`
-- `FolderDownMajorTwotone`
-- `FolderMajorMonotone`
-- `FolderMajorTwotone`
-- `FolderMinusMajorMonotone`
-- `FolderMinusMajorTwotone`
-- `FolderPlusMajorMonotone`
-- `FolderPlusMajorTwotone`
-- `FolderUpMajorMonotone`
-- `FolderUpMajorTwotone`
-- `FollowUpEmailMajorMonotone`
-- `FollowUpEmailMajorTwotone`
-- `FoodMajorMonotone`
-- `FoodMajorTwotone`
-- `FooterMajorTwotone`
-- `FormsMajorMonotone`
-- `FormsMajorTwotone`
-- `GamesConsoleMajorMonotone`
-- `GamesConsoleMajorTwotone`
-- `GiftCardMajorMonotone`
-- `GlobeMajorMonotone`
-- `GlobeMajorTwotone`
-- `GrammarMajorMonotone`
-- `GrammarMajorTwotone`
-- `HashtagMajorMonotone`
-- `HashtagMajorTwotone`
-- `HeartMajorMonotone`
-- `HeartMajorTwotone`
-- `HideKeyboardMajorMonotone`
-- `HideKeyboardMajorTwotone`
-- `HintMajorTwotone`
-- `IconsMajorMonotone`
-- `IconsMajorTwotone`
-- `IllustrationMajorMonotone`
-- `IllustrationMajorTwotone`
-- `ImageAltMajorTwotone`
-- `ImageMajorMonotone`
-- `ImagesMajorMonotone`
-- `ImagesMajorTwotone`
-- `ImageWithTextMajorTwotone`
-- `ImageWithTextOverlayMajorTwotone`
-- `ImportStoreMajorMonotone`
-- `ImportStoreMajorTwotone`
-- `IncomingMajorMonotone`
-- `IncomingMajorTwotone`
-- `InventoryMajorMonotone`
-- `InventoryMajorTwotone`
-- `IqMajorMonotone`
-- `IqMajorTwotone`
-- `JobsMajorMonotone`
-- `JobsMajorTwotone`
-- `KeyMajorMonotone`
-- `KeyMajorTwotone`
-- `LabelPrinterMajorMonotone`
-- `LabelPrinterMajorTwotone`
-- `LandingPageMajorMonotone`
-- `LandingPageMajorTwotone`
-- `LegalMajorTwotone`
-- `ListMajorMonotone`
-- `ListMajorTwotone`
-- `LiveViewMajorMonotone`
-- `LiveViewMajorTwotone`
-- `LocationMajorMonotone`
-- `LockMajorMonotone`
-- `LockMajorTwotone`
-- `LogoBlockMajorTwotone`
-- `ManagedStoreMajorMonotone`
-- `ManagedStoreMajorTwotone`
-- `MarketingMajorTwotone`
-- `MaximizeMajorMonotone`
-- `MaximizeMajorTwotone`
-- `MentionMajorMonotone`
-- `MentionMajorTwotone`
-- `MicrophoneMajorMonotone`
-- `MicrophoneMajorTwotone`
-- `MinimizeMajorMonotone`
-- `MinimizeMajorTwotone`
-- `MobileAcceptMajorMonotone`
-- `MobileAcceptMajorTwotone`
-- `MobileBackArrowMajorMonotone`
-- `MobileBackArrowMajorTwotone`
-- `MobileCancelMajorTwotone`
-- `MobileChevronMajorMonotone`
-- `MobileChevronMajorTwotone`
-- `MobileHamburgerMajorTwotone`
-- `MobileHorizontalDotsMajorMonotone`
-- `MobileHorizontalDotsMajorTwotone`
-- `MobileMajorMonotone`
-- `MobilePlusMajorMonotone`
-- `MobilePlusMajorTwotone`
-- `MobileVerticalDotsMajorMonotone`
-- `MobileVerticalDotsMajorTwotone`
-- `MonerisMajorMonotone`
-- `MonerisMajorTwotone`
-- `NatureMajorMonotone`
-- `NatureMajorTwotone`
-- `NavigationMajorMonotone`
-- `NoteMajorMonotone`
-- `NoteMajorMonotone`
-- `NoteMajorTwotone`
-- `NoteMajorTwotone`
-- `NotificationMajorTwotone`
-- `OnlineStoreMajorMonotone`
-- `OrdersMajorMonotone`
-- `OutgoingMajorMonotone`
-- `OutgoingMajorTwotone`
-- `PackageMajorMonotone`
-- `PageDownMajorMonotone`
-- `PageDownMajorTwotone`
-- `PageMajorMonotone`
-- `PageMinusMajorMonotone`
-- `PageMinusMajorTwotone`
-- `PagePlusMajorMonotone`
-- `PagePlusMajorTwotone`
-- `PageUpMajorMonotone`
-- `PageUpMajorTwotone`
-- `PaintBrushMajorMonotone`
-- `PauseCircleMajorMonotone`
-- `PauseCircleMajorTwotone`
-- `PauseMajorMonotone`
-- `PauseMajorTwotone`
-- `PaymentsMajorMonotone`
-- `PhoneInMajorMonotone`
-- `PhoneInMajorTwotone`
-- `PhoneMajorMonotone`
-- `PhoneMajorTwotone`
-- `PhoneOutMajorMonotone`
-- `PhoneOutMajorTwotone`
-- `PinMajorMonotone`
-- `PinMajorTwotone`
-- `PlayCircleMajorTwotone`
-- `PlayMajorMonotone`
-- `PlayMajorTwotone`
-- `PointOfSaleMajorMonotone`
-- `PointOfSaleMajorTwotone`
-- `PopularMajorMonotone`
-- `PopularMajorTwotone`
-- `PrintMajorMonotone`
-- `PrintMajorTwotone`
-- `ProductsMajorMonotone`
-- `QuestionMarkMajorMonotone`
-- `QuickSaleMajorMonotone`
-- `QuickSaleMajorTwotone`
-- `ReceiptMajorMonotone`
-- `ReceiptMajorTwotone`
-- `RecentSearchesMajorMonotone`
-- `RecentSearchesMajorTwotone`
-- `RedoMajorTwotone`
-- `RefreshMajorMonotone`
-- `RefreshMajorTwotone`
-- `RefundMajorMonotone`
-- `RefundMajorTwotone`
-- `RemoveProductMajorMonotone`
-- `RemoveProductMajorTwotone`
-- `RepeatOrderMajorMonotone`
-- `RepeatOrderMajorTwotone`
-- `ReplaceMajorTwotone`
-- `ReportsMajorMonotone`
-- `ReportsMajorTwotone`
-- `ResourcesMajorMonotone`
-- `ResourcesMajorTwotone`
-- `RiskMajorMonotone`
-- `RiskMajorTwotone`
-- `SandboxMajorMonotone`
-- `SandboxMajorTwotone`
-- `SearchMajorMonotone`
-- `SearchMajorTwotone`
-- `SectionMajorMonotone`
-- `SecureMajorMonotone`
-- `SecureMajorTwotone`
-- `SendMajorMonotone`
-- `SendMajorTwotone`
-- `SettingsMajorMonotone`
-- `ShipmentMajorTwotone`
-- `ShopcodesMajorMonotone`
-- `ShopcodesMajorTwotone`
-- `SidebarLeftMajorMonotone`
-- `SidebarLeftMajorTwotone`
-- `SidebarRightMajorMonotone`
-- `SidebarRightMajorTwotone`
-- `SlideshowMajorTwotone`
-- `SmileyHappyMajorMonotone`
-- `SmileyHappyMajorTwotone`
-- `SmileyJoyMajorMonotone`
-- `SmileyJoyMajorTwotone`
-- `SmileyNeutralMajorMonotone`
-- `SmileyNeutralMajorTwotone`
-- `SmileySadMajorMonotone`
-- `SmileySadMajorTwotone`
-- `SocialAdMajorTwotone`
-- `SocialPostMajorMonotone`
-- `SocialPostMajorTwotone`
-- `SoftPackMajorTwotone`
-- `SortAscendingMajorMonotone`
-- `SortAscendingMajorTwotone`
-- `SortDescendingMajorMonotone`
-- `SortDescendingMajorTwotone`
-- `SoundMajorMonotone`
-- `SoundMajorTwotone`
-- `StoreMajorMonotone`
-- `StoreMajorTwotone`
-- `StoreStatusMajorMonotone`
-- `StoreStatusMajorTwotone`
-- `TabletMajorMonotone`
-- `TabletMajorTwotone`
-- `TapChipMajorMonotone`
-- `TapChipMajorTwotone`
-- `TaxMajorMonotone`
-- `TaxMajorTwotone`
-- `TeamMajorMonotone`
-- `TeamMajorTwotone`
-- `TextBlockMajorMonotone`
-- `TextMajorMonotone`
-- `TextMajorTwotone`
-- `ThemeEditMajorMonotone`
-- `ThemeEditMajorTwotone`
-- `ThemesMajorTwotone`
-- `ThemeStoreMajorTwotone`
-- `ThumbsDownMajorMonotone`
-- `ThumbsDownMajorTwotone`
-- `ThumbsUpMajorTwotone`
-- `TimelineAttachmentMajorMonotone`
-- `TimelineAttachmentMajorTwotone`
-- `TipsMajorMonotone`
-- `TipsMajorTwotone`
-- `ToolsMajorMonotone`
-- `ToolsMajorTwotone`
-- `TransactionFeeDollarMajorMonotone`
-- `TransactionFeeDollarMajorTwotone`
-- `TransactionFeeEuroMajorMonotone`
-- `TransactionFeeEuroMajorTwotone`
-- `TransactionFeePoundMajorMonotone`
-- `TransactionFeePoundMajorTwotone`
-- `TransactionFeeRupeeMajorMonotone`
-- `TransactionFeeRupeeMajorTwotone`
-- `TransactionFeeYenMajorMonotone`
-- `TransactionFeeYenMajorTwotone`
-- `TransactionMajorMonotone`
-- `TransactionMajorTwotone`
-- `TransferInMajorMonotone`
-- `TransferInMajorTwotone`
-- `TransferMajorMonotone`
-- `TransferMajorTwotone`
-- `TransferOutMajorMonotone`
-- `TransferOutMajorTwotone`
-- `TransferWithinShopifyMajorMonotone`
-- `TransferWithinShopifyMajorTwotone`
-- `TransportMajorMonotone`
-- `TransportMajorTwotone`
-- `TroubleshootMajorMonotone`
-- `TroubleshootMajorTwotone`
-- `TypeMajorTwotone`
-- `UndoMajorTwotone`
-- `UnfulfilledMajorMonotone`
-- `UnfulfilledMajorTwotone`
-- `UnknownDeviceMajorMonotone`
-- `UnknownDeviceMajorTwotone`
-- `UpdateInventoryMajorMonotone`
-- `UpdateInventoryMajorTwotone`
-- `VariantMajorMonotone`
-- `VariantMajorTwotone`
-- `ViewMajorTwotone`
-- `ViewportNarrowMajorMonotone`
-- `ViewportNarrowMajorTwotone`
-- `ViewportWideMajorTwotone`
-- `VocabularyMajorTwotone`
-- `WandMajorMonotone`
-- `WandMajorTwotone`
-- `WearableMajorMonotone`
-- `WearableMajorTwotone`
-- `WholesaleMajorMonotone`
-- `WifiMajorMonotone`
-- `WifiMajorTwotone`
-- `AppExtensionMinor`
-- `ArchiveMinor`
-- `CapturePaymentMinor`
-- `CircleMinusMinor`
-- `CircleMinusOutlineMinor`
-- `CircleTickOutlineMinor`
-- `ClipboardMinor`
-- `ConnectMinor`
-- `DragHandleMinor`
-- `DropdownMinor`
-- `ExternalSmallMinor`
-- `GiftCardMinor`
-- `GlobeMinor`
-- `ImageAltMinor`
-- `InfoMinor`
-- `InstallMinor`
-- `InviteMinor`
-- `LanguageMinor`
-- `LockMinor`
-- `MarkFulfilledMinor`
-- `MarkPaidMinor`
-- `MaximizeMinor`
-- `MinimizeMinor`
-- `NotesMinor`
-- `OrderStatusMinor`
-- `PaginationEndMinor`
-- `PaginationStartMinor`
-- `PauseMinor`
-- `PinMinor`
-- `PlayMinor`
-- `PriceLookupMinor`
-- `PromoteMinor`
-- `QuestionMarkMinor`
-- `ReadTimeMinor`
-- `RefundMinor`
-- `ReplayMinor`
-- `ReportMinor`
-- `ResetMinor`
-- `ReturnMinor`
-- `SettingsMinor`
-- `ShareIosMinor`
-- `ShareMinor`
-- `SortMinor`
-- `ThumbsDownMinor`
-- `ThumbsUpMinor`
-- `TickMinor`
+- New icon `AnalyticsMajorTwotone`
+- New icon `AppsMajorMonotone`
+- New icon `AppsMajorTwotone`
+- New icon `CalendarMajorTwotone`
+- New icon `CartMajorTwotone`
+- New icon `CashDollarMajorMonotone`
+- New icon `CircleTickMajorMonotone`
+- New icon `ClockMinor`
+- New icon `CurrencyConvertMinor`
+- New icon `CustomersMajorTwotone`
+- New icon `DiscountsMajorTwotone`
+- New icon `DomainsMajorMonotone`
+- New icon `EditMinor`
+- New icon `GiftCardMajorTwotone`
+- New icon `HeaderMajorTwotone`
+- New icon `HintMajorMonotone`
+- New icon `HomeMajorTwotone`
+- New icon `ImageAltMajorMonotone`
+- New icon `LinkMinor`
+- New icon `LocationsMinor`
+- New icon `MarketingMajorMonotone`
+- New icon `NavigationMajorTwotone`
+- New icon `PackageMajorTwotone`
+- New icon `PaymentsMajorTwotone`
+- New icon `ProfileMajorTwotone`
+- New icon `ShipmentMajorMonotone`
+- New icon `SocialAdMajorMonotone`
+- New icon `SoftPackMajorMonotone`
+- New icon `VocabularyMajorMonotone`
+- New icon `WholesaleMajorTwotone`
 
-## 3.2.0 - 2019-03-14
+## 3.0.0
 
-Added 5 new icons from Shopify/online-store-web:
-
-- `CirclePlusMajorMonotone`
-- `RedoMajorMonotone`
-- `ThemeStoreMajorMonotone`
-- `ThemesMajorMonotone`
-- `UndoMajorMonotone`
-
-## v3.1.0 - 2019-03-11
-
-### New icons
-
-These icons were transferred from Shopify/web’s `app/icons` directory:
-
-- `AnalyticsMajorTwotone`
-- `AppsMajorMonotone`
-- `AppsMajorTwotone`
-- `CalendarMajorTwotone`
-- `CartMajorTwotone`
-- `CashDollarMajorMonotone`
-- `CircleTickMajorMonotone`
-- `ClockMinor`
-- `CurrencyConvertMinor`
-- `CustomersMajorTwotone`
-- `DiscountsMajorTwotone`
-- `DomainsMajorMonotone`
-- `EditMinor`
-- `GiftCardMajorTwotone`
-- `HeaderMajorTwotone`
-- `HintMajorMonotone`
-- `HomeMajorTwotone`
-- `ImageAltMajorMonotone`
-- `LinkMinor`
-- `LocationsMinor`
-- `MarketingMajorMonotone`
-- `NavigationMajorTwotone`
-- `PackageMajorTwotone`
-- `PaymentsMajorTwotone`
-- `ProfileMajorTwotone`
-- `ShipmentMajorMonotone`
-- `SocialAdMajorMonotone`
-- `SoftPackMajorMonotone`
-- `VocabularyMajorMonotone`
-- `WholesaleMajorTwotone`
-
-## v3.0.0 - 2019-03-06
-
-### Breaking Changes
+### Major Changes
 
 - Export icons as React Components built using [SVGR](https://www.smooth-code.com/open-source/svgr/) instead of a bespoke object format.
 - Export names are now PascalCase instead of camelCase to denote that they are React Components. For example: `addMinor` is now `AddMinor`
@@ -934,14 +823,14 @@ These icons were transferred from Shopify/web’s `app/icons` directory:
 
 - Added several new icons from the online-store-web project.
 
-## v2.0.0 - 2019-02-06
+## 2.0.0
 
-### Breaking Changes
+### Major Changes
 
 - Export icons individually in order to enable tree shaking.
 - Icon exports are now suffixed with their type (`Major` or `Minor`). This allows for a future where the same concept has both a major and minor icon. It also avoids inconsistencies to work around cases where icons names clashed with JS reserved keywords (e.g. delete, import and export).
 - Removed the `ellipsis` icon as has been deprecated in favor of the `horizontalDots` icon. The icons are visually identical so this is a straight replacement.
 
-## v1.0.0 - 2019-01-18
+## 1.0.0
 
 Initial Release

--- a/polaris-react/CHANGELOG.md
+++ b/polaris-react/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [these versioning and changelog guidelines](/.github/CONTRIBUTING.md#changelog).
-
----
-
-## 9.8.0 - 2022-05-19
-
-### Enhancements
+## 9.8.0
 
 - Ported internal breakpoint and layout functions to SCSS variables ([#5722](https://github.com/Shopify/polaris/pull/5722))
 - Added `extraSmall` to the available sizes of the `Thumbnail` and `SkeletonThumbnail` ([#5770](https://github.com/Shopify/polaris/pull/5770))
@@ -16,20 +8,12 @@ The format is based on [these versioning and changelog guidelines](/.github/CONT
 - Added support for tooltips on Navigation items ([#5750](https://github.com/Shopify/polaris/pull/5750))
 - Change types for DataTable `totalsName` prop to allow for ReactNode ([#5454](https://github.com/Shopify/polaris/pull/5365/))
 - Implemented accessibility role and attributes in `SettingToggle` ([#5470](https://github.com/Shopify/polaris/pull/5470))
-
-### Bug fixes
-
 - Fixed vertical scroll on small screens in `EmptyState` ([#5779](https://github.com/Shopify/polaris/pull/5779))
 - Fixed broken links in documentation ([#5824](https://github.com/Shopify/polaris/pull/5824))
 - Fixed key prop error introduced in [sticky header](https://github.com/Shopify/polaris/pull/5494) ([#5826](https://github.com/Shopify/polaris/pull/5826))
-
-### Documentation
-
 - Replaced `deprecationNotice` with `notice` object ([#5841](https://github.com/Shopify/polaris/pull/5841))
 
-## 9.7.0 - 2022-05-10
-
-### Enhancements
+## 9.7.0
 
 - Replaced hardcoded `padding` or `margin` values with spacing tokens ([#5528](https://github.com/Shopify/polaris/pull/5528))
 - Added `border-width-4` and `border-width-5` tokens and replaced hardcoded values ([#5528](https://github.com/Shopify/polaris/pull/5528))
@@ -43,51 +27,31 @@ The format is based on [these versioning and changelog guidelines](/.github/CONT
 - Adjusted a hardcoded `padding` value for `FileUpload` and replaced it with a spacing token ([#5675](https://github.com/Shopify/polaris/pull/5675))
 - Added `disable` prop to the action groups title of the Page header ([#5702](https://github.com/Shopify/polaris/pull/5702))
 - Added `onClick` prop to the action groups title of the Page header ([#5751](https://github.com/Shopify/polaris/pull/5751))
-
-### Bug fixes
-
 - Used prop-provided `selectable` value in `IndexTable` ([#5661](https://github.com/Shopify/polaris/pull/5661))
 - Fixed passing inline styles to the root element of the `CustomProperties` component ([#5661](https://github.com/Shopify/polaris/pull/5661))
 - Replaced incorrect usage of `aria-expanded` on `Collapsible` with `aria-hidden` ([#5661](https://github.com/Shopify/polaris/pull/5661))
 - Removed usage of deprecated and removed in v18 React types ([#5704](https://github.com/Shopify/polaris/pull/5704))
 - Fixed `plain-button-backdrop` background color on colored backgrounds ([#5687](https://github.com/Shopify/polaris/pull/5687))
 - Fixed scrolling bug in DataTable sticky header ([#5700](https://github.com/Shopify/polaris/pull/5700))
-
-### Documentation
-
 - Added wrapper with height on `Combobox` example for autocomplete with loading ([#5624](https://github.com/Shopify/polaris/pull/5624))
-
-### Dependency upgrades
-
 - Removed `lodash` ([#5544](https://github.com/Shopify/polaris/pull/5544))
 - Uses more permissive dependency for `@types/react` and `@types/react-dom` ([#5575](https://github.com/Shopify/polaris/pull/5575))
-
-### Code quality
-
 - Replaced `skeleton-content` and `thumbnail-size` mixins with css values ([#5630](https://github.com/Shopify/polaris/pull/5630))
 
-## 9.6.0 - 2022-04-29
+## 9.6.0
 
 - Added an `autoSelection` prop to `Listbox` to support setting the first option as the default action option ([#5667](https://github.com/Shopify/polaris/pull/5667))
 - Added `autoSelection` `AutoSelection.First` to `Autocomplete` `Listbox` when `actionBefore` is set ([#5667](https://github.com/Shopify/polaris/pull/5667))
 
-### Enhancements
-
-## 9.5.2 - 2022-04-26
-
-### Bug fixes
+## 9.5.2
 
 - Fixed documentation example for `ComboBox` ([#5622](https://github.com/Shopify/polaris/pull/5622))
 
-## 9.5.1 - 2022-04-26
-
-### Bug fixes
+## 9.5.1
 
 - Fixed default `Pip` color in `Badge` ([#5616](https://github.com/Shopify/polaris/pull/5616))
 
-## 9.5.0 - 2022-04-22
-
-### Enhancements
+## 9.5.0
 
 - Added `icon` prop to the `Badge` component ([#5292](https://github.com/Shopify/polaris/pull/5292))
 - Improved styling for the `DataTable` component when the `increaseTableDensity` prop is set to `true` ([#5480](https://github.com/Shopify/polaris/pull/5480))
@@ -97,20 +61,12 @@ The format is based on [these versioning and changelog guidelines](/.github/CONT
 - Removed whitespace from CustomProperties output ([#5570](https://github.com/Shopify/polaris/pull/5570))
 - Added a `height` prop to `Combobox` and `Popover.Pane` to support setting a fixed `height` and `man-height` on the `Scrollable` ([#5571](https://github.com/Shopify/polaris/pull/5571))
 - Made `Pip` a sub-component of `Badge` and exposed it to outside ([#5520](https://github.com/Shopify/polaris/pull/5520))
-
-### Bug fixes
-
 - Fixed focus and hover style on `Tag` for removable tag with link ([#5567](https://github.com/Shopify/polaris/pull/5567))
 - Fixed border size on vertical content on `TextField` ([#5571](https://github.com/Shopify/polaris/pull/5571))
 - Fixed `aria-activedescendent` being unset in `Combobox` on option select when `allowMultiple` is `true` ([#5584](https://github.com/Shopify/polaris/pull/5584))
-
-### Documentation
-
 - Fixed `Combobox` multi-select examples not resetting the input value and list on option select ([#5584](https://github.com/Shopify/polaris/pull/5584))
 
-## 9.4.0 - 2022-04-08
-
-### Enhancements
+## 9.4.0
 
 - Increased token coverage by creating `@keyframes` tokens and replacing hardcoded instances ([5427](https://github.com/Shopify/polaris/pull/5427/))
 - Added support for setting a ReactNode on `DataTable` `totalsName` prop ([#5454](https://github.com/Shopify/polaris/pull/5365/))
@@ -120,16 +76,11 @@ The format is based on [these versioning and changelog guidelines](/.github/CONT
 - Added a `willLoadMoreOptions` prop to `Combobox` that's passed to `Listbox` through context so that `onKeyToBottom` is only called if `willLoadMoreOptions` is `true` ([5303](https://github.com/Shopify/polaris/pull/5303))
 - Improved `Autocomplete` performance when options are lazy loaded by passing `willLoadMoreResults` to the `Combobox` `willLoadMoreOptions` prop when present ([5303](https://github.com/Shopify/polaris/pull/5303))
 - Updated `Listbox` scroll UX to behave natively when navigating options with keyboard instead of scrolling the active option to the top of the visible list ([5303](https://github.com/Shopify/polaris/pull/5303))
-
-### Bug fixes
-
 - Fixed automatic selection of first navigable `Listbox.Option` not resetting in `Listbox` ([5303](https://github.com/Shopify/polaris/pull/5303))
 - Fixed subdued styles not applying to `Listbox.TextOption` when `disabled` ([5303](https://github.com/Shopify/polaris/pull/5303))
 - Fixed `Listbox.TextOption` keyboard focus ring flashing when focus moves to an option being scrolled into view ([5303](https://github.com/Shopify/polaris/pull/5303))
 
-## 9.3.0 - 2022-04-06
-
-### Enhancements
+## 9.3.0
 
 - Updated `Listbox` to only scroll when active option outside of view ([#5401](https://github.com/Shopify/polaris/pull/5401/))
 - Added visual density updates to `Tag` component for mobile view ([#5353](https://github.com/Shopify/polaris/pull/5353))
@@ -145,74 +96,46 @@ The format is based on [these versioning and changelog guidelines](/.github/CONT
 - Created `icon-attention` and `surface-attention` color tokens ([5389](https://github.com/Shopify/polaris/pull/5389))
 - Increased token coverage by removing unnecessary `transitions` and `animations` with hard coded duration values ([5405](https://github.com/Shopify/polaris/pull/5405/))
 - Added optional visual density updates and zebra striping to `DataTable` ([#5365](https://github.com/Shopify/polaris/pull/5365/))
-
-### Bug fixes
-
 - Fixed accessibility issues on focus and option create in `Combobox` and `Listbox` ([#5298](https://github.com/Shopify/polaris/pull/5298))
 - Fixed accessibility issues and logic to set active descendant in `Listbox` ([#5297](https://github.com/Shopify/polaris/pull/5297))
 - Fixed alignment of right-hand side of `Header` in `Page` ([#5390](https://github.com/Shopify/polaris/pull/5390))
 - Fixed `disabled` `Listbox.TextOption` not setting `disabled` on the `Checkbox` rendered when `allowMultiple` is `true` ([#5428](https://github.com/Shopify/polaris/pull/5428))
-
-### Dependency upgrades
-
 - Bumped `@shopify/polaris-icons` to `v4.18.2` ([#5312](https://github.com/Shopify/polaris/pull/5312))
 - Bumped marked from 0.7.0 to 4.0.10 ([#4898](https://github.com/Shopify/polaris/pull/4898))
-
-### Code quality
-
 - Replace `calc()` with space token equivalent ([#5295](https://github.com/Shopify/polaris/pull/5295))
 
-## 9.2.3 - 2022-03-22
-
-### Bug fixes
+## 9.2.3
 
 - Fixed flash of unstyled content in the CustomProperties component ([#5299](https://github.com/Shopify/polaris/pull/5299))
 
-## 9.2.2 - 2022-03-11
-
-### Bug fixes
+## 9.2.2
 
 - Passed TextField event object to onFocus callback to address failing admin unit tests ([#5265](https://github.com/Shopify/polaris-react/pull/5265))
 
-## 9.2.1 - 2022-03-11
-
-### Bug fixes
+## 9.2.1
 
 - Moved all CSS custom properties to be defined under the Polaris color-scheme selector ([#5257](https://github.com/Shopify/polaris-react/pull/5257))
 
-## 9.2.0 - 2022-03-09
-
-### Enhancements
+## 9.2.0
 
 - Added the `selectTextOnFocus` prop to `TextField` ([#5216](https://github.com/Shopify/polaris-react/pull/5216))
-
-### Bug fixes
-
 - Fixed Sheet animation by replacing deprecated `easing()` with css custom property ([#5251](https://github.com/Shopify/polaris-react/pull/5251))
 
-## 9.1.0 - 2022-03-08
-
-### Enhancements
+## 9.1.0
 
 - Added `SkeletonTabs` component ([#5229](https://github.com/Shopify/polaris-react/pull/5229))
 - Added an inset box-shadow to `ColorPicker` to make it easier to see the draggers ([#4948](https://github.com/Shopify/polaris-react/pull/4948))
-
-### Bug fixes
-
 - Fixed logo appearing in `Navigation` at 769px ([#5213](https://github.com/Shopify/polaris-react/pull/5213))
 - Reintroduced `top: 0` to `VisuallyHidden` CSS to prevent unexpected scrolling when using a `Sheet` ([#5208](https://github.com/Shopify/polaris-react/pull/5208))
 - Fixed `Form` > `VisuallyHidden` markup causing excessive vertical whitespace ([#5181](https://github.com/Shopify/polaris-react/pull/5181))
 - Fixed a bug in `Toast` where it wasn't rendering ([#5224](https://github.com/Shopify/polaris-react/pull/5224))
-
-### Documentation
-
 - Removed `examples` dir and all references ([#5207](https://github.com/Shopify/polaris-react/pull/5207))
 
-## 9.0.0 - 2022-02-15
+## 9.0.0
 
 For instructions on updating from v8 to v9, see our [migration guide](https://github.com/Shopify/polaris-react/blob/main/documentation/guides/migrating-from-v8-to-v9.md).
 
-### Breaking changes
+### Major changes
 
 **CSS custom properties**
 
@@ -279,56 +202,30 @@ For instructions on updating from v8 to v9, see our [migration guide](https://gi
 
 - Removed `build/styles` directory from build output ([#4728](https://github.com/Shopify/polaris-react/pull/4728))
 - Dropped support for node < 16 ([#4778](https://github.com/Shopify/polaris-react/pull/4778))
-
-### New components
-
 - Added `CustomProperties` component ([#4642](https://github.com/Shopify/polaris-react/pull/4642))
-
-### Enhancements
-
 - Added duration token values between `0` and `500` with `50ms` increments ([#4781](https://github.com/Shopify/polaris-react/pull/4781))
 - Aligned easing tokens and values with CSS defaults ([#4790](https://github.com/Shopify/polaris-react/pull/4790))
-
-### Bug fixes
-
 - Fixed `ContextualSaveBar` not registering the `secondaryMenu` in the `Frame` context ([#5116](https://github.com/Shopify/polaris-react/pull/5116))
 - Fixed `monochrome` `outline` `Button` `children` being visible when `loading` ([#5145](https://github.com/Shopify/polaris-react/pull/5145))
-
-### Dependency upgrades
-
 - Removed `@shopify/polaris-tokens` dependency ([#4868](https://github.com/Shopify/polaris-react/pull/4868))
-
-### Code quality
-
 - Replaced font-weight values with tokens ([#4599](https://github.com/Shopify/polaris-react/issues/4599))
 - Replaced hardcoded spacing values with spacing tokens ([#4775](https://github.com/Shopify/polaris-react/pull/4775))
 - Avoid some usage of `/` for division in preparation for dart-sass support [#4933](https://github.com/Shopify/polaris-react/pull/4933))
-
-### Deprecations
-
 - Deprecated `additionalNavigation` in `<Page>` component
 
-## 8.2.2 - 2022-02-10
-
-### Bug fixes
+## 8.2.2
 
 - Updated Navigation alignment in `Navigation` ([#5135](https://github.com/Shopify/polaris-react/pull/5135))
 
-## 8.2.1 - 2022-02-04
-
-### Bug fixes
+## 8.2.1
 
 - Reverted [ColorPicker] Add an inset box-shadow to make it easier to see the draggers ([#4948](https://github.com/Shopify/polaris-react/pull/4948))
 
-## 8.2.0 - 2022-02-04
-
-### Dependency upgrades
+## 8.2.0
 
 - Bumped `@shopify/polaris-icons` to v4.17.0 ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
 
-## 8.1.0 - 2022-02-04
-
-### Enhancements
+## 8.1.0
 
 - Add an inset box-shadow to `ColorPicker` to make it easier to see the draggers ([#4948](https://github.com/Shopify/polaris-react/pull/4948))
 - Tightened up the Navigation component UI density. ([#4874](https://github.com/Shopify/polaris-react/pull/4874))
@@ -336,9 +233,6 @@ For instructions on updating from v8 to v9, see our [migration guide](https://gi
 - Remove the info icon and external link guidance from FooterHelp ([#4982](https://github.com/Shopify/polaris-react/pull/4982))
 - Normalise spacing around the `Header` within the `Page` ([#4911](https://github.com/Shopify/polaris-react/pull/4911))
 - Added a `secondaryMenu` prop to the `ContextualSaveBar` component ([#5018](https://github.com/Shopify/polaris-react/pull/5018))
-
-### Bug fixes
-
 - Fixed `segmented` `ButtonGroup` misaligning icon only buttons when grouped with text only buttons ([#4079](https://github.com/Shopify/polaris-react/issues/4079))
 - Added missing styles for `destructive` `Page` `secondaryActions` ([#4647](https://github.com/Shopify/polaris-react/pull/4647))
 - Removed `min-height` from `Page` `additionalNavigation` ([#4952](https://github.com/Shopify/polaris-react/pull/4952))
@@ -357,27 +251,19 @@ For instructions on updating from v8 to v9, see our [migration guide](https://gi
 - Fixed an issue where token values in px weren't converted to rems ([#5000](https://github.com/Shopify/polaris-react/pull/5000))
 - Fixed `display` on `Banner` `secondaryAction` on focus in Firefox ([#5001](https://github.com/Shopify/polaris-react/pull/5001))
 - Fixed focus ring display on focus of `TopBar` `NavigationIcon` ([#5010](https://github.com/Shopify/polaris-react/pull/5010))
-
-### Development workflow
-
 - Improve error logging in the event of sass errors ([#4954](https://github.com/Shopify/polaris-react/pull/4954))
 
-## 8.0.0 - 2022-01-20
+## 8.0.0
 
 For instructions on updating from v7 to v8, see our [migration guide](https://github.com/Shopify/polaris-react/blob/main/documentation/guides/migrating-from-v7-to-v8.md).
 
-### Breaking changes
+### Major changes
 
 - Updated the base font size to `100%` from `62.5%` and update `rem` values accordingly, along with `pxtorem` `rootValue` ([#4794](https://github.com/Shopify/polaris-react/pull/4794))
 - Updated required node version to `v16.9.1` ([#4853](https://github.com/Shopify/polaris-react/pull/4853))
-
-### Enhancements
-
 - Removed `_SECRET_INTERNAL_FilterControl` and `_SECRET_INTERNAL_FilterControlProps` exports. These exports have been deprecated since Polaris v5 and are not part of our stable API, which is why we are removing them in a minor release. ([#4905](https://github.com/Shopify/polaris-react/pull/4905))
 
-## 7.6.0 - 2022-01-18
-
-### Enhancements
+## 7.6.0
 
 - Keyboard arrow navigation support added in `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
 - Menu role attribute value support added in `ActionList/Section` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
@@ -389,9 +275,6 @@ For instructions on updating from v7 to v8, see our [migration guide](https://gi
 - Bumped the `@shopify/storybook-a11y-test` package to the latest version `0.3.0` ([#4870](https://github.com/Shopify/polaris-react/pull/4870))
 - Added a `warning` variation to `TextStyle` ([#4880](https://github.com/Shopify/polaris-react/pull/4880))
 - Added a class to hide the clear button in the `TextField` component instead of removing it from the DOM ([#4897](https://github.com/Shopify/polaris-react/pull/4897))
-
-### Bug fixes
-
 - Fixed a bug where remove button could shrink in the `Tag` component ([#4816](https://github.com/Shopify/polaris-react/issues/4816))
 - Fixed incorrect `Popover` position in `Combobox` when an element is conditionally rendered before the `Combobox` ([#4825](https://github.com/Shopify/polaris-react/pull/4825))
 - Reverted the deprecation of the "attention" `status` in `Badge` ([#4840](https://github.com/Shopify/polaris-react/pull/4840))
@@ -400,43 +283,24 @@ For instructions on updating from v7 to v8, see our [migration guide](https://gi
 - Fixed a bug where a checkbox showed on an `Autocomplete` action when `allowMultiple` is true ([#4887](https://github.com/Shopify/polaris-react/pull/4887))
 - Fixed a bug where the `Listbox.Action` was not treated like an action when used outside `Autocomplete` ([#4893](https://github.com/Shopify/polaris-react/pull/4893))
 - Fixed a bug where the `Checkbox` in a `Combobox` with `allowMultiple` would steal focus and close the `Popover` when clicked ([#4895](https://github.com/Shopify/polaris-react/pull/4895))
-
-### Documentation
-
 - Fixed a bug in the `Icon` component where examples did not show ([#4843](https://github.com/Shopify/polaris-react/pull/4843))
 - Added arrow navigation instructions in keyboard support for `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
 - Updated examples to properly support JAWS screen reader for `Popover` and `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
-
-### Development workflow
-
 - Removed `dev start` command. Thank you to [@aaronadamsCA](https://github.com/aaronadamsCA) for the contribution ([#4876](https://github.com/Shopify/polaris-react/pull/4876)).
-
-### Dependency upgrades
 
 - Bumped `@shopify/polaris-icons` to v4.11.0 ([#4837](https://github.com/Shopify/polaris-react/pull/4837))
 - Bumped `@storybook/react` to 6.4.10 ([#4796](https://github.com/Shopify/polaris-react/pull/4796))
 - Bumped `@shopify/storybook-a11y-test` to 0.4.3 ([#4796](https://github.com/Shopify/polaris-react/pull/4796))
 - Removed dependency `serve`. Thank you to [@aaronadamsCA](https://github.com/aaronadamsCA) for the contribution ([#4876](https://github.com/Shopify/polaris-react/pull/4876)).
 
-## 7.5.0 - 2021-12-09
-
-### Enhancements
+## 7.5.0
 
 - Removed animation from `Skeleton` components ([#4697](https://github.com/Shopify/polaris-react/pull/4697))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
 - Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
-
-### Bug fixes
-
 - Centered full width `Popover` on small viewports ([#4114](https://github.com/Shopify/polaris-react/pull/4114))
-
-### Development workflow
-
 - Remove analyze custom properties check. ([#4718](https://github.com/Shopify/polaris-react/pull/4718))
 - Removed support for importing from `components` as it slows tests down ([#4735](https://github.com/Shopify/polaris-react/pull/4735), [#4739](https://github.com/Shopify/polaris-react/pull/4739))
-
-### Dependency upgrades
-
 - Bumped `postcss` to `v8.3.1` ([#4701](https://github.com/Shopify/polaris-react/pull/4701))
 - Bumped `@shopify/postcss-plugin` to `v5.0.1` ([#4701](https://github.com/Shopify/polaris-react/pull/4701))
 - Bumped `postcss-loader` to `v4.2.0` ([#4701](https://github.com/Shopify/polaris-react/pull/4701))
@@ -445,30 +309,20 @@ For instructions on updating from v7 to v8, see our [migration guide](https://gi
 - Bumped `sass-loader` to `v10.1.1` ([#4783](https://github.com/Shopify/polaris-react/pull/4783))
 - Bumped `stylelint` to `v14.1.0` and `@shopify/stylelint-plugin` to `v11.0.0` ([#4798](https://github.com/Shopify/polaris-react/pull/4798))
 - Bumped `eslint` to `v8.3.0` and `@shopify/eslint-plugin` to `v41.0.1` ([#4797](https://github.com/Shopify/polaris-react/pull/4797))
-
-### Code quality
-
 - Removed `rem()` function from `tokens.ts` ([#4695](https://github.com/Shopify/polaris-react/pull/4695))
 - Remove unnecessary import of `Tokens` in `Collapsible` test ([#4722](https://github.com/Shopify/polaris-react/pull/4722))
 - Remove legacy tokens and use default theme for `.storybook/manager.js` ([#4729](https://github.com/Shopify/polaris-react/pull/4729))
-
-### Deprecations
-
 - Deprecated `thumbnail` property for `Page` ([#4733](https://github.com/Shopify/polaris-react/pull/4733))
 - Deprecated `secondaryActions` property for `SkeletonPage` ([#4740](https://github.com/Shopify/polaris-react/pull/4740))
 
-## 7.4.1 - 2021-11-18
-
-### Bug fixes
+## 7.4.1
 
 - Added back miscellaneous css custom properties ([#4679](https://github.com/Shopify/polaris-react/pull/4679))
 - Added back custom and unnecessary font weight properties ([#4677](https://github.com/Shopify/polaris-react/pull/4677))
 - Fixed an issue with `Popover` where the transform property interfered with descendants positioning ([#4685](https://github.com/Shopify/polaris-react/pull/4685))
 - Fixed screen reader accessibility issue of the `Checkbox` component ([#4631](https://github.com/Shopify/polaris-react/pull/4631))
 
-## 7.4.0 - 2021-11-18
-
-### Enhancements
+## 7.4.0
 
 - Allowed for `readonly` items in ActionList ([#4623](https://github.com/Shopify/polaris-react/pull/4623))
 - Updated `VisuallyHidden` styles to not use `top` or `clip` ([#4641](https://github.com/Shopify/polaris-react/pull/4641))
@@ -476,98 +330,54 @@ For instructions on updating from v7 to v8, see our [migration guide](https://gi
 - Updated timeout of `Popover` exit to `durationFast`. ([#4651](https://github.com/Shopify/polaris-react/pull/4651))
 - Reduced the size of the `progress` pip in `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 - Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
-
-### Bug fixes
-
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
 - Fixed an issue with `TextField` where date and time were uneditable on click ([#4671](https://github.com/Shopify/polaris-react/pull/4671))
-
-### Documentation
-
 - Added an example for the `small` `size` variant of `Badge` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 - Updated top bar description and keywords to include `header` ([#4672](https://github.com/Shopify/polaris-react/pull/4672))
-
-### Development workflow
-
 - Tightened up what absolute imports are allowed. Removed `baseUrl` from `tsconfig.json`. Attempting to do an absolute import from `src/X` or `components/X` now results in a error when type-checking. ([#4643](https://github.com/Shopify/polaris-react/pull/4643))
-
-### Code quality
-
 - Cleaned up Button styling and $button-filled mixin([#4635](https://github.com/Shopify/polaris-react/pull/4635))
 - Removed filter functions ([#4650](https://github.com/Shopify/polaris-react/pull/4650))
 - Removed all color() invocations ([#4636](https://github.com/Shopify/polaris-react/pull/4636))
-
-### Deprecations
-
 - Deprecated passing `attention` to the `status` prop on `Badge` in favor of `warning` ([#4658](https://github.com/Shopify/polaris-react/pull/4658))
 
-## 7.3.1 - 2021-11-12
-
-### Bug fixes
+## 7.3.1
 
 - Reverted exit timeout in `Popover` to avoid race conditions ([#4633](https://github.com/Shopify/polaris-react/pull/4633))
 
-## 7.3.0 - 2021-11-10
-
-### Enhancements
+## 7.3.0
 
 - Added helper hooks `useIndexTableRowHovered`, `useIndexTableRowSelected`, and `useIndexTableContainerScroll` to `IndexTable` ([#4286](https://github.com/Shopify/polaris-react/pull/4286))
 - Added token for slim border radius ([#4573](https://github.com/Shopify/polaris-react/pull/4573))
 - Improved `Popover` component and its animation ([#4580](https://github.com/Shopify/polaris-react/pull/4580))
 - Improved `base` easing curve ([#4580](https://github.com/Shopify/polaris-react/pull/4580))
 - Removed vertical padding from wrapping div of `ActionList` ([#4571](https://github.com/Shopify/polaris-react/pull/4571))
-
-### Bug fixes
-
 - Removed extraneous space in `MediaCard` when card has no actions (thanks to [@emilycritter](https://github.com/emilycritter) for the [pull request](https://github.com/Shopify/polaris-react/pull/4538))
 - Fixed a bug in `Stack` where vertical spacing was off ([#4572](https://github.com/Shopify/polaris-react/pull/4572))
-
-### Documentation
-
 - Fixed typo in `DropZone` documentation [4566](https://github.com/Shopify/polaris-react/pull/4566)
-
-### Development workflow
-
 - Updated Loom to v1 ([#950](https://github.com/Shopify/global-nav/pull/950))
-
-### Dependency upgrades
 
 Bumped polaris-icons to v4.10.0 ([#4569](https://github.com/Shopify/polaris-react/pull/4569))
 
-## 7.2.0 - 2021-10-28
-
-### Enhancements
+## 7.2.0
 
 - Updated the primary and secondary action type on `MediaCard` to `ComplexAction` ([#4546](https://github.com/shopify/polaris-react/pull/4546))
-
-### Bug fixes
-
 - Fixed `Stack.Item` having margin when empty ([#4556](https://github.com/Shopify/polaris-react/pull/4556))
-
 - Fixed `Stack` not wrapping valid children in `Stack.Item` ([#4556](https://github.com/Shopify/polaris-react/pull/4556)) (thanks [@benjamindoe](https://github.com/benjamindoe) for the [original issue](https://github.com/Shopify/polaris-react/issues/4555))
 
-## 7.1.0 - 2021-10-25
-
-### Enhancements
+## 7.1.0
 
 - Added the `ariaControls` prop to `Checkbox` ([#4509](https://github.com/Shopify/polaris-react/pull/4509))
 - Reduced vertical spacing in `Page` ([#4541](https://github.com/Shopify/polaris-react/pull/4541))
-
-### Bug fixes
-
 - Fixed empty children being wrapped with `Item` in `Stack` ([#4487](https://github.com/Shopify/polaris-react/pull/4487))
-
-### Documentation
-
 - Created an example for an IndexTable with multiple promoted bulk actions ([4497](https://github.com/Shopify/polaris-react/pull/4497))
 - Light edits to the best practices for `Modal` and `Banner` ([#4501](https://github.com/Shopify/polaris-react/pull/4501))
 - Removed banner in navigation example ([#4533](https://github.com/Shopify/polaris-react/pull/4533))
 
-## 7.0.0 - 2021-09-23
+## 7.0.0
 
 For instructions on updating from v6 to v7, see our [migration guide](https://github.com/Shopify/polaris-react/blob/main/documentation/guides/migrating-from-v6-to-v7.md).
 
-### Breaking changes
+### Major changes
 
 - Updated `react` and `react-dom` to version 16.14.0. This is now the minimum version of React required to use the `@shopify/polaris` library.
 - Dropping support for node 10.x
@@ -578,9 +388,6 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Remove the `esnext` folder from the package. If you use Polaris in an app built with sewing-kit, it must use at least sewing-kit 0.152.0 to leverage esnext builds. ([#4425](https://github.com/Shopify/polaris-react/pull/4425))
 - The component styles have moved fromm `dist/styles.css` to `build/esm/styles.css`. Consumers who import styles shall need to update their import path. ([#4424](https://github.com/Shopify/polaris-react/pull/4424))
 - The public Sass API has moved from `dist/styles/_public-api.scss` to `build/styles/_public-api.scss`. Consumers who use our Sass API shall need to update their import path. ([#4424](https://github.com/Shopify/polaris-react/pull/4424))
-
-### Enhancements
-
 - Add `lastColumnSticky` prop to `IndexTable` to create a sticky last cell and optional sticky last heading on viewports larger than small ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Added `id` prop to `Layout` and `Heading` for hash linking ([#4307](https://github.com/Shopify/polaris-react/pull/4307))
 - Added `external` prop to `Navigation.Item` component ([#4310](https://github.com/Shopify/polaris-react/pull/4310))
@@ -600,9 +407,6 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Added support for React 17 ([#4432](https://github.com/Shopify/polaris-react/pull/4432))
 - Added support for multi-sectioned options in `Autocomplete` [#4221](https://github.com/Shopify/polaris-react/pull/4221)
 - Enables optional `onClick` property for `subNavigationItem` on `Nav/Item` component to execute, if provided ([#4394](https://github.com/Shopify/polaris-react/pull/4394))
-
-### Bug fixes
-
 - Fixed `IndexTable` row hover state colour when unselected ([#4359](https://github.com/Shopify/polaris-react/pull/4359))
 - Fixed `selected` prop having no effect for `Navigation.Item` when `url` prop is not specified ([#4375](https://github.com/Shopify/polaris-react/pull/4375))
 - Fixed screen readers reading out the clear button in `TextField` when there is no input ([#4369](https://github.com/Shopify/polaris-react/pull/4369))
@@ -615,18 +419,9 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Adjust `IndexTable` sticky z-index to avoid collisions with focused `TextField` ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Fixed an accessibility bug in `Icon` where `aria-label` was used incorrectly ([#4414](https://github.com/Shopify/polaris-react/pull/4414))
 - Restored pointing device interactivity to prefix and suffix slots of the `TextField` component ([#4477](https://github.com/Shopify/polaris-react/pull/4477))
-
-### Documentation
-
 - Fixed incorrect url for tophatting the `Playground` component inside an iframe ([4392](https://github.com/Shopify/polaris-react/pull/4392))
 - Simplified content guidelines section for text field component and linked out to thorough guidelines on the text fields experience page ([#4422](https://github.com/Shopify/polaris-react/pull/4422))
-
-### Development workflow
-
 - Use `loom` for test and linting harnesses. ([#4402](https://github.com/Shopify/polaris-react/pull/4402), [#4471](https://github.com/Shopify/polaris-react/pull/4471))
-
-### Code quality
-
 - Rebuilt `Autocomplete` internals using new `Combobox` and `Listbox` components built on the ARIA 1.2 spec for improved accessibility ([#3910](https://github.com/Shopify/polaris-react/pull/3910))
 - Updated `@shopify/react-testing` to v3.2.0 for React 17 support in tests ([#4349](https://github.com/Shopify/polaris-react/pull/4349))
 - Modernized tests for Avatar, Backdrop, Badge, Banner components([#4306](https://github.com/Shopify/polaris-react/pull/4306))
@@ -670,9 +465,7 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Modernized tests for DatePicker, DescriptionList, and DisplayText ([#4360](https://github.com/Shopify/polaris-react/pull/4360))
 - Modernized tests for TextField ([#4456](https://github.com/Shopify/polaris-react/pull/4456))
 
-## 6.6.0 - 2021-07-08
-
-### Enhancements
+## 6.6.0
 
 - Prevented `KeypressListener` attaching/detaching on every render ([#4173](https://github.com/Shopify/polaris-react/pull/4173))
 - Added `animated` prop in `ProgressBar` ([#4251](https://github.com/Shopify/polaris-react/pull/4251))
@@ -681,22 +474,14 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Renamed and exposed Card compound components types ([#4261](https://github.com/Shopify/polaris-react/pull/4261))
 - Added `monospaced` prop to `TextField` component ([#4264](https://github.com/Shopify/polaris-react/pull/4264))
 - Added base tight spacing option to `Stack` component([#4273](https://github.com/Shopify/polaris-react/pull/4273))
-
-### Bug fixes
-
 - Fix Safari issue where `Button` text is gray instead of white after changing state from disabled to enabled ([#4270](https://github.com/Shopify/polaris-react/pull/4270))
 - Fix console warnings when `DataTable` unmounts ([#4249](https://github.com/Shopify/polaris-react/pull/4249))
 - Fix console warnings displaying multiple times in `Sheet` ([#4269](https://github.com/Shopify/polaris-react/pull/4269))
 - Remove top shadow when `Popover` and `Scrollable` scroll hinting is complete ([#4265](https://github.com/Shopify/polaris-react/pull/4265))
 
-## 6.5.0 - 2021-06-02
-
-### Enhancements
+## 6.5.0
 
 - Disabled `pointer-events` on the prefix and suffix elements of the `TextField` component ([#4207](https://github.com/Shopify/polaris-react/pull/4207))
-
-### Bug fixes
-
 - Fixed `focus-ring` mixin for when unitless addition occurred ([#4234](https://github.com/Shopify/polaris-react/pull/4234))
 - Fixed `Scrollable` lower bound detection for lower resolution screens ([#4218](https://github.com/Shopify/polaris-react/pull/4218))
 - Fixed a bug where the inner nested drop zone was not available during a dragging event. ([#4123](https://github.com/Shopify/polaris-react/pull/4123))
@@ -708,12 +493,9 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Fixed offset in `DualThumb` when used with a min value different from 0 [#4172](https://github.com/Shopify/polaris-react/pull/4172)
 - Fixed loading state stacking in `ResourceList` ([#4208](https://github.com/Shopify/polaris-react/issues/4208))
 - Fixed focus order of visually hidden input in `DropZone` ([#4219](https://github.com/Shopify/polaris-react/pull/4219))
-
-### Deprecations
-
 - Deprecate `Sheet` component [#4210](https://github.com/Shopify/polaris-react/pull/4210)
 
-## 6.4.0 - 2021-05-11
+## 6.4.0
 
 - Add `variableHeight` prop to `DropZone` so children control its height ([#4136](https://github.com/Shopify/polaris-react/pull/4136))
 - Add print styles to `Card`, `Heading`, `Layout`, `Layout.Section`, `Subheading`, `TextStyle` components ([#4142](https://github.com/Shopify/polaris-react/pull/4142))
@@ -724,20 +506,18 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Add `small` prop to `Modal` so that width can be decreased to 380px ([#4177](https://github.com/Shopify/polaris-react/pull/4177))
 - Add `status` prop to `IndexTable.Row` to allow table rows to specify background colors([#4146](https://github.com/Shopify/polaris-react/pull/4146))
 
-## 6.3.0 - 2021-04-19
+## 6.3.0
 
 - Add `hoverable` prop to `DataTable` ([#4074](https://github.com/Shopify/polaris-react/pull/4074))
 - Added `interactive` color variant to `Icon` ([#4112](https://github.com/Shopify/polaris-react/pull/4112))
 - Update `IndexTable` hover styles for sticky column ([#4113](https://github.com/Shopify/polaris-react/pull/4113))
 - Add `colSpan` to the cells in `DataTable` so that cells fill the table width ([#4120](https://github.com/Shopify/polaris-react/pull/4120))
 
-## 6.2.2 - 2021-04-08
+## 6.2.2
 
 - Reverts `<TextField>` to use `autocomplete=off` instead of `autocomplete=nope` ([#4108](https://github.com/Shopify/polaris-react/pull/4108))
 
-## 6.2.1 - 2021-04-05
-
-### Bug fixes
+## 6.2.1
 
 - Added `hideOnPrint` prop to `Card` and `CardSection` ([#4071](https://github.com/Shopify/polaris-react/pull/4071))
 - `DropZone` now has plural sentences when `allowMultiple` is true [#4037](https://github.com/Shopify/polaris-react/pull/4037)
@@ -749,34 +529,21 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - update error background color in `Select` ([#4089](https://github.com/Shopify/polaris-react/pull/4089))
 - Fixed `Trapfocus` issue that was preventing tabbing with react forms ([#4100](https://github.com/Shopify/polaris-react/pull/4100))
 
-## 6.2.0 - 2021-03-17
-
-### Enhancements
+## 6.2.0
 
 - Added `zIndexOverride` prop to `Popover` ([#3937](https://github.com/Shopify/polaris-react/pull/3937))
 - Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
 - Added an `onError` hook to the `Avatar` component ([#4052](https://github.com/Shopify/polaris-react/pull/4052))
-
-### Bug fixes
-
 - `IndexTable` Remove parent resource name from bulk select action ([#4013](https://github.com/Shopify/polaris-react/pull/4013))
 - Ensured `@charset` declaration is the first thing in our styles.css file ([#4019](https://github.com/Shopify/polaris-react/pull/4019))
 - Fix `Modal.Section` divider color to match header and footer divider ([#4021](https://github.com/Shopify/polaris-react/pull/4021))
 - Fix `IndexTable` sticky header alignment and jank ([#4033](https://github.com/Shopify/polaris-react/pull/4033)
 - Remove focus ring on click for ActionList ([#4034](https://github.com/Shopify/polaris-react/pull/4034))
 - Updated `<TextField>` to use `autocomplete=nope` instead of `autocomplete=off` ([#4053](https://github.com/Shopify/polaris-react/pull/4053))
-
-### Dependency upgrades
-
 - Update `@shopify/polaris-tokens to v3.0.0 ([#4030](https://github.com/Shopify/polaris-react/pull/4030))
-
-### Documentation
-
 - Replaced mentions of "invalid" with not "valid" ([#4056](https://github.com/Shopify/polaris-react/pull/4056))
 
-## 6.1.0 - 2021-02-25
-
-### Enhancements
+## 6.1.0
 
 - Added `focus-visible` polyfill and default styles ([#3695](https://github.com/Shopify/polaris-react/pull/3695))
 - Added `removeUnderline` prop to `Button` to remove underline when `plain` and `monochrome` are true ([#3998](https://github.com/Shopify/polaris-react/pull/3998))
@@ -784,9 +551,6 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Reset `color` in `unstyled-button` mixin ([#4008](https://github.com/Shopify/polaris-react/pull/4008))
 - Added `IndexTable / IndexProvider` component ([#3646](https://github.com/Shopify/polaris-react/pull/3646))
 - Added `dataHref` prop to `ResourceItem` which gets passed to the main `li` element as `data-href`([#3975](https://github.com/Shopify/polaris-react/pull/3975))
-
-### Bug fixes
-
 - Updated examples for `DropZone` so they accept all image types ([#3701](https://github.com/Shopify/polaris-react/pull/3701)) (thanks [@malanjp](https://github.com/malanjp) for the pull request)
 - Added focus styles to the dismissiable navigation button in `Frame` ([#3936](https://github.com/Shopify/polaris-react/pull/3936))
 - Fixed virtual cursor leaving dialog in `Modal`, `Navigation` and `Sheet` ([#3931](https://github.com/Shopify/polaris-react/pull/3931))
@@ -808,34 +572,20 @@ For instructions on updating from v6 to v7, see our [migration guide](https://gi
 - Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
 - Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard ([#3962](https://github.com/Shopify/polaris-react/pull/3962))
 - Fixed `Autocomplete` popover height not being calculated correctly ([#4015](https://github.com/Shopify/polaris-react/pull/4015))
-
-### Documentation
-
 - Added an example for the `onRemove` prop to `Tag` and clarified that no remove button is rendered when `onClick` is set ([#2987](https://github.com/Shopify/polaris-react/pull/2987))
-
-### Development workflow
-
 - Convert `List`, `Tabs.List`, `Connected.Item` and `Filter.ConnectedFiltterControl.Item` to be functional components ([#3961](https://github.com/Shopify/polaris-react/pull/3961))
 
-## 6.0.1 - 2021-01-29
-
-### Enhancements
+## 6.0.1
 
 - Updated Link underline style on print to be lighter ([#3943](https://github.com/Shopify/polaris-react/pull/3943))
-
-### Bug fixes
-
 - Fix issue with currentColor in icons is black instead of white ([#3938](https://github.com/Shopify/polaris-react/pull/3938))
-
-### Development workflow
-
 - Fix flakey `Tooltip` test that fails due to opacity transition ([#3940](https://github.com/Shopify/polaris-react/pull/3940))
 
-## 6.0.0 - 2021-01-27
+## 6.0.0
 
 For instructions on updating from v5 to v6, see our [migration guide](https://github.com/Shopify/polaris-react/blob/main/documentation/guides/migrating-from-v5-to-v6.md).
 
-### Breaking changes
+### Major changes
 
 - `Link` is underlined by default, added `removeUnderline` prop to remove underline ([#3705](https://github.com/Shopify/polaris-react/pull/3705))
 - Remove `light` property from `Tooltip` as it now defaults to a light background ([#3846](https://github.com/Shopify/polaris-react/pull/3846))
@@ -853,48 +603,28 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Removed `plain` property in `Pagination` as it no longer has any effect. ([#3833](https://github.com/Shopify/polaris-react/pull/3833))
 - Removed `separator` property in `Page` as it no longer has any effect. ([#3918](https://github.com/Shopify/polaris-react/pull/3918))
 - Renamed `additionalMetaData` to `additionalMetadata` in `Header` for consistency with `Title`. ([#3918](https://github.com/Shopify/polaris-react/pull/3918))
-
-### Enhancements
-
 - Removed duplicate color definition from disclosure `Icon` in `Tabs` ([#3926](https://github.com/Shopify/polaris-react/pull/3926))
-
-### Bug fixes
-
 - Fixed an accessibility issue where high contrast styles wouldn’t be applied to the `Tag` component ([#3810](https://github.com/Shopify/polaris-react/pull/3810))
 - Fixed `ColorPicker` checker background to remain visible on a white background ([#3812](https://github.com/Shopify/polaris-react/pull/3812))
 
-## 5.15.1 - 2021-01-25
-
-### Bug fixes
+## 5.15.1
 
 - Add support for backdrop to newDesignLanguage colors in icon ([#3911](https://github.com/Shopify/polaris-react/pull/3911))
 
-## 5.15.0 - 2021-01-21
-
-### Enhancements
+## 5.15.0
 
 - Added `titleHidden` property for Modal ([#3905](https://github.com/Shopify/polaris-react/pull/3905))
 - Added `accessibilityLabel` property for Sheet ([#3906](https://github.com/Shopify/polaris-react/pull/3906))
 
-## 5.14.1 - 2021-01-21
-
-### Enhancements
+## 5.14.1
 
 - Added missing fallbacks to icons and removed warning ([#3897](https://github.com/Shopify/polaris-react/pull/3897)
-
-### Development workflow
-
 - Changed `master` branch name to `main` ([#3899](https://github.com/Shopify/polaris-react/pull/3899))
 
-## 5.14.0 - 2021-01-20
-
-### Enhancements
+## 5.14.0
 
 - Changed `Label` and `Labelled`’s `label` prop type to `React.ReactNode` instead of `string` ([#3787](https://github.com/Shopify/polaris-react/pull/3787))
 - Added `focusable` prop to `Scrollable` for when child content do not have focus ([#3867](https://github.com/Shopify/polaris-react/pull/3867))
-
-### Bug fixes
-
 - Fixed an incorrect translation key for `accessibilityLabel` in `Tooltip`([#3843](https://github.com/Shopify/polaris-react/pull/3843))
 - Fix shadows on filled `Button`s not touching the bottom edge ([#3841](https://github.com/Shopify/polaris-react/pull/3841))
 - Adjust `Thumbnail` icon color to be subdued ([#3846](https://github.com/Shopify/polaris-react/pull/3846))
@@ -903,15 +633,11 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Fixed `ActionList` not rendering `.active` indicator ([#3854](https://github.com/Shopify/polaris-react/pull/3854))
 - Prevent loss of focus when clicking clear all filters in `Filters` ([#3754](https://github.com/Shopify/polaris-react/pull/3754))
 
-## 5.13.1 - 2021-01-13
-
-### Bug fixes
+## 5.13.1
 
 - Fix the `Button` focus state offset ([#3832](https://github.com/Shopify/polaris-react/pull/3832))
 
-## 5.13.0 - 2021-01-11
-
-### Enhancements
+## 5.13.0
 
 - Updated `OptionList` selected styles ([#3633](https://github.com/Shopify/polaris-react/pull/3633))
 - Added the ability to hide the clear filter button on the filter component ([#3049](https://github.com/Shopify/polaris-react/pull/3049))
@@ -929,9 +655,6 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Coverted `TooltipOverlay` to a functional component ([#3631](https://github.com/Shopify/polaris-react/pull/3631))
 - New `ariaDescribedBy` prop for `Button` ([#3664](https://github.com/Shopify/polaris-react/pull/3686))
 - Changed the way sub navigation menus are rendered for improved accessibility ([#3661](https://github.com/Shopify/polaris-react/pull/3661))
-
-### Bug fixes
-
 - Fixed an accessibility issue where high contrast styles wouldn’t be applied to the `Tag` component ([#3810](https://github.com/Shopify/polaris-react/pull/3810))
 - `plain` variant `children` no longer remain visible while `loading` for `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - No longer spin `disclosure` 180deg when toggling between `up` and `down` on `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
@@ -966,38 +689,22 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Removed `-ms-high-contrast` media query from `ms-high-contrast-outline` as it is non-standard and updated the outline color from `windowText` to `transparent` ([#3775](https://github.com/Shopify/polaris-react/pull/3775)).
 - Fixed `Collapsible` expand and collapse animation ([#3779](https://github.com/Shopify/polaris-react/pull/3779))
 - Fixed a bug in `Page` where re-rendering of `secondaryActions` could cause layout jittering ([#3641](https://github.com/Shopify/polaris-react/pull/3641))
-
-### Development workflow
-
 - Replaced Travis with GitHub actions ([#3739](https://github.com/Shopify/polaris-react/pull/3739))
-
-### Code quality
-
 - Removed skipped accessibility tests and fixes component accessibility issues ([#3721](https://github.com/Shopify/polaris-react/pull/3721))
 - Extracted `TagsWrapper` from `Filters` for testability ([#3688](https://github.com/Shopify/polaris-react/pull/3688))
-
-### Deprecations
-
 - `stretchContent` has been replaced by `textAlign="left" + fullWidth` for `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - Deprecated `Popover`'s prop `preventAutofocus`. Use `autofocusTarget` instead ([#3602](https://github.com/Shopify/polaris-react/issues/3602))
 
-## 5.12.0 - 2020-12-09
-
-### Enhancements
+## 5.12.0
 
 - Added `flush` prop to `Card.Section` ([#3645](https://github.com/Shopify/polaris-react/pull/3645))
 - Added `stretchContent` prop for `Button` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
 - Added `accessibilityLabel` to `Link` component ([#3691](https://github.com/Shopify/polaris-react/pull/3691))
-
-### Bug fixes
-
 - Added dependency list to useImperativeHandle in `Banner` ([#3478](https://github.com/Shopify/polaris-react/pull/3478))
 - Internationalized `Badge` labels ([#3655](https://github.com/Shopify/polaris-react/pull/3655))
 - Aligned the `::before` 'indicator' to edge of container for `ActionList` ([#3619](https://github.com/Shopify/polaris-react/pull/3619))
 
-## 5.11.0 - 2020-12-03
-
-### Enhancements
+## 5.11.0
 
 - Allowed `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
 - Added `role` prop for `Button` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
@@ -1005,9 +712,6 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
 - Added `role="presentational"` to list items for `Tabs` ([#3647](https://github.com/Shopify/polaris-react/pull/3647))
 - Allowed consumers to set custom container element on `PortalsManager` ([#3644](https://github.com/Shopify/polaris-react/pull/3644))
-
-### Bug fixes
-
 - Fixed `FocusManager` from tracking inactive items that prevented trap focusing([#3630](https://github.com/Shopify/polaris-react/pull/3630))
 - Added escape keybind to `Tooltip` ([#3627](https://github.com/Shopify/polaris-react/pull/3627))
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
@@ -1022,28 +726,19 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Added a `alwaysRenderCustomProperties` to `ThemeProvider` for elements that render outside of the DOM tree to their parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
 - Fixed keyboard interactions for the `Tab` component ([#3650](https://github.com/Shopify/polaris-react/pull/3650))
 - Fixed keyboard interaction when selected Tab was focused and rendering the wrong `::before` colour ([#3669](https://github.com/Shopify/polaris-react/pull/3669))
-
-### Documentation
-
 - Fixed `preventAutoFocus` prop description for `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 
-## 5.10.2 - 2020-12-01
-
-### Bug fixes
+## 5.10.2
 
 - Increased precision of hue, saturation, lightness, and alpha in HSBLA `color-transformers` (https://github.com/Shopify/polaris-react/pull/3640)
 
-## 5.10.1 - 2020-11-13
-
-### Bug fixes
+## 5.10.1
 
 - Fixed alignment of `Page` and `TopBar` so the search aligns to the page. ([#3610](https://github.com/Shopify/polaris-react/pull/3610))
 - Fixed `TopBar` search clear button alignment on iOS ([#3618](https://github.com/Shopify/polaris-react/pull/3618))
 - Fixed HSB brightness conversion by increasing precision from 2 decimals to 4 ([#3621](https://github.com/Shopify/polaris-react/pull/3621))
 
-## 5.10.0 - 2020-10-30
-
-### Enhancements
+## 5.10.0
 
 - Added `ariaExpanded` prop to `TextField` ([#3589](https://github.com/Shopify/polaris-react/pull/3589))
 - Updated `MediaCard` to accept ReactNode as title and make `primaryAction` optional (thanks to [@devchris](https://github.com/devchris) for the [pull request](https://github.com/Shopify/polaris-react/pull/3552))
@@ -1052,74 +747,45 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Generalized Tooltip's `content` prop's type to not only accept string, but any `React.Node`. ([#3559](https://github.com/Shopify/polaris-react/pull/3559))
 - Updated `TopBar` to show the logo when there is no navigation or search fields ([#3523](https://github.com/Shopify/polaris-react/pull/3523))
 - Updated critical `Banner` icon to be a diamond ([#3567](https://github.com/Shopify/polaris-react/pull/3567))
-
-### Bug fixes
-
 - Fixed `SkeletonPage` to make the title font size consistent with the `Page` component ([#3449](https://github.com/Shopify/polaris-react/pull/3449))
 - Removed `Navigation.Item` color change when focused ([#3562](https://github.com/Shopify/polaris-react/pull/3562))
 - Adds monochrome styling to `connectedDisclosure` prop on `Button` component and fix spacing issue ([#3588](https://github.com/Shopify/polaris-react/pull/3588)
-
-### Development workflow
-
 - Updated our CI accessibility checks to use the axe runnner provided by Storybook's a11y addon. Now now errors match between CI and local runs in Storybook ([#3284](https://github.com/Shopify/polaris-react/pull/3284))
 - Updated sewing-kit to 0.140.0 and TypeScript to 4.0.0 ([#3566](https://github.com/Shopify/polaris-react/pull/3566))
-
-### Code quality
-
 - **`Button`:** Reduced redundant code repeated within `UnstyledButton` ([#3494](https://github.com/Shopify/polaris-react/pull/3494))
 
-## 5.9.1 - 2020-10-23
-
-### Bug fixes
+## 5.9.1
 
 - Fixed Button connected disclosure height when button text has more than 2 lines ([#3536](https://github.com/Shopify/polaris-react/pull/3536))
 
-## 5.9.0 - 2020-10-22
-
-### Enhancements
+## 5.9.0
 
 - Updated `Textfield` with a type of number to not render a spinner if step is set to 0 ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
-
-### Bug fixes
-
 - Fixed `Filters` overflow ([#3532](https://github.com/Shopify/polaris-react/pull/3532))
 - Refactored `Portal` to render all `Portals` in a single container ([#3544](https://github.com/Shopify/polaris-react/pull/3544))
 - Fixed `Filters` overflow ([#3532](https://github.com/Shopify/polaris-react/pull/3532))
 
-## 5.8.0 - 2020-10-15
-
-### Bug fixes
+## 5.8.0
 
 - Fixed alignment of badges in navigation items ([#3440](https://github.com/Shopify/polaris-react/pull/3440))
-
-### Documentation
-
 - The Details Page in Storybook now renders the `SearchDismissOverlay` when typing in the search field. ([#3471](https://github.com/Shopify/polaris-react/pull/3471))
 
-## 5.7.0 - 2020-10-09
-
-### Enhancements
+## 5.7.0
 
 - Added `OutlineableAction` to the `ComplexAction` type ([#3405](https://github.com/Shopify/polaris-react/pull/3405))
 - Added `UnstyledButton` component and refactored `Banner` to use it ([#3406](https://github.com/Shopify/polaris-react/pull/3406))
 - Added `prefix` field to `options` prop on `Select` ([#3373](https://github.com/Shopify/polaris-react/pull/3373))
 
-## 5.6.1 - 2020-10-09
-
-### Bug fixes
+## 5.6.1
 
 - Fixed `BulkActions` from hiding child actions ([#3450](https://github.com/Shopify/polaris-react/pull/3450))
 
-## 5.6.0 - 2020-10-03
-
-### Bug fixes
+## 5.6.0
 
 - Added `RefOject` as a possible type for the `activator` prop on `Modal` ([#3395](https://github.com/Shopify/polaris-react/pull/3395))
 - Fixed `Button` from flashing an icon and changing its width when loading ([#3370](https://github.com/Shopify/polaris-react/pull/3370))
 
-## 5.5.0 - 2020-10-02
-
-### Enhancements
+## 5.5.0
 
 - Update `@shopify/polaris-icons` to version 4.0.0 ([#3327](https://github.com/Shopify/polaris-react/pull/3327))
 - Moved `li` wrapper on `ResourceList` to `ResourceListItem` ([#3302](https://github.com/Shopify/polaris-react/pull/3302))
@@ -1132,28 +798,19 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Added `spacing` prop to `DescriptionList` ([#3359](https://github.com/Shopify/polaris-react/pull/3359))
 - Export `BannerHandles` from `Banner` ([#3368](https://github.com/Shopify/polaris-react/pull/3368))
 - Added `prefix` prop to `ActionList` items ([#3313](https://github.com/Shopify/polaris-react/pull/3313))
-
-### Bug fixes
-
 - Fixes `Badge` when it becomes 2 lines due to small viewport ([#3315](https://github.com/Shopify/polaris-react/pull/3315))
 - Update `DatePicker` layout so that `Popover` can calculate the width correctly ([#3330](https://github.com/Shopify/polaris-react/pull/3330))
 
-## 5.4.0 - 2020-09-24
-
-### Enhancements
+## 5.4.0
 
 - Hide `ActionMenu`, `Actions`, `RollupActions` menu popover overlays when printing ([#3277](https://github.com/Shopify/polaris-react/pull/3277))
 - Updated `DatePicker` component to use semantic HTML table structure ([#3303](https://github.com/Shopify/polaris-react/pull/3303))
 
-## 5.3.1 - 2020-09-16
-
-### Bug fixes
+## 5.3.1
 
 - Add position relative back to FrameContent [#3259](https://github.com/Shopify/polaris-react/pull/3259)
 
-## 5.3.0 - 2020-09-15
-
-### Enhancements
+## 5.3.0
 
 - Vertically center tag text in `Tag` ([#3206](https://github.com/Shopify/polaris-react/pull/3206))
 - Update `EmptySearchResult` illustration ([#3185](https://github.com/Shopify/polaris-react/pull/3185)).
@@ -1161,27 +818,18 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Added support for the `inputMode` attribute on the `TextField` component ([#3222](https://github.com/Shopify/polaris-react/pull/3222)).
 - Added `expandOnPrint` prop to `Collapsible` for print support ([#3231](https://github.com/Shopify/polaris-react/pull/3231))
 - Added `hideOnPrint` prop to `Popover` to allow hiding the overlay when printing ([#3242](https://github.com/Shopify/polaris-react/pull/3242))
-
-### Bug fixes
-
 - Fix `Button` css in a `connectedTop` or `fullWidth` `ButtonGroup` ([#3215](https://github.com/Shopify/polaris-react/pull/3215)).
 - Fixed `Banner`’s `id` being mismatched on server VS client ([#3199](https://github.com/Shopify/polaris-react/pull/3199)).
 - Fixed the border and pip fill colors on the `Badge` to show when printing ([#3226](https://github.com/Shopify/polaris-react/pull/3226)).
 
-### Code quality
-
 - Updated Storybook to v6 ([#3184](https://github.com/Shopify/polaris-react/pull/3184))
 - Converted `ActionMenu` to functional component ([#3139](https://github.com/Shopify/polaris-react/pull/3193))
 
-## 5.2.1 - 2020-08-18
-
-### Enhancements
+## 5.2.1
 
 - Added `position: relative` to content container within Frame ([#3178](https://github.com/Shopify/polaris-react/pull/3178))
 
-## 5.2.0 - 2020-08-12
-
-### Enhancements
+## 5.2.0
 
 - Added optional `videoProgress` and `showVideoProgress` props to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
 - Enabled much easier tree-shaking in consuming apps by having a multi-file build instead of a single-file build ([#3137](https://github.com/Shopify/polaris-react/pull/3137))
@@ -1190,39 +838,22 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Exported `PositionedOverlay` component for use in consuming applications ([#3161](https://github.com/Shopify/polaris-react/pull/3161))
 - Updated package.json to use `esnext` as a custom mainField instead of `sewing-kit:esnext` to match updated sewing-kit behavior ([#3169](https://github.com/Shopify/polaris-react/pull/3169))
 - Updated type restrictions for `Tabs` to allow its `content` prop to accept `React.ReactNode` instead of `string` ([#3171](https://github.com/Shopify/polaris-react/pull/3171))
-
-### Development workflow
-
 - Fixed `build-consumer` script to handle excludes in package.json's `files` array ([#3136](https://github.com/Shopify/polaris-react/pull/3136))
-
-### Code quality
-
 - Removed the `new-top-bar-height` sass function and replaced its usage with the `--p-top-bar-height` custom property ([#3158](https://github.com/Shopify/polaris-react/pull/3158))
 
-## 5.1.0 - 2020-07-23
-
-### Enhancements
+## 5.1.0
 
 - Added a `dismissOnMouseOut` prop to `Tooltip` to dismiss Tooltip once pointer is no longer over children ([#3086](https://github.com/Shopify/polaris-react/pull/3086))
-
-### Bug fixes
-
 - Fixed case where `DatePicker` did not translate the weekday name in an aria label ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
 - Updated browserslist config to be an explicit list instead of extending an existing config, so that consuming apps don't need to depend upon `@shopify/browserslist-config` ([#3132](https://github.com/Shopify/polaris-react/pull/3132))
-
-### Documentation
-
 - Updated Polaris to the latest version in the [CDN Styles example](https://github.com/Shopify/polaris-react/tree/main/examples/cdn-styles?rgh-link-date=2020-06-12T21%3A05%3A52Z) ([#3068](https://github.com/Shopify/polaris-react/pull/3068))
 - Updated `TextField` example to use a number instead of a boolean ([#3114](https://github.com/Shopify/polaris-react/pull/3114))
-
-### Code quality
-
 - Updated linting to prefer the fragment shorthand `<>` instead of `<React.Fragment>` ([#3133](https://github.com/Shopify/polaris-react/pull/3133))
 - Updated how we access React exports such as React.Component and React.PureComponent to help treeshakability ([#3133](https://github.com/Shopify/polaris-react/pull/3133))
 
-## 5.0.0 - 2020-07-21
+## 5.0.0
 
-### Breaking changes
+### Major changes
 
 - Upgraded `react` and `react-dom` peer-dependencies to 16.9.0 to enable the use of `React.Profiler` ([#2462](https://github.com/Shopify/polaris-react/pull/2462))
 - Removed `NavigationMessageProps` as the `Message` component no longer exists ([#2502](https://github.com/Shopify/polaris-react/pull/2502))
@@ -1241,21 +872,9 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Removed `Year` type export (used by the DatePicker's props). Replace its usage with `number`. ([#3121](https://github.com/Shopify/polaris-react/pull/3121))
 - Removed the `Month` enum export (used by the DatePicker's props). Replace its usage with a number from 0 to 11, representing the number of the month in question - `Month.January` becomes `0`, `Month.December` becomes `11` etc. ([#3121](https://github.com/Shopify/polaris-react/pull/3121))
 - Removed the `TypeOf` enum, and `GeneralObject`, `DeepPartial`, `EffectCallback`, `DependencyList` and `Comparator` type exports - these were for internal use, and were never documented for external use. ([#3123](https://github.com/Shopify/polaris-react/pull/3123))
-
-### Enhancements
-
 - Added an activator prop to `Modal` so that focus can be returned to it when the `Modal` is closed ([#2206](https://github.com/Shopify/polaris-react/pull/2206))
-
-### Bug fixes
-
 - Fixed case where `DatePicker` did not translate the month name in an aria label ([#3121](https://github.com/Shopify/polaris-react/pull/3121))
-
-### Dependency upgrades
-
 - Updated browserlist to use `@shopify/browserslist-config` ([#3101](https://github.com/Shopify/polaris-react/pull/3101))
-
-### Code quality
-
 - Converted `Modal` to a functional component ([#2376](https://github.com/Shopify/polaris-react/pull/2376))
 - Migrated to use `react-transition-group` instead of the material-ui fork. ([#3094](https://github.com/Shopify/polaris-react/pull/3094))
 - Removed `withAppProvider` higher-order component. ([#3098](https://github.com/Shopify/polaris-react/pull/3098))
@@ -1263,45 +882,27 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Removed dependency on `@shopify/useful-types`
 - Removed dependency on `@shopify/javascript-utilities` ([#3108](https://github.com/Shopify/polaris-react/pull/3108))
 
-## 4.27.0 - 2020-07-14
-
-### Enhancements
+## 4.27.0
 
 - Removed padding from the details container in `EmptyState` to account for new illustration size ([#3069](https://github.com/Shopify/polaris-react/pull/3069))
 - Added `blueDark` to the list of possible `color` values for an `Icon` with a backdrop ([#3076](https://github.com/Shopify/polaris-react/pull/3076))
 - Improved responsive layout for secondary actions in `Banner` ([#3093](https://github.com/Shopify/polaris-react/pull/3093))
-
-### Bug fixes
-
 - Added `flex: 1 1 auto` to `Banner` `.ContentWrapper` CSS selector ([#3062](https://github.com/Shopify/polaris-react/pull/3062))
 - Fixed mis-alignment on `Page` action rollup ([#3064](https://github.com/Shopify/polaris-react/pull/3064))
 - Ensured Sass mixins can compile in Dart Sass ([#3064](https://github.com/Shopify/polaris-react/pull/3063))
 - Added a border to `TextField` when focus is lost after autofill is implemented([#3075](https://github.com/Shopify/polaris-react/pull/3075))
 - Fixed alignment of `ResourceItem` when there is no media ([#3080](https://github.com/Shopify/polaris-react/pull/3080))
 - Fixed stacking order of `CloseButton` on `Modal` without a title ([#3077](https://github.com/Shopify/polaris-react/pull/3077))
-
-### Documentation
-
 - Updated AppProvider test component information (thanks to [@jprosevear](https://github.com/jprosevear) for the [pull request](https://github.com/Shopify/polaris-react/pull/3104))
-
-### Development workflow
-
 - Updated sewing-kit to v0.132.2 and storybook to v5.3.19 ([#3072](https://github.com/shopify/polaris-react/pull/3072))
-
-### Code quality
-
 - Migrated tests using document.activeElement to use react-testing ([#3070](https://github.com/Shopify/polaris-react/pull/3070))
 - Reduced file size of the empty search SVG by 50% (from 12k to 6k gzipped) ([#3105](https://github.com/Shopify/polaris-react/pull/3105))
 
-## 4.26.1 - 2020-06-16
-
-### Code quality
+## 4.26.1
 
 - Default to `any` for ItemType in resource list ([#3059](https://github.com/Shopify/polaris-react/pull/3059))
 
-## 4.26.0 - 2020-06-16
-
-### Enhancements
+## 4.26.0
 
 - Added spacing to `EmptyState` when within content to account for new illustration styles ([#3047](https://github.com/Shopify/polaris-react/pull/3047))
 - Changed Resource List to a generic functional component (thanks to [@athornburg](https://github.com/Shopify/polaris-react/pull/2843))
@@ -1312,9 +913,7 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
   Set `active` prop of `Popover` to true on keyDown in `ComboBox` to fix `Autocomplete` suggestions not showing when searching and selecting via keyboard ([#3028](https://github.com/Shopify/polaris-react/pull/3028))
 - Increased the max-width of the `EmptyState` content to 400px ([#3040](https://github.com/Shopify/polaris-react/pull/3040))
 
-## 4.25.2 - 2020-06-16
-
-### Enhancements
+## 4.25.2
 
 ⚠️ This release was released as a patch version in error. Please use v4.26.0.
 
@@ -1326,245 +925,138 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Set `active` prop of `Popover` to true on keyDown in `ComboBox` to fix `Autocomplete` suggestions not showing when searching and selecting via keyboard ([#3028](https://github.com/Shopify/polaris-react/pull/3028))
   Set `active` prop of `Popover` to true on keyDown in `ComboBox` to fix `Autocomplete` suggestions not showing when searching and selecting via keyboard ([#3028](https://github.com/Shopify/polaris-react/pull/3028))
 - Increased the max-width of the `EmptyState` content to 400px ([#3040](https://github.com/Shopify/polaris-react/pull/3040))
-
-### Development workflow
-
 - Updated how global animations are referenced, in order to publish a single entrypoint for the public Sass API (`styles/_public-api.scss`), instead of two (`styles/_public-api.scss` for “vanilla” SCSS and `styles/esnext/_public-api.scss` for CSS Modules) ([#3032](https://github.com/Shopify/polaris-react/pull/3032))
-
-### Code quality
-
 - Deleted an unused prop and its types in `Navigation` ([#3043](https://github.com/Shopify/polaris-react/pull/3043))
 
-## 4.25.1 - 2020-06-10
-
-### Bug fixes
+## 4.25.1
 
 - Fix latest release on NPM
 
-## 4.25.0 - 2020-06-04
-
-### Enhancements
+## 4.25.0
 
 - Added `ReactNode` as an accepted prop type to `primaryAction` on the `Page` component ([#3002](https://github.com/Shopify/polaris-react/pull/3002))
 
-## 4.24.0 - 2020-05-28
-
-### Enhancements
+## 4.24.0
 
 - Added a `fullWidth` prop to `ContextualSaveBar` to support full width layout within a content context ([#3014](https://github.com/Shopify/polaris-react/pull/3014))
 - Added an optional `size` prop to `MediaCard` to support varying media sizes in the card ([#3013](https://github.com/Shopify/polaris-react/pull/3013))
 
-## 4.23.0 - 2020-05-28
-
-### Enhancements
+## 4.23.0
 
 - Added a `fullWidth` prop to `EmptyState` to support full width layout within a content context ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
 - Added an `emptyState` prop to `ResourceList` to support in context empty states in list views ([#2569](https://github.com/Shopify/polaris-react/pull/2569))
 - Improved top bar transitions when theme changes ([#3007](https://github.com/Shopify/polaris-react/pull/3007))
-
-### Bug fixes
-
 - Fixed incorrect `icon` color of `Button` when `destructive` and `plain` ([#2958](https://github.com/Shopify/polaris-react/issues/2958))
-
-### Development workflow
-
 - Improved speed of type-check and build by enabling TypeScript's `skipLibCheck` option ([#2981](https://github.com/Shopify/polaris-react/pull/2981))
-
-### Dependency upgrades
-
 - Updated TypeScript to 3.9.2 ([#2981](https://github.com/Shopify/polaris-react/pull/2981))
 
-## 4.22.0 - 2020-05-11
-
-### Enhancements
+## 4.22.0
 
 - Truncated long sort options in `ResourceList` ([#2957](https://github.com/Shopify/polaris-react/pull/2957)
 - Updated type restrictions for `Pagination` to allow its `label` prop to accept `React.ReactNode` instead of `string` ([#2972](https://github.com/Shopify/polaris-react/pull/2972))
 - Added an `emptySearchState` prop to `ResourceList` to enable the customization of the empty search state ([#2971](https://github.com/Shopify/polaris-react/pull/2971))
-
-### Bug fixes
-
 - Added an outline on `Banner` for Windows high contrast mode ([#2878](https://github.com/Shopify/polaris-react/pull/2878))
 - Fixed Autocomplete / ComboBox focus ([#1089](https://github.com/Shopify/polaris-react/issues/1089))
 - Fixed missing rounded corners on `Banner` ([#2975](https://github.com/Shopify/polaris-react/pull/2975))
 - Fixed typing for `EmptyState` action ([#2977](https://github.com/Shopify/polaris-react/pull/2977))
-
-### Code quality
-
 - Converted `ComboBox` to a functional component ([#2918](https://github.com/Shopify/polaris-react/pull/2918))
-
-### Deprecations
-
 - Deprecated `styles/foundation.scss` and `styles/shared.scss` as entry points to the Polaris Sass public API. They have been replaced with a single file `styles/_public-api.scss`. By having a single entry point we make it a little easier for consuming applications to use our public API - you only need to import one file instead of two. Any references to these two files should be replaced with a reference to `_public-api.scss` which lives in the same folder. Consuming applications using sewing-kit should replace references to `esnext/styles/foundation.scss` and `esnext/styles/shared.scss` with a single reference to `esnext/styles/_public-api.scss`. Note the API itself has not changed - only the mechanism by which you access it. ([#2974](https://github.com/Shopify/polaris-react/pull/2974))
 
-## 4.21.0 - 2020-04-28
-
-### Enhancements
+## 4.21.0
 
 - Added `additionalNavigation` prop to `Page` ([#2942](https://github.com/Shopify/polaris-react/pull/2942))
 
-## 4.20.1 - 2020-04-23
-
-### Bug fixes
+## 4.20.1
 
 - Fixed performance of `ResourceItem` due to inclusion of `children` in deep prop comparison within `shouldComponentUpdate` ([#2936](https://github.com/Shopify/polaris-react/pull/2936))
 
-## 4.20.0 - 2020-04-22
-
-### Enhancements
+## 4.20.0
 
 - Removed `max-height` property from `Tooltip` (thanks to [@thayannevls](https://github.com/thayannevls) for the [pull request](https://github.com/Shopify/polaris-react/pull/2908))
 - Update `TopBar.Menu` to be properly themed in active, hover and focused state ([#2928](https://github.com/Shopify/polaris-react/pull/2928))
 - Added a centeredLayout prop to `EmptyState` ([#2939](https://github.com/Shopify/polaris-react/pull/2939))
-
-### Bug fixes
-
 - Fixed `Tag` submitting forms when `onClick` is set ([#2895](https://github.com/Shopify/polaris-react/pull/2895))
 - Fixed `DescriptionList` content overflowing when `term` or `description` have long unbroken words ([#2880](https://github.com/Shopify/polaris-react/pull/2880))
 - Fixed focusing bug on Filters where a newly opened filter would not initially focus the first input, and a newly opened filter would incorrectly focus after an input selection ([#2871](https://github.com/Shopify/polaris-react/pull/2871))
-
-### Development workflow
-
 - Fixed automatic pull request generation for `web` and `styleguide` when updating Polaris ([#2892](https://github.com/Shopify/polaris-react/pull/2892))
 - Added an example to `Layout` that showcases how to space a banner ([#2929](https://github.com/Shopify/polaris-react/pull/2929))
 
-## 4.19.0 - 2020-04-15
-
-### Enhancements
+## 4.19.0
 
 - Updated `Filters` to only show the "More filters" button if necessary ([#2856](https://github.com/Shopify/polaris-react/pull/2856)).
 - Updated `TopBar` component to show `secondaryMenu` on small screens ([#2913](https://github.com/Shopify/polaris-react/pull/2913))
 - `Badge` adds `critical` status prop styling ([#2902](https://github.com/Shopify/polaris-react/pull/2902))
-
-### Bug fixes
-
 - Added `border-radius` to the `MediaCard` container ([#2919](https://github.com/Shopify/polaris-react/pull/2919))
-
-### Code quality
-
 - Set `importsNotUsedAsValues` to `error` in TypeScript configuration to force us to be explicit when importing types ([#2901](https://github.com/Shopify/polaris-react/pull/2901))
 
-## 4.18.0 - 2020-04-09
-
-### New components
+## 4.18.0
 
 - Added [`MediaCard`](https://polaris.shopify.com/components/structure/video-card) and [`VideoThumbnail`](https://polaris.shopify.com/components/images-and-icons/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
 - Added [`VideoThumbnail`](https://polaris.shopify.com/components/images-and-icons/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
-
-### Enhancements
-
 - Added utilities for parsing video duration (https://polaris.shopify.com/components/images-and-icons/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
-
-### Dependency upgrades
-
 - Updated polaris-tokens to use new font stack ([#2906](https://github.com/Shopify/polaris-react/pull/2906))
 
-## 4.17.1 - 2020-04-06
-
-### Bug fixes
+## 4.17.1
 
 - `TopBar` navigation icon to use the `var(--top-bar-color)` ([#2898](https://github.com/Shopify/polaris-react/pull/2898)).
 
-### Documentation
-
 - Fixed two typos in the `Form` documentation ([#2879](https://github.com/Shopify/polaris-react/pull/2879))
-
-### Code quality
-
 - Don't use `export *` when exporting from type-only files as importing empty files causes webpack to produce unwanted boilerplate ([#2897](https://github.com/Shopify/polaris-react/pull/2897))
 
-## 4.17.0 - 2020-04-03
-
-### Enhancements
+## 4.17.0
 
 - Added `showFocusBorder` prop to the `TopBar.SearchField` to allow users to add show a border on focus ([#2886](https://github.com/Shopify/polaris-react/pull/2886)).
 - Added a theme prop for `frameOffset` ([#2887](https://github.com/Shopify/polaris-react/pull/2887))
 - Updated the font stack to put `Segoe UI` before `Roboto` ([#2891](https://github.com/Shopify/polaris-react/pull/2891))
-
-### Bug fixes
-
 - Fixed right padding styling issue with the `Tag` component and remove right padding on a removable `Tag` ([#2860](https://github.com/Shopify/polaris-react/pull/2860)).
 - Fixed secondary navigation spacing when no icon is present ([#2874](https://github.com/Shopify/polaris-react/pull/2874)).
 
-### Dependency upgrades
-
 - Updated sewing-kit to v0.120.0, and typescript to 3.8.3 ([#2873](https://github.com/Shopify/polaris-react/pull/2873))
-
-### Code quality
-
 - Use `downlevel-dts` to produce compatible type definitions for consuming apps using older TypeScript versions ([#2875](https://github.com/Shopify/polaris-react/pull/2875))
 
-## 4.16.1 - 2020-03-19
+## 4.16.1
 
 - Made no noteworthy changes
 
-## 4.16.0 - 2020-03-13
-
-### Enhancements
+## 4.16.0
 
 - Added optional `onClick` prop to `Tag` ([#2774](https://github.com/Shopify/polaris-react/pull/2774))
 - Added transition properties to `Collapsible` ([#2835](https://github.com/Shopify/polaris-react/pull/2835))
-
-### Bug fixes
-
 - Fixed issue with passed to `ComboBox` component options prop was mutated ([#2818](https://github.com/Shopify/polaris-react/pull/2818))
 - Fixed an issue which caused `Popover` to close when clicking on a descendant SVG ([#2827](https://github.com/Shopify/polaris-react/pull/2827))
-
-### Code quality
-
 - Removed redundant null check in `TextField` ([#2783](https://github.com/Shopify/polaris-react/pull/2783))
 
-## 4.15.2 - 2020-03-09
-
-### Code quality
+## 4.15.2
 
 - Updated shrink-ray to v2 ([#2800](https://github.com/Shopify/polaris-react/pull/2800))
 
-## 4.15.1 - 2020-03-07
-
-### Bug fixes
+## 4.15.1
 
 - Reverted const context type to support older versions of typescript in consuming apps ([e7c5e16](https://github.com/Shopify/polaris-react/commit/e7c5e16e8e7b2e70993c5e33c6e34bea428b35b8))
 - Fixed broken link in `ThemeProvider` docs ([0ff672d](https://github.com/Shopify/polaris-react/commit/0ff672d2802cb6f4832176de889fe2ab39b101f0))
 
-## 4.15.0 - 2020-03-06
-
-### Enhancements
+## 4.15.0
 
 - Added high contrast outline to `Popover`, `Card` and `Indicator` ([#2792](https://github.com/Shopify/polaris-react/pull/2792))
 - Removed `overflow: hidden` from `Card` ([#2806](https://github.com/Shopify/polaris-react/pull/2806))
 - Truncated long sort options in `ResourceList` ([#2809](https://github.com/Shopify/polaris-react/pull/2809)
-
-### Bug fixes
-
 - Fixed incorrect used while importing from `polaris-tokens` ([#2778](https://github.com/Shopify/polaris-react/pull/2778))
 - Fixed `DropZone` not supporting new file selection when `allowMultiple` is `false` ([#2737](https://github.com/Shopify/polaris-react/pull/2737))
 - Fixed `Pagination` sizing on small screens with tooltips ([2747](https://github.com/Shopify/polaris-react/pull/2747))
 - Fixed `Popover` setting a `tabindex` and other accessibility attributes on the activator wrapper when the `activator` is disabled ([#2473](https://github.com/Shopify/polaris-react/pull/2473))
 - Added a `verticalAlignment` prop to `ResourceItem` to support control of content alignment ([#2743](https://github.com/Shopify/polaris-react/pull/2743)
-
-### Development workflow
-
 - Added `check:custom-property` job in travis ([#2778](https://github.com/Shopify/polaris-react/pull/2778))
 - Exported missing OptionListProps ([#2777](https://github.com/Shopify/polaris-react/pull/2777))
 - Omitted the Storybook `AppProvider` decorator for component examples which already contain an `AppProvider` ([#2807](https://github.com/Shopify/polaris-react/pull/2807))
 - Added an `omitAppProvider` front matter concept to prevent automatic wrapping of component examples with an `AppProvider` ([#2815](https://github.com/Shopify/polaris-react/pull/2815))
-
-### Code quality
-
 - Removed various type assertions and bumped test coverage ([#2638](https://github.com/Shopify/polaris-react/pull/2638))
 
-## 4.14.0 - 2020-02-26
-
-### Enhancements
+## 4.14.0
 
 - Added high contrast outline to `ActionList` ([#2713](https://github.com/Shopify/polaris-react/pull/2713))
 - Added high contrast border to `Button` ([#2712](https://github.com/Shopify/polaris-react/pull/2712))
 - Added styled placeholder image to `Avatar` when initials are blank ([#2693](https://github.com/Shopify/polaris-react/pull/2693))
 - Added a `preferInputActivator` prop to `Popover` to allow better positioning of the overlay ([#2754](https://github.com/Shopify/polaris-react/pull/2754))
-
-### Bug fixes
-
 - Updated Polaris Tokens, which now builds modern tokens using TypeScript, fixing issues where Edge threw errors related to modern JavaScript features ([#2763](https://github.com/Shopify/polaris-react/pull/2763))
 - Fixed `TrapFocus` stealing focus from other `TrapFocus`'s ([#2681](https://github.com/Shopify/polaris-react/pull/2681))
 - Fixed focus state color on monochrome `Buttons` ([#2684](https://github.com/Shopify/polaris-react/pull/2684))
@@ -1572,119 +1064,73 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Fixed the position property for the backdrop on `Select` from being overwritten by the focus ring ([#2748](https://github.com/Shopify/polaris-react/pull/2748))
 - Fixed `ResourceItem` `Actions` visibility on mouse out ([#2742](https://github.com/Shopify/polaris-react/pull/2742))
 - Fixed initial server / client render mismatch in `Avatar` ([#2751](https://github.com/Shopify/polaris-react/pull/2751))
-
-### Development workflow
-
 - Added first implementation of custom property validation ([#2616](https://github.com/Shopify/polaris-react/pull/2616))
 - Refactored consumer build test (renamed to system integration test) ([#2735](https://github.com/Shopify/polaris-react/pull/2735))
 - Added Storybook Knobs for customizing theme ([#2674](https://github.com/Shopify/polaris-react/pull/2674))
-
-### Code quality
-
 - Updated dependencies in example apps ([#2722](https://github.com/Shopify/polaris-react/pull/2722))
 - Fixed `Tabs` tests that were preventing `React` updates ([#2702](https://github.com/Shopify/polaris-react/pull/2702))
 - Moved to Travis for CI ([#2652](https://github.com/Shopify/polaris-react/pull/2652))
 
 ---
 
-## 4.13.1 - 2020-02-02
-
-### Bug fixes
+## 4.13.1
 
 - Fixed a Sass build error ([#2453](https://github.com/Shopify/polaris-react/pull/2703))
 
 ---
 
-## 4.13.0 - 2020-02-02
-
-### Enhancements
+## 4.13.0
 
 - Replaced customer avatar images ([#2453](https://github.com/Shopify/polaris-react/pull/2453))
 - Added an optional `totalsName` prop to `DataTable` to support custom headings in the totals row ([#2660](https://github.com/Shopify/polaris-react/pull/2660))
 - Added `cursor: pointer` to `Choice` ([#2491](https://github.com/Shopify/polaris-react/pull/2491))
-
-### Bug fixes
-
 - Fixed `Uncaught TypeError: Cannot read property 'rightEdge' of undefined` in `DataTable` ([#2672](https://github.com/Shopify/polaris-react/pull/2672))
 - Fixed excessive rendering in `DatePicker` ([#2671](https://github.com/Shopify/polaris-react/pull/2671))
 - Fixed plurality of `DataTable` totals row heading ([#2660](https://github.com/Shopify/polaris-react/pull/2660))
-
-### Documentation
-
 - Changed placeholder product names in `Card` code examples ([#2677](https://github.com/Shopify/polaris-react/pull/2677))
 
 ---
 
-## 4.12.0 - 2020-01-27
-
-### Enhancements
+## 4.12.0
 
 - Added a split variant to `Button` ([#2329](https://github.com/Shopify/polaris-react/pull/2329))
 - Allow DataTable headers to be React Elements ([#2635](https://github.com/Shopify/polaris-react/pull/2635))
 - Added support for explicit order of items in `ActionMenu` ([2057](https://github.com/Shopify/polaris-react/pull/2057))
 - Made the `DataTable` horizontal `Navigation` optional ([#2647](https://github.com/Shopify/polaris-react/pull/2647))
-
-### Bug fixes
-
 - Fixed `ReferenceError: React is not defined` in `Button` for the `esnext` build ([#2657](https://github.com/Shopify/polaris-react/pull/2657))
 - Fixed scrolling with scrollbar not working in Popover when content changes on scroll ([#2627](https://github.com/Shopify/polaris-react/pull/2627))
 - Fixed side-effects from being create during `Modal`s render ([#2644](https://github.com/Shopify/polaris-react/pull/2644))
 - Work around a build crash when using create-react-app due to a bug in css parsing in `postcss-custom-properties` ([#2643](https://github.com/Shopify/polaris-react/pull/2643))
 - Removed the `visited` CSS styling for tabs using the `url` prop ([#2639](https://github.com/Shopify/polaris-react/pull/2639))
-
-### Development workflow
-
 - Reworked the yarn splash Github comment and added average splash zone information ([#2649](https://github.com/Shopify/polaris-react/pull/2649))
 - Re-enabled the web unit tests in the consumer build test ([#2663](https://github.com/Shopify/polaris-react/pull/2663))
-
-### Code quality
-
 - Converted `/tests/build.test.js` to TypeScript ([#2617](https://github.com/Shopify/polaris-react/pull/2617))
 - Use `export *` to rexport component content in component indexs and subcomponent listings ([#2625](https://github.com/Shopify/polaris-react/pull/2625))
 - Use `export *` to rexport utility content ([#2636](https://github.com/Shopify/polaris-react/pull/2636))
 
-## 4.11.0 - 2020-01-17
+## 4.11.0
 
-### Breaking changes
+### Major changes
 
 - Remove unstable telemetry API for icons ([#2561](https://github.com/Shopify/polaris-react/pull/2561))
-
-### Enhancements
-
 - Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
 - Added `searchResultsOverlayVisible` prop to `TopBar` which adds a translucent background to the search dismissal overlay when results are displayed ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
-
-### Bug fixes
-
 - Fixed a bug where `Navigation` calls `onNavigationDismiss` on large screens when focused and the escape key is pressed ([#2607](https://github.com/Shopify/polaris-react/pull/2607))
 - Fixed issue with `Filters` component displaying an undesired margin top and bottom on the button element on Safari ([#2292](https://github.com/Shopify/polaris-react/pull/2292))
 - Fixed `RangeSlider` focus state style issues ([#1926](https://github.com/Shopify/polaris-react/pull/1926))
 - Ensure passing `{key: undefined}` into i18n will throw a runtime error in the same way as not passing in the key at all (this was ensured through type-checking at the TypeScript level but people could force through with casting to `any`) ([#2598](https://github.com/Shopify/polaris-react/pull/2598))
 - Ensure the normalizedValue within `TextField` is a string (this was already ensured through type-checking at the TypeScript level, but people could force through with casting to `any`, which caused problems) ([#2598](https://github.com/Shopify/polaris-react/pull/2598))
-
 - Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589](https://github.com/Shopify/polaris-react/pull/2589))
 - Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
 - Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of the activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
 - Search dismissal overlay now covers the entire screen ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
 - Search results component will no longer unmount when hidden ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
 - Search results will now match the width of the search field ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
-
-### Documentation
-
 - Updated `Card` with custom footer actions example to be right-aligned ([#2603](https://github.com/Shopify/polaris-react/pull/2603))
 - Updated styleguide links in the docs ([#2521](https://github.com/Shopify/polaris-react/pull/2521))
 - Updated `Subheading` documentation to be more consistent and accurate ([#2591](https://github.com/Shopify/polaris-react/pull/2591/))
-
-### Development workflow
-
 - Updated Storybook to v5.3.2 ([#2618](https://github.com/Shopify/polaris-react/pull/2618))
-
-### Dependency upgrades
-
 - Updated `@shopify/polaris-icons` to v3.9.0 ([#2610](https://github.com/Shopify/polaris-react/pull/2610))
-
-### Code quality
-
 - Converted `MenuGroup` into a functional component ([#2536](https://github.com/Shopify/polaris-react/pull/2536))
 - Converted `Layout` into a functional component ([#2538](https://github.com/Shopify/polaris-react/pull/2538))
 - Converted `FormLayout` into a functional component ([#2539](https://github.com/Shopify/polaris-react/pull/2539))
@@ -1699,51 +1145,32 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 
 ---
 
-## 4.10.2 - 2019-12-20
-
-### Bug fixes
+## 4.10.2
 
 - Fixed errors when consuming apps manage to pass `undefined` as a value into an translation replacements object ([#2579](https://github.com/Shopify/polaris-react/pull/2579))
 
-## 4.10.1 - 2019-12-20
-
-### Bug fixes
+## 4.10.1
 
 - Fixed type-error in `TrapFocus` that caused `querySelector` to run on null ([#2574](https://github.com/Shopify/polaris-react/pull/2574))
-
-### Development workflow
-
 - Refactored I18n class ([#2562](https://github.com/Shopify/polaris-react/pull/2562))
 
-## 4.10.0 - 2019-12-18
-
-### Bug fixes
+## 4.10.0
 
 - Fixed `TextField` to no longer render `aria-invalid="false"`. Thank you to [@alexcleduc](https://github.com/AlexCLeduc) for the contribution ([#2339](https://github.com/Shopify/polaris-react/pull/2339)).
 - Fixed `TextField` to only render `min` ,`max` and `step` attributes when explicitly passed. Thank you to [@alexcleduc](https://github.com/AlexCLeduc) for the contribution ([#2339](https://github.com/Shopify/polaris-react/pull/2339)).
 - Removed reference to `document` in `DropZone` ([#2560](https://github.com/Shopify/polaris-react/pull/2560))
 - Fixed Firefox issue in in `DropZone` ([#2568](https://github.com/Shopify/polaris-react/pull/2568))
 - Fixed layout issue `DropZone` ([#2568](https://github.com/Shopify/polaris-react/pull/2568))
-
-### Dependency upgrades
-
 - Updated to TypeScript 3.7 ([#2549](https://github.com/Shopify/polaris-react/pull/2549))
 - Updated stylelint-config-shopify to 7.4.0 ([#2558](https://github.com/Shopify/polaris-react/pull/2558))
 
-## 4.9.1 - 2019-12-11
-
-### Bug fixes
+## 4.9.1
 
 - Removed reference to `window` in `DropZone` ([#2532](https://github.com/Shopify/polaris-react/pull/2532))
 - Fixed a regression in `TrapFocus` that prevented focus outside of an `iframe` ([#2530](https://github.com/Shopify/polaris-react/pull/2530))
-
-### Documentation
-
 - Changed a link to the Polaris icons documentation so it would point to npm (a public resource) rather than the `Shopify/polaris-icons` repository (which is now private) ([#2452](https://github.com/Shopify/polaris-react/pull/2452))
 
-## 4.9.0 - 2019-12-06
-
-### Enhancements
+## 4.9.0
 
 - Added `external` prop to `ResourceList` ([#2408](https://github.com/Shopify/polaris-react/pull/2408))
 - Added `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
@@ -1757,9 +1184,6 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - `Page` no longer renders navigation or actions in print mode ([#2469](https://github.com/Shopify/polaris-react/pull/2469))
 - Migrated `Dropzone` to a functional component and reduced its complexity ([#2360](https://github.com/Shopify/polaris-react/pull/2360))
 - Added `fluidContent` prop to `Popover` ([#2494](https://github.com/Shopify/polaris-react/pull/2494))
-
-### Bug fixes
-
 - Prevented scrolling to `Popover` content in development ([#2403](https://github.com/Shopify/polaris-react/pull/2403))
 - Fixed an issue which caused HSL colors to not display in Edge ([#2418](https://github.com/Shopify/polaris-react/pull/2418))
 - Fixed an issue where the `DropZone` component jumped from an extra-large layout to a layout based on the width of its container ([#2412](https://github.com/Shopify/polaris-react/pull/2412))
@@ -1771,108 +1195,63 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Fixed the `EmptyState` styles conditional on the `imageContained` prop not being applied ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
 - Fixed `TrapFocus` to keep focus within the container when tabbing past the last element ([#2397](https://github.com/Shopify/polaris-react/pull/2397))
 - Fixed an accessibility issue where the `Form` implicit submit was still accessible via keyboard ([#2447](https://github.com/Shopify/polaris-react/pull/2447))
-
-### Documentation
-
 - Added a details page and kitchen sink example to Storybook ([#2402](https://github.com/Shopify/polaris-react/pull/2402))
 - Combined the interface used by `Page` so the types can be parsed ([#2358](https://github.com/Shopify/polaris-react/pull/2358))
 - Updated the `PageActions` example ([#2471](https://github.com/Shopify/polaris-react/pull/2471))
 - Fixed spacing of the `Filters` data table example ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
 - Fixed duplicate and unclear prop descriptions of `EmptyState` ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
 - Added an example for a light `Tooltip` ([#2434](https://github.com/Shopify/polaris-react/pull/2434))
-
-### Development workflow
-
 - Updated splash Github Action to the latest Docker beta version ([#2474](https://github.com/Shopify/polaris-react/pull/2474))
 - Updated local splash script to use npm package @shopify/splash ([#2474](https://github.com/Shopify/polaris-react/pull/2474))
 - Added `dev test:coverage` as an alias for `yarn test:coverage` ([#2496](https://github.com/Shopify/polaris-react/pull/2496))
 - Added `dev open coverage` and `yarn open:coverage` commands to open the coverage report ([#2496](https://github.com/Shopify/polaris-react/pull/2496))
 - Fixed `yarn test:coverage` so it generates a coverage report ([#2496](https://github.com/Shopify/polaris-react/pull/2496))
 - Updated `yarn test:coverage` so it automatically opens the coverage report when complete ([#2496](https://github.com/Shopify/polaris-react/pull/2496))
-
-### Dependency upgrades
-
 - Upgraded to `@shopify/react-testing v1.8.0` ([#2465](https://github.com/Shopify/polaris-react/pull/2465))
 - Upgraded to Prettier to `v1.19.1` ([#2443](https://github.com/Shopify/polaris-react/pull/2443))
-
-### Code quality
-
 - Changed `TextField` to use a custom hook ([#2464](https://github.com/Shopify/polaris-react/pull/2464))
 - Changed `aria-labelledby` to always exist on `TextField` ([#2401](https://github.com/Shopify/polaris-react/pull/2401))
 - Converted `ButtonGroup > Item` into a functional component ([#2441](https://github.com/Shopify/polaris-react/pull/2441))
 - Refactored `BulkActions` to make use of `ButtonGroup` ([#2441](https://github.com/Shopify/polaris-react/pull/2441))
 
-## 4.8.0 - 2019-11-12
-
-### Enhancements
+## 4.8.0
 
 - Updated `Popover` to focus the correct element when closed ([#2255](https://github.com/Shopify/polaris-react/pull/2255))
 - Updated the type of the `title` prop in `ChoiceList` from `string` to `ReactNode` ([#2355](https://github.com/Shopify/polaris-react/pull/2355))
 - Added `disabled` prop to `Filters` component ([#2389](https://github.com/Shopify/polaris-react/pull/2389))
 - Added `helpText` prop to `Filters` component ([#2389](https://github.com/Shopify/polaris-react/pull/2389))
-
-### Bug fixes
-
 - Fixed an issue where types were not generated for a JSON config file ([#2361](https://github.com/Shopify/polaris-react/pull/2361))
-
-### Development workflow
-
 - Enabled maintainers running `yarn dev` to hide [`yarn splash`](https://github.com/Shopify/polaris-react/tree/main/scripts/splash) reports from the console by running `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
 - Updated to sewing-kit 0.112.0 and eslint 6 and updated vscode config to use the eslint plugin to format js/ts files ([#2369](https://github.com/Shopify/polaris-react/pull/2369))
-
-### Code quality
-
 - Migrated `Popover` to use hooks ([#2386](https://github.com/Shopify/polaris-react/pull/2386))
 
-## 4.7.3 - 2019-10-31
-
-### Enhancements
+## 4.7.3
 
 - Added unstable telemetry API to gather analytics about icon usage ([#2368](https://github.com/Shopify/polaris-react/pull/2368))
-
-### Bug fixes
-
 - Fixed an accessibility issue with `TextField` `multiline` where `aria-multiline` would be set to an invalid type `number` ([#2351](https://github.com/Shopify/polaris-react/pull/2351))
 - Revert [#2231](https://github.com/Shopify/polaris-react/pull/2351) as it breaks middle aligned popovers ([#2237](https://github.com/Shopify/polaris-react/pull/2237))
 - Fixed alignement of disclosure icons on `ResourceItem` ([#2370](https://github.com/Shopify/polaris-react/pull/2370))
 
-## 4.7.2 - 2019-10-30
-
-### Bug fixes
+## 4.7.2
 
 - Fixed a bug with `TextField` which caused infinite layout and high CPU load in Safari, related to [WebKit Bug 194332](https://bugs.webkit.org/show_bug.cgi?id=194332) ([#2379](https://github.com/Shopify/polaris-react/pull/2379))
 - Fixed an accessibility issue with `TextField` `multiline` where `aria-multiline` would be set to an invalid type `number` ([#2351](https://github.com/Shopify/polaris-react/pull/2351))
 - Fixed alignment of disclosure icons on `ResourceItem` ([#2370](https://github.com/Shopify/polaris-react/pull/2370))
-
-### Documentation
-
 - Updated the `AppProvider` section in the Polaris [v3 to v4 migration guide](https://github.com/Shopify/polaris-react/blob/main/documentation/guides/migrating-from-v3-to-v4.md) ([#2312](https://github.com/Shopify/polaris-react/pull/2312))
 - Updated the `Using translations` section in the [AppProvider README](https://github.com/Shopify/polaris-react/blob/main/src/components/AppProvider/README.md#using-translations) ([#2312](https://github.com/Shopify/polaris-react/pull/2312))
-
-### Development workflow
-
 - Removed the need to upload assets with each release ([#2346](https://github.com/Shopify/polaris-react/pull/2346))
-
-### Code quality
-
 - Migrated `FilterValueSelector` to use hooks instead of withAppProvider ([#2156](https://github.com/Shopify/polaris-react/pull/2156))
 - Added `useIsMountedRef` hook to use while building components ([#2167](https://github.com/Shopify/polaris-react/pull/2167))
 
-## 4.7.1 - 2019-10-23
-
-### Bug fixes
+## 4.7.1
 
 - Fixed a bug with `Button` which caused infinite layout and high CPU load in Safari, related to [WebKit Bug 194332](https://bugs.webkit.org/show_bug.cgi?id=194332) ([#2350](https://github.com/Shopify/polaris-react/pull/2350))
 
-## 4.7.0 - 2019-10-22
-
-### Enhancements
+## 4.7.0
 
 - Updated `OptionList` section title to match `ActionList` section title ([#2300](https://github.com/Shopify/polaris-react/pull/2300))
 - Added `pressed` state to `Button` ([#2148](https://github.com/Shopify/polaris-react/pull/2148))
 - Updated the type of the `label` prop in `ChoiceList` (nested prop of `choices`) from `string` to `ReactNode` ([#2325](https://github.com/Shopify/polaris-react/pull/2325)).
-
-### Bug fixes
 
 - Fixed `actionGroups` to only render `MenuActions` when actions are provided in the `Page` ([#2266](https://github.com/Shopify/polaris-react/pull/2266))
 - Fixed `PositionedOverlay` incorrectly calculating `Topbar.UserMenu` `Popover` width ([#2231](https://github.com/Shopify/polaris-react/pull/2231))
@@ -1881,73 +1260,40 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Fixed Stack Item proportion when shrinking ([#2319](https://github.com/Shopify/polaris-react/pull/2319))
 - Fixed animation of `Collapsible` with children having margins ([#1980](https://github.com/Shopify/polaris-react/pull/1980))
 - Added vertical adjustment to `OptionList` control items ([#2313](https://github.com/Shopify/polaris-react/pull/2313))
-
-### Dependency upgrades
-
 - Updated sewing-kit to v0.111.0 and storybook to v5.2.4 ([#2326](https://github.com/Shopify/polaris-react/pull/2326))
 
-## 4.6.1 - 2019-10-17
-
-### Enhancements
+## 4.6.1
 
 - Added CSS custom properties to `Portal` container ([#2306](https://github.com/Shopify/polaris-react/pull/2306))
-
-### Bug fixes
-
 - Fixed a regression with the positioning of the `Popover` component ([#2305](https://github.com/Shopify/polaris-react/pull/2305))
 
-## 4.6.0 - 2019-10-16
-
-### Enhancements
+## 4.6.0
 
 - Added a `totalItemsCount` prop to the `ResourceList` component ([#2233](https://github.com/Shopify/polaris-react/pull/2233))
 - Prevented the `Header` primary action label on the `Page` component from wrapping when the title is too long ([#2262](https://github.com/Shopify/polaris-react/pull/2262))
-
-### Bug fixes
-
 - Fixed an issue with the `Stack` component where a `Stack.Item` was not getting a minimum width ([#2273](https://github.com/Shopify/polaris-react/pull/2273))
 - Fixed an issue with `Filters` applying inconsistent border styles to sibling filters when
   there is only one filter in the filter list ([#2284](https://github.com/Shopify/polaris-react/pull/2284))
 - Added `aria-disabled` to the `Select` component’s content when it is disabled ([#2281](https://github.com/Shopify/polaris-react/pull/2281))
-
-### Documentation
-
 - Added accessibility documentation for the `DropZone` component ([#2243](https://github.com/Shopify/polaris-react/pull/2243))
 - Improved accessibility documentation for the `Spinner` component ([#2258](https://github.com/Shopify/polaris-react/pull/2258))
-
-### Development workflow
-
 - Added support for context customization in Storybook using addon-contexts ([#2281](https://github.com/Shopify/polaris-react/pull/2281))
-
-### Code quality
-
 - Migrated `DateSelector` to use hooks instead of withAppProvider ([#2193](https://github.com/Shopify/polaris-react/pull/2193))
 - Migrated `Toast` to use hooks ([#2222](https://github.com/Shopify/polaris-react/pull/2222))
 - Removed `link`, `theme` and `scrollLockManager` from the object returned by `withAppProvider` as nothing consumes them any more ([#2277](https://github.com/Shopify/polaris-react/pull/2277))
 
-## 4.5.0 - 2019-10-08
-
-### Enhancements
+## 4.5.0
 
 - Added `showTotalsInFooter` prop to `DataTable` for control over placement of “Totals” row ([#2200](https://github.com/Shopify/polaris-react/pull/2200))
 - Removed the need for z-indexes in `Icon` ([#2207](https://github.com/Shopify/polaris-react/pull/2207))
 - Added `hasFocusableParent` to `Spinner` ([#2176](https://github.com/Shopify/polaris-react/pull/2176))
-
-### Bug fixes
-
 - Fixed tabs that don’t wrap correctly on small screens in pre-iOS 13 Safari ([#2232](https://github.com/Shopify/polaris-react/pull/2232))
 - Fixed `BulkActions` checkbox losing selection on focus ([#2138](https://github.com/Shopify/polaris-react/pull/2138))
 - Moved rendering of the portal component’s node within the node created by the theme provider component to enable theming through CSS Custom Properties ([#2224](https://github.com/Shopify/polaris-react/pull/2224))
 - Fixed a bug which caused the `Popover` overlay to remain in the DOM if it was updated during exiting ([#2246](https://github.com/Shopify/polaris-react/pull/2246))
 - Fixed `Breadcrumbs` to use `accessibilityLabel` prop when passed in ([#2254](https://github.com/Shopify/polaris-react/pull/2254))
-
-### Documentation
-
 - Added accessibility documentation for the date picker component ([#2242](https://github.com/Shopify/polaris-react/pull/2242))
 - Added accessibility documentation for the empty state component ([#2244](https://github.com/Shopify/polaris-react/pull/2244))
-
-### Code quality
-
 - Improved code quality for the theme provider component ([#2225](https://github.com/Shopify/polaris-react/pull/2225)):
 
   - updated type for `theme` prop to `ThemeConfig` to distinguish from the type `Theme` which is shared over context. A `Theme` contains only the logo properties, while `ThemeConfig` can contain a `colors` property.
@@ -1959,15 +1305,10 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
   - fixed an issue where `colorToHsla` inconsistently returned an alpha value
   - fixed an issue where `lightenColor` and `darkenColor` would lighten or darken absolute lightness values (0, 100)
 
-## 4.4.0 - 2019-10-03
-
-### Enhancements
+## 4.4.0
 
 - Removed the need for z-indexes in `Icon` ([#2207](https://github.com/Shopify/polaris-react/pull/2207))
 - Added `features` prop to `AppProvider` ([#2204](https://github.com/Shopify/polaris-react/pull/2204))
-
-### Bug fixes
-
 - Fixed loss of focus on `TextField` when changing connectedRight/connectedLeft content while user is typing ([#2170](https://github.com/Shopify/polaris-react/pull/2170))
 - Fixed `type` for clearButton ([#2060](https://github.com/Shopify/polaris-react/pull/2060))
 - Prevented the `onSelect` prop of `Tabs` from changing scroll position ([#2196](https://github.com/Shopify/polaris-react/pull/2196))
@@ -1975,36 +1316,22 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Removed the `ResourceList` `Item` hover state when `Item` is deselected ([#1952](https://github.com/Shopify/polaris-react/pull/1952))
 - Fixed `Subheading`’s `font-weight` ([#2218](https://github.com/Shopify/polaris-react/pull/2218))
 - Fixed `fullWidth` `CardSection`s when contained in a page with a `Nav` ([#2227](https://github.com/Shopify/polaris-react/pull/2227))
-
-### Documentation
-
 - Converted `SettingToggle`, `Sheet`, and `Tabs` examples to functional components ([#2134](https://github.com/Shopify/polaris-react/pull/2134))
 - Converted `Form`, `Frame`, and `Loading` examples to functional components ([#2130](https://github.com/Shopify/polaris-react/pull/2130))
 - Replaced Latin abbreviations with English words in Text field content guidelines ([#2192](https://github.com/Shopify/polaris-react/pull/2192))
 - Converted `SettingToggle`, `Sheet`, and `Tabs` examples to functional components ([#2134](https://github.com/Shopify/polaris-react/pull/2134))
 - Converted `DatePicker`, `DropZone`, and `Filters` examples to functional components ([#2129](https://github.com/Shopify/polaris-react/pull/2129))
-
-### Code quality
-
 - Added `MediaQueryProvider` to ease the use of media queries and reduce duplication ([#2117](https://github.com/Shopify/polaris-react/pull/2117))
 - Migrated `Tab` to use hooks instead of `withAppProvider` ([#2123](https://github.com/Shopify/polaris-react/pull/2123))
-
-### Development workflow
-
 - Added a GitHub action, [discoverability-action](https://github.com/Shopify/discoverability-action), that runs `yarn splash` on PR diffs and leaves a comment with the output ([#2208](https://github.com/Shopify/polaris-react/pull/2208))
 
-## 4.3.0 - 2019-09-23
-
-### Enhancements
+## 4.3.0
 
 - Added new label prop to `Pagination` which is used to insert contextual info between navigation buttons ([#2098](https://github.com/Shopify/polaris-react/pull/2098))
 - Updated `trigger` to use `act` ([#2141](https://github.com/Shopify/polaris-react/pull/2141))
 - Changed border color of `Drop zone` to have better contrast from the background and to be lighter when disabled ([#2119](https://github.com/Shopify/polaris-react/pull/2119))
 - Adjusted search results overlay to take up 100% height of the screen on small screens and to match the width of the search bar on large screens. ([#2103](https://github.com/Shopify/polaris-react/pull/2103))
 - Added skipToContentTarget prop to Frame component ([#2080](https://github.com/Shopify/polaris-react/pull/2080))
-
-### Bug fixes
-
 - Updated `Card` footer actions to be left aligned instead of right by default ([#2075](https://github.com/Shopify/polaris-react/issues/2075))
 - Fixed vertical alignment of Tabs disclosure activator ([#2087](https://github.com/Shopify/polaris-react/pull/2087))
 - Fixed `Modal` setting an invalid `id` on `aria-labelledby` when no `title` is set ([#2115](https://github.com/Shopify/polaris-react/pull/2115))
@@ -2015,9 +1342,6 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Removed `React.Children.only` from `AppProvider`and `ThemeProvider` ([#2121](https://github.com/Shopify/polaris-react/pull/2121))
 - Fixed visual bug where button width changed in Filters component. Thank you to [@alexieyizhe](https://github.com/alexieyizhe) for the contribution ([#2003](https://github.com/Shopify/polaris-react/pull/2003)).
 - Changed `text-rendering` to `auto` in `Select` to prevent Safari 13 from crashing ([#2179](https://github.com/Shopify/polaris-react/pull/2179))
-
-### Documentation
-
 - Converted `Autocomplete`, `Banner`, and `ChoiceList` examples to functional components ([#2127](https://github.com/Shopify/polaris-react/pull/2127))
 - Converted `Collapsible`, `ColorPicker`, and `DataTable` examples to functional components ([#2128](https://github.com/Shopify/polaris-react/pull/2128))
 - Converted `Modal`, `OptionList`, and `Popover` examples to functional components ([#2131](https://github.com/Shopify/polaris-react/pull/2131))
@@ -2027,14 +1351,8 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Updated the `withContext` section in the [v3 to v4 migration guide](https://github.com/Shopify/polaris-react/blob/main/documentation/guides/migrating-from-v3-to-v4.md) ([#2124](https://github.com/Shopify/polaris-react/pull/2124))
 - Clarified when to use the `external` prop on the `Link` component ([#2153](https://github.com/Shopify/polaris-react/pull/2153))
 - Updated documentation examples to include disclosure on `Popover` activators ([#2171](https://github.com/Shopify/polaris-react/pull/2171))
-
-### Development workflow
-
 - Added [`yarn splash` (beta)](/scripts/splash/), a command-line interface to observe the splash zone of a change across the component library ([#2113](https://github.com/Shopify/polaris-react/pull/2113))
 - Updated Storybook – [v5.2 release notes](https://medium.com/storybookjs/storybook-5-2-794958b9b111) ([#2157](https://github.com/Shopify/polaris-react/pull/2157))
-
-### Code quality
-
 - Added `useLazyRef` hook to use while building components ([#2166](https://github.com/Shopify/polaris-react/pull/2166))
 - Migrated `FilterCreator` to use hooks instead of withAppProvider ([#2156](https://github.com/Shopify/polaris-react/pull/2156))
 - Created a custom error for lack of context providers ([#2136](https://github.com/Shopify/polaris-react/pull/2136))
@@ -2045,66 +1363,39 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Migrated `Avatar` to use hooks instead of withAppProvider ([#2067](https://github.com/Shopify/polaris-react/pull/2067))
 - Updated `Day` and `DatePicker` to use hooks ([#2089](https://github.com/Shopify/polaris-react/pull/2089))
 
-## 4.2.1 - 2019-09-10
-
-### Bug fixes
+## 4.2.1
 
 - Fixed TypeScript not generating correct types for functional components that have subcomponents ([#2111](https://github.com/Shopify/polaris-react/pull/2111))
 
-## 4.2.0 - 2019-09-09
-
-### Enhancements
+## 4.2.0
 
 - Added support for min/max dates in `TextField` by setting a string on `min` and `max` props ([#1991](https://github.com/Shopify/polaris-react/pull/1991))
 - Made the `title` prop on `Page` optional, supporting continued use of `Page` for structure in apps using the App Bridge React [`TitleBar`](https://github.com/Shopify/app-bridge/tree/master/packages/app-bridge-react/src/components/TitleBar) ([#2082](https://github.com/Shopify/polaris-react/pull/2082))
-
-### Bug fixes
-
 - Fixed inconsistent padding of sections in `Modal` ([#2072](https://github.com/Shopify/polaris-react/pull/2072))
 - Fixed animation for Modal when being rendered asynchronously ([#2076](https://github.com/Shopify/polaris-react/pull/2076))
 - Fixed item content from overflowing past the container in `Stack` ([#2071](https://github.com/Shopify/polaris-react/pull/2071))
 - Fixed `Dropzone` hover, disabled, and focus states ([#1994](https://github.com/Shopify/polaris-react/pull/1994))
 - Added `name` prop to `ResourceItem` to fix accessibility labels ([#2077](https://github.com/Shopify/polaris-react/pull/2077))
 - Fixed misalignment of `ResourceItem` actions ([#2051](https://github.com/Shopify/polaris-react/pull/2051))
-
-### Documentation
-
 - Added Android/iOS images for Plain destructive button ([#2081](https://github.com/Shopify/polaris-react/pull/2081))
 - Removed mobile mention from right-aligned text component guidelines ([#2081](https://github.com/Shopify/polaris-react/pull/2081))
 - Added mobile example images error state of Single Choice List ([#2007](https://github.com/Shopify/polaris-react/pull/2007))
-
-### Dependency upgrades
-
 - Updated Prettier to v1.18.2 ([#2070](https://github.com/Shopify/polaris-react/pull/2070))
-
-### Development workflow
-
 - Added a displayName to the function generated by the `withAppProvider` HoC for a better devtools experience ([#2093](https://github.com/Shopify/polaris-react/pull/2093))
-
-### Code quality
-
 - Migrated `ActionMenu.RollupAction`, `Autocomplete`, `Card`, `EmptySearchResult`, `Form`, `SkeletonPage` and `TopBar` to use hooks instead of withAppProvider ([#2065](https://github.com/Shopify/polaris-react/pull/2065))
 - Added `useUniqueId` hook that can be used to get a unique id that remains consistent between rerenders and updated components to use it where appropriate ([#2079](https://github.com/Shopify/polaris-react/pull/2079))
 
-## 4.1.0 - 2019-09-03
-
-### Enhancements
+## 4.1.0
 
 - Moved `ResourceItem` to its own component ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
 - Updated `ResourceList` sort to show an inline label ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
 - Removed the `tap-highlight-color` for `Buttons` ([#1545](https://github.com/Shopify/polaris-react/pull/1545))
-
-### Bug fixes
-
 - Removed `Tooltip` on disabled `Pagination` buttons ([#1963](https://github.com/Shopify/polaris-react/pull/1963))
 - Fixed accessibility labels on `ResourceList.Item` persistent action disclosure icon ([#1973](https://github.com/Shopify/polaris-react/pull/1973))
 - Fixed accessibility issue with `Autocomplete` where keyboard navigation of options was laggy and skipped options ([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 - Fixed bug where `Autocomplete` was bubbling up the `Enter` key event unexpectedly ([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 - Fixed `ContextualSaveBar` actions overflowing on small screens ([#1967](https://github.com/Shopify/polaris-react/pull/1967))
 - Fixed `Tabs` rollup automatically opening from keyboard navigation of tab list ([#1933](https://github.com/Shopify/polaris-react/pull/1933))
-
-### Documentation
-
 - Updated example section to include new examples and remove old ones ([#1979](https://github.com/Shopify/polaris-react/pull/1979))
 - Updated example for the `ResourceList.Item` persistent actions accessibility labels ([#1973](https://github.com/Shopify/polaris-react/pull/1973))
 - Removed `FilterControl` documentation and case studies from `ResourceList` documentation ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
@@ -2112,24 +1403,15 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 - Added an example to `Filters` showing the use of `children` ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
 - Added guidance for making animated gifs in PRs and issues more accessibility-friendly ([#1998](https://github.com/Shopify/polaris-react/pull/1998))
 - Added `RadioButton` guidance to make one option selected by default ([#2005](https://github.com/Shopify/polaris-react/pull/2005))
-
-### Development workflow
-
 - Update subcomponents to use named exports for components and better names props exports ([#2058](https://github.com/Shopify/polaris-react/pull/2058))
-
-### Code quality
-
 - Removed mocks in various tests suites that are now redundant ([#1978](https://github.com/Shopify/polaris-react/pull/1978))
-
-### Deprecations
-
 - Deprecated `FilterControl`. Use `Filters` instead ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
 
-## 4.0.0 - 2019-08-28
+## 4.0.0
 
 For instructions on updating from v3 to v4, see our [migration guide](https://github.com/Shopify/polaris-react/blob/main/documentation/guides/migrating-from-v3-to-v4.md).
 
-### Breaking changes
+### Major changes
 
 - Removed `groups` prop on `Select`. Pass groups to the `options` prop instead. ([#1831](https://github.com/Shopify/polaris-react/pull/1831))
 - Removed `Autocomplete.ComboBox.TextField` and `Autocomplete.ComboBox.OptionList`. You should use the `Autocomplete.TextField` and `OptionList` components instead. ([#1830](https://github.com/Shopify/polaris-react/pull/1830))
@@ -2149,16 +1431,11 @@ For instructions on updating from v3 to v4, see our [migration guide](https://gi
 - Removed `LinkLikeComponent` type export. Use `AppProviderProps['linkComponent']` instead. ([#1864](https://github.com/Shopify/polaris-react/pull/1864))
 - Removed the `Modal.Dialog` and `Tabs.Panel` subcomponents as they were undocumented parts of our public API meant for internal use only ([#1899](https://github.com/Shopify/polaris-react/pull/1899)).
 
-### Enhancements
-
 - Added a new `create-react-app` example in TypeScript demonstrating use of Polaris with `react-testing` ([#1937](https://github.com/Shopify/polaris-react/pull/1937))
 - Exported `AppliedFilterInterface` and `FilterInterface` from `Filters` ([#1924](https://github.com/Shopify/polaris-react/pull/1924))
 - Improved color contrast of links inside `Banner` ([#1651](https://github.com/Shopify/polaris-react/pull/1651))
 - Add underline to Links and Plain button on hover, so it doesn’t rely on color alone for accessibility ([#1885](https://github.com/Shopify/polaris-react/pull/1885))
 - Add `onQueryFocus` callback prop to the `Filters` component ([#1948](https://github.com/Shopify/polaris-react/pull/1948))
-
-### Bug fixes
-
 - Fixed types merge of `ActionMenu` `MenuAction` and `MenuGroup.actions` ([#1895](https://github.com/Shopify/polaris-react/pull/1895))
 - Fixed the activator buttons of `Page` `actionGroups` not toggling the `Popover` `active` state on click [#1905](https://github.com/Shopify/polaris-react/pull/1905)
 - Fixed Windows high contrast support of `Badge` `progress` ([#1928](https://github.com/Shopify/polaris-react/pull/1928))
@@ -2169,31 +1446,19 @@ For instructions on updating from v3 to v4, see our [migration guide](https://gi
 - Fixed cross-origin error being thrown in `Modal` when loading an external app ([#1992](https://github.com/Shopify/polaris-react/pull/1992))
 - Fixed regression in `PopoverOverlay` causing `onClose` to be fired when Popover is opening and trigger was not the activator ([#2000](https://github.com/Shopify/polaris-react/pull/2000))
 - Fixed issue with `ContextualSaveBar` blocking search when hidden ([#2044](https://github.com/Shopify/polaris-react/pull/2044))
-
-### Documentation
-
 - Updated `AppProvider` app bridge example to use our `AppBridgeContext` ([#1877](https://github.com/Shopify/polaris-react/pull/1877))
-
-### Development workflow
-
 - Added support for React hooks in Storybook ([#1665](https://github.com/Shopify/polaris-react/pull/1665))
 - Created `toBeDisabled`, `mountWithContext` and added custom testing matchers ([#1596](https://github.com/Shopify/polaris-react/pull/1596))
 - Added `PolarisTestProvider` helper to ease configuration of required Polaris contexts in tests, see [polaris examples](https://github.com/Shopify/polaris-react/tree/main/examples) for usage ([#1810](https://github.com/Shopify/polaris-react/pull/1810))
 - Enabled strict mode in TypeScript ([#1883](https://github.com/Shopify/polaris-react/pull/1883))
 - Moved to `unpkg.com` for our CDN CSS assets, instead of using `sdks.shopifycdn.com`. Existing URLs will continue to work but new versions will only be available at `unpkg.com`. ([#1960](https://github.com/Shopify/polaris-react/pull/1960))
 - Added [ChromaUI](https://www.chromaui.com/) integration for previewing Storybook builds, to potentially replace our self-hosted Heroku instance ([#1975](https://github.com/Shopify/polaris-react/pull/1975))
-
-### Dependency upgrades
-
 - Updated `@shopify/polaris` in all examples to 4.0.0-rc.2 ([#1937](https://github.com/Shopify/polaris-react/pull/1937))
 - Added `@material-ui/react-transition-group` and removed `react-transition-group` to support `React.StrictMode` ([#1759](https://github.com/Shopify/polaris-react/pull/1759))
 - Added `@shopify/react-testing` ([#1596](https://github.com/Shopify/polaris-react/pull/1596))
 - Removed`@shopify/css-utilities` ([#1586](https://github.com/Shopify/polaris-react/pull/1586))
 - Removed `@types/prop-types` and `prop-types` ([#1505](https://github.com/Shopify/polaris-react/pull/1505))
 - Updated`react` to 16.8.6 and `enzyme` to 3.9.1 ([#1392](https://github.com/Shopify/polaris-react/pull/1392))
-
-### Code quality
-
 - Bumped test coverage in `Collapsible` ([#1929](https://github.com/Shopify/polaris-react/pull/1929))
 - Bumped test coverage in `DropZone`, `Frame`, `Icon`, and `Loading` ([#1927](https://github.com/Shopify/polaris-react/pull/1927))
 - Removed unused type definitions ([#1862](https://github.com/Shopify/polaris-react/pull/1862))
@@ -2238,95 +1503,52 @@ For instructions on updating from v3 to v4, see our [migration guide](https://gi
 - Removed context from `Collapsible` ([#1114](https://github.com/Shopify/polaris-react/pull/1114))
 - Refactored `Frame` and its subcomponents to use the `createContext` API instead of legacy context ([#803](https://github.com/Shopify/polaris-react/pull/803))
 - Upgraded the `Banner`, `Card`, and `Modal` components from legacy context API to use `createContext` ([#786](https://github.com/Shopify/polaris-react/pull/786))
-
-### Deprecations
-
 - Renamed `singleColumn`on`Page`to`narrowWidth` ([#1606](https://github.com/Shopify/polaris-react/pull/1606))
 
-## 3.21.1 - 2019-08-12
-
-### Enhancements
+## 3.21.1
 
 - Added `onQueryFocus` callback prop to the `Filters` component ([#1948](https://github.com/Shopify/polaris-react/pull/1948))
 
-## 3.21.0 - 2019-07-31
-
-### Enhancements
+## 3.21.0
 
 - Added a `subtitle` and `thumbnail` prop to `Page` ([#1880](https://github.com/Shopify/polaris-react/pull/1880))
-
-### Bug fixes
-
 - Fixed accessibility issue with ChoiceList errors not being correctly connected to the inputs ([#1824](https://github.com/Shopify/polaris-react/pull/1824))
 - Fixed `Tab` `aria-controls` pointing to a non-existent `Panel` `id` ([#1869](https://github.com/Shopify/polaris-react/pull/1869))
 - Fixed `Toast` accessibility issue by moving `aria-live` prop to `ToastManager` ([#1873](https://github.com/Shopify/polaris-react/pull/1873))
-
-### Code quality
-
 - Use `@shopify/typescript-configs` as the base of `tsconfig.json` for the project ([#1829](https://github.com/Shopify/polaris-react/pull/1829))
 
-## 3.20.0 - 2019-07-16
-
-### Enhancements
+## 3.20.0
 
 - Added a `verticalAlign` prop to `DataTable` ([#1790](https://github.com/Shopify/polaris-react/pull/1790))
 - Improved focus and hover states for `Navigation` ([#1822](https://github.com/Shopify/polaris-react/pull/1822))
-
-### Bug fixes
-
 - Fixed the `SearchInput` clear button which was overflowing the search bar in Firefox 65+ ([#1795](https://github.com/Shopify/polaris-react/pull/1795))
 - Fixed a bug preventing the display of `Tooltip` when cursor enters from a disabled element ([#1783](https://github.com/Shopify/polaris-react/pull/1783))
 - Fixed React imports in the `Filters` component to use `import * as React` for projects that don’t use `esModuleInterop` ([#1820](https://github.com/Shopify/polaris-react/pull/1820))
 - Fixed `tabIndex` on `main` element causing event delegation issues ([#1821](https://github.com/Shopify/polaris-react/pull/1821))
 - Fixed icon color for destructive ActionList items ([#1836](https://github.com/Shopify/polaris-react/pull/1836))
 - Fixed not being able to explictly set `autoComplete` prop on`Autocomplete.TextField` ([#1839](https://github.com/Shopify/polaris-react/pull/1839))
-
-### Documentation
-
 - Added links to App Bridge React component documentation in deprecation notices for embedded components ([#1765](https://github.com/Shopify/polaris-react/pull/1765))
 - Improved link text for App Bridge deprecation notices [#1802](https://github.com/Shopify/polaris-react/pull/1802)
-
-### Development workflow
-
 - Use explicit imports for our base Sass mixins instead of having them implictly defined at build-time. This simplifes our build config and other tooling that wants to build us from source [[#1680](https://github.com/Shopify/polaris-react/pull/1680)]
 
-## 3.19.0 - 2019-07-09
-
-### New components
+## 3.19.0
 
 - `Filters`: Use to filter the items of a list or table ([#1718](https://github.com/Shopify/polaris-react/pull/1718))
-
-### Enhancements
-
 - Added the rollover and Windows high contrast mode to `Disclosure` button on `Tabs` ([#1755](https://github.com/Shopify/polaris-react/pull/1755))
 - Added support for disabling all choices in `ChoiceList` ([#1758](https://github.com/Shopify/polaris-react/pull/1758))
 - Components in our Sass build (the `styles` folder) are now precompiled to avoid the chance of accidentally overwriting any of our global variables, mixins and functions ([#1764](https://github.com/Shopify/polaris-react/pull/1764))
 - Changed `Skip to content` to render an anchor instead of a button to meet accessiblity level A guidelines ([#1785](https://github.com/Shopify/polaris-react/pull/1785))
-
-### Bug fixes
-
 - Fixed a regression introduced in [#1247](https://github.com/Shopify/polaris-react/pull/1247), where icons inside of `Link` would always be recolored to match the text color ([#1729](https://github.com/Shopify/polaris-react/pull/1729))
 - Fixed the `DiscardConfirmationModal` not closing when the discard button is clicked ([#1784](https://github.com/Shopify/polaris-react/pull/1784))
 - Fixed `Navigation.Item` `secondaryAction` wrapping when content wraps ([#1678](https://github.com/Shopify/polaris-react/pull/1678))
-
-### Documentation
-
 - Added links to App Bridge React component documentation in deprecation notices for embedded components ([#1765](https://github.com/Shopify/polaris-react/pull/1765))
-
-### Development workflow
-
 - Renamed `yarn run ts` to `yarn run type-check` to match most other Shopify projects ([#1745](https://github.com/Shopify/polaris-react/pull/1745))
 - Fixed deprecation notice in build ([#1754](https://github.com/Shopify/polaris-react/pull/1754))
 - Simplified our rollup plugin for Sass compilation while retaining identical behaviour ([#1753](https://github.com/Shopify/polaris-react/pull/1753))
 
-## 3.18.0 - 2019-06-26
-
-### New components
+## 3.18.0
 
 - `ActionMenu`: Use for display of actions and action groups within the context of a header ([#1653](https://github.com/Shopify/polaris-react/pull/1653))
-
-### Enhancements
-
 - Added the `stopAnnouncements` prop to `Banner`, which disables screen reader announcements when content changes ([#1719](https://github.com/Shopify/polaris-react/pull/1719))
 - Add `selectable` prop to `ResourceList` component (thanks to [@vict-shevchenko](https://github.com/vict-shevchenko) for the [pull request](https://github.com/Shopify/polaris-react/pull/1614))
 - Allow `Link` and `Button` interactions when rendered as `prefix/suffix` within `<TextField />` ([#1394](https://github.com/Shopify/polaris-react/pull/1394))
@@ -2336,40 +1558,20 @@ For instructions on updating from v3 to v4, see our [migration guide](https://gi
 - Long `Page > Header` breadcrumb labels will now truncate instead of breaking layout ([#1653](https://github.com/Shopify/polaris-react/pull/1653))
 - Improves performance of `TabMeasure` component ([#1544](https://github.com/Shopify/polaris-react/pull/1544))
 - Added `secondaryFooterActions` prop to `Card` which adds an action list of secondary actions to the footer [#1625](https://github.com/Shopify/polaris-react/pull/1625)
-
-### Bug fixes
-
 - Fixes `monochrome` variant of `Link` and `Button` components to support multi-line link text ([#1686](https://github.com/Shopify/polaris-react/pull/1686))
 - Fixed the first column of `DataTable` not rendering in iOS Safari ([#1605](https://github.com/Shopify/polaris-react/pull/1605))
 - Fixed paint loss on scroll of `TextField` `Spinner` ([#1740](https://github.com/Shopify/polaris-react/pull/1740))
-
-### Documentation
-
 - Mentioned that the Contextual Save Bar is now available for embedded apps through App Bridge directly [#1721](https://github.com/Shopify/polaris-react/pull/1721)
 - Mentioned [Polaris icons](https://polaris-icons.shopify.com) in the Icon component documentation ([#1693](https://github.com/Shopify/polaris-react/pull/1693))
 - Added an example to `Card` for custom action layout with a secondary action and a plain button (thanks to [@sharoonthomas](https://github.com/sharoonthomas) for the [pull request](https://github.com/Shopify/polaris-react/pull/1705))
-
-### Development workflow
-
 - Updated Storybook to `v5.1.9` ([#1728](https://github.com/Shopify/polaris-react/pull/1728))
-
-### Code quality
-
 - Updated `PositionedOverlay` to no longer use `componentWillReceiveProps`([#1621](https://github.com/Shopify/polaris-react/pull/1621))
-
-### Deprecations
-
 - `Card` `secondaryFooterAction` is now deprecated. Set an array of secondary actions on the `secondaryFooterActions` prop instead [#1625](https://github.com/Shopify/polaris-react/pull/1625)
 
-## 3.17.0 - 2019-06-11
-
-### Deprecations
+## 3.17.0
 
 - Deprecated passing a string representing a "bundled icon" into `<Icon source>` Pass in an svg component imported from `@shopify/polaris-icons` instead ([#1534](https://github.com/Shopify/polaris-react/pull/1534)).
 - Deprecated all usage of the Shopify App Bridge in Polaris React ([#1573](https://github.com/Shopify/polaris-react/pull/1573))
-
-### Enhancements
-
 - Made the `action` prop optional on `EmptyState` ([#1583](https://github.com/Shopify/polaris-react/pull/1583))
 - Prevented Firefox from showing an extra dotted border on focused buttons ([#1409](https://github.com/Shopify/polaris-react/pull/1409))
 - Added `resolveItemId` prop to `ResourceList` which is used in the new multiselect feature ([#1261](https://github.com/Shopify/polaris-react/pull/1261))
@@ -2379,9 +1581,6 @@ For instructions on updating from v3 to v4, see our [migration guide](https://gi
 - Added `textAlign` prop to Button ([#1576](https://github.com/Shopify/polaris-react/pull/1576))
 - Made `Button` red when given both the `plain` and `destructive` props ([#1603](https://github.com/Shopify/polaris-react/pull/1603))
 - Added support for disabled, destructive, and loading actions in `Card` and `Card.Section` ([#1622](https://github.com/Shopify/polaris-react/1622))
-
-### Bug fixes
-
 - Removed unnecessary border-radius from `Modal` body ([#1584](https://github.com/Shopify/polaris-react/pull/1584))
 - Fixed accessibility issues in `DropZone`, `Form`, `Modal`, `Section`, `Page`, `Tabs`, `TextField` and `TopBar` ([#1565](https://github.com/Shopify/polaris-react/pull/1565),[#1582](https://github.com/Shopify/polaris-react/pull/1582)).
 - Fixed inconsistent width depending on your browser/version in `Sheet` ([#1569](https://github.com/Shopify/polaris-react/pull/1569))
@@ -2392,9 +1591,6 @@ For instructions on updating from v3 to v4, see our [migration guide](https://gi
 - Fixed `ResourcePicker` not updating function references for `onSelection` and `onCancel` callbacks [#1451](https://github.com/Shopify/polaris-react/pull/1451)
 - Fixed `TextField` `label` being set as the value of the `label` node, as well as the `aria-label` `aria-labelledby` attributes, when only one method will suffice ([#1615](https://github.com/Shopify/polaris-react/pull/1615))
 - Fixed accessibility issues for Windows High Contrast mode on `Tabs` and `Popover` ([#1629](https://github.com/Shopify/polaris-react/pull/1629))
-
-### Documentation
-
 - Updated icon documentation to use imports from polaris-icons ([#1561](https://github.com/Shopify/polaris-react/pull/1561))
 - Fixed an accessibility issue in the `Collapsible` component example ([#1591](https://github.com/Shopify/polaris-react/pull/1591))
 - Added accessibility documentation for the `RangeSlider` component ([#1630](https://github.com/Shopify/polaris-react/pull/1630))
@@ -2405,91 +1601,49 @@ For instructions on updating from v3 to v4, see our [migration guide](https://gi
 - Added accessibility documentation for the `KeyboardKey` component ([#1640](https://github.com/Shopify/polaris-react/pull/1640))
 - Added accessibility documentation for the `Tag` component ([#1647](https://github.com/Shopify/polaris-react/pull/1647))
 - Added accessibility documentation for the `Modal` component ([#1648](https://github.com/Shopify/polaris-react/pull/1648))
-
-### Development workflow
-
 - Made the a11y test that runs in CI fail if it finds any issues ([#1564](https://github.com/Shopify/polaris-react/pull/1564))
 - Updated Storybook to `v5.1.0-rc.4` ([#1616](https://github.com/Shopify/polaris-react/pull/1616))
 - Fixed a visual regression testing issue with the Card component ([#1618](https://github.com/Shopify/polaris-react/pull/1618))
 - Updated to sewing-kit v0.85.5 ([#1633](https://github.com/Shopify/polaris-react/pull/1633))
-
-### Dependency upgrades
-
 - Upgraded TypeScript dependency to `3.5.1` ([#1650](https://github.com/Shopify/polaris-react/pull/1650))
-
-### Code quality
-
 - Enabled the color contrast test in pa11y ([#1645](https://github.com/Shopify/polaris-react/pull/1645))
 - Combined jsdocs in `Icon` for the `untrusted` prop ([#1607](https://github.com/Shopify/polaris-react/pull/1607))
 
-## 3.16.0 - 2019-05-22
-
-### Enhancements
+## 3.16.0
 
 - Added support for dual values to `RangeSlider` component ([#1436](https://github.com/Shopify/polaris-react/pull/1436))
 - Updated type restrictions for `AnnotatedSection` to allow its `title` prop to accept `React.ReactNode` instead of `string` ([#1431](https://github.com/Shopify/polaris-react/pull/1431))
-
-### Bug fixes
-
 - Fixed an issue where the JavaScript breakpoints incorrectly set the navigation bar collapsed breakpoint ([#1475](https://github.com/Shopify/polaris-react/pull/1475))
 - Added a border to `Toast` messages to make them more visible in Windows high contrast mode ([#1469](https://github.com/Shopify/polaris-react/pull/1469))
 - Added `box-shadow` to the `Banner` to make it more visible in Windows high contrast mode ([#1481](https://github.com/Shopify/polaris-react/pull/1481))
 - Added `box-shadow` to the `Card` to make it more visible in Windows high contrast mode ([#1524](https://github.com/Shopify/polaris-react/pull/1524))
 - Fixed UI regressions in `Navigation` component hover and active states ([#1551](https://github.com/Shopify/polaris-react/pull/1551))
-
-### Development workflow
-
 - Updated Storybook to `v5.1.0-alpha.39`, improving component searchability in the sidebar ([#1488](https://github.com/Shopify/polaris-react/pull/1488))
-
-### Dependency upgrades
-
 - Removed runtime dependency on `@shopify/images` as we never needed it at runtime ([#1474](https://github.com/Shopify/polaris-react/pull/1474))
 - Removed `@shopify/react-utilities` and replaced some of the functionality with `@shopify/css-utilities` or by moving the utilities into Polaris itself ([#1473](https://github.com/Shopify/polaris-react/pull/1473))
 
-## 3.15.0 - 2019-05-14
+## 3.15.0
 
 This release fixes an issue introduced in `v3.14.0` that caused the `esnext` build not to succeed resulting in build errors for consumers ([#1466](https://github.com/Shopify/polaris-react/pull/1466))
-
-### Enhancements
 
 - Enhanced `NavigationItem`’s color accessibility for `active`, `focus`, `hover` and `Selected` states ([1304](https://github.com/Shopify/polaris-react/pull/1304))
 - Added `align` prop to `TextField` ([#1428](https://github.com/Shopify/polaris-react/pull/1428))
 - Added `clearButton` prop to `TextField` ([#1226](https://github.com/Shopify/polaris-react/pull/1226))
-
-### Bug fixes
-
 - Fixed `Checkbox` from improperly toggling when disabled ([#1467](https://github.com/Shopify/polaris-react/pull/1467))
 - Fixed `Popover` fade-in flutter on iOS by switching Transition component for CSSTransition ([#1400](https://github.com/Shopify/polaris-react/pull/1400))
 - Improved the visibility of focus styles for the `Link` component. ([#1425](https://github.com/Shopify/polaris-react/pull/1425))
-
-### Documentation
-
 - Updated accessibility testing documentation ([#1449](https://github.com/Shopify/polaris-react/pull/1449))
 - Added guidelines for tertiary actions in modals to `Modal` component documentation ([#1336](https://github.com/Shopify/polaris-react/pull/1336))
-
-### Development workflow
-
 - Updated the a11y shitlist and re-enabled the pa11y job in CI. The job always passes for now, as a way for us to judge whether it is stable and can be made a required check. ([#1456](https://github.com/Shopify/polaris-react/pull/1456))
-
-### Code quality
-
 - Simplified logic in Checkbox component ([#1453](https://github.com/Shopify/polaris-react/pull/1453))
 
-## 3.14.0 - 2019-05-08
-
-### New components
+## 3.14.0
 
 - Added the `Sheet`component ([#1250](https://github.com/Shopify/polaris-react/pull/1250))
-
-### Enhancements
-
 - Added translations for all supported locales ([#1358](https://github.com/Shopify/polaris-react/pull/1358))
 - Improved the performance of `ResourceList` ([#1313](https://github.com/Shopify/polaris-react/pull/1313))
 - Added `withinContentContainer` context to `Navigation` ([#1393](https://github.com/Shopify/polaris-react/pull/1393))
 - Added support for`Tooltip` content to wrap nonbreaking strings [#1395](https://github.com/Shopify/polaris-react/pull/1395)
-
-### Bug fixes
-
 - Removed `window` call on `server` executed code [#1427](https://github.com/Shopify/polaris-react/pull/1427)
 - Fixed `onClick` from firing three times when using the enter key on a `ResourceList` item ([#1188](https://github.com/Shopify/polaris-react/pull/1188))
 - Resolved console `[Intervention]` errors for touch interactions on `ColorPicker` ([#1414](https://github.com/Shopify/polaris-react/pull/1414))
@@ -2506,9 +1660,6 @@ This release fixes an issue introduced in `v3.14.0` that caused the `esnext` bui
 - Fixed certain children of a `TextContainer` having no top margin ([#1357](https://github.com/Shopify/polaris-react/pull/1357))
 - Added border to `Tooltip` in Windows high contrast mode ([#1405](https://github.com/Shopify/polaris-react/pull/1405))
 - Fixed `Navigation.Section` rollup collapsing when `Navigation.Item` `subNavigationItems` expand ([#1417](https://github.com/Shopify/polaris-react/pull/1417))
-
-### Documentation
-
 - Updated `Link` accessibility documentation for the `external` prop to reflect new behavior ([#1347](https://github.com/Shopify/polaris-react/pull/1347))
 - Added accessibility documentation for `VisuallyHidden` ([#1348](https://github.com/Shopify/polaris-react/pull/1348))
 - Added accessibility documentation for `TextStyle` ([#1350](https://github.com/Shopify/polaris-react/pull/1350))
@@ -2522,28 +1673,17 @@ This release fixes an issue introduced in `v3.14.0` that caused the `esnext` bui
 - Added accessibility documentation for `Icon` ([#1404](https://github.com/Shopify/polaris-react/pull/1404))
 - Added accessibility documentation for `Popover` ([#1408](https://github.com/Shopify/polaris-react/pull/1408))
 - Fixed content example for `ContextualSaveBar` guidelines ([#1423](https://github.com/Shopify/polaris-react/pull/1423))
-
-### Dependency upgrades
-
 - Updated most `devDependencies` ([#1327](https://github.com/Shopify/polaris-react/pull/1327))
 - Bumped `@shopify/react-utilites` to remove a transitive dependency on `core-js` ([#1343](https://github.com/Shopify/polaris-react/pull/1343))
 - Updated App Bridge to version 1.3.0 ([#1349](https://github.com/Shopify/polaris-react/pull/1349))
 - Updated `typescript` to 3.2.4 ([#1388](https://github.com/Shopify/polaris-react/pull/1388))
 - Updated `sewing-kit` to 0.83.1 and babel-preset-shopify to ^18.1.0 ([#1344](https://github.com/Shopify/polaris-react/pull/1344))
-
-### Code quality
-
 - Updated `Dropzone.FileUpload` to no longer use `componentWillReceiveProps` and `componentWillMount` ([#1233](https://github.com/Shopify/polaris-react/pull/1233))
 - Removed a `window.open` implementation error in `ResourceList.Item` ([#1294](<(https://github.com/Shopify/polaris-react/pull/1294)>))
 
-## 3.13.0 - 2019-04-22
-
-### Deprecations
+## 3.13.0
 
 - Deprecated Navigation `Item`’s `iconBody` prop. Pass a string into the `icon` prop instead. ([#1299](https://github.com/Shopify/polaris-react/pull/1299))
-
-### Enhancements
-
 - Added an `onChange` handler to `CheckableButton` ([#1326](https://github.com/Shopify/polaris-react/pull/1326))
 - `Labelled` now wraps its content, no longer causing a `label + action` to get unreasonably squished ([#1309](https://github.com/Shopify/polaris-react/pull/1309))
 - Updated `polaris-tokens` from `2.3.0` to `2.5.0` and converted all use of `duration` values ([#1268](https://github.com/Shopify/polaris-react/pull/1268))
@@ -2554,9 +1694,6 @@ This release fixes an issue introduced in `v3.14.0` that caused the `esnext` bui
 - Exported overlay and layer data attributes for use in consumer components ([#1266](https://github.com/Shopify/polaris-react/pull/1266))
 - Added new `frame-with-nav-max-width` variable and matching `frame-with-nav-when-not-max-width` mixin ([#1311](https://github.com/Shopify/polaris-react/pull/1311))
 - Updated `Resizer` to schedule `handleHeightCheck` to run in next animation frame ([#1301](https://github.com/Shopify/polaris-react/pull/1301))
-
-### Bug fixes
-
 - Fixed `ResourceList` actions from show at incorrect breakpoints or while in select mode ([#1333](https://github.com/Shopify/polaris-react/pull/1333))
 - Fixed Search overlay stretching below the viewport ([#1260](https://github.com/Shopify/polaris-react/pull/1260))
 - Added `onChange` and `value` to select `AppProvider` examples to remove console errors ([#1320](https://github.com/Shopify/polaris-react/pull/1320))
@@ -2565,46 +1702,29 @@ This release fixes an issue introduced in `v3.14.0` that caused the `esnext` bui
 - Stopped passing the `polaris` context into the div rendered by `Scrollable` ([#1271](https://github.com/Shopify/polaris-react/pull/1271))
 - Fixed clickable area on sortable column headers on `DataTable` ([#1273](https://github.com/Shopify/polaris-react/pull/1273))
 
-### Development workflow
-
 Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/1140))
-
-### Dependency upgrades
 
 - Remove core-js ([#1328](https://github.com/Shopify/polaris-react/pull/1328))
 - Upgraded Polaris icons to include the full icon set ([#1284](https://github.com/Shopify/polaris-react/pull/1284))
-
-### Code quality
-
 - Migrated the refs in `DropZone` to use the new createRef API ([#1063](https://github.com/Shopify/polaris-react/pull/1063))
 - Updated `ResourceList` to no longer use `componentWillReceiveProps`([#1235](https://github.com/Shopify/polaris-react/pull/1235))
 - Updated `Tabs` to no longer use `componentWillReceiveProps`([#1221](https://github.com/Shopify/polaris-react/pull/1221))
 - Removed an unneeded media query from Modal’s `Header` component ([#1272](https://github.com/Shopify/polaris-react/pull/1272))
 - Replaced all instances where we pass a string representing a bundled icon into `Button`. Prefer passing in the React Component from `@shopify/polaris-icons` ([#1297](https://github.com/Shopify/polaris-react/pull/1297))
 
-## 3.12.0 - 2019-03-29
-
-### Enhancements
+## 3.12.0
 
 - Added a public `focus` method on `Banner` ([#1219](https://github.com/Shopify/polaris-react/pull/1219))
 - Added an `onScrollToBottom` prop to `Popover.Pane` ([#1248](https://github.com/Shopify/polaris-react/pull/1248))
 - Added a `placeholder` prop to `FilterControl` ([#1257](https://github.com/Shopify/polaris-react/pull/1257))
 - Added support for setting string values on the `TextField` `autoComplete` prop ([#1259](https://github.com/Shopify/polaris-react/pull/1259))
-
-### Bug fixes
-
 - Fixed disabled states while loading for `ResourceList` ([#1237](https://github.com/Shopify/polaris-react/pull/1237))
 - Fixed `Checkbox` from losing focus and not receiving some modified events([#1112](https://github.com/Shopify/polaris-react/pull/1112))
 - Added translation for the cancel button on the `ResourceList` `BulkActions` ([#1243](https://github.com/Shopify/polaris-react/pull/1243))
 - Fixed the `Autocomplete` `onLoadMoreResults` prop not being called on scrolling to the end of the option list ([#1249](https://github.com/Shopify/polaris-react/pull/1249))
-
-### Documentation
-
 - Removed `button group joined to the bottom of a component` example ([#1267](https://github.com/Shopify/polaris-react/pull/1267))
 
-## 3.11.0 - 2019-03-21
-
-### Enhancements
+## 3.11.0
 
 - Updated `Navigation` badge prop to accept a react node ([#1142](https://github.com/Shopify/polaris-react/pull/1142))
 - Changed max width on `Search` to 694px so that it is perfectly centered in the top bar ([#1107](https://github.com/Shopify/polaris-react/issues/1107))
@@ -2612,44 +1732,27 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - Remove all usage of `@shopify/javascript-utilities/decorators`, namely `autobind`, `debounce`, and `memoize` ([#1148](https://github.com/Shopify/polaris-react/issues/1148))
 - Added `Empty State` footerContent prop ([#1200](https://github.com/Shopify/polaris-react/pull/1200))
 - Added viewport condition to `TopBar` to enlarge the `contextControl` wrapper on wider screens ([#1231](https://github.com/Shopify/polaris-react/pull/1231))
-
-### Bug fixes
-
 - Fixed selectMode on `ResourceList` not toggling when items are selected programmatically ([#1224](https://github.com/Shopify/polaris-react/pull/1224))
 - Fixed unnecessary height on `TextField` due to unhandled carriage returns ([#901](https://github.com/Shopify/polaris-react/pull/901))
 - Ensured server side rendering matches client side rendering for [embedded app components](https://github.com/Shopify/polaris-react/blob/main/documentation/Embedded%20apps.md#components-which-wrap-shopify-app-bridge) ([#976](https://github.com/Shopify/polaris-react/pull/976))
 - Fixed rendering of the spinner on `TextField` when setting to readOnly ([#1118](https://github.com/Shopify/polaris-react/pull/1199))
 - Fixed webpack example that does not compile ([#1189](https://github.com/Shopify/polaris-react/issues/1189))
-
-### Documentation
-
 - Added accessibility documentation for `Checkbox`, `RadioButton`, and `ChoiceList` ([#1145](https://github.com/Shopify/polaris-react/pull/1145))
-
-### Dependency upgrades
-
 - Regenerated the yarn.lock file in the browserify example to resolve security vulnerabilities ([#1202](https://github.com/Shopify/polaris-react/issues/1202))
 - Updated browserify example dependencies and dev dependencies ([#1191](https://github.com/Shopify/polaris-react/issues/1191))
 - Updated webpack example dependencies and dev dependencies ([#1189](https://github.com/Shopify/polaris-react/issues/1189))
-
-### Code quality
-
 - Replaced all occurrences of `_.merge` with a custom `merge` function ([#1018](https://github.com/Shopify/polaris-react/pull/1018))
 - Replaced all occurrences of `_.pick` with a custom pick function ([#1020](https://github.com/Shopify/polaris-react/pull/1020))
 - Deleted the icons index file that would re-export icons, and replaced it with direct imports ([#1195](https://github.com/Shopify/polaris-react/pull/1195))
 - Replaces all instances where we pass a string representing a bundled icon into `Icon`. Prefer passing in the React Component from `@shopify/polaris-icons` ([#1196](https://github.com/Shopify/polaris-react/pull/1196))
 
-## 3.10.0 - 2019-03-07
-
-### Enhancements
+## 3.10.0
 
 - Added Polaris version information tracking in App Bridge actions ([#1087](https://github.com/Shopify/polaris-react/pull/1087))
 - Re-added the navigation’s border-right ([#1096](https://github.com/Shopify/polaris-react/pull/1096))
 - Added `onScrolledToBottom` prop to `Modal` ([#1117](https://github.com/Shopify/polaris-react/pull/1117))
 - Updated `Navigation.Item` to use `Icon` when `iconBody` prop is passed in. Renders these icons in an `img` tag now. ([#1094](https://github.com/Shopify/polaris-react/pull/1094))
 - Added focus state outlines to be visible when using Windows High Contrast Mode for `Button` ([#1101](https://github.com/Shopify/polaris-react/pull/1101))
-
-### Bug fixes
-
 - Reverted a change that constrained `DropZone` height based on inherited wrapper height [#1129](https://github.com/Shopify/polaris-react/pull/1129)
 - Fixed missing rounded corners on `Tag` button states ([#1078](https://github.com/Shopify/polaris-react/pull/1078))
 - Removed reference to `window.Polaris`, which in some cases could be undefined ([#1104](https://github.com/Shopify/polaris-react/issues/1104))
@@ -2657,9 +1760,6 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - Removed left margin from vertical `Stack` to prevent overflow ([#1024](https://github.com/Shopify/polaris-react/pull/1024))
 - Fixed the size differences between `SkeletonThumbnail` and `Thumbnail` ([#1141](https://github.com/Shopify/polaris-react/pull/1141)) (thanks [@mbaumbach](https://github.com/mbaumbach) for the [issue report](https://github.com/Shopify/polaris-react/issues/1135))
 - Refactored `ComboBox` tests that were not running ([#1137](https://github.com/Shopify/polaris-react/pull/1137))
-
-### Documentation
-
 - Updated related component documentation for `Page`, `PageActions`, and `Pagination` ([#1103](https://github.com/Shopify/polaris-react/pull/1103))
 - Improved `Modal` documentation for properties only available in a stand-alone app context ([#1065](https://github.com/Shopify/polaris-react/pull/1065))
 - Added accessibility documentation about `Banner` ([#1071](https://github.com/Shopify/polaris-react/pull/1071))
@@ -2667,13 +1767,7 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - Added accessibility documentation for `Loading` ([#1075](https://github.com/Shopify/polaris-react/pull/1075))
 - Fixed documentation about the `ariaPressed` prop for `Button` ([#1097](https://github.com/Shopify/polaris-react/pull/1097))
 - Fixed examples using the `selected` prop for `Autocomplete` ([#1053](https://github.com/Shopify/polaris-react/pull/1053))
-
-### Development workflow
-
 - Added viewport meta tag to Storybook frame ([#1026](https://github.com/Shopify/polaris-react/pull/1026))
-
-### Code quality
-
 - Removed lodash decorators and replace all occurrences of `_.throttle` with `debounce` ([#1009](https://github.com/Shopify/polaris-react/pull/1009))
 - Removed all occurrences of `_.replace` ([#1012](https://github.com/Shopify/polaris-react/pull/1012))
 - Added lodash to `create-react-app` example ([#1010](https://github.com/Shopify/polaris-react/pull/1010))
@@ -2683,114 +1777,66 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - Replaced all occurrences of `_.get` with a custom `get` function ([#1013](https://github.com/Shopify/polaris-react/pull/1013))
 - Moved icons specific to `Banner`, `DropZone`, and `ResourceList` to [@shopify/polaris-icons](https://www.npmjs.com/package/@shopify/polaris-icons) ([#1042](https://github.com/Shopify/polaris-react/pull/1042))
 - Updated spinner component to use the `Image` component instead of an SVG tag to render ([#1042](https://github.com/Shopify/polaris-react/pull/1042))
-
-### Deprecations
-
 - Deprecated passing a React Element into the `Icon` component in favor of passing a React Component ([#1042](https://github.com/Shopify/polaris-react/pull/1042))
 - Deprecated the untrusted prop in the `Icon` component ([#1042](https://github.com/Shopify/polaris-react/pull/1042))
 
-## 3.9.0 - 2019-02-21
-
-### Enhancements
+## 3.9.0
 
 - Used `base-tight` `spacing` value instead of `rem(12px)` ([#1044](https://github.com/Shopify/polaris-react/pull/1044))
-
-### Bug fixes
-
 - Fixed the `focused` prop on `TextField` so it sets the focus state ([#990](https://github.com/Shopify/polaris-react/pull/990))
 - Resolved an unsupported `React.Fragment` syntax ([#1080](https://github.com/Shopify/polaris-react/pull/1080))
 - Constrained `DropZone` height based on inherited wrapper height [#908](https://github.com/Shopify/polaris-react/pull/908)
 - Reverted a change that adjusted padding in the `Card` component introduced in ([#962](https://github.com/Shopify/polaris-react/pull/962))
 
-## 3.8.0 - 2019-02-20
-
-### New components
+## 3.8.0
 
 - `SkeletonThumbnail` for representing thumbnails in loading state
-
-### Enhancements
 
 - Updates `TopBar.UserMenu` interaction states styling ([#1006](https://github.com/Shopify/polaris-react/pull/1006))
 - Added `download` prop to `Button` and `UnstyledLink` components that enables setting the download attribute ([#1027](https://github.com/Shopify/polaris-react/pull/1027))
 - Added support for internationalization of month and week names to `DatePicker` ([#1005](https://github.com/Shopify/polaris-react/pull/1005))
 - Added `untrusted` prop to `Icon` to render SVG strings in an img tag ([#926](https://github.com/Shopify/polaris-react/pull/926))
 - Added a `data-href` to `ResourceList.Item`s that have a `url` prop ([#1054](https://github.com/Shopify/polaris-react/pull/1054))
-
-### Bug fixes
-
 - Fixed `type="number"` `TextField` to prevent conditions where press-and-hold could increment or decrement infinitely ([#1029](https://github.com/Shopify/polaris-react/pull/1029))
 - Fixed the top border of `DataTable` overlapping its container’s border ([#975](https://github.com/Shopify/polaris-react/pull/975))
 - Fixed the `DataTable` sort direction not reversing on second sort of the initially sorted column ([#918](https://github.com/Shopify/polaris-react/pull/918)) (thanks [@tabrez96](https://github.com/tabrez96) for the [issue report](https://github.com/Shopify/polaris-react/issues/873))
 - Changed the offset from 5px to 4px in `Tooltip` between activator and message to be consistent with `Popover` ([#1019](https://github.com/Shopify/polaris-react/pull/1019))
 - Fixed `Card` header not showing when `title` empty or not set ([#1031](https://github.com/Shopify/polaris-react/pull/1032))
 - Fixed an issue on Chrome when you use a `TextField` inside `Collapsible` which is inside a scrollable element, the text disappeared if you focused a fully hidden `TextField` ([#1047](https://github.com/Shopify/polaris-react/pull/1047))
-
-### Documentation
-
 - Added accessibility documentation for the button and link components ([#924](https://github.com/Shopify/polaris-react/pull/924))
 - Added accessibility recommendations for the text field and autocomplete components ([#968](https://github.com/Shopify/polaris-react/pull/968))
-
-### Development workflow
-
 - Added a test that builds Polaris for web and polaris-styleguide. This test takes ~20 minutes to run so it’s only configured to run for main ([931](https://github.com/Shopify/polaris-react/pull/931))
 - Enabled `no-vague-titles eslint` rule ([#1051](https://github.com/Shopify/polaris-react/pull/1051))
 
-## 3.7.1 - 2019-02-12
-
-### Bug fixes
+## 3.7.1
 
 - Moved character counter to bottom of multiline text input ([#992](https://github.com/Shopify/polaris-react/pull/992))
 - Aligned `TopBar` search input and results with page content ([#1008](https://github.com/Shopify/polaris-react/issues/1008))
-
-### Documentation
-
 - Added all props example of `ResourceList` in the [style guide](https://polaris.shopify.com) ([#978](https://github.com/Shopify/polaris-react/pull/978))
 
-## 3.7.0 - 2019-02-11
-
-### Enhancements
+## 3.7.0
 
 - Removed `TopBar` logo background ([#957](https://github.com/Shopify/polaris-react/pull/957))
 - Updated `TopBar` search results width to adapt to search input and added a minimum width ([#969](https://github.com/Shopify/polaris-react/pull/969))
 - Updated `Card.Section` to accept `React.ReactNode` as `title` ([#781](https://github.com/Shopify/polaris-react/pull/781))
 - Added `contextControl` prop to `TopBar` and `Navigation` ([#966](https://github.com/Shopify/polaris-react/pull/966))
-
-### Bug fixes
-
 - Fixed `Collapsible` to use `overflow: visible;` once fully open ([#951](https://github.com/Shopify/polaris-react/pull/951))
 - Fixed the `DataTable` sort direction not reversing on second sort of the initially sorted column ([#918](https://github.com/Shopify/polaris-react/pull/918)) (thanks [@tabrez96](https://github.com/tabrez96) for the [issue report](https://github.com/Shopify/polaris-react/issues/873))
 - Fixed `TextField` when passing `null` to `value` ([#964](https://github.com/Shopify/polaris-react/pull/964)) (thanks [@mbaumbach](https://github.com/mbaumbach) for the [original issue](https://github.com/Shopify/polaris-react/issues/959))
 - Changed the default value for `showHidden` prop on `ResourcePicker` for backward compatibility with legacy EASDK ([#981](https://github.com/Shopify/polaris-react/pull/981))
 - Adjusted top and bottom padding to the header, footer and sections in `Card` to add space between action buttons in the header and footer and the card sections. ([#962](https://github.com/Shopify/polaris-react/pull/962))
-
-### Documentation
-
 - Added accessibility documentation for the account connection and setting toggle components ([#970](https://github.com/Shopify/polaris-react/pull/970))
 - Added accessibility documentation for the avatar component ([#973](https://github.com/Shopify/polaris-react/pull/973))
 - Updated docs about App Bridge usage in AppProvider ([#945](https://github.com/Shopify/polaris-react/pull/945))
 - Added all props example to `DataTable` in the [style guide](https://polaris.shopify.com) ([#1003](https://github.com/Shopify/polaris-react/pull/939))
-
-### Development workflow
-
 - Fixed links to Polaris component pages in story descriptions ([#933](https://github.com/Shopify/polaris-react/pull/933))
-
-### Dependency upgrades
-
 - Upgraded to `@shopify/polaris-icons` v2.0.0 ([#982](https://github.com/Shopify/polaris-react/pull/982))
-
-### Code quality
-
 - Updated `import styles from './foo.scss';` from non-standard `import * as styles from './foo.scss';` when importing scss files ([#929](https://github.com/Shopify/polaris-react/pull/929))
 - Removed internal ellipsis icon as it is deprecated, and horizontalDots should be used instead ([#974](https://github.com/Shopify/polaris-react/pull/974))
 
-## 3.6.0 - 2019-01-30
-
-### Enhancements
+## 3.6.0
 
 - Updated `TextField` to accept a `showCharacterCount` prop enabling the display of character count ([#709](https://github.com/Shopify/polaris-react/pull/709))
-
-### Bug fixes
-
 - Fixed vertical misalignment in `Banner.Header`([#870](https://github.com/Shopify/polaris-react/pull/870))
 - Removed a duplicate `activatorWrapper` in `Popover` when destructuring props ([#916](https://github.com/Shopify/polaris-react/pull/916))
 - Fixed `Banner` secondaryAction content wrapping in Firefox ([#719](https://github.com/Shopify/polaris-react/pull/719))
@@ -2801,52 +1847,27 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - Changed `Tabs` example to contain children so the `Panel` renders for accessibility ([#893](https://github.com/Shopify/polaris-react/pull/893))
 - Fixed timezone not being accounted for in `ResourceList` date filter control ([#710](https://github.com/Shopify/polaris-react/pull/710))
 - Removed unnecessary tooltip text in the `TopBar` component ([#859](https://github.com/Shopify/polaris-react/pull/859))
-
-### Documentation
-
 - Added `Stack.Item` properties and description to [style guide](https://polaris.shopify.com)’s ([#772](https://github.com/Shopify/polaris-react/pull/772))
 - Added accessibility documentation to the resource list and data table components ([#927](https://github.com/Shopify/polaris-react/pull/927))
 - Added accessibility recommendations for the caption component ([#928](https://github.com/Shopify/polaris-react/pull/928/))
-
-### Development workflow
-
 - Improved build speed by adjusting our rollup workflow ([#912](https://github.com/Shopify/polaris-react/pull/912)) and not optimizing svgs in the node_modules folder ([#920](https://github.com/Shopify/polaris-react/pull/920))
 - Fixed an issue where deployments would use an old version of Yarn, and open a pull request to polaris-styleguide with thousands of deleted integrity hashes in `yarn.lock` ([#856](https://github.com/Shopify/polaris-react/pull/856))
-
-### Dependency upgrades
-
 - Updated App Bridge to version 1.0.3 ([#844](https://github.com/Shopify/polaris-react/pull/844))
-
-### Deprecations
-
 - Deprecated `Navigation.UserMenu` in favor of `TopBar.UserMenu` ([#849](https://github.com/Shopify/polaris-react/pull/849))
 - Deprecated `Navigation`’s `userMenu` prop ([#930](https://github.com/Shopify/polaris-react/pull/930))
 
-## 3.5.0 - 2019-01-16
-
-### Enhancements
+## 3.5.0
 
 - Update build toolchain to use Babel v7, PostCSS v7 and Rollup v1. Updated our build targets match our [supported browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers), leading to a reduction in bundle size ([#837](https://github.com/Shopify/polaris-react/pull/837))
-
-### Bug fixes
-
 - Ensured disabled `Button` components with a `url` prop output valid HTML ([#773](https://github.com/Shopify/polaris-react/pull/773))
 - Fixed `DropZone` which was unable to add a duplicate file back to back or add a file again once removed [#782](https://github.com/Shopify/polaris-react/pull/782). Thank you [@jzsplk](https://github.com/jzsplk) for the contribution [#425](https://github.com/Shopify/polaris-react/issues/425) and [@vladucu](https://github.com/vladucu) for the clear example.
 - Added a fallback to the `safeAreaFor` Sass mixin to handle browsers that don’t support `env` and `constant` ([#881](https://github.com/Shopify/polaris-react/pull/881))
-
-### Documentation
-
 - Added deprecation guidelines ([#853](https://github.com/Shopify/polaris-react/pull/853))
-
-### Development workflow
-
 - Replaced our home-grown playground with Storybook (still accessed through `yarn dev`) ([#768](https://github.com/Shopify/polaris-react/pull/768))
 - Removed our usage of babel-node for build scripts - use plain node instead ([#836](https://github.com/Shopify/polaris-react/pull/836))
 - Ensured CSS builds are reproducible ([#869](https://github.com/Shopify/polaris-react/pull/869))
 
-## 3.4.0 - 2019-01-08
-
-### Enhancements
+## 3.4.0
 
 - Moved icons to a separate npm package ([#686](https://github.com/Shopify/polaris-react/pull/686))
 - Added `oneHalf` and `oneThird` props to `Layout` component ([#724](https://github.com/Shopify/polaris-react/pull/724))
@@ -2854,9 +1875,6 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - Updated `Page` header layout so actions take up less room on small screens ([#707](https://github.com/Shopify/polaris-react/pull/707))
 - Added `alternateTool` prop to `ResourceList` component ([#812](https://github.com/Shopify/polaris-react/pull/812))
 - Updated color of warning status `ExceptionList` items from dark orange to dark yellow for better differentiation from critical status items ([#813](https://github.com/Shopify/polaris-react/pull/813))
-
-### Bug fixes
-
 - Fixed `TextField` not showing the correct color while it has focus and an error ([#806](https://github.com/Shopify/polaris-react/pull/806))
 - Fixed `ResourceList` not rendering `BulkActions` on initial load when items were selected ([#746](https://github.com/Shopify/polaris-react/pull/746))
 - Fixed the new variant of the `Badge` component so that it is simpler and easier to read ([#751](https://github.com/Shopify/polaris-react/pull/751))
@@ -2868,59 +1886,35 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - Fixed `ResourceList` not rendering a header after initial load (thanks to [@andrewpye](https://github.com/andrewpye) for the [original issue](https://github.com/Shopify/polaris-react/issues/735))
 - Fixed `TextField` not passing `step` to the input ([#829](https://github.com/Shopify/polaris-react/pull/829))
 - Renamed `Option` and `Group` types in `Select` to work around typedoc oddness ([#830](https://github.com/Shopify/polaris-react/pull/830))
-
-### Documentation
-
 - Modified image paths to fit the [style guide](https://polaris.shopify.com)’s new Markdown parsing rules ([#753](https://github.com/Shopify/polaris-react/pull/753))
-
-### Development workflow
-
 - Added a slight delay to the Percy screenshot script to give time for components to render fully ([#704](https://github.com/Shopify/polaris-react/pull/704))
 - Refactored to remove cyclical type imports ([#759](https://github.com/Shopify/polaris-react/pull/759), [#754](https://github.com/Shopify/polaris-react/pull/754), and [#767](https://github.com/Shopify/polaris-react/pull/767))
-
-### Dependency upgrades
-
 - Upgraded `@shopify/polaris-tokens` to v2.1.1 ([#813](https://github.com/Shopify/polaris-react/pull/813))
 
-## 3.3.0 - 2018-12-12
-
-### Enhancements
+## 3.3.0
 
 - Added support for `ResourceList.Item` opening a URL in new tab if <kbd>command</kbd> or <kbd>control</kbd> keys are pressed during click ([#690](https://github.com/Shopify/polaris-react/pull/690))
 - Added `primaryAction` prop to `SkeletonPage` ([#488](https://github.com/Shopify/polaris-react/pull/488))
 - Added support for press-and-hold to increment and decrement value in a `type="number"` `TextField` ([#573](https://github.com/Shopify/polaris-react/pull/573)) (thanks to [@andrewpye](https://github.com/andrewpye) for the [original issue](https://github.com/Shopify/polaris-react/issues/420))
 - Forced `Avatar` to fall back to `initials` when the image fails to load ([#712](https://github.com/Shopify/polaris-react/pull/712))
-
-### Bug fixes
-
 - Fixed `Popover` not opening in a small `Scrollable` container ([#658](https://github.com/Shopify/polaris-react/pull/658))
 - Fixed `Page` header component to only render actions wrapper when actions are present ([#732](https://github.com/Shopify/polaris-react/pull/732))
 - Fixed `ContextualSaveBarProps` type not being exported ([#734](https://github.com/Shopify/polaris-react/pull/734))
 - Fixed `Avatar` proportions when image is not square ([#740](https://github.com/Shopify/polaris-react/pull/740))
-
-### Development workflow
-
 - Upgraded to TypeScript 3.1.6 ([#700](https://github.com/Shopify/polaris-react/pull/700))
 - Moved some inconsistent prop types around for compatibility with the style guide’s Props Explorer ([#727](https://github.com/Shopify/polaris-react/pull/727))
 
-## 3.2.1 - 2018-12-04
-
-### Bug fixes
+## 3.2.1
 
 - Fixed `ToastProps` type not being exported ([#722](https://github.com/Shopify/polaris-react/pull/722))
 - Fixed Shopify App Bridge import issues in `AppProvider` and `enzyme` test utilities ([#720](https://github.com/Shopify/polaris-react/pull/720))
 
-## 3.2.0 - 2018-12-04
-
-### Enhancements
+## 3.2.0
 
 - Updated `TextField` to no longer use `componentWillReceiveProps`([#628](https://github.com/Shopify/polaris-react/pull/628))
 - Updated `EventListener` to no longer use `componentWillUpdate` ([#628](https://github.com/Shopify/polaris-react/pull/628))
 - Allowed `Icon` to accept a React Node as a source ([#635](https://github.com/Shopify/polaris-react/pull/635)) (thanks to [@mbriggs](https://github.com/mbriggs) for the [original issue](https://github.com/Shopify/polaris-react/issues/449))
 - Added `alignContentFlush` prop to ContextualSaveBar ([#654](https://github.com/Shopify/polaris-react/pull/654))
-
-### Bug fixes
-
 - Fixed `Pagination` from calling `onNext` and `onPrevious` while `hasNext` and `hasPrevious` are false for key press events ([#643](https://github.com/Shopify/polaris-react/pull/643))
 - Removed min-width from `FormLayout` `Items` and applying it only to `Items` used inside a `FormLayout.Group` ([#650](https://github.com/Shopify/polaris-react/pull/650))
 - Removed added space in `ChoiceList` when choice has children on selection but is not selected ([#665](https://github.com/Shopify/polaris-react/issues/665))
@@ -2928,42 +1922,25 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - Updated the `InlineError` text color, the error border-color on form fields and the error `Icon` color to be the same red. ([#676](https://github.com/Shopify/polaris-react/pull/676))
 - Fixed `AppProvider` server side rendering support ([#696](https://github.com/Shopify/polaris-react/pull/696)) (thanks [@sbstnmsch](https://github.com/sbstnmsch) for the [original issue](https://github.com/Shopify/polaris-react/issues/372))
 - Fixed `TextField` autocomplete disabling by setting autocomplete="nope" when `autoComplete` prop is `false` ([#708](https://github.com/Shopify/polaris-react/pull/708))
-
-### Documentation
-
 - Updated documentation links to match the new style guide link structure ([#478](https://github.com/Shopify/polaris-react/pull/478))
-
-### Development workflow
-
 - `yarn run tophat` has been removed and its functionality has been moved into the `yarn run dev` server. Example editing now supports hot-reloading so you don’t need restart the server anymore.
-
-### Dependency upgrades
 
 - Bumped `@shopify/polaris-tokens` to v2.0.0. This is a **breaking change** for consumers of color design tokens in languages such as JavaScript and Sass ([full release notes](https://github.com/Shopify/polaris-tokens/blob/master/CHANGELOG.md#200---2018-10-23))
 
-## 3.1.1 - 2018-11-19
-
-### Bug fixes
+## 3.1.1
 
 - Fixed selector import in `DataTable` and `Cell` ([#638](https://github.com/Shopify/polaris-react/pull/638))
 
-## 3.1.0 - 2018-11-16
-
-### Enhancements
+## 3.1.0
 
 - Improved `Avatar` so it falls back to `initials` when the image fails to load ([#557](https://github.com/Shopify/polaris-react/pull/557))
 - Added `onScrolledToBottom` prop to `Scrollable` ([#568](https://github.com/Shopify/polaris-react/pull/568))
-
-### Bug fixes
-
 - Fixed `Action`’s selector in `Page`’s `Header` component ([#523](https://github.com/Shopify/polaris-react/pull/523))
 - Fixed `Card` spacing in small devices ([#608](https://github.com/shopify/polaris-react/pull/608))
 - Fixed `ResourceList` `BulkActions` that were remaining in fixed position outside the `boundingElement` ([#627](https://github.com/Shopify/polaris-react/pull/627))
 - Improved readability of `Badge` with `size` small and `status` new for navigation ([#633](https://github.com/shopify/polaris-react/pull/633))
 
-## 3.0.1 - 2018-11-14
-
-### Bug fixes
+## 3.0.1
 
 - Fixed `Datepicker` ranges when `start` and `end` dates are similar but have different references ([#601](https://github.com/Shopify/polaris-react/pull/601))
 - Fixed `DataTable` column visibility calculation in production environments by using a `data-polaris-header-cell` attribute instead of class-based targeting ([#615](https://github.com/Shopify/polaris-react/pull/615))
@@ -2975,9 +1952,9 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 - `TextStyle` strong variant now uses a span tag instead of b ([#606](https://github.com/Shopify/polaris-react/pull/606))
 - Fixed non-blocking context errors when using `Toast` or `Loading` in an embedded app ([#613](https://github.com/Shopify/polaris-react/pull/613))
 
-## 3.0.0 - 2018-11-09
+## 3.0.0
 
-### Breaking changes
+### Major changes
 
 - Added padding top and bottom on `Card.Section` when set to full width
 - Fixed `Portal` rendering by using `componentDidMount` lifecycle hook as opposed to `componentWillMount`
@@ -3013,8 +1990,6 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 #### License
 
 - Updated the license from MIT to a custom license based on MIT. The new license restricts Polaris usage to applications that integrate or interoperate with Shopify software or services, with additional restrictions for external, stand-alone applications.
-
-### New components
 
 We’ve released a suite of new components that, when combined, form the application frame of a stand-alone (or non-embedded) Polaris app.
 
@@ -3052,16 +2027,12 @@ The contextual save bar tells merchants their options once they have made change
 
 The autocomplete component is an input field that provides selectable suggestions as a merchant types into it. It allows merchants to quickly search through and select from large collections of options.
 
-### Enhancements
-
 - Changed `Form` to default the `method` to `post` in order to prevent accidental leaking of form details
 - Added support for boolean type on Choice error prop
 - Changed the esnext folder to contain individual, minimally transpiled JavaScript component files, as well as raw style and image assets
 - Added `onPortalCreated` prop to `Portal`
 - Improved consistency of `Badge` styling
 - Explicitly specifying `list-style` on `List`
-
-### Bug fixes
 
 - Fixed console error and used new ref syntax in `DataTable` (thanks to [@duythien0912](https://github.com/duythien0912) for the [original issue](https://github.com/Shopify/polaris-react/issues/403))
 - Fixed the ability to upload multiple files even when `allowedMultiple` prop is false
@@ -3070,9 +2041,6 @@ The autocomplete component is an input field that provides selectable suggestion
 - Fixed issue in `Page`, where styling wasn’t being applied correctly to Page Actions
 - Removed unnecessary bindings on the `Modal`’s `onClose` prop
 - Rearranged `primaryFooterAction` and `secondaryFooterAction` in `Card` (thanks [@sivakumar-kailasam](https://github.com/sivakumar-kailasam) for the [original issue](https://github.com/Shopify/polaris-react/issues/551))
-
-### Documentation
-
 - Updated banner guidelines to make it clearer when success banners should be used vs success toasts.
 - Added examples for iOS and Android section header
 - Added examples for iOS and Android thumbnail
@@ -3084,8 +2052,6 @@ The autocomplete component is an input field that provides selectable suggestion
 - Added examples for iOS and Android list
 - Clarified placement and usage of `Banner`
 - Added an explanation to `Modal` about why it can’t be closed by clicking outside the modal and should only be closed by clicking `X` or `Cancel`
-
-### Development workflow
 
 - Moved sub-sub-components within `ResourceList` into components folders
 - Removed empty state from `ResourceList` if there are no items and `loading` is true
@@ -3101,39 +2067,27 @@ The autocomplete component is an input field that provides selectable suggestion
 - Updated the project README
 - Moved active development to the public repository
 
-## 2.12.1 - 2018-10-11
-
-### Bug fixes
+## 2.12.1
 
 - Fixes type imports in the build
 
-## 2.12.0 - 2018-10-11
-
-### Enhancements
+## 2.12.0
 
 - Removed tip from `Popover`
 - Increased speed of `Popover` transition from 500ms to 100ms
 - Improved text contrast in `Badge`.
 - Added named `medium` size to Button that renders the same as omiting the size attribute
 
-### Bug fixes
-
 - Fixed typo in `Collapsible` example
 - Fixed padding and margins on `SkeletonPage` to match `Page`
 - Fixed spacing between `Page` title and metadata
 
-### Documentation
-
 - Made `ActionList`, `OptionList` and `Popover` examples active by default so previews are visible without interacting
 - Improved the manual accessibility checklist
 
-### Development workflow
-
 - Batched Percy snapshots per component
 
-## 2.11.0 - 2018-10-03
-
-### Enhancements
+## 2.11.0
 
 - `Tab.Item` with a `url` prop now renders an `UnstyledLink` instead of a `Button` when displayed in `Popover` and you can now keyboard navigate the disclosure in `Tabs`
 - Refs can be placed on `DropZone.FileUpload`
@@ -3142,12 +2096,8 @@ The autocomplete component is an input field that provides selectable suggestion
 - Update example description in `ExceptionList` documentation
 - Move Modal CloseButton into its own subcomponent, instead of being part of the Header subcomponent. This is an internal implementation detail if you are using the React component. If you are using (s)css and are defining class names manually you will need to update references to `Polaris-Modal-Header__CloseButton` and `Polaris-Modal-Header--withoutTitle` to `Polaris-Modal-CloseButton` and `Polaris-Modal-CloseButton--withoutTitle` respectively.
 
-### Development workflow
-
 - Added `d.ts` files to test coverage ignore
 - `Page` is no longer self-closing in the playground
-
-### Bug fixes
 
 - Fixed `Button` alignment issue caused by unnecessary icon markup rendering ([#2339](Fixing button alignment #2339)) (thanks to ([@mbaumbach](https://github.com/mbaumbach)) for the ([original issue](https://github.com/Shopify/polaris-react/issues/429)))
 - Fixed console error and used new ref syntax in `DataTable` (thanks to [@duythien0912](https://github.com/duythien0912) for the [original issue](https://github.com/Shopify/polaris-react/issues/403))
@@ -3160,12 +2110,8 @@ The autocomplete component is an input field that provides selectable suggestion
 - Fixed form inputs in `Popover` that were disappearing instead of top aligning thanks to [@mbaumbach](https://github.com/mbaumbach) for the [original issue](https://github.com/Shopify/polaris-react/issues/435)
 - Removed a redundant class on `OptionList` list items
 
-### Documentation
-
 - Made `Modal` examples show the modal dialog by default
 - Changed fitted `Tabs` to have equal width when enough space is present ([#2314](https://github.com/Shopify/polaris-react/issues/2314))
-
-### New components
 
 #### withContext
 
@@ -3175,34 +2121,22 @@ Use `withContext` to pass consumer context to a component.
 
 Use `withRef` with `compose` to forwardRefs to a component.
 
-## 2.10.0 - 2018-09-18
-
-### Enhancements
+## 2.10.0
 
 - Updated `Button` to accept a `React.ReactNode` for its `icon` prop
 
-### Documentation
-
 - Refined accessibility checklist
-
-### Bug Fixes
 
 - Added truncation to `Tag`
 
-## 2.9.0 - 2018-09-10
-
-### Enhancements
+## 2.9.0
 
 - Updated date filter labels in resource list
 - Changed `placeholder` prop in `Select` to be the default selection
 - Added a `loading` prop to `ResourceList` that places a spinner overtop items and disables bulk actions
 
-### Documentation
-
 - Clarified when and how to use icons in the banner component
 - Updated footer help component guidelines to include content instructions for app developers
-
-### Bug fixes
 
 - Fixed resource list component to correctly handle inclusive filter keys
 - Fixed date field in DateSelector to not render an error when date is added by the date picker and field is blurred
@@ -3214,40 +2148,26 @@ Use `withRef` with `compose` to forwardRefs to a component.
 - Fixed `Banner` spacing when inside of a section
 - Fixed `Stack` so it doesn’t add extra spacing between items in Safari
 
-## 2.8.0 - 2018-08-30
-
-### Bug fixes
+## 2.8.0
 
 - Reverted a change that caused the built embedded.js bundle to be way larger than it should be due to broad imports
 
-### Enhancements
-
 - Added support for boolean type on Choice error prop
-
-### Documentation
 
 - Updated banner guidelines to make it clearer when success banners should be used vs success toasts.
 - Updated display text documentation to have a separate example for medium and large display
 
-## 2.7.2 - 2018-08-27
-
-### Bug fixes
+## 2.7.2
 
 - Reverted a change that caused items in a `Popover` component not to be clickable
 
-## 2.7.1 - 2018-08-27
-
-### Documentation
+## 2.7.1
 
 - Fixed paths to images in the “Attention badge” example
 
-### Bug fixes
-
 - Fixed the `Page` component’s `primaryAction` to support `LoadableAction`s and `DisableableAction`s
 
-## 2.7.0 - 2018-08-27
-
-### Enhancements
+## 2.7.0
 
 - Adjusted spacing for `ChoiceChildren` in `ChoiceList` for readability
 - Made `Card.Header` a separate publicly accessible component
@@ -3256,29 +2176,19 @@ Use `withRef` with `compose` to forwardRefs to a component.
 - Added validation for non-numeric input in a type="number" `TextField`
 - Added circle information icon
 
-### Documentation
-
 - Updated `Banner` guidelines to make it clearer when success banners should be used vs success toasts
 
-## 2.6.1 - 2018-08-21
-
-### Development workflow
+## 2.6.1
 
 - Moved `pa11y` and `object-hash` from dependencies to devDependencies
 
-### Bug fixes
-
 - Fixed inconsistent `DropZone` error styling
 
-## 2.6.0 - 2018-08-21
-
-### Development workflow
+## 2.6.0
 
 - Added a `test:coverage` script to gather and display test coverage results
 - Added Codecov test coverage checks to pull requests
 - Added automated a11y testing to CI
-
-### Enhancements
 
 - Added support for `titleMetadata` in `Page` component
 - Added support for `FilterType.DateSelector` in `ResourceList` component
@@ -3309,8 +2219,6 @@ Use `withRef` with `compose` to forwardRefs to a component.
 - Added a `disabled` prop to the `Choice` component. `Checkbox` and `RadioButton` labels are now styled to reflect their disabled state
 - Added support for Windows High Contrast mode in the `Select`, `Checkbox` and `RadioButton` components
 
-### Bug fixes
-
 - Fixed `TextField` resizer rendering when `multiline` was false
 - Fixed `Modal` header condensing
 - Fixed `Tooltip` so active prop activates on initial render
@@ -3326,8 +2234,6 @@ Use `withRef` with `compose` to forwardRefs to a component.
 - Fixed an issue that caused problems for some build tools
 - Fixed the word-break of long text in `Label` and `Banner` on small screens
 
-### Documentation
-
 - Added examples for iOS and Android `RadioButton`
 - Added examples for iOS and Android `Banner`
 - Added `Toast` component
@@ -3337,56 +2243,36 @@ Use `withRef` with `compose` to forwardRefs to a component.
 - Added examples for iOS and Android `Avatar`
 - Added `Stepper` component
 
-### New components
-
 #### [InlineError](https://polaris.shopify.com/components/forms/inline-error)
 
 Use inline errors to describe custom form inputs or form groups when invalid.
 
-## 2.5.0 - 2018-07-20
-
-### Enhancements
+## 2.5.0
 
 - Updated sub component structure
 - Added `weekStartsOn` prop to `DatePicker`
-
-### Bug fixes
 
 - Remove `stickyManager` from `AppProviderProps` interface
 - Fixed a bug where `Layout.AnnotatedSection` would output a wrapper div for a `description` even when its contents were empty
 - Remove extra padding from annotated section
 
-### Documentation
-
 - Added iOS and Android examples to the `Card` component
 - Added iOS and Android examples to the `ChoiceList` component
-
-### Development workflow
 
 - Renamed `yarn start:vrt` to `yarn tophat` and updated the folder name to match
 - Improved `yarn tophat`’s design, and added a `/all-components` route
 
-### Enhancements
-
 - Added `weekStartsOn` prop to `DatePicker`
 
-## 2.4.0 - 2018-07-12
-
-### Enhancements
+## 2.4.0
 
 - Changed `Form` to submit a form by default when the <kbd>enter</kbd> key is pressed, and added the prop `implicitSubmit` to disable this default
 
-### Bug fixes
-
 - Fixed `TextField` padding when a `prefix` or `suffix` is included
 
-## 2.3.1 - 2018-07-05
-
-### Enhancements
+## 2.3.1
 
 - Removed the min-width of 320px from `ResourceList`
-
-### Bug fixes
 
 - Resolve issue with `RangeSlider` component not accepting `0` as a `max` value
 - Slightly reduced spacing for `prefix` and `suffix` on the `RangeSlider` component
@@ -3394,28 +2280,19 @@ Use inline errors to describe custom form inputs or form groups when invalid.
 - Fixed height of cells in `DataTable` that are rendered after initial page load (for example: in a `Tab` or a `Popover`) (thanks [@flewid](https://github.com/flewid) for the [original issue](https://github.com/Shopify/polaris-react/issues/344))
 - Fixed `DatePicker` month styling for previous years
 
-## 2.3.0 - 2018-07-03
-
-### New components
+## 2.3.0
 
 #### [Option list](https://polaris.shopify.com/components/lists-and-tables/option-list)
 
 Use `OptionList` to present a group of selectable items outside of the context of a `Form`.
 
-### Documentation
-
 - Fixed `Form` examples
-
-### Enhancements
 
 - Added `prefix` and `suffix` props to `RangeSlider` for better layout control
 - Added testing documentation and examples in `AppProvider`
 - Performance: optimized avatar SVG files
 - Updated `yarn run optimize` to add new line at the end of SVG files
 - Added a more compact variant of `Select`, with the form label appearing inside the control)
-
-### Bug fixes
-
 - Adjusted padding on `TextField` to work with Chrome’s autofill
 - Fixed a regression where the version of Polaris wasn’t globally available anymore
 - Updated the interaction state visuals for `ActionList`
@@ -3428,57 +2305,39 @@ Use `OptionList` to present a group of selectable items outside of the context o
 
 - Updated [`@shopify/polaris-tokens`](https://npmjs.com/package/@shopify/polaris-tokens), the single source of truth for colors
 
-## 2.2.0 - 2018-06-12
-
-### New components
+## 2.2.0
 
 #### [Range slider](https://polaris.shopify.com/components/forms/range-slider)
 
 Use `RangeSlider` to select a number value between a min and max range.
 
-### Enhancements
-
 - Added a fixed prop to `Popover` allowing for a fixed position
 - Added badge prop to the `ItemDescriptor` type and action group
 - Added `text-breakword` mixin for easier word breaking when dealing with long unspaced strings
 
-### Bug fixes
-
 - Fixed unexpected form submission when switching tabs in a `Tabs` component wrapped in a `Form`
 - Added missing `'Shopify.API.setWindowLocation'` message handler to the EASDK
 
-## 2.1.2 - 2018-06-06
-
-### Enhancements
+## 2.1.2
 
 - Added support for `Card` to accept a block for a title
 - Added an intermediate prop typing for `Link` to allow redefinition of prop definitions
-
-### Bug fixes
 
 - Fixed an issue where `ResourceList` filters lost padding (thanks [@BarryCarlyon](https://github.com/BarryCarlyon) for the [original issue](https://github.com/Shopify/polaris-react/issues/330))
 - Fixed unexpected focus jumps when `DatePicker` props are updated
 - Fixed the spacing and text wrapping of `ExceptionList` title and description
 
-## 2.1.1 - 2018-05-30
-
-### Bug fixes
+## 2.1.1
 
 - Fixed `DropZone` to prevent it from kicking into small size too soon
 
-### Documentation
-
 - Various content and markdown fixes
 
-## 2.1.0 - 2018-05-03
-
-### New components
+## 2.1.0
 
 #### [Exception list](https://polaris.shopify.com/components/lists-and-tables/exception-list)
 
 Use Exception lists to draw the merchant’s attention to important information that adds extra context to a task.
-
-### Enhancements
 
 - Added an `ellipsis` prop to `ActionList.Item` allowing for an ellipsis suffix after the content
 - Added a `preferredAlignment` prop to `Popover` allowing it to be aligned to the left, center, or right of its activator
@@ -3487,8 +2346,6 @@ Use Exception lists to draw the merchant’s attention to important information 
 - Exposed Group interface from the `Select` component
 - Renamed `plain-list` mixin to `unstyled-list`
 - Removed padding from `DropZone` and applied it to `FileUpload` instead
-
-### Bug fixes
 
 - Fixed unexpected window scroll on rendering `DataTable` (thanks [@mfurniss](https://github.com/mfurniss) for the [original issue](https://github.com/Shopify/polaris-react/issues/317))
 - Fixed focused inner interaction state on `ResourceList.Item` for reverse tabbing
@@ -3502,7 +2359,7 @@ Use Exception lists to draw the merchant’s attention to important information 
 - Fixed `ResourceList` reverse tabbing focus interaction on action buttons
 - Fixed padding in the case where a `ResourceList` had no filters
 
-## 2.0.0 - 2018-05-07
+## 2.0.0
 
 Summary: this is the first major version of Polaris React since launch. Included in this release are:
 
@@ -3510,7 +2367,7 @@ Summary: this is the first major version of Polaris React since launch. Included
 - Improvements to existing components, such as `ResourceList`, `ChoiceList`, and `Card`
 - A few breaking API changes
 
-### Breaking changes
+### Major changes
 
 #### React 16+
 
@@ -3604,8 +2461,6 @@ If you’re using VS Code, here are the exact search / replace instructions to f
 - replace `\bcolor\(([a-z-]+), ([a-z-]+)\)` with `color('$1', '$2')`
 - replace `\bcolor\(([a-z-]+), ([a-z-]+), (.*)\)` with `color('$1', '$2', $3)`
 
-### New components
-
 #### [Data table](https://polaris.shopify.com/components/lists-and-tables/data-table)
 
 Since launching Polaris components, we’ve had many people ask why we didn’t include tables. While we have been moving away from using tables for comparisons that aren’t tabular data (resource lists, for example), we recognize that there are still cases to use them.
@@ -3626,8 +2481,6 @@ In the original Polaris React, the modal component was only available to embedde
 
 The app provider is a required component that enables sharing global app config with the components in Polaris. This is used for the internationalization of strings in Polaris components, as well as set other configuration such as a custom link component that all the Polaris components will use. This unlocks new ways for us to share configuration at an app level and have the components react to that configuration.
 
-### Enhancements
-
 - Added `error` prop to `ChoiceList`
 - `TextField`, `Select`, and `Checkbox` now accept the types `string` or `ReactElement` for the `error` prop
 - Added optional `id` props to more components, and restructured the prop definitions to allow projects to make `id` props mandatory
@@ -3635,65 +2488,48 @@ The app provider is a required component that enables sharing global app config 
 - Added `fullHeight` prop to `Popover` to override max-height
 - Added `allowRange` as a property for `DatePicker`
 - Added the `external` option to the `secondaryAction.action` prop on the `Banner` component. Thank you to ([Andrew Cargill](https://github.com/cargix1)) for the issue ([#236](https://github.com/Shopify/polaris-react/issues/236))
-
-### Bug fixes
-
 - Enforced subdued description `TextStyle` in `AnnotatedSection`
 - Fixed overflow of `TextField` that caused the border to be cut off
 - Allowed specific props in the `TextField` component to pass through properties to the input child
 - Fixed `ActionList` component to provide section dividers when a `title` was not provided
 - Fixed an issue in the `Select` component where placeholder didn’t properly appear on Firefox and appeared disabled on all browsers
 
-## 1.14.2 - 2018-05-02
+## 1.14.2
 
 _This will be the last v1.x release outside of critical security fixes._
-
-### Bug fixes
 
 - Add margin-left spacing to disclosure icon within `Button` component
 - Remove margins on segmented `ButtonGroup`
 - Fixed text alignment of `Link` so that it inherits from its parent node
 
-## 1.14.1 - 2018-04-10
-
-### Bug fixes
+## 1.14.1
 
 - Fixing an error with the release process
 
-## 1.14.0 - 2018-04-10
-
-### Enhancements
+## 1.14.0
 
 - Changed `term` in `DescriptionList` component to accept `React.ReactNode` to allow for more than just `string` type
 
-## 1.13.1 - 2018-03-29
+## 1.13.1
 
 - Added missing `publishConfig.access` setting in `package.json`, in accordance with the new Shipit requirements for public npm packages
 
-## 1.13.0 - 2018-03-29
-
-### Enhancements
+## 1.13.0
 
 - Added an `id` prop to Collapsible to be referenced by the `aria-controls` attribute of the component triggering the collapse
-
-### Bug fixes
 
 - Fixed external prop not working within `ActionList` component
 - Fixed a syntax error in one of the `Card` component examples (thanks [@meecrobe](https://github.com/meecrobe) for the [original issue](https://github.com/Shopify/polaris-react/issues/281))
 
-## 1.12.4 - 2018-03-19
+## 1.12.4
 
 - Enhanced `Avatar` to work better when provided non-square images
 - Move documentation file so it’s picked up by the style guide
 
-## 1.12.3 - 2018-03-16
-
-### Bug fixes
+## 1.12.3
 
 - Fixed disclosure centering on the `Tabs` component
 - Fixed an issue where a style void would appear between breakpoints at high text zoom levels
-
-### Documentation
 
 - Removed purpose section from component READMEs
 - Added `EmbeddedPage` under the Embedded section
@@ -3701,31 +2537,21 @@ _This will be the last v1.x release outside of critical security fixes._
 - Added screenshots to the embedded components
 - Clarified usage of `Card` header and `FooterActions`
 
-## 1.12.2 - 2018-03-08
-
-### Documentation
+## 1.12.2
 
 - Moving property descriptions out of READMEs and into source files
 
-## 1.12.1 - 2018-03-06
-
-### Bug fixes
+## 1.12.1
 
 - Fixed server-side environments
 
-### Documentation
-
 - Updated component examples that use state to use an es6 class
 
-## 1.12.0 - 2018-02-28
-
-### Bug fixes
+## 1.12.0
 
 - Fixed `TextField` overflow issues when inside `Scrollable`
 - Fixed `Select` focus state bug occuring in Firefox
 - Fixed vertical alignment of text within full width variant of the button component
-
-### Enhancements
 
 - Changed `Checkbox` label to allow string or React.ReactNode
 - Update `TextField` type with currency
@@ -3735,23 +2561,17 @@ _This will be the last v1.x release outside of critical security fixes._
 - Exposed Status from the `Banner` component
 - Added `titleHidden` prop to `Page`
 
-### Documentation
-
 - Clarified intended usage for `EmptyState`
 
 ### Chores
 
 - Added version number to source
 
-## 1.11.0 - 2018-02-13
+## 1.11.0
 
 - Changed Action to Disableable Action in Card
 
-### Enhancements
-
 - Added `renderChildren` prop to `ChoiceList` component
-
-### Bug fixes
 
 - Fixed an issue with `FooterHelp` links not expanding to full-width on mobile devices ([#759](https://github.com/Shopify/polaris-react/issues/759))
 - Added breadcrumbs to `SkeletonPage`
@@ -3762,24 +2582,18 @@ _This will be the last v1.x release outside of critical security fixes._
 - Fixed an issue in `TextInput`, when you increment or decrement with a float value, and the digits after the decimal point where wrong (thanks [@cgidzinski](https://github.com/cgidzinski) for the [original issue](https://github.com/Shopify/polaris-react/issues/761))
 - Added top alignment to FormLayout.Group
 
-### Documentation
-
 - Fixed capitalization of prop names in `Pagination` component’s documentation (thanks [@donnguyen](https://github.com/donnguyen) for the [original issue](https://github.com/Shopify/polaris-react/issues/141))
 - Exposed Option from the `Select` component
 
-## 1.10.2 - 2018-01-22
-
-### Bug fixes
+## 1.10.2
 
 - Fixed the public repository’s build (which was missing the new CircleCI configuration files)
 
-## 1.10.1 - 2018-01-19
-
-### Bug fixes
+## 1.10.1
 
 - Fixed CSS-only `Checkbox` (thanks [@daddy88](https://github.com/daddy88) for the [original issue](https://github.com/Shopify/polaris-react/issues/252))
 
-## 1.10.0 - 2018-01-17
+## 1.10.0
 
 - Restored the correct `latest` version to the CDN
 - Fixed rgbToHsb function when red is the largest number and added tests (thanks [@emcmanus](https://github.com/emcmanus) for the [original issue](https://github.com/Shopify/polaris-react/issues/251))
@@ -3789,15 +2603,11 @@ _This will be the last v1.x release outside of critical security fixes._
 
 - Added tests for `ColorPicker` color utilities
 
-## 1.9.1 - 2017-12-21
-
-### Documentation
+## 1.9.1
 
 - Ammending changelog
 
-## 1.9.0 - 2017-12-21
-
-### Enhancements
+## 1.9.0
 
 - Added `onActionAnyItem` prop to action list and used to close `Page` `actionGroups` on click or keypress of any item
 - Added `content` prop to `Tabs` and deprecated use of `title`
@@ -3808,41 +2618,29 @@ _This will be the last v1.x release outside of critical security fixes._
 - Added `singleColumn` prop to page
 - Added `focused` prop to `TextField`
 
-### Bug fixes
-
 - Fixed positioned overlay not responding to `Scrollable` container events
 - Fixed first focusable item focus in `Popover`
 - Fixed typos in the select component documentation (thanks [@mattchidley](https://github.com/mattchidley) for the [original issue](https://github.com/Shopify/polaris-react/issues/224))
 
-## 1.8.3 - 2017-10-26
-
-### Bug fixes
+## 1.8.3
 
 - Moved react-transition-group from a dev dependency to a dependency
 
-## 1.8.2 - 2017-10-24
-
-### Bug fixes
+## 1.8.2
 
 - Fixed `Stack` not returning children
 
-## 1.8.1 - 2017-10-24
-
-### Bug fixes
+## 1.8.1
 
 - Added missing yarn config file which was causing the build to fail
 
-## 1.8.0 - 2017-10-23
-
-### Documentation
+## 1.8.0
 
 - Updated README to consistently use contractions (thanks [@stefanmiodrag](https://github.com/stefanmiodrag) for the [original pull request](https://github.com/Shopify/polaris-react/pull/191))
 - Improved example description for `Layout` component
 - Updated `Spinner` documentation
 - Improved component purpose documentation across components
 - Improved documentation for `TextStyle` component
-
-### Enhancements
 
 - Added support for React 16
 - Added an option to show or hide unpublished products from the `ResourcePicker`
@@ -3853,15 +2651,11 @@ _This will be the last v1.x release outside of critical security fixes._
 - Added support for disabled secondary `Page` actions
 - Changed `TextField` and `Select` to now focus on clicking only within the area from the input to the end of its label text
 
-### Bug fixes
-
 - Fixed `Layout` component example description
 - Fixed `SkeletonPage` header appearing in embedded apps (thanks [@rkbhochalya](https://github.com/rkbhochalya) for the [original issue](https://github.com/Shopify/polaris-react/issues/202)))
 - Fixed border-radius on `ActionList` component in Chrome
 
-## 1.7.0 - 2017-10-06
-
-### Enhancements
+## 1.7.0
 
 - Added `SkeletonPage`, `SkeletonBodyText` and `SkeletonDisplayText` components
 - Added `Spinner` component
@@ -3872,9 +2666,6 @@ _This will be the last v1.x release outside of critical security fixes._
 - `Stack` now supports non-wrapping layouts on small screens
 - Updated `TextField` min and max documentation
 - Breadcrumbs now accept a callback through onAction (thanks [@arypbatista](https://github.com/arypbatista) for the [original issue](https://github.com/Shopify/polaris-react/issues/188))
-
-### Bug fixes
-
 - Fixed issue with embedded app breadcrumb linking to Shopify settings page (thanks [@cargix1](https://github.com/cargix1) for the [original issue](https://github.com/Shopify/polaris-react/issues/116))
 - Fixed `Avatar` to display image and initials simultaneously
 - Fixed various links to embedded components
@@ -3883,9 +2674,7 @@ _This will be the last v1.x release outside of critical security fixes._
 - Fixed plain and `fullWidth` `Button` alignment
 - Add a minor delay to `Tooltip` display
 
-## 1.6.0 - 2017-09-25
-
-### Enhancements
+## 1.6.0
 
 - Documented disabled prop for `Checkbox` and `RadioButton` (thanks [@LeoAref](https://github.com/LeoAref) for the [original issue](https://github.com/Shopify/polaris-react/issues/114))
 - Documented progress prop for `Badge` (thanks [@sp4cecat](https://github.com/sp4cecat) for the [original issue](https://github.com/Shopify/polaris-react/issues/172))
@@ -3896,52 +2685,38 @@ _This will be the last v1.x release outside of critical security fixes._
 - Added subtract icon
 - Improved acessibility for `Pagination`
 
-### Bug fixes
-
 - Fixed failed dependency installation for unauthenticated GitHub users (thanks [@mikeyhew](https://github.com/mikeyhew) for the [original issue](https://github.com/Shopify/polaris-react/issues/184))
 - Fixed `Page` header spacing
 - Fixed `TextField` focus ring transition
 - Fixed `Popover` not resizing on content updates
 
-## 1.5.2 - 2017-09-18
-
-### Bug fixes
+## 1.5.2
 
 - Fixes alignment of `PageAction` links
 
-## 1.5.1 - 2017-08-30
-
-### Bug fixes
+## 1.5.1
 
 - Fixed disabled `Button` when using local class names
 - Fixed `Scrollable` resize listener not autobinding
 
-## 1.5.0 - 2017-08-30
-
-### Enhancements
+## 1.5.0
 
 - Updated `Scrollable` component to remember scroll position on re-render
 - Added checkmark icon to the `Icon` component
 - Added an example for a disabled `TextField`
 
-### Bug fixes
-
 - Fixed typo in `Icon` code example
 
-## 1.4.1 - 2017-08-24
+## 1.4.1
 
 Various documentation fixes.
 
-## 1.4.0 - 2017-08-22
-
-### Enhancements
+## 1.4.0
 
 - Updated import, export, and view icons
 - Improved documentation of various components
 - Improved how `ActionList` handles images and groups
 - Exposed PopoverCloseSource from `Popover` component
-
-### Bug fixes
 
 - Fixed `PageActions` spacing in IE11
 - Fixed ID inconsistency on `TextField`
@@ -3952,23 +2727,17 @@ Various documentation fixes.
 
 - Upgraded javascript-utilities to the latest version
 
-## 1.3.1 - 2017-08-10
-
-### Bug fixes
+## 1.3.1
 
 - Fixed classnames in built \*.scss files
 - Fixed broken link in description list README
 
-## 1.3.0 - 2017-08-09
-
-### Enhancements
+## 1.3.0
 
 - Added an `esnext` build (allows production builds to perform class/method tree shaking)
 - Changed KeyboardKey component to use `kbd` tag
 - Added publishing `docs` folder to npm package
 - Added `fullWidth` option to `Popover` component
-
-### Bug fixes
 
 - Updated Static HTML page examples to correct markup (thanks [@bartcoppens](https://github.com/bartcoppens) for the [original issue](https://github.com/Shopify/polaris-react/issues/159))
 - Hide increment and decrement buttons on number input when disabled (thanks [@kguller](https://github.com/kguller) for the [original issue](https://github.com/Shopify/polaris-react/issues/163))
@@ -3990,8 +2759,6 @@ Various documentation fixes.
 
 ## 1.2.0 (July 27, 2017)
 
-### Enhancements
-
 - Added helpText to `ChoiceList` choices (thanks [@cgenevier](https://github.com/cgenevier) for the [original issue](https://github.com/Shopify/polaris-react/issues/103))
 - Added save icon
 - Added `accessibilityLabel` to `Tabs`
@@ -4002,9 +2769,6 @@ Various documentation fixes.
 - Use default subheading type styles for `ActionList`
 - Improved large `Button` styles
 - Updated font-weight for text emphasis (thanks [@bakura10](https://github.com/bakura10) for the [original issue](https://github.com/Shopify/polaris-react/issues/156))
-
-### Bug fixes
-
 - Removed the focus state for `Banner` on click
 - Fixed disabled `Pagination` button looking active
 - Fixed alignment on `Button`
@@ -4022,8 +2786,6 @@ Various documentation fixes.
 - Updated to Sketch version 45.2
 - Updated layer styles and fonts styles to take advantage of Sketch’s new organizational features.
 
-### Documentation
-
 - Fixed disabled `Button` documentation (thanks [@michaelsunglee](https://github.com/michaelsunglee) for the [original issue](https://github.com/Shopify/polaris-react/issues/113))
 - Fixed project URL in CircleCI badge
 - Fixed Stack documentation (thanks [@nerfologist](https://github.com/nerfologist) for the [original issue](https://github.com/Shopify/polaris-react/issues/120))
@@ -4038,15 +2800,13 @@ Various documentation fixes.
 - Updated EASDK metadata structure for generic interfaces
 - Removed postinstall hook
 
-## 1.1.1 - 2017-06-19
+## 1.1.1
 
 ### Chores
 
 - Fixed a repo issue that caused the public repo release not to happen
 
-## 1.1.0 - 2017-06-19
-
-### Enhancements
+## 1.1.0
 
 - Added automatic inference of the `target` property of EASDK buttons in `Page` `primaryAction` and `secondaryAction` based on their URL (thanks [@jimmyn](https://github.com/jimmyn) for the [original issue](https://github.com/Shopify/polaris-react/issues/46))
 - Added automatic inference of the `target` property of EASDK breadcrumbs in `Page` `breadcrumbs` prop based on the URL
@@ -4061,8 +2821,6 @@ Various documentation fixes.
 ### Changes
 
 - `Avatar` now renders as a `span` instead of a `div`
-
-### Bug fixes
 
 - Fixed contents in `Layout.AnnotatedSection` breaking out of their container (thanks [@cargix1](https://github.com/cargix1) for the [original issue](https://github.com/Shopify/polaris-react/issues/75))
 - Fixed spacing above a `primaryAction` in `CalloutCard` when there is no `secondaryAction`
@@ -4079,8 +2837,6 @@ Various documentation fixes.
 - Updated icon and internal padding of `FooterHelp`
 - Updated the `EmptyState` layout and typographic styles
 
-### Documentation
-
 - Fixed the code examples on the `EmbeddedApp` documentation
 - Added a simple `EmbeddedApp` example
 - Renamed the “Tables and lists” category to “Lists”
@@ -4096,7 +2852,7 @@ Various documentation fixes.
 - Added the correct viewport tag to the Playground
 - Hid deprecation errors during tests
 
-## 1.0.3 - 2017-05-11
+## 1.0.3
 
 ### Big fixes
 
@@ -4120,8 +2876,6 @@ Various documentation fixes.
 - Minor updates to Dataviz and Reports examples
 - Added indicators to Home notifications
 
-### Documentation
-
 - Synchronized component documentation with the style guide ([1e89559](https://github.com/Shopify/polaris-react/commit/1e895594afedb63787e6c05a167f5146901e88e6))
 
 ### Chores
@@ -4132,9 +2886,7 @@ Various documentation fixes.
 - Removed the `@import` statements at the top of source Sass files
 - Updated TSLint and related linting dependencies
 
-## 1.0.2 - 2017-04-25
-
-### Bug fixes
+## 1.0.2
 
 - Fixed an issue where subcomponents with variations would use a single `-` instead of `--` (thanks [@johnsonab](https://github.com/johnsonab) for the [original issue](https://github.com/Shopify/polaris-react/issues/9))
 - Fixed a missing typing dependency and a missing `embedded` types entry point that were causing issues using this package with TypeScript (thanks [@buggy](https://github.com/buggy) for the [original](https://github.com/Shopify/polaris-react/issues/19) [issues](https://github.com/Shopify/polaris-react/issues/20))
@@ -4143,8 +2895,6 @@ Various documentation fixes.
 ### Dependency updates
 
 - Started using the [`prop-types` package](https://github.com/reactjs/prop-types) instead of getting `PropTypes` from `react`, as the latter is deprecated as of React 15.5.0
-
-### Documentation
 
 - Corrected the name of `documentation/Embeddded apps.md` to `documentation/Embedded apps.md` (thanks [@chrispappas](https://github.com/chrispappas) for the [original issue](https://github.com/Shopify/polaris-react/issues/10))
 - Fixed the `ColorPicker` documentation to show valid values for `saturation`, `brightness`, and `alpha` (thanks [@allanarmstrong](https://github.com/allanarmstrong) for the [original issue](https://github.com/Shopify/polaris-react/issues/13))
@@ -4155,12 +2905,12 @@ Various documentation fixes.
 - Added license to `package.json` and to the root of the repo (thanks [@d2s](https://github.com/d2s) for the [original issue](https://github.com/Shopify/polaris-react/issues/15))
 - Fixed an issue where the Webpack example would complain about a missing dependency (thanks [@rafaedez](https://github.com/rafaedez) for the [original issue](https://github.com/Shopify/polaris-react/issues/21))
 
-## 1.0.1 - 2017-04-20
+## 1.0.1
 
 ### Chores
 
 - Switch repo to public access
 
-## 1.0.0 - 2017-04-20
+## 1.0.0
 
 - Initial release

--- a/polaris-tokens/CHANGELOG.md
+++ b/polaris-tokens/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-## [5.0.1] - 2022-05-02
+## 5.0.1
 
 - Exposes .scss file [#5689](https://github.com/Shopify/polaris/pull/5689)
 - Fixes and issue with ESM interoperability [#5686](https://github.com/Shopify/polaris/pull/5686)
 
-## [5.0.0] - 2022-04-29
+## 5.0.0
 
 Polaris Tokens v5.0.0 features an overhaul of the package and the APIs for accessing tokens. Documentation on all of the available tokens can be found at [polaris.shopify.com/tokens/getting-started-with-tokens](https://polaris.shopify.com/tokens/getting-started-with-tokens).
 
@@ -18,131 +13,131 @@ The Sass variables, maps, functions, mixins, and CSS Filters have all been remov
 
 This new version standardizes the token naming across all of the package outputs. Each token is formatted in [kebab-case](https://wiki.c2.com/?KebabCase) following common CSS variable name conventions.
 
-## [4.0.0] - 2021-09-17
+## 4.0.0
 
 - Removed color theme for 6 River Systems MFP UI design system ([#208](https://github.com/Shopify/polaris-tokens/pull/208))
 
-## [3.1.0] - 2021-04-15
+## 3.1.0
 
 Added `iconInteractive` to colors ([#189](https://github.com/Shopify/polaris-tokens/pull/189))
 
-## [3.0.0] - 2021-03-10
+## 3.0.0
 
 - **Breaking:** Move `onSurface.onSurfaceBackground` to `surface.surfaceSearchField`. ([#183](https://github.com/Shopify/polaris-tokens/pull/183))
   Consumers of the variant `onSurfaceBackground` should replace it with `surfaceSearchField`. The color value is unchanged.
 
-## [2.21.1] - 2021-03-03
+## 2.21.1
 
 - Fix `icon` and `action` colors not being exposed in `dist/color-filters.color-map.scss`. ([#182](https://github.com/Shopify/polaris-tokens/pull/182))
 
-## [2.21.0] - 2021-03-02
+## 2.21.0
 
 - Added `mergeConfigs` and `Config` to the public API of `dist-modern/index.js` ([#180](https://github.com/Shopify/polaris-tokens/pull/180))
 - Added esm support for legacy tokens. Doing `import {colorInk} from '@shopify/polaris-tokens';` shall load content from `dist/index.esm.js` which allows for better tree shaking. A default export so you can do `import tokens from '@shopify/polaris-tokens';` is provided for backwards compatability however this is just a stopgap, and will be removed in polaris-tokens v3.0.0. You should use either named imports (`import {colorInk}`) or a namespace import (`import * as tokens`) ([#181](https://github.com/Shopify/polaris-tokens/pull/181))
 
-## [2.20.0] - 2021-02-24
+## 2.20.0
 
 - Added color theme for 6 River Systems MFP UI design system ([#179](https://github.com/Shopify/polaris-tokens/pull/179))
 
-## [2.19.0] - 2021-02-17
+## 2.19.0
 
 - Added support for `.hbs` (handlebars) format templates ([#176](https://github.com/Shopify/polaris-tokens/pull/176))
 - Increased contrast of dark border divider ([#177](https://github.com/Shopify/polaris-tokens/pull/177))
 
-## [2.18.0] - 2021-01-26
+## 2.18.0
 
 - Added prefixed CSS custom properties output for colors ([#174](https://github.com/Shopify/polaris-tokens/pull/174), [#175](https://github.com/Shopify/polaris-tokens/pull/175))
 
-## [2.17.0] - 2021-01-13
+## 2.17.0
 
 - Froze and deprecated design tokens in `./dist`. In a future version, this directory may be moved to `./dist-legacy` ([#170](https://github.com/Shopify/polaris-tokens/pull/170))
 
-## [2.16.0] - 2020-12-17
+## 2.16.0
 
 - Added textPrimary with hovered and pressed variations ([#164](https://github.com/Shopify/polaris-tokens/pull/164))
 
-## [2.15.0] - 2020-11-07
+## 2.15.0
 
 - Changed borderShadow value ([#157](https://github.com/Shopify/polaris-tokens/pull/157))
 
-## [2.14.0] - 2020-11-01
+## 2.14.0
 
 - Adds states for surfaceNeutral ([#155](https://github.com/Shopify/polaris-tokens/pull/155))
 - Changed dark mode values for some subdued borders ([#156](https://github.com/Shopify/polaris-tokens/pull/156))
 
-## [2.13.1] - 2020-11-01
+## 2.13.1
 
 - Moved mistaken border variants to surface variants ([#154](https://github.com/Shopify/polaris-tokens/pull/154))
 
-## [2.13.0] - 2020-11-01
+## 2.13.0
 
 - Add subdued variants to warning, highlight, and success ([#153](https://github.com/Shopify/polaris-tokens/pull/153))
 
-## [2.12.9] - 2020-09-11
+## 2.12.9
 
 - Update action secondary depressed color / add border depressed ([#150](https://github.com/Shopify/polaris-tokens/pull/150))
 
-## [2.12.8] - 2020-09-10
+## 2.12.8
 
 - Add icon and action colors to color-filters-map ([#149](https://github.com/Shopify/polaris-tokens/pull/149))
 
-## [2.12.7] - 2020-09-09
+## 2.12.7
 
 - Updates the onSurface background name ([#147](https://github.com/Shopify/polaris-tokens/pull/147))
 
-## [2.12.6] - 2020-09-09
+## 2.12.6
 
 - Added background under onSurface ([#146](https://github.com/Shopify/polaris-tokens/pull/146))
 
-## [2.12.5] - 2020-09-08
+## 2.12.5
 
 - Updated borderSubdued and added borderShadow, borderShadowSubdued, and divider colors ([#145](https://github.com/Shopify/polaris-tokens/pull/145))
 
-## [2.12.4] - 2020-08-27
+## 2.12.4
 
 - Updated background, surface, and action colors ([#140](https://github.com/Shopify/polaris-tokens/pull/140))
 
-## [2.12.3] - 2020-04-07
+## 2.12.3
 
 - Updated the font stack so that Segoe UI comes before Roboto. ([#131](https://github.com/Shopify/polaris-tokens/pull/131))
 
-## [2.12.2] - 2020-03-25
+## 2.12.2
 
 - Loosened the type of the first argument of `color-factory` to account for stricter merge checks in Typescript 3.8 ([#130](https://github.com/Shopify/polaris-tokens/pull/130))
 
-## [2.12.1] - 2020-03-18
+## 2.12.1
 
 - Adjusted Figma metadata for variants. Adjusted description of one variant. ([#126](https://github.com/Shopify/polaris-tokens/pull/126))
 
-## [2.12.0] - 2020-03-13
+## 2.12.0
 
 - Added variants for border subdued roles ([#123](https://github.com/Shopify/polaris-tokens/pull/123))
 
-## [2.11.0] - 2020-03-11
+## 2.11.0
 
 - Added missing variants ([#121](https://github.com/Shopify/polaris-tokens/pull/121))
 - Updated hover variants ([#120](https://github.com/Shopify/polaris-tokens/pull/120))
 - Updated color variants to use `saturationAdjustmentFn` instead of `saturation` ([#119](https://github.com/Shopify/polaris-tokens/pull/119))
 
-## [2.10.0] - 2020-03-05
+## 2.10.0
 
 - Removed `borderSecondary`, `borderSecondaryHovered`, and `borderSecondaryDisabled` color variants from the `secondary` role in favor of `border` and the newly added `borderHovered` and `borderDisabled` color variants in the `onSurface` role ([#115](https://github.com/Shopify/polaris-tokens/pull/115))
   - Note: This is technically a breaking change although we will continue to ship as minor and patch versions until the new color system is enabled by default in production
 
-## [2.9.0] - 2020-03-03
+## 2.9.0
 
 - Added Figma color name metadata ([#110](https://github.com/Shopify/polaris-tokens/pull/110))
 
-## [2.8.2] - 2020-02-27
+## 2.8.2
 
 - Fixed an issue where dev environment utils and types were exported ([#113](https://github.com/Shopify/polaris-tokens/pull/113))
 
-## [2.8.1] - 2020-02-27
+## 2.8.1
 
 - Updated color variants to match Figma ([#108](https://github.com/Shopify/polaris-tokens/pull/108))
 - Updated `interactiveCritical` description ([#107](https://github.com/Shopify/polaris-tokens/pull/107))
 
-## [2.8.0] - 2020-02-20
+## 2.8.0
 
 - Added color factory and built modern tokens ([#105](https://github.com/Shopify/polaris-tokens/pull/105))
   - Added surface disabled variant and updated other variant configs ([#101](https://github.com/Shopify/polaris-tokens/pull/101))
@@ -155,40 +150,40 @@ Added `iconInteractive` to colors ([#189](https://github.com/Shopify/polaris-tok
   - Marked the config as optional and the colors as partial ([dd3d8fc](https://github.com/Shopify/polaris-tokens/commit/dd3d8fc05572fb03e764a85a0519bbd3dde11855))
   - Added the Color Factory. Long live the Color Factory! ([#89](https://github.com/Shopify/polaris-tokens/pull/89))
 
-## [2.7.0] - 2019-10-28
+## 2.7.0
 
 - Updated filter for the Blue color ([#64](https://github.com/Shopify/polaris-tokens/pull/64))
 - Removed reliance on the Invision DSM import script (colors are now directly managed in `tokens/colors.yml`) ([#66](https://github.com/Shopify/polaris-tokens/pull/66))
 - Added a JSON color export for iOS ([`colors.ios.json`](/dist/colors.ios.json)) ([#86](https://github.com/Shopify/polaris-tokens/pull/86))
 
-## [2.6.0] - 2019-06-06
+## 2.6.0
 
 - Update `color-blue` to `#006fbb` from `#007ace` for accessibility ([#63](https://github.com/Shopify/polaris-tokens/pull/63))
 - Add missing `colorYellowDark` values from ([#44](https://github.com/Shopify/polaris-tokens/pull/44))
 
-## [2.5.0] - 2019-04-19
+## 2.5.0
 
 - Duration tokens (with `type: time`) are treated as unitless and converted to milliseconds in JavaScript formats
 
-## [2.4.0] - 2019-04-04
+## 2.4.0
 
 - Added color names to the Sketch palette ([#53](https://github.com/Shopify/polaris-tokens/pull/53))
 - Fixed a bug where the font family value was wrapped in quotes ([#58](https://github.com/Shopify/polaris-tokens/pull/58))
 
-## [2.3.0] - 2019-02-19
+## 2.3.0
 
 - Added spacing-map format, usable as `spacing.spacing-map.scss` ([#52](https://github.com/Shopify/polaris-tokens/pull/52))
 
-## [2.2.0] - 2019-02-19
+## 2.2.0
 
 - Updated devDependencies ([#45](https://github.com/Shopify/polaris-tokens/pull/45))
 - Added `base-tight` to the spacing map ([#48](https://github.com/Shopify/polaris-tokens/pull/48))
 
-## [2.1.1] - 2019-01-04
+## 2.1.1
 
 - No changes in this version (re-publishing as the 2.1.0 Gem release failed)
 
-## [2.1.0] - 2019-01-04
+## 2.1.0
 
 - Updated `color-yellow-dark` for accessibility ([#44](https://github.com/Shopify/polaris-tokens/pull/44))
 - Documented how to import tokens using ES Modules ([#37](https://github.com/Shopify/polaris-tokens/pull/37))
@@ -196,7 +191,7 @@ Added `iconInteractive` to colors ([#189](https://github.com/Shopify/polaris-tok
 - Updated Node.js & Ruby dependencies
 - Reformatted files using sewing-kit
 
-## [2.0.0] - 2018-10-23
+## 2.0.0
 
 - **Breaking:** renamed `colors.android-colors.xml` to `colors.android.xml`
 - **Breaking:** removed `-base` suffix from base color token names (fixes [#16](https://github.com/Shopify/polaris-tokens/issues/16))
@@ -212,24 +207,24 @@ Added `iconInteractive` to colors ([#189](https://github.com/Shopify/polaris-tok
 - Updated dependencies, including Theo to from `^7.0.1` to `8.0.0-beta.2`
 - Updated the Android token format to enable it to format other properties than just colors
 
-## [1.3.1] - 2018-07-09
+## 1.3.1
 
 - Updated devDependencies, including [Prettier](https://prettier.io/). This reformatted SCSS files in `./dist/` but didn’t impact the tokens themselves.
 
-## [1.3.0] - 2018-06-29
+## 1.3.0
 
 - Added [`colors.android-colors.xml`](https://github.com/Shopify/polaris-tokens/blob/main/dist/colors.android-colors.xml), for Android apps
 
-## [1.2.0] - 2018-05-30
+## 1.2.0
 
 - `ase` and `clr` palettes: removed the `color-` prefix from color names
 - Updated devDependencies
 
-## [1.1.0] - 2018-04-24
+## 1.1.0
 
 Polaris tokens are now available as both a [npm package](https://www.npmjs.com/package/@shopify/polaris-tokens) and a [Ruby gem](https://rubygems.org/gems/polaris_tokens)! Check the [README](https://github.com/Shopify/polaris-tokens/blob/main/README.md) for installation and usage instructions for both.
 
-## 1.0.0 - 2018-04-13
+## 1.0.0
 
 First stable release 🎉
 
@@ -238,48 +233,3 @@ Color design tokens are now used in:
 - `Shopify/shopify`
 - `Shopify/polaris-styleguide`
 - `Shopify/polaris-react` (`@shopify/polaris` v2 on npm)
-
-[unreleased]: https://github.com/Shopify/polaris-tokens/compare/v4.0.0...HEAD
-[4.0.0]: https://github.com/Shopify/polaris-tokens/compare/v3.1.0...v4.0.0
-[3.1.0]: https://github.com/Shopify/polaris-tokens/compare/v3.0.0...v3.1.0
-[3.0.0]: https://github.com/Shopify/polaris-tokens/compare/v2.21.1...v3.0.0
-[2.21.1]: https://github.com/Shopify/polaris-tokens/compare/v2.21.0...v2.21.1
-[2.21.0]: https://github.com/Shopify/polaris-tokens/compare/v2.20.0...v2.21.0
-[2.20.0]: https://github.com/Shopify/polaris-tokens/compare/v2.19.0...v2.20.0
-[2.19.0]: https://github.com/Shopify/polaris-tokens/compare/v2.18.0...v2.19.0
-[2.18.0]: https://github.com/Shopify/polaris-tokens/compare/v2.17.0...v2.18.0
-[2.17.0]: https://github.com/Shopify/polaris-tokens/compare/v2.16.0...v2.17.0
-[2.16.0]: https://github.com/Shopify/polaris-tokens/compare/v2.15.0...v2.16.0
-[2.15.0]: https://github.com/Shopify/polaris-tokens/compare/v2.14.0...v2.15.0
-[2.14.0]: https://github.com/Shopify/polaris-tokens/compare/v2.13.1...v2.14.0
-[2.13.1]: https://github.com/Shopify/polaris-tokens/compare/v2.13.0...v2.13.1
-[2.13.0]: https://github.com/Shopify/polaris-tokens/compare/v2.12.9...v2.13.0
-[2.12.9]: https://github.com/Shopify/polaris-tokens/compare/v2.12.8...v2.12.9
-[2.12.8]: https://github.com/Shopify/polaris-tokens/compare/v2.12.7...v2.12.8
-[2.12.7]: https://github.com/Shopify/polaris-tokens/compare/v2.12.6...v2.12.7
-[2.12.6]: https://github.com/Shopify/polaris-tokens/compare/v2.12.5...v2.12.6
-[2.12.5]: https://github.com/Shopify/polaris-tokens/compare/v2.12.4...v2.12.5
-[2.12.4]: https://github.com/Shopify/polaris-tokens/compare/v2.12.3...v2.12.4
-[2.12.3]: https://github.com/Shopify/polaris-tokens/compare/v2.12.2...v2.12.3
-[2.12.2]: https://github.com/Shopify/polaris-tokens/compare/v2.12.1...v2.12.2
-[2.12.1]: https://github.com/Shopify/polaris-tokens/compare/v2.12.0...v2.12.1
-[2.12.0]: https://github.com/Shopify/polaris-tokens/compare/v2.11.0...v2.12.0
-[2.11.0]: https://github.com/Shopify/polaris-tokens/compare/v2.10.0...v2.11.0
-[2.10.0]: https://github.com/Shopify/polaris-tokens/compare/v2.9.0...v2.10.0
-[2.9.0]: https://github.com/Shopify/polaris-tokens/compare/v2.8.2...v2.9.0
-[2.8.2]: https://github.com/Shopify/polaris-tokens/compare/v2.8.1...v2.8.2
-[2.8.1]: https://github.com/Shopify/polaris-tokens/compare/v2.8.0...v2.8.1
-[2.8.0]: https://github.com/Shopify/polaris-tokens/compare/v2.7.0...v2.8.0
-[2.7.0]: https://github.com/Shopify/polaris-tokens/compare/v2.6.0...v2.7.0
-[2.6.0]: https://github.com/Shopify/polaris-tokens/compare/v2.5.0...v2.6.0
-[2.5.0]: https://github.com/Shopify/polaris-tokens/compare/v2.4.0...v2.5.0
-[2.4.0]: https://github.com/Shopify/polaris-tokens/compare/v2.3.0...v2.4.0
-[2.3.0]: https://github.com/Shopify/polaris-tokens/compare/v2.2.0...v2.3.0
-[2.2.0]: https://github.com/Shopify/polaris-tokens/compare/v2.1.1...v2.2.0
-[2.1.1]: https://github.com/Shopify/polaris-tokens/compare/v2.1.0...v2.1.1
-[2.1.0]: https://github.com/Shopify/polaris-tokens/compare/v2.0.0...v2.1.0
-[2.0.0]: https://github.com/Shopify/polaris-tokens/compare/v1.3.1...v2.0.0
-[1.3.1]: https://github.com/Shopify/polaris-tokens/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/Shopify/polaris-tokens/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/Shopify/polaris-tokens/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/Shopify/polaris-tokens/compare/v1.0.0...v1.1.0

--- a/stylelint-polaris/CHANGELOG.md
+++ b/stylelint-polaris/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.0
+
+Initial release


### PR DESCRIPTION
### WHY are these changes introduced?

Before we start shipping automated changelogs this cleans up the format for future changes.

### WHAT is this pull request doing?

- [x] Removes the description below the `# Changelog` title
- [x] Adds `Changelog.md` files for directories without them
- [x] Removes `v` in front of versions
- [x] Removes sub titles before changes. This feels easier to parse as the changes are already descriptive.
- [x] Removes dates from changelogs. Unsure the value of dates. Developers just need the information from the changes that shipped not the date.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
