### PR TITLE
feat: Update not-condensed-content mixins to use Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/TopBar/TopBar.scss
+++ b/polaris-react/src/components/TopBar/TopBar.scss
@@ -119,7 +119,7 @@ $breakpoints-page-left-alignment-down: breakpoints-down(
   justify-content: flex-end;
   height: 100%;
 
-  @media #{$breakpoints-not-condensed-content-up} {
+  @media #{$p-breakpoints-md-up} {
     position: relative;
   }
 }

--- a/polaris-react/src/styles/foundation/_layout.scss
+++ b/polaris-react/src/styles/foundation/_layout.scss
@@ -16,7 +16,6 @@ $layout-width-secondary-max: 320px;
 $layout-width-one-half-width-base: 450px;
 $layout-width-one-third-width-base: 240px;
 $layout-width-nav-base: $navigation-width;
-$layout-width-page-content-not-condensed: 680px;
 $layout-width-page-content-partially-condensed: 450px;
 $layout-width-inner-spacing-base: $dangerous-magic-space-4;
 $layout-width-outer-spacing-min: $dangerous-magic-space-5;

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -31,5 +31,3 @@ $breakpoints-page-content-when-layout-not-stacked-up: breakpoints-up(800px);
 $breakpoints-page-content-when-layout-stacked-down: breakpoints-down(1040px, $inclusive: true);
 
 $breakpoints-page-content-when-partially-condensed-down: breakpoints-down(984px, $inclusive: true);
-
-$breakpoints-not-condensed-content-up: breakpoints-up($not-condensed-content);

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -27,13 +27,9 @@
 
 $page-max-width: $layout-width-primary-max + $layout-width-secondary-max + $layout-width-inner-spacing-base;
 
-$not-condensed-content: breakpoint($layout-width-page-content-not-condensed);
-
 $breakpoints-page-content-when-layout-not-stacked-up: breakpoints-up(800px);
 $breakpoints-page-content-when-layout-stacked-down: breakpoints-down(1040px, $inclusive: true);
 
 $breakpoints-page-content-when-partially-condensed-down: breakpoints-down(984px, $inclusive: true);
 
 $breakpoints-page-content-when-not-fully-condensed-up: breakpoints-up(490px);
-
-$breakpoints-not-condensed-content-up: breakpoints-up($not-condensed-content);


### PR DESCRIPTION
Part of #5714 

Checklist:
- What components were updated?
  - `TopBar`
- What Polaris media condition was used?
  - From: `@include breakpoint-after($not-condensed-content)`
  - To: `$p-breakpoints-md-up`
- Did the breakpoint value change? `Yes`
  - From: `680px`
  - To: `768px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `breakpoint-after.+not-condensed-content`
- Is the layout using a mobile first strategy? `Yes`

Before:

https://user-images.githubusercontent.com/32409546/175141691-ec74d828-7be3-4bfb-a705-1e13522938a3.mov

After:

https://user-images.githubusercontent.com/32409546/175141710-85e72fe2-36c3-48be-800a-789482d9628d.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
