### PR TITLE
[ActionList] Exports ActionList.Item subcomponent

### DIFF
--- a/.changeset/moody-bananas-lick.md
+++ b/.changeset/moody-bananas-lick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[ActionList] Exports ActionList.Item subcomponent

--- a/.changeset/moody-bananas-lick.md
+++ b/.changeset/moody-bananas-lick.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-[ActionList] Exports ActionList.Item subcomponent
+Exported the `ActionList.Item` sub-component

--- a/polaris-react/src/components/ActionList/ActionList.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.tsx
@@ -8,7 +8,8 @@ import {KeypressListener} from '../KeypressListener';
 import {ActionListItemDescriptor, ActionListSection, Key} from '../../types';
 import {classNames} from '../../utilities/css';
 
-import {Section} from './components';
+import {Section, Item} from './components';
+import type {ItemProps} from './components';
 import styles from './ActionList.scss';
 
 export interface ActionListProps {
@@ -21,6 +22,8 @@ export interface ActionListProps {
   /** Callback when any item is clicked or keypressed */
   onActionAnyItem?: ActionListItemDescriptor['onAction'];
 }
+
+export type ActionListItemProps = ItemProps;
 
 export function ActionList({
   items,
@@ -110,3 +113,5 @@ export function ActionList({
     </Element>
   );
 }
+
+ActionList.Item = Item;

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -120,9 +120,9 @@ export function Item({
   );
 
   return (
-    <li role={role === 'menuitem' ? 'presentation' : undefined}>
+    <>
       {scrollMarkup}
       {control}
-    </li>
+    </>
   );
 }

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -37,14 +37,18 @@ export function Section({
   const actionMarkup = section.items.map(
     ({content, helpText, onAction, ...item}, index) => {
       return (
-        <Item
+        <li
           key={`${content}-${index}`}
-          content={content}
-          helpText={helpText}
-          role={actionRole}
-          onAction={handleAction(onAction)}
-          {...item}
-        />
+          role={actionRole === 'menuitem' ? 'presentation' : undefined}
+        >
+          <Item
+            content={content}
+            helpText={helpText}
+            role={actionRole}
+            onAction={handleAction(onAction)}
+            {...item}
+          />
+        </li>
       );
     },
   );

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -38,7 +38,10 @@ export {AccountConnection} from './components/AccountConnection';
 export type {AccountConnectionProps} from './components/AccountConnection';
 
 export {ActionList} from './components/ActionList';
-export type {ActionListProps} from './components/ActionList';
+export type {
+  ActionListProps,
+  ActionListItemProps,
+} from './components/ActionList';
 
 export {ActionMenu} from './components/ActionMenu';
 export type {ActionMenuProps} from './components/ActionMenu';


### PR DESCRIPTION
### WHY are these changes introduced?

Supersedes https://github.com/Shopify/polaris/pull/6005

We have an use-case in Shopify Email for ActionLists that are stacked with only a single item but it was too spaced due to internal padding rules of the component, so we had to resort to hacks to override this:

<table>
    <thead><tr><th>Before</th><th>After</th></tr></thead>
    <tbody><tr><td> 
<img src="https://user-images.githubusercontent.com/167921/171499462-5bc11dbd-2b79-46a2-bca8-47b21ec52dc5.png" width="250"/>
</td><td>
<img src="https://user-images.githubusercontent.com/167921/171500236-a90ddc67-061e-4436-a55c-66a7ec7c0697.png" width="250" />
</td></tr></tbody>
</table>

This PR would allow us to remove the hacks and use the ActionList.Item component directly.

### WHAT is this pull request doing?

This PR exports the ActionList > Item component as a subcomponent ActionList.Item so that it can be used by itself. 

I also had to move the  `<li />` from the Item to the Section.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
