### PR TITLE
[polaris.shopify.com reboot] Update CodeExample.module.scss

### DIFF
--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
@@ -7,7 +7,7 @@
 }
 
 .TitleBar {
-  padding: 05rem 0.75em;
+  padding: 0.5rem 0.75em;
   background: var(--surface-subdued);
   margin: 1px 1px 0 1px;
   border-radius: var(--border-radius-600) var(--border-radius-600)


### PR DESCRIPTION
In #6118 there were a bunch of design tweaks. One of them was to the `.TitleBar` class in [polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss](https://github.com/Shopify/polaris/commit/e466952cfae5c97ecde6b97aefb23fe249945c7b#diff-1cc289cb75f254affc15538af11a4a33974628c1ee40833a8c6c4e78a90317e3L10). I think the desired change was for `0.5rem` instead of `05rem`

Before

<img width="752" alt="Screen Shot 2022-06-14 at 3 52 27 PM" src="https://user-images.githubusercontent.com/6355760/173676649-73642b88-49bb-43be-9ce0-6473413f062c.png">


After

<img width="749" alt="Screen Shot 2022-06-14 at 3 52 34 PM" src="https://user-images.githubusercontent.com/6355760/173676679-73e4d5d2-78b7-4f7c-bcc2-9ec94316e8c9.png">

