### PR TITLE
Fix breakpoint tokens

### DIFF
--- a/.changeset/nasty-carpets-design.md
+++ b/.changeset/nasty-carpets-design.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'@shopify/polaris-tokens': patch
+---
+
+Fixed breakpoint tokens

--- a/polaris-react/scripts/gen-media-queries.js
+++ b/polaris-react/scripts/gen-media-queries.js
@@ -59,5 +59,5 @@ function getDownMediaCondition(breakpoint) {
 }
 
 function toEm(value) {
-  return `${parseInt(value, 10) / 16}em`;
+  return `${parseInt(value, 10)}em`;
 }

--- a/polaris-tokens/src/tokens.ts
+++ b/polaris-tokens/src/tokens.ts
@@ -65,10 +65,10 @@ export interface Tokens {
 }
 
 export const tokens: Tokens = {
-  legacyTokens: tokensToRems(legacyTokens),
-  breakpoints,
+  breakpoints: tokensToRems(breakpoints),
   colorSchemes,
   depth,
+  legacyTokens: tokensToRems(legacyTokens),
   motion,
   shape: tokensToRems(shape),
   spacing: tokensToRems(spacing),

--- a/polaris-tokens/src/tokens.ts
+++ b/polaris-tokens/src/tokens.ts
@@ -65,10 +65,10 @@ export interface Tokens {
 }
 
 export const tokens: Tokens = {
-  breakpoints: tokensToRems(breakpoints),
+  legacyTokens: tokensToRems(legacyTokens),
+  breakpoints,
   colorSchemes,
   depth,
-  legacyTokens: tokensToRems(legacyTokens),
   motion,
   shape: tokensToRems(shape),
   spacing: tokensToRems(spacing),


### PR DESCRIPTION
We were converting breakpoint px values to `rem`, then to `em` in `gen-media-queries`. So the px value would be dived by 16, then the rem value would be divided by 16 so we had super small em values as breakpoints.

This change removes pxToRem at the token level so we go straight from pxToEm in `gen-media-queries`