### PR TITLE
[Token] change shadow-popover token

### DIFF
--- a/.changeset/rare-games-wave.md
+++ b/.changeset/rare-games-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Changed popover token to be a little stronger and provide more visual distinction with background

--- a/.changeset/rare-games-wave.md
+++ b/.changeset/rare-games-wave.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-tokens': minor
 ---
 
-Changed popover token to be a little stronger and provide more visual distinction with background
+Changed popover shadow token to be a little stronger and provide more visual distinction with background

--- a/polaris-tokens/src/token-groups/depth.ts
+++ b/polaris-tokens/src/token-groups/depth.ts
@@ -22,7 +22,8 @@ export const depth = {
     value: '0 0 5px rgba(23, 24, 24, 0.05), 0 1px 2px rgba(0, 0, 0, 0.15)',
   },
   'shadow-popover': {
-    value: '-1px 0 20px rgba(23, 24, 24, 0.05), 0 1px 5px rgba(0, 0, 0, 0.15)',
+    value:
+      '0 3px 6px -3px rgba(23, 24, 24, 0.08), 0 8px 20px -4px rgba(23, 24, 24, 0.12)',
   },
   'shadow-layer': {
     value:


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes #6164 to help make the Polaris `Popover` component stand out more against background. 

### WHAT is this pull request doing?
This PR changes the `--p-shadow-popover` token to give it more depth and affordance. This change also sets the table for [other changes](https://vault.shopify.io/projects/25772) coming to components in the `TopBar` that utilize the `Popover` component. 

**Before and after**
![Before and after](https://user-images.githubusercontent.com/5749440/174155277-e43bda2f-eb82-49ee-8b99-1328217e27bb.png)
[Figma file with more examples](https://www.figma.com/file/VtQCN16EenaNUeJHkYASFW/?node-id=4737%3A4)
