### PR TITLE
feat: Update Sheet to Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/Frame/Frame.scss
+++ b/polaris-react/src/components/Frame/Frame.scss
@@ -11,7 +11,7 @@
     background-color: transparent;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     width: calc(100% - var(--pc-frame-offset));
     margin-left: var(--pc-frame-offset);
   }
@@ -34,7 +34,7 @@
     display: none !important;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     z-index: 1;
     left: var(--pc-frame-offset);
     display: flex;
@@ -111,7 +111,7 @@
     outline: none;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     display: none;
   }
 
@@ -137,7 +137,7 @@
     display: none !important;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     left: var(--pc-frame-offset);
     width: calc(100% - var(--pc-frame-offset));
   }
@@ -150,7 +150,7 @@
   left: 0;
   width: 100%;
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     left: var(--pc-frame-offset);
     width: calc(100% - var(--pc-frame-offset));
   }
@@ -167,7 +167,7 @@
   @include safe-area-for(padding-left, 0, left);
   @include safe-area-for(padding-bottom, 0, bottom);
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     .hasNav & {
       padding-left: $layout-width-nav-base;
       @media print {
@@ -198,7 +198,7 @@
   bottom: 0;
   width: 100%;
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     left: var(--pc-frame-offset);
 
     .hasNav & {
@@ -225,7 +225,7 @@
     display: none !important;
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     .hasNav & {
       left: var(--pc-frame-offset);
     }

--- a/polaris-react/src/components/Sheet/Sheet.scss
+++ b/polaris-react/src/components/Sheet/Sheet.scss
@@ -14,7 +14,7 @@ $sheet-desktop-width: 380px;
     border-left: var(--p-border-base);
   }
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     right: 0;
     width: $sheet-desktop-width;
   }
@@ -32,7 +32,7 @@ $sheet-desktop-width: 380px;
   bottom: 0;
   left: 0;
 
-  @media #{$breakpoints-frame-when-nav-displayed-up} {
+  @media #{$p-breakpoints-md-up} {
     left: auto;
     width: $sheet-desktop-width;
   }

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -42,7 +42,6 @@ $breakpoints-page-content-when-partially-condensed-down: breakpoints-down(984px,
 $breakpoints-page-content-when-not-fully-condensed-up: breakpoints-up(490px);
 $breakpoints-page-content-when-fully-condensed-down: breakpoints-down(754px, $inclusive: true);
 
-$breakpoints-frame-when-nav-displayed-up: breakpoints-up(769px);
 $breakpoints-frame-when-nav-hidden-down: breakpoints-down(768.84px, $inclusive: true);
 
 $breakpoints-nav-min-window-corrected-up: breakpoints-up($nav-min-window-corrected);


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5714 

### WHAT is this pull request doing?
Updating `Sheet` to use Polaris MD media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@include frame-when-nav-displayed`
  - To: `$p-breakpoints-md-up`
- Did the breakpoint value change? 
  - From: `769px`
  - To: `768px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris?  `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `frame-when-nav-displayed`
- Is the layout using a mobile first strategy? `Yes`
 
#### Before/After Examples
**Before**

https://user-images.githubusercontent.com/21976492/174893993-95a5497d-2e9a-44a8-8116-cd02ed3656a4.mp4


**After**

https://user-images.githubusercontent.com/21976492/174894010-1fad5a38-213e-4670-9a82-0b679a1a161b.mp4


