### PR TITLE
[Page] Add 'onActionRollup' prop to Page component.

### DIFF
--- a/.changeset/clean-rockets-beam.md
+++ b/.changeset/clean-rockets-beam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added 'onActionRollup' prop to Page component.

--- a/polaris-react/src/components/ActionMenu/ActionMenu.tsx
+++ b/polaris-react/src/components/ActionMenu/ActionMenu.tsx
@@ -19,6 +19,8 @@ export interface ActionMenuProps {
   rollup?: boolean;
   /** Label for rolled up actions activator */
   rollupActionsLabel?: string;
+  /** Callback that returns true when secondary actions are rolled up into action groups, and false when not */
+  onActionRollup?(hasRolledUp: boolean): void;
 }
 
 export function ActionMenu({
@@ -26,6 +28,7 @@ export function ActionMenu({
   groups = [],
   rollup,
   rollupActionsLabel,
+  onActionRollup,
 }: ActionMenuProps) {
   if (actions.length === 0 && groups.length === 0) {
     return null;
@@ -47,7 +50,11 @@ export function ActionMenu({
           sections={rollupSections}
         />
       ) : (
-        <Actions actions={actions} groups={groups} />
+        <Actions
+          actions={actions}
+          groups={groups}
+          onActionRollup={onActionRollup}
+        />
       )}
     </div>
   );

--- a/polaris-react/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/polaris-react/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -20,6 +20,8 @@ interface Props {
   actions?: MenuActionDescriptor[];
   /** Collection of page-level action groups */
   groups?: MenuGroupDescriptor[];
+  /** Callback that returns true when secondary actions are rolled up into action groups, and false when not */
+  onActionRollup?(hasRolledUp: boolean): void;
 }
 
 interface MeasuredActions {
@@ -29,7 +31,7 @@ interface MeasuredActions {
 
 const ACTION_SPACING = 8;
 
-export function Actions({actions = [], groups = []}: Props) {
+export function Actions({actions = [], groups = [], onActionRollup}: Props) {
   const i18n = useI18n();
   const actionsLayoutRef = useRef<HTMLDivElement>(null);
   const menuGroupWidthRef = useRef<number>(0);
@@ -37,6 +39,7 @@ export function Actions({actions = [], groups = []}: Props) {
   const actionsAndGroupsLengthRef = useRef<number>(0);
   const timesMeasured = useRef(0);
   const actionWidthsRef = useRef<number[]>([]);
+  const rollupActiveRef = useRef<boolean | null>(null);
   const [activeMenuGroup, setActiveMenuGroup] = useState<string | undefined>(
     undefined,
   );
@@ -124,6 +127,17 @@ export function Actions({actions = [], groups = []}: Props) {
       }
     });
 
+    if (onActionRollup) {
+      // Note: Do not include last group actions since we are skipping `lastMenuGroup` above
+      // as it is always rendered with its own actions
+      const isRollupActive =
+        newShowableActions.length < actionsAndGroups.length - 1;
+      if (rollupActiveRef.current !== isRollupActive) {
+        onActionRollup(isRollupActive);
+        rollupActiveRef.current = isRollupActive;
+      }
+    }
+
     setMeasuredActions({
       showable: newShowableActions,
       rolledUp: newRolledUpActions,
@@ -131,7 +145,7 @@ export function Actions({actions = [], groups = []}: Props) {
 
     timesMeasured.current += 1;
     actionsAndGroupsLengthRef.current = actionsAndGroups.length;
-  }, [actions, groups, lastMenuGroup, lastMenuGroupWidth]);
+  }, [actions, groups, lastMenuGroup, lastMenuGroupWidth, onActionRollup]);
 
   const handleResize = useMemo(
     () =>

--- a/polaris-react/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/polaris-react/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -5,7 +5,7 @@ import type {
   MenuGroupDescriptor,
   ActionListItemDescriptor,
 } from '../../../types';
-import {MenuGroup, RollupActions} from '../components';
+import {MenuGroup, RollupActions, Actions} from '../components';
 import {ActionMenu, ActionMenuProps} from '../ActionMenu';
 import {Button} from '../../Button';
 import {ButtonGroup} from '../../ButtonGroup';
@@ -195,6 +195,21 @@ describe('<ActionMenu />', () => {
     wrapper.find(Button)!.trigger('onClick');
 
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders <Actions /> passing `onActionRollup` as prop if it exists', () => {
+    const onActionRollup = jest.fn();
+    const wrapper = mountWithApp(
+      <ActionMenu
+        {...mockProps}
+        actions={[{content: 'mock'}]}
+        onActionRollup={onActionRollup}
+      />,
+    );
+
+    expect(wrapper).toContainReactComponent(Actions, {
+      onActionRollup,
+    });
   });
 });
 

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -54,6 +54,8 @@ export interface HeaderProps extends TitleProps {
   additionalNavigation?: React.ReactNode;
   // Additional meta data
   additionalMetadata?: React.ReactNode | string;
+  /** Callback that returns true when secondary actions are rolled up into action groups, and false when not */
+  onActionRollup?(hasRolledUp: boolean): void;
 }
 
 const SHORT_TITLE = 20;
@@ -73,6 +75,7 @@ export function Header({
   secondaryActions = [],
   actionGroups = [],
   compactTitle = false,
+  onActionRollup,
 }: HeaderProps) {
   const i18n = useI18n();
   const {isNavigationCollapsed} = useMediaQuery();
@@ -150,6 +153,7 @@ export function Header({
             ? i18n.translate('Polaris.Page.Header.rollupActionsLabel', {title})
             : undefined
         }
+        onActionRollup={onActionRollup}
       />
     );
   } else if (isReactElement(secondaryActions)) {

--- a/polaris-react/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/polaris-react/src/components/Page/components/Header/tests/Header.test.tsx
@@ -250,6 +250,21 @@ describe('<Header />', () => {
 
       expect(wrapper).toContainReactComponent(CustomSecondaryActions);
     });
+
+    it('renders <ActionMenu /> passing `onActionRollup` as prop if it exists', () => {
+      const onActionRollup = jest.fn();
+      const wrapper = mountWithApp(
+        <Header
+          {...mockProps}
+          secondaryActions={mockSecondaryActions}
+          onActionRollup={onActionRollup}
+        />,
+      );
+
+      expect(wrapper).toContainReactComponent(ActionMenu, {
+        onActionRollup,
+      });
+    });
   });
 
   const primaryAction: HeaderProps['primaryAction'] = {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Right now, the Page component by default introduces the `More Actions` action group to perform roll ups. However, when there is an action group already present, then all secondary actions are going to roll up to this one. This might not be desirable, given that the existing action group could have nothing to do with the secondary actions, or the existing action group could be disabled as well and in this case we would roll up items into a disabled action group.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

To solve the above problem, this PR adds `isRollingUp` prop to the Page component. The idea is that we are able to pass a callback `isRollingUp`, and listen on the consumer side whether a roll up is happening or not. For the above issue, one fix here would be to manually introduce `More Actions` action group when a roll up happens.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

You can test by passing the prop to any `Page` component in the playground:
```JS
onActionRollup={(hasRolledUp) => { console.log('HAS ROLLED UP: ', hasRolledUp); }}
```

The results should be similar to the following:

https://user-images.githubusercontent.com/16692690/171854652-8f80ae5d-978e-4b84-b462-c7d6687f44e8.mov


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
