### PR TITLE
[Tooltip] [TextField] Remove stopPropagation from Tooltip 

### DIFF
--- a/.changeset/dirty-grapes-fail.md
+++ b/.changeset/dirty-grapes-fail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Remove stopPropagation from click handler in the Tooltip component. Relax instanceof check in focus-setting logic in TextField component to allow SVG elements as prefix/suffix/verticalContent. 

--- a/.changeset/dirty-grapes-fail.md
+++ b/.changeset/dirty-grapes-fail.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Remove stopPropagation from click handler in the Tooltip component. Relax instanceof check in focus-setting logic in TextField component to allow SVG elements as prefix/suffix/verticalContent. 
+Fixed click events not propagating in `Tooltip` and added support for SVG elements as `prefix`, `suffix`, and `verticalContent` in `TextField` 

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -585,17 +585,17 @@ export function TextField({
     event.preventDefault();
   }
 
-  function isPrefixOrSuffix(target: HTMLElement | EventTarget) {
+  function isPrefixOrSuffix(target: Element | EventTarget) {
     return (
-      target instanceof HTMLElement &&
+      target instanceof Element &&
       ((prefixRef.current && prefixRef.current.contains(target)) ||
         (suffixRef.current && suffixRef.current.contains(target)))
     );
   }
 
-  function isVerticalContent(target: HTMLElement | EventTarget) {
+  function isVerticalContent(target: Element | EventTarget) {
     return (
-      target instanceof HTMLElement &&
+      target instanceof Element &&
       verticalContentRef.current &&
       (verticalContentRef.current.contains(target) ||
         verticalContentRef.current.contains(document.activeElement))

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -95,7 +95,6 @@ export function Tooltip({
       onBlur={handleBlur}
       onMouseLeave={handleMouseLeave}
       onMouseOver={handleMouseEnterFix}
-      onClick={stopPropagation}
       ref={setActivator}
       onKeyUp={handleKeyUp}
     >
@@ -136,7 +135,3 @@ export function Tooltip({
 }
 
 function noop() {}
-
-function stopPropagation(event: React.MouseEvent<any>) {
-  event.stopPropagation();
-}

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -121,21 +121,6 @@ describe('<Tooltip />', () => {
       accessibilityLabel,
     });
   });
-
-  it('invokes stopPropagation', () => {
-    const stopPropagationSpy = jest.fn();
-    const tooltip = mountWithApp(
-      <Tooltip content="Inner content">
-        <Link>link content</Link>
-      </Tooltip>,
-    );
-
-    tooltip
-      .find('span')!
-      .trigger('onClick', {stopPropagation: stopPropagationSpy});
-
-    expect(stopPropagationSpy).toHaveBeenCalled();
-  });
 });
 
 function findWrapperComponent(tooltip: any) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5981

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This PR does two things:
- Reverts https://github.com/Shopify/polaris/pull/3959, which will once again allow click events on Tooltips to propagate to other listeners 
- Relaxes a `target instanceof HTMLElement` check to `target instanceof Element` that will allow click events on SVG/Icon elements to pass the early return condition in [`isPrefixOrSuffix`](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/TextField/TextField.tsx#L590) and [`isVerticalContent`](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/TextField/TextField.tsx#L598).

Looking back at the [original PR](https://github.com/Shopify/polaris/pull/3959), I think perhaps the actual issue is not with the `Tooltip`, but rather a problem with the `TextField`'s focus logic. There is an early return in the [`handleClick`](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/TextField/TextField.tsx#L618-L629) function that avoids calling `focus()` on the input if the event target is either a prefix/suffix/verticalContent. The issue is that the `instanceof` only returns true if the target is an `HTMLElement`, which doesn't work for `Icon` components, which may have a prototype of either `SVGPathElement` or `SVGSVGElement`.

I suspect that this `instanceof` check was only added to satisfy Typescript, but definitely let me know if there are some nuances that I'm missing!

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Clicking on the suffix in each of these `TextField` components should _not_ call focus to the input.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```tsx
import React, {useState, useCallback} from 'react';
import {InfoMinor, QuestionMarkMinor} from '@shopify/polaris-icons';

import {Page, TextField, Tooltip, Icon} from '../src';

function TooltipTextFieldExample() {
  const [value, setValue] = useState('');
  const handleChange = useCallback((newValue) => setValue(newValue), []);
  return (
    <div style={{padding: '75px 0', width: '300px'}}>
      <TextField
        id="input-1"
        value={value}
        label="Icon with Tooltip suffix -- SVGSVGElement"
        onChange={handleChange}
        autoComplete="off"
        suffix={
          <Tooltip content="To show a reduced price, move the variant's original price into Compare at price. Enter a lower value into Price.">
            <Icon source={QuestionMarkMinor} />
          </Tooltip>
        }
      />
      <TextField
        id="just-icon"
        value={value}
        label="Just an Icon -- SVGPathElement"
        onChange={handleChange}
        autoComplete="off"
        suffix={<Icon source={InfoMinor} />}
      />
      <TextField
        id="just-div"
        value={value}
        label="Just a div -- HTMLDivElement"
        onChange={handleChange}
        autoComplete="off"
        suffix={<div>Suffix</div>}
      />
    </div>
  );
}

export function Playground() {
  return (
    <Page title="Playground">
      <TooltipTextFieldExample />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
