### PR TITLE
feat: Update Header to use Polaris LG media conditions

### DIFF
--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -4,7 +4,6 @@ $action-menu-rollup-computed-width: 40px;
 $breakpoints-mobile-layout-up: breakpoints-up(468px);
 $breakpoints-mobile-layout-down: breakpoints-down(468px, $inclusive: true);
 $breakpoints-medium-layout-down: breakpoints-down(860px, $inclusive: true);
-$breakpoints-desktop-layout-down: breakpoints-down(1080px, $inclusive: true);
 
 .Header {
   @include page-header-layout;
@@ -222,7 +221,7 @@ $breakpoints-desktop-layout-down: breakpoints-down(1080px, $inclusive: true);
 }
 
 .longTitle {
-  @media #{$breakpoints-desktop-layout-down} {
+  @media #{$p-breakpoints-lg-down} {
     @include condensed-layout;
   }
 }


### PR DESCRIPTION
Part of #5716 

Checklist:
- What Polaris media condition was used: `$p-breakpoints-lg-down`
- Did the breakpoint value change? `Yes`
  - From: `1080px`
  - To: `1040px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `1080px`
- Is the layout using a mobile first strategy? `No`

Before:

https://user-images.githubusercontent.com/32409546/174197694-1c01566a-c6e9-48f0-99e6-9b76551dd66f.mov

After:

https://user-images.githubusercontent.com/32409546/174197726-65035048-89f8-46e4-be4a-a45bf7675b35.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
