### PR TITLE
[Page] Fix page without header section causes scroll

### DIFF
--- a/.changeset/shy-suns-peel.md
+++ b/.changeset/shy-suns-peel.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fix scroll caused by Page without header section
+Fixed  `Page` without header section causing unnecessary scrollbar

--- a/.changeset/shy-suns-peel.md
+++ b/.changeset/shy-suns-peel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix scroll caused by Page without header section

--- a/polaris-react/src/styles/shared/_page.scss
+++ b/polaris-react/src/styles/shared/_page.scss
@@ -9,10 +9,10 @@
 }
 
 @mixin page-content-layout {
-  margin: var(--p-space-2) 0;
+  padding: var(--p-space-2) 0;
 
   @include page-content-when-not-partially-condensed {
-    margin-top: var(--p-space-5);
+    padding-top: var(--p-space-5);
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

When a `Page` component does not have any attribute that generates a `Header`, the content adds some margin to create a proper separation to the top of the page. That separation is created with a margin (contrary to the header, which uses padding to create that space) which affects the `body` position and creates an undesired scroll.

<details>
      <summary>Bug reproduction on the playground</summary>
      <img src="https://screenshot.click/25-09-5q3ay-wp6gs.gif" alt="canvas section off the playground, empty except for a text 'Page with no header section'. The page scrolls slightly up and down ">
    </details>

### WHAT is this pull request doing?

Changed the margin by padding so it doesn't affect the body position.

Before:
![playground, the body element of the canvas is selected with the element inspector. A red arrow points to a space left between the body and the top of the page. At the bottom, the body overflows the canvas](https://screenshot.click/25-25-nhhhj-g1n5q.png)

After:
![playground, the body element of the canvas is selected with the element inspector. It fits the canvas area perfectly](https://screenshot.click/25-27-9cr6m-c3ltj.png)


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
