### PR TITLE
[Collapsible] Re-measure when children change

### DIFF
--- a/.changeset/warm-days-doubt.md
+++ b/.changeset/warm-days-doubt.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fixed a bug where collapsible wouldn't update height when children change
+Fixed a bug where `Collapsible` wouldn't update height when children change

--- a/.changeset/warm-days-doubt.md
+++ b/.changeset/warm-days-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed a bug where collapsible wouldn't update height when children change

--- a/polaris-react/src/components/Collapsible/Collapsible.tsx
+++ b/polaris-react/src/components/Collapsible/Collapsible.tsx
@@ -70,6 +70,11 @@ export function Collapsible({
   );
 
   useEffect(() => {
+    if (isFullyClosed) return;
+    setAnimationState('measuring');
+  }, [children, isFullyClosed]);
+
+  useEffect(() => {
     if (open !== isOpen) {
       setAnimationState('measuring');
     }

--- a/polaris-react/src/components/Collapsible/README.md
+++ b/polaris-react/src/components/Collapsible/README.md
@@ -75,7 +75,10 @@ function CollapsibleExample() {
           <Collapsible
             open={open}
             id="basic-collapsible"
-            transition={{duration: '150ms', timingFunction: 'ease-in-out'}}
+            transition={{
+              duration: 'var(--p-duration-150)',
+              timingFunction: 'var(--p-ease-in-out)',
+            }}
             expandOnPrint
           >
             <TextContainer>

--- a/polaris-react/src/components/Collapsible/README.md
+++ b/polaris-react/src/components/Collapsible/README.md
@@ -75,7 +75,7 @@ function CollapsibleExample() {
           <Collapsible
             open={open}
             id="basic-collapsible"
-            transition={{duration: '500ms', timingFunction: 'ease-in-out'}}
+            transition={{duration: '150ms', timingFunction: 'ease-in-out'}}
             expandOnPrint
           >
             <TextContainer>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/6078

**Before:**

https://user-images.githubusercontent.com/6844391/173076671-3ec6ffb8-83ce-4ab3-9160-c07bea185dda.mp4

**After:**

https://user-images.githubusercontent.com/6844391/173076692-32df822c-02bc-469d-9b3d-324fda531df0.mp4

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Re-measures content height when children change

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Playground is attached

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';
import {HomeMinor, OrdersMinor, ProductsMinor} from '@shopify/polaris-icons';

import {Frame, Navigation} from '../src';

const list1 = [
  {label: 'a', url: 'path/to/one'},
  {label: 'b', url: 'path/to/two'},
];
const list2 = [
  {label: 'one', url: 'path/to/one'},
  {label: 'two', url: 'path/to/two'},
  {label: 'three', url: 'path/to/three'},
];
const list3 = [
  {label: '1', url: 'path/to/one'},
  {label: '2', url: 'path/to/two'},
  {label: '3', url: 'path/to/three'},
  {label: '4', url: 'path/to/four'},
  {label: '5', url: 'path/to/five'},
];

export function Playground() {
  const [selected, setSelected] = useState('home');
  const [subitems, setSubitems] = useState(list2);

  return (
    <Frame>
      <button onClick={() => setSubitems(list1)}>list 1</button>
      <button onClick={() => setSubitems(list2)}>list 2</button>
      <button onClick={() => setSubitems(list3)}>list 3</button>
      <Navigation location="/">
        <Navigation.Section
          items={[
            {
              url: '/',
              label: 'Home',
              icon: HomeMinor,
              matches: selected === 'home',
              onClick: () => setSelected('home'),
            },
            {
              url: '/',
              label: 'Orders',
              icon: OrdersMinor,
              subNavigationItems: subitems,
              matches: selected === 'orders',
              onClick: () => setSelected('orders'),
            },
            {
              url: '/',
              label: 'Products',
              icon: ProductsMinor,
              matches: selected === 'products',
              onClick: () => setSelected('products'),
            },
          ]}
        />
        <ul>
          {subitems.map((item) => (
            <li key={item.label}>{item.label}</li>
          ))}
        </ul>
      </Navigation>
    </Frame>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
