### PR TITLE
[polaris.shopify.com reboot] Add syntax highlighting to code examples

### DIFF
--- a/.changeset/tall-lizards-buy.md
+++ b/.changeset/tall-lizards-buy.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Add syntax highlighting to component code examples

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
@@ -1,20 +1,30 @@
+@import "../../styles/mixins.scss";
+
 .CodeExample {
-  border-radius: var(--border-radius-400);
-  overflow: hidden;
-  box-shadow: var(--card-shadow);
   line-height: 1.4;
-}
+  border-radius: var(--border-radius-400);
+  max-width: calc(100vw - 1.5rem);
 
-.TitleBar {
-  padding: 0.5rem 0.75em;
-  background: var(--surface-subdued);
-  margin: 1px 1px 0 0.5px;
-  border-radius: var(--border-radius-400) var(--border-radius-400)
-    var(--border-radius-300) var(--border-radius-300);
+  @include dark-mode {
+    box-shadow: var(--card-shadow);
+  }
 
-  .Title {
-    font-size: var(--font-size-50);
-    font-weight: var(--font-weight-500);
+  &.minimalist {
+    box-shadow: none;
+    border: 1px solid var(--border-color-light);
+
+    .CopyButton svg {
+      filter: brightness(-500%);
+
+      @include dark-mode {
+        filter: brightness(500);
+      }
+    }
+  }
+
+  &:not(.minimalist) {
+    background: #202021;
+    color: #e7e7e7;
   }
 }
 
@@ -29,10 +39,13 @@
   position: absolute;
   padding: 0.5rem;
   background: transparent;
-  display: flex;
-  align-items: center;
   opacity: 0.5;
   border-radius: var(--border-radius-200);
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
 
   &:hover {
     opacity: 1;
@@ -48,10 +61,15 @@
   font-family: "SF Mono", SFMono-Regular, ui-monospace, "DejaVu Sans Mono",
     Menlo, Consolas, monospace;
   white-space: pre;
-  padding: 0.66rem 0.66rem;
-  font-size: 13px;
-  color: var(--text-strong);
+  padding: 0.5rem 0.66rem;
+  font-size: 14px;
+  line-height: 1.6;
   overflow: auto;
+}
+
+.CodeExample.minimalist .Code {
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .LineNumber {

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
@@ -1,25 +1,25 @@
 import Image from "../Image";
 import Tooltip from "../Tooltip";
 import iconClipboard from "../../../public/icon-clipboard.svg";
-import styles from "./CodeExample.module.scss";
+import Prism from "prismjs";
 import { useCopyToClipboard } from "../../utils/hooks";
+import styles from "./CodeExample.module.scss";
+import { className } from "../../utils/various";
 
 interface Props {
   language: "terminal" | "typescript";
   title?: string;
+  minimalist?: boolean;
   children: string;
 }
 
-function CodeExample({ title, children }: Props) {
+function CodeExample({ minimalist, children }: Props) {
   const [copy, didJustCopy] = useCopyToClipboard(children);
 
   return (
-    <div className={styles.CodeExample}>
-      {title && (
-        <div className={styles.TitleBar}>
-          <div className={styles.Title}>{title}</div>
-        </div>
-      )}
+    <div
+      className={className(styles.CodeExample, minimalist && styles.minimalist)}
+    >
       <div className={styles.CopyButtonWrapper}>
         <Tooltip
           ariaLabel="Copy to clipboard"
@@ -30,21 +30,43 @@ function CodeExample({ title, children }: Props) {
             </div>
           )}
         >
-          <button type="button" className={styles.CopyButton} onClick={copy}>
-            <Image
-              src={iconClipboard}
-              alt="Copy"
-              width={16}
-              height={16}
-              fadeIn={false}
-              icon
-            />
+          <button
+            type="button"
+            className={styles.CopyButton}
+            onClick={copy}
+            aria-label="Copy to clipboard"
+          >
+            <ClipboardIcon />
           </button>
         </Tooltip>
       </div>
 
-      <div className={styles.Code}>{children.toString().trim()}</div>
+      {minimalist ? (
+        <div className={styles.Code}>{children}</div>
+      ) : (
+        <div
+          className={styles.Code}
+          dangerouslySetInnerHTML={{
+            __html: Prism.highlight(
+              String(children).trim(),
+              Prism.languages.javascript,
+              "javasript"
+            ),
+          }}
+        ></div>
+      )}
     </div>
+  );
+}
+
+function ClipboardIcon() {
+  return (
+    <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M15 2a1 1 0 011 1v13.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 014 16.5V3a1 1 0 112 0v1a2 2 0 002 2h4a2 2 0 002-2V3a1 1 0 011-1zm-4 2H9a1 1 0 110-2h2a1 1 0 110 2z"
+        fill="#fff"
+      />
+    </svg>
   );
 }
 

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -277,7 +277,7 @@ function SidebarContent({
         </p>
 
         <div className={styles.CodeExampleWrapper}>
-          <CodeExample language="typescript">
+          <CodeExample language="typescript" minimalist>
             {`import {
   ${selectedIcon.name}
 } from '@shopify/polaris-icons';`}
@@ -293,7 +293,7 @@ function SidebarContent({
         </p>
 
         <div className={styles.CodeExampleWrapper}>
-          <CodeExample language="typescript">
+          <CodeExample language="typescript" minimalist>
             {`<Icon
   source={${selectedIcon.name}}
   color="base"

--- a/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
+++ b/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
@@ -15,6 +15,10 @@
     font-size: 14px;
     padding: 0.33rem 0.5rem;
     line-height: 1.4;
+
+    p {
+      margin: 0;
+    }
   }
 
   &::after {


### PR DESCRIPTION
<img width="899" alt="Screen Shot 2022-06-22 at 6 21 09 PM" src="https://user-images.githubusercontent.com/875708/175084196-05b3e2f4-7b7a-47b6-8885-3268393ff115.png">
