### PR TITLE
Simplify /snapit workflow

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -70,9 +70,7 @@ jobs:
           script: |
             const execa = require('execa')
 
-            const versionProcess = execa.command('yarn version-packages -- --snapshot snapshot-release')
-            versionProcess.stdout.pipe(process.stdout)
-            await versionProcess
+            await execa.command('yarn version-packages -- --snapshot snapshot-release', { stdio: 'inherit' })
 
             const releaseProcess = execa.command('yarn release -- --no-git-tags --snapshot --tag snapshot-release')
             releaseProcess.stdout.pipe(process.stdout)


### PR DESCRIPTION
Simplify the `/snapit` workflow by updating the `yarn version-packages` command to inherit the parent's `stdio` instead of manually piping `versionProcess.stdout`