### PR TITLE
feat: Update typography mixins to use Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/Choice/Choice.scss
+++ b/polaris-react/src/components/Choice/Choice.scss
@@ -37,7 +37,7 @@
 }
 
 .Control {
-  @media #{$breakpoints-typography-not-condensed-down} {
+  @media #{$p-breakpoints-md-down} {
     --p-choice-size: 22px;
   }
   display: flex;
@@ -63,7 +63,7 @@
 }
 
 .Descriptions {
-  @media #{$breakpoints-typography-not-condensed-down} {
+  @media #{$p-breakpoints-md-down} {
     --p-choice-size: 22px;
   }
   padding-left: calc(var(--p-space-2) + var(--p-choice-size));

--- a/polaris-react/src/components/ChoiceList/ChoiceList.scss
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.scss
@@ -7,7 +7,7 @@
 }
 
 .ChoiceItem:not(:last-child) {
-  @media #{$breakpoints-typography-not-condensed-down} {
+  @media #{$p-breakpoints-md-down} {
     margin-bottom: var(--p-space-4);
   }
 }
@@ -23,7 +23,7 @@
 }
 
 .ChoiceChildren {
-  @media #{$breakpoints-typography-not-condensed-down} {
+  @media #{$p-breakpoints-md-down} {
     margin-top: var(--p-space-4);
   }
 
@@ -35,7 +35,7 @@
   margin-top: var(--p-space-1);
   margin-bottom: var(--p-space-2);
 
-  @media #{$breakpoints-typography-not-condensed-down} {
+  @media #{$p-breakpoints-md-down} {
     margin-top: var(--p-space-4);
   }
 }
@@ -46,7 +46,7 @@
   margin: 0 0 var(--p-space-1);
   padding: 0;
 
-  @media #{$breakpoints-typography-not-condensed-down} {
+  @media #{$p-breakpoints-md-down} {
     margin-bottom: var(--p-space-5);
   }
 }

--- a/polaris-react/src/components/Frame/components/Toast/Toast.scss
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.scss
@@ -1,6 +1,5 @@
 @import '../../../../styles/common';
 
-$breakpoints-legacy-up: breakpoints-up(640px);
 $Backdrop-opacity: 0.88;
 
 .Toast {
@@ -13,7 +12,7 @@ $Backdrop-opacity: 0.88;
   color: var(--p-text);
   margin-bottom: var(--p-space-5);
 
-  @media #{$breakpoints-legacy-up} {
+  @media #{$p-breakpoints-md-up} {
     padding: var(--p-space-4);
   }
 

--- a/polaris-react/src/components/Frame/components/Toast/Toast.scss
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.scss
@@ -49,7 +49,7 @@ $Backdrop-opacity: 0.88;
   @include recolor-icon(currentColor);
   cursor: pointer;
 
-  @media #{$breakpoints-legacy-up} {
+  @media #{$p-breakpoints-md-up} {
     align-self: flex-start;
     margin: calc(-1 * var(--p-space-2)) calc(-1 * var(--p-space-4))
       calc(-1 * var(--p-space-2)) 0;

--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -369,7 +369,7 @@ $disabled-fade: 0.6;
     font-size: var(--p-font-size-2);
     color: var(--p-text-subdued);
 
-    @media #{$breakpoints-typography-not-condensed-up} {
+    @media #{$p-breakpoints-md-up} {
       font-size: var(--p-font-size-1);
     }
   }

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.scss
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.scss
@@ -6,7 +6,7 @@
   font-size: var(--p-font-size-9);
   line-height: var(--p-line-height-4);
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-7);
   }
 }

--- a/polaris-react/src/components/RadioButton/RadioButton.scss
+++ b/polaris-react/src/components/RadioButton/RadioButton.scss
@@ -44,7 +44,7 @@
 .Backdrop {
   // ::before is the selected dot, ::after the focus-ring
 
-  @media #{$breakpoints-typography-not-condensed-down} {
+  @media #{$p-breakpoints-md-down} {
     --p-icon-size-small: 10px;
   }
 

--- a/polaris-react/src/components/SkeletonDisplayText/SkeletonDisplayText.scss
+++ b/polaris-react/src/components/SkeletonDisplayText/SkeletonDisplayText.scss
@@ -5,7 +5,7 @@ $skeleton-display-text-max-width: 120px;
 @mixin skeleton-display-text-height {
   height: var(--pc-skeleton-display-text-height);
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     height: var(--pc-skeleton-display-text-height-not-condensed);
   }
 }

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -49,7 +49,7 @@ $skeleton-display-text-max-width: 120px;
   font-size: 24px;
   line-height: 28px;
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: 20px;
   }
 }

--- a/polaris-react/src/styles/shared/_typography.scss
+++ b/polaris-react/src/styles/shared/_typography.scss
@@ -1,15 +1,9 @@
-$breakpoints-typography-not-condensed-up: breakpoints-up(640px);
-$breakpoints-typography-not-condensed-down: breakpoints-down(
-  640px,
-  $inclusive: true
-);
-
 @mixin text-style-caption {
   font-size: var(--p-font-size-2);
   font-weight: var(--p-font-weight-regular);
   line-height: var(--p-line-height-2);
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-1);
     line-height: var(--p-line-height-1);
   }
@@ -20,7 +14,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-line-height-3);
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-5);
   }
 }
@@ -31,7 +25,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   line-height: var(--p-line-height-1);
   text-transform: uppercase;
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-1);
   }
 }
@@ -45,7 +39,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   text-transform: initial;
   letter-spacing: initial;
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-3);
   }
 }
@@ -58,7 +52,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   text-transform: initial;
   letter-spacing: initial;
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-3);
   }
 }
@@ -71,7 +65,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   text-transform: initial;
   letter-spacing: initial;
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-3);
   }
 }
@@ -84,7 +78,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   text-transform: initial;
   letter-spacing: initial;
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-5);
   }
 }
@@ -94,7 +88,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-line-height-6);
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-13);
     line-height: var(--p-line-height-7);
   }
@@ -105,7 +99,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-line-height-4);
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-12);
     line-height: var(--p-line-height-5);
   }
@@ -116,7 +110,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   font-weight: var(--p-font-weight-regular);
   line-height: var(--p-line-height-4);
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-10);
     line-height: var(--p-line-height-5);
   }
@@ -127,7 +121,7 @@ $breakpoints-typography-not-condensed-down: breakpoints-down(
   font-weight: var(--p-font-weight-regular);
   line-height: var(--p-line-height-3);
 
-  @media #{$breakpoints-typography-not-condensed-up} {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-7);
     line-height: var(--p-line-height-4);
   }


### PR DESCRIPTION
Part of #5714 

Checklist:
- What components were updated?
  - `Choice`
  - `ChoiceList`
  - `Navigation`
  - `Title`
  - `RadioButton`
  - `SkeletonDisplayText`
  - `SkeletonPage`
- What Polaris media condition was used?
  - From: `@include when-typography-not-condensed`
  - To: `$p-breakpoints-md-up`
  - From: `@include when-typography-condensed`
  - To: `$p-breakpoints-md-down`
- Did the breakpoint value change? `Yes`
  - From: `640px`(up)
  - To: `768px`
  - From: `640px` (down)
  - To: `767.95px` 
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `Yes`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `when-typography-condensed|when-typography-not-condensed`
- Is the layout using a mobile first strategy? `No`

Before (`Details Page` - `when-typography-not-condensed`):

https://user-images.githubusercontent.com/32409546/175170615-4d808f9b-1d38-43c3-a05a-5fd7fff5b5b9.mov


After (`Details Page` - `$p-breakpoints-md-up`):

https://user-images.githubusercontent.com/32409546/175170632-424e2da9-6753-48f0-9cf8-f5a4cdd166da.mov

Before (`ChoiceList` - `when-typography-condensed`):

https://user-images.githubusercontent.com/32409546/175170876-f47310b8-1892-43fc-917f-4c6989c991af.mov

After (`ChoiceList` - `$p-breakpoints-md-down`):

https://user-images.githubusercontent.com/32409546/175171201-6c4999f8-8760-4244-a3eb-da841e7b676b.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
