### PR TITLE
[Listbox] Fix loss of scroll position when lazy loading

### DIFF
--- a/polaris-react/src/components/Listbox/Listbox.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.tsx
@@ -238,19 +238,30 @@ export function Listbox({
       option.getAttribute(OPTION_VALUE_ATTRIBUTE),
     );
 
-    const listIsUnchangedOrAppended =
+    const listIsUnchanged =
+      nextValues.length === currentValues.length &&
+      nextValues.every((value, index) => {
+        return currentValues[index] === value;
+      });
+
+    const listIsAppended =
       currentValues.length !== 0 &&
-      nextValues.length >= currentValues.length &&
+      nextValues.length > currentValues.length &&
       currentValues.every((value, index) => {
         return nextValues[index] === value;
       });
 
-    if (listIsUnchangedOrAppended) {
+    if (listIsUnchanged) {
       if (optionIsAlreadyActive && actionContentHasUpdated) {
         setCurrentOptions(nextOptions);
         handleChangeActiveOption(nextOption);
       }
 
+      return;
+    }
+
+    if (listIsAppended) {
+      setCurrentOptions(nextOptions);
       return;
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

When lazy loading the next options, the Listbox scroll position would reset to the first active option at the beginning of the list.

### WHAT is this pull request doing?

Fixes scroll position being reset to the top of the Listbox when lazy loading the next set of options while preserving keyboard navigation.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
| Resource | Before | After |
|---|---|---|
| Polaris Storybook | <img width="1552" alt="lazy-load-storybook-before" src="https://user-images.githubusercontent.com/26749317/171893867-03f1b29b-7d33-45f2-9336-73bb966bd5d6.gif"> | <img width="1552" alt="lazy-load-storybook-after" src="https://user-images.githubusercontent.com/26749317/171893853-01771664-c419-4abf-b84c-e288256a4485.gif"> |
| Admin orders | <img width="1552" alt="lazy-load-admin-before" src="https://user-images.githubusercontent.com/26749317/171892516-aa1ac958-b5c8-418b-b77a-fb65b85ae484.gif"> | <img width="1552" alt="lazy-load-admin-after" src="https://user-images.githubusercontent.com/26749317/171892492-13f40301-4d70-4e31-9ce9-5973012e3340.gif"> |

### How to 🎩

[Spinstance](https://shop1.shopify.test-lazy-loading.lo-kim.us.spin.dev/admin/draft_orders/new)
[Polaris storybook](https://5d559397bae39100201eedc1-vvirrrrgtx.chromatic.com/?path=/story/all-components-autocomplete--autocomplete-with-lazy-loading)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
