### PR TITLE
[Polaris website refresh] Add copy/paste utility for tokens

### DIFF
--- a/.changeset/fuzzy-crabs-provide.md
+++ b/.changeset/fuzzy-crabs-provide.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Added cop/paste tooltip

--- a/polaris.shopify.com/public/icon-clipboard.svg
+++ b/polaris.shopify.com/public/icon-clipboard.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" style="filter: brightness(1.25);">
+    <path d="M15 2a1 1 0 011 1v13.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 014 16.5V3a1 1 0 112 0v1a2 2 0 002 2h4a2 2 0 002-2V3a1 1 0 011-1zm-4 2H9a1 1 0 110-2h2a1 1 0 110 2z" fill="#5C5F62"/>
+</svg>

--- a/polaris.shopify.com/src/components/TokenList/TokenList.module.scss
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.module.scss
@@ -82,49 +82,35 @@
   }
 }
 
-.TokenName {
-  display: block;
-  float: left;
-  padding: 0.33rem 1rem;
+.TokenContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.33rem 0.5rem;
   background: #fff0df;
-  border-radius: var(--border-radius-round);
-  font-size: var(--font-size-400);
+  border-radius: var(--border-radius-400);
+  font-size: var(--font-size-200);
+  gap: 0.1rem;
+}
+
+.TokenName {
+  white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: pre;
-  max-width: 100%;
-  cursor: pointer;
+}
 
-  &:hover {
+.TokenClipboard {
+  min-width: 19px;
+
+  button {
     position: relative;
-    max-width: unset;
-    z-index: 1;
-    width: max-content;
+    top: 0.15rem;
+    background-color: transparent;
 
-    .Clipboard {
+    &:hover {
       filter: brightness(0.2);
     }
   }
-}
-
-.TokenNameCopied {
-  display: block;
-  float: left;
-  padding: 0.33rem 1rem;
-  color: var(--primary);
-  background: #fff0df;
-  border-radius: var(--border-radius-round);
-  font-size: var(--font-size-400);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: pre;
-  max-width: 100%;
-}
-
-.Clipboard {
-  position: relative;
-  top: 0.15rem;
-  padding-right: 0.2rem;
 }
 
 .TokenDescription {

--- a/polaris.shopify.com/src/components/TokenList/TokenList.module.scss
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.module.scss
@@ -99,7 +99,32 @@
     position: relative;
     max-width: unset;
     z-index: 1;
+    width: max-content;
+
+    .Clipboard {
+      filter: brightness(0.2);
+    }
   }
+}
+
+.TokenNameCopied {
+  display: block;
+  float: left;
+  padding: 0.33rem 1rem;
+  color: var(--primary);
+  background: #fff0df;
+  border-radius: var(--border-radius-round);
+  font-size: var(--font-size-400);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  max-width: 100%;
+}
+
+.Clipboard {
+  position: relative;
+  top: 0.15rem;
+  padding-right: 0.2rem;
 }
 
 .TokenDescription {

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -8,6 +8,7 @@ import styles from "./TokenList.module.scss";
 import { useCopyToClipboard } from "../../utils/hooks";
 import iconClipboard from "../../../public/icon-clipboard.svg";
 import Image from "../Image";
+import Tooltip from "../Tooltip";
 
 interface ColumnsConfig {
   preview: boolean;
@@ -115,7 +116,7 @@ function TokenListItem({
   isHighlighted,
 }: TokenListItemProps) {
   const figmaUsage = getFigmaUsageForToken(name, value);
-  const tokenNameWithPrefix = `--p-${name}`
+  const tokenNameWithPrefix = `--p-${name}`;
   const [copy, didJustCopy] = useCopyToClipboard(tokenNameWithPrefix);
 
   return (
@@ -135,22 +136,31 @@ function TokenListItem({
           )}
           {columns.name && (
             <td>
-              {didJustCopy ? 
-                <span className={styles.TokenNameCopied}>Copied!</span> : 
-                <span>
-                  <div className={styles.TokenName} onClick={copy}>
-                    <span className={styles.Clipboard}>
+              <span className={styles.TokenContainer}>
+                <div className={styles.TokenName}>
+                  <span>{tokenNameWithPrefix}</span>
+                </div>
+                <div className={styles.TokenClipboard}>
+                  <Tooltip
+                    ariaLabel="Copy to clipboard"
+                    placement="top"
+                    renderContent={() => (
+                      <div className={styles.TokenToolTip}>
+                        <p>{didJustCopy ? "Copied!" : "Copy to clipboard"}</p>
+                      </div>
+                    )}
+                  >
+                    <button onClick={copy}>
                       <Image
                         src={iconClipboard}
                         alt={"Copy"}
                         width={19}
                         height={19}
                       />
-                    </span>
-                    <span>{tokenNameWithPrefix}</span>
-                  </div>
-                </span>
-              }
+                    </button>
+                  </Tooltip>
+                </div>
+              </span>
             </td>
           )}
           {columns.value && <td className={styles.Value}>{value}</td>}

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -5,6 +5,9 @@ import {
 import { createContext } from "react";
 import { className } from "../../utils/various";
 import styles from "./TokenList.module.scss";
+import { useCopyToClipboard } from "../../utils/hooks";
+import iconClipboard from "../../../public/icon-clipboard.svg";
+import Image from "../Image";
 
 interface ColumnsConfig {
   preview: boolean;
@@ -112,6 +115,8 @@ function TokenListItem({
   isHighlighted,
 }: TokenListItemProps) {
   const figmaUsage = getFigmaUsageForToken(name, value);
+  const tokenNameWithPrefix = `--p-${name}`
+  const [copy, didJustCopy] = useCopyToClipboard(tokenNameWithPrefix);
 
   return (
     <TokenListContext.Consumer>
@@ -130,7 +135,22 @@ function TokenListItem({
           )}
           {columns.name && (
             <td>
-              <span className={styles.TokenName}>--p-{name}</span>
+              {didJustCopy ? 
+                <span className={styles.TokenNameCopied}>Copied!</span> : 
+                <span>
+                  <div className={styles.TokenName} onClick={copy}>
+                    <span className={styles.Clipboard}>
+                      <Image
+                        src={iconClipboard}
+                        alt={"Copy"}
+                        width={19}
+                        height={19}
+                      />
+                    </span>
+                    <span>{tokenNameWithPrefix}</span>
+                  </div>
+                </span>
+              }
             </td>
           )}
           {columns.value && <td className={styles.Value}>{value}</td>}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5902
Reiteration of https://github.com/Shopify/polaris/pull/5959

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds a clipboard icon next to the token name, which when clicked copies the token to the user clipboard along with showing a tooltip with the action status.

https://user-images.githubusercontent.com/59836805/171886029-0d186dc9-b9d2-44ce-aea0-b6f380c262c6.mp4

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->



### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
