### PR TITLE
[ActionList.Item] Moves CSS variables for `ActionList.Item`

### DIFF
--- a/.changeset/nine-files-reflect.md
+++ b/.changeset/nine-files-reflect.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-[ActionList.Item] Moves CSS variables `ActionList.Item` so that it can be used standalone
+Moved item-related CSS variables to the `ActionList` `.Item` class

--- a/.changeset/nine-files-reflect.md
+++ b/.changeset/nine-files-reflect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[ActionList.Item] Moves CSS variables `ActionList.Item` so that it can be used standalone

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -1,11 +1,6 @@
 @import '../../styles/common';
 
 .ActionList {
-  --pc-action-list-image-size: 20px;
-  --pc-action-list-item-min-height: var(--p-space-10);
-  --pc-action-list-item-vertical-padding: calc(
-    (var(--pc-action-list-item-min-height) - var(--p-line-height-2)) / 2
-  );
   outline: none;
   list-style: none;
   margin: 0;
@@ -42,6 +37,11 @@
 }
 
 .Item {
+  --pc-action-list-image-size: 20px;
+  --pc-action-list-item-min-height: var(--p-space-10);
+  --pc-action-list-item-vertical-padding: calc(
+    (var(--pc-action-list-item-min-height) - var(--p-line-height-2)) / 2
+  );
   @include unstyled-button;
   @include focus-ring;
   display: block;


### PR DESCRIPTION
### WHY are these changes introduced?

On https://github.com/Shopify/polaris/pull/6229 we exposed the ActionList.Item component but it's styling is depedant on variables that were defined in the `.ActionList` class (but weren't used anywhere else besides children of the `.Item` element.

I missed that when tophatting because I was overwriting those variables in Email.

### WHAT is this pull request doing?

This PR ensure that the CSS variables are applied to the `. Item` element instead.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
