### PR TITLE
[polaris.shopify.com] Tweak component grid size

### DIFF
--- a/.changeset/friendly-bears-press.md
+++ b/.changeset/friendly-bears-press.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Tweaked component grid items size so that 3 items are visible on the same row when searching on a laptop sized computer.

--- a/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.module.scss
+++ b/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.module.scss
@@ -4,7 +4,7 @@
 .ComponentGrid {
   display: grid;
   // https://evanminto.com/blog/intrinsically-responsive-css-grid-minmax-min/
-  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(17rem, 100%), 1fr));
   gap: 0.75rem;
 }
 


### PR DESCRIPTION
Before:

<img width="1228" alt="Screen Shot 2022-07-02 at 12 40 38 PM" src="https://user-images.githubusercontent.com/875708/176997287-07b960d6-c13d-4c9a-bf7a-ff068dc0deb6.png">

After:

<img width="1254" alt="Screen Shot 2022-07-02 at 12 40 57 PM" src="https://user-images.githubusercontent.com/875708/176997290-2aa94cf5-cb91-4b70-9db7-3a89f62ca3a4.png">

