### PR TITLE
Revert updating height related media conditions

### DIFF
--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -12,7 +12,7 @@ $breakpoints-xsmall-width-up: breakpoints-up(
   $xsmall-width + $dangerous-magic-space-16
 );
 
-$breakpoints-height-limit-up: breakpoints-up($height-limit + $vertical-spacing);
+$breakpoints-height-limit-up: '(min-height: #{breakpoint($height-limit + $vertical-spacing)})';
 
 .Container {
   position: fixed;

--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -2,7 +2,7 @@
 @import './variables';
 
 $item-wrapper-loading-height: 64px;
-$breakpoints-legacy-up: breakpoints-up(600px);
+$breakpoints-empty-search-results-height-up: '(min-height: #{breakpoint(600px)})';
 
 @mixin disabled-pointer-events {
   pointer-events: none;
@@ -187,7 +187,7 @@ $breakpoints-legacy-up: breakpoints-up(600px);
   padding-top: var(--p-space-8);
   padding-bottom: var(--p-space-8);
 
-  @media #{$breakpoints-legacy-up} {
+  @media #{$breakpoints-empty-search-results-height-up} {
     padding-top: var(--p-space-16);
     padding-bottom: var(--p-space-16);
   }


### PR DESCRIPTION
### WHY are these changes introduced?
We need to revert some height related media conditions that were being replaced with width based media conditions. 

### WHAT is this pull request doing?
Making sure these media conditions are using `min-height` not `min-width`