### PR TITLE
Remove polaris.shopify.com from ignored in Changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["polaris.shopify.com"]
+  "ignore": []
 }


### PR DESCRIPTION
Removing the `polaris.shopify.com` package from the Changsets config will allow the site to be versioned and a changelog to be created when updated.

This will also help avoid the situation as described in #6016

> **Note**:  the `polaris.shopify.com` package is already private so it should not be published to npm when released

Closes #6016