### PR TITLE
Update stylelint-polaris/media-queries-allowed-list to error by default

### DIFF
--- a/polaris-react/src/components/Card/Card.scss
+++ b/polaris-react/src/components/Card/Card.scss
@@ -40,7 +40,7 @@
   @media #{$p-breakpoints-sm-up} {
     padding: var(--p-space-5) var(--p-space-5) 0;
   }
-  
+
   @media print and #{$p-breakpoints-sm-up} {
     padding: var(--p-space-2) var(--p-space-4) var(--p-space-0);
   }

--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -63,6 +63,7 @@ $breakpoints-height-limit-up: '(min-height: #{breakpoint($height-limit + $vertic
 
   &.limitHeight {
     @media #{$p-breakpoints-md-up} {
+      /* stylelint-disable-next-line stylelint-polaris/media-queries-allowed-list */
       @media #{$breakpoints-height-limit-up} {
         max-height: $height-limit;
       }

--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -187,6 +187,7 @@ $breakpoints-empty-search-results-height-up: '(min-height: #{breakpoint(600px)})
   padding-top: var(--p-space-8);
   padding-bottom: var(--p-space-8);
 
+  /* stylelint-disable-next-line stylelint-polaris/media-queries-allowed-list */
   @media #{$breakpoints-empty-search-results-height-up} {
     padding-top: var(--p-space-16);
     padding-bottom: var(--p-space-16);

--- a/stylelint-polaris/configs/internal.js
+++ b/stylelint-polaris/configs/internal.js
@@ -45,18 +45,15 @@ module.exports = {
         ],
       },
     },
-    [mediaQueriesAllowedList]: [
-      {
-        // Allowed media types and media conditions
-        // https://www.w3.org/TR/mediaqueries-5/#media
-        allowedMediaTypes: ['print', 'screen'],
-        allowedMediaFeatureNames: ['forced-colors', '-ms-high-contrast'],
-        allowedScssInterpolations: [
-          // TODO: Add utility to @shopify/polaris-tokens to getMediaConditionNames
-          /^\$p-breakpoints-(xs|sm|md|lg|xl)-(up|down|only)$/,
-        ],
-      },
-      {severity: 'warning'},
-    ],
+    [mediaQueriesAllowedList]: {
+      // Allowed media types and media conditions
+      // https://www.w3.org/TR/mediaqueries-5/#media
+      allowedMediaTypes: ['print', 'screen'],
+      allowedMediaFeatureNames: ['forced-colors', '-ms-high-contrast'],
+      allowedScssInterpolations: [
+        // TODO: Add utility to @shopify/polaris-tokens to getMediaConditionNames
+        /^\$p-breakpoints-(xs|sm|md|lg|xl)-(up|down|only)$/,
+      ],
+    },
   },
 };

--- a/stylelint-polaris/plugins/media-queries-allowed-list/index.js
+++ b/stylelint-polaris/plugins/media-queries-allowed-list/index.js
@@ -74,19 +74,17 @@ const {rule} = stylelint.createPlugin(
           root,
         },
         (warning) => {
-          const media = warning.node.params;
-
           if (
             // The built-in `media-feature-name-allowed-list` rule
             // doesn't handle this case:
             allowedMediaFeatureNames.includes('-ms-high-contrast') &&
-            /^\(\s*-ms-high-contrast:.+?\)$/.test(media)
+            warning.text.includes('-ms-high-contrast')
           ) {
             return;
           }
 
           stylelint.utils.report({
-            message: messages.rejected(media),
+            message: messages.rejected(warning.node.params),
             ruleName,
             result,
             node: warning.node,

--- a/stylelint-polaris/plugins/media-queries-allowed-list/index.js
+++ b/stylelint-polaris/plugins/media-queries-allowed-list/index.js
@@ -73,9 +73,20 @@ const {rule} = stylelint.createPlugin(
           ruleSettings: allowedMediaFeatureNames,
           root,
         },
-        (warning) =>
+        (warning) => {
+          const media = warning.node.params;
+
+          if (
+            // The built-in `media-feature-name-allowed-list` rule
+            // isn't properly handling this case:
+            allowedMediaFeatureNames.includes('-ms-high-contrast') &&
+            /^\(\s*-ms-high-contrast:.+?\)$/.test(media)
+          ) {
+            return;
+          }
+
           stylelint.utils.report({
-            message: messages.rejected(warning.node.params),
+            message: messages.rejected(media),
             ruleName,
             result,
             node: warning.node,
@@ -83,7 +94,8 @@ const {rule} = stylelint.createPlugin(
             column: warning.column,
             endLine: warning.endLine,
             endColumn: warning.endColumn,
-          }),
+          });
+        },
       );
 
       root.walkAtRules('media', (atRule) => {

--- a/stylelint-polaris/plugins/media-queries-allowed-list/index.js
+++ b/stylelint-polaris/plugins/media-queries-allowed-list/index.js
@@ -78,7 +78,7 @@ const {rule} = stylelint.createPlugin(
 
           if (
             // The built-in `media-feature-name-allowed-list` rule
-            // isn't properly handling this case:
+            // doesn't handle this case:
             allowedMediaFeatureNames.includes('-ms-high-contrast') &&
             /^\(\s*-ms-high-contrast:.+?\)$/.test(media)
           ) {

--- a/stylelint-polaris/plugins/media-queries-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/media-queries-allowed-list/index.test.js
@@ -100,5 +100,13 @@ testRule({
       description: 'Defining media queries an unsupported media type',
       message: messages.rejected('screen'),
     },
+    {
+      code: '@media (-ms-high-contrast: active) and (min-width: 0px) {}',
+      description:
+        'Uses allowed prefixed media feature name and disallowed min-width',
+      message: messages.rejected(
+        '(-ms-high-contrast: active) and (min-width: 0px)',
+      ),
+    },
   ],
 });

--- a/stylelint-polaris/plugins/media-queries-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/media-queries-allowed-list/index.test.js
@@ -4,7 +4,7 @@ const {messages, ruleName} = require('.');
 // https://www.w3.org/TR/mediaqueries-5/#media
 const config = {
   allowedMediaTypes: ['print'],
-  allowedMediaFeatureNames: ['forced-colors'],
+  allowedMediaFeatureNames: ['forced-colors', '-ms-high-contrast'],
   allowedScssInterpolations: [
     /^\$p-breakpoints-(xs|sm|md|lg|xl)-(up|down|only)$/,
   ],
@@ -35,6 +35,10 @@ testRule({
     {
       code: '@media (forced-colors: active) {}',
       description: 'Uses allowed media feature name',
+    },
+    {
+      code: '@media (-ms-high-contrast: active) {}',
+      description: 'Uses allowed prefixed media feature name',
     },
   ],
 


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR updates the `internal` `stylelint-polari/media-query-allowed-list` config to error by default.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
