### PR TITLE
[polaris.shopify.com reboot] Edit skip-to-content button

### DIFF
--- a/.changeset/sweet-windows-smash.md
+++ b/.changeset/sweet-windows-smash.md
@@ -1,0 +1,10 @@
+---
+'polaris-for-vscode': patch
+'@shopify/polaris-icons': patch
+'@shopify/polaris': patch
+'@shopify/polaris-tokens': patch
+'polaris.shopify.com': patch
+'@shopify/stylelint-polaris': patch
+---
+
+Fix "skip to content" bug

--- a/polaris.shopify.com/src/components/Header/Header.module.scss
+++ b/polaris.shopify.com/src/components/Header/Header.module.scss
@@ -91,7 +91,7 @@
 
 .SkipToContentLink {
   left: 0%;
-  background-color: white;
+  background-color: var(--surface);
   border-radius: var(--border-radius-200);
   color: var(--text-strong);
   font-weight: var(--font-weight-500);
@@ -100,7 +100,7 @@
   margin-left: 0.5rem;
   padding: 1rem;
   position: absolute;
-  transform: translateY(-100%);
+  transform: translateY(-115%);
 
   &:focus {
     transform: translateY(0%);

--- a/polaris.shopify.com/src/components/HomePage/HomePage.tsx
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.tsx
@@ -8,7 +8,7 @@ function HomePage({}: Props) {
   return (
     <div className={styles.HomePage}>
       <div className={styles.Intro}>
-        <Container id="main" className={styles.IntroContent}>
+        <Container className={styles.IntroContent}>
           <h1>A design system built for commerce</h1>
           <Link href="/resources">Explore the system</Link>
 

--- a/polaris.shopify.com/src/components/Layout/Layout.tsx
+++ b/polaris.shopify.com/src/components/Layout/Layout.tsx
@@ -44,7 +44,9 @@ function Layout({
           )}
           <div className={styles.Post}>
             {showTOC && <TOC items={tocItems} />}
-            <div className={styles.PostContent}>{children}</div>
+            <div id="main" className={styles.PostContent}>
+              {children}
+            </div>
           </div>
         </div>
       </article>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

[#6132](https://github.com/Shopify/polaris/issues/6132)

Fixes bug with current skip-content-button showing in dark-mode

<img width="400" alt="button-bug" src="https://screenshot.click/15-09-uglez-6jsoj.png">

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Moves content button further up Y axis and replaces background colour with `var(--surface)` to make sure that tokenized colour is used