### PR TITLE
Fail /snapit on pull requests from forked repositories

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -1,0 +1,120 @@
+name: Snapshot
+
+on:
+  issue_comment:
+    types:
+      - created
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  snapshot:
+    name: Snapshot Release
+    if: |
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/snapit' || github.event.comment.body == '/snapshot-release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce permission requirement
+        uses: prince-chrismc/check-actor-permissions-action@v1
+        with:
+          permission: write
+
+      - name: Add initial reaction
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: eyes
+
+      # issue_comment requires us to checkout the branch
+      # https://github.com/actions/checkout/issues/331#issuecomment-707103442
+      - name: Get pull request data
+        uses: actions/github-script@v3
+        id: pr_data
+        with:
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            }
+            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+            try {
+              const result = await github.pulls.get(request)
+              return result.data
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            }
+
+      - name: Checkout pull request branch
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ fromJSON(steps.pr_data.outputs.result).head.repo.full_name }}
+          ref: ${{ fromJSON(steps.pr_data.outputs.result).head.sha }}
+
+      # Because changeset entries are consumed and removed on the
+      # 'changeset-release/main' branch, we need to reset the files
+      # so the following 'changeset version --snapshot' command will
+      # regenerate the package version bumps with the snapshot releases
+      - name: Reset changeset entries on changeset-release/main branch
+        run: |
+          if [[ $(git branch --show-current) == 'changeset-release/main' ]]; then
+            git checkout origin/main -- .changeset
+          fi
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Create an .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create and publish snapshot release
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const execa = require('execa')
+            await execa.command('yarn version-packages -- --snapshot snapshot-release', { stdio: 'inherit' })
+            const releaseProcess = execa.command('yarn release -- --no-git-tags --snapshot --tag snapshot-release')
+            releaseProcess.stdout.pipe(process.stdout)
+            const {stdout} = await releaseProcess
+            const newTags = Array.from(
+              stdout.matchAll(/New tag:\s+([^\s\n]+)/g),
+            ).map(
+              ([_, tag]) => tag,
+            )
+            if (newTags.length) {
+              const multiple = newTags.length > 1
+              const body = (
+                `🫰✨ **Thanks @${context.actor}! ` +
+                `Your snapshot${multiple ? 's have' : ' has'} been published to npm.**\n\n` +
+                `Test the snapshot${multiple ? 's' : ''} by updating your \`package.json\` ` +
+                `with the newly published version${multiple ? 's' : ''}:\n` +
+                newTags.map(tag => (
+                  '```sh\n' +
+                  `yarn add ${tag}\n` +
+                  '```'
+                )).join('\n')
+              )
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              })
+            }
+      - name: Add final reaction
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: rocket

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -26,8 +26,6 @@ jobs:
           comment-id: ${{ github.event.comment.id }}
           reactions: eyes
 
-      # issue_comment requires us to checkout the branch
-      # https://github.com/actions/checkout/issues/331#issuecomment-707103442
       - name: Validate and get pull request data
         uses: actions/github-script@v6
         id: pr_data

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -77,6 +77,7 @@ jobs:
           if [[ $(git branch --show-current) == 'changeset-release/main' ]]; then
             git checkout origin/main -- .changeset
           fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
@@ -86,12 +87,12 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Create an .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cat << EOF > "$HOME/.npmrc"
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
           EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create and publish snapshot release
         uses: actions/github-script@v6
@@ -100,17 +101,21 @@ jobs:
         with:
           script: |
             const execa = require('execa')
+
             await execa.command('yarn version-packages -- --snapshot snapshot-release', { stdio: 'inherit' })
+
             const releaseProcess = execa.command('yarn release -- --no-git-tags --snapshot --tag snapshot-release')
             releaseProcess.stdout.pipe(process.stdout)
+
             const {stdout} = await releaseProcess
-            const newTags = Array.from(
-              stdout.matchAll(/New tag:\s+([^\s\n]+)/g),
-            ).map(
-              ([_, tag]) => tag,
-            )
+
+            const newTags = Array
+              .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
+              .map(([_, tag]) => tag)
+
             if (newTags.length) {
               const multiple = newTags.length > 1
+
               const body = (
                 `🫰✨ **Thanks @${context.actor}! ` +
                 `Your snapshot${multiple ? 's have' : ' has'} been published to npm.**\n\n` +
@@ -129,6 +134,7 @@ jobs:
                 body,
               })
             }
+
       - name: Add final reaction
         uses: peter-evans/create-or-update-comment@v2
         with:

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -28,29 +28,47 @@ jobs:
 
       # issue_comment requires us to checkout the branch
       # https://github.com/actions/checkout/issues/331#issuecomment-707103442
-      - name: Get pull request data
-        uses: actions/github-script@v3
+      - name: Validate and get pull request data
+        uses: actions/github-script@v6
         id: pr_data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
-            const request = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            }
-            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
             try {
-              const result = await github.pulls.get(request)
-              return result.data
+              const pullRequest = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              })
+              
+              // Pull request from fork
+              if (context.payload.repository.full_name !== pullRequest.data.head.repo.full_name) {
+                const errorMessage = '`/snapit` is not supported on pull requests from forked repositories.'
+
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: errorMessage,
+                })
+
+                core.setFailed(errorMessage)
+                return
+              }
+              core.setOutput('repoFullName', pullRequest.data.head.repo.full_name)
+              core.setOutput('headSha', pullRequest.data.head.sha)
             } catch (err) {
               core.setFailed(`Request failed with error ${err}`)
             }
 
+      # issue_comment requires us to checkout the pull request branch
+      # https://github.com/actions/checkout/issues/331#issuecomment-707103442
       - name: Checkout pull request branch
         uses: actions/checkout@v2
         with:
-          repository: ${{ fromJSON(steps.pr_data.outputs.result).head.repo.full_name }}
-          ref: ${{ fromJSON(steps.pr_data.outputs.result).head.sha }}
+          repository: ${{ steps.pr_data.outputs.repoFullName }}
+          ref: ${{ steps.pr_data.outputs.headSha }}
 
       # Because changeset entries are consumed and removed on the
       # 'changeset-release/main' branch, we need to reset the files


### PR DESCRIPTION
This PR updates `/snapit` to fail on pull requests from forked repositories and checkout the `head.sha` of the pull request.