### PR TITLE
[Page] Fix divider so that it has a padding of 32px

### DIFF
--- a/.changeset/brave-kids-heal.md
+++ b/.changeset/brave-kids-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+changes divider padding on page component

--- a/polaris-react/src/components/Page/Page.scss
+++ b/polaris-react/src/components/Page/Page.scss
@@ -37,5 +37,5 @@ body {
 
 .divider {
   border-top: var(--p-border-divider);
-  padding-top: var(--p-space-4);
+  padding-top: var(--p-space-8);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

- Changes the page padding underneath the divider from 16px to 32px 

Fixes https://github.com/Shopify/shopify/issues/353025

Please see here for fix results: https://github.com/Shopify/web/pull/65757

Storybook example:
![Screenshot of page with divider](https://screenshot.click/31-05-1937-86931.png)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)