### PR TITLE
[EmptyState] Switch order of actions to align with Polaris guidelines.

### DIFF
--- a/.changeset/eighty-turtles-tell.md
+++ b/.changeset/eighty-turtles-tell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Switch the order of the actions in the EmptyState

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -106,8 +106,8 @@ export function EmptyState({
     primaryActionMarkup || secondaryActionMarkup ? (
       <div className={styles.Actions}>
         <Stack alignment="center" distribution="center" spacing="tight">
-          {primaryActionMarkup}
           {secondaryActionMarkup}
+          {primaryActionMarkup}
         </Stack>
       </div>
     ) : null;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

To improve consistency across the admin. ButtonGroups state that the primary action should be on the right hand side, whereas the EmptyState has it on the left.

<img width="1389" alt="Screenshot 2022-06-27 at 13 08 40" src="https://user-images.githubusercontent.com/2562596/175937843-d17c6e10-07f3-48fe-b1e4-fb44b53584d3.png">


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
