### PR TITLE
[polaris.shopify.com reboot] Fix/icons download button

### DIFF
--- a/.changeset/itchy-apples-dream.md
+++ b/.changeset/itchy-apples-dream.md
@@ -1,10 +1,5 @@
 ---
-'polaris-for-vscode': patch
-'@shopify/polaris-icons': patch
-'@shopify/polaris': patch
-'@shopify/polaris-tokens': patch
 'polaris.shopify.com': patch
-'@shopify/stylelint-polaris': patch
 ---
 
 Fix download icon button

--- a/.changeset/itchy-apples-dream.md
+++ b/.changeset/itchy-apples-dream.md
@@ -1,0 +1,10 @@
+---
+'polaris-for-vscode': patch
+'@shopify/polaris-icons': patch
+'@shopify/polaris': patch
+'@shopify/polaris-tokens': patch
+'polaris.shopify.com': patch
+'@shopify/stylelint-polaris': patch
+---
+
+Fix download icon button

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 /polaris-react/build
 /polaris-react/build-internal
 /polaris-react/src/styles/_media-queries.scss
+/polaris.shopify.com/public/icons

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -3,14 +3,15 @@
   "version": "0.2.1",
   "private": true,
   "scripts": {
-    "build": "next build",
-    "dev": "next dev",
+    "build": "yarn run copy-icons && next build",
+    "dev": "yarn run copy-icons && next dev",
     "start": "next start ",
     "lint": "TIMING=1 eslint --cache .",
     "clean": "rm -rf .turbo node_modules .next *.tsbuildinfo",
     "create-component": "generact --root src/components src/components/Template/Template.tsx",
     "parse-components": "node src/scripts/parseComponents.mjs",
-    "parse-guidelines": "node src/scripts/parseGuidelines.mjs"
+    "parse-guidelines": "node src/scripts/parseGuidelines.mjs",
+    "copy-icons": "node src/scripts/copy-icons.mjs"
   },
   "dependencies": {
     "@headlessui/react": "^1.5.0",

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.module.scss
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.module.scss
@@ -149,3 +149,20 @@
     color: var(--text-subdued);
   }
 }
+
+.DownloadIconButton {
+  align-items: center;
+  appearance: none;
+  background: var(--primary);
+  color: var(--surface);
+  padding: 0.75rem 0.66rem;
+  border: none;
+  font-size: var(--font-size-100);
+  font-weight: var(--font-weight-500);
+  border-radius: var(--border-radius-400);
+  user-select: none;
+  box-shadow: inset 0 -2px rgba(0, 0, 0, 0.075);
+  display: block;
+  text-align: center;
+  cursor: pointer;
+}

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -13,7 +13,6 @@ import { className, getTitleTagValue } from "../../utils/various";
 import IconGrid from "../IconGrid";
 import TextField from "../TextField";
 import CodeExample from "../CodeExample";
-import { LinkButton } from "../Button/Button";
 import Image from "../Image";
 import { Icon } from "../../types";
 
@@ -168,16 +167,14 @@ function IconsPage() {
                 </div>
 
                 <div className={styles.ActionButtons}>
-                  <LinkButton
-                    href={
-                      importedSvgs(`./${selectedIcon.fileName}.svg`).default.src
-                    }
+                  {console.log(selectedIcon.fileName)}
+                  <a
+                    className={styles.DownloadIconButton}
+                    href={`/icons/${selectedIcon.fileName}.svg`}
                     download
-                    primary
-                    fill
                   >
                     Download SVG
-                  </LinkButton>
+                  </a>
                 </div>
               </div>
 

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -167,7 +167,6 @@ function IconsPage() {
                 </div>
 
                 <div className={styles.ActionButtons}>
-                  {console.log(selectedIcon.fileName)}
                   <a
                     className={styles.DownloadIconButton}
                     href={`/icons/${selectedIcon.fileName}.svg`}

--- a/polaris.shopify.com/src/scripts/copy-icons.mjs
+++ b/polaris.shopify.com/src/scripts/copy-icons.mjs
@@ -1,0 +1,23 @@
+import path from 'path';
+import {existsSync, rmSync, mkdirSync} from 'fs';
+import {copyFile} from 'fs/promises';
+import metadata from '@shopify/polaris-icons/metadata';
+
+const srcDir = path.join(
+  process.cwd(),
+  '../polaris-icons/dist/svg',
+);
+
+const distDir = path.join(process.cwd(), 'public/icons');
+
+if (existsSync(distDir)) rmSync(distDir, {recursive: true});
+mkdirSync(distDir);
+
+const copyPromises = Object.keys(metadata).map((iconName) =>
+  copyFile(
+    path.join(srcDir, `${iconName}.svg`),
+    path.join(distDir, `${iconName}.svg`),
+  ),
+);
+
+await Promise.all(copyPromises);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6074 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<img width="700" alt="download-icon" src="https://user-images.githubusercontent.com/59836805/173888397-05611a06-d2f3-463d-a7c7-b89d39dd629d.gif">

Adds a `copy-icons` script that copies all icon SVG's from the `polaris-icons` repo.  As a result when users now click `Download SVG` on the icons page, the svg is now downloaded as opposed to being opened fullscreen in a separate tab. 

I did replace the `<LinkButton>` component and used an `<a>` tag instead. This allowed for the correct behaviour but would like to revisit the `<LinkButton>` component in the future for reusability.
