### PR TITLE
[Collapsible] Add `preventMeasuringOnChildrenUpdate` prop on Collapsible

### DIFF
--- a/.changeset/spotty-carrots-flow.md
+++ b/.changeset/spotty-carrots-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add Collapsible `preventMeasuringOnChildrenUpdate` prop

--- a/polaris-react/src/components/Collapsible/Collapsible.tsx
+++ b/polaris-react/src/components/Collapsible/Collapsible.tsx
@@ -20,6 +20,8 @@ export interface CollapsibleProps {
   open: boolean;
   /** Assign transition properties to the collapsible */
   transition?: Transition;
+  /** Prevents component from re-measuring when child is updated **/
+  preventMeasuringOnChildrenUpdate?: boolean;
   /** The content to display inside the collapsible. */
   children?: React.ReactNode;
 }
@@ -31,6 +33,7 @@ export function Collapsible({
   expandOnPrint,
   open,
   transition,
+  preventMeasuringOnChildrenUpdate,
   children,
 }: CollapsibleProps) {
   const [height, setHeight] = useState(0);
@@ -70,9 +73,9 @@ export function Collapsible({
   );
 
   useEffect(() => {
-    if (isFullyClosed) return;
+    if (isFullyClosed || preventMeasuringOnChildrenUpdate) return;
     setAnimationState('measuring');
-  }, [children, isFullyClosed]);
+  }, [children, isFullyClosed, preventMeasuringOnChildrenUpdate]);
 
   useEffect(() => {
     if (open !== isOpen) {

--- a/polaris-react/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/polaris-react/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -132,6 +132,42 @@ describe('<Collapsible />', () => {
       ).not.toBeNull();
     });
   });
+
+  describe('preventMeasuringOnChildrenUpdate', () => {
+    it('does not re-measure on child update when preventMeasuringOnChildUpdate is true', () => {
+      const id = 'test-collapsible';
+
+      const collapsible = mountWithApp(
+        <Collapsible id={id} open preventMeasuringOnChildrenUpdate>
+          <div>Foo</div>
+        </Collapsible>,
+      );
+
+      collapsible.setProps({children: <div>Bar</div>});
+
+      expect(collapsible).toContainReactComponent('div', {
+        id,
+        style: {maxHeight: 'none', overflow: 'visible'},
+      });
+    });
+
+    it('re-measures on child update when preventMeasuringOnChildUpdate is false', () => {
+      const id = 'test-collapsible';
+
+      const collapsible = mountWithApp(
+        <Collapsible id={id} open preventMeasuringOnChildrenUpdate={false}>
+          <div>Foo</div>
+        </Collapsible>,
+      );
+
+      collapsible.setProps({children: <div>Bar</div>});
+
+      expect(collapsible).toContainReactComponent('div', {
+        id,
+        style: {maxHeight: '0px', overflow: 'hidden'},
+      });
+    });
+  });
 });
 
 function CollapsibleWithToggle(props: Omit<CollapsibleProps, 'open'>) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/6283 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Add an optional prop `preventMeasuringOnChildUpdate` on Collapsible component to allow consumers to opt-out of the behaviour or measuring when children change.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->


**Before**
Remeasures every time the child updates
![](https://screenshot.click/22-52-06j8m-oic2h.gif)

**After**:
Does not remeasure
![](https://screenshot.click/22-53-mecdj-ak6wu.gif)

### How to 🎩

See playground attached 

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Page, Button, Collapsible, Card} from '../src';

export function Playground() {
  const [suggestionsVisible, setSuggestionsVisible] = useState(false);

  return (
    <Page title="Playground">
      <Card sectioned>
        <Collapsible
          open
          id="basic-collapsible"
          transition={{
            duration: 'var(--p-duration-150)',
            timingFunction: 'var(--p-ease-in-out)',
          }}
          expandOnPrint
        >
          <div style={{height: '200px', position: 'relative'}}>
            <Button
              onClick={() => {
                setSuggestionsVisible((visibility) => !visibility);
              }}
            >
              Show suggestions
            </Button>
            {suggestionsVisible && (
              <div
                style={{
                  display: suggestionsVisible ? 'block' : 'none',
                  height: '400px',
                  backgroundColor: 'blue',
                  position: 'absolute',
                  left: '1rem',
                  top: '3.5rem',
                }}
              >
                Lorem ipsum
              </div>
            )}
          </div>
        </Collapsible>
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide