### PR TITLE
[Polaris website refresh] Refactor Left Nav and TOC

### DIFF
--- a/.changeset/flat-monkeys-lie.md
+++ b/.changeset/flat-monkeys-lie.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Refactored left nav and table of contents layouts

--- a/polaris.shopify.com/src/components/ComponentsPage/ComponentsPage.module.scss
+++ b/polaris.shopify.com/src/components/ComponentsPage/ComponentsPage.module.scss
@@ -11,6 +11,11 @@
   }
 }
 
+.Post {
+  position: relative;
+  flex: 1;
+}
+
 .Filters {
   position: relative;
   margin-bottom: 1rem;

--- a/polaris.shopify.com/src/components/ComponentsPage/ComponentsPage.tsx
+++ b/polaris.shopify.com/src/components/ComponentsPage/ComponentsPage.tsx
@@ -1,70 +1,58 @@
+
 import Head from "next/head";
 import components from "../../data/components.json";
 import {
   getComponentCategories,
   stripMarkdownLinks,
   slugify,
-  getComponentNav,
 } from "../../utils/various";
 import MaxPageWidthDiv from "../MaxPageWidthDiv";
 import styles from "./ComponentsPage.module.scss";
 import { getTitleTagValue } from "../../utils/various";
 import ComponentGrid from "../ComponentGrid";
-import { NavItem } from "../Nav/Nav";
-import NavContentTOCLayout from "../NavContentTOCLayout";
 
 const componentCategories = getComponentCategories();
 
 interface Props {}
 
-function ComponentsPage({}: Props) {
-  const navItems: NavItem[] = getComponentNav();
-
+export default function ComponentsPage({}: Props) {
+  
   return (
     <MaxPageWidthDiv className={styles.ComponentsPage}>
       <Head>
         <title>{getTitleTagValue("Components")}</title>
       </Head>
-
-      <NavContentTOCLayout
-        navItems={navItems}
-        showTOC={false}
-        title="Components"
-        content={
-          <>
-            {componentCategories.map((category) => {
-              return (
-                <div key={category} className={styles.Category}>
-                  <h2 className={styles.CategoryName}>{category}</h2>
-                  <ComponentGrid>
-                    {components
-                      .filter(
-                        (component) =>
-                          component.frontMatter.category === category
-                      )
-                      .map(({ frontMatter, intro }) => {
-                        const { name, category } = frontMatter;
-                        const url = `/components/${slugify(category)}/${slugify(
-                          name.toLowerCase()
-                        )}`;
-                        return (
-                          <ComponentGrid.Item
-                            key={name}
-                            name={name}
-                            description={stripMarkdownLinks(intro)}
-                            url={url}
-                          />
-                        );
-                      })}
-                  </ComponentGrid>
-                </div>
-              );
-            })}
-          </>
-        }
-      />
+      <h1>Components</h1>
+      <article className={styles.Post}>
+        {componentCategories.map((category) => {
+          return (
+            <div key={category} className={styles.Category}>
+              <h2 className={styles.CategoryName}>{category}</h2>
+              <ComponentGrid>
+                {components
+                  .filter(
+                    (component) =>
+                      component.frontMatter.category === category
+                  )
+                  .map(({ frontMatter, intro }) => {
+                    const { name, category } = frontMatter;
+                    const url = `/components/${slugify(category)}/${slugify(
+                      name.toLowerCase()
+                    )}`;
+                    return (
+                      <ComponentGrid.Item
+                        key={name}
+                        name={name}
+                        description={stripMarkdownLinks(intro)}
+                        url={url}
+                      />
+                    );
+                  })}
+              </ComponentGrid>
+            </div>
+          );
+        })}
+      </article>
     </MaxPageWidthDiv>
   );
 }
-
-export default ComponentsPage;

--- a/polaris.shopify.com/src/components/LeftNavLayout/LeftNavLayout.module.scss
+++ b/polaris.shopify.com/src/components/LeftNavLayout/LeftNavLayout.module.scss
@@ -1,0 +1,78 @@
+.LeftNavLayout {
+  --gap: 7rem;
+  --nav-width: 12rem;
+  --toc-width: 12rem;
+  margin-top: var(--header-margin);
+  display: flex;
+  gap: var(--gap);
+}
+
+.Nav {
+  min-width: var(--nav-width);
+  max-width: var(--nav-width);
+  align-self: flex-start;
+}
+
+.Post {
+  position: relative;
+  flex: 1;
+  .LeftNavLayout.showTOC & {
+    max-width: calc(
+      100% - var(--nav-width) - var(--gap) - var(--gap) - var(--toc-width)
+    );
+  }
+}
+
+.TOC {
+  position: absolute;
+  font-size: var(--font-size-100);
+  width: var(--toc-width);
+  right: calc((var(--toc-width) + 5rem) * -1);
+  height: 100%;
+
+  > ul {
+    position: sticky;
+    top: 2rem;
+  }
+
+  > ul > li:not(:first-child) {
+    margin-top: 0.5rem;
+  }
+
+  a {
+    color: inherit;
+    display: block;
+    white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: var(--toc-width);
+
+    &:hover {
+      color: var(--text-strong);
+    }
+  }
+
+  &.isNested {
+    ul ul {
+      a {
+        position: relative;
+        padding-left: 0.66rem;
+        &:before {
+          content: "";
+          display: block;
+          position: absolute;
+          left: 0;
+          top: 0;
+          bottom: 0;
+          margin: auto;
+          min-width: 4px;
+          max-width: 4px;
+          min-height: 4px;
+          max-height: 4px;
+          border-radius: var(--border-radius-round);
+          background: var(--text);
+        }
+      }
+    }
+  }
+}

--- a/polaris.shopify.com/src/components/LeftNavLayout/LeftNavLayout.tsx
+++ b/polaris.shopify.com/src/components/LeftNavLayout/LeftNavLayout.tsx
@@ -1,0 +1,30 @@
+import { className, slugify } from "../../utils/various";
+import MaxPageWidthDiv from "../MaxPageWidthDiv";
+import Nav, { NavItem } from "../Nav/Nav";
+import styles from "./LeftNavLayout.module.scss";
+
+interface Props {
+  navItems?: NavItem[];
+  children: React.ReactNode;
+}
+
+const LeftNavLayout = ({
+  navItems,
+  children
+}: Props) => {
+  return (
+    <MaxPageWidthDiv
+      className={className(
+        styles.LeftNavLayout,
+      )}
+    >
+      <div className={styles.Nav}>
+        {navItems && <Nav navItems={navItems} />}
+      </div>
+      {children}
+    </MaxPageWidthDiv>
+  );
+}
+
+
+export default LeftNavLayout;

--- a/polaris.shopify.com/src/components/LeftNavLayout/LeftNavLayout.tsx
+++ b/polaris.shopify.com/src/components/LeftNavLayout/LeftNavLayout.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { useTOC } from "../../utils/hooks";
 import { className, slugify } from "../../utils/various";
-import Longform from "../Longform";
-import Markdown from "../Markdown";
 import MaxPageWidthDiv from "../MaxPageWidthDiv";
 import Nav, { NavItem } from "../Nav/Nav";
 import styles from "./LeftNavLayout.module.scss";

--- a/polaris.shopify.com/src/components/LeftNavLayout/LeftNavLayout.tsx
+++ b/polaris.shopify.com/src/components/LeftNavLayout/LeftNavLayout.tsx
@@ -1,17 +1,21 @@
+import React from "react";
+import { useTOC } from "../../utils/hooks";
 import { className, slugify } from "../../utils/various";
+import Longform from "../Longform";
+import Markdown from "../Markdown";
 import MaxPageWidthDiv from "../MaxPageWidthDiv";
 import Nav, { NavItem } from "../Nav/Nav";
 import styles from "./LeftNavLayout.module.scss";
 
 interface Props {
-  navItems?: NavItem[];
-  children: React.ReactNode;
+  navItems: NavItem[];
+  children: React.ReactNode
 }
 
-const LeftNavLayout = ({
+function LeftNavLayout({
   navItems,
   children
-}: Props) => {
+}: Props) {
   return (
     <MaxPageWidthDiv
       className={className(
@@ -21,10 +25,10 @@ const LeftNavLayout = ({
       <div className={styles.Nav}>
         {navItems && <Nav navItems={navItems} />}
       </div>
+
       {children}
     </MaxPageWidthDiv>
   );
 }
-
 
 export default LeftNavLayout;

--- a/polaris.shopify.com/src/components/LeftNavLayout/index.ts
+++ b/polaris.shopify.com/src/components/LeftNavLayout/index.ts
@@ -1,0 +1,3 @@
+import LeftNavLayout from "./LeftNavLayout";
+
+export default LeftNavLayout;

--- a/polaris.shopify.com/src/components/LeftNavWithTOCLayout/LeftNavWithTOCLayout.module.scss
+++ b/polaris.shopify.com/src/components/LeftNavWithTOCLayout/LeftNavWithTOCLayout.module.scss
@@ -1,0 +1,79 @@
+.LeftNavWithTOCLayout {
+  --gap: 7rem;
+  --nav-width: 12rem;
+  --toc-width: 12rem;
+  margin-top: var(--header-margin);
+  display: flex;
+  gap: var(--gap);
+}
+
+.Nav {
+  min-width: var(--nav-width);
+  max-width: var(--nav-width);
+  align-self: flex-start;
+}
+
+.Post {
+  position: relative;
+  flex: 1;
+  .LeftNavWithTOCLayout.showTOC & {
+    max-width: calc(
+      100% - var(--nav-width) - var(--gap) - var(--gap) - var(--toc-width)
+    );
+  }
+}
+
+.TOC {
+  position: absolute;
+  font-size: var(--font-size-100);
+  width: var(--toc-width);
+  right: calc((var(--toc-width) + 5rem) * -1);
+  height: 100%;
+  top: 0;
+
+  > ul {
+    position: sticky;
+    top: 2rem;
+  }
+
+  > ul > li:not(:first-child) {
+    margin-top: 0.5rem;
+  }
+
+  a {
+    color: inherit;
+    display: block;
+    white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: var(--toc-width);
+
+    &:hover {
+      color: var(--text-strong);
+    }
+  }
+
+  &.isNested {
+    ul ul {
+      a {
+        position: relative;
+        padding-left: 0.66rem;
+        &:before {
+          content: "";
+          display: block;
+          position: absolute;
+          left: 0;
+          top: 0;
+          bottom: 0;
+          margin: auto;
+          min-width: 4px;
+          max-width: 4px;
+          min-height: 4px;
+          max-height: 4px;
+          border-radius: var(--border-radius-round);
+          background: var(--text);
+        }
+      }
+    }
+  }
+}

--- a/polaris.shopify.com/src/components/LeftNavWithTOCLayout/LeftNavWithTOCLayout.tsx
+++ b/polaris.shopify.com/src/components/LeftNavWithTOCLayout/LeftNavWithTOCLayout.tsx
@@ -1,7 +1,5 @@
 import { useTOC } from "../../utils/hooks";
 import { className, slugify } from "../../utils/various";
-import Longform from "../Longform";
-import Markdown from "../Markdown";
 import MaxPageWidthDiv from "../MaxPageWidthDiv";
 import Nav, { NavItem } from "../Nav/Nav";
 import styles from "./LeftNavWithTOCLayout.module.scss";

--- a/polaris.shopify.com/src/components/LeftNavWithTOCLayout/LeftNavWithTOCLayout.tsx
+++ b/polaris.shopify.com/src/components/LeftNavWithTOCLayout/LeftNavWithTOCLayout.tsx
@@ -1,0 +1,73 @@
+import { useTOC } from "../../utils/hooks";
+import { className, slugify } from "../../utils/various";
+import Longform from "../Longform";
+import Markdown from "../Markdown";
+import MaxPageWidthDiv from "../MaxPageWidthDiv";
+import Nav, { NavItem } from "../Nav/Nav";
+import styles from "./LeftNavWithTOCLayout.module.scss";
+
+interface Props {
+  content: string | React.ReactNode;
+  navItems?: NavItem[];
+  title?: string;
+  customNav?: React.ReactNode;
+  showTOC?: boolean;
+  children: React.ReactNode
+}
+
+function LeftNavWithTOCLayout({
+  navItems,
+  content,
+  children
+}: Props) {
+  return (
+    <MaxPageWidthDiv
+      className={className(
+        styles.LeftNavWithTOCLayout,
+        styles.showTOC
+      )}
+    >
+      <div className={styles.Nav}>
+        {navItems && <Nav navItems={navItems} />}
+      </div>
+
+      <article className={styles.Post}>
+        {children}
+        <TOC rerenderOnChange={content} />
+      </article>
+    </MaxPageWidthDiv>
+  );
+}
+
+function TOC({
+  rerenderOnChange,
+}: {
+  rerenderOnChange: string | React.ReactNode;
+}) {
+  const [toc] = useTOC(rerenderOnChange);
+
+  const isNested = !!toc.find((item) => item.children.length > 0);
+
+  return (
+    <div className={className(styles.TOC, isNested && styles.isNested)}>
+      <ul>
+        {toc.map((node) => (
+          <li key={node.name}>
+            <a href={`#${slugify(node.name)}`}>{node.name}</a>
+            {node.children.length > 0 && (
+              <ul>
+                {node.children.map((child) => (
+                  <li key={child.name}>
+                    <a href={`#${slugify(child.name)}`}>{child.name}</a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default LeftNavWithTOCLayout;

--- a/polaris.shopify.com/src/components/LeftNavWithTOCLayout/index.ts
+++ b/polaris.shopify.com/src/components/LeftNavWithTOCLayout/index.ts
@@ -1,0 +1,3 @@
+import LeftNavWithTOCLayout from "./LeftNavWithTOCLayout";
+
+export default LeftNavWithTOCLayout;

--- a/polaris.shopify.com/src/pages/_app.tsx
+++ b/polaris.shopify.com/src/pages/_app.tsx
@@ -1,18 +1,30 @@
+import type { ReactElement, ReactNode } from 'react'
+import type { NextPage } from 'next'
 import type { AppProps } from "next/app";
 // import "@shopify/polaris/build/esm/styles.css";
 import "../styles/globals.scss";
 import Page from "../components/Page";
 import { useRouter } from "next/router";
 
-function MyApp({ Component, pageProps }: AppProps) {
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode
+}
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout
+}
+
+function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const router = useRouter();
   const isPolaris = router.asPath.startsWith("/generated-examples");
+  const getLayout = Component.getLayout ?? ((page) => page)
+
   return (
-    <Page skipHeaderAndFooter={isPolaris}>
-      <div style={{ background: isPolaris ? "#fafafa" : "unset" }}>
-        <Component {...pageProps} />
-      </div>
-    </Page>
+      <Page skipHeaderAndFooter={isPolaris}>
+        <div style={{ background: isPolaris ? "#fafafa" : "unset" }}>
+          {getLayout(<Component {...pageProps} />)}
+        </div>
+      </Page>
   );
 }
 

--- a/polaris.shopify.com/src/pages/components/[category]/[component].tsx
+++ b/polaris.shopify.com/src/pages/components/[category]/[component].tsx
@@ -12,13 +12,8 @@ import {
 } from "../../../utils/various";
 import fs from "fs";
 import path from "path";
-import MaxPageWidthDiv from "../../../components/MaxPageWidthDiv";
-import ComponentsPage from "../../../components/ComponentsPage";
-import Nav from "../../../components/Nav";
-import componentsMeta from "../../../data/components.json";
 import { NavItem } from "../../../components/Nav/Nav";
 import NavContentTOCLayout from "../../../components/NavContentTOCLayout";
-import styles from './component.module.scss'
 import LeftNavWithTOCLayout from '../../../components/LeftNavWithTOCLayout'
 
 interface Props {

--- a/polaris.shopify.com/src/pages/components/[category]/[component].tsx
+++ b/polaris.shopify.com/src/pages/components/[category]/[component].tsx
@@ -24,7 +24,7 @@ interface Props {
 const navItems: NavItem[] = getComponentNav();
 
 
-type NextPageWithLayout = NextPage & Props & {
+type NextPageWithLayout = NextPage<Props> & {
   getLayout?: (page: ReactElement) => ReactNode
 }
 

--- a/polaris.shopify.com/src/pages/components/[category]/[component].tsx
+++ b/polaris.shopify.com/src/pages/components/[category]/[component].tsx
@@ -1,3 +1,4 @@
+import type { ReactElement, ReactNode } from 'react'
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Head from "next/head";
 import Longform from "../../../components/Longform";
@@ -17,11 +18,53 @@ import Nav from "../../../components/Nav";
 import componentsMeta from "../../../data/components.json";
 import { NavItem } from "../../../components/Nav/Nav";
 import NavContentTOCLayout from "../../../components/NavContentTOCLayout";
+import styles from './component.module.scss'
+import LeftNavWithTOCLayout from '../../../components/LeftNavWithTOCLayout'
 
 interface Props {
   name: string;
   readme: string;
 }
+
+const navItems: NavItem[] = getComponentNav();
+
+
+type NextPageWithLayout = NextPage & Props & {
+  getLayout?: (page: ReactElement) => ReactNode
+}
+
+const ComponentsTwo: NextPageWithLayout = ({ name, readme }) => {
+  const navItems: NavItem[] = getComponentNav();
+
+  return (
+    <>
+      <Head>
+        <title>{getTitleTagValue(name)}</title>
+      </Head>
+
+      {name && (
+          <Longform>
+            <h1>{name}</h1>
+          </Longform>
+        )}
+        <Longform>
+          <Markdown text={readme} skipH1 />
+        </Longform>
+    </>
+  );
+};
+
+
+
+ComponentsTwo.getLayout = function getLayout(page: ReactElement) {
+  const { readme } = page.props
+  return (
+    <LeftNavWithTOCLayout navItems={navItems} content={readme}>
+      {page}
+    </LeftNavWithTOCLayout>
+  )
+}
+
 
 const Components: NextPage<Props> = ({ name, readme }) => {
   const navItems: NavItem[] = getComponentNav();
@@ -92,4 +135,4 @@ export const getStaticPaths: GetStaticPaths = async () => {
   };
 };
 
-export default Components;
+export default ComponentsTwo;

--- a/polaris.shopify.com/src/pages/components/[category]/component.module.scss
+++ b/polaris.shopify.com/src/pages/components/[category]/component.module.scss
@@ -1,9 +1,0 @@
-.Post {
-  position: relative;
-  flex: 1;
-  .NavContentTOCLayout.showTOC & {
-    max-width: calc(
-      100% - var(--nav-width) - var(--gap) - var(--gap) - var(--toc-width)
-    );
-  }
-}

--- a/polaris.shopify.com/src/pages/components/[category]/component.module.scss
+++ b/polaris.shopify.com/src/pages/components/[category]/component.module.scss
@@ -1,0 +1,9 @@
+.Post {
+  position: relative;
+  flex: 1;
+  .NavContentTOCLayout.showTOC & {
+    max-width: calc(
+      100% - var(--nav-width) - var(--gap) - var(--gap) - var(--toc-width)
+    );
+  }
+}

--- a/polaris.shopify.com/src/pages/components/index.tsx
+++ b/polaris.shopify.com/src/pages/components/index.tsx
@@ -1,8 +1,30 @@
+import type { ReactElement, ReactNode } from 'react'
+
 import type { NextPage } from "next";
 import ComponentsPage from "../../components/ComponentsPage";
+import LeftNavLayout from '../../components/LeftNavLayout'
+import {
+  getComponentNav,
+} from "../../utils/various";
+import { NavItem } from "../../components/Nav/Nav";
 
 interface Props {}
 
-const Components: NextPage<Props> = () => <ComponentsPage />;
+const navItems: NavItem[] = getComponentNav();
+
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode
+}
+
+const Components: NextPageWithLayout = () => <ComponentsPage />;
+
+
+Components.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <LeftNavLayout navItems={navItems}>
+      {page}
+    </LeftNavLayout>
+  )
+}
 
 export default Components;


### PR DESCRIPTION
Using the Next.js [per page layouts](https://nextjs.org/docs/basic-features/layouts#per-page-layouts) approach. This refactor:
* breaks up the left nav into it's own layout
* breaks up the left nav with TOC into a separate layout
* Refactors the `Components` index page to use the left nav layout
* Refactors the individual components page `[component].tsx` to use the left nav with TOC layout
* makes everything more modular to easily assemble pages with layout of choice

**What still ain't right?**
* pretty much all of the styling is duplicated and I made no effort to clean it up. This is just implementing the new layout approach and bringing the consuming pages to parity with the visual styles today. But boy is the code ugly still 😬 
* This creates two separate layouts `LeftNavLayout` and `LeftNavWithTOCLayout`. These two layouts are probably at least 50% the same code. Ideally we could get to a place where we can split out the TOC into a separate component and compose pages using nested layouts. I couldn't figure out a quick way to do with in CSS modules world because modules pretty much eliminates the C in CSS so I decided to put that down for now in order to unblock enablement work. Ideally a proper solution will end up like the following example. I'll make a ticket to capture this issue.
```
<LeftNavLayout>
  {children} // this is the page contents
  <TableOfContents />
</LeftNavLayout>
```