### PR TITLE
Use rollup.config.mjs files

### DIFF
--- a/polaris-for-vscode/rollup.config.mjs
+++ b/polaris-for-vscode/rollup.config.mjs
@@ -1,13 +1,11 @@
-import nodeResolve from '@rollup/plugin-node-resolve';
+import {babel} from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
-import babel from '@rollup/plugin-babel';
+import {nodeResolve} from '@rollup/plugin-node-resolve';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
-/**
- * @type {import('rollup').RollupOptions}
- */
-const rollupOptions = {
+/** @type {import('rollup').RollupOptions} */
+export default {
   input: ['src/client.ts', 'src/server.ts'],
   output: [
     {
@@ -36,6 +34,3 @@ const rollupOptions = {
     'vscode-languageserver-textdocument',
   ],
 };
-
-// eslint-disable-next-line import/no-default-export
-export default rollupOptions;

--- a/polaris-icons/rollup.config.mjs
+++ b/polaris-icons/rollup.config.mjs
@@ -1,16 +1,17 @@
 // rollup.config.js
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import {createFilter} from '@rollup/pluginutils';
-import babel from '@rollup/plugin-babel';
+import {babel} from '@rollup/plugin-babel';
 import virtual from '@rollup/plugin-virtual';
 import glob from 'glob';
 import jsYaml from 'js-yaml';
-import convert from '@svgr/core';
+import svgr from '@svgr/core';
 import {optimize} from 'svgo';
 
-const iconBasePath = path.resolve(__dirname, 'icons');
+const convert = svgr.default;
+const iconBasePath = new URL('./icons', import.meta.url).pathname;
 const iconPaths = glob.sync(path.join(iconBasePath, '*.yml'));
 
 const iconExports = [];
@@ -204,7 +205,7 @@ function replaceFillAttributeSvgoPlugin() {
 }
 
 /** @type {import('rollup').RollupOptions} */
-const config = [
+export default [
   {
     input: 'src/index.ts',
     output: [
@@ -277,6 +278,3 @@ const config = [
     ],
   },
 ];
-
-// eslint-disable-next-line import/no-default-export
-export default config;

--- a/polaris-react/rollup.config.mjs
+++ b/polaris-react/rollup.config.mjs
@@ -16,17 +16,18 @@ import postcssPlugins from './config/postcss-plugins.js';
 const pkg = JSON.parse(
   readFileSync(new URL('./package.json', import.meta.url).pathname),
 );
+const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
 function generateConfig({output, targets, stylesConfig}) {
   return {
     input: './src/index.ts',
     plugins: [
       externals({deps: true, packagePath: './package.json'}),
-      nodeResolve({extensions: ['.js', '.jsx', '.ts', '.tsx']}),
+      nodeResolve({extensions}),
       commonjs(),
       babel({
         rootMode: 'upward',
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        extensions,
         exclude: 'node_modules/**',
         babelHelpers: 'bundled',
         // Options that may be present on the `babelConfig` object but

--- a/polaris-tokens/rollup.config.mjs
+++ b/polaris-tokens/rollup.config.mjs
@@ -1,17 +1,17 @@
-import path from 'path';
+import {readFileSync} from 'fs';
+import * as path from 'path';
 
-import nodeResolve from '@rollup/plugin-node-resolve';
+import {babel} from '@rollup/plugin-babel';
+import {nodeResolve} from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import babel from '@rollup/plugin-babel';
 
-import pkg from './package.json';
-
+const pkg = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url).pathname),
+);
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
-/**
- * @type {import('rollup').RollupOptions}
- */
-const rollupOptions = {
+/** @type {import('rollup').RollupOptions} */
+export default {
   input: 'src/index.ts',
   output: [
     {
@@ -45,6 +45,3 @@ const rollupOptions = {
     ...Object.keys(pkg.peerDependencies ?? {}),
   ],
 };
-
-// eslint-disable-next-line import/no-default-export
-export default rollupOptions;


### PR DESCRIPTION
### WHY are these changes introduced?

Consistent behaviour across package builds.

This avoids having to transpile the rollup config files, as instead they
get passed straight to nodejs, which can handle mjs files nativly.

### WHAT is this pull request doing?

Convert all rollup.config.js files to rollup.config.mjs files
Along the way reorder some imports for alphabetical consistency