### PR TITLE
Trim the search query so space doesn't force a new search

### DIFF
--- a/polaris.shopify.com/src/utils/search.ts
+++ b/polaris.shopify.com/src/utils/search.ts
@@ -14,7 +14,6 @@ import metadata from "@shopify/polaris-icons/metadata";
 
 import components from "../data/components.json";
 import foundations from "../data/foundations.json";
-import { foundationsNavItems } from "../data/navItems";
 
 const MAX_RESULTS: { [key: string]: number } = {
   Foundations: 3,
@@ -152,7 +151,7 @@ export function search(query: string): GroupedSearchResults {
   };
 
   if (query.length > 0) {
-    const fuseResults = fuse.search(query);
+    const fuseResults = fuse.search(query.trim());
 
     const scoredResults: SearchResults = fuseResults.map((result) => ({
       ...result.item,


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris/issues/6274

I am unsure if this is the desired behaviour. It's nice pressing space and seeing it search broader then the component. I personally would prefer keeping the current functionality but here is a PR to test out a fix and have a conversation around.