### PR TITLE
[Polaris website refresh] Fix full width color-picker example

### DIFF
--- a/.changeset/sour-jars-appear.md
+++ b/.changeset/sour-jars-appear.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix color picker full width example

--- a/polaris.shopify.com/src/pages/examples/color-pickerpicker-with-transparent-value-full-width.tsx
+++ b/polaris.shopify.com/src/pages/examples/color-pickerpicker-with-transparent-value-full-width.tsx
@@ -10,7 +10,11 @@ function ColorPickerWithTransparentValueExample() {
     alpha: 0.7,
   });
 
-  return <ColorPicker fullWidth onChange={setColor} color={color} allowAlpha />;
+  return (
+    <div style={{ width: "500px" }}>
+      <ColorPicker fullWidth onChange={setColor} color={color} allowAlpha />
+    </div>
+  );
 }
 
 export default withPolarisExample(ColorPickerWithTransparentValueExample);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6306 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fixs issue that was preventing the full width to be displayed of the example - ["Colorpicker with transparent value full width"](http://localhost:3000/components/color-picker)

#### Before

![](https://screenshot.click/23-55-ty2pq-nyh9n.png)

#### After
![](https://screenshot.click/23-55-zfu6w-j8v8v.png)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

