### PR TITLE
[polaris.shopify.com reboot] Add hover styles to cards

### DIFF
--- a/.changeset/large-adults-crash.md
+++ b/.changeset/large-adults-crash.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Add hover styles to cards to clarify that they can be clicked/tapped

--- a/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.module.scss
+++ b/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.module.scss
@@ -20,6 +20,10 @@
     box-shadow: var(--card-shadow);
     overflow: hidden;
 
+    &:hover {
+      box-shadow: var(--card-shadow-hover);
+    }
+
     &:focus-visible {
       box-shadow: var(--focus-outline);
     }

--- a/polaris.shopify.com/src/components/FoundationsIndexPage/FoundationsIndexPage.module.scss
+++ b/polaris.shopify.com/src/components/FoundationsIndexPage/FoundationsIndexPage.module.scss
@@ -39,6 +39,10 @@
     border-radius: var(--border-radius-800);
     box-shadow: var(--card-shadow);
 
+    &:hover {
+      box-shadow: var(--card-shadow-hover);
+    }
+
     &:focus-visible {
       box-shadow: var(--focus-outline);
     }

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -35,8 +35,8 @@ body {
   --border-inset-color: #aaa;
   --border: 1px solid var(--border-color);
   --card-shadow: 0 0 0 1px rgb(0 0 0 / 10%), 0 1px 2px rgb(0 0 0 / 4%);
-  --card-shadow-hover: 0 4px 7px rgba(0, 0, 0, 0.1),
-    0 0 0 0.5px var(--border-color);
+  --card-shadow-hover: 0 3px 5px rgba(0, 0, 0, 0.075),
+    0 0 0 1px rgba(0 0 0 / 10%);
   --decorative-1: #dfefd2;
   --decorative-2: #ffe6cd;
   --decorative-3: #f8dff1;


### PR DESCRIPTION
Adds a light hover effect to clickable cards. I didn't add it to the cards on the `Icons` page because the tooltips add enough visual noise as it is.

https://user-images.githubusercontent.com/875708/174428299-a8afc6cb-5a33-445a-bdfc-1541563f3144.mov

Fixes #6188 

