### PR TITLE
Deprecate Layout.AnnotatedSection

### DIFF
--- a/.changeset/shy-needles-battle.md
+++ b/.changeset/shy-needles-battle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Deprecated Layout.AnnotatedSection

--- a/polaris-react/src/components/Layout/Layout.tsx
+++ b/polaris-react/src/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// eslint-disable-next-line import/no-deprecated
 import {AnnotatedSection, Section} from './components';
 import styles from './Layout.scss';
 
@@ -11,12 +12,13 @@ export interface LayoutProps {
 }
 
 export const Layout: React.FunctionComponent<LayoutProps> & {
+  // eslint-disable-next-line import/no-deprecated
   AnnotatedSection: typeof AnnotatedSection;
   Section: typeof Section;
 } = function Layout({sectioned, children}: LayoutProps) {
   const content = sectioned ? <Section>{children}</Section> : children;
   return <div className={styles.Layout}>{content}</div>;
 };
-
+// eslint-disable-next-line import/no-deprecated
 Layout.AnnotatedSection = AnnotatedSection;
 Layout.Section = Section;

--- a/polaris-react/src/components/Layout/README.md
+++ b/polaris-react/src/components/Layout/README.md
@@ -449,6 +449,47 @@ Use for settings pages. When settings are grouped thematically in annotated sect
 </Page>
 ```
 
+### Annotated layout using plain Layout.Sections
+
+Use for settings pages. When settings are grouped thematically in annotated sections, the title and description on each section helps merchants quickly find the setting they’re looking for.
+
+```jsx
+<Page fullWidth>
+  <Layout>
+    <Layout.Section oneThird>
+      <div style={{marginTop: 'var(--p-space-5)'}}>
+        <TextContainer>
+          <Heading id="storeDetails">Store details</Heading>
+          <p>
+            <TextStyle variation="subdued">
+              Shopify and your customers will use this information to contact
+              you.
+            </TextStyle>
+          </p>
+        </TextContainer>
+      </div>
+    </Layout.Section>
+    <Layout.Section>
+      <Card sectioned>
+        <FormLayout>
+          <TextField
+            label="Store name"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            type="email"
+            label="Account email"
+            onChange={() => {}}
+            autoComplete="email"
+          />
+        </FormLayout>
+      </Card>
+    </Layout.Section>
+  </Layout>
+</Page>
+```
+
 ### Annotated layout with Banner at the top
 
 Use for settings pages that need a banner or other content at the top.

--- a/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -10,7 +10,7 @@ export interface AnnotatedSectionProps {
   description?: React.ReactNode;
   id?: string;
 }
-
+/** @deprecated Annotated sections can be composed. See examples for styling */
 export function AnnotatedSection(props: AnnotatedSectionProps) {
   const {children, title, description, id} = props;
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris/issues/6329

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
