### PR TITLE
Update radio button and checkbox border color

### DIFF
--- a/.changeset/plenty-doors-type.md
+++ b/.changeset/plenty-doors-type.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris': minor
+'@shopify/polaris': patch
 ---
 
 Revert border color for checkbox and radio button

--- a/.changeset/plenty-doors-type.md
+++ b/.changeset/plenty-doors-type.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Revert border color for checkbox and radio button

--- a/polaris-react/src/components/RadioButton/RadioButton.scss
+++ b/polaris-react/src/components/RadioButton/RadioButton.scss
@@ -54,7 +54,7 @@
   display: block;
   width: 100%;
   height: 100%;
-  border: var(--p-control-border-width) solid var(--p-border-subdued);
+  border: var(--p-control-border-width) solid var(--p-border);
   border-radius: var(--p-border-radius-half);
   background-color: var(--p-surface);
   transition: border-color var(--p-duration-100) var(--p-ease);

--- a/polaris-react/src/styles/shared/_controls.scss
+++ b/polaris-react/src/styles/shared/_controls.scss
@@ -19,7 +19,7 @@
 @mixin control-backdrop($style: base) {
   @if $style == base {
     position: relative;
-    border: var(--p-control-border-width) solid var(--p-border-subdued);
+    border: var(--p-control-border-width) solid var(--p-border);
     background-color: var(--p-surface);
     border-radius: var(--p-border-radius-1);
 


### PR DESCRIPTION
### WHY are these changes introduced?

- Fixes https://github.com/Shopify/polaris/issues/6114
- Reverts the change to radio button and checkbox border color made in https://github.com/Shopify/polaris/pull/5712

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Change border color for radio buttons and checkboxes back to `--p-border`

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

- `yarn dev` to view in Storybook