### PR TITLE
[Polaris website reboot] Fix/Update Top Nav Breakpoints & Styling

### DIFF
--- a/.changeset/fresh-ducks-return.md
+++ b/.changeset/fresh-ducks-return.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Update top nav

--- a/polaris.shopify.com/src/components/Header/Header.module.scss
+++ b/polaris.shopify.com/src/components/Header/Header.module.scss
@@ -6,6 +6,7 @@
 
 .HeaderInner {
   display: flex;
+  align-items: center;
   gap: 3em;
   height: var(--header-height);
 
@@ -14,7 +15,6 @@
 
     ul {
       display: flex;
-      align-items: center;
       font-size: var(--font-size-100);
       font-weight: var(--font-weight-500);
 
@@ -57,12 +57,12 @@
       }
     }
 
-    @media screen and (max-width: $breakpointDesktop) {
+    @media screen and (max-width: $breakpointTablet) {
       display: none;
     }
   }
 
-  @media screen and (max-width: $breakpointDesktop) {
+  @media screen and (max-width: $breakpointTablet) {
     gap: 0.5rem;
     justify-content: space-between;
   }
@@ -84,7 +84,7 @@
     transform: translate3d(0, -1px, 0);
   }
 
-  @media screen and (max-width: $breakpointDesktop) {
+  @media screen and (max-width: $breakpointTablet) {
     display: none;
   }
 }
@@ -111,11 +111,17 @@
 }
 
 .DarkModeToggle {
+  display: flex;
   background: transparent;
   width: 3rem;
   margin: 0.5rem 0 0.5rem auto;
   border-radius: var(--border-radius-800);
   margin-right: -2rem;
+
+  @media screen and (max-width: $breakpointTablet) {
+    padding-right: 4rem;
+    padding-left: 3rem;
+  }
 }
 
 .LightModeIcon {
@@ -153,7 +159,7 @@
   align-items: center;
   width: 18.25rem;
 
-  @media screen and (max-width: $breakpointDesktop) {
+  @media screen and (max-width: $breakpointTablet) {
     width: 100%;
   }
 
@@ -176,7 +182,7 @@
     height: 20px;
   }
 
-  @media screen and (max-width: $breakpointDesktop) {
+  @media screen and (max-width: $breakpointTablet) {
     visibility: visible;
     display: flex;
     align-items: center;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6154 and #6155 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<img width="642" alt="Screen Shot 2022-06-17 at 8 58 29 AM" src="https://user-images.githubusercontent.com/59836805/174306607-7f4cb61b-e555-4bf6-8bf4-821050c7fbf5.gif">

- The top nav was collapsing at 1400px, now it stays open until 768px and smaller.
- Dark Mode toggle also no longer hidden when searchbar expands below 768px and smaller.

#### Concerns

- Navbar may still be a bit too crowded as the searchbar and dark toggle cant be shown with all of the buttons at smaller desktop sizes. #6214 May solve this issue

