### PR TITLE
[Button] - Add "start" and "end" options for textAlign prop

### DIFF
--- a/.changeset/sweet-jars-matter.md
+++ b/.changeset/sweet-jars-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added the ability to use "start" or "end" in the Button's textAlign property

--- a/.changeset/sweet-jars-matter.md
+++ b/.changeset/sweet-jars-matter.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Added the ability to use "start" or "end" in the Button's textAlign property
+Added support for setting `start` and `end` on the `Button` `textAlign` prop

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -66,6 +66,15 @@
   }
 }
 
+.textAlignStart {
+  justify-content: flex-start;
+  text-align: start;
+
+  .Content {
+    justify-content: flex-start;
+  }
+}
+
 .textAlignCenter {
   justify-content: center;
   text-align: center;
@@ -74,6 +83,15 @@
 .textAlignRight {
   justify-content: flex-end;
   text-align: right;
+
+  .Content {
+    justify-content: flex-end;
+  }
+}
+
+.textAlignEnd {
+  justify-content: flex-end;
+  text-align: end;
 
   .Content {
     justify-content: flex-end;

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -33,7 +33,7 @@ export interface ButtonProps extends BaseButton {
    */
   size?: 'slim' | 'medium' | 'large';
   /** Changes the inner text alignment of the button */
-  textAlign?: 'left' | 'right' | 'center';
+  textAlign?: 'left' | 'right' | 'center' | 'start' | 'end';
   /** Gives the button a subtle alternative to the default button styling, appropriate for certain backdrops */
   outline?: boolean;
   /** Allows the button to grow to the width of its container */


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6120<!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This adds the ability to specify "start" or "end" as the textAlign property on the Button component. This is especially useful for right-to-left languages as the alignment property is figured out based on the direction of the html document, not explicitly right or left.

Direction ltr with "start":
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/1019769/173656429-66f1c59c-23f2-4381-8eca-94250b5a4a21.png">

Direction rtl with "start":
<img width="1690" alt="image" src="https://user-images.githubusercontent.com/1019769/173656567-51a3c68b-42f2-47b0-bab3-7b6b431437a0.png">


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] ~~Updated the component's `README.md` with documentation changes~~ - updated the TypeScript prop to show this new ability.
- [ ] ~~[Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide~~ N/A - dit not update the README.md file
