### PR TITLE
[TokenList] Add copy/paste tooltip for tokens v1

### DIFF
--- a/.changeset/smart-feet-listen.md
+++ b/.changeset/smart-feet-listen.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Add copy/paste tooltip for tokens

--- a/polaris.shopify.com/public/icon-clipboard.svg
+++ b/polaris.shopify.com/public/icon-clipboard.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" style="filter: brightness(1.25);">
+    <path d="M15 2a1 1 0 011 1v13.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 014 16.5V3a1 1 0 112 0v1a2 2 0 002 2h4a2 2 0 002-2V3a1 1 0 011-1zm-4 2H9a1 1 0 110-2h2a1 1 0 110 2z" fill="#5C5F62"/>
+</svg>

--- a/polaris.shopify.com/src/components/TokenList/TokenList.module.scss
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.module.scss
@@ -56,6 +56,10 @@
 }
 
 .TokenName {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
   h4 {
     display: inline;
     border-radius: var(--border-radius-400);
@@ -85,5 +89,24 @@
         display: flex;
       }
     }
+  }
+}
+
+.TokenToolTip {
+  p {
+    font-size: 14px;
+    margin-top: 0rem;
+  }
+}
+
+.TokenToolTipImage {
+  display: flex;
+  padding-left: 0.1rem;
+  min-width: 25px;
+  filter: brightness(1.25);
+
+  &:hover {
+    filter: brightness(0.5);
+    cursor: pointer;
   }
 }

--- a/polaris.shopify.com/src/components/TokenList/TokenList.module.scss
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.module.scss
@@ -103,7 +103,6 @@
   display: flex;
   padding-left: 0.1rem;
   min-width: 25px;
-  filter: brightness(1.25);
 
   &:hover {
     filter: brightness(0.5);

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -6,11 +6,7 @@ import {
 import { className } from "../../utils/various";
 import Tooltip from "../Tooltip";
 import { useCopyToClipboard } from "../../utils/hooks";
-const importedSvgs = require.context(
-  "../../../../polaris-icons/icons",
-  true,
-  /\.svg$/
-);
+import iconClipboard from "../../../public/icon-clipboard.svg"
 import Image from "../Image";
 
 interface TokenListProps {
@@ -86,7 +82,8 @@ function TokenListItem({
   isHighlighted,
 }: TokenListItemProps) {
   const figmaRecommendation = getFigmaRecommendationForToken(name, value);
-  const [copy, didJustCopy] = useCopyToClipboard(`--p-${name}`);
+  const tokenNameWithPrefix = `--p-${name}`
+  const [copy, didJustCopy] = useCopyToClipboard(tokenNameWithPrefix);
 
   return (
     <li
@@ -101,7 +98,7 @@ function TokenListItem({
       </div>
       <div className={styles.TokenInfo}>
         <div className={styles.TokenName}>
-          <h4>--p-{name}</h4>
+          <h4>{tokenNameWithPrefix}</h4>
           <Tooltip 
             ariaLabel="Copy to clipboard"
             placement="top"
@@ -113,9 +110,9 @@ function TokenListItem({
               </div>
             )}
           >
-            <div className={styles.TokenToolTipImage} onClick={()=>copy()}>
+            <div className={styles.TokenToolTipImage} onClick={copy}>
               <Image
-                src={importedSvgs(`./ClipboardMinor.svg`)}
+                src={iconClipboard}
                 alt={"Copy"}
                 width={19}
                 height={19}

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -4,6 +4,14 @@ import {
   TokenPropertiesWithName,
 } from "../../types";
 import { className } from "../../utils/various";
+import Tooltip from "../Tooltip";
+import { useCopyToClipboard } from "../../utils/hooks";
+const importedSvgs = require.context(
+  "../../../../polaris-icons/icons",
+  true,
+  /\.svg$/
+);
+import Image from "../Image";
 
 interface TokenListProps {
   layout?: "grid" | "list";
@@ -78,6 +86,7 @@ function TokenListItem({
   isHighlighted,
 }: TokenListItemProps) {
   const figmaRecommendation = getFigmaRecommendationForToken(name, value);
+  const [copy, didJustCopy] = useCopyToClipboard(`--p-${name}`);
 
   return (
     <li
@@ -93,6 +102,26 @@ function TokenListItem({
       <div className={styles.TokenInfo}>
         <div className={styles.TokenName}>
           <h4>--p-{name}</h4>
+          <Tooltip 
+            ariaLabel="Copy to clipboard"
+            placement="top"
+            renderContent={() => (
+              <div className={styles.TokenToolTip}>
+                <p>
+                  {didJustCopy ? "Copied!" : "Copy to clipboard"}
+                </p>
+              </div>
+            )}
+          >
+            <div className={styles.TokenToolTipImage} onClick={()=>copy()}>
+              <Image
+                src={importedSvgs(`./ClipboardMinor.svg`)}
+                alt={"Copy"}
+                width={19}
+                height={19}
+              />
+            </div>
+          </Tooltip>
         </div>
         {description && <p>{description}</p>}
         {figmaRecommendation && (


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#5902](https://github.com/Shopify/polaris/issues/5902)

Currently there is no quick way for users to copy tokens directly from the webpage.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds a clipboard icon next to the token name, which when clicked copies the token to the user clipboard along with showing a tooltip with the action status.

<details>
<summary>
After — feature implemented
</summary>
</details>

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:
-->

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
