### PR TITLE
[Polaris website reboot] Fix ResourcesPage broken links

### DIFF
--- a/.changeset/cyan-stingrays-breathe.md
+++ b/.changeset/cyan-stingrays-breathe.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Update "Getting Started" page

--- a/polaris.shopify.com/src/components/ResourcesPage/ResourcesPage.tsx
+++ b/polaris.shopify.com/src/components/ResourcesPage/ResourcesPage.tsx
@@ -61,7 +61,7 @@ function ResourcesPage({}: Props) {
                       {
                         icon: "figma",
                         label: "Library",
-                        url: "https://www.figma.com/community/file/930504625460155381",
+                        url: "https://www.figma.com/community/file/1111360433678236702",
                       },
                     ]}
                   />
@@ -89,7 +89,7 @@ function ResourcesPage({}: Props) {
                       {
                         icon: "link",
                         label: "Browse tokens",
-                        url: "/tokens",
+                        url: "/tokens/colors",
                       },
                       {
                         icon: "github",
@@ -99,7 +99,7 @@ function ResourcesPage({}: Props) {
                       {
                         icon: "figma",
                         label: "Library",
-                        url: "https://www.figma.com/community/file/930504178610771955",
+                        url: "https://www.figma.com/community/file/1111359207966840858",
                       },
                     ]}
                   />
@@ -140,7 +140,7 @@ function ResourcesPage({}: Props) {
                     {
                       icon: "figma",
                       label: "Library",
-                      url: "https://www.figma.com/community/file/930503928500000754",
+                      url: "https://www.figma.com/community/file/1110993965108325096",
                     },
                   ]}
                 />
@@ -173,7 +173,7 @@ function ResourcesPage({}: Props) {
                       {
                         icon: "install",
                         label: "Get the extension",
-                        url: "#",
+                        url: "https://marketplace.visualstudio.com/items?itemName=Shopify.polaris-for-vscode",
                       },
                     ]}
                   />


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6157 #6158 #6159 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- "Get the extension" link now directs user to [VS code website](https://marketplace.visualstudio.com/items?itemName=Shopify.polaris-for-vscode) where the extension can be downloaded
- Link to Figma libraries are working for all components
- The "Browse tokens" link now points to the tokens page