### PR TITLE
feat: Update DescriptionList to Polaris SM media conditions

### DIFF
--- a/polaris-react/src/components/DescriptionList/DescriptionList.scss
+++ b/polaris-react/src/components/DescriptionList/DescriptionList.scss
@@ -1,13 +1,11 @@
 @import '../../styles/common';
 
-$breakpoints-legacy-up: breakpoints-up(590px);
-
 .DescriptionList {
   margin: 0;
   padding: 0;
   word-break: break-word;
 
-  @media #{$breakpoints-legacy-up} {
+  @media #{$p-breakpoints-sm-up} {
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
@@ -22,7 +20,7 @@ $breakpoints-legacy-up: breakpoints-up(590px);
     padding: var(--p-space-2) 0 var(--p-space-1);
   }
 
-  @media #{$breakpoints-legacy-up} {
+  @media #{$p-breakpoints-sm-up} {
     flex: 0 1 25%;
     padding: var(--p-space-4) var(--p-space-4) var(--p-space-4) 0;
 
@@ -49,7 +47,7 @@ $breakpoints-legacy-up: breakpoints-up(590px);
     border-top: var(--p-border-divider);
   }
 
-  @media #{$breakpoints-legacy-up} {
+  @media #{$p-breakpoints-sm-up} {
     flex: 1 1 51%;
     padding: var(--p-space-4) 0;
 


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5713     

### WHAT is this pull request doing?
Updating `DescriptionList` to use Polaris SM media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@include page-content-breakpoint-after($breakpoint)`
  - To: `@media #{$p-breakpoints-sm-up}`
- Did the breakpoint value change? `Yes`
  - From: `590px`
  - To: `490px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `page-content-breakpoint-after.+breakpoint`
- Is the layout using a mobile first strategy? `Yes`
 
#### Before/After Examples
**Before**

https://user-images.githubusercontent.com/21976492/175399189-0d15d7d5-cef7-44e9-8cee-d1156e96520a.mp4


**After**


https://user-images.githubusercontent.com/21976492/175399494-0f84d35e-e649-4077-a516-5f60e6592011.mp4





