### PR TITLE
[polaris.shopify.com] Fix component example (page, narrow width)

### DIFF
--- a/.changeset/hip-terms-care.md
+++ b/.changeset/hip-terms-care.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix page components (narrow width) example

--- a/polaris.shopify.com/src/pages/examples/page-narrow-width.tsx
+++ b/polaris.shopify.com/src/pages/examples/page-narrow-width.tsx
@@ -1,20 +1,24 @@
 import { Page, Card, PageActions } from "@shopify/polaris";
 import React from "react";
-
-<Page
-  narrowWidth
-  breadcrumbs={[{ content: "Orders", url: "/orders" }]}
-  title="Add payment method"
-  primaryAction={{ content: "Save", disabled: true }}
->
-  <Card title="Credit card" sectioned>
-    <p>Credit card information</p>
-  </Card>
-  <PageActions
-    primaryAction={{ content: "Save", disabled: true }}
-    secondaryActions={[{ content: "Delete" }]}
-  />
-</Page>;
-
 import { withPolarisExample } from "../../components/PolarisExamplePage";
-export default withPolarisExample(() => <p />);
+
+function PageExample() {
+  return (
+    <Page
+      narrowWidth
+      breadcrumbs={[{ content: "Orders", url: "/orders" }]}
+      title="Add payment method"
+      primaryAction={{ content: "Save", disabled: true }}
+    >
+      <Card title="Credit card" sectioned>
+        <p>Credit card information</p>
+      </Card>
+      <PageActions
+        primaryAction={{ content: "Save", disabled: true }}
+        secondaryActions={[{ content: "Delete" }]}
+      />
+    </Page>
+  );
+}
+
+export default withPolarisExample(PageExample);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6384  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

The component example for Page (narrrow width) is no longer broken and can now be shown as a preview

![](https://screenshot.click/27-28-u2mn3-jp1ej.png)

