### PR TITLE
Add CSS unit utilities

### DIFF
--- a/.changeset/bright-wasps-think.md
+++ b/.changeset/bright-wasps-think.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': patch
+---
+
+Added CSS unit utilities

--- a/polaris-tokens/src/utilities.ts
+++ b/polaris-tokens/src/utilities.ts
@@ -2,11 +2,76 @@ import type {Tokens, TokenGroup} from './tokens';
 
 const BASE_FONT_SIZE = 16;
 
+const UNIT_PX = 'px';
+const UNIT_EM = 'em';
+const UNIT_REM = 'rem';
+
+// https://regex101.com/r/zvY2bu/1
+const DIGIT_REGEX = new RegExp(String.raw`-?\d+(?:\.\d+|\d*)`);
+const UNIT_REGEX = new RegExp(`${UNIT_PX}|${UNIT_EM}|${UNIT_REM}`);
+
+export function getUnit(value = '') {
+  const unit = value.match(
+    new RegExp(`${DIGIT_REGEX.source}(${UNIT_REGEX.source})`),
+  );
+
+  return unit && unit[1];
+}
+
+export function toPx(value = '') {
+  const unit = getUnit(value);
+
+  if (!unit) return value;
+
+  if (unit === UNIT_PX) {
+    return value;
+  }
+
+  if (unit === UNIT_EM || unit === UNIT_REM) {
+    return `${parseFloat(value) * BASE_FONT_SIZE}${UNIT_PX}`;
+  }
+}
+
+export function toEm(value = '', fontSize = BASE_FONT_SIZE) {
+  const unit = getUnit(value);
+
+  if (!unit) return value;
+
+  if (unit === UNIT_EM) {
+    return value;
+  }
+
+  if (unit === UNIT_PX) {
+    return `${parseFloat(value) / fontSize}${UNIT_EM}`;
+  }
+
+  if (unit === UNIT_REM) {
+    return `${(parseFloat(value) * BASE_FONT_SIZE) / fontSize}${UNIT_EM}`;
+  }
+}
+
+export function toRem(value = '') {
+  const unit = getUnit(value);
+
+  if (!unit) return value;
+
+  if (unit === UNIT_REM) {
+    return value;
+  }
+
+  if (unit === UNIT_EM) {
+    return `${parseFloat(value)}${UNIT_REM}`;
+  }
+
+  if (unit === UNIT_PX) {
+    return `${parseFloat(value) / BASE_FONT_SIZE}${UNIT_REM}`;
+  }
+}
+
 function rem(value: string) {
   return value.replace(
-    // https://regex101.com/r/RBL7EE/1
-    /\d+(?:\.\d+|\d*)px/g,
-    (px: string) => `${parseInt(px, 10) / BASE_FONT_SIZE}rem`,
+    new RegExp(`${DIGIT_REGEX.source}(${UNIT_PX})`, 'g'),
+    (px: string) => toRem(px) ?? px,
   );
 }
 

--- a/polaris-tokens/tests/utilities.test.js
+++ b/polaris-tokens/tests/utilities.test.js
@@ -4,6 +4,10 @@ import {
   getCustomPropertyNames,
   getKeyframeNames,
   tokensToRems,
+  toPx,
+  toEm,
+  toRem,
+  getUnit,
 } from '../src/utilities';
 
 describe('createVar', () => {
@@ -29,10 +33,82 @@ describe('getKeyframeNames', () => {
 
 describe('tokensToRems', () => {
   it("converts a token group's value from px to rems", () => {
-    const tokenGroup = {foo: {value: '12px'}, bar: {value: '16px'}};
+    const tokenGroup = {
+      foo: {value: '12px'},
+      bar: {value: '16px'},
+      baz: {value: '16px 32px'},
+    };
+
     const result = tokensToRems(tokenGroup);
 
     expect(result.foo.value).toBe('0.75rem');
     expect(result.bar.value).toBe('1rem');
+    expect(result.baz.value).toBe('1rem 2rem');
+  });
+});
+
+describe('getUnit', () => {
+  it('retrieves a supported length unit from a value', () => {
+    expect(getUnit('1px')).toBe('px');
+    expect(getUnit('1em')).toBe('em');
+    expect(getUnit('1rem')).toBe('rem');
+    expect(getUnit('-1rem')).toBe('rem');
+    expect(getUnit('1.5rem')).toBe('rem');
+    expect(getUnit('-1.5rem')).toBe('rem');
+    expect(getUnit('1')).toBeNull();
+    expect(getUnit('px')).toBeNull();
+    expect(getUnit('1vw')).toBeNull();
+    expect(getUnit(undefined)).toBeNull();
+  });
+});
+
+describe('toPx', () => {
+  it('converts a supported length unit to px', () => {
+    expect(toPx('1px')).toBe('1px');
+    expect(toPx('1em')).toBe('16px');
+    expect(toPx('1rem')).toBe('16px');
+    expect(toPx('-1rem')).toBe('-16px');
+    expect(toPx('1.5rem')).toBe('24px');
+    expect(toPx('-1.5rem')).toBe('-24px');
+    expect(toPx('1vw')).toBe('1vw');
+    expect(toPx('1')).toBe('1');
+    expect(toPx('px')).toBe('px');
+    expect(toPx(undefined)).toBe('');
+  });
+});
+
+describe('toEm', () => {
+  it('converts a supported length unit to em', () => {
+    expect(toEm('1px')).toBe('0.0625em');
+    expect(toEm('1em')).toBe('1em');
+    expect(toEm('1rem')).toBe('1em');
+    expect(toEm('-1rem')).toBe('-1em');
+    expect(toEm('1.5rem')).toBe('1.5em');
+    expect(toEm('-1.5rem')).toBe('-1.5em');
+    expect(toEm('1vw')).toBe('1vw');
+    expect(toEm('1')).toBe('1');
+    expect(toEm('px')).toBe('px');
+    expect(toEm(undefined)).toBe('');
+  });
+
+  it('converts a supported length unit to em with a custom font size', () => {
+    expect(toEm('1px', 8)).toBe('0.125em');
+    expect(toEm('1em', 8)).toBe('1em');
+    expect(toEm('1rem', 8)).toBe('2em');
+  });
+});
+
+describe('toRem', () => {
+  it('converts a supported length unit to rem', () => {
+    expect(toRem('1px')).toBe('0.0625rem');
+    expect(toRem('1em')).toBe('1rem');
+    expect(toRem('1rem')).toBe('1rem');
+    expect(toRem('-1rem')).toBe('-1rem');
+    expect(toRem('1.5rem')).toBe('1.5rem');
+    expect(toRem('-1.5rem')).toBe('-1.5rem');
+    expect(toRem('1vw')).toBe('1vw');
+    expect(toRem('1')).toBe('1');
+    expect(toRem('px')).toBe('px');
+    expect(toRem(undefined)).toBe('');
   });
 });


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR introduces new utilities to `@shopify/polaris-tokens` for converting CSS values from one length unit to another.
- `getUnit`: Retrieves the length unit from a CSS value
- `toPx`: Converts an `em` or `rem` value to `px`
- `toEm`: Converts a `px` or `rem` value to `em`
- `toRem`: Converts a `px` or `em` value to `rem`

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
