### PR TITLE
[Listbox][autoSelection] Add support for manual selection

### DIFF
--- a/.changeset/quick-mice-pull.md
+++ b/.changeset/quick-mice-pull.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added support for manual selection to `Listbox`

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -76,12 +76,12 @@ The tag multi-select input enables merchants to efficiently add or remove tags f
 
 ## Examples
 
-### Single select autocomplete
+### Single select autocomplete with automatic selection
 
 Use when merchants can select one option from a predefined or editable list.
 
 ```jsx
-function ComboboxExample() {
+function AutoSelectComboboxExample() {
   const deselectedOptions = useMemo(
     () => [
       {value: 'rustic', label: 'Rustic'},
@@ -168,12 +168,106 @@ function ComboboxExample() {
 }
 ```
 
-### Multi-select autocomplete
+### Single select autocomplete with manual selection
+
+Use when merchants can select one option from a predefined or editable list.
+
+```jsx
+function ManualSelectComboboxExample() {
+  const deselectedOptions = useMemo(
+    () => [
+      {value: 'rustic', label: 'Rustic'},
+      {value: 'antique', label: 'Antique'},
+      {value: 'vinyl', label: 'Vinyl'},
+      {value: 'vintage', label: 'Vintage'},
+      {value: 'refurbished', label: 'Refurbished'},
+    ],
+    [],
+  );
+
+  const [selectedOption, setSelectedOption] = useState();
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(deselectedOptions);
+
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
+
+      if (value === '') {
+        setOptions(deselectedOptions);
+        return;
+      }
+
+      const filterRegex = new RegExp(value, 'i');
+      const resultOptions = deselectedOptions.filter((option) =>
+        option.label.match(filterRegex),
+      );
+      setOptions(resultOptions);
+    },
+    [deselectedOptions],
+  );
+
+  const updateSelection = useCallback(
+    (selected) => {
+      const matchedOption = options.find((option) => {
+        return option.value.match(selected);
+      });
+
+      setSelectedOption(selected);
+      setInputValue((matchedOption && matchedOption.label) || '');
+    },
+    [options],
+  );
+
+  const optionsMarkup =
+    options.length > 0
+      ? options.map((option) => {
+          const {label, value} = option;
+
+          return (
+            <Listbox.Option
+              key={`${value}`}
+              value={value}
+              selected={selectedOption === value}
+              accessibilityLabel={label}
+            >
+              {label}
+            </Listbox.Option>
+          );
+        })
+      : null;
+
+  return (
+    <div style={{height: '225px'}}>
+      <Combobox
+        activator={
+          <Combobox.TextField
+            prefix={<Icon source={SearchMinor} />}
+            onChange={updateText}
+            label="Search tags"
+            labelHidden
+            value={inputValue}
+            placeholder="Search tags"
+          />
+        }
+      >
+        {options.length > 0 ? (
+          <Listbox autoSelection="NONE" onSelect={updateSelection}>
+            {optionsMarkup}
+          </Listbox>
+        ) : null}
+      </Combobox>
+    </div>
+  );
+}
+```
+
+### Multi-select autocomplete with automatic selection
 
 Use when merchants can select one or more options from a predefined or editable list.
 
 ```jsx
-function MultiComboboxExample() {
+function MultiAutoComboboxExample() {
   const deselectedOptions = useMemo(
     () => [
       {value: 'rustic', label: 'Rustic'},
@@ -276,6 +370,126 @@ function MultiComboboxExample() {
       >
         {optionsMarkup ? (
           <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
+        ) : null}
+      </Combobox>
+      <TextContainer>
+        <Stack>{tagsMarkup}</Stack>
+      </TextContainer>
+    </div>
+  );
+}
+```
+
+### Multi-select autocomplete with manual selection
+
+Use when merchants can select one or more options from a predefined or editable list.
+
+```jsx
+function MultiManualComboboxExample() {
+  const deselectedOptions = useMemo(
+    () => [
+      {value: 'rustic', label: 'Rustic'},
+      {value: 'antique', label: 'Antique'},
+      {value: 'vinyl', label: 'Vinyl'},
+      {value: 'vintage', label: 'Vintage'},
+      {value: 'refurbished', label: 'Refurbished'},
+    ],
+    [],
+  );
+
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(deselectedOptions);
+
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
+
+      if (value === '') {
+        setOptions(deselectedOptions);
+        return;
+      }
+
+      const filterRegex = new RegExp(value, 'i');
+      const resultOptions = deselectedOptions.filter((option) =>
+        option.label.match(filterRegex),
+      );
+      setOptions(resultOptions);
+    },
+    [deselectedOptions],
+  );
+
+  const updateSelection = useCallback(
+    (selected) => {
+      if (selectedOptions.includes(selected)) {
+        setSelectedOptions(
+          selectedOptions.filter((option) => option !== selected),
+        );
+      } else {
+        setSelectedOptions([...selectedOptions, selected]);
+      }
+
+      const matchedOption = options.find((option) => {
+        return option.value.match(selected);
+      });
+
+      updateText('');
+    },
+    [options, selectedOptions],
+  );
+
+  const removeTag = useCallback(
+    (tag) => () => {
+      const options = [...selectedOptions];
+      options.splice(options.indexOf(tag), 1);
+      setSelectedOptions(options);
+    },
+    [selectedOptions],
+  );
+
+  const tagsMarkup = selectedOptions.map((option) => (
+    <Tag key={`option-${option}`} onRemove={removeTag(option)}>
+      {option}
+    </Tag>
+  ));
+
+  const optionsMarkup =
+    options.length > 0
+      ? options.map((option) => {
+          const {label, value} = option;
+
+          return (
+            <Listbox.Option
+              key={`${value}`}
+              value={value}
+              selected={selectedOptions.includes(value)}
+              accessibilityLabel={label}
+            >
+              {label}
+            </Listbox.Option>
+          );
+        })
+      : null;
+
+  return (
+    <div style={{height: '225px'}}>
+      <Combobox
+        allowMultiple
+        activator={
+          <Combobox.TextField
+            prefix={<Icon source={SearchMinor} />}
+            onChange={updateText}
+            label="Search tags"
+            labelHidden
+            value={inputValue}
+            placeholder="Search tags"
+          />
+        }
+      >
+        {optionsMarkup ? (
+          <Listbox autoSelection="NONE" onSelect={updateSelection}>
+            {optionsMarkup}
+          </Listbox>
         ) : null}
       </Combobox>
       <TextContainer>
@@ -492,7 +706,7 @@ function LoadingAutocompleteExample() {
         );
         setOptions(resultOptions);
         setLoading(false);
-      }, 300);
+      }, 400);
     },
     [deselectedOptions, loading, options],
   );
@@ -510,7 +724,7 @@ function LoadingAutocompleteExample() {
   );
 
   const optionsMarkup =
-    options.length > 0
+    options.length > 0 && !loading
       ? options.map((option) => {
           const {label, value} = option;
 
@@ -527,12 +741,23 @@ function LoadingAutocompleteExample() {
         })
       : null;
 
-  const loadingMarkup = loading ? <Listbox.Loading /> : null;
+  const loadingMarkup = loading ? (
+    <div
+      style={{
+        height: '220px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Listbox.Loading />
+    </div>
+  ) : null;
 
   const listboxMarkup =
     optionsMarkup || loadingMarkup ? (
       <Listbox onSelect={updateSelection}>
-        {optionsMarkup && !loading ? optionsMarkup : null}
+        {optionsMarkup}
         {loadingMarkup}
       </Listbox>
     ) : null;
@@ -540,6 +765,7 @@ function LoadingAutocompleteExample() {
   return (
     <div style={{height: '225px'}}>
       <Combobox
+        height="220px"
         activator={
           <Combobox.TextField
             prefix={<Icon source={SearchMinor} />}

--- a/polaris-react/src/components/Listbox/Listbox.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.tsx
@@ -38,6 +38,8 @@ export enum AutoSelection {
   FirstSelected = 'FIRST_SELECTED',
   /** Default active option is always the first interactive option. */
   First = 'FIRST',
+  /** Default to the manual selection pattern. */
+  None = 'NONE',
 }
 
 export interface ListboxProps {
@@ -284,10 +286,15 @@ export function Listbox({
   ]);
 
   useEffect(() => {
-    if (!loading && children && Children.count(children) > 0) {
+    if (
+      autoSelection !== AutoSelection.None &&
+      !loading &&
+      children &&
+      Children.count(children) > 0
+    ) {
       resetActiveOption();
     }
-  }, [children, activeOption, loading, resetActiveOption]);
+  }, [children, autoSelection, activeOption, loading, resetActiveOption]);
 
   useEffect(() => {
     if (listboxRef.current) {
@@ -338,6 +345,16 @@ export function Listbox({
       let element = activeOption?.element;
       let totalOptions = -1;
 
+      if (!activeOption && autoSelection === AutoSelection.None) {
+        const nextOptions = getNavigableOptions();
+        const nextActiveOption = getFirstNavigableOption(nextOptions);
+        setCurrentOptions(nextOptions);
+        return {
+          element: nextActiveOption?.element,
+          nextIndex: nextActiveOption?.index || 0,
+        };
+      }
+
       while (totalOptions++ < lastIndex) {
         nextIndex = getNextIndex(currentIndex, lastIndex, key);
         element = currentOptions[nextIndex];
@@ -359,11 +376,14 @@ export function Listbox({
       return {element, nextIndex};
     },
     [
+      autoSelection,
       currentOptions,
       activeOption,
       willLoadMoreOptions,
       getNextIndex,
       handleKeyToBottom,
+      getFirstNavigableOption,
+      getNavigableOptions,
     ],
   );
 

--- a/polaris-react/src/components/Listbox/tests/Listbox.test.tsx
+++ b/polaris-react/src/components/Listbox/tests/Listbox.test.tsx
@@ -759,8 +759,63 @@ describe('<Listbox>', () => {
   });
 
   describe('auto-selection', () => {
+    describe('manual selection', () => {
+      it('does not set an initial active option', () => {
+        const selectedListbox = (
+          <Listbox enableKeyboardControl autoSelection={AutoSelection.None}>
+            <Listbox.Option value="one" selected={false}>
+              one
+            </Listbox.Option>
+            <Listbox.Option value="two" selected={false}>
+              two
+            </Listbox.Option>
+            <Listbox.Option value="three" selected>
+              three
+            </Listbox.Option>
+          </Listbox>
+        );
+        const wrapper = mountWithApp(selectedListbox);
+        const listbox = wrapper.find('ul', {role: 'listbox'})!;
+
+        expect(
+          listbox.domNode?.getAttribute('aria-activedescendant'),
+        ).toBeNull();
+      });
+
+      it('sets the initial active option to the first option on arrow down', async () => {
+        const selectedListbox = (
+          <Listbox enableKeyboardControl autoSelection={AutoSelection.None}>
+            <Listbox.Option value="one" selected={false}>
+              one
+            </Listbox.Option>
+            <Listbox.Option value="two" selected={false}>
+              two
+            </Listbox.Option>
+            <Listbox.Option value="three" selected>
+              three
+            </Listbox.Option>
+          </Listbox>
+        );
+        const wrapper = mountWithApp(selectedListbox);
+        const listbox = wrapper.find('ul', {role: 'listbox'})!;
+        const options = wrapper.findAll('li', {role: 'option'});
+
+        expect(
+          listbox.domNode?.getAttribute('aria-activedescendant'),
+        ).toBeNull();
+
+        await wrapper.act(async () => {
+          await Promise.resolve(triggerDown(wrapper));
+        });
+
+        expect(listbox.domNode?.getAttribute('aria-activedescendant')).toBe(
+          options[0].domNode?.id,
+        );
+      });
+    });
+
     describe('when list has selected options', () => {
-      it('sets the initial active option to the first selected option by default', () => {
+      it('sets the initial active option to the first selected option', () => {
         const selectedListbox = (
           <Listbox>
             <Listbox.Option value="one" selected={false}>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->


### WHAT is this pull request doing?

This PR adds support for opting for the manual selection pattern instead of auto-selection by adding the option to set `AutoSelection.None` on the `autoSelection` prop.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
