### PR TITLE
[Polaris website reboot] Make `Getting Started` the new homepage

### DIFF
--- a/.changeset/two-crabs-rule.md
+++ b/.changeset/two-crabs-rule.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-Remove homepage and make Getting Started the new site index page
+Removed homepage and make Getting Started the new site index page

--- a/.changeset/two-crabs-rule.md
+++ b/.changeset/two-crabs-rule.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Remove homepage and make Getting Started the new site index page

--- a/polaris.shopify.com/src/components/NavItems/NavItems.tsx
+++ b/polaris.shopify.com/src/components/NavItems/NavItems.tsx
@@ -5,10 +5,6 @@ const headerNavItems: {
   url: string;
 }[] = [
   {
-    label: "Getting started",
-    url: "/resources",
-  },
-  {
     label: "Foundations",
     url: "/foundations",
   },

--- a/polaris.shopify.com/src/pages/index.tsx
+++ b/polaris.shopify.com/src/pages/index.tsx
@@ -1,17 +1,5 @@
-import type { NextPage } from "next";
-import Head from "next/head";
-import HomePage from "../components/HomePage";
-import { getTitleTagValue } from "../utils/various";
+import ResourcesPage from "../components/ResourcesPage";
 
-const Home: NextPage = () => {
-  return (
-    <>
-      <Head>
-        <title>{getTitleTagValue()}</title>
-      </Head>
-      <HomePage />
-    </>
-  );
-};
+const Resources = () => <ResourcesPage />;
 
-export default Home;
+export default Resources;

--- a/polaris.shopify.com/src/pages/resources.tsx
+++ b/polaris.shopify.com/src/pages/resources.tsx
@@ -1,5 +1,0 @@
-import ResourcesPage from "../components/ResourcesPage";
-
-const Resources = () => <ResourcesPage />;
-
-export default Resources;


### PR DESCRIPTION
resolves [6140](https://github.com/Shopify/polaris/issues/6140)

removed from top nav and `pages/resource`. Figure we can keep the `ResourcePage` component so that we can come back to it after launch