### PR TITLE
remove #polaris slack link

### DIFF
--- a/polaris.shopify.com/content/contributing/documention.md
+++ b/polaris.shopify.com/content/contributing/documention.md
@@ -17,7 +17,7 @@ Most documentation about the design system is meant for polaris.shopify.com. How
 
 Internal Shopify teams usually create documentation for polaris.shopify.com, but we also welcome edits from Shopify's open source community.
 
-If you have a smaller question, reach out in [#polaris](https://shopify.slack.com/archives/C4Y8N30KD) if you work at Shopify, or the [Shopify Partners Slack](http://shopifypartners.slack.com) if you're an open source contributor. To get help with the strategy for a larger contribution early on, start a [GitHub discussion](https://github.com/Shopify/polaris/discussions/new) with the system community.
+If you have a smaller question, reach out in #polaris if you work at Shopify, or the [Shopify Partners Slack](http://shopifypartners.slack.com) if you're an open source contributor. To get help with the strategy for a larger contribution early on, start a [GitHub discussion](https://github.com/Shopify/polaris/discussions/new) with the system community.
 
 ## Quick guide
 


### PR DESCRIPTION
### WHY are these changes introduced?

Per the team's conversation, we agreed to remove internal links to the polaris Slack channel.

### WHAT is this pull request doing?

Removes polaris slack link from documentation page. 