### PR TITLE
Improve component image perceived performance

### DIFF
--- a/.changeset/fuzzy-parents-pull.md
+++ b/.changeset/fuzzy-parents-pull.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Load component previews more eagerly

--- a/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.tsx
+++ b/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.tsx
@@ -44,6 +44,7 @@ function ComponentGridItem({
               quality={70}
               sizes="300px"
               alt={`Screenshot of the ${name} component`}
+              lazyBoundary="1000px"
             />
           </div>
           <div className={styles.ComponentDescription}>


### PR DESCRIPTION
Loads component images 1000px before they enter the viewport. This makes the experience feel faster without being loading too many extra bytes.