### PR TITLE
feat: Update layout-not-stacked mixins to Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/Layout/Layout.scss
+++ b/polaris-react/src/components/Layout/Layout.scss
@@ -93,7 +93,7 @@ $relative-size: $primary-basis / $secondary-basis;
     padding: var(--p-space-4) 0 0;
   }
 
-  @media #{$breakpoints-page-content-when-layout-not-stacked-up} {
+  @media #{$p-breakpoints-md-up} {
     padding: var(--p-space-5) var(--p-space-5) var(--p-space-5) 0;
   }
 }

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -87,10 +87,6 @@ $skeleton-display-text-max-width: 120px;
   @media #{$p-breakpoints-md-up} {
     margin-top: 0;
   }
-
-  @media #{$breakpoints-page-content-when-layout-not-stacked-up} {
-    margin-top: 0;
-  }
 }
 
 .Actions {

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -33,7 +33,6 @@ $breakpoints-frame-with-nav-when-not-max-width-down: breakpoints-down(1238px, $i
 
 $breakpoints-page-when-not-max-width-down: breakpoints-down(998px, $inclusive: true);
 
-$breakpoints-page-content-when-layout-not-stacked-up: breakpoints-up(800px);
 $breakpoints-page-content-when-layout-stacked-down: breakpoints-down(1040px, $inclusive: true);
 
 $breakpoints-page-content-when-partially-condensed-down: breakpoints-down(984px, $inclusive: true);


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5714

### WHAT is this pull request doing?
Updating `Layout` and `SkeletonPage` to use Polaris MD media conditions.

#### Checklist
- What components were updated?
  - `Layout`
  - `SkeletonPage`
- What Polaris media condition was used?
  - From: `@include page-content-when-layout-not-stacked()`
  - To: `$p-breakpoints-md-up`
- Did the breakpoint value change? `Yes`
  - From: `800px`
  - To: `768px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `page-content-when-layout-not-stacked`
- Is the layout using a mobile first strategy? `Yes`
 
#### Before/After Examples
**Before (Layout)**

https://user-images.githubusercontent.com/21976492/175142253-515f6db2-cd31-4740-a953-ce20dd94291f.mp4


**After (Layout)**


https://user-images.githubusercontent.com/21976492/175142265-c841bb39-904a-4fd8-8814-961604d50325.mp4

_Note: We need to do more follow up work on layout-width and Layout flex basis values:_ 

- #6328 
- #6329 
