### PR TITLE
Update experimental breakpoints for down media conditions

### DIFF
--- a/.changeset/tidy-lemons-poke.md
+++ b/.changeset/tidy-lemons-poke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated experimental breakpoints for down media conditions

--- a/polaris-react/scripts/gen-media-queries.js
+++ b/polaris-react/scripts/gen-media-queries.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
 const path = require('path');
 
-const {tokens} = require('@shopify/polaris-tokens');
+const {tokens, toEm, toPx} = require('@shopify/polaris-tokens');
 
 const polarisReactDir = path.join(__dirname, '..');
 const stylesDir = path.join(polarisReactDir, 'src/styles');
@@ -56,10 +56,12 @@ function getUpMediaCondition(breakpoint) {
   return `(min-width: ${toEm(breakpoint)})`;
 }
 
+/**
+ * Down media condition breakpoints are being substracted by 0.05px to prevent
+ * them from overwriting up media queries. We experimented with multiple offsets
+ * and felt that 0.05px would be the safest across different pixel densities.
+ */
 function getDownMediaCondition(breakpoint) {
-  return `(max-width: ${toEm(parseFloat(breakpoint) - 0.05)})`;
-}
-
-function toEm(value) {
-  return `${parseFloat(value)}em`;
+  const offsetBreakpoint = parseFloat(toPx(breakpoint)) - 0.05;
+  return `(max-width: ${toEm(`${offsetBreakpoint}px`)})`;
 }

--- a/polaris-react/scripts/gen-media-queries.js
+++ b/polaris-react/scripts/gen-media-queries.js
@@ -57,9 +57,9 @@ function getUpMediaCondition(breakpoint) {
 }
 
 function getDownMediaCondition(breakpoint) {
-  return `(max-width: ${toEm(breakpoint)})`;
+  return `(max-width: ${toEm(parseFloat(breakpoint) - 0.05)})`;
 }
 
 function toEm(value) {
-  return `${parseInt(value, 10)}em`;
+  return `${parseFloat(value)}em`;
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Prevent `down` and `up` media queries (generated from `breakpoints` token aliases) from overlapping/overwriting one another. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Because we favor `up` media queries we chose to subtract a `0.05px` offset from `down` media queries. In our demo we experimented with multiple offsets and felt that `0.05px` would be the safest across different pixel densities.

<details>
<summary>Example of generated media conditions</summary>

```scss
/* Breakpoints - Aliases */
$p-breakpoints-xs: 0em;
$p-breakpoints-sm: 30.625em;
$p-breakpoints-md: 48em;
$p-breakpoints-lg: 65em;
$p-breakpoints-xl: 90em;

/* Breakpoints - Media conditions */
$p-breakpoints-xs-up: '(min-width: 0em)';
$p-breakpoints-xs-down: '(max-width: -0.003125em)';
$p-breakpoints-xs-only: '(min-width: 0em) and (max-width: 30.621875em)';

$p-breakpoints-sm-up: '(min-width: 30.625em)';
$p-breakpoints-sm-down: '(max-width: 30.621875em)';
$p-breakpoints-sm-only: '(min-width: 30.625em) and (max-width: 47.996875em)';

$p-breakpoints-md-up: '(min-width: 48em)';
$p-breakpoints-md-down: '(max-width: 47.996875em)';
$p-breakpoints-md-only: '(min-width: 48em) and (max-width: 64.996875em)';

$p-breakpoints-lg-up: '(min-width: 65em)';
$p-breakpoints-lg-down: '(max-width: 64.996875em)';
$p-breakpoints-lg-only: '(min-width: 65em) and (max-width: 89.996875em)';

$p-breakpoints-xl-up: '(min-width: 90em)';
$p-breakpoints-xl-down: '(max-width: 89.996875em)';
$p-breakpoints-xl-only: '(min-width: 90em)';

```
</details>

**Example in `px` (Chrome)**
[CodeSandbox](https://codesandbox.io/s/thirsty-tesla-itqv6w?file=/src/styles.css&resolutionWidth=960&resolutionHeight=675)

https://user-images.githubusercontent.com/21976492/173157206-13586b78-6649-4ae0-b45a-a74fe6ae9d02.mov


**Example in `em` (Chrome)**

https://user-images.githubusercontent.com/21976492/173157204-b7380863-bcf4-4f76-b4d1-a8d5264520d6.mov


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Co-Authored-By: Aaron Casanova <32409546+aaronccasanova@users.noreply.github.com>
