### PR TITLE
[polaris.shopify.com] Add custom scrollbars for global search

### DIFF
--- a/.changeset/perfect-boats-roll.md
+++ b/.changeset/perfect-boats-roll.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Added custom scroll bars to the global search component

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.module.scss
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.module.scss
@@ -126,6 +126,7 @@
   overflow: auto;
   overscroll-behavior: contain;
   flex: 1;
+  @include custom-scrollbars;
 }
 
 .ResultsGroup {

--- a/polaris.shopify.com/src/styles/mixins.scss
+++ b/polaris.shopify.com/src/styles/mixins.scss
@@ -3,3 +3,22 @@
     @content;
   }
 }
+
+@mixin custom-scrollbars {
+  &::-webkit-scrollbar {
+    width: 5px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--text-subdued);
+    border-radius: var(--border-radius-200);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--text-strong);
+  }
+}

--- a/polaris.shopify.com/src/styles/mixins.scss
+++ b/polaris.shopify.com/src/styles/mixins.scss
@@ -6,7 +6,7 @@
 
 @mixin custom-scrollbars {
   &::-webkit-scrollbar {
-    width: 5px;
+    width: 13px;
   }
 
   &::-webkit-scrollbar-track {
@@ -15,7 +15,9 @@
 
   &::-webkit-scrollbar-thumb {
     background: transparent;
-    border-radius: var(--border-radius-200);
+    border-radius: var(--border-radius-round);
+    // Increases draggable area
+    border: 4px solid var(--surface);
   }
 
   &:hover {

--- a/polaris.shopify.com/src/styles/mixins.scss
+++ b/polaris.shopify.com/src/styles/mixins.scss
@@ -10,15 +10,21 @@
   }
 
   &::-webkit-scrollbar-track {
-    background: transparent;
+    background-color: transparent;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: var(--text-subdued);
+    background: transparent;
     border-radius: var(--border-radius-200);
   }
 
-  &::-webkit-scrollbar-thumb:hover {
-    background: var(--text-strong);
+  &:hover {
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--text-subdued);
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background-color: var(--text-strong);
+    }
   }
 }


### PR DESCRIPTION
Fixes #6357 

- Only visible on hover
- Visually thin, but they have a hidden touch that allow you to drag even if you're a few pixels outside the visible scroll bar

https://user-images.githubusercontent.com/875708/176786441-9d0e9dea-8728-4959-8bc8-6ba3562b0e93.mov


