### PR TITLE
[Modal] Add fullScreen prop for mobile screens

### DIFF
--- a/.changeset/great-bobcats-wonder.md
+++ b/.changeset/great-bobcats-wonder.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added the `fullScreen` prop to `Modal` to set its height to the viewport height on small screens

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -59,6 +59,8 @@ export interface ModalProps extends FooterProps {
   activator?: React.RefObject<HTMLElement> | React.ReactElement;
   /** Removes Scrollable container from the modal content */
   noScroll?: boolean;
+  /** Sets modal to the height of the viewport on small screens */
+  fullScreen?: boolean;
 }
 
 export const Modal: React.FunctionComponent<ModalProps> & {
@@ -85,6 +87,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   onIFrameLoad,
   onTransitionEnd,
   noScroll,
+  fullScreen,
 }: ModalProps) {
   const [iframeHeight, setIframeHeight] = useState(IFRAME_LOADING_HEIGHT);
 
@@ -191,6 +194,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
         large={large}
         small={small}
         limitHeight={limitHeight}
+        fullScreen={fullScreen}
       >
         <Header titleHidden={titleHidden} id={headerId} onClose={onClose}>
           {title}

--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -88,6 +88,13 @@ $dangerous-magic-space-16: 64px;
       max-width: $large-width;
     }
   }
+
+  &.fullScreen {
+    height: 100%;
+    @include breakpoint-after($layout-width-page-with-nav-base) {
+      height: unset;
+    }
+  }
 }
 
 .animateFadeUp {

--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.tsx
@@ -21,6 +21,7 @@ export interface DialogProps {
   onEntered?(): void;
   onExited?(): void;
   in?: boolean;
+  fullScreen?: boolean;
 }
 
 export function Dialog({
@@ -33,6 +34,7 @@ export function Dialog({
   large,
   small,
   limitHeight,
+  fullScreen,
   ...props
 }: DialogProps) {
   const containerNode = useRef<HTMLDivElement>(null);
@@ -41,6 +43,7 @@ export function Dialog({
     small && styles.sizeSmall,
     large && styles.sizeLarge,
     limitHeight && styles.limitHeight,
+    fullScreen && styles.fullScreen,
   );
   const TransitionChild = instant ? Transition : FadeUp;
 

--- a/polaris-react/src/components/Modal/tests/Modal.test.tsx
+++ b/polaris-react/src/components/Modal/tests/Modal.test.tsx
@@ -187,7 +187,7 @@ describe('<Modal>', () => {
       expect(modal).toContainReactComponent(Dialog, {small: true});
     });
 
-    it('does not pass small to Dialog be default', () => {
+    it('does not pass small to Dialog by default', () => {
       const modal = mountWithApp(
         <Modal title="foo" onClose={jest.fn()} open>
           <Badge />
@@ -209,7 +209,7 @@ describe('<Modal>', () => {
       expect(modal).toContainReactComponent(Dialog, {limitHeight: true});
     });
 
-    it('does not pass limitHeight to Dialog be default', () => {
+    it('does not pass limitHeight to Dialog by default', () => {
       const modal = mountWithApp(
         <Modal title="foo" onClose={jest.fn()} open>
           <Badge />
@@ -217,6 +217,28 @@ describe('<Modal>', () => {
       );
 
       expect(modal).toContainReactComponent(Dialog, {limitHeight: undefined});
+    });
+  });
+
+  describe('fullScreen', () => {
+    it('passes fullScreen to Dialog if true', () => {
+      const modal = mountWithApp(
+        <Modal title="foo" fullScreen onClose={jest.fn()} open>
+          <Badge />
+        </Modal>,
+      );
+
+      expect(modal).toContainReactComponent(Dialog, {fullScreen: true});
+    });
+
+    it('does not pass fullScreen to Dialog be default', () => {
+      const modal = mountWithApp(
+        <Modal title="foo" onClose={jest.fn()} open>
+          <Badge />
+        </Modal>,
+      );
+
+      expect(modal).toContainReactComponent(Dialog, {fullScreen: undefined});
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

- Fixes https://github.com/Shopify/polaris/issues/6145

<!--
  Context about the problem that’s being addressed.
-->

This PR adds a new optional prop `fullScreen` to <Modal/> that, on mobile screens, fixes the height of the modal to 100%. The goal is to provide an option for a full screen menu without having to hack the component.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
before:
https://screenshot.click/15-11-8qxsa-axnkf.mp4
after:
https://screenshot.click/15-10-buryg-3seyg.mp4

_Note the height of the modal jumping when the content changes._

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
