### PR TITLE
feat: Update not-partially-condensed mixins to Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/EmptyState/EmptyState.scss
+++ b/polaris-react/src/components/EmptyState/EmptyState.scss
@@ -45,7 +45,7 @@ $centered-illustration-width: 226px;
   align-items: center;
   justify-content: center;
 
-  @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     left: var(--p-space-5);
   }
 }
@@ -72,7 +72,7 @@ $centered-illustration-width: 226px;
   padding: 0;
   margin: 0;
 
-  @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     flex-basis: 50%;
   }
 }
@@ -113,7 +113,7 @@ $centered-illustration-width: 226px;
 
 .imageContained {
   .Image {
-    @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+    @media #{$p-breakpoints-md-up} {
       position: initial;
       width: 100%;
     }

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -53,7 +53,7 @@
     padding: 0 var(--p-space-5);
   }
 
-  @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     padding: 0 var(--p-space-8);
   }
 }

--- a/polaris-react/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/polaris-react/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -164,7 +164,7 @@ $range-output-size: 32px;
   .Thumbs:focus + .Output & {
     transform: translateY(calc(-1 * var(--pc-range-slider-output-spacing)));
 
-    @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+    @media #{$p-breakpoints-md-up} {
       transform: translateY(
         calc(-1 * (var(--pc-range-slider-output-spacing) * 0.5))
       );

--- a/polaris-react/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/polaris-react/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -209,7 +209,7 @@ $range-output-translate-x: calc(
   .Input:focus + .Output & {
     transform: translateY(calc(-1 * var(--pc-range-slider-output-spacing)));
 
-    @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+    @media #{$p-breakpoints-md-up} {
       transform: translateY(
         calc(-1 * (var(--pc-range-slider-output-spacing) * 0.4))
       );

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -84,7 +84,7 @@ $skeleton-display-text-max-width: 120px;
     margin-bottom: calc(-1 * var(--p-space-2));
   }
 
-  @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     margin-top: 0;
   }
 

--- a/polaris-react/src/components/TopBar/components/Search/Search.scss
+++ b/polaris-react/src/components/TopBar/components/Search/Search.scss
@@ -20,7 +20,7 @@
     border-radius: var(--p-border-radius-2);
   }
 
-  @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     margin: var(--p-space-1) var(--p-space-8) 0;
   }
 }

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -36,7 +36,6 @@ $breakpoints-page-when-not-max-width-down: breakpoints-down(998px, $inclusive: t
 $breakpoints-page-content-when-layout-not-stacked-up: breakpoints-up(800px);
 $breakpoints-page-content-when-layout-stacked-down: breakpoints-down(1040px, $inclusive: true);
 
-$breakpoints-page-content-when-not-partially-condensed-up: breakpoints-up(744px);
 $breakpoints-page-content-when-partially-condensed-down: breakpoints-down(984px, $inclusive: true);
 
 $breakpoints-page-content-when-not-fully-condensed-up: breakpoints-up(490px);

--- a/polaris-react/src/styles/shared/_page.scss
+++ b/polaris-react/src/styles/shared/_page.scss
@@ -11,7 +11,7 @@
 @mixin page-content-layout {
   margin: var(--p-space-2) 0;
 
-  @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     margin-top: var(--p-space-5);
   }
 }
@@ -39,7 +39,7 @@
     padding-right: 0;
   }
 
-  @media #{$breakpoints-page-content-when-not-partially-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     padding: var(--p-space-5) 0;
   }
 }


### PR DESCRIPTION
Part of #5714 

Checklist:
- What components were updated?
  - `EmptyState`
  - `ContextualSaveBar`
  - `DualThumb`
  - `SingleThumb`
  - `SkeletonPage`
  - `Search`
  - `Page`
- What Polaris media condition was used?
  - From: `@include page-content-when-not-partially-condensed`
  - To: `$p-breakpoints-md-up`
- Did the breakpoint value change? `Yes`
  - From: `744px`
  - To: `768px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `page-content-when-not-partially-condensed|page-header-layout|page-content-layout`
- Is the layout using a mobile first strategy? `Yes`

<details>
  <summary>Search</summary>
  
**Before:**

https://user-images.githubusercontent.com/32409546/174879803-cd4c9963-9c2a-4595-9b53-7ec6d779cbf9.mov

**After:**

https://user-images.githubusercontent.com/32409546/174879831-4b5b778a-c116-4e2f-bab8-84acedd6489b.mov

</details>

<details>
  <summary>Page</summary>
  
**Before:**

https://user-images.githubusercontent.com/32409546/174889900-fd755fb1-2c10-4e17-b3db-8c94e54b354f.mov

**After:**

https://user-images.githubusercontent.com/32409546/174879651-e9e9b765-980b-48e4-828c-e3a5bdf46008.mov

</details>

<details>
  <summary>SkeletonPage</summary>
  
**Before:**

https://user-images.githubusercontent.com/32409546/174879526-ed96a731-09a5-42bc-88a0-834bf1d7dc80.mov

**After:**

https://user-images.githubusercontent.com/32409546/174879727-043f9c36-b687-4445-a249-c89702dae213.mov

</details>

<details>
  <summary>DualThumb|SingleThumb</summary>
  
**Before:**

https://user-images.githubusercontent.com/32409546/174879330-72b66c24-ff85-42c5-94ee-5ee9efc0fd29.mov

**After:**

https://user-images.githubusercontent.com/32409546/174879383-eeb419c1-d384-43cf-b93d-ac3e1fc3e1df.mov

</details>

<details>
  <summary>ContextualSaveBar</summary>
  
**Before:**

https://user-images.githubusercontent.com/32409546/174879209-05364d4b-34c3-49b8-bda5-f8864126b23e.mov

**After:**

https://user-images.githubusercontent.com/32409546/174879242-6ace1691-08e2-4b80-9110-d3107546b4fd.mov

</details>

<details>
  <summary>EmptyState</summary>
  
**Before:**

https://user-images.githubusercontent.com/32409546/174879013-515ae1ce-a7a7-4ede-a1e1-36e5a16a3faf.mov

**After:**

https://user-images.githubusercontent.com/32409546/174879048-7337f16f-26f7-42c3-8bca-71a5225bc3a5.mov

</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
