### PR TITLE
[polaris.shopify.com reboot] Tweak design of icons detail view

### DIFF
--- a/.changeset/sweet-windows-fold.md
+++ b/.changeset/sweet-windows-fold.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Remove modal from icons page

--- a/polaris.shopify.com/src/components/Button/Button.module.scss
+++ b/polaris.shopify.com/src/components/Button/Button.module.scss
@@ -1,14 +1,14 @@
 .Button {
   display: inline-block;
   appearance: none;
-  background: var(--surface);
-  padding: 0.2rem 0.66rem 0.2rem;
+  background: var(--surface-subdued);
+  color: var(--text-strong);
+  padding: 0.5rem 0.66rem;
   border: none;
-  font-size: var(--font-size-300);
+  font-size: var(--font-size-200);
   font-weight: var(--font-weight-400);
-  border-radius: var(--border-radius-500);
+  border-radius: var(--border-radius-400);
   cursor: pointer;
-  color: inherit;
   user-select: none;
 
   &:hover {
@@ -17,6 +17,8 @@
 
   &.small {
     font-size: var(--font-size-200);
+    padding: 0.33rem;
+    line-height: 1;
   }
 
   &.pill {

--- a/polaris.shopify.com/src/components/Button/Button.tsx
+++ b/polaris.shopify.com/src/components/Button/Button.tsx
@@ -10,7 +10,9 @@ interface Props {
 }
 
 interface ButtonProps extends Props, HTMLProps<HTMLButtonElement> {}
-interface LinkButtonProps extends Props, PropsWithChildren<LinkProps> {}
+interface LinkButtonProps extends Props, PropsWithChildren<LinkProps> {
+  download?: boolean;
+}
 
 function Button({ small, pill, primary, children, ...rest }: ButtonProps) {
   return (
@@ -34,6 +36,7 @@ export function LinkButton({
   pill,
   href,
   primary,
+  download,
   children,
   ...rest
 }: LinkButtonProps) {
@@ -46,6 +49,7 @@ export function LinkButton({
           pill && styles.pill,
           primary && styles.primary
         )}
+        download={download}
         {...rest}
       >
         {children}

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
@@ -1,34 +1,49 @@
 .CodeExample {
-  margin: 1.5rem 0;
-  background: linear-gradient(45deg, #080619, #0b0334);
-  color: white;
+  margin: 1rem 0;
+  background: var(--surface-subdued);
   border-radius: var(--border-radius-600);
+  overflow: hidden;
 }
 
-.Title {
-  background: rgba(255, 255, 255, 0.1);
-  text-align: center;
-  font-size: var(--font-size-200);
-  font-weight: var(--font-weight-500);
-  border-radius: var(--border-radius-600) var(--border-radius-600) 0 0;
-  padding: 0.5em;
-  color: rgba(255, 255, 255, 0.5);
-  box-shadow: inset 0 -1px rgba(255, 255, 255, 0.05);
+.TitleBar {
+  position: relative;
+  padding: 0.4em;
+  background: rgba(0, 0, 0, 0.025);
+
+  .Title {
+    text-align: center;
+    font-size: var(--font-size-100);
+    font-weight: var(--font-weight-400);
+  }
+
+  .CopyButton {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+    padding: 0 0.5rem;
+    background: transparent;
+    display: flex;
+    align-items: center;
+    opacity: 0.5;
+    &:hover {
+      opacity: 1;
+    }
+  }
 }
 
 .Code {
   font-family: "SF Mono", SFMono-Regular, ui-monospace, "DejaVu Sans Mono",
     Menlo, Consolas, monospace;
   white-space: pre;
-  padding: 1rem;
-  font-size: var(--font-size-200);
+  padding: 0.7rem 1rem;
+  font-size: var(--font-size-100);
+  color: var(--text-strong);
 }
 
 .LineNumber {
   opacity: 0.25;
-  margin-right: 1rem;
+  margin-right: 0.75rem;
   user-select: none;
-}
-
-.Line {
 }

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
@@ -1,4 +1,9 @@
+import Image from "next/image";
+import Tooltip from "../Tooltip";
+import iconCancel from "../../../public/icon-cancel.svg";
+import iconClipboard from "../../../public/icon-clipboard.svg";
 import styles from "./CodeExample.module.scss";
+import { useCopyToClipboard } from "../../utils/hooks";
 
 interface Props {
   language: "terminal" | "typescript";
@@ -7,10 +12,28 @@ interface Props {
 }
 
 function CodeExample({ title, children }: Props) {
+  const [copy, didJustCopy] = useCopyToClipboard(children);
   const lines = children.split("\n");
+
   return (
     <div className={styles.CodeExample}>
-      <div className={styles.Title}>{title}</div>
+      <div className={styles.TitleBar}>
+        <div className={styles.Title}>{title}</div>
+        <Tooltip
+          ariaLabel="Copy to clipboard"
+          placement="top"
+          renderContent={() => (
+            <div className={styles.IconToolTip}>
+              <p>{didJustCopy ? "Copied" : "Copy"}</p>
+            </div>
+          )}
+        >
+          <button type="button" onClick={copy} className={styles.CopyButton}>
+            <Image src={iconClipboard} alt="Copy" width={19} height={19} />
+          </button>
+        </Tooltip>
+      </div>
+
       <div className={styles.Code}>
         {lines.map((line, i) => (
           <div className={styles.Line} key={line}>

--- a/polaris.shopify.com/src/components/IconGrid/IconGrid.module.scss
+++ b/polaris.shopify.com/src/components/IconGrid/IconGrid.module.scss
@@ -1,6 +1,6 @@
 .IconGrid {
   display: grid;
-  gap: 8px;
+  gap: 4px;
   grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
 }
 
@@ -19,7 +19,7 @@
     background: var(--surface-subdued);
     padding-top: 5px;
     aspect-ratio: 5 / 4;
-    border-radius: var(--border-radius-800);
+    border-radius: var(--border-radius-200);
     transition: background-color 0.05s linear;
     box-shadow: var(--card-shadow);
 

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.module.scss
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.module.scss
@@ -63,11 +63,11 @@
   display: flex;
   gap: 3rem;
 
-  > div:nth-child(1) {
+  .IconGrids {
     flex: 1;
   }
 
-  > div:nth-child(2) {
+  .Sidebar {
     align-self: flex-start;
     position: sticky;
     top: 2rem;

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.module.scss
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.module.scss
@@ -25,167 +25,59 @@
   }
 }
 
-.ModalContainer {
-  h3 {
+.SelectedIcon {
+  .IconName {
     font-size: var(--font-size-600);
-  }
-
-  h5 {
-    font-size: var(--font-size-500);
-    color: var(--text-strong);
-    font-weight: var(--font-weight-400);
-  }
-
-  div {
-    font-size: var(--font-size-100);
-  }
-
-  ::-webkit-scrollbar {
-    width: 15px;
-  }
-  ::-webkit-scrollbar-track {
-    background-color: transparent;
-  }
-  ::-webkit-scrollbar-thumb {
-    background-color: rgba(109, 105, 105, 0.622);
-    border-radius: 20px;
-    border: 3px solid white;
-    background-clip: content-box;
-
-    &:hover {
-      background-color: rgba(7, 7, 7, 0.5);
-    }
-  }
-}
-
-.Modal {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  max-width: 800px;
-  height: 500px;
-  margin: auto;
-  background: white;
-  border-radius: 25px 10px 10px 25px;
-  box-shadow: 0px 0px 100px -10px grey;
-  padding: 2rem;
-  overflow: auto;
-}
-
-.ModalHeader {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.ModalHeaderLeft {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.IconTitle {
-  padding-left: 1rem;
-}
-
-.IconDescription {
-  padding-top: 0.6rem;
-}
-
-.CancelButton {
-  background-color: transparent;
-}
-
-.Break {
-  border-bottom: 2px solid var(--surface-subdued);
-  padding-top: 1rem;
-  margin-bottom: 0.3rem;
-}
-
-.SnippetHeader {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding-bottom: 0.7rem;
-  padding-top: 0.7rem;
-}
-
-.ModalFooter {
-  display: flex;
-  flex-direction: column;
-  padding-top: 1rem;
-
-  a {
-    font-size: var(--font-size-200);
-    padding-bottom: 0.5rem;
-  }
-}
-
-.KeywordsButtonGroup {
-  button {
-    font-size: var(--font-size-100);
-    border-radius: var(--border-radius-500);
-    margin: 0.25rem 0 0.25rem 0.7rem;
-    padding: 0.2rem 0.7rem;
-  }
-}
-
-.Keywords {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.ActionButtons {
-  button {
-    color: var(--surface);
     font-weight: var(--font-weight-500);
-    background-color: var(--text-strong);
-    border-radius: var(--border-radius-500);
-    margin-top: 1rem;
-    margin-right: 1rem;
-    padding: 0.7rem 1.5rem;
-  }
-}
 
-.CodeSnippet {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-}
-
-.IconClipboard {
-  min-width: 19px;
-
-  button {
-    background-color: transparent;
-
-    &:hover {
-      filter: brightness(0.2);
+    span {
+      color: var(--text-subdued);
     }
   }
+
+  .ActionButtons {
+    margin-top: 1rem;
+  }
+
+  .IconDescription {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .Keywords {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.1rem;
+    font-size: var(--font-size-100);
+    color: var(--text-subdued);
+  }
+
+  h3 {
+    margin: 2rem 0 0.5rem;
+    font-size: var(--font-size-500);
+    font-weight: var(--font-weight-500);
+  }
 }
 
-@keyframes sidebar-enter {
-  0% {
-    width: 0;
+.SplitLayout {
+  display: flex;
+  gap: 3rem;
+
+  > div:nth-child(1) {
+    flex: 1;
   }
 
-  100% {
-    width: 28rem;
+  > div:nth-child(2) {
+    align-self: flex-start;
+    position: sticky;
+    top: 2rem;
+    width: 25%;
   }
 }
 
-@keyframes sidebar-inner-enter {
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
+.ProposeChangeLink {
+  margin-top: 1rem;
+  display: inline-block;
+  color: var(--text-subdued);
+  font-size: var(--font-size-100);
 }

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -1,9 +1,7 @@
 import Head from "next/head";
-import Image from "../Image";
 import { useState } from "react";
 import Fuse from "fuse.js";
 import styles from "./IconsPage.module.scss";
-import Longform from "../Longform";
 import MaxPageWidthDiv from "../MaxPageWidthDiv";
 import metadata from "@shopify/polaris-icons/metadata";
 const importedSvgs = require.context(
@@ -14,11 +12,9 @@ const importedSvgs = require.context(
 import { getTitleTagValue } from "../../utils/various";
 import IconGrid from "../IconGrid";
 import TextField from "../TextField";
-import { Dialog } from "@headlessui/react";
-import iconCancel from "../../../public/icon-cancel.svg";
-import Tooltip from "../Tooltip";
-import { useCopyToClipboard } from "../../utils/hooks";
-import iconClipboard from "../../../public/icon-clipboard.svg";
+import CodeExample from "../CodeExample";
+import { LinkButton } from "../Button/Button";
+import Button from "../Button";
 
 let icons = Object.entries(metadata).map(([fileName, icon]) => ({
   ...icon,
@@ -39,27 +35,6 @@ const fuse = new Fuse(Object.values(icons), {
 function IconsPage() {
   const [filterString, setFilterString] = useState("");
   const [selectedIconName, setSelectedIconName] = useState<string>();
-  const [isOpen, setIsOpen] = useState(false);
-
-  const importSnippet = `import {
-    ${selectedIconName}
-} from '@shopify/polaris-icons';`;
-
-  const usageSnippet = `<Icon
-  source={${selectedIconName}}
-  color="base" 
-/>`;
-
-  const [copyImport, didJustCopyImport] = useCopyToClipboard(importSnippet);
-  const [copyUsage, didJustCopyUsage] = useCopyToClipboard(usageSnippet);
-
-  const closeModal = () => {
-    setIsOpen(false);
-  };
-
-  const openModal = () => {
-    setIsOpen(true);
-  };
 
   let filteredIcons = [...icons];
 
@@ -78,18 +53,6 @@ function IconsPage() {
     throw new Error(`Could not find icon ${selectedIconName}`);
   }
 
-  const handleCopy = (type: string) => {
-    if (type === "Import") {
-      copyImport();
-    } else if (type === "Usage") {
-      copyUsage();
-    }
-  };
-
-  if (selectedIcon) {
-    console.log(importedSvgs(`./${selectedIcon.fileName}.svg`).default.src);
-  }
-
   const updateURL = `https://github.com/Shopify/polaris-icons/issues/new?assignees=@shopify/icon-guild&labels=Update,Proposal&template=propose-updates-to-existing-icons.md&title=%5BProposal%5D%20Update%20${selectedIconName}`;
 
   return (
@@ -100,228 +63,158 @@ function IconsPage() {
 
       <div className={styles.Filter}>
         <h1>Icons</h1>
-        <div className={styles.TextField}>
-          <TextField
-            value={filterString}
-            onChange={(value) => setFilterString(value)}
-            placeholder="Filter icons"
-          />
-        </div>
       </div>
 
-      <div className={styles.IconGrids}>
-        {majorIcons.length > 0 && (
-          <>
-            <div className={styles.SectionHeading}>
-              <p>
-                <b>Major icons.</b> Used for things like lorem ipsum dolor et
-                amet consecteur
-              </p>
-            </div>
-            <IconGrid>
-              {majorIcons.map((icon) => (
-                <IconGrid.Item
-                  key={icon.name}
-                  icon={icon}
-                  onClick={() => {
-                    setSelectedIconName(icon.name);
-                    openModal();
-                  }}
-                  isHighlighted={false}
-                />
-              ))}
-            </IconGrid>
-          </>
-        )}
+      <div className={styles.SplitLayout}>
+        <div className={styles.IconGrids}>
+          <div className={styles.TextField}>
+            <TextField
+              value={filterString}
+              onChange={(value) => setFilterString(value)}
+              placeholder="Filter icons"
+            />
+          </div>
 
-        {minorIcons.length > 0 && (
-          <>
-            <div className={styles.SectionHeading}>
-              <p>
-                <b>Minor icons.</b> Used for things like lorem ipsum dolor et
-                amet consecteur
-              </p>
-            </div>
-            <IconGrid>
-              {minorIcons.map((icon) => (
-                <IconGrid.Item
-                  key={icon.name}
-                  icon={icon}
-                  onClick={() => {}}
-                  isHighlighted={false}
-                />
-              ))}
-            </IconGrid>
-          </>
-        )}
-      </div>
-
-      {selectedIcon && (
-        <Dialog
-          className={styles.ModalContainer}
-          open={isOpen}
-          onClose={() => setIsOpen(false)}
-        >
-          <Dialog.Panel className={styles.Modal}>
-            <Dialog.Title as="div" className={styles.ModalHeader}>
-              <div className={styles.ModalHeaderLeft}>
-                <div
-                  className={styles.Preview}
-                  style={{ filter: "brightness(-500%)" }}
-                >
-                  <Image
-                    src={importedSvgs(`./${selectedIcon.fileName}.svg`)}
-                    alt={metadata[selectedIcon.fileName].description}
-                    width={48}
-                    height={48}
+          {majorIcons.length > 0 && (
+            <>
+              <div className={styles.SectionHeading}>
+                <p>
+                  <b>Major icons.</b> Used for things like lorem ipsum dolor et
+                  amet consecteur
+                </p>
+              </div>
+              <IconGrid>
+                {majorIcons.map((icon) => (
+                  <IconGrid.Item
+                    key={icon.name}
+                    icon={icon}
+                    onClick={() => setSelectedIconName(icon.name)}
+                    isHighlighted={false}
                   />
-                </div>
-                <h3 className={styles.IconTitle}>
-                  {selectedIcon.name} ({selectedIcon.set})
-                </h3>
+                ))}
+              </IconGrid>
+            </>
+          )}
+
+          {minorIcons.length > 0 && (
+            <>
+              <div className={styles.SectionHeading}>
+                <p>
+                  <b>Minor icons.</b> Used for things like lorem ipsum dolor et
+                  amet consecteur
+                </p>
               </div>
-              <button
-                type="button"
-                className={styles.CancelButton}
-                onClick={closeModal}
-              >
+
+              <IconGrid>
+                {minorIcons.map((icon) => (
+                  <IconGrid.Item
+                    key={icon.name}
+                    icon={icon}
+                    onClick={() => {}}
+                    isHighlighted={false}
+                  />
+                ))}
+              </IconGrid>
+            </>
+          )}
+        </div>
+
+        <div>
+          {selectedIcon && (
+            <div className={styles.SelectedIcon}>
+              {/* <div className={styles.Preview}>
                 <Image
-                  src={iconCancel}
+                  src={importedSvgs(`./${selectedIcon.fileName}.svg`)}
                   alt={metadata[selectedIcon.fileName].description}
-                  width={25}
-                  height={25}
+                  width={24}
+                  height={24}
                 />
-              </button>
-            </Dialog.Title>
-            <Dialog.Description className={styles.IconDescription}>
-              <span className={styles.IconMeta}>
-                {metadata[selectedIcon.fileName].description}
-              </span>
-            </Dialog.Description>
-            <hr className={styles.Break} />
-            <Longform>
-              <div className={styles.SnippetHeader}>
-                <h5>Import</h5>
-                <div>
-                  Learn how to{" "}
-                  <a href="https://www.npmjs.com/package/@shopify/polaris-icons#usage">
-                    import icons
-                  </a>
-                </div>
+              </div> */}
+
+              <h2 className={styles.IconName}>
+                {selectedIcon.name} <span>{selectedIcon.set}</span>
+              </h2>
+
+              {selectedIcon.description !== "N/A" && (
+                <p className={styles.IconDescription}>
+                  {selectedIcon.description}
+                </p>
+              )}
+
+              <p className={styles.Keywords}>
+                {selectedIcon.keywords
+                  .filter((keyword) => keyword !== "N/A")
+                  .map((keyword) => {
+                    return (
+                      <Button
+                        type="button"
+                        key={keyword}
+                        onClick={() => setFilterString(`${keyword}`)}
+                        small
+                      >
+                        {keyword}
+                      </Button>
+                    );
+                  })}
+              </p>
+
+              <div className={styles.ActionButtons}>
+                <LinkButton
+                  href={
+                    importedSvgs(`./${selectedIcon.fileName}.svg`).default.src
+                  }
+                  download
+                  primary
+                >
+                  Download SVG
+                </LinkButton>
               </div>
-              <pre className={styles.CodeSnippet}>
-                <div>
-                  {`import {
+
+              <h3>Figma usage</h3>
+              <p>
+                Use the{" "}
+                <a href="https://www.figma.com/community/file/1110993965108325096">
+                  Polaris Icon Library
+                </a>{" "}
+                to access all icons right inside Figma.
+              </p>
+
+              <h3>React usage</h3>
+              <p>
+                Import the icon from{" "}
+                <a href="https://www.npmjs.com/package/@shopify/polaris-icons#usage">
+                  polaris-icons
+                </a>
+                :
+              </p>
+
+              <CodeExample title="Import" language="typescript">
+                {`import {
   ${selectedIcon.name}
 } from '@shopify/polaris-icons';`}
-                </div>
-                <div className={styles.IconClipboard}>
-                  <Tooltip
-                    ariaLabel="Copy to clipboard"
-                    placement="top"
-                    renderContent={() => (
-                      <div className={styles.IconToolTip}>
-                        <p>{didJustCopyImport ? "Copied" : "Copy"}</p>
-                      </div>
-                    )}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => {
-                        handleCopy("Import");
-                      }}
-                    >
-                      <Image
-                        src={iconClipboard}
-                        alt={"Copy"}
-                        width={19}
-                        height={19}
-                      />
-                    </button>
-                  </Tooltip>
-                </div>
-              </pre>
-              <div className={styles.SnippetHeader}>
-                <h5>Usage</h5>
-                <div>
-                  Learn more about the{" "}
-                  <a href="https://polaris.shopify.com/components/images-and-icons/icon">
-                    icon componant
-                  </a>
-                </div>
-              </div>
-              <pre className={styles.CodeSnippet}>
-                <div>
-                  {`<Icon
+              </CodeExample>
+
+              <p>
+                Then render it using the{" "}
+                <a href="https://polaris.shopify.com/components/images-and-icons/icon">
+                  icon component
+                </a>
+                :
+              </p>
+              <CodeExample title="Component" language="typescript">
+                {`<Icon
   source={${selectedIcon.name}}
-  color="base" 
+  color="base"
 />`}
-                </div>
-                <div className={styles.IconClipboard}>
-                  <Tooltip
-                    ariaLabel="Copy to clipboard"
-                    placement="top"
-                    renderContent={() => (
-                      <div className={styles.IconToolTip}>
-                        <p>{didJustCopyUsage ? "Copied" : "Copy"}</p>
-                      </div>
-                    )}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => {
-                        handleCopy("Usage");
-                      }}
-                    >
-                      <Image
-                        src={iconClipboard}
-                        alt={"Copy"}
-                        width={19}
-                        height={19}
-                      />
-                    </button>
-                  </Tooltip>
-                </div>
-              </pre>
-              <div className={styles.ModalFooter}>
-                <a href={updateURL}>Propose an update to this icon</a>
-                <div className={styles.Keywords}>
-                  <h5>Keywords</h5>
-                  <div className={styles.KeywordsButtonGroup}>
-                    {selectedIcon.keywords.map((keyword) => {
-                      return (
-                        <button
-                          type="button"
-                          key={keyword}
-                          onClick={() => {
-                            setFilterString(`${keyword}`);
-                          }}
-                        >
-                          {keyword}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            </Longform>
-            <hr className={styles.Break} />
-            <div className={styles.ActionButtons}>
-              <a href="https://www.figma.com/community/file/1110993965108325096">
-                <button>Polaris Icon Library</button>
-              </a>
-              <a
-                href={
-                  importedSvgs(`./${selectedIcon.fileName}.svg`).default.src
-                }
-                download
-              >
-                <button>SVG</button>
+              </CodeExample>
+
+              <a className={styles.ProposeChangeLink} href={updateURL}>
+                Propose a change to this icon
               </a>
             </div>
-          </Dialog.Panel>
-        </Dialog>
-      )}
+          )}
+        </div>
+      </div>
     </MaxPageWidthDiv>
   );
 }

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -119,7 +119,7 @@ function IconsPage() {
           )}
         </div>
 
-        <div>
+        <div className={styles.Sidebar}>
           {selectedIcon && (
             <div className={styles.SelectedIcon}>
               {/* <div className={styles.Preview}>

--- a/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
+++ b/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
@@ -2,15 +2,16 @@
   pointer-events: none;
   max-width: 300px;
   z-index: 2;
+  filter: drop-shadow(0 5px 20px rgba(0, 0, 0, 0.1));
 
   .Content {
     overflow: hidden;
-    border-radius: var(--border-radius-500);
-    background: var(--text);
+    border-radius: var(--border-radius-800);
+    background: var(--surface);
     text-align: center;
-    color: white;
     font-size: 14px;
-    padding: 0.33rem 0.5rem;
+    padding: 0.5rem 0.5rem;
+    line-height: 1.4;
   }
 
   &::after {
@@ -23,7 +24,7 @@
     width: 10px;
     height: 10px;
     margin: 0 auto;
-    background: var(--text);
+    background: var(--surface);
     transform: rotate(45deg);
     z-index: 0;
   }


### PR DESCRIPTION
Changes the design to use a sidebar instead of a modal, per popular request.

This simplifies the UI and reduces the amount of code we need.

I also moved @chazdean's excellent "copy code" solution into a dedicated component so that it can be reused across the site.

<img width="1615" alt="Screen Shot 2022-06-07 at 10 46 38 PM" src="https://user-images.githubusercontent.com/875708/172479390-d9a54335-b891-46c3-ab73-b4bb1bb16a4b.png">