### PR TITLE
[Button/Link] Add new prop dataPrimaryLink to support clickable IndexTable columns

### DIFF
--- a/.changeset/forty-doors-pretend.md
+++ b/.changeset/forty-doors-pretend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Support dataPrimaryLink on Link/Button for clickable IndexTable columns

--- a/.changeset/forty-doors-pretend.md
+++ b/.changeset/forty-doors-pretend.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Support dataPrimaryLink on Link/Button for clickable IndexTable columns
+Added the `dataPrimaryLink` prop to `Link` and `Button` to support navigation on click of an `IndexTable.Row`

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -50,7 +50,7 @@ export interface ButtonProps extends BaseButton {
   icon?: React.ReactElement | IconSource;
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
-  /** Allows the button to be clicked-through when rendered inside collection list components */
+  /** Indicates whether or not the button is the primary navigation link when rendered inside of an `IndexTable.Row` */
   dataPrimaryLink?: boolean;
 }
 

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -50,6 +50,8 @@ export interface ButtonProps extends BaseButton {
   icon?: React.ReactElement | IconSource;
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
+  /** Allows the button to be clicked-through when rendered inside collection list components */
+  dataPrimaryLink?: boolean;
 }
 
 interface CommonButtonProps
@@ -67,6 +69,7 @@ interface CommonButtonProps
   > {
   className: UnstyledButtonProps['className'];
   onMouseUp: MouseUpBlurHandler;
+  'data-primary-link'?: boolean;
 }
 
 type LinkButtonProps = Pick<ButtonProps, 'url' | 'external' | 'download'>;
@@ -125,6 +128,7 @@ export function Button({
   textAlign,
   fullWidth,
   connectedDisclosure,
+  dataPrimaryLink,
 }: ButtonProps) {
   const i18n = useI18n();
 
@@ -267,6 +271,7 @@ export function Button({
     onMouseUp: handleMouseUpByBlurring,
     onMouseEnter,
     onTouchStart,
+    'data-primary-link': dataPrimaryLink,
   };
   const linkProps: LinkButtonProps = {
     url,

--- a/polaris-react/src/components/Button/tests/Button.test.tsx
+++ b/polaris-react/src/components/Button/tests/Button.test.tsx
@@ -449,4 +449,28 @@ describe('<Button />', () => {
       });
     });
   });
+
+  describe('dataPrimaryLink', () => {
+    it('adds data-primary-link attribute to the link', () => {
+      const link = mountWithApp(
+        <Button url="https://examp.le" dataPrimaryLink>
+          Test
+        </Button>,
+      );
+
+      const selector: any = {
+        'data-primary-link': true,
+      };
+      expect(link).toContainReactComponent('a', selector);
+    });
+
+    it('adds data-primary-link attribute to the button', () => {
+      const link = mountWithApp(<Button dataPrimaryLink>Test</Button>);
+
+      const selector: any = {
+        'data-primary-link': true,
+      };
+      expect(link).toContainReactComponent('button', selector);
+    });
+  });
 });

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -1030,9 +1030,9 @@ function StickyLastCellIndexTableExample() {
 }
 ```
 
-### Index table with click-through link
+### Index table with clickable link column
 
-An index table with a primary link element that can be clicked. This disables the default behavior of clicking the row to trigger row selection.
+An index table with a primary link element. The link click overrides the default behavior of row selection.
 
 ```jsx
 function ClickThroughLinkIndexTableExample() {
@@ -1110,9 +1110,9 @@ function ClickThroughLinkIndexTableExample() {
 }
 ```
 
-### Index table with click-through button
+### Index table with clickable button column
 
-An index table with a primary button element that can be clicked. This disables the default behavior of clicking the row to trigger row selection.
+An index table with a primary button element. The button click overrides the default behavior of row selection.
 
 ```jsx
 function ClickThroughLinkIndexTableExample() {

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -1030,9 +1030,9 @@ function StickyLastCellIndexTableExample() {
 }
 ```
 
-### Index table with clickable link column
+### Index table with row navigation link
 
-An index table with a primary link element. The link click overrides the default behavior of row selection.
+Use when clicking the row should navigate merchants to another page, like the row item's detail page. When a row contains a `Link` with the `dataPrimaryLink` prop set to `true`, clicking the row will trigger navigation to the link's `url` instead of selecting the row as well as trigger the callback set on the `IndexTable` `onNavigation` prop if provided.
 
 ```jsx
 function ClickThroughLinkIndexTableExample() {
@@ -1071,16 +1071,15 @@ function ClickThroughLinkIndexTableExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
           <Link
-            onClick={() => console.log(`Clicked ${location}`)}
             dataPrimaryLink
+            url={url}
+            onClick={() => console.log(`Clicked ${name}`)}
           >
-            {location}
+            <TextStyle variation="strong">{name}</TextStyle>
           </Link>
         </IndexTable.Cell>
+        <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>
         <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
       </IndexTable.Row>
@@ -1112,10 +1111,10 @@ function ClickThroughLinkIndexTableExample() {
 
 ### Index table with clickable button column
 
-An index table with a primary button element. The button click overrides the default behavior of row selection.
+Use when clicking the row should navigate merchants to another page, like the row item's detail page. When a row contains a `Button` with the `dataPrimaryLink` prop set to `true`, clicking the row will navigate to the `Button` `url` if set instead of selecting the row as well as trigger the callback set on the `IndexTable` `onNavigation` prop if provided.
 
 ```jsx
-function ClickThroughLinkIndexTableExample() {
+function ClickThroughButtonIndexTableExample() {
   const customers = [
     {
       id: '3411',
@@ -1151,16 +1150,15 @@ function ClickThroughLinkIndexTableExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
           <Button
-            onClick={() => console.log(`Clicked ${location}`)}
             dataPrimaryLink
+            url={url}
+            onClick={() => console.log(`Clicked ${name}`)}
           >
-            {location}
+            <TextStyle variation="strong">{name}</TextStyle>
           </Button>
         </IndexTable.Cell>
+        <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>
         <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -1030,6 +1030,86 @@ function StickyLastCellIndexTableExample() {
 }
 ```
 
+### Index table with click-through link
+
+An index table with a primary link element that can be clicked. This disables the default behavior of clicking the row to trigger row selection.
+
+```jsx
+function ClickThroughLinkIndexTableExample() {
+  const customers = [
+    {
+      id: '3411',
+      url: 'customers/341',
+      name: 'Mae Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$2,400',
+    },
+    {
+      id: '2561',
+      url: 'customers/256',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+  ];
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(customers);
+
+  const rowMarkup = customers.map(
+    ({id, name, location, orders, amountSpent}, index) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <TextStyle variation="strong">{name}</TextStyle>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Link
+            onClick={() => console.log(`Clicked ${location}`)}
+            dataPrimaryLink
+          >
+            {location}
+          </Link>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{orders}</IndexTable.Cell>
+        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <Card>
+      <IndexTable
+        resourceName={resourceName}
+        itemCount={customers.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {title: 'Name'},
+          {title: 'Location'},
+          {title: 'Order count'},
+          {title: 'Amount spent', hidden: false},
+        ]}
+      >
+        {rowMarkup}
+      </IndexTable>
+    </Card>
+  );
+}
+```
+
 ### Index table without checkboxes
 
 An index table without checkboxes and bulk actions.

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -1110,6 +1110,86 @@ function ClickThroughLinkIndexTableExample() {
 }
 ```
 
+### Index table with click-through button
+
+An index table with a primary button element that can be clicked. This disables the default behavior of clicking the row to trigger row selection.
+
+```jsx
+function ClickThroughLinkIndexTableExample() {
+  const customers = [
+    {
+      id: '3411',
+      url: 'customers/341',
+      name: 'Mae Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$2,400',
+    },
+    {
+      id: '2561',
+      url: 'customers/256',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+  ];
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(customers);
+
+  const rowMarkup = customers.map(
+    ({id, name, location, orders, amountSpent}, index) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <TextStyle variation="strong">{name}</TextStyle>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Button
+            onClick={() => console.log(`Clicked ${location}`)}
+            dataPrimaryLink
+          >
+            {location}
+          </Button>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{orders}</IndexTable.Cell>
+        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <Card>
+      <IndexTable
+        resourceName={resourceName}
+        itemCount={customers.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {title: 'Name'},
+          {title: 'Location'},
+          {title: 'Order count'},
+          {title: 'Amount spent', hidden: false},
+        ]}
+      >
+        {rowMarkup}
+      </IndexTable>
+    </Card>
+  );
+}
+```
+
 ### Index table without checkboxes
 
 An index table without checkboxes and bulk actions.

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -1063,7 +1063,7 @@ function ClickThroughLinkIndexTableExample() {
     useIndexResourceState(customers);
 
   const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
+    ({id, url, name, location, orders, amountSpent}, index) => (
       <IndexTable.Row
         id={id}
         key={id}
@@ -1142,7 +1142,7 @@ function ClickThroughButtonIndexTableExample() {
     useIndexResourceState(customers);
 
   const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
+    ({id, url, name, location, orders, amountSpent}, index) => (
       <IndexTable.Row
         id={id}
         key={id}

--- a/polaris-react/src/components/IndexTable/components/Row/tests/Row.test.tsx
+++ b/polaris-react/src/components/IndexTable/components/Row/tests/Row.test.tsx
@@ -6,6 +6,8 @@ import {IndexTable, IndexTableProps} from '../../../IndexTable';
 import {RowHoveredContext} from '../../../../../utilities/index-table';
 import {Row} from '../Row';
 import {Checkbox} from '../../Checkbox';
+import {Button} from '../../../../Button';
+import {Link} from '../../../../Link';
 
 const defaultEvent = {
   preventDefault: noop,
@@ -219,6 +221,25 @@ describe('<Row />', () => {
 
     expect(onNavigationSpy).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    ['<Link>', () => <Link url="/" dataPrimaryLink />],
+    ['<Button>', () => <Button url="/" dataPrimaryLink />],
+  ])(
+    'calls onNavigation when clicked %s',
+    (_: string, renderElement: () => JSX.Element) => {
+      const onNavigationSpy = jest.fn();
+      const row = mountWithTable(
+        <Row {...defaultProps} onNavigation={onNavigationSpy}>
+          <th>{renderElement()}</th>
+        </Row>,
+      );
+
+      triggerOnClick(row, 1, defaultEvent);
+
+      expect(onNavigationSpy).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it('calls onClick when clicked', () => {
     const onClickSpy = jest.fn();

--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -26,6 +26,8 @@ export interface LinkProps {
   onClick?(): void;
   /** Descriptive text to be read to screenreaders */
   accessibilityLabel?: string;
+  /** Allows the link to be clicked-through when rendered inside collection list components */
+  dataPrimaryLink?: boolean;
 }
 
 export function Link({
@@ -37,6 +39,7 @@ export function Link({
   monochrome,
   removeUnderline,
   accessibilityLabel,
+  dataPrimaryLink,
 }: LinkProps) {
   const i18n = useI18n();
   let childrenMarkup = children;
@@ -77,6 +80,7 @@ export function Link({
             external={external}
             id={id}
             aria-label={accessibilityLabel}
+            data-primary-link={dataPrimaryLink}
           >
             {childrenMarkup}
           </UnstyledLink>
@@ -87,6 +91,7 @@ export function Link({
             className={className}
             id={id}
             aria-label={accessibilityLabel}
+            data-primary-link={dataPrimaryLink}
           >
             {childrenMarkup}
           </button>

--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -26,7 +26,7 @@ export interface LinkProps {
   onClick?(): void;
   /** Descriptive text to be read to screenreaders */
   accessibilityLabel?: string;
-  /** Allows the link to be clicked-through when rendered inside collection list components */
+  /** Indicates whether or not the link is the primary navigation link when rendered inside of an `IndexTable.Row` */
   dataPrimaryLink?: boolean;
 }
 

--- a/polaris-react/src/components/Link/tests/Link.test.tsx
+++ b/polaris-react/src/components/Link/tests/Link.test.tsx
@@ -153,4 +153,28 @@ describe('<Link />', () => {
       });
     });
   });
+
+  describe('dataPrimaryLink', () => {
+    it('adds data-primary-link attribute to the link', () => {
+      const link = mountWithApp(
+        <Link url="https://examp.le" dataPrimaryLink>
+          Test
+        </Link>,
+      );
+
+      const selector: any = {
+        'data-primary-link': true,
+      };
+      expect(link).toContainReactComponent('a', selector);
+    });
+
+    it('adds data-primary-link attribute to the button', () => {
+      const link = mountWithApp(<Link dataPrimaryLink>Test</Link>);
+
+      const selector: any = {
+        'data-primary-link': true,
+      };
+      expect(link).toContainReactComponent('button', selector);
+    });
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

- Fixes #6093
- Fixes #4138
- Fixes #6091

The `IndexTable.Row` component supports clicking through links with the `data-primary-link` attribute. However, none of our linkable components has a prop that supports this feature.

Users often resort to workarounds such as using a container like `<div data-primary-link><Link url=''/></div>` or a HTML primitive like `<a data-primary-link href=''></a>`. Primitive elements are not styled with Polaris's design system and can lead to design inconsistencies.

### WHAT is this pull request doing?

Added new prop `dataPrimaryLink` to `Button` and `Link` components to offer an official solution to this problem.

### How to 🎩

Start storybook and check the stories below. Verify that clicking a Link or Button should print a console log indicating which row was clicked.

- Index table
  - Index table with clickable link column
  - Index table with clickable button column

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

I’ve tophatted these changes in the following browsers:

- [x] Chrome latest
- [x] FF latest
- [x] Safari latest
- [x] Edge
- [x] In at least one of the above browsers, test both retina and non-retina displays
- [ ] iPhone (5/SE/X) (10+) Safari Mobile
- [ ] iPad (10+) Safari Mobile
- [x] Android device (5.x) Chrome

### 👾 Related bugs

Bugs that I found while tophatting. They are not caused by this PR and are only triggered in Storybook's environment. I will open bug reports for them as soon as I have more information:

1. Clicking a Link or Button with `dataPrimaryLink` on the 🎩 stories above fires the own link's `onClick` event twice. Sounds like a Storybook funkiness, I could not reproduce it outside Storybook's environment: https://codesandbox.io/s/vigorous-cookies-iixcil?file=/src/App.tsx
2. On Storybook's `Docs` view, clicking the checkboxes of these two stories has no effect - it does not select any of the rows. This problem only happens in the `Docs` view and works fine on the default `Canvas` view, although it seems somehow related to `data-primary-link` because the checkboxes work fine for all the other stories in both views.
