### PR TITLE
[Card] Fix card header that goes to the next line when actions or titles are long

### DIFF
--- a/.changeset/swift-carpets-poke.md
+++ b/.changeset/swift-carpets-poke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+fix card header to ensure it links don't go to next line

--- a/polaris-react/src/components/Card/Card.scss
+++ b/polaris-react/src/components/Card/Card.scss
@@ -37,6 +37,11 @@
 .Header {
   padding: var(--p-space-4) var(--p-space-4) 0;
 
+  .Action {
+    display: flex;
+    justify-content: flex-end;
+  }
+
   @include page-content-when-not-fully-condensed {
     padding: var(--p-space-5) var(--p-space-5) 0;
   }

--- a/polaris-react/src/components/Card/README.md
+++ b/polaris-react/src/components/Card/README.md
@@ -692,6 +692,27 @@ Use when you need further control over the spacing of your card sections.
 </Card>
 ```
 
+### Card with a long title and long action
+
+<!-- example-for: web -->
+
+Use when there is a long version of title and actions on card header.
+
+```jsx
+<Card
+  sectioned
+  title="Aperçu du résultat sur les moteurs de recherche"
+  actions={[{content: 'Modifier le référencement naturel de la page'}]}
+>
+  <Card.Section>
+    <TextContainer>
+      Add a description to see how this product might appear in a search engine
+      listing
+    </TextContainer>
+  </Card.Section>
+</Card>
+```
+
 ---
 
 ## Related components

--- a/polaris-react/src/components/Card/components/Header/Header.tsx
+++ b/polaris-react/src/components/Card/components/Header/Header.tsx
@@ -15,7 +15,9 @@ export interface CardHeaderProps {
 
 export function Header({children, title, actions}: CardHeaderProps) {
   const actionMarkup = actions ? (
-    <ButtonGroup>{buttonsFrom(actions, {plain: true})}</ButtonGroup>
+    <ButtonGroup>
+      {buttonsFrom(actions, {plain: true, textAlign: 'right'})}
+    </ButtonGroup>
   ) : null;
 
   const titleMarkup = isValidElement(title) ? (
@@ -26,9 +28,11 @@ export function Header({children, title, actions}: CardHeaderProps) {
 
   const headingMarkup =
     actionMarkup || children ? (
-      <Stack alignment="baseline">
+      <Stack alignment="baseline" wrap={false}>
         <Stack.Item fill>{titleMarkup}</Stack.Item>
-        {actionMarkup}
+        <Stack.Item fill>
+          <div className={styles.Action}>{actionMarkup}</div>
+        </Stack.Item>
         {children}
       </Stack>
     ) : (


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

- Card on the search engine listing preview is breaking on longer languages as found by the quality crew team.
- Fixes https://github.com/Shopify/shopify/issues/326986

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Allows longer actions and titles to have enough room
- Creates a story for the fix

![Screenshot of the card showing fix with longer actions and titles](https://screenshot.click/26-25-28913-93530.png)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
