### PR TITLE
feat: Update partially-condensed mixins to Polaris LG media conditions

### DIFF
--- a/polaris-react/src/components/ResourceItem/ResourceItem.scss
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.scss
@@ -45,7 +45,7 @@ $breakpoints-legacy-down: breakpoints-down(458px);
         @include action-unhide;
 
         // stylelint-disable-next-line max-nesting-depth
-        @media #{$breakpoints-page-content-when-partially-condensed-down} {
+        @media #{$p-breakpoints-lg-down} {
           display: none;
         }
       }
@@ -191,7 +191,7 @@ $breakpoints-legacy-down: breakpoints-down(458px);
     @include action-unhide;
   }
 
-  @media #{$breakpoints-page-content-when-partially-condensed-down} {
+  @media #{$p-breakpoints-lg-down} {
     display: none;
   }
 }
@@ -208,7 +208,7 @@ $breakpoints-legacy-down: breakpoints-down(458px);
     pointer-events: initial;
     height: 100%;
 
-    @media #{$breakpoints-page-content-when-partially-condensed-down} {
+    @media #{$p-breakpoints-lg-down} {
       display: none;
     }
   }
@@ -227,7 +227,7 @@ $breakpoints-legacy-down: breakpoints-down(458px);
     display: none;
   }
 
-  @media #{$breakpoints-page-content-when-partially-condensed-down} {
+  @media #{$p-breakpoints-lg-down} {
     display: flex;
     flex: 0 0 var(--pc-resource-item-disclosure-width);
     justify-content: center;

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -35,7 +35,7 @@ $skeleton-display-text-max-width: 120px;
 .TitleAndPrimaryAction {
   display: flex;
 
-  @media #{$breakpoints-page-content-when-partially-condensed-down} {
+  @media #{$p-breakpoints-lg-down} {
     display: block;
   }
 }
@@ -115,7 +115,7 @@ $skeleton-display-text-max-width: 120px;
     padding-right: 0;
   }
 
-  @media #{$breakpoints-page-content-when-partially-condensed-down} {
+  @media #{$p-breakpoints-lg-down} {
     &:not(:last-child) {
       display: none;
     }

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -36,8 +36,6 @@ $breakpoints-page-when-not-max-width-down: breakpoints-down(998px, $inclusive: t
 $breakpoints-page-content-when-layout-not-stacked-up: breakpoints-up(800px);
 $breakpoints-page-content-when-layout-stacked-down: breakpoints-down(1040px, $inclusive: true);
 
-$breakpoints-page-content-when-partially-condensed-down: breakpoints-down(984px, $inclusive: true);
-
 $breakpoints-page-content-when-not-fully-condensed-up: breakpoints-up(490px);
 $breakpoints-page-content-when-fully-condensed-down: breakpoints-down(754px, $inclusive: true);
 


### PR DESCRIPTION
Part of #5716

Checklist:
- What components were updated?
  - `ResourceItem`
  - `SkeletonPage`
- What Polaris media condition was used?
  - From: `@include page-content-when-partially-condensed()`
  - To: `$p-breakpoints-lg-down`
- Did the breakpoint value change? `Yes`
  - From: `984px`
  - To: `1040px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `page-content-when-partially-condensed`
- Is the layout using a mobile first strategy? `No`

Before (`ResourceItem`):

https://user-images.githubusercontent.com/32409546/175131283-9a0eefdc-51af-48f8-abbd-41e26e4f0658.mov

After (`ResourceItem`):

https://user-images.githubusercontent.com/32409546/175131302-d1995c2e-c87a-42ec-a4e0-755a587361e9.mov

Before (`SkeletonPage`):

https://user-images.githubusercontent.com/32409546/175131322-03d3d54b-1142-4806-94ad-ba9db6a9ece9.mov

After (`SkeletonPage`):

https://user-images.githubusercontent.com/32409546/175131341-9d9e7ca2-cd34-4005-86d2-a4db276cfba2.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
