### PR TITLE
[polaris.shopify.com reboot] Fix unable to select Minor Icons

### DIFF
--- a/.changeset/swift-pets-jog.md
+++ b/.changeset/swift-pets-jog.md
@@ -1,0 +1,7 @@
+---
+'@shopify/polaris': patch
+'@shopify/polaris-tokens': patch
+'polaris.shopify.com': patch
+---
+
+fix minor icon select

--- a/.changeset/swift-pets-jog.md
+++ b/.changeset/swift-pets-jog.md
@@ -1,6 +1,4 @@
 ---
-'@shopify/polaris': patch
-'@shopify/polaris-tokens': patch
 'polaris.shopify.com': patch
 ---
 

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -17,6 +17,7 @@ import TextField from "../TextField";
 import CodeExample from "../CodeExample";
 import { LinkButton } from "../Button/Button";
 import Button from "../Button";
+import { Icon } from "../../types";
 
 let icons = Object.entries(metadata).map(([fileName, icon]) => ({
   ...icon,
@@ -36,9 +37,8 @@ const fuse = new Fuse(Object.values(icons), {
 
 function IconsPage() {
   const [filterString, setFilterString] = useState("");
-  const [selectedIconName, setSelectedIconName] = useState<string>(
-    icons[0].name
-  );
+  const [selectedIcon, setSelectedIcon] = useState<Icon>(icons[0]);
+  const selectedIconName = selectedIcon.name;
 
   let filteredIcons = [...icons];
 
@@ -46,14 +46,19 @@ function IconsPage() {
     const fuseResults = fuse.search(filterString);
     filteredIcons = fuseResults.map((result) => result.item);
   }
+
   const majorIcons = filteredIcons.filter((icon) => icon.set === "major");
   const minorIcons = filteredIcons.filter((icon) => icon.set === "minor");
 
-  const selectedIcon = icons.find((icon) => icon.name === selectedIconName);
-
-  if (selectedIconName && !selectedIcon) {
-    throw new Error(`Could not find icon ${selectedIconName}`);
-  }
+  const getSelectedIcon = (iconParam: Icon) => {
+    const foundIcon = icons.find(
+      (icon) => icon.name === iconParam.name && icon.set === iconParam.set
+    );
+    if (!foundIcon) {
+      throw new Error(`Could not find icon ${iconParam.name}`);
+    }
+    setSelectedIcon(foundIcon);
+  };
 
   const updateURL = `https://github.com/Shopify/polaris-icons/issues/new?assignees=@shopify/icon-guild&labels=Update,Proposal&template=propose-updates-to-existing-icons.md&title=%5BProposal%5D%20Update%20${selectedIconName}`;
 
@@ -90,7 +95,7 @@ function IconsPage() {
                   <IconGrid.Item
                     key={icon.name}
                     icon={icon}
-                    onClick={() => setSelectedIconName(icon.name)}
+                    onClick={() => getSelectedIcon(icon)}
                     isHighlighted={false}
                   />
                 ))}
@@ -112,7 +117,7 @@ function IconsPage() {
                   <IconGrid.Item
                     key={icon.name}
                     icon={icon}
-                    onClick={() => {}}
+                    onClick={() => getSelectedIcon(icon)}
                     isHighlighted={false}
                   />
                 ))}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6075 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fixes bug that when clicking minor icons on the Icons page nothing happens. Also created `getSelectedIcon` function that filters icon list using icon name and set so icon name can be displayed correctly on sidebar with minor | major

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

