### PR TITLE
[PageActions] Add ReactNode as an accepted primaryAction prop value for customizability

### DIFF
--- a/.changeset/four-doors-cheer.md
+++ b/.changeset/four-doors-cheer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Adds the ability for the primaryAction in PageActions to take a ReactNode

--- a/.changeset/four-doors-cheer.md
+++ b/.changeset/four-doors-cheer.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Adds the ability for the primaryAction in PageActions to take a ReactNode
+Adds support for setting a `ReactNode` on the `PageActions` `primaryActions` prop

--- a/.changeset/four-doors-cheer.md
+++ b/.changeset/four-doors-cheer.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Adds support for setting a `ReactNode` on the `PageActions` `primaryActions` prop
+Added support for setting a `ReactNode` on the `PageActions` `primaryAction` prop

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -15,7 +15,7 @@ import styles from './PageActions.scss';
 
 export interface PageActionsProps {
   /** The primary action for the page */
-  primaryAction?: DisableableAction & LoadableAction;
+  primaryAction?: (DisableableAction & LoadableAction) | React.ReactNode;
   /** The secondary actions for the page */
   secondaryActions?: ComplexAction[] | React.ReactNode;
 }
@@ -26,9 +26,15 @@ export function PageActions({
   primaryAction,
   secondaryActions,
 }: PageActionsProps) {
-  const primaryActionMarkup = primaryAction
-    ? buttonsFrom(primaryAction, {primary: true})
-    : null;
+  let primaryActionMarkup: MaybeJSX = null;
+  if (isReactElement(primaryAction)) {
+    primaryActionMarkup = <>{primaryAction}</>;
+  } else if (primaryAction) {
+    primaryActionMarkup = buttonsFrom(primaryAction, {primary: true});
+  }
+  // const primaryActionMarkup = primaryAction
+  //   ? buttonsFrom(primaryAction, {primary: true})
+  //   : null;
 
   let secondaryActionsMarkup: MaybeJSX = null;
   if (isInterface(secondaryActions) && secondaryActions.length > 0) {

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -32,9 +32,6 @@ export function PageActions({
   } else if (primaryAction) {
     primaryActionMarkup = buttonsFrom(primaryAction, {primary: true});
   }
-  // const primaryActionMarkup = primaryAction
-  //   ? buttonsFrom(primaryAction, {primary: true})
-  //   : null;
 
   let secondaryActionsMarkup: MaybeJSX = null;
   if (isInterface(secondaryActions) && secondaryActions.length > 0) {

--- a/polaris-react/src/components/PageActions/README.md
+++ b/polaris-react/src/components/PageActions/README.md
@@ -114,6 +114,32 @@ Not all page actions require a secondary action.
 />
 ```
 
+### Page actions with custom primary action
+
+Use to create a custom primary action.
+
+```jsx
+<PageActions
+  primaryAction={
+    <Button
+      primary
+      connectedDisclosure={{
+        accessibilityLabel: 'Other save actions',
+        actions: [{content: 'Save as new'}],
+      }}
+    >
+      Save
+    </Button>
+  }
+  secondaryActions={[
+    {
+      content: 'Delete',
+      destructive: true,
+    },
+  ]}
+/>
+```
+
 ### Page actions with custom secondary action
 
 Use to create a custom secondary action.

--- a/polaris-react/src/components/PageActions/README.md
+++ b/polaris-react/src/components/PageActions/README.md
@@ -125,7 +125,7 @@ Use to create a custom primary action.
       primary
       connectedDisclosure={{
         accessibilityLabel: 'Other save actions',
-        actions: [{content: 'Save as new'}],
+        actions: [{content: 'Save as draft'}],
       }}
     >
       Save

--- a/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
+++ b/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
@@ -54,6 +54,15 @@ describe('<PageActions />', () => {
       mountWithApp(<PageActions primaryAction={mockAction} />);
       expect(buttonsFrom).toHaveBeenCalledWith(mockAction, {primary: true});
     });
+
+    it('renders <CustomPrimaryAction /> if `ReactNode` is provided as `primaryAction`', () => {
+      const CustomPrimaryAction = () => null;
+      const pageActions = mountWithApp(
+        <PageActions primaryAction={<CustomPrimaryAction />} />,
+      );
+
+      expect(pageActions).toContainReactComponent(CustomPrimaryAction);
+    });
   });
 
   describe('secondaryActions', () => {

--- a/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
+++ b/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
@@ -55,7 +55,7 @@ describe('<PageActions />', () => {
       expect(buttonsFrom).toHaveBeenCalledWith(mockAction, {primary: true});
     });
 
-    it('renders <CustomPrimaryAction /> if `ReactNode` is provided as `primaryAction`', () => {
+    it('renders a `ReactNode`', () => {
       const CustomPrimaryAction = () => null;
       const pageActions = mountWithApp(
         <PageActions primaryAction={<CustomPrimaryAction />} />,


### PR DESCRIPTION
### WHY are these changes introduced?

This PR is related to [recent changes](https://github.com/Shopify/polaris/pull/5495
) to support passing a `React.ReactNode` to the `secondaryActions` prop of the `PageActions` component (and much of this PR's description is plagiarized from that one; thank you @stefanlegg!).

Currently `primaryAction` on `PageActions` only allows for passing props as `DisableableAction & LoadableAction`. This doesn't allow for flexibility and results in accessibility issues in some cases.

In cases where the primary action opens a modal, we are unable to move focus back to the button that opened it after the modal is closed. With this change to accept `React.ReactNode` we are better able to support keyboard users through passing an entire modal as the primary action to leverage modal's built-in focus management, or through passing a custom button with a ref to receive the focus.

This is also consistent with current behavior of the `Page` component, which can accept a `React.ReactNode` as its `primaryAction` prop.

### WHAT is this pull request doing?

This PR maintains the existing `primaryAction` prop, while adding the option to pass a `React.ReactNode` instead for customizability.

I've also added a new example to the README for this component, highlighting this new supported prop type by passing in a custom button to `primaryAction`.

#### My new example in storybook
![It displays a destructive delete button as the secondary action to the left, and a custom Save button with a drop-down arrow beside it as the primary action.](https://user-images.githubusercontent.com/7571219/170517336-ddb71e53-ee42-46e5-a42f-f6a74fc0b89c.png)

![It also displays correctly on small mobile mode in storybook](https://user-images.githubusercontent.com/7571219/170517337-b3e59b5c-be40-4277-8eee-28c09ce489bb.png)

#### My new example on the style guide site

![The new example I added displays on the polaris-styleguide site running locally](https://user-images.githubusercontent.com/7571219/170515321-108f105d-2e8c-4d33-aa81-28dae227c1c0.png)

#### Tophatted in web

The disabled button to the right has been passed in as a `React.ReactNode`.

![The bottom of a page in settings showing a destructive delete pixel button on the left and a disabled connect pixel button on the right](https://user-images.githubusercontent.com/7571219/170520404-daa5e34d-2ba3-4509-801e-abf91e8fa2a4.png)


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Use the Polaris snapshot release with polaris-styleguide (`yarn add @shopify/polaris@0.0.0-snapshot-release-20220525220051`) to verify that the new example displays in the documentation.

In storybook, verify that the `PageActions/Page actions with custom primary action` story displays a custom primary action, in this case a "Save" button with a drop-down option to "save as draft".

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
