### PR TITLE
Add grid page

### DIFF
--- a/.changeset/silent-dots-cross.md
+++ b/.changeset/silent-dots-cross.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Add missing component readme (Grid)

--- a/polaris.shopify.com/content/components/grid.md
+++ b/polaris.shopify.com/content/components/grid.md
@@ -1,0 +1,46 @@
+---
+name: Grid
+category: Structure
+keywords:
+  - one column
+  - two column
+  - three column
+  - column
+  - row
+  - column layouts
+  - grid layouts
+  - containers
+  - full width containers
+  - css grid
+notice:
+  status: alpha
+  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
+examples:
+  - fileName: grid-two-column.tsx
+    title: Two column wrapping layout
+    description: >-
+      Use to create a two column layout that wraps at a breakpoint and aligns to a twelve column grid.
+  - fileName: grid-two-third-one-third.tsx
+    title: Two-thirds column one-third column wrapping layout
+    description: >-
+      Use to create a two-thirds, one-third column layout that wraps at a breakpoint and aligns to a twelve column grid.
+  - fileName: grid-three-thirds.tsx
+    title: Three one-third column wrapping layout with a custom column count
+    description: >-
+      Use to create a three column layout that wrap at a breakpoint and aligns to a twelve column grid.
+  - fileName: grid-custom-layout.tsx
+    title: Custom layout using grid areas and custom columns
+    description: >-
+      Use to create a layout that can be customized at specific breakpoints.
+---
+
+# Grid
+
+Create complex layouts based on [CSS Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/grid)
+
+---
+
+## Related components
+
+- To lay out a set of smaller components in a row, [use the stack component](https://polaris.shopify.com/components/structure/stack)
+- To lay out form fields, [use the form layout component](https://polaris.shopify.com/components/forms/form-layout)

--- a/polaris.shopify.com/src/pages/examples/grid-custom-layout.tsx
+++ b/polaris.shopify.com/src/pages/examples/grid-custom-layout.tsx
@@ -1,0 +1,52 @@
+import { Page, Grid, Card } from "@shopify/polaris";
+import React from "react";
+import { withPolarisExample } from "../../components/PolarisExamplePage";
+
+function GridExample() {
+  return (
+    <Page fullWidth>
+      <Card sectioned>
+        <Grid
+          columns={{ xs: 1, sm: 4, md: 4, lg: 6, xl: 6 }}
+          areas={{
+            xs: ["product", "sales", "orders"],
+            sm: [
+              "product product product product",
+              "sales sales orders orders",
+            ],
+            md: ["sales product product orders"],
+            lg: ["product product product product sales orders"],
+            xl: ["product product sales sales orders orders"],
+          }}
+        >
+          <Grid.Cell area="product">
+            <div
+              style={{
+                height: "60px",
+                background: "aquamarine",
+              }}
+            />
+          </Grid.Cell>
+          <Grid.Cell area="sales">
+            <div
+              style={{
+                height: "60px",
+                background: "aquamarine",
+              }}
+            />
+          </Grid.Cell>
+          <Grid.Cell area="orders">
+            <div
+              style={{
+                height: "60px",
+                background: "aquamarine",
+              }}
+            />
+          </Grid.Cell>
+        </Grid>
+      </Card>
+    </Page>
+  );
+}
+
+export default withPolarisExample(GridExample);

--- a/polaris.shopify.com/src/pages/examples/grid-three-thirds.tsx
+++ b/polaris.shopify.com/src/pages/examples/grid-three-thirds.tsx
@@ -1,0 +1,24 @@
+import { Page, Grid, Card } from "@shopify/polaris";
+import React from "react";
+import { withPolarisExample } from "../../components/PolarisExamplePage";
+
+function GridExample() {
+  return (
+    <Page fullWidth>
+      <Grid columns={{ sm: 3 }}>
+        <Grid.Cell columnSpan={{ xs: 6, sm: 4, md: 4, lg: 8, xl: 8 }}>
+          <Card title="Sales" sectioned>
+            <p>View a summary of your online store’s sales.</p>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell columnSpan={{ xs: 6, sm: 2, md: 2, lg: 4, xl: 4 }}>
+          <Card title="Orders" sectioned>
+            <p>View a summary of your online store’s orders.</p>
+          </Card>
+        </Grid.Cell>
+      </Grid>
+    </Page>
+  );
+}
+
+export default withPolarisExample(GridExample);

--- a/polaris.shopify.com/src/pages/examples/grid-two-column.tsx
+++ b/polaris.shopify.com/src/pages/examples/grid-two-column.tsx
@@ -1,0 +1,24 @@
+import { Page, Grid, Card } from "@shopify/polaris";
+import React from "react";
+import { withPolarisExample } from "../../components/PolarisExamplePage";
+
+function GridExample() {
+  return (
+    <Page fullWidth>
+      <Grid>
+        <Grid.Cell columnSpan={{ xs: 6, sm: 3, md: 3, lg: 6, xl: 6 }}>
+          <Card title="Sales" sectioned>
+            <p>View a summary of your online store’s sales.</p>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell columnSpan={{ xs: 6, sm: 3, md: 3, lg: 6, xl: 6 }}>
+          <Card title="Orders" sectioned>
+            <p>View a summary of your online store’s orders.</p>
+          </Card>
+        </Grid.Cell>
+      </Grid>
+    </Page>
+  );
+}
+
+export default withPolarisExample(GridExample);

--- a/polaris.shopify.com/src/pages/examples/grid-two-third-one-third.tsx
+++ b/polaris.shopify.com/src/pages/examples/grid-two-third-one-third.tsx
@@ -1,0 +1,24 @@
+import { Page, Grid, Card } from "@shopify/polaris";
+import React from "react";
+import { withPolarisExample } from "../../components/PolarisExamplePage";
+
+function GridExample() {
+  return (
+    <Page fullWidth>
+      <Grid columns={{ sm: 3 }}>
+        <Grid.Cell columnSpan={{ xs: 6, sm: 4, md: 4, lg: 8, xl: 8 }}>
+          <Card title="Sales" sectioned>
+            <p>View a summary of your online store’s sales.</p>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell columnSpan={{ xs: 6, sm: 2, md: 2, lg: 4, xl: 4 }}>
+          <Card title="Orders" sectioned>
+            <p>View a summary of your online store’s orders.</p>
+          </Card>
+        </Grid.Cell>
+      </Grid>
+    </Page>
+  );
+}
+
+export default withPolarisExample(GridExample);


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris/issues/6278

I couldn't generate this page and did it manually. The current process for copying content and deciding where it should live has to be cleaned up and simplified.