### PR TITLE
[ResourceList] Style spinner inside resource list to be fixed position

### DIFF
--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -224,6 +224,9 @@ $item-wrapper-loading-height: 64px;
   z-index: resource-list(spinner-stacking-order);
   display: flex;
   justify-content: center;
+  span {
+    position: fixed;
+  }
 }
 
 .LoadingOverlay {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/core-issues/issues/40270

### WHAT is this pull request doing?

  Summary of the changes committed.

In some cases a ResourceList extends beyond the bounds of the container it is rendered in. In these cases, when the loading spinner is shown, it can end up mispositioned. By adding position fixed to the spinner container span, we can keep the spinner centred in the list. 

See video below for an example:

https://user-images.githubusercontent.com/9765013/175050165-1c03034a-16aa-41e6-b891-80e55b501541.mp4

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

The issue can be seen in the following sandbox: https://rujgs4.csb.app/ 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
