### PR TITLE
[Navigation] Add logoSuffix prop

### DIFF
--- a/.changeset/silent-bikes-double.md
+++ b/.changeset/silent-bikes-double.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add Navigation `logoSuffix` prop

--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -74,6 +74,10 @@ $nav-max-width: 360px;
     @include safe-area-for(flex-basis, $top-bar-height, left);
     @include safe-area-for(padding-left, var(--p-space-4), left);
   }
+
+  &.hasLogoSuffix {
+    gap: var(--p-space-2);
+  }
 }
 
 .Logo,

--- a/polaris-react/src/components/Navigation/Navigation.tsx
+++ b/polaris-react/src/components/Navigation/Navigation.tsx
@@ -4,6 +4,7 @@ import {Scrollable} from '../Scrollable';
 import {WithinContentContext} from '../../utilities/within-content-context';
 import {Image} from '../Image';
 import {UnstyledLink} from '../UnstyledLink';
+import {classNames} from '../../utilities/css';
 import {getWidth} from '../../utilities/get-width';
 import {useFrame} from '../../utilities/frame';
 
@@ -18,6 +19,8 @@ export interface NavigationProps {
   onDismiss?(): void;
   /** id of the element used as aria-labelledby */
   ariaLabelledBy?: string;
+  /** Accepts a component that is used to supplement the logo markup */
+  logoSuffix?: React.ReactNode;
 }
 
 export const Navigation: React.FunctionComponent<NavigationProps> & {
@@ -29,12 +32,18 @@ export const Navigation: React.FunctionComponent<NavigationProps> & {
   location,
   onDismiss,
   ariaLabelledBy,
+  logoSuffix,
 }: NavigationProps) {
   const {logo} = useFrame();
   const width = getWidth(logo, 104);
 
   const logoMarkup = logo ? (
-    <div className={styles.LogoContainer}>
+    <div
+      className={classNames(
+        styles.LogoContainer,
+        logoSuffix && styles.hasLogoSuffix,
+      )}
+    >
       <UnstyledLink
         url={logo.url || ''}
         className={styles.LogoLink}
@@ -47,6 +56,7 @@ export const Navigation: React.FunctionComponent<NavigationProps> & {
           style={{width}}
         />
       </UnstyledLink>
+      {logoSuffix}
     </div>
   ) : null;
 

--- a/polaris-react/src/components/Navigation/tests/Navigation.test.tsx
+++ b/polaris-react/src/components/Navigation/tests/Navigation.test.tsx
@@ -25,6 +25,17 @@ describe('<Navigation />', () => {
     });
   });
 
+  it('will render logo suffix when `logoSuffix` is provided', () => {
+    const LogoSuffix = () => <div>Suffix</div>;
+    const navigation = mountWithApp(
+      <Navigation location="/" logoSuffix={<LogoSuffix />} />,
+      {
+        frame: {logo: {url: 'https://shopify.com/logo'}},
+      },
+    );
+    expect(navigation).toContainReactComponent(LogoSuffix);
+  });
+
   describe('context', () => {
     it('passes location context', () => {
       const Child: React.FunctionComponent = (_props) => {


### PR DESCRIPTION
### WHY are these changes introduced?

When this prop is provided, the node will be rendered next to the logo with a small gap between them when the Frame is showing the mobile navigation. 

### WHAT is this pull request doing?

Adds optional prop `logoSuffix` of type `React.ReactNode`. It accepts a component that is used to supplement the logo markup. 

#### Example

<img width="436" alt="Screen Shot 2022-06-09 at 9 51 20 PM" src="https://user-images.githubusercontent.com/2091116/172975667-44e13863-e94d-4f67-a2ec-9ce37ffe9c45.png">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx

import React, {useCallback, useState} from 'react';
import {
  HomeMinor,
  OrdersMinor,
  MarketingMinor,
  ProductsMinor,
} from '@shopify/polaris-icons';

import {Navigation, Frame} from '../src';

export function Playground() {
  const logo = {
    width: 124,
    topBarSource: `data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjMwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik0yMS40OCA2LjEwMWEuMjUzLjI1MyAwIDAgMC0uMjQtLjIyYy0uMSAwLTIuMDgtLjA0LTIuMDgtLjA0cy0xLjY2LTEuNi0xLjgyLTEuNzhjLS4xNi0uMTYtLjQ4LS4xMi0uNi0uMDhsLS44NC4yNmMtLjA4LS4yOC0uMjItLjYyLS40LS45OC0uNTgtMS4xMi0xLjQ2LTEuNzItMi41LTEuNzItLjA4IDAtLjE0IDAtLjIyLjAyLS4wNC0uMDQtLjA2LS4wOC0uMS0uMS0uNDYtLjQ4LTEuMDQtLjcyLTEuNzQtLjctMS4zNC4wNC0yLjY4IDEuMDItMy43OCAyLjc0LS43NiAxLjIyLTEuMzQgMi43NC0xLjUyIDMuOTItMS41NC40OC0yLjYyLjgyLTIuNjYuODItLjc4LjI0LS44LjI2LS45IDEtLjA0LjU2LTIuMDggMTYuMzQtMi4wOCAxNi4zNGwxNy4xMiAyLjk2IDcuNDItMS44NGMtLjAyIDAtMy4wNC0yMC40Ni0zLjA2LTIwLjZabS02LjQ0LTEuNThjLS40LjEyLS44NC4yNi0xLjMyLjQyIDAtLjY4LS4xLTEuNjQtLjQtMi40NCAxLjAyLjE2IDEuNTIgMS4zMiAxLjcyIDIuMDJabS0yLjIyLjY4Yy0uOS4yOC0xLjg4LjU4LTIuODYuODguMjgtMS4wNi44LTIuMSAxLjQ0LTIuOC4yNC0uMjYuNTgtLjU0Ljk2LS43LjQuNzguNDggMS44OC40NiAyLjYyWm0tMS44NC0zLjU0Yy4zMiAwIC41OC4wNi44LjIyLS4zNi4xOC0uNzIuNDYtMS4wNC44Mi0uODYuOTItMS41MiAyLjM0LTEuNzggMy43Mi0uODIuMjYtMS42Mi41LTIuMzQuNzIuNDgtMi4xOCAyLjMtNS40MiA0LjM2LTUuNDhaIiBmaWxsPSIjOTVCRjQ3Ii8+PHBhdGggZD0iTTIxLjI0IDUuODgxYy0uMSAwLTIuMDgtLjA0LTIuMDgtLjA0cy0xLjY2LTEuNi0xLjgyLTEuNzhhLjMyMS4zMjEgMCAwIDAtLjIyLS4xdjI0LjU4bDcuNDItMS44NC0zLjA0LTIwLjZjLS4wNC0uMTQtLjE2LS4yMi0uMjYtLjIyWiIgZmlsbD0iIzVFOEUzRSIvPjxwYXRoIGQ9Im0xMyA5LjcwMS0uODYgMy4yMnMtLjk2LS40NC0yLjEtLjM2Yy0xLjY4LjEtMS42OCAxLjE2LTEuNjggMS40Mi4xIDEuNDQgMy44OCAxLjc2IDQuMSA1LjE0LjE2IDIuNjYtMS40IDQuNDgtMy42OCA0LjYyLTIuNzIuMTQtNC4yMi0xLjQ2LTQuMjItMS40NmwuNTgtMi40NnMxLjUyIDEuMTQgMi43MiAxLjA2Yy43OC0uMDQgMS4wOC0uNyAxLjA0LTEuMTQtLjEyLTEuODgtMy4yLTEuNzYtMy40LTQuODYtLjE2LTIuNiAxLjU0LTUuMjIgNS4zLTUuNDYgMS40Ni0uMSAyLjIuMjggMi4yLjI4WiIgZmlsbD0iI2ZmZiIvPjxwYXRoIGQ9Ik0zNC41OCAxNi41NjFjLS44Ni0uNDYtMS4zLS44Ni0xLjMtMS40IDAtLjY4LjYyLTEuMTIgMS41OC0xLjEyIDEuMTIgMCAyLjEyLjQ2IDIuMTIuNDZsLjc4LTIuNHMtLjcyLS41Ni0yLjg0LS41NmMtMi45NiAwLTUuMDIgMS43LTUuMDIgNC4wOCAwIDEuMzYuOTYgMi4zOCAyLjI0IDMuMTIgMS4wNC41OCAxLjQgMSAxLjQgMS42MiAwIC42NC0uNTIgMS4xNi0xLjQ4IDEuMTYtMS40MiAwLTIuNzgtLjc0LTIuNzgtLjc0bC0uODQgMi40czEuMjQuODQgMy4zNC44NGMzLjA0IDAgNS4yNC0xLjUgNS4yNC00LjItLjAyLTEuNDYtMS4xMi0yLjUtMi40NC0zLjI2Wk00Ni43IDExLjUwMWMtMS41IDAtMi42OC43Mi0zLjU4IDEuOGwtLjA0LS4wMiAxLjMtNi44SDQxbC0zLjMgMTcuMzJoMy4zOGwxLjEyLTUuOTJjLjQ0LTIuMjQgMS42LTMuNjIgMi42OC0zLjYyLjc2IDAgMS4wNi41MiAxLjA2IDEuMjYgMCAuNDYtLjA0IDEuMDQtLjE0IDEuNWwtMS4yOCA2Ljc4aDMuMzhsMS4zMi03Yy4xNC0uNzQuMjQtMS42Mi4yNC0yLjIyLjAyLTEuOTItLjk4LTMuMDgtMi43Ni0zLjA4Wk01Ny4xNCAxMS41MDFjLTQuMDggMC02Ljc4IDMuNjgtNi43OCA3Ljc4IDAgMi42MiAxLjYyIDQuNzQgNC42NiA0Ljc0IDQgMCA2LjctMy41OCA2LjctNy43OC4wMi0yLjQyLTEuNC00Ljc0LTQuNTgtNC43NFptLTEuNjYgOS45NGMtMS4xNiAwLTEuNjQtLjk4LTEuNjQtMi4yMiAwLTEuOTQgMS01LjEgMi44NC01LjEgMS4yIDAgMS42IDEuMDQgMS42IDIuMDQgMCAyLjA4LTEuMDIgNS4yOC0yLjggNS4yOFpNNzAuNCAxMS41MDFjLTIuMjggMC0zLjU4IDIuMDItMy41OCAyLjAyaC0uMDRsLjItMS44MmgtM2MtLjE0IDEuMjItLjQyIDMuMS0uNjggNC41bC0yLjM2IDEyLjRoMy4zOGwuOTQtNS4wMmguMDhzLjcuNDQgMS45OC40NGMzLjk4IDAgNi41OC00LjA4IDYuNTgtOC4yIDAtMi4yOC0xLjAyLTQuMzItMy41LTQuMzJabS0zLjI0IDkuOThjLS44OCAwLTEuNC0uNS0xLjQtLjVsLjU2LTMuMTZjLjQtMi4xMiAxLjUtMy41MiAyLjY4LTMuNTIgMS4wNCAwIDEuMzYuOTYgMS4zNiAxLjg2IDAgMi4yLTEuMyA1LjMyLTMuMiA1LjMyWk03OC43NCA2LjY0MWMtMS4wOCAwLTEuOTQuODYtMS45NCAxLjk2IDAgMSAuNjQgMS43IDEuNiAxLjdoLjA0YzEuMDYgMCAxLjk2LS43MiAxLjk4LTEuOTYgMC0uOTgtLjY2LTEuNy0xLjY4LTEuN1pNNzQgMjMuNzgxaDMuMzhsMi4zLTEyaC0zLjRsLTIuMjggMTJaTTg4LjMgMTEuNzYxaC0yLjM2bC4xMi0uNTZjLjItMS4xNi44OC0yLjE4IDIuMDItMi4xOC42IDAgMS4wOC4xOCAxLjA4LjE4bC42Ni0yLjY2cy0uNTgtLjMtMS44NC0uM2MtMS4yIDAtMi40LjM0LTMuMzIgMS4xMi0xLjE2Ljk4LTEuNyAyLjQtMS45NiAzLjg0bC0uMS41NmgtMS41OGwtLjUgMi41NmgxLjU4bC0xLjggOS40OGgzLjM4bDEuOC05LjQ4aDIuMzRsLjQ4LTIuNTZaTTk2LjQ2IDExLjc4MXMtMi4xMiA1LjM0LTMuMDYgOC4yNmgtLjA0Yy0uMDYtLjk0LS44NC04LjI2LS44NC04LjI2aC0zLjU2TDkxIDIyLjgwMWMuMDQuMjQuMDIuNC0uMDguNTYtLjQuNzYtMS4wNiAxLjUtMS44NCAyLjA0LS42NC40Ni0xLjM2Ljc2LTEuOTIuOTZsLjk0IDIuODhjLjY4LS4xNCAyLjEyLS43MiAzLjMyLTEuODQgMS41NC0xLjQ0IDIuOTgtMy42OCA0LjQ0LTYuNzJsNC4xNC04LjloLTMuNTRaIiBmaWxsPSIjMDAwIi8+PC9zdmc+`,
    url: 'https://shopify.com',
    accessibilityLabel: 'Shopify ',
  };

  const navigation = (
    <Navigation location="/" logoSuffix="Logo suffix">
      <Navigation.Section
        items={[
          {
            url: '/path/to/place',
            label: 'Home',
            icon: HomeMinor,
          },
          {
            url: '/path/to/place',
            label: 'Orders',
            icon: OrdersMinor,
            badge: '15',
            subNavigationItems: [
              {
                url: '/admin/orders/collections',
                disabled: false,
                selected: false,
                label: 'Collections',
              },
              {
                url: '/admin/orders/inventory',
                disabled: false,
                label: 'Inventory',
              },
            ],
          },
          {
            url: '/path/to/place',
            label: 'Marketing',
            icon: MarketingMinor,
            badge: '15',
            subNavigationItems: [
              {
                url: '/admin/analytics/collections',
                disabled: false,
                selected: false,
                label: 'Reports',
              },
              {
                url: '/admin/analytics/inventory',
                disabled: false,
                label: 'Live view',
              },
            ],
          },
          {
            url: '/admin/products',
            label: 'Products',
            icon: ProductsMinor,
            selected: true,
            subNavigationItems: [
              {
                url: '/?path=/story/all-components-navigation--navigation-with-multiple-secondary-navigations',
                disabled: false,
                selected: false,
                label: 'Collections',
              },
              {
                url: '/admin/products/inventory',
                disabled: false,
                selected: true,
                label: 'Inventory',
              },
            ],
          },
        ]}
      />
    </Navigation>
  );

  return (
    <div style={{height: '250px'}}>
      <Frame logo={logo} navigation={navigation} showMobileNavigation />
    </div>
  );
}


```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
