### PR TITLE
feat: Update Dialog to Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -12,8 +12,6 @@ $breakpoints-xsmall-width-up: breakpoints-up(
   $xsmall-width + $dangerous-magic-space-16
 );
 
-$breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
-
 .Container {
   position: fixed;
   z-index: var(--p-z-11);
@@ -68,9 +66,7 @@ $breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
 
   &.limitHeight {
     @media #{$p-breakpoints-md-up} {
-      @media #{$breakpoints-height-limit-up} {
-        max-height: $height-limit;
-      }
+      max-height: $height-limit;
     }
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5714    

### WHAT is this pull request doing?
Updating `Dialog` to use Polaris MD media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@media (min-height: $height-limit + $vertical-spacing)`
  - To: `@media #{$p-breakpoints-md-up}`
- Did the breakpoint value change? `Yes`
  - From: `660px`
  - To: `768px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `height-limit.+vertical-spacing`
- Is the layout using a mobile first strategy? `Yes`
 
#### Before/After Examples
**Before**
_Note: The first few seconds of this video is showing that the layout is not changing at 660px._

https://user-images.githubusercontent.com/21976492/175395299-06ed3ab2-6372-4740-ae92-1d55de5f3ed0.mp4


**After**

https://user-images.githubusercontent.com/21976492/175395319-029e2594-9c8b-465e-a248-cef8d6e98d18.mp4


