### PR TITLE
feat: Update TopBar to Polaris LG media conditions

### DIFF
--- a/polaris-react/src/components/TopBar/TopBar.scss
+++ b/polaris-react/src/components/TopBar/TopBar.scss
@@ -4,10 +4,6 @@
 $icon-size: 20px;
 
 $breakpoints-context-control-expand-up: breakpoints-up(1400px);
-$breakpoints-page-left-alignment-down: breakpoints-down(
-  1238px,
-  $inclusive: true
-);
 
 .TopBar {
   position: relative;
@@ -132,7 +128,7 @@ $breakpoints-page-left-alignment-down: breakpoints-down(
   max-width: none;
   margin-left: calc((100% - #{$page-max-width}) / 2);
 
-  @media #{$breakpoints-page-left-alignment-down} {
+  @media #{$p-breakpoints-lg-down} {
     margin-left: 0;
     margin-right: var(--p-space-1);
   }


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5716   

### WHAT is this pull request doing?
Updating `TopBar` to use Polaris LG media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@media (max-width: $page-left-alignment-breakpoint-max)`
  - To: `$p-breakpoints-lg-down`
- Did the breakpoint value change? `Yes`
  - From: `1238px`
  - To: `1039.95px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `No`
  - Search pattern: `page-left-alignment-breakpoint-max`
- Is the layout using a mobile first strategy? `No`
 
#### Before/After Examples
**Before**

https://user-images.githubusercontent.com/21976492/175364196-9126020e-0d3e-4238-b7b3-01a38152a8bc.mp4


**After**

https://user-images.githubusercontent.com/21976492/175364213-c92c1d98-fccb-4d48-a69e-f9ae94218fad.mp4



