### PR TITLE
[Pages] Fix missing padding at the bottom of pages without a PageAction or FooterHelper component

### DIFF
--- a/.changeset/hip-bugs-draw.md
+++ b/.changeset/hip-bugs-draw.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+adds some styling to page

--- a/.changeset/odd-singers-kick.md
+++ b/.changeset/odd-singers-kick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+adds some styling to Page component

--- a/polaris-react/src/components/Page/Page.scss
+++ b/polaris-react/src/components/Page/Page.scss
@@ -39,3 +39,7 @@ body {
   border-top: var(--p-border-divider);
   padding-top: var(--p-space-4);
 }
+
+.noFooter {
+  padding-bottom: var(--p-space-6);
+}

--- a/polaris-react/src/components/Page/Page.tsx
+++ b/polaris-react/src/components/Page/Page.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import {isElementOfType} from 'react-dom/test-utils';
 
+import {elementChildren} from '../../utilities/components';
 import {classNames} from '../../utilities/css';
 import {isInterface} from '../../utilities/is-interface';
 import {isReactElement} from '../../utilities/is-react-element';
+import {FooterHelp} from '../FooterHelp';
+import {PageActions} from '../PageActions';
 
 import {Header, HeaderProps} from './components';
 import styles from './Page.scss';
@@ -41,9 +45,18 @@ export function Page({
     (rest.actionGroups != null && rest.actionGroups.length > 0) ||
     (rest.breadcrumbs != null && rest.breadcrumbs.length > 0);
 
+  const hasFooterContent = elementChildren(children)
+    .map(
+      (child) =>
+        isElementOfType(child, PageActions) ||
+        isElementOfType(child, FooterHelp),
+    )
+    .at(-1);
+
   const contentClassName = classNames(
     !hasHeaderContent && styles.Content,
     divider && hasHeaderContent && styles.divider,
+    !hasFooterContent && styles.noFooter,
   );
 
   const headerMarkup = hasHeaderContent ? <Header {...rest} /> : null;

--- a/polaris-react/src/components/Page/Page.tsx
+++ b/polaris-react/src/components/Page/Page.tsx
@@ -45,13 +45,12 @@ export function Page({
     (rest.actionGroups != null && rest.actionGroups.length > 0) ||
     (rest.breadcrumbs != null && rest.breadcrumbs.length > 0);
 
-  const hasFooterContent = elementChildren(children)
-    .map(
-      (child) =>
-        isElementOfType(child, PageActions) ||
-        isElementOfType(child, FooterHelp),
-    )
-    .at(-1);
+  const footerContent =
+    elementChildren(children)[elementChildren(children).length - 1];
+
+  const hasFooterContent =
+    isElementOfType(footerContent, PageActions) ||
+    isElementOfType(footerContent, FooterHelp);
 
   const contentClassName = classNames(
     !hasHeaderContent && styles.Content,

--- a/polaris-react/src/components/Page/tests/Page.test.tsx
+++ b/polaris-react/src/components/Page/tests/Page.test.tsx
@@ -7,6 +7,8 @@ import {Badge} from '../../Badge';
 import {Card} from '../../Card';
 import {Page, PageProps} from '../Page';
 import {Header} from '../components';
+import {PageActions} from '../../PageActions';
+import {FooterHelp} from '../../FooterHelp';
 
 window.matchMedia =
   window.matchMedia ||
@@ -22,6 +24,8 @@ describe('<Page />', () => {
   const mockProps: PageProps = {
     title: 'Test',
   };
+  const footerAction = <PageActions />;
+  const footerHelp = <FooterHelp />;
 
   beforeEach(() => {
     animationFrame.mock();
@@ -260,14 +264,18 @@ describe('<Page />', () => {
 
   describe('divider', () => {
     it('renders border when divider is true and header props exist', () => {
-      const wrapper = mountWithApp(<Page {...mockProps} divider />);
+      const wrapper = mountWithApp(
+        <Page {...mockProps} divider>
+          {footerAction}
+        </Page>,
+      );
       expect(wrapper).toContainReactComponent('div', {
         className: 'divider',
       });
     });
 
     it('does not render border when divider is true and no header props exist', () => {
-      const wrapper = mountWithApp(<Page divider />);
+      const wrapper = mountWithApp(<Page divider>{footerAction}</Page>);
       expect(wrapper).not.toContainReactComponent('div', {
         className: 'Content divider',
       });
@@ -288,6 +296,22 @@ describe('<Page />', () => {
     it('is not rendered when there is no header content', () => {
       const page = mountWithApp(<Page title="" />);
       expect(page).not.toContainReactComponent(Header);
+    });
+  });
+
+  describe('footer or pageactions', () => {
+    it('renders some spacing at the bottom when there is no FooterHelp or PageAction component', () => {
+      const wrapper = mountWithApp(<Page {...mockProps} />);
+      expect(wrapper).toContainReactComponent('div', {
+        className: 'noFooter',
+      });
+    });
+
+    it('does not render spacing at the bottom when there is a Pageaction or FooterHelp component', () => {
+      const wrapper = mountWithApp(<Page>{footerHelp}</Page>);
+      expect(wrapper).not.toContainReactComponent('div', {
+        className: 'noFooter',
+      });
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

- Pages without a footer lack spacing at the bottom as found by the quality team
- The feedback provided on my last PR pointed out that the PageAction has additional padding to it, and as discovered on more issues (see below), the FooterHelper also has some additional padding
- This PR adds the padding only to Pages that have neither PageAction not FooterHelper as their last elements

Fixes https://github.com/Shopify/shopify/issues/331158 and https://github.com/Shopify/shopify/issues/3431263
Related closed PR https://github.com/Shopify/polaris/pull/5898

- If this is to be approved, the manual bottom margins applied to a few pages such as the notifications, reports and payouts pages will need to be fixed

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
