### PR TITLE
[IndexTable] Fix variable name when last column is sticky.

### DIFF
--- a/.changeset/orange-maps-smoke.md
+++ b/.changeset/orange-maps-smoke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fix variable name in sticky IndexTable

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -283,7 +283,7 @@ $loading-panel-height: 53px;
   .TableCell:last-child,
   .TableHeading-last {
     @include breakpoint-after($breakpoint-small) {
-      filter: drop-shadow(-1px 0 0 var(--p-border-divider));
+      filter: drop-shadow(-1px 0 0 var(--p-divider));
     }
   }
 }

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -970,6 +970,10 @@ function StickyLastCellIndexTableExample() {
       location: 'Decatur, USA',
       orders: 20,
       amountSpent: '$2,400',
+      status: 'Created',
+      channel: 'Point of Sale',
+      paymentStatus: 'Refunded',
+      fulfillmentStatus: 'Fulfilled',
     },
     {
       id: '2561',
@@ -978,6 +982,10 @@ function StickyLastCellIndexTableExample() {
       location: 'Los Angeles, USA',
       orders: 30,
       amountSpent: '$140',
+      status: 'Created',
+      channel: 'Online Store',
+      paymentStatus: 'Paid',
+      fulfillmentStatus: 'Unfulfilled',
     },
   ];
   const resourceName = {
@@ -989,7 +997,20 @@ function StickyLastCellIndexTableExample() {
     useIndexResourceState(customers);
 
   const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
+    (
+      {
+        id,
+        name,
+        location,
+        orders,
+        amountSpent,
+        status,
+        channel,
+        paymentStatus,
+        fulfillmentStatus,
+      },
+      index,
+    ) => (
       <IndexTable.Row
         id={id}
         key={id}
@@ -1002,6 +1023,10 @@ function StickyLastCellIndexTableExample() {
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>
         <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
+        <IndexTable.Cell>{status}</IndexTable.Cell>
+        <IndexTable.Cell>{channel}</IndexTable.Cell>
+        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>
     ),
   );
@@ -1020,6 +1045,10 @@ function StickyLastCellIndexTableExample() {
           {title: 'Location'},
           {title: 'Order count'},
           {title: 'Amount spent', hidden: false},
+          {title: 'Status'},
+          {title: 'Channel'},
+          {title: 'Payment status'},
+          {title: 'Fulfillment status'},
         ]}
         lastColumnSticky
       >


### PR DESCRIPTION
### WHY are these changes introduced?

Because we are referencing an incorrect CSS custom property name resulting in no visible border.


### WHAT is this pull request doing?

Updating the CSS custom property used when the last column in an IndexTable is sticky.

### Before
<img width="1178" alt="Screenshot 2022-06-28 at 17 10 21" src="https://user-images.githubusercontent.com/2562596/176234950-17c87578-f968-404d-9b1c-9f33b65d265c.png">

### After
<img width="1222" alt="Screenshot 2022-06-28 at 17 10 45" src="https://user-images.githubusercontent.com/2562596/176234972-99b501ba-ae7e-40c1-bb94-da1b064e9662.png">

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
