### PR TITLE
[Button] Prevents disclosure icon from overflowing its container

### DIFF
--- a/.changeset/loud-coins-warn.md
+++ b/.changeset/loud-coins-warn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Prevents the Button disclosure icon from overflowing its container

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -21,6 +21,7 @@
   --pc-button-spinner-size: 20px;
   --pc-button-segment: 10;
   --pc-button-focused: 20;
+  --pc-button-disclosure-icon-offset: -6px;
   @include button-base;
 
   &.disabled {
@@ -105,9 +106,8 @@
 
   &:last-child {
     // This compensates for the disclosure icon, which is substantially
-    // inset within the viewbox (and makes it look like there is too much
-    // spacing on the right of the button)
-    margin-right: calc(-1 * (var(--p-space-2)));
+    // inset within the viewbox
+    margin-right: var(--pc-button-disclosure-icon-offset);
     margin-left: var(--p-space-1);
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The Button with disclosure icon is overflowing the content's container of the Button component. The padding should be 16px on the sides by the looks of it. 


<img width="1244" alt="Screen Shot 2022-06-28 at 3 07 47 PM" src="https://user-images.githubusercontent.com/2091116/176263733-5fb1f7b0-87b3-4434-b26c-826afd4521fd.png">


### WHAT is this pull request doing?

Updates the spacing the icon to make sure it stays within the boundaries of its container. 

<img width="622" alt="Screen Shot 2022-06-28 at 2 37 43 PM" src="https://user-images.githubusercontent.com/2091116/176262984-19ecbd86-93e1-477d-b987-fa4cf7d09bef.png">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';
import {Page} from '../src';

export function Playground() {
    const [expanded, setExpanded] = useState(false);

  return (
    <Page title="Playground">
      <Button
        fullWidth
        textAlign="left"
        disclosure={expanded ? "up" : "down"}
        onClick={() => setExpanded(!expanded)}
      >
        {expanded ? "Show less" : "Show more"}
      </Button>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
