### PR TITLE
[Polaris website refresh] Add keyboard shortcut to trigger search

### DIFF
--- a/.changeset/silver-buttons-hide.md
+++ b/.changeset/silver-buttons-hide.md
@@ -1,0 +1,7 @@
+---
+'@shopify/polaris': patch
+'@shopify/polaris-tokens': patch
+'polaris.shopify.com': patch
+---
+
+Add keyboard shortcut

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { search } from "../../utils/search";
 import {
   GroupedSearchResults,
@@ -54,6 +54,7 @@ function GlobalSearch({}: Props) {
     getComboboxProps,
     highlightedIndex,
     getItemProps,
+    openMenu,
   } = useCombobox({
     id: "global-search",
     items: resultsInRenderedOrder,
@@ -72,6 +73,21 @@ function GlobalSearch({}: Props) {
 
   let resultIndex = -1;
 
+  useEffect(() => {
+    document.addEventListener("keydown", (event) => {
+      const searchbar = document.getElementById("searchbar");
+      let isKKey = event.key === "k" || event.key === "K";
+      let isMetaKey = event.metaKey;
+      if (isMetaKey && isKKey) {
+        event.preventDefault();
+        openMenu();
+        if (searchbar !== null) {
+          searchbar.focus();
+        }
+      }
+    });
+  });
+
   return (
     <div className={styles.GlobalSearch}>
       <label {...getLabelProps()} className="sr-only">
@@ -81,7 +97,7 @@ function GlobalSearch({}: Props) {
         <WrappedTextField
           renderTextField={(className) => (
             <input
-              {...getInputProps({})}
+              {...getInputProps({ id: "searchbar" })}
               placeholder="Search"
               className={className}
             />

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
@@ -35,6 +35,7 @@ function getSearchResultAsString(result: SearchResult | null): string {
 function GlobalSearch({}: Props) {
   const [searchResults, setSearchResults] = useState<GroupedSearchResults>();
   const router = useRouter();
+  const globalSearchID = "global-search";
 
   let resultsInRenderedOrder: SearchResults = [];
   if (searchResults) {
@@ -56,7 +57,7 @@ function GlobalSearch({}: Props) {
     getItemProps,
     openMenu,
   } = useCombobox({
-    id: "global-search",
+    id: globalSearchID,
     items: resultsInRenderedOrder,
     onInputValueChange: ({ inputValue }) => {
       const results = search(inputValue || "");
@@ -75,10 +76,9 @@ function GlobalSearch({}: Props) {
 
   useEffect(() => {
     document.addEventListener("keydown", (event) => {
-      const searchbar = document.getElementById("searchbar");
-      let isKKey = event.key === "k" || event.key === "K";
-      let isMetaKey = event.metaKey;
-      if (isMetaKey && isKKey) {
+      const searchbar = document.getElementById(globalSearchID);
+      let isKKey = "/";
+      if (isKKey) {
         event.preventDefault();
         openMenu();
         if (searchbar !== null) {
@@ -97,7 +97,7 @@ function GlobalSearch({}: Props) {
         <WrappedTextField
           renderTextField={(className) => (
             <input
-              {...getInputProps({ id: "searchbar" })}
+              {...getInputProps({ id: globalSearchID })}
               placeholder="Search"
               className={className}
             />
@@ -118,7 +118,7 @@ function GlobalSearch({}: Props) {
           <>
             <div className={styles.Header}>
               <h2>{resultsInRenderedOrder.length} results</h2>
-              <p>Tip: Use command-K to open search</p>
+              <p>Tip: Use / to open search</p>
             </div>
           </>
         )}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#5908](https://github.com/Shopify/polaris/issues/5908)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds global shortcut (command + K) that opens search and sets focus

https://user-images.githubusercontent.com/59836805/172496371-e3b6a817-b0df-460c-a444-72d2526255f3.mov

<!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
