### PR TITLE
[Polaris website refresh] Update Search field to clear when closed

### DIFF
--- a/.changeset/polite-shrimps-bake.md
+++ b/.changeset/polite-shrimps-bake.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Add clear searchbar field on close

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
@@ -103,6 +103,12 @@ function GlobalSearch({}: Props) {
     };
   }, [setIsOpen, router.events]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchTerm("");
+    }
+  }, [isOpen]);
+
   const handleKeyboardNavigation: KeyboardEventHandler<HTMLDivElement> = (
     evt
   ) => {


### PR DESCRIPTION
### WHAT is this pull request doing?

The search field will now clear after search window has been closed or after user clicks the search results 

<details>
      <summary>After Changes</summary>
      <img src="https://user-images.githubusercontent.com/59836805/175451228-e6b0741e-98ee-4ca0-8647-5fe01d0acec3.gif" alt="search-bar clear">
    </details>

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

