### PR TITLE
[Tooltip] Pin the tooltip-overlay to mouse

### DIFF
--- a/.changeset/chilled-impalas-sleep.md
+++ b/.changeset/chilled-impalas-sleep.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+minor

--- a/.changeset/four-socks-eat.md
+++ b/.changeset/four-socks-eat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+move tooltip to right

--- a/.changeset/stupid-dragons-cry.md
+++ b/.changeset/stupid-dragons-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+position tooltip overlay correctly

--- a/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -146,6 +146,7 @@ export class PositionedOverlay extends PureComponent<
       width: width == null || isNaN(width) ? undefined : width,
       zIndex: zIndexOverride || zIndex || undefined,
       transform: transform ?? undefined,
+      pointerEvents: 'none',
     };
 
     const className = classNames(
@@ -280,9 +281,13 @@ export class PositionedOverlay extends PureComponent<
             measuring: false,
             activatorRect: getRectForNode(activator),
             left:
-              preferredAlignment !== 'right' ? horizontalPosition : undefined,
+              preferredAlignment !== 'right'
+                ? horizontalPosition + overlayRect.width / 2
+                : undefined,
             right:
-              preferredAlignment === 'right' ? horizontalPosition : undefined,
+              preferredAlignment === 'right'
+                ? horizontalPosition + overlayRect.width / 2
+                : undefined,
             top: lockPosition ? top : verticalPosition.top,
             lockPosition: Boolean(fixed),
             height: verticalPosition.height || 0,

--- a/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -42,6 +42,7 @@ export interface PositionedOverlayProps {
   render(overlayDetails: OverlayDetails): React.ReactNode;
   onScrollOut?(): void;
   transform?: string;
+  isTooltip?: boolean;
 }
 
 interface State {
@@ -214,6 +215,7 @@ export class PositionedOverlay extends PureComponent<
           fullWidth,
           fixed,
           preferInputActivator = true,
+          isTooltip,
         } = this.props;
 
         const preferredActivator = preferInputActivator
@@ -273,17 +275,21 @@ export class PositionedOverlay extends PureComponent<
           preferredAlignment,
         );
 
+        const tooltipHorizontalCorrection = isTooltip
+          ? overlayRect.width / 2
+          : 0;
+
         this.setState(
           {
             measuring: false,
             activatorRect: getRectForNode(activator),
             left:
               preferredAlignment !== 'right'
-                ? horizontalPosition + overlayRect.width / 2
+                ? horizontalPosition + tooltipHorizontalCorrection
                 : undefined,
             right:
               preferredAlignment === 'right'
-                ? horizontalPosition + overlayRect.width / 2
+                ? horizontalPosition + tooltipHorizontalCorrection
                 : undefined,
             top: lockPosition ? top : verticalPosition.top,
             lockPosition: Boolean(fixed),

--- a/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -42,6 +42,7 @@ export interface PositionedOverlayProps {
   zIndexOverride?: number;
   render(overlayDetails: OverlayDetails): React.ReactNode;
   onScrollOut?(): void;
+  transform?: string;
 }
 
 interface State {
@@ -135,6 +136,7 @@ export class PositionedOverlay extends PureComponent<
       preventInteraction,
       classNames: propClassNames,
       zIndexOverride,
+      transform,
     } = this.props;
 
     const style = {
@@ -143,6 +145,7 @@ export class PositionedOverlay extends PureComponent<
       right: right == null || isNaN(right) ? undefined : right,
       width: width == null || isNaN(width) ? undefined : width,
       zIndex: zIndexOverride || zIndex || undefined,
+      transform: transform ?? undefined,
     };
 
     const className = classNames(

--- a/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -37,7 +37,6 @@ export interface PositionedOverlayProps {
   preferredAlignment?: PreferredAlignment;
   fullWidth?: boolean;
   fixed?: boolean;
-  preventInteraction?: boolean;
   classNames?: string;
   zIndexOverride?: number;
   render(overlayDetails: OverlayDetails): React.ReactNode;
@@ -133,7 +132,6 @@ export class PositionedOverlay extends PureComponent<
     const {
       render,
       fixed,
-      preventInteraction,
       classNames: propClassNames,
       zIndexOverride,
       transform,
@@ -146,13 +144,12 @@ export class PositionedOverlay extends PureComponent<
       width: width == null || isNaN(width) ? undefined : width,
       zIndex: zIndexOverride || zIndex || undefined,
       transform: transform ?? undefined,
-      pointerEvents: 'none',
     };
 
     const className = classNames(
       styles.PositionedOverlay,
       fixed && styles.fixed,
-      preventInteraction && styles.preventInteraction,
+      styles.preventInteraction,
       propClassNames,
     );
 

--- a/polaris-react/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/polaris-react/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -6,6 +6,7 @@ import {EventListener} from '../../EventListener';
 import {PositionedOverlay} from '../PositionedOverlay';
 import * as mathModule from '../utilities/math';
 import * as geometry from '../../../utilities/geometry';
+import styles from '../PositionedOverlay.scss';
 
 describe('<PositionedOverlay />', () => {
   const mockProps = {
@@ -195,6 +196,80 @@ describe('<PositionedOverlay />', () => {
       expect(positionedOverlay).toContainReactComponent('div', {
         style: expect.objectContaining({zIndex: 100}),
       });
+    });
+  });
+
+  describe('isTooltip', () => {
+    it('adds half of the overlay width if isTooltip is true', () => {
+      const calculateHorizontalPositionMock = jest.spyOn(
+        mathModule,
+        'calculateHorizontalPosition',
+      );
+      calculateHorizontalPositionMock.mockReturnValue(30);
+
+      const getRectForNodeSpy = jest.spyOn(geometry, 'getRectForNode');
+      getRectForNodeSpy.mockReturnValue({
+        height: 0,
+        left: 0,
+        top: 0,
+        width: 100,
+        center: {x: 0, y: 0},
+      });
+
+      const positionedOverlay = mountWithApp(
+        <PositionedOverlay {...mockProps} isTooltip />,
+      );
+
+      expect(getRectForNodeSpy).toHaveBeenCalledWith(
+        positionedOverlay.instance.overlay,
+      );
+
+      positionedOverlay.forceUpdate();
+
+      expect(positionedOverlay).toContainReactComponent('div', {
+        style: expect.objectContaining({
+          left: 80,
+          right: undefined,
+        }),
+      });
+
+      calculateHorizontalPositionMock.mockRestore();
+    });
+
+    it('does not add half of the overlay width if isTooltip is false', () => {
+      const calculateHorizontalPositionMock = jest.spyOn(
+        mathModule,
+        'calculateHorizontalPosition',
+      );
+      calculateHorizontalPositionMock.mockReturnValue(30);
+
+      const getRectForNodeSpy = jest.spyOn(geometry, 'getRectForNode');
+      getRectForNodeSpy.mockReturnValue({
+        height: 0,
+        left: 0,
+        top: 0,
+        width: 100,
+        center: {x: 0, y: 0},
+      });
+
+      const positionedOverlay = mountWithApp(
+        <PositionedOverlay {...mockProps} isTooltip={false} />,
+      );
+
+      expect(getRectForNodeSpy).toHaveBeenCalledWith(
+        positionedOverlay.instance.overlay,
+      );
+
+      positionedOverlay.forceUpdate();
+
+      expect(positionedOverlay).toContainReactComponent('div', {
+        style: expect.objectContaining({
+          left: 30,
+          right: undefined,
+        }),
+      });
+
+      calculateHorizontalPositionMock.mockRestore();
     });
   });
 

--- a/polaris-react/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/polaris-react/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -6,7 +6,6 @@ import {EventListener} from '../../EventListener';
 import {PositionedOverlay} from '../PositionedOverlay';
 import * as mathModule from '../utilities/math';
 import * as geometry from '../../../utilities/geometry';
-import styles from '../PositionedOverlay.scss';
 
 describe('<PositionedOverlay />', () => {
   const mockProps = {

--- a/polaris-react/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/polaris-react/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -199,27 +199,6 @@ describe('<PositionedOverlay />', () => {
     });
   });
 
-  describe('preventInteraction', () => {
-    it('passes preventInteraction to PositionedOverlay when preventInteraction is true', () => {
-      const positionedOverlay = mountWithApp(
-        <PositionedOverlay {...mockProps} preventInteraction />,
-      );
-      expect(positionedOverlay).toContainReactComponent('div', {
-        className: expect.stringContaining(styles.preventInteraction),
-      });
-    });
-
-    it('does not pass preventInteraction to PositionedOverlay by default', () => {
-      const positionedOverlay = mountWithApp(
-        <PositionedOverlay {...mockProps} />,
-      );
-
-      expect(positionedOverlay).not.toContainReactComponent('div', {
-        className: expect.stringContaining(styles.preventInteraction),
-      });
-    });
-  });
-
   describe('lifecycle', () => {
     it('updates safely', () => {
       const positionedOverlay = mountWithApp(

--- a/polaris-react/src/components/PositionedOverlay/utilities/math.ts
+++ b/polaris-react/src/components/PositionedOverlay/utilities/math.ts
@@ -110,7 +110,7 @@ export function calculateHorizontalPosition(
 
   return Math.min(
     maximum,
-    Math.max(0, activatorRect.center.x - overlayRect.width / 9),
+    Math.max(0, activatorRect.center.x - overlayRect.width / 2),
   );
 }
 

--- a/polaris-react/src/components/PositionedOverlay/utilities/math.ts
+++ b/polaris-react/src/components/PositionedOverlay/utilities/math.ts
@@ -110,7 +110,7 @@ export function calculateHorizontalPosition(
 
   return Math.min(
     maximum,
-    Math.max(0, activatorRect.center.x - overlayRect.width / 2),
+    Math.max(0, activatorRect.center.x - overlayRect.width / 9),
   );
 }
 

--- a/polaris-react/src/components/Tooltip/README.md
+++ b/polaris-react/src/components/Tooltip/README.md
@@ -67,7 +67,7 @@ To continue using Shopify, this amount must be paid immediately.
 Use only when necessary to provide an explanation for an interface element.
 
 ```jsx
-<div style={{padding: '75px 0'}}>
+<div style={{padding: '75px'}}>
   <Tooltip active content="This order has shipping labels.">
     <TextStyle variation="strong">Order #1001</TextStyle>
   </Tooltip>

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -146,15 +146,15 @@ export function Tooltip({
     if (childWrapperContainer.current == null) return;
     const {x, y, width, height} =
       childWrapperContainer.current.getBoundingClientRect();
-    const centerX = width / 7;
-    const centerY = height / 2;
+    const positionX = width / 7;
+    const positionY = height / 4;
     const {clientX, clientY} = event;
 
     const tooltipLeft = clientX - x;
     const tooltipTop = clientY - y;
 
-    const transformX = tooltipLeft - centerX;
-    const transformY = tooltipTop - centerY;
+    const transformX = tooltipLeft - positionX;
+    const transformY = tooltipTop - positionY;
 
     setTooltipTransform(`translate(${transformX}px, ${transformY}px)`);
   }

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -41,15 +41,18 @@ export function Tooltip({
   accessibilityLabel,
 }: TooltipProps) {
   const WrapperComponent: any = activatorWrapper;
+  const ChildWrapperComponent: any = activatorWrapper;
   const {
     value: active,
     setTrue: handleFocus,
     setFalse: handleBlur,
   } = useToggle(Boolean(originalActive));
   const [activatorNode, setActivatorNode] = useState<HTMLElement | null>(null);
+  const [tooltipTransform, setTooltipTransform] = useState<string>('');
 
   const id = useUniqueId('TooltipContent');
   const activatorContainer = useRef<HTMLElement>(null);
+  const childWrapperContainer = useRef<HTMLDivElement>(null);
   const mouseEntered = useRef(false);
 
   useEffect(() => {
@@ -83,6 +86,7 @@ export function Tooltip({
         accessibilityLabel={accessibilityLabel}
         onClose={noop}
         preventInteraction={dismissOnMouseOut}
+        transform={tooltipTransform}
       >
         {content}
       </TooltipOverlay>
@@ -98,7 +102,12 @@ export function Tooltip({
       ref={setActivator}
       onKeyUp={handleKeyUp}
     >
-      {children}
+      <ChildWrapperComponent
+        onMouseMove={handleMouseMove}
+        ref={childWrapperContainer}
+      >
+        {children}
+      </ChildWrapperComponent>
       {portal}
     </WrapperComponent>
   );
@@ -126,11 +135,28 @@ export function Tooltip({
     mouseEntered.current = false;
     handleBlur();
   }
-
   // https://github.com/facebook/react/issues/10109
   // Mouseenter event not triggered when cursor moves from disabled button
   function handleMouseEnterFix() {
     !mouseEntered.current && handleMouseEnter();
+  }
+
+  function handleMouseMove(event: React.MouseEvent) {
+    if (!active) return;
+    if (childWrapperContainer.current == null) return;
+    const {x, y, width, height} =
+      childWrapperContainer.current.getBoundingClientRect();
+    const centerX = width / 2;
+    const centerY = height / 2;
+    const {clientX, clientY} = event;
+
+    const tooltipLeft = clientX - x;
+    const tooltipTop = clientY - y;
+
+    const transformX = tooltipLeft - centerX;
+    const transformY = tooltipTop - centerY;
+
+    setTooltipTransform(`translate(${transformX}px, ${transformY}px)`);
   }
 }
 

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -15,8 +15,6 @@ export interface TooltipProps {
   content: React.ReactNode;
   /** Toggle whether the tooltip is visible */
   active?: boolean;
-  /** Dismiss tooltip when not interacting with its children */
-  dismissOnMouseOut?: TooltipOverlayProps['preventInteraction'];
   /**
    * The direction the tooltip tries to display
    * @default 'below'
@@ -34,7 +32,6 @@ export interface TooltipProps {
 export function Tooltip({
   children,
   content,
-  dismissOnMouseOut,
   active: originalActive,
   preferredPosition = 'above',
   activatorWrapper = 'span',
@@ -85,7 +82,6 @@ export function Tooltip({
         active={active}
         accessibilityLabel={accessibilityLabel}
         onClose={noop}
-        preventInteraction={dismissOnMouseOut}
         transform={tooltipTransform}
       >
         {content}

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -146,14 +146,14 @@ export function Tooltip({
     if (childWrapperContainer.current == null) return;
     const {x, y, width, height} =
       childWrapperContainer.current.getBoundingClientRect();
-    const centerX = width / 2;
+    const centerX = width / 6;
     const centerY = height / 2;
     const {clientX, clientY} = event;
 
     const tooltipLeft = clientX - x;
     const tooltipTop = clientY - y;
 
-    const transformX = tooltipLeft;
+    const transformX = tooltipLeft - centerX;
     const transformY = tooltipTop - centerY;
 
     setTooltipTransform(`translate(${transformX}px, ${transformY}px)`);

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -36,7 +36,7 @@ export function Tooltip({
   content,
   dismissOnMouseOut,
   active: originalActive,
-  preferredPosition = 'below',
+  preferredPosition = 'above',
   activatorWrapper = 'span',
   accessibilityLabel,
 }: TooltipProps) {
@@ -153,7 +153,7 @@ export function Tooltip({
     const tooltipLeft = clientX - x;
     const tooltipTop = clientY - y;
 
-    const transformX = tooltipLeft - centerX;
+    const transformX = tooltipLeft;
     const transformY = tooltipTop - centerY;
 
     setTooltipTransform(`translate(${transformX}px, ${transformY}px)`);

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -146,7 +146,7 @@ export function Tooltip({
     if (childWrapperContainer.current == null) return;
     const {x, y, width, height} =
       childWrapperContainer.current.getBoundingClientRect();
-    const centerX = width / 6;
+    const centerX = width / 7;
     const centerY = height / 2;
     const {clientX, clientY} = event;
 

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -146,8 +146,8 @@ export function Tooltip({
     if (childWrapperContainer.current == null) return;
     const {x, y, width, height} =
       childWrapperContainer.current.getBoundingClientRect();
-    const positionX = width / 7;
-    const positionY = height / 4;
+    const positionX = width / 2;
+    const positionY = height / 2;
     const {clientX, clientY} = event;
 
     const tooltipLeft = clientX - x;

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -4,7 +4,7 @@ $content-max-width: 200px;
 
 .TooltipOverlay {
   --pc-tooltip-overlay-offset: var(--p-space-1);
-  margin: var(--pc-tooltip-overlay-offset) var(--p-space-4) var(--p-space-4);
+  margin: var(--pc-tooltip-overlay-offset) var(--p-space-2) var(--p-space-2);
   opacity: 1;
   box-shadow: var(--p-shadow-popover);
   border-radius: var(--p-border-radius-1);
@@ -23,7 +23,7 @@ $content-max-width: 200px;
 }
 
 .positionedAbove {
-  margin: var(--p-space-4) var(--p-space-4) var(--pc-tooltip-overlay-offset);
+  margin: 0 var(--p-space-1) var(--pc-tooltip-overlay-offset);
 }
 
 .Content {

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -23,7 +23,7 @@ $content-max-width: 200px;
 }
 
 .positionedAbove {
-  margin: 0 var(--p-space-1) var(--pc-tooltip-overlay-offset);
+  margin: var(--p-space-3) var(--p-space-2) var(--pc-tooltip-overlay-offset);
 }
 
 .Content {

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -55,6 +55,7 @@ export function TooltipOverlay({
       styles.TooltipOverlay,
       measuring && styles.measuring,
       positioning === 'above' && styles.positionedAbove,
+      positioning === 'below' && styles.positionedBelow,
     );
 
     const contentStyles = measuring ? undefined : {minHeight: desiredHeight};

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -38,6 +38,7 @@ export function TooltipOverlay({
       preferredPosition={preferredPosition}
       render={renderTooltip}
       transform={transform}
+      isTooltip
     />
   ) : null;
 

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -19,6 +19,7 @@ export interface TooltipOverlayProps {
   activator: HTMLElement;
   accessibilityLabel?: string;
   onClose(): void;
+  transform?: string;
 }
 
 export function TooltipOverlay({
@@ -29,6 +30,7 @@ export function TooltipOverlay({
   id,
   children,
   accessibilityLabel,
+  transform,
 }: TooltipOverlayProps) {
   const i18n = useI18n();
   const markup = active ? (
@@ -38,6 +40,7 @@ export function TooltipOverlay({
       preferredPosition={preferredPosition}
       preventInteraction={preventInteraction}
       render={renderTooltip}
+      transform={transform}
     />
   ) : null;
 

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -13,7 +13,6 @@ import styles from './TooltipOverlay.scss';
 export interface TooltipOverlayProps {
   id: string;
   active: boolean;
-  preventInteraction?: PositionedOverlayProps['preventInteraction'];
   preferredPosition?: PositionedOverlayProps['preferredPosition'];
   children?: React.ReactNode;
   activator: HTMLElement;
@@ -26,7 +25,6 @@ export function TooltipOverlay({
   active,
   activator,
   preferredPosition = 'below',
-  preventInteraction,
   id,
   children,
   accessibilityLabel,
@@ -38,7 +36,6 @@ export function TooltipOverlay({
       active={active}
       activator={activator}
       preferredPosition={preferredPosition}
-      preventInteraction={preventInteraction}
       render={renderTooltip}
       transform={transform}
     />

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -35,17 +35,6 @@ describe('<Tooltip />', () => {
     expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
   });
 
-  it('passes preventInteraction to TooltipOverlay when dismissOnMouseOut is true', () => {
-    const tooltip = mountWithApp(
-      <Tooltip dismissOnMouseOut content="Inner content" active>
-        <Link>link content</Link>
-      </Tooltip>,
-    );
-    expect(tooltip).toContainReactComponent(TooltipOverlay, {
-      preventInteraction: true,
-    });
-  });
-
   it('renders on mouseOver', () => {
     const tooltip = mountWithApp(
       <Tooltip content="Inner content">


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

- Having an interactive tooltip that follows the cursor on hover is an idea proposed by Tobi and the quality team

Closes https://github.com/Shopify/shopify/issues/321500

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Here is a demo showing the tooltip on hover</summary>
      <img src="https://screenshot.click/24-57-95784-62899.webm" alt="Tooltip following mouse on hover">
    </details>
-->

- This PR wraps the content in a component (`ChildWrapperCommponent`) which tracks mouse movements on hover
- We then introduce a string using the useState hook and use that to _transform_ the tooltip element
- We finally calculate the the difference in the mouse coordinates and center of the element to place the tooltip accordingly.

[Click here for a short demo](https://screenshot.click/24-57-95784-62899.webm)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
