### PR TITLE
[IndexTable] Hide ScrollBar when table is not scrollable

### DIFF
--- a/.changeset/great-coats-kick.md
+++ b/.changeset/great-coats-kick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[IndexTable] Hide scroll bar when table is not scrollable

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -437,6 +437,10 @@ $scroll-bar-size: var(--p-space-2);
   pointer-events: none;
 }
 
+.scrollBarContainerHidden {
+  display: none;
+}
+
 .ScrollBar {
   overflow-x: scroll;
   width: 100%;

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -102,6 +102,8 @@ function IndexTableBase({
   const [tableInitialized, setTableInitialized] = useState(false);
   const [isSmallScreenSelectable, setIsSmallScreenSelectable] = useState(false);
   const [stickyWrapper, setStickyWrapper] = useState<HTMLElement | null>(null);
+  const [hideScrollContainer, setHideScrollContainer] =
+    useState<boolean>(false);
 
   const tableHeadings = useRef<HTMLElement[]>([]);
   const stickyTableHeadings = useRef<HTMLElement[]>([]);
@@ -109,6 +111,7 @@ function IndexTableBase({
   const firstStickyHeaderElement = useRef<HTMLDivElement>(null);
   const stickyHeaderElement = useRef<HTMLDivElement>(null);
   const scrollBarElement = useRef<HTMLDivElement>(null);
+  const scrollContainerElement = useRef<HTMLDivElement>(null);
   const scrollingWithBar = useRef(false);
   const scrollingContainer = useRef(false);
 
@@ -208,6 +211,11 @@ function IndexTableBase({
       scrollBarElement.current.style.setProperty(
         '--pc-index-table-scroll-bar-content-width',
         `${tableElement.current.offsetWidth - SCROLL_BAR_PADDING}px`,
+      );
+
+      setHideScrollContainer(
+        scrollContainerElement.current?.offsetWidth ===
+          tableElement.current?.offsetWidth,
       );
     }
   }, [tableInitialized]);
@@ -534,6 +542,7 @@ function IndexTableBase({
   const scrollBarWrapperClassNames = classNames(
     styles.ScrollBarContainer,
     condensed && styles.scrollBarContainerCondensed,
+    hideScrollContainer && styles.scrollBarContainerHidden,
   );
 
   const scrollBarClassNames = classNames(
@@ -543,7 +552,10 @@ function IndexTableBase({
   const scrollBarMarkup =
     itemCount > 0 ? (
       <AfterInitialMount>
-        <div className={scrollBarWrapperClassNames}>
+        <div
+          className={scrollBarWrapperClassNames}
+          ref={scrollContainerElement}
+        >
           <div
             onScroll={handleScrollBarScroll}
             className={styles.ScrollBar}

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -263,6 +263,22 @@ describe('<IndexTable>', () => {
 
       expect(scrollContainerScrollLeft).toBe(updatedScrollLeft);
     });
+
+    it('sets scrollBarContainerHidden class on scroll container when table is not scrollable', () => {
+      const index = mountWithApp(
+        <IndexTable {...defaultProps} itemCount={1}>
+          {mockTableItems.map(mockRenderRow)}
+        </IndexTable>,
+      );
+
+      const afterInitialMounts = index.findAll(AfterInitialMount);
+
+      expect(
+        afterInitialMounts[afterInitialMounts.length - 1],
+      ).toContainReactComponent('div', {
+        className: expect.stringContaining('scrollBarContainerHidden'),
+      });
+    });
   });
 
   describe('headings', () => {


### PR DESCRIPTION
`IndexTable` currently always appends a `ScrollBarContainer` even when it is not needed. 

<details><summary>Before Image</summary>
<img width="798" alt="Screen Shot 2022-06-09 at 4 50 20 PM" src="https://user-images.githubusercontent.com/9326713/172963683-bad6cb06-0c99-4088-884f-b8ab026654a9.png">

</details>
<details><summary>After Image</summary>
<img width="799" alt="Screen Shot 2022-06-09 at 4 49 56 PM" src="https://user-images.githubusercontent.com/9326713/172963689-eaba38d3-577b-4f97-a2f5-9a78444709cc.png">

</details>
<details><summary>Issue in Prod (products index)</summary>
<img width="1305" alt="Screen Shot 2022-06-09 at 4 55 13 PM" src="https://user-images.githubusercontent.com/9326713/172963816-e80626b4-744f-4e33-bac2-2a7363b22e4d.png">

</details>


### WHY are these changes introduced?

We were noticing some extra spacing on the `IndexTable` for a new view being prepped as part of an internal Taxes team project.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Append a class to hide the markup. Use this `playground.tsx` code and view at different screen widths (i.e. one small width screen to view visible scrollbar, and wider screen width to view hidden elements).:

<details><summary>Playground code example:</summary>

Add the following code to `PlayGround.tsx`:

```tsx
import React from 'react';

import {Page} from '../src';
import {IndexTable, TextStyle, Card, useIndexResourceState} from '../src';

export function Playground() {
  const customers = [
    {
      id: '3411',
      url: 'customers/341',
      name: 'Mae Jemison',
      location: 'Decatur, USA',
      orders: 20,
      amountSpent: '$2,400',
    },
    {
      id: '2561',
      url: 'customers/256',
      name: 'Ellen Ochoa',
      location: 'Los Angeles, USA',
      orders: 30,
      amountSpent: '$140',
    },
  ];
  const resourceName = {
    singular: 'customer',
    plural: 'customers',
  };

  const {selectedResources, allResourcesSelected, handleSelectionChange} =
    useIndexResourceState(customers);

  const rowMarkup = customers.map(
    ({id, name, location, orders, amountSpent}, index) => (
      <IndexTable.Row
        id={id}
        key={id}
        selected={selectedResources.includes(id)}
        position={index}
      >
        <IndexTable.Cell>
          <TextStyle variation="strong">{name}</TextStyle>
        </IndexTable.Cell>
        <IndexTable.Cell>{location}</IndexTable.Cell>
        <IndexTable.Cell>{orders}</IndexTable.Cell>
        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
      </IndexTable.Row>
    ),
  );
  return (
    <Page title="Playground">
      <Card>
        <Card.Section flush>
          <IndexTable
            resourceName={resourceName}
            itemCount={customers.length}
            selectedItemsCount={
              allResourcesSelected ? 'All' : selectedResources.length
            }
            onSelectionChange={handleSelectionChange}
            headings={[
              {title: 'Name'},
              {title: 'Location'},
              {title: 'Order count'},
              {title: 'Amount spent'},
            ]}
          >
            {rowMarkup}
          </IndexTable>
        </Card.Section>
      </Card>
    </Page>
  );
}

```
</details>


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
