### PR TITLE
feat: Update Dialog to use Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -96,7 +96,7 @@ $breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
 
   &.fullScreen {
     height: 100%;
-    @include breakpoint-after($layout-width-page-with-nav-base) {
+    @media #{$p-breakpoints-md-up} {
       height: unset;
     }
   }


### PR DESCRIPTION
### WHY are these changes introduced?
A new media condition was introduced on `polaris/main` since we started working on this branch and is using a function we removed. This PR is replacing that addition so it doesn't keep failing tests on the `next-breakpoints` branch. 

Part of #5714

### WHAT is this pull request doing?
Updating `Dialog` to use Polaris MD media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@include breakpoint-after(layout-width(page-with-nav))`
  - To: `$p-breakpoints-md-up`
- Did the breakpoint value change? `Yes`
  - From: `769px`
  - To: `768px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `breakpoint-after.+layout-width.+page-with-nav`
- Is the layout using a mobile first strategy? `Yes`
 
#### Before/After Examples
**Before**
_Note: Forgive the extra in between pixel value in this one. Since we already updated this component on this branch with these values it's a bit tricky to get the true original again for this one._ 


https://user-images.githubusercontent.com/21976492/175108464-0365d368-8cd0-4e3d-96f5-a34f129163d0.mp4


**After**

https://user-images.githubusercontent.com/21976492/175108482-9fa582b0-1d89-4e57-9dce-6a66053cfbc6.mp4


