### PR TITLE
feat: Update Dialog to use Polaris SM media conditions

### DIFF
--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -6,12 +6,6 @@ $height-limit: 600px;
 $xsmall-width: 380px;
 $small-width: 620px;
 $large-width: 980px;
-// @TODO simplify media queries so this isn't needed
-$dangerous-magic-space-16: 64px;
-$breakpoints-xsmall-width-up: breakpoints-up(
-  $xsmall-width + $dangerous-magic-space-16
-);
-
 $breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
 
 .Container {
@@ -79,7 +73,7 @@ $breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
       max-width: calc(100% - var(--p-space-16));
     }
 
-    @media #{$breakpoints-xsmall-width-up} {
+    @media #{$p-breakpoints-sm-up} {
       max-width: $xsmall-width;
     }
   }


### PR DESCRIPTION
Part of #5713 

Checklist:
- What Polaris media condition was used: `$p-breakpoints-sm-up`
- Did the breakpoint value change? `Yes`
  - From: `444px`
  - To: `490px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `No`
- Is the layout using a mobile first strategy? `Yes`

Before (Dialog):

https://user-images.githubusercontent.com/32409546/175399618-5e46f08c-13db-4c53-ae47-03e9f7dca17c.mov

After (Dialog):

https://user-images.githubusercontent.com/32409546/175399665-8058a9f4-8a3c-42cf-a133-1778b726fa82.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
