### PR TITLE
[ActionList] Decouples ActionButton from ActionList

### DIFF
--- a/.changeset/wet-mice-share.md
+++ b/.changeset/wet-mice-share.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[ActionList] Includes variable for ActionList padding

--- a/.changeset/wet-mice-share.md
+++ b/.changeset/wet-mice-share.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris': patch
+'@shopify/polaris': minor
 ---
 
-[ActionList] Includes variable for ActionList padding
+[ActionButton] Exposes ActionButton component

--- a/polaris-react/src/components/ActionButton/ActionButton.scss
+++ b/polaris-react/src/components/ActionButton/ActionButton.scss
@@ -1,0 +1,117 @@
+@import '../../styles/common';
+
+.ActionButton {
+  --pc-action-list-image-size: 20px;
+  --pc-action-list-item-min-height: var(--p-space-10);
+  --pc-action-list-item-vertical-padding: calc(
+    (var(--pc-action-list-item-min-height) - var(--p-line-height-2)) / 2
+  );
+  @include unstyled-button;
+  @include focus-ring;
+  display: block;
+  width: 100%;
+  min-height: var(--pc-action-list-item-min-height);
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  padding: var(--pc-action-list-item-vertical-padding) var(--p-space-2);
+  border-radius: var(--p-border-radius-1);
+  border-top: var(--p-border-width-1) solid transparent;
+  color: inherit;
+  @media (forced-colors: active) {
+    border: var(--p-border-width-1) solid transparent;
+  }
+
+  &:hover {
+    background-color: var(--p-surface-hovered);
+    text-decoration: none;
+    outline: var(--p-border-width-3) solid transparent;
+  }
+
+  &:active {
+    @include recolor-icon(var(--p-interactive));
+    background-color: var(--p-surface-pressed);
+  }
+
+  &:focus:not(:active) {
+    @include focus-ring($style: 'focused');
+    outline: var(--p-border-width-3) solid transparent;
+  }
+
+  &:visited {
+    color: inherit;
+  }
+
+  &.active {
+    @include recolor-icon(var(--p-interactive));
+    background-color: var(--p-surface-selected);
+
+    &::before {
+      @include list-selected-indicator;
+    }
+  }
+
+  &.destructive {
+    @include recolor-icon(var(--p-icon-critical));
+    color: var(--p-interactive-critical);
+
+    &:hover {
+      background-color: var(--p-surface-critical-subdued-hovered);
+    }
+
+    // stylelint-disable-next-line selector-max-class
+    &:active,
+    &.active {
+      background-color: var(--p-surface-critical-subdued-pressed);
+    }
+  }
+
+  &.disabled {
+    background-image: none;
+    color: var(--p-text-disabled);
+
+    // stylelint-disable-next-line selector-max-class
+    .Prefix,
+    .Suffix {
+      @include recolor-icon(var(--p-icon-disabled));
+    }
+  }
+}
+
+.Content {
+  display: flex;
+  align-items: center;
+}
+
+.Prefix {
+  @include recolor-icon(var(--p-icon));
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: center;
+  align-items: center;
+  height: var(--pc-action-list-image-size);
+  width: var(--pc-action-list-image-size);
+  border-radius: var(--p-border-radius-base);
+
+  // We need the negative margin to ensure that the image does not set
+  // the minimum height of the action item.
+  margin: calc(-0.5 * var(--pc-action-list-image-size)) var(--p-space-4)
+    calc(-0.5 * var(--pc-action-list-image-size)) 0;
+  background-size: cover;
+  background-position: center center;
+}
+
+.Suffix {
+  @include recolor-icon(var(--p-icon));
+  margin-left: var(--p-space-4);
+}
+
+.ContentBlock,
+.ContentBlockInner {
+  display: block;
+}
+
+.Text {
+  @include layout-flex-fix;
+  flex: 1 1 auto;
+}

--- a/polaris-react/src/components/ActionButton/ActionButton.tsx
+++ b/polaris-react/src/components/ActionButton/ActionButton.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 
-import {classNames} from '../../../../utilities/css';
-import type {ActionListItemDescriptor} from '../../../../types';
-import {Scrollable} from '../../../Scrollable';
-import {Icon} from '../../../Icon';
-import {UnstyledLink} from '../../../UnstyledLink';
-import {Badge} from '../../../Badge';
-import {TextStyle} from '../../../TextStyle';
-import styles from '../../ActionList.scss';
-import {handleMouseUpByBlurring} from '../../../../utilities/focus';
+import {classNames} from '../../utilities/css';
+import type {ActionListItemDescriptor} from '../../types';
+import {Scrollable} from '../Scrollable';
+import {Icon} from '../Icon';
+import {UnstyledLink} from '../UnstyledLink';
+import {Badge} from '../Badge';
+import {TextStyle} from '../TextStyle';
+import {handleMouseUpByBlurring} from '../../utilities/focus';
 
-export type ItemProps = ActionListItemDescriptor;
+import styles from './ActionButton.scss';
 
-export function Item({
+export type ActionButtonProps = ActionListItemDescriptor;
+
+export function ActionButton({
   id,
   badge,
   content,
@@ -30,9 +31,9 @@ export function Item({
   ellipsis,
   active,
   role,
-}: ItemProps) {
+}: ActionButtonProps) {
   const className = classNames(
-    styles.Item,
+    styles.ActionButton,
     disabled && styles.disabled,
     destructive && styles.destructive,
     active && styles.active,
@@ -120,9 +121,9 @@ export function Item({
   );
 
   return (
-    <li role={role === 'menuitem' ? 'presentation' : undefined}>
+    <>
       {scrollMarkup}
       {control}
-    </li>
+    </>
   );
 }

--- a/polaris-react/src/components/ActionButton/index.ts
+++ b/polaris-react/src/components/ActionButton/index.ts
@@ -1,0 +1,1 @@
+export * from './ActionButton';

--- a/polaris-react/src/components/ActionButton/tests/ActionButton.test.tsx
+++ b/polaris-react/src/components/ActionButton/tests/ActionButton.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
-import {Item} from '../Item';
-import {TextStyle} from '../../../../TextStyle';
-import {UnstyledLink} from '../../../../UnstyledLink';
+import {ActionButton} from '../ActionButton';
+import {TextStyle} from '../../TextStyle';
+import {UnstyledLink} from '../../UnstyledLink';
 
-describe('<Item />', () => {
+describe('<ActionButton />', () => {
   it('adds a style property when the image prop is present', () => {
-    const item = mountWithApp(<Item image="some-image.png" />);
+    const item = mountWithApp(<ActionButton image="some-image.png" />);
     expect(item).toContainReactComponent('span', {
       style: {
         backgroundImage: 'url(some-image.png',
@@ -17,50 +17,55 @@ describe('<Item />', () => {
 
   it('fires onAction callback on click or keypress', () => {
     const mockOnAction = jest.fn();
-    const item = mountWithApp(<Item onAction={mockOnAction} />);
+    const item = mountWithApp(<ActionButton onAction={mockOnAction} />);
     item.find('button')!.trigger('onClick');
     expect(mockOnAction).toHaveBeenCalledTimes(1);
   });
 
   it('passes the external prop down to the link', () => {
-    const item = mountWithApp(<Item external url="https://www.shopify.com" />);
+    const item = mountWithApp(
+      <ActionButton external url="https://www.shopify.com" />,
+    );
     expect(item).toContainReactComponent(UnstyledLink, {
       external: true,
     });
   });
 
   it('renders an ellipsis when the ellipsis prop is true', () => {
-    const item = mountWithApp(<Item content="Test" ellipsis />);
+    const item = mountWithApp(<ActionButton content="Test" ellipsis />);
     expect(item).toContainReactText('Test…');
   });
 
   it('renders a suffix when the suffix prop is defined', () => {
     const Suffix = () => <span>Suffix</span>;
-    const item = mountWithApp(<Item suffix={<Suffix />} />);
+    const item = mountWithApp(<ActionButton suffix={<Suffix />} />);
     expect(item).toContainReactComponent(Suffix);
   });
 
   it('renders a prefix when the prefix prop is defined', () => {
     const Prefix = () => <span>Prefix</span>;
-    const item = mountWithApp(<Item prefix={<Prefix />} />);
+    const item = mountWithApp(<ActionButton prefix={<Prefix />} />);
     expect(item).toContainReactComponent(Prefix);
   });
 
   it('does not render a label when content is undefined and ellipsis is true', () => {
-    const item = mountWithApp(<Item ellipsis />);
+    const item = mountWithApp(<ActionButton ellipsis />);
     expect(item).toContainReactText('');
   });
 
   it('renders helpText when the helpText prop is defined', () => {
     const helpText = 'Foo';
-    const item = mountWithApp(<Item helpText={helpText} />);
+    const item = mountWithApp(<ActionButton helpText={helpText} />);
     expect(item.find(TextStyle)).toContainReactText(helpText);
   });
 
   it('passes `accessibilityLabel` to `<button />`', () => {
     const mockAccessibilityLabel = 'mock label';
     const item = mountWithApp(
-      <Item accessibilityLabel={mockAccessibilityLabel} onAction={noop} />,
+      <ActionButton
+        accessibilityLabel={mockAccessibilityLabel}
+        onAction={noop}
+      />,
     );
     expect(item).toContainReactComponent('button', {
       'aria-label': mockAccessibilityLabel,
@@ -70,7 +75,7 @@ describe('<Item />', () => {
   it('passes `accessibilityLabel` to `<UnstyledLink />`', () => {
     const mockAccessibilityLabel = 'mock label';
     const item = mountWithApp(
-      <Item
+      <ActionButton
         accessibilityLabel={mockAccessibilityLabel}
         url="https://www.shopify.com"
       />,
@@ -81,7 +86,9 @@ describe('<Item />', () => {
   });
 
   it('passes `url` as null to `<UnstyledLink />` when disabled', () => {
-    const item = mountWithApp(<Item url="https://shopify.com" disabled />);
+    const item = mountWithApp(
+      <ActionButton url="https://shopify.com" disabled />,
+    );
     expect(item).toContainReactComponent(UnstyledLink, {
       url: null,
     });
@@ -89,7 +96,7 @@ describe('<Item />', () => {
 
   it('passes `onClick` as null to `<UnstyledLink />` when disabled', () => {
     const item = mountWithApp(
-      <Item onAction={noop} disabled url="https://shopify.com" />,
+      <ActionButton onAction={noop} disabled url="https://shopify.com" />,
     );
     expect(item).toContainReactComponent(UnstyledLink, {
       onClick: null,

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -1,12 +1,6 @@
 @import '../../styles/common';
 
 .ActionList {
-  --pc-action-list-image-size: 20px;
-  --pc-action-list-item-min-height: var(--p-space-10);
-  --pc-action-list-item-vertical-padding: calc(
-    (var(--pc-action-list-item-min-height) - var(--p-line-height-2)) / 2
-  );
-  --pc-action-list-actions-padding: var(--p-space-2);
   outline: none;
   list-style: none;
   margin: 0;
@@ -22,7 +16,7 @@
   list-style: none;
   margin: 0;
   border-top: var(--p-border-divider);
-  padding: var(--pc-action-list-actions-padding);
+  padding: var(--p-space-2);
 }
 
 .ActionList,
@@ -40,115 +34,4 @@
 
 .Section:not(:first-child) .Title {
   padding-top: var(--p-space-1);
-}
-
-.Item {
-  @include unstyled-button;
-  @include focus-ring;
-  display: block;
-  width: 100%;
-  min-height: var(--pc-action-list-item-min-height);
-  text-align: left;
-  text-decoration: none;
-  cursor: pointer;
-  padding: var(--pc-action-list-item-vertical-padding) var(--p-space-2);
-  border-radius: var(--p-border-radius-1);
-  border-top: var(--p-border-width-1) solid transparent;
-  color: inherit;
-  @media (forced-colors: active) {
-    border: var(--p-border-width-1) solid transparent;
-  }
-
-  &:hover {
-    background-color: var(--p-surface-hovered);
-    text-decoration: none;
-    outline: var(--p-border-width-3) solid transparent;
-  }
-
-  &:active {
-    @include recolor-icon(var(--p-interactive));
-    background-color: var(--p-surface-pressed);
-  }
-
-  &:focus:not(:active) {
-    @include focus-ring($style: 'focused');
-    outline: var(--p-border-width-3) solid transparent;
-  }
-
-  &:visited {
-    color: inherit;
-  }
-
-  &.active {
-    @include recolor-icon(var(--p-interactive));
-    background-color: var(--p-surface-selected);
-
-    &::before {
-      @include list-selected-indicator;
-    }
-  }
-
-  &.destructive {
-    @include recolor-icon(var(--p-icon-critical));
-    color: var(--p-interactive-critical);
-
-    &:hover {
-      background-color: var(--p-surface-critical-subdued-hovered);
-    }
-
-    // stylelint-disable-next-line selector-max-class
-    &:active,
-    &.active {
-      background-color: var(--p-surface-critical-subdued-pressed);
-    }
-  }
-
-  &.disabled {
-    background-image: none;
-    color: var(--p-text-disabled);
-
-    // stylelint-disable-next-line selector-max-class
-    .Prefix,
-    .Suffix {
-      @include recolor-icon(var(--p-icon-disabled));
-    }
-  }
-}
-
-.Content {
-  display: flex;
-  align-items: center;
-}
-
-.Prefix {
-  @include recolor-icon(var(--p-icon));
-  display: flex;
-  flex: 0 0 auto;
-  justify-content: center;
-  align-items: center;
-  height: var(--pc-action-list-image-size);
-  width: var(--pc-action-list-image-size);
-  border-radius: var(--p-border-radius-base);
-
-  // We need the negative margin to ensure that the image does not set
-  // the minimum height of the action item.
-  margin: calc(-0.5 * var(--pc-action-list-image-size)) var(--p-space-4)
-    calc(-0.5 * var(--pc-action-list-image-size)) 0;
-  background-size: cover;
-  background-position: center center;
-}
-
-.Suffix {
-  @include recolor-icon(var(--p-icon));
-  margin-left: var(--p-space-4);
-}
-
-.ContentBlock,
-.ContentBlockInner {
-  display: block;
-}
-
-.Text {
-  @include layout-flex-fix;
-  flex: 1 1 auto;
 }

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -6,6 +6,7 @@
   --pc-action-list-item-vertical-padding: calc(
     (var(--pc-action-list-item-min-height) - var(--p-line-height-2)) / 2
   );
+  --pc-action-list-actions-padding: var(--p-space-2);
   outline: none;
   list-style: none;
   margin: 0;
@@ -21,7 +22,7 @@
   list-style: none;
   margin: 0;
   border-top: var(--p-border-divider);
-  padding: var(--p-space-2);
+  padding: var(--pc-action-list-actions-padding);
 }
 
 .ActionList,

--- a/polaris-react/src/components/ActionList/components/Item/index.ts
+++ b/polaris-react/src/components/ActionList/components/Item/index.ts
@@ -1,1 +1,0 @@
-export * from './Item';

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Item} from '../Item';
+import {ActionButton} from '../../../ActionButton';
 import type {
   ActionListItemDescriptor,
   ActionListSection,
@@ -37,14 +37,18 @@ export function Section({
   const actionMarkup = section.items.map(
     ({content, helpText, onAction, ...item}, index) => {
       return (
-        <Item
+        <li
           key={`${content}-${index}`}
-          content={content}
-          helpText={helpText}
-          role={actionRole}
-          onAction={handleAction(onAction)}
-          {...item}
-        />
+          role={actionRole === 'menuitem' ? 'presentation' : undefined}
+        >
+          <ActionButton
+            content={content}
+            helpText={helpText}
+            onAction={handleAction(onAction)}
+            role={actionRole}
+            {...item}
+          />
+        </li>
       );
     },
   );

--- a/polaris-react/src/components/ActionList/components/Section/tests/Section.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/tests/Section.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
-import {Item} from '../../Item';
+import {ActionButton} from '../../../../ActionButton';
 import {Section} from '../Section';
 
 describe('<Section />', () => {
@@ -18,7 +18,7 @@ describe('<Section />', () => {
       />,
     );
 
-    expect(section).toContainReactComponentTimes(Item, 2);
+    expect(section).toContainReactComponentTimes(ActionButton, 2);
   });
 
   it('renders items as li when hasMultipleSections is false', () => {
@@ -53,7 +53,7 @@ describe('<Section />', () => {
     expect(section).toContainReactComponentTimes('li', 3);
   });
 
-  it('passes content to Item', () => {
+  it('passes content to ActionButton', () => {
     const callback = () => {};
     const section = mountWithApp(
       <Section
@@ -68,12 +68,12 @@ describe('<Section />', () => {
       />,
     );
 
-    expect(section.findAll(Item)[0]).toHaveReactProps({
+    expect(section.findAll(ActionButton)[0]).toHaveReactProps({
       content: 'Import file',
     });
   });
 
-  it('passes helpText to Item', () => {
+  it('passes helpText to ActionButton', () => {
     const section = mountWithApp(
       <Section
         hasMultipleSections
@@ -86,12 +86,12 @@ describe('<Section />', () => {
       />,
     );
 
-    expect(section.findAll(Item)[0]).toHaveReactProps({
+    expect(section.findAll(ActionButton)[0]).toHaveReactProps({
       helpText: 'Foo',
     });
   });
 
-  it('passes the onActionAnyItem callback to Item', () => {
+  it('passes the onActionAnyActionButton callback to ActionButton', () => {
     const spy = jest.fn();
     const section = mountWithApp(
       <Section
@@ -106,7 +106,7 @@ describe('<Section />', () => {
       />,
     );
 
-    section.findAll(Item)[0].findAll('button')[0].trigger('onClick');
+    section.findAll(ActionButton)[0].findAll('button')[0].trigger('onClick');
 
     expect(spy).toHaveBeenCalledTimes(1);
   });

--- a/polaris-react/src/components/ActionList/components/index.ts
+++ b/polaris-react/src/components/ActionList/components/index.ts
@@ -1,3 +1,1 @@
-export * from './Item';
-
 export * from './Section';

--- a/polaris-react/src/components/ActionList/tests/ActionList.test.tsx
+++ b/polaris-react/src/components/ActionList/tests/ActionList.test.tsx
@@ -4,9 +4,10 @@ import {mountWithApp} from 'tests/utilities';
 
 import {ActionList} from '../ActionList';
 import {Badge} from '../../Badge';
-import {Item, Section} from '../components';
+import {Section} from '../components';
 import {Key} from '../../../types';
 import {KeypressListener} from '../../KeypressListener';
+import {ActionButton} from '../../ActionButton';
 
 describe('<ActionList />', () => {
   let mockOnActionAnyItem: jest.Mock;
@@ -67,7 +68,7 @@ describe('<ActionList />', () => {
     ];
 
     const actionList = mountWithApp(<ActionList items={items} />);
-    actionList.findAll(Item).forEach((item, index) => {
+    actionList.findAll(ActionButton).forEach((item, index) => {
       expect(item).toHaveReactProps({
         content: `${items[index].content}`,
       });

--- a/polaris-react/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
+++ b/polaris-react/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
@@ -4,11 +4,9 @@ import {mountWithApp} from 'tests/utilities';
 
 import {Button} from '../../../../Button';
 import {Popover} from '../../../../Popover';
+import {ActionButton} from '../../../../ActionButton';
 // eslint-disable-next-line @shopify/strict-component-boundaries
-import {
-  Item as ActionListItem,
-  Section as ActionListSection,
-} from '../../../../ActionList/components';
+import {Section as ActionListSection} from '../../../../ActionList/components';
 import {RollupActions} from '../RollupActions';
 
 describe('<RollupActions />', () => {
@@ -53,7 +51,7 @@ describe('<RollupActions />', () => {
 
       wrapper.find(Button, {icon: HorizontalDotsMinor})!.trigger('onClick');
 
-      expect(wrapper.findAll(ActionListItem)).toHaveLength(mockItems.length);
+      expect(wrapper.findAll(ActionButton)).toHaveLength(mockItems.length);
     });
 
     it('<ActionList /> closes the <Popover /> when `onActionAnyItem` is called', () => {
@@ -68,8 +66,8 @@ describe('<RollupActions />', () => {
         active: true,
       });
 
-      const firstActionListItem = wrapper.findAll(ActionListItem)[0];
-      firstActionListItem.trigger('onAction');
+      const firstActionButton = wrapper.findAll(ActionButton)[0];
+      firstActionButton.trigger('onAction');
 
       popoverComponent = wrapper.find(Popover);
       expect(popoverComponent!).toHaveReactProps({

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -40,6 +40,9 @@ export type {AccountConnectionProps} from './components/AccountConnection';
 export {ActionList} from './components/ActionList';
 export type {ActionListProps} from './components/ActionList';
 
+export {ActionButton} from './components/ActionButton';
+export type {ActionButtonProps} from './components/ActionButton';
+
 export {ActionMenu} from './components/ActionMenu';
 export type {ActionMenuProps} from './components/ActionMenu';
 


### PR DESCRIPTION
### WHY are these changes introduced?

In Shopify Email we leverage the ActionList with a single item in a slim pattern for our sidebar. We used to resort to a hack to override polaris styling to achieve our design without having to re-implement a custom component that would be identical to ActionListItem.

This PR exposes a new ActionButton component was initial used internally by ActionList as a standalone component.

If this PR is deemed good to merge I can write the documentation for this component.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
