### PR TITLE
feat: Update Dialog to Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -54,7 +54,7 @@ $breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
     border: var(--p-border-width-1) solid transparent;
   }
 
-  @media #{$breakpoints-frame-when-nav-hidden-down} {
+  @media #{$p-breakpoints-md-down} {
     bottom: 0;
     max-height: 100%;
   }

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -43,7 +43,6 @@ $breakpoints-page-content-when-not-fully-condensed-up: breakpoints-up(490px);
 $breakpoints-page-content-when-fully-condensed-down: breakpoints-down(754px, $inclusive: true);
 
 $breakpoints-frame-when-nav-displayed-up: breakpoints-up(769px);
-$breakpoints-frame-when-nav-hidden-down: breakpoints-down(768.84px, $inclusive: true);
 
 $breakpoints-nav-min-window-corrected-up: breakpoints-up($nav-min-window-corrected);
 


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5714 

### WHAT is this pull request doing?
Updating `Dialog` to use Polaris MD media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@include frame-when-nav-hidden`
  - To: `$p-breakpoints-md-down`
- Did the breakpoint value change? 
  - From: `768.84px`
  - To: `767.95px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris?  `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `frame-when-nav-hidden`
- Is the layout using a mobile first strategy? `No`
 
#### Before/After Examples
**Before**
Using @aaronccasanova's example from #6218

https://user-images.githubusercontent.com/21976492/174899271-19b0f6a5-3749-42eb-b3a8-0bbeb276b062.mov


**After**
_Note: my red marker is opposite from the previous example but the behavior is consistent._

https://user-images.githubusercontent.com/21976492/174899290-3af00984-3941-4c49-9757-4b163e7bf1b7.mp4
