### PR TITLE
[polaris.shopify.com reboot] Feat/add "skip to content" link

### DIFF
--- a/.changeset/sweet-days-play.md
+++ b/.changeset/sweet-days-play.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Add "skip to content" link

--- a/polaris.shopify.com/src/components/Header/Header.module.scss
+++ b/polaris.shopify.com/src/components/Header/Header.module.scss
@@ -76,6 +76,24 @@
   }
 }
 
+.SkipToContentLink {
+  left: 0%;
+  background-color: white;
+  border-radius: var(--border-radius-200);
+  color: var(--text-strong);
+  font-weight: var(--font-weight-500);
+  font-size: var(--font-size-100);
+  margin-top: 0.4rem;
+  margin-left: 0.5rem;
+  padding: 1rem;
+  position: absolute;
+  transform: translateY(-100%);
+
+  &:focus {
+    transform: translateY(0%);
+  }
+}
+
 .DarkModeToggle {
   background: transparent;
   width: 3rem;

--- a/polaris.shopify.com/src/components/Header/Header.tsx
+++ b/polaris.shopify.com/src/components/Header/Header.tsx
@@ -77,6 +77,10 @@ function Header({ currentSection }: Props) {
           </a>
         </Link>
 
+        <a className={styles.SkipToContentLink} href="#main">
+          Skip to content
+        </a>
+
         <nav className={styles.Nav}>
           <ul>
             <NavItems currentSection={currentSection} />

--- a/polaris.shopify.com/src/components/HomePage/HomePage.tsx
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.tsx
@@ -8,7 +8,7 @@ function HomePage({}: Props) {
   return (
     <div className={styles.HomePage}>
       <div className={styles.Intro}>
-        <Container className={styles.IntroContent}>
+        <Container id="main" className={styles.IntroContent}>
           <h1>A design system built for commerce</h1>
           <Link href="/resources">Explore the system</Link>
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6069 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<img width="600" alt="Screen Shot 2022-06-09 at 3 29 53 PM" src="https://user-images.githubusercontent.com/59836805/172929228-a92fd960-1cda-4fa3-909a-44c39bfaf307.png">


Adds a "skip to main content" link that is focusable on tab. When clicked browser will jump to main content of page. 

- Currently only working on Hompage
- Main content on other pages can easily be added by adding `id="main"` to main content container on other pages
- Do we want it on all other pages?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->
