### PR TITLE
Deprecate `CustomProperties` component and `colorScheme` prop

### DIFF
--- a/documentation/guides/migrating-from-v9-to-v10.md
+++ b/documentation/guides/migrating-from-v9-to-v10.md
@@ -1,0 +1,81 @@
+# Migrating from v9 to v10
+
+Polaris v10.0.0 ([full release notes](https://github.com/Shopify/polaris/releases/tag/v10.0.0)) features removal of the dark color scheme along with the `CustomProperties` component.
+
+## Table of Contents
+
+- [Consolidated color schemes](#consolidated-color-schemes)
+- [Components](#components)
+  - [Removed support for `colorScheme`](#removed-support-for-colorscheme)
+  - [Using dark color tokens](#using-dark-color-tokens)
+  - [Removing `CustomProperties`](#removing-customproperties)
+
+## Consolidated color schemes
+
+The dark color palette has been removed. Polaris is now only supporting one opinionated color palette for the admin.
+
+Supporting light and dark palettes lead to unnecessary complexity in our token system and how handle color schemes in Polaris. Dark values have been added into the single consolidated palette to support current dark interface needs.
+
+## Components
+
+### Removed support for `colorScheme`
+
+The following components no longer have support for the `colorScheme` prop:
+
+- AppProvider
+- PolarisTestProvider
+- Popover
+- Menu
+- UserMenu
+
+### Using dark color tokens
+
+If you are currently using a dark color scheme in your UI, we recommend assessing the reasoning for using a dark. If a dark interface isn't providing intentional benefits, considering using the default light tokens.
+
+You can use the following mapping to port CSS custom properties to the newly added dark values if a dark interface makes sense for your UI:
+
+| Light CSS Custom Property      | Dark Replacement Value              |
+| ------------------------------ | ----------------------------------- |
+| `--p-surface`                  | `--p-surface-dark`                  |
+| `--p-surface-neutral-subdued`  | `--p-surface-neutral-subdued-dark`  |
+| `--p-surface-hovered`          | `--p-surface-hovered-dark`          |
+| `--p-surface-search-field`     | `--p-surface-search-field-dark`     |
+| `--p-border`                   | `--p-border-on-dark`                |
+| `--p-divider`                  | `--p-divider-dark`                  |
+| `--p-icon`                     | `--p-icon-on-dark`                  |
+| `--p-text`                     | `--p-text-on-dark`                  |
+| `--p-text-subdued`             | `--p-text-subdued-on-dark`          |
+| `--p-interactive`              | `--p-interactive-on-dark`           |
+| `--p-interactive-pressed`      | `--p-interactive-pressed-on-dark`   |
+| `--p-action-secondary-hovered` | `--p-action-secondary-hovered-dark` |
+| `--p-action-secondary-pressed` | `--p-action-secondary-pressed-dark` |
+
+For example, the following style modifications would be the necessary in order to maintain a dark UI:
+
+```diff
+.Toast {
+-  background: var(--p-surface);
+-  color: var(--p-text);
++  background: var(--p-surface-dark);
++  color: var(--p-text-on-dark);
+}
+```
+
+### Removing `CustomProperties`
+
+The `CustomProperties` component has been deprecated as a result of simplifying to a single light color scheme. As a result, a number of internal components using `CustomProperties` have been updated to either use the dark token alternatives or removed support for a dark interface entirely.
+
+It is preferred to either remove usage of a dark interface or adjust styles to use the dark version of the color tokens. However, if you need to replace the `CustomProperties` component in order style components that may be difficult to target, you can use the following method to map the light color tokens to the dark equivalents:
+
+```diff
+- import {CustomProperties} from '@shopify/polaris-react';
+
+const App = (props) => (
+-  <CustomProperties colorScheme="dark">
+-    {props.children}
+-  </CustomProperties>
++  <div style={{ '--p-surface': 'var(--p-surface-dark)' }}>
++    {props.children}
++  </div>
+)
+```

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 
 import {
+  // eslint-disable-next-line import/no-deprecated
   CustomProperties,
   CustomPropertiesProps,
   DEFAULT_COLOR_SCHEME,
@@ -41,7 +42,7 @@ export interface AppProviderProps {
   features?: FeaturesConfig;
   /** Inner content of the application */
   children?: React.ReactNode;
-  /** Determines what color scheme is applied to child content. */
+  /** @deprecated Determines what color scheme is applied to child content. */
   colorScheme?: CustomPropertiesProps['colorScheme'];
 }
 
@@ -102,6 +103,13 @@ export class AppProvider extends Component<AppProviderProps, State> {
     );
     document.body.style.backgroundColor = 'var(--p-background)';
     document.body.style.color = 'var(--p-text)';
+
+    if (this.props.colorScheme && process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Deprecation: The `colorScheme` prop on the `AppProvider` has been deprecated. See the v10 migration guide for replacing dark color scheme styles. https://github.com/Shopify/polaris/blob/main/documentation/guides/migrating-from-v9-to-v10.md',
+      );
+    }
   };
 
   render() {

--- a/polaris-react/src/components/CustomProperties/CustomProperties.tsx
+++ b/polaris-react/src/components/CustomProperties/CustomProperties.tsx
@@ -18,6 +18,13 @@ export interface CustomPropertiesProps {
   as?: React.ElementType;
 }
 
+/**
+ * @deprecated The CustomProperties component will be removed in the next
+ * major version. See the Polaris token documentation for replacing
+ * colors relying on dark color scheme values.
+ *
+ * https://polaris.shopify.com/tokens/all-tokens
+ */
 export function CustomProperties(props: CustomPropertiesProps) {
   const {
     as: Component = 'div',
@@ -26,6 +33,13 @@ export function CustomProperties(props: CustomPropertiesProps) {
     colorScheme = DEFAULT_COLOR_SCHEME,
     style,
   } = props;
+
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: The `CustomProperties` component has been deprecated. See the v10 migration guide for replacing dark color scheme styles. https://github.com/Shopify/polaris/blob/main/documentation/guides/migrating-from-v9-to-v10.md',
+    );
+  }
 
   return (
     <Component

--- a/polaris-react/src/components/CustomProperties/tests/CustomProperties.test.tsx
+++ b/polaris-react/src/components/CustomProperties/tests/CustomProperties.test.tsx
@@ -2,6 +2,7 @@ import type {ColorScheme} from '@shopify/polaris-tokens';
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
+// eslint-disable-next-line import/no-deprecated
 import {CustomProperties, DEFAULT_COLOR_SCHEME} from '../CustomProperties';
 
 interface ColorSchemeAttribute {

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -8,6 +8,7 @@ import {ContextualSaveBarProps, useFrame} from '../../../../utilities/frame';
 import {getWidth} from '../../../../utilities/get-width';
 import {useI18n} from '../../../../utilities/i18n';
 import {useToggle} from '../../../../utilities/use-toggle';
+// eslint-disable-next-line import/no-deprecated
 import {CustomProperties} from '../../../CustomProperties';
 
 import {DiscardConfirmationModal} from './components';

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -3,6 +3,7 @@ import {mountWithApp} from 'tests/utilities';
 
 import {Button} from '../../../../Button';
 import {Image} from '../../../../Image';
+// eslint-disable-next-line import/no-deprecated
 import {CustomProperties} from '../../../../CustomProperties';
 import {ContextualSaveBar} from '../ContextualSaveBar';
 import {DiscardConfirmationModal} from '../components';
@@ -296,6 +297,7 @@ describe('<ContextualSaveBar />', () => {
 
   it('renders a CustomProperties with a dark color scheme', () => {
     const contextualSaveBar = mountWithApp(<ContextualSaveBar />);
+    // eslint-disable-next-line import/no-deprecated
     expect(contextualSaveBar).toContainReactComponent(CustomProperties, {
       colorScheme: 'dark',
     });

--- a/polaris-react/src/components/Frame/components/Toast/Toast.tsx
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.tsx
@@ -7,6 +7,7 @@ import {Button} from '../../../Button';
 import {Icon} from '../../../Icon';
 import {KeypressListener} from '../../../KeypressListener';
 import type {ToastProps} from '../../../../utilities/frame';
+// eslint-disable-next-line import/no-deprecated
 import {CustomProperties} from '../../../CustomProperties';
 
 import styles from './Toast.scss';

--- a/polaris-react/src/components/PolarisTestProvider/PolarisTestProvider.tsx
+++ b/polaris-react/src/components/PolarisTestProvider/PolarisTestProvider.tsx
@@ -4,6 +4,7 @@ import {PortalsManager} from '../PortalsManager';
 import {FocusManager} from '../FocusManager';
 import {merge} from '../../utilities/merge';
 import {FrameContext} from '../../utilities/frame';
+// eslint-disable-next-line import/no-deprecated
 import {CustomProperties, CustomPropertiesProps} from '../CustomProperties';
 import {MediaQueryContext} from '../../utilities/media-query';
 import {
@@ -37,6 +38,7 @@ export interface WithPolarisTestProviderOptions {
   // Contexts provided by AppProvider
   i18n?: ConstructorParameters<typeof I18n>[0];
   link?: LinkLikeComponent;
+  /** @deprecated */
   colorScheme?: CustomPropertiesProps['colorScheme'];
   mediaQuery?: Partial<MediaQueryContextType>;
   features?: FeaturesConfig;

--- a/polaris-react/src/components/Popover/Popover.tsx
+++ b/polaris-react/src/components/Popover/Popover.tsx
@@ -71,7 +71,7 @@ export interface PopoverProps {
   hideOnPrint?: boolean;
   /** Callback when popover is closed */
   onClose(source: PopoverCloseSource): void;
-  /** Accepts a color scheme for the contents of the popover */
+  /** @deprecated Accepts a color scheme for the contents of the popover */
   colorScheme?: PopoverOverlayProps['colorScheme'];
   /**
    * The preferred auto focus target defaulting to the popover container
@@ -195,6 +195,13 @@ const PopoverComponent = forwardRef<PopoverPublicAPI, PopoverProps>(
       }
       setAccessibilityAttributes();
     }, [activatorNode, setAccessibilityAttributes]);
+
+    if (colorScheme && process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Deprecation: The `colorScheme` prop on the `Popover` component has been deprecated. See the v10 migration guide for replacing dark color scheme styles. https://github.com/Shopify/polaris/blob/main/documentation/guides/migrating-from-v9-to-v10.md',
+      );
+    }
 
     const portal = activatorNode ? (
       <Portal idPrefix="popover">

--- a/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -2,6 +2,7 @@ import React, {PureComponent, Children, createRef} from 'react';
 import {tokens} from '@shopify/polaris-tokens';
 
 import {
+  // eslint-disable-next-line import/no-deprecated
   CustomProperties,
   CustomPropertiesProps,
 } from '../../../CustomProperties';

--- a/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
+++ b/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
@@ -21,7 +21,7 @@ export interface MenuProps {
   onClose(): void;
   /** A callback function to handle closing the menu popover */
   onClose(): void;
-  /** Accepts a color scheme for the contents of the menu */
+  /** @deprecated Accepts a color scheme for the contents of the menu */
   colorScheme?: PopoverProps['colorScheme'];
   /** A string that provides the accessibility labeling */
   accessibilityLabel?: string;
@@ -58,6 +58,13 @@ export function Menu(props: MenuProps) {
   );
 
   const isFullHeight = Boolean(message);
+
+  if (colorScheme && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: The `colorScheme` prop on the `Menu` component has been deprecated. See the v10 migration guide for replacing dark color scheme styles. https://github.com/Shopify/polaris/blob/main/documentation/guides/migrating-from-v9-to-v10.md',
+    );
+  }
 
   return (
     <Popover

--- a/polaris-react/src/components/TopBar/components/Search/Search.tsx
+++ b/polaris-react/src/components/TopBar/components/Search/Search.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// eslint-disable-next-line import/no-deprecated
 import {CustomProperties} from '../../../CustomProperties';
 import {classNames} from '../../../../utilities/css';
 import {SearchDismissOverlay} from '../SearchDismissOverlay';

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -26,7 +26,7 @@ export interface UserMenuProps {
   open: boolean;
   /** A callback function to handle opening and closing the user menu */
   onToggle(): void;
-  /** Accepts a color scheme for the contents of the user menu */
+  /** @deprecated Accepts a color scheme for the contents of the user menu */
   colorScheme?: MenuProps['colorScheme'];
 }
 
@@ -59,6 +59,13 @@ export function UserMenu({
       </span>
     </>
   );
+
+  if (colorScheme && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: The `colorScheme` prop on the `UserMenu` component has been deprecated. See the v10 migration guide for replacing dark color scheme styles. https://github.com/Shopify/polaris/blob/main/documentation/guides/migrating-from-v9-to-v10.md',
+    );
+  }
 
   return (
     <Menu


### PR DESCRIPTION
## What does this PR do

- Add deprecation warnings to usages of the `CustomProperties` component
- Add deprecation warnings to all components with a `colorScheme` prop
- Document migration strategy for using new dark color tokens

Closes #5991 

## Deprecation warnings

| `CustomProperties` | `colorScheme` | `console.log` | 
| --- | --- | --- |
| <img width="870" alt="customproperties" src="https://user-images.githubusercontent.com/11774595/171744130-bbf89a2e-9b34-4376-b05d-47c3b5e759c5.png"> | <img width="676" alt="colorscheme" src="https://user-images.githubusercontent.com/11774595/171744146-a5d95d80-0956-43bb-9c2b-d69ced15d9bd.png"> | <img width="906" alt="consolelog" src="https://user-images.githubusercontent.com/11774595/171744383-66c849e8-bf26-4046-ba49-6edb72206ccd.png"> |



