### PR TITLE
polaris.shopify.com restore prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,3 @@ dist
 node_modules
 /polaris-react/build
 /polaris-react/build-internal
-
-# temp ignore polaris.shopify.com
-/polaris.shopify.com


### PR DESCRIPTION
In #5562 we ignored [polaris.shopify.com in .prettierignore](https://github.com/Shopify/polaris/commit/a5ed02614ff842b1c3086bdc68eddb06a384beea#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R7-R9). This PR reverts that change so format on save and other formatting works again.