### PR TITLE
feat: Update MediaCard to use Polaris SM media conditions

### DIFF
--- a/polaris-react/src/components/MediaCard/MediaCard.scss
+++ b/polaris-react/src/components/MediaCard/MediaCard.scss
@@ -32,7 +32,7 @@ $breakpoints-portrait-breakpoint-down: breakpoints-down(
     }
   }
 
-  @media #{$breakpoints-page-content-when-not-fully-condensed-up} {
+  @media #{$p-breakpoints-sm-up} {
     border-top-left-radius: var(--p-border-radius-2);
     border-top-right-radius: var(--p-border-radius-2);
   }


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5808

### WHAT is this pull request doing?
Updating `MediaCard` to use Polaris SM media conditions.

#### Checklist
- What Polaris media condition was used: `$p-breakpoints-sm-up`
- Did the breakpoint value change? `No`
  - From: `N/A`
  - To: `N/A`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breakpoint variable, function, or mixin used elsewhere in Web? `No`
- Is the layout using a mobile first strategy? `Yes`

#### Before/After Examples
**Before**

https://user-images.githubusercontent.com/21976492/174136244-f882d240-baa7-4b1f-bfe9-5a9d095d6979.mp4

**After**

https://user-images.githubusercontent.com/21976492/174136281-e2c21630-ad84-4ef7-8e9d-1ec9c02f0e52.mp4








