### PR TITLE
Add more tokens for dark UI

### DIFF
--- a/.changeset/tidy-parrots-doubt.md
+++ b/.changeset/tidy-parrots-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Added color and shape tokens for dark UI: `border-divider-on-dark` and `surface-pressed-dark`.

--- a/documentation/guides/migrating-from-v9-to-v10.md
+++ b/documentation/guides/migrating-from-v9-to-v10.md
@@ -39,9 +39,11 @@ You can use the following mapping to port CSS custom properties to the newly add
 | `--p-surface`                  | `--p-surface-dark`                  |
 | `--p-surface-neutral-subdued`  | `--p-surface-neutral-subdued-dark`  |
 | `--p-surface-hovered`          | `--p-surface-hovered-dark`          |
+| `--p-surface-pressed`          | `--p-surface-pressed-dark`          |
 | `--p-surface-search-field`     | `--p-surface-search-field-dark`     |
 | `--p-border`                   | `--p-border-on-dark`                |
 | `--p-divider`                  | `--p-divider-dark`                  |
+| `--p-border-divider`           | `--p-border-divider-on-dark`        |
 | `--p-icon`                     | `--p-icon-on-dark`                  |
 | `--p-text`                     | `--p-text-on-dark`                  |
 | `--p-text-subdued`             | `--p-text-subdued-on-dark`          |

--- a/polaris-tokens/src/token-groups/color.light.ts
+++ b/polaris-tokens/src/token-groups/color.light.ts
@@ -77,6 +77,11 @@ export const colors = {
     description:
       'For use as a surface color on interactive elements such as resource list items and action list items when in a pressed state.',
   },
+  'surface-pressed-dark': {
+    value: 'rgba(62, 64, 67, 1)',
+    description:
+      'For use as a dark surface color on interactive elements such as resource list items and action list items when in a pressed state.',
+  },
   'surface-depressed': {
     value: 'rgba(237, 238, 239, 1)',
     description:

--- a/polaris-tokens/src/token-groups/shape.ts
+++ b/polaris-tokens/src/token-groups/shape.ts
@@ -56,4 +56,7 @@ export const shape = {
   'border-divider': {
     value: 'var(--p-border-width-1) solid var(--p-divider)',
   },
+  'border-divider-on-dark': {
+    value: 'var(--p-border-width-1) solid var(--p-divider-dark)',
+  },
 };

--- a/polaris-tokens/tests/utilities.test.js
+++ b/polaris-tokens/tests/utilities.test.js
@@ -17,7 +17,7 @@ describe('createVar', () => {
 
 describe('getCustomPropertyNames', () => {
   it('extracts the token names', () => {
-    expect(getCustomPropertyNames(tokens)).toHaveLength(271);
+    expect(getCustomPropertyNames(tokens)).toHaveLength(273);
   });
 });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6043

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds the following dark tokens: `border-divider-on-dark` and `surface-pressed-dark`