### PR TITLE
feat: Update Frame to Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/Frame/Frame.scss
+++ b/polaris-react/src/components/Frame/Frame.scss
@@ -11,7 +11,7 @@
     background-color: transparent;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     width: calc(100% - var(--pc-frame-offset));
     margin-left: var(--pc-frame-offset);
   }
@@ -34,7 +34,7 @@
     display: none !important;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     z-index: 1;
     left: var(--pc-frame-offset);
     display: flex;
@@ -111,7 +111,7 @@
     outline: none;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     display: none;
   }
 
@@ -137,7 +137,7 @@
     display: none !important;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     left: var(--pc-frame-offset);
     width: calc(100% - var(--pc-frame-offset));
   }
@@ -150,7 +150,7 @@
   left: 0;
   width: 100%;
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     left: var(--pc-frame-offset);
     width: calc(100% - var(--pc-frame-offset));
   }
@@ -167,7 +167,7 @@
   @include safe-area-for(padding-left, 0, left);
   @include safe-area-for(padding-bottom, 0, bottom);
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     .hasNav & {
       padding-left: $layout-width-nav-base;
       @media print {
@@ -198,7 +198,7 @@
   bottom: 0;
   width: 100%;
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     left: var(--pc-frame-offset);
 
     .hasNav & {
@@ -225,7 +225,7 @@
     display: none !important;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     .hasNav & {
       left: var(--pc-frame-offset);
     }


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5714 

### WHAT is this pull request doing?
Updating `Frame` to use Polaris MD media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@include frame-when-nav-displayed`
  - To: `$p-breakpoints-md-up`
- Did the breakpoint value change? 
  - From: `769px`
  - To: `768px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris?  `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `frame-when-nav-displayed`
- Is the layout using a mobile first strategy? `Yes`
 
#### Before/After Examples
**Before (Frame 1)**


https://user-images.githubusercontent.com/21976492/174879075-9c58322c-f40c-4ce1-a9f4-2be7ac176b1d.mp4



**After (Frame 1)**


https://user-images.githubusercontent.com/21976492/174879097-91d2aa6e-33bd-47e2-b702-ac8c8419d514.mp4



**Before (Frame 2)**


https://user-images.githubusercontent.com/21976492/174879123-e800a805-251c-4872-a6d7-6d6494151767.mp4



**After (Frame 2)**


https://user-images.githubusercontent.com/21976492/174879149-4ee57a44-d704-448f-9d59-928c140a0560.mp4


**Before (Contextual Save Bar)**

https://user-images.githubusercontent.com/21976492/174879390-ebd5b04b-ceb1-4b64-8b42-05793392cfcf.mp4


**After (Contextual Save Bar)**


https://user-images.githubusercontent.com/21976492/174879410-8786a192-b3e7-4eee-9ff9-a083933822a9.mp4


**Before (Loading)**

https://user-images.githubusercontent.com/21976492/174879452-90964588-be8b-4319-acb9-8f4e9983592f.mp4


**After (Loading)**

https://user-images.githubusercontent.com/21976492/174879472-f970ba42-79f1-4863-8fc5-c8d4755de1dd.mp4


