### PR TITLE
[Badge][Pip] Remove default `status` value

### DIFF
--- a/.changeset/clever-scissors-lay.md
+++ b/.changeset/clever-scissors-lay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Badge` `status` and `progress` types and removed default `status` from `Pip`

--- a/polaris-react/src/components/Badge/components/Pip/Pip.tsx
+++ b/polaris-react/src/components/Badge/components/Pip/Pip.tsx
@@ -15,7 +15,7 @@ export interface PipProps {
 }
 
 export function Pip({
-  status = 'info',
+  status,
   progress = 'complete',
   accessibilityLabelOverride,
 }: PipProps) {

--- a/polaris-react/src/components/Badge/tests/Badge.test.tsx
+++ b/polaris-react/src/components/Badge/tests/Badge.test.tsx
@@ -44,7 +44,7 @@ describe('<Badge />', () => {
     const badge = mountWithApp(<Badge progress="incomplete" />);
 
     expect(badge).toContainReactComponent('span', {
-      className: 'Pip statusInfo progressIncomplete',
+      className: 'Pip progressIncomplete',
     });
   });
 
@@ -119,13 +119,13 @@ describe('<Badge />', () => {
     badge = mountWithApp(<Badge progress="incomplete" />);
 
     expect(badge).toContainReactComponent(VisuallyHidden, {
-      children: ' Incomplete',
+      children: 'Incomplete',
     });
 
     badge = mountWithApp(<Badge status="attention" />);
 
     expect(badge).toContainReactComponent(VisuallyHidden, {
-      children: 'Attention ',
+      children: 'Attention',
     });
 
     badge = mountWithApp(<Badge />);
@@ -147,7 +147,7 @@ describe('<Badge.Pip />', () => {
     badge = mountWithApp(<Badge.Pip progress="partiallyComplete" />);
 
     expect(badge).toContainReactComponent(VisuallyHidden, {
-      children: 'Info Partially complete',
+      children: 'Partially complete',
     });
 
     badge = mountWithApp(<Badge.Pip status="attention" />);
@@ -159,7 +159,7 @@ describe('<Badge.Pip />', () => {
     badge = mountWithApp(<Badge.Pip />);
 
     expect(badge).toContainReactComponent(VisuallyHidden, {
-      children: 'Info Complete',
+      children: 'Complete',
     });
   });
 });

--- a/polaris-react/src/components/Badge/types.ts
+++ b/polaris-react/src/components/Badge/types.ts
@@ -1,3 +1,11 @@
+export type Status =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'critical'
+  | 'attention'
+  | 'new';
+
 export enum StatusValue {
   Info = 'info',
   Success = 'success',
@@ -6,12 +14,13 @@ export enum StatusValue {
   Attention = 'attention',
   New = 'new',
 }
-// uses template literal types to get the string representation of the values of the FieldsMap enums
-export type Status = `${StatusValue}`;
+
+export type Progress = 'incomplete' | 'partiallyComplete' | 'complete';
+
 export enum ProgressValue {
   Incomplete = 'incomplete',
   PartiallyComplete = 'partiallyComplete',
   Complete = 'complete',
 }
-export type Progress = `${ProgressValue}`;
+
 export type Size = 'small' | 'medium';

--- a/polaris-react/src/components/Badge/utils.ts
+++ b/polaris-react/src/components/Badge/utils.ts
@@ -13,6 +13,7 @@ export function getDefaultAccessibilityLabel(
   if (!progress && !status) {
     return '';
   }
+
   switch (progress) {
     case ProgressValue.Incomplete:
       progressLabel = i18n.translate(
@@ -50,8 +51,14 @@ export function getDefaultAccessibilityLabel(
       break;
   }
 
-  return i18n.translate('Polaris.Badge.progressAndStatus', {
-    progressLabel,
-    statusLabel,
-  });
+  if (!status && progress) {
+    return progressLabel;
+  } else if (status && !progress) {
+    return statusLabel;
+  } else {
+    return i18n.translate('Polaris.Badge.progressAndStatus', {
+      progressLabel,
+      statusLabel,
+    });
+  }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes the `progress` `Badge` with no `status` set having a blue pip instead of gray.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Removes the default `status` of `info` from `Pip`
- Re-simplifies the types for `Badge` `status` and `progress` props so they're parsable by `typedoc`
- Fixes the a11y label utility so that instead of always returning the label for status and progress, it outputs the correct label based on whether `status` and/or `progress` are set

|Before|After|
|---|---|
|<img width="76" alt="Screen Shot 2022-06-09 at 1 04 30 PM" src="https://user-images.githubusercontent.com/18447883/172904081-3ee091ab-b145-41f3-bba6-2ce3e1eb4dba.png">|<img width="77" alt="Screen Shot 2022-06-09 at 1 04 02 PM" src="https://user-images.githubusercontent.com/18447883/172904151-d24a75a1-66e9-4d0f-99b0-318cf3f93530.png">|
|<img width="716" alt="Screen Shot 2022-06-09 at 2 07 36 PM" src="https://user-images.githubusercontent.com/18447883/172915176-4648dad8-136b-4a0f-940a-339588813bea.png">|<img width="714" alt="Screen Shot 2022-06-09 at 2 07 11 PM" src="https://user-images.githubusercontent.com/18447883/172915202-8c29800b-7b89-4de6-88c3-65c1bc8f03e8.png">|
|<img width="715" alt="Screen Shot 2022-06-09 at 2 07 43 PM" src="https://user-images.githubusercontent.com/18447883/172915241-e52a0e57-0b50-4d02-89f2-af7a9097087d.png">|<img width="718" alt="Screen Shot 2022-06-09 at 2 07 18 PM" src="https://user-images.githubusercontent.com/18447883/172915278-dbe03288-670e-468d-8930-c7d2a4c49760.png">|

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
