### PR TITLE
feat: Update Dialog to use Polaris LG media conditions

### DIFF
--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -12,10 +12,6 @@ $breakpoints-xsmall-width-up: breakpoints-up(
   $xsmall-width + $dangerous-magic-space-16
 );
 
-$breakpoints-large-width-up: breakpoints-up(
-  $large-width + $dangerous-magic-space-16
-);
-
 $breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
 
 .Container {
@@ -93,7 +89,7 @@ $breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
       max-width: calc(100% - var(--p-space-16));
     }
 
-    @media #{$breakpoints-large-width-up} {
+    @media #{$p-breakpoints-lg-up} {
       max-width: $large-width;
     }
   }


### PR DESCRIPTION
Part of #5716 

Checklist:
- What Polaris media condition was used: `$p-breakpoints-md-up`
- Did the breakpoint value change? `Yes`
  - From: `1044px`
  - To: `1040px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `\$large-width \+`
- Is the layout using a mobile first strategy? `Yes`

Before (Dialog):

https://user-images.githubusercontent.com/32409546/174195658-4ca60a62-904d-47fd-adb3-34ff6df38108.mov

After (Dialog):

https://user-images.githubusercontent.com/32409546/174195671-2e6a3281-387a-4ec8-9cec-b608222dd7ad.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
