### PR TITLE
[Polaris website reboot] Reposition global search bar to end of nv

### DIFF
--- a/.changeset/purple-hounds-hunt.md
+++ b/.changeset/purple-hounds-hunt.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Repositioned global search bar to end of nav

--- a/polaris.shopify.com/src/components/Header/Header.module.scss
+++ b/polaris.shopify.com/src/components/Header/Header.module.scss
@@ -158,6 +158,7 @@
   display: flex;
   align-items: center;
   width: 18.25rem;
+  margin-left: auto;
 
   @media screen and (max-width: $breakpointTablet) {
     width: 100%;


### PR DESCRIPTION
Fixes [6236](https://github.com/Shopify/polaris/issues/6236)
<img width="1624" alt="Screen Shot 2022-06-17 at 12 29 32 PM" src="https://user-images.githubusercontent.com/4642404/174339205-d829f1dc-a8e1-4c61-ad81-31c3e943cf53.png">

