### PR TITLE
Consolidate typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "size-limit": "^5.0.3",
     "stylelint": "^14.1.0",
     "turbo": "^1.2.8",
-    "typescript": ">=3.0.0"
+    "typescript": "^4.6.3"
   },
   "prettier": "@shopify/prettier-config",
   "size-limit": [

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -120,7 +120,6 @@
     "semver": "^6.3.0",
     "shx": "^0.3.2",
     "svgo": "^2.8.0",
-    "typescript": "~4.3.5",
     "webpack": "5"
   },
   "browserslist": [

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -42,7 +42,6 @@
     "generact": "^0.4.0",
     "js-yaml": "^4.1.0",
     "marked": "^4.0.16",
-    "rehype-raw": "^6.1.1",
-    "typescript": "4.5.5"
+    "rehype-raw": "^6.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17792,20 +17792,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
-
-typescript@>=3.0.0, typescript@^4.1.0-dev.20200804:
+typescript@^4.1.0-dev.20200804, typescript@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
-
-typescript@~4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
### WHY are these changes introduced?

Let's specify typescript once at the root of the repo instead of inside
packages. This makes it easier to update the typescript version by only having to modify it in one place

### WHAT is this pull request doing?

Removes typescript references from individual package package.json files in favour of mentioning it just in the root package.json