### PR TITLE
[polaris.shopify.com reboot] Improved focus states and a11y behaviour

### DIFF
--- a/.changeset/angry-wolves-pay.md
+++ b/.changeset/angry-wolves-pay.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Improved focus states and a11y behaviour

--- a/polaris.shopify.com/src/components/Button/Button.module.scss
+++ b/polaris.shopify.com/src/components/Button/Button.module.scss
@@ -44,5 +44,13 @@
     background: var(--primary);
     color: var(--surface);
     box-shadow: inset 0 -2px rgba(0, 0, 0, 0.075);
+    &:focus {
+      box-shadow: var(--focus-outline);
+      border: 2px solid red;
+    }
+  }
+
+  &:focus-visible {
+    box-shadow: var(--focus-outline);
   }
 }

--- a/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.module.scss
+++ b/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.module.scss
@@ -10,15 +10,18 @@
 
 .Component {
   display: flex;
-  // background: var(--surface-subdued);
-  border-radius: var(--border-radius-600);
-  box-shadow: var(--card-shadow);
 
   a {
     position: relative;
     display: flex;
     flex-direction: column;
     color: inherit;
+    border-radius: var(--border-radius-600);
+    box-shadow: var(--card-shadow);
+
+    &:focus-visible {
+      box-shadow: var(--focus-outline);
+    }
   }
 
   &.isHighlighted a {

--- a/polaris.shopify.com/src/components/FoundationsIndexPage/FoundationsIndexPage.module.scss
+++ b/polaris.shopify.com/src/components/FoundationsIndexPage/FoundationsIndexPage.module.scss
@@ -43,6 +43,10 @@
     border-radius: var(--border-radius-800);
     box-shadow: var(--card-shadow);
 
+    &:focus-visible {
+      box-shadow: var(--focus-outline);
+    }
+
     &:before {
       content: "";
       display: block;

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.module.scss
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.module.scss
@@ -18,6 +18,7 @@
     &:focus {
       position: relative;
       z-index: 2;
+      box-shadow: var(--focus-outline);
     }
 
     &::placeholder {

--- a/polaris.shopify.com/src/components/Header/Header.module.scss
+++ b/polaris.shopify.com/src/components/Header/Header.module.scss
@@ -90,15 +90,19 @@
 }
 
 .SkipToContentLink {
-  left: 0%;
+  top: 2px;
+  right: 2px;
+  left: 2px;
+  height: calc(var(--header-height) - 4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-500);
   background-color: var(--surface);
-  border-radius: var(--border-radius-200);
   color: var(--text-strong);
   font-weight: var(--font-weight-500);
-  font-size: var(--font-size-100);
-  margin-top: 0.4rem;
-  margin-left: 0.5rem;
-  padding: 1rem;
+  z-index: 1;
+
   position: absolute;
   transform: translateY(-115%);
 

--- a/polaris.shopify.com/src/components/Header/Header.module.scss
+++ b/polaris.shopify.com/src/components/Header/Header.module.scss
@@ -102,7 +102,6 @@
   color: var(--text-strong);
   font-weight: var(--font-weight-500);
   z-index: 1;
-
   position: absolute;
   transform: translateY(-115%);
 

--- a/polaris.shopify.com/src/components/Header/Header.tsx
+++ b/polaris.shopify.com/src/components/Header/Header.tsx
@@ -12,15 +12,18 @@ import NavItems from "../NavItems";
 
 import styles from "./Header.module.scss";
 import shopifyLogo from "../../../public/shopify-logo.svg";
+import { useRouter } from "next/router";
 
 interface Props {
   currentSection?: string;
 }
 
 function Header({ currentSection }: Props) {
+  const router = useRouter();
   const [showMenu, setShowMenu] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const darkMode = useDarkMode(false);
+  const [showSkipToContentLink, setShowSkipToContentLink] = useState(true);
 
   useEffect(() => {
     function hideSideNavOnResize() {
@@ -34,6 +37,11 @@ function Header({ currentSection }: Props) {
     return () => window.removeEventListener("resize", hideSideNavOnResize);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    const mainContent = document.querySelector("#main");
+    setShowSkipToContentLink(mainContent !== null);
+  }, [router.asPath]);
 
   const handleCloseMenu = () => {
     setShowMenu(false);
@@ -77,9 +85,11 @@ function Header({ currentSection }: Props) {
           </a>
         </Link>
 
-        <a className={styles.SkipToContentLink} href="#main">
-          Skip to content
-        </a>
+        {showSkipToContentLink && (
+          <a className={styles.SkipToContentLink} href="#main">
+            Skip to content
+          </a>
+        )}
 
         <nav className={styles.Nav}>
           <ul>

--- a/polaris.shopify.com/src/components/IconGrid/IconGrid.module.scss
+++ b/polaris.shopify.com/src/components/IconGrid/IconGrid.module.scss
@@ -25,7 +25,7 @@
   }
 
   &.isHighlighted button,
-  button:focus {
+  button:focus-visible {
     box-shadow: var(--focus-outline);
   }
 }

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.module.scss
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.module.scss
@@ -165,4 +165,8 @@
   display: block;
   text-align: center;
   cursor: pointer;
+
+  &:focus-visible {
+    box-shadow: var(--focus-outline);
+  }
 }


### PR DESCRIPTION
- Improved focus states
- Only show "skip to main content" button if there is a main content to skip to
- Make "skip to main content" link span the full width of the page (looks nicer on big screens)

<img width="723" alt="Screen Shot 2022-06-15 at 10 40 02 PM" src="https://user-images.githubusercontent.com/875708/173922959-14bbf965-ed30-4a1c-8da1-a83acdcb0a17.png">

<img width="849" alt="Screen Shot 2022-06-15 at 10 39 47 PM" src="https://user-images.githubusercontent.com/875708/173922951-6a724a7e-896b-4f81-8254-d5c870ab73d0.png">

<img width="1505" alt="Screen Shot 2022-06-15 at 10 40 21 PM" src="https://user-images.githubusercontent.com/875708/173922962-dd6794bb-98e0-4c96-b0d1-4627afd70b23.png">

