### PR TITLE
Change icon name casing

### DIFF
--- a/.changeset/fresh-drinks-change.md
+++ b/.changeset/fresh-drinks-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': minor
+---
+
+Change icon names to start with an uppercase

--- a/polaris-icons/icons/AbandonedCartMajor.yml
+++ b/polaris-icons/icons/AbandonedCartMajor.yml
@@ -1,4 +1,4 @@
-name: abandoned cart
+name: Abandoned cart
 set: major
 description: Used to represent a prospective purchase that a buyer didn’t complete.
 keywords:

--- a/polaris-icons/icons/AccessibilityMajor.yml
+++ b/polaris-icons/icons/AccessibilityMajor.yml
@@ -1,4 +1,4 @@
-name: accessibility
+name: Accessibility
 set: major
 description: Used to represent accessibility information or features.
 keywords:

--- a/polaris-icons/icons/ActivitiesMajor.yml
+++ b/polaris-icons/icons/ActivitiesMajor.yml
@@ -1,4 +1,4 @@
-name: activities
+name: Activities
 set: major
 description: Used as a navigation item in our emoji picker for the activities category.
 keywords:

--- a/polaris-icons/icons/AddCodeMajor.yml
+++ b/polaris-icons/icons/AddCodeMajor.yml
@@ -1,4 +1,4 @@
-name: add code
+name: Add code
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/AddImageMajor.yml
+++ b/polaris-icons/icons/AddImageMajor.yml
@@ -1,4 +1,4 @@
-name: add image
+name: Add image
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/AddMajor.yml
+++ b/polaris-icons/icons/AddMajor.yml
@@ -1,4 +1,4 @@
-name: add
+name: Add
 set: major
 description: Used as an action to add a new content block or layout component.
 keywords:

--- a/polaris-icons/icons/AddNoteMajor.yml
+++ b/polaris-icons/icons/AddNoteMajor.yml
@@ -1,4 +1,4 @@
-name: add note
+name: Add note
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/AddProductMajor.yml
+++ b/polaris-icons/icons/AddProductMajor.yml
@@ -1,4 +1,4 @@
-name: add product
+name: Add product
 set: major
 description: Used as an action to add a new product.
 keywords:

--- a/polaris-icons/icons/AdjustMinor.yml
+++ b/polaris-icons/icons/AdjustMinor.yml
@@ -1,4 +1,4 @@
-name: adjust
+name: Adjust
 set: minor
 description: Used to denote that an adjustment can be made.
 keywords:

--- a/polaris-icons/icons/AffiliateMajor.yml
+++ b/polaris-icons/icons/AffiliateMajor.yml
@@ -1,4 +1,4 @@
-name: affiliate
+name: Affiliate
 set: major
 authors:
   # - Sasha Oliveira

--- a/polaris-icons/icons/AlertMinor.yml
+++ b/polaris-icons/icons/AlertMinor.yml
@@ -1,4 +1,4 @@
-name: alert
+name: Alert
 set: minor
 description: Used to give merchants more information about something they should be aware of.
 keywords:

--- a/polaris-icons/icons/AnalyticsMajor.yml
+++ b/polaris-icons/icons/AnalyticsMajor.yml
@@ -1,4 +1,4 @@
-name: analytics
+name: Analytics
 set: major
 description: Used to represent analytics or data.
 keywords:

--- a/polaris-icons/icons/AnalyticsMinor.yml
+++ b/polaris-icons/icons/AnalyticsMinor.yml
@@ -1,4 +1,4 @@
-name: analytics
+name: Analytics
 set: minor
 description: Used to represent analytics or data.
 keywords:

--- a/polaris-icons/icons/AppExtensionMinor.yml
+++ b/polaris-icons/icons/AppExtensionMinor.yml
@@ -1,4 +1,4 @@
-name: app extension
+name: App extension
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/AppsMajor.yml
+++ b/polaris-icons/icons/AppsMajor.yml
@@ -1,4 +1,4 @@
-name: apps
+name: Apps
 set: major
 description: Used to represent partner apps.
 keywords:

--- a/polaris-icons/icons/AppsMinor.yml
+++ b/polaris-icons/icons/AppsMinor.yml
@@ -1,4 +1,4 @@
-name: apps
+name: Apps
 set: minor
 description: Used to represent partner apps.
 keywords:

--- a/polaris-icons/icons/ArchiveMajor.yml
+++ b/polaris-icons/icons/ArchiveMajor.yml
@@ -1,4 +1,4 @@
-name: archive
+name: Archive
 set: major
 description: Used to represent archiving an item or resource.
 keywords:

--- a/polaris-icons/icons/ArchiveMinor.yml
+++ b/polaris-icons/icons/ArchiveMinor.yml
@@ -1,4 +1,4 @@
-name: archive
+name: Archive
 set: minor
 authors:
   - Adam Whitcroft

--- a/polaris-icons/icons/ArrowDownMinor.yml
+++ b/polaris-icons/icons/ArrowDownMinor.yml
@@ -1,4 +1,4 @@
-name: arrow down
+name: Arrow down
 set: minor
 description: Used to represent a negative trend when looking at analytical information.
 keywords:

--- a/polaris-icons/icons/ArrowLeftMinor.yml
+++ b/polaris-icons/icons/ArrowLeftMinor.yml
@@ -1,4 +1,4 @@
-name: arrow left
+name: Arrow left
 set: minor
 authors:
   - Adam Whitcroft

--- a/polaris-icons/icons/ArrowRightMinor.yml
+++ b/polaris-icons/icons/ArrowRightMinor.yml
@@ -1,4 +1,4 @@
-name: arrow right
+name: Arrow right
 set: minor
 authors:
   - Adam Whitcroft

--- a/polaris-icons/icons/ArrowUpMinor.yml
+++ b/polaris-icons/icons/ArrowUpMinor.yml
@@ -1,4 +1,4 @@
-name: arrow up
+name: Arrow up
 set: minor
 authors:
   - Adam Whitcroft

--- a/polaris-icons/icons/AttachmentMajor.yml
+++ b/polaris-icons/icons/AttachmentMajor.yml
@@ -1,4 +1,4 @@
-name: attachment
+name: Attachment
 set: major
 description: Used to represent an attachment.
 keywords:

--- a/polaris-icons/icons/AutomationMajor.yml
+++ b/polaris-icons/icons/AutomationMajor.yml
@@ -1,4 +1,4 @@
-name: automation
+name: Automation
 set: major
 authors:
   - Adam Whitcroft

--- a/polaris-icons/icons/BackspaceMajor.yml
+++ b/polaris-icons/icons/BackspaceMajor.yml
@@ -1,4 +1,4 @@
-name: backspace
+name: Backspace
 set: major
 description: Used to represent backspace on a mobile keyboard.
 keywords:

--- a/polaris-icons/icons/BalanceMajor.yml
+++ b/polaris-icons/icons/BalanceMajor.yml
@@ -1,4 +1,4 @@
-name: balance
+name: Balance
 set: major
 description: The account’s current balance. This amount is comprised of any transaction not yet included in a payout.
 keywords:

--- a/polaris-icons/icons/BankMajor.yml
+++ b/polaris-icons/icons/BankMajor.yml
@@ -1,4 +1,4 @@
-name: bank
+name: Bank
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/BarcodeMajor.yml
+++ b/polaris-icons/icons/BarcodeMajor.yml
@@ -1,4 +1,4 @@
-name: barcode
+name: Barcode
 set: major
 description: Used to represent a barcode.
 keywords:

--- a/polaris-icons/icons/BehaviorMajor.yml
+++ b/polaris-icons/icons/BehaviorMajor.yml
@@ -1,4 +1,4 @@
-name: behavior
+name: Behavior
 set: major
 description: Used to represent a user clicking, or interacting with something.
 keywords:

--- a/polaris-icons/icons/BehaviorMinor.yml
+++ b/polaris-icons/icons/BehaviorMinor.yml
@@ -1,4 +1,4 @@
-name: behavior
+name: Behavior
 set: minor
 description: Used to represent a user clicking, or interacting with something.
 keywords:

--- a/polaris-icons/icons/BillingStatementDollarMajor.yml
+++ b/polaris-icons/icons/BillingStatementDollarMajor.yml
@@ -1,4 +1,4 @@
-name: billing statement (dollar)
+name: Billing statement (dollar)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/BillingStatementEuroMajor.yml
+++ b/polaris-icons/icons/BillingStatementEuroMajor.yml
@@ -1,4 +1,4 @@
-name: billing statement (euro)
+name: Billing statement (euro)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/BillingStatementPoundMajor.yml
+++ b/polaris-icons/icons/BillingStatementPoundMajor.yml
@@ -1,4 +1,4 @@
-name: billing statement (pound)
+name: Billing statement (pound)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/BillingStatementRupeeMajor.yml
+++ b/polaris-icons/icons/BillingStatementRupeeMajor.yml
@@ -1,4 +1,4 @@
-name: billing statement (rupee)
+name: Billing statement (rupee)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/BillingStatementYenMajor.yml
+++ b/polaris-icons/icons/BillingStatementYenMajor.yml
@@ -1,4 +1,4 @@
-name: billing statement (yen)
+name: Billing statement (yen)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/BlockMinor.yml
+++ b/polaris-icons/icons/BlockMinor.yml
@@ -1,4 +1,4 @@
-name: block
+name: Block
 set: minor
 description: Used to represent a content block as a sub-element of a section, page or layout.
 keywords:

--- a/polaris-icons/icons/BlockquoteMajor.yml
+++ b/polaris-icons/icons/BlockquoteMajor.yml
@@ -1,4 +1,4 @@
-name: blockquote
+name: Blockquote
 set: major
 description: Used to represent a quote.
 keywords:

--- a/polaris-icons/icons/BlogMajor.yml
+++ b/polaris-icons/icons/BlogMajor.yml
@@ -1,4 +1,4 @@
-name: blog
+name: Blog
 set: major
 description: Used to represent a blog post, or something being written.
 keywords:

--- a/polaris-icons/icons/BugMajor.yml
+++ b/polaris-icons/icons/BugMajor.yml
@@ -1,4 +1,4 @@
-name: bug
+name: Bug
 set: major
 description: Used to represent a bug in code.
 keywords:

--- a/polaris-icons/icons/ButtonCornerPillMajor.yml
+++ b/polaris-icons/icons/ButtonCornerPillMajor.yml
@@ -1,4 +1,4 @@
-name: button corner pill
+name: Button corner pill
 set: major
 description: Used to represent the corner shape of a button.
 keywords:

--- a/polaris-icons/icons/ButtonCornerRoundedMajor.yml
+++ b/polaris-icons/icons/ButtonCornerRoundedMajor.yml
@@ -1,4 +1,4 @@
-name: button corner rounded
+name: Button corner rounded
 set: major
 description: Used to represent the corner shape of a button.
 keywords:

--- a/polaris-icons/icons/ButtonCornerSquareMajor.yml
+++ b/polaris-icons/icons/ButtonCornerSquareMajor.yml
@@ -1,4 +1,4 @@
-name: button corner square
+name: Button corner square
 set: major
 description: Used to represent the corner shape of a button.
 keywords:

--- a/polaris-icons/icons/ButtonMinor.yml
+++ b/polaris-icons/icons/ButtonMinor.yml
@@ -1,4 +1,4 @@
-name: button
+name: Button
 set: minor
 description: Used to represent a button block appearing as a sub-element of a section, page or layout.
 keywords:

--- a/polaris-icons/icons/BuyButtonButtonLayoutMajor.yml
+++ b/polaris-icons/icons/BuyButtonButtonLayoutMajor.yml
@@ -1,4 +1,4 @@
-name: buy button button layout
+name: Buy button button layout
 set: major
 description: Used to represent a centered layout for our Buy Button.
 keywords:

--- a/polaris-icons/icons/BuyButtonHorizontalLayoutMajor.yml
+++ b/polaris-icons/icons/BuyButtonHorizontalLayoutMajor.yml
@@ -1,4 +1,4 @@
-name: buy button horizontal layout
+name: Buy button horizontal layout
 set: major
 description: Used to represent a horizontal layout for our Buy Button.
 keywords:

--- a/polaris-icons/icons/BuyButtonMajor.yml
+++ b/polaris-icons/icons/BuyButtonMajor.yml
@@ -1,4 +1,4 @@
-name: buy button
+name: Buy button
 set: major
 description: Used to represent our Buy Button.
 keywords:

--- a/polaris-icons/icons/BuyButtonVerticalLayoutMajor.yml
+++ b/polaris-icons/icons/BuyButtonVerticalLayoutMajor.yml
@@ -1,4 +1,4 @@
-name: buy button vertical layout
+name: Buy button vertical layout
 set: major
 description: Used to represent a vertical layout for our Buy Button.
 keywords:

--- a/polaris-icons/icons/CalendarMajor.yml
+++ b/polaris-icons/icons/CalendarMajor.yml
@@ -1,4 +1,4 @@
-name: calendar
+name: Calendar
 set: major
 description: Used to represent a calendar.
 keywords:

--- a/polaris-icons/icons/CalendarMinor.yml
+++ b/polaris-icons/icons/CalendarMinor.yml
@@ -1,4 +1,4 @@
-name: calendar
+name: Calendar
 set: minor
 description: Used to denote the action of opening a date picker.
 keywords:

--- a/polaris-icons/icons/CalendarTickMajor.yml
+++ b/polaris-icons/icons/CalendarTickMajor.yml
@@ -1,4 +1,4 @@
-name: calendar tick
+name: Calendar tick
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/CameraMajor.yml
+++ b/polaris-icons/icons/CameraMajor.yml
@@ -1,4 +1,4 @@
-name: camera
+name: Camera
 set: major
 description: Used to represent a camera.
 keywords:

--- a/polaris-icons/icons/CancelSmallMinor.yml
+++ b/polaris-icons/icons/CancelSmallMinor.yml
@@ -1,4 +1,4 @@
-name: cancel small
+name: Cancel small
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/CapitalMajor.yml
+++ b/polaris-icons/icons/CapitalMajor.yml
@@ -1,4 +1,4 @@
-name: capital
+name: Capital
 set: major
 description: Used to help direct merchants to the Capital page
 keywords:

--- a/polaris-icons/icons/CapturePaymentMinor.yml
+++ b/polaris-icons/icons/CapturePaymentMinor.yml
@@ -1,4 +1,4 @@
-name: capture payment
+name: Capture payment
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/CardReaderChipMajor.yml
+++ b/polaris-icons/icons/CardReaderChipMajor.yml
@@ -1,4 +1,4 @@
-name: card reader chip
+name: Card reader chip
 set: major
 description: Used to represent a card chip reader.
 keywords:

--- a/polaris-icons/icons/CardReaderMajor.yml
+++ b/polaris-icons/icons/CardReaderMajor.yml
@@ -1,4 +1,4 @@
-name: card reader
+name: Card reader
 set: major
 description: Used to represent the Shopify Tap and Chip reader.
 keywords:

--- a/polaris-icons/icons/CardReaderTapMajor.yml
+++ b/polaris-icons/icons/CardReaderTapMajor.yml
@@ -1,4 +1,4 @@
-name: card reader tap
+name: Card reader tap
 set: major
 description: Used to represent the Shopify Tap and Chip reader.
 keywords:

--- a/polaris-icons/icons/CaretDownMinor.yml
+++ b/polaris-icons/icons/CaretDownMinor.yml
@@ -1,4 +1,4 @@
-name: caret down
+name: Caret down
 set: minor
 description: Used to denote the action of expanding a section to reveal more content, like a popover or an accordion. Also used to represent sorting order.
 keywords:

--- a/polaris-icons/icons/CaretUpMinor.yml
+++ b/polaris-icons/icons/CaretUpMinor.yml
@@ -1,4 +1,4 @@
-name: caret up
+name: Caret up
 set: minor
 description: Used to denote the action of contracting a section to hide additional content, like an accordion. Also used to represent sorting order.
 keywords:

--- a/polaris-icons/icons/CartDownMajor.yml
+++ b/polaris-icons/icons/CartDownMajor.yml
@@ -1,4 +1,4 @@
-name: cart down
+name: Cart down
 set: major
 description: Used to represent saving the contents of a shopping cart.
 keywords:

--- a/polaris-icons/icons/CartMajor.yml
+++ b/polaris-icons/icons/CartMajor.yml
@@ -1,4 +1,4 @@
-name: cart
+name: Cart
 set: major
 description: Used to represent a shopping cart.
 keywords:

--- a/polaris-icons/icons/CartUpMajor.yml
+++ b/polaris-icons/icons/CartUpMajor.yml
@@ -1,4 +1,4 @@
-name: cart up
+name: Cart up
 set: major
 description: Used to represent retrieving the contents of saved shopping cart.
 keywords:

--- a/polaris-icons/icons/CashDollarMajor.yml
+++ b/polaris-icons/icons/CashDollarMajor.yml
@@ -1,4 +1,4 @@
-name: cash (dollar)
+name: Cash (dollar)
 set: major
 description: Used to represent Dollar currency.
 keywords:

--- a/polaris-icons/icons/CashEuroMajor.yml
+++ b/polaris-icons/icons/CashEuroMajor.yml
@@ -1,4 +1,4 @@
-name: cash (euro)
+name: Cash (euro)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/CashPoundMajor.yml
+++ b/polaris-icons/icons/CashPoundMajor.yml
@@ -1,4 +1,4 @@
-name: cash (pound)
+name: Cash (pound)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/CashRupeeMajor.yml
+++ b/polaris-icons/icons/CashRupeeMajor.yml
@@ -1,4 +1,4 @@
-name: cash (rupee)
+name: Cash (rupee)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/CashYenMajor.yml
+++ b/polaris-icons/icons/CashYenMajor.yml
@@ -1,4 +1,4 @@
-name: cash (yen)
+name: Cash (yen)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/CategoriesMajor.yml
+++ b/polaris-icons/icons/CategoriesMajor.yml
@@ -1,4 +1,4 @@
-name: categories
+name: Categories
 set: major
 description: Used to represent either list of categories or files.
 keywords:

--- a/polaris-icons/icons/ChannelsMajor.yml
+++ b/polaris-icons/icons/ChannelsMajor.yml
@@ -1,4 +1,4 @@
-name: channels
+name: Channels
 set: major
 description: Used to represent channels, or items connected by a common root.
 keywords:

--- a/polaris-icons/icons/ChatMajor.yml
+++ b/polaris-icons/icons/ChatMajor.yml
@@ -1,4 +1,4 @@
-name: chat
+name: Chat
 set: major
 description: Used to represent a conversation, or verbal communication.
 keywords:

--- a/polaris-icons/icons/ChecklistAlternateMajor.yml
+++ b/polaris-icons/icons/ChecklistAlternateMajor.yml
@@ -1,4 +1,4 @@
-name: checklist alternate
+name: Checklist alternate
 set: major
 description: Used to represent a checklist.
 keywords:

--- a/polaris-icons/icons/ChecklistMajor.yml
+++ b/polaris-icons/icons/ChecklistMajor.yml
@@ -1,4 +1,4 @@
-name: checklist
+name: Checklist
 set: major
 description: Used to represent a completed checklist.
 keywords:

--- a/polaris-icons/icons/CheckoutMajor.yml
+++ b/polaris-icons/icons/CheckoutMajor.yml
@@ -1,4 +1,4 @@
-name: checkout
+name: Checkout
 set: major
 description: Used to represent a shopping cart.
 keywords:

--- a/polaris-icons/icons/ChevronDownMinor.yml
+++ b/polaris-icons/icons/ChevronDownMinor.yml
@@ -1,4 +1,4 @@
-name: chevron down
+name: Chevron down
 set: minor
 description: Used to denote the action of expanding a section to reveal more content.
 keywords:

--- a/polaris-icons/icons/ChevronLeftMinor.yml
+++ b/polaris-icons/icons/ChevronLeftMinor.yml
@@ -1,4 +1,4 @@
-name: chevron left
+name: Chevron left
 set: minor
 description: Used to indicate that merchants will be directed to their previous location or to navigate to a previous item.
 keywords:

--- a/polaris-icons/icons/ChevronRightMinor.yml
+++ b/polaris-icons/icons/ChevronRightMinor.yml
@@ -1,4 +1,4 @@
-name: chevron right
+name: Chevron right
 set: minor
 description: Used to indicate that merchants will be directed to the next item.
 keywords:

--- a/polaris-icons/icons/ChevronUpMinor.yml
+++ b/polaris-icons/icons/ChevronUpMinor.yml
@@ -1,4 +1,4 @@
-name: chevron up
+name: Chevron up
 set: minor
 description: Used to denote the action of contracting a section to hide additional content.
 keywords:

--- a/polaris-icons/icons/CircleAlertMajor.yml
+++ b/polaris-icons/icons/CircleAlertMajor.yml
@@ -1,4 +1,4 @@
-name: circle alert
+name: Circle alert
 set: major
 description: Used to give merchants more information about something they should be aware of.
 keywords:

--- a/polaris-icons/icons/CircleCancelMajor.yml
+++ b/polaris-icons/icons/CircleCancelMajor.yml
@@ -1,4 +1,4 @@
-name: circle cancel
+name: Circle cancel
 set: major
 description: Used to represent an action to cancel or remove an item or resource.
 keywords:

--- a/polaris-icons/icons/CircleCancelMinor.yml
+++ b/polaris-icons/icons/CircleCancelMinor.yml
@@ -1,4 +1,4 @@
-name: circle cancel
+name: Circle cancel
 set: minor
 description: Used to represent an action to cancel or remove an item or resource.
 keywords:

--- a/polaris-icons/icons/CircleChevronDownMinor.yml
+++ b/polaris-icons/icons/CircleChevronDownMinor.yml
@@ -1,4 +1,4 @@
-name: circle chevron down
+name: Circle chevron down
 set: minor
 description: Used to represent a collapsible section, or an action to navigate down.
 keywords:

--- a/polaris-icons/icons/CircleChevronLeftMinor.yml
+++ b/polaris-icons/icons/CircleChevronLeftMinor.yml
@@ -1,4 +1,4 @@
-name: circle chevron left
+name: Circle chevron left
 set: minor
 description: Used to represent an action to navigate back.
 keywords:

--- a/polaris-icons/icons/CircleChevronRightMinor.yml
+++ b/polaris-icons/icons/CircleChevronRightMinor.yml
@@ -1,4 +1,4 @@
-name: circle chevron right
+name: Circle chevron right
 set: minor
 description: Used to help direct merchants from a item’s name in a list to the item’s show page.
 keywords:

--- a/polaris-icons/icons/CircleChevronUpMinor.yml
+++ b/polaris-icons/icons/CircleChevronUpMinor.yml
@@ -1,4 +1,4 @@
-name: circle chevron up
+name: Circle chevron up
 set: minor
 description: Used to represent a collapsible section, or an action to navigate up.
 keywords:

--- a/polaris-icons/icons/CircleDisableMinor.yml
+++ b/polaris-icons/icons/CircleDisableMinor.yml
@@ -1,4 +1,4 @@
-name: circle disable
+name: Circle disable
 set: minor
 description: Used to denote the action of disabling something, like a discount code.
 keywords:

--- a/polaris-icons/icons/CircleDisabledMajor.yml
+++ b/polaris-icons/icons/CircleDisabledMajor.yml
@@ -1,4 +1,4 @@
-name: circle disabled
+name: Circle disabled
 set: major
 description: Used to represent an item or resource that is disabled, or an action that is not allowed.
 keywords:

--- a/polaris-icons/icons/CircleDotsMajor.yml
+++ b/polaris-icons/icons/CircleDotsMajor.yml
@@ -1,4 +1,4 @@
-name: circle dots
+name: Circle dots
 set: major
 description: Used to represent an action to reveal a menu, or more options.
 keywords:

--- a/polaris-icons/icons/CircleDownMajor.yml
+++ b/polaris-icons/icons/CircleDownMajor.yml
@@ -1,4 +1,4 @@
-name: circle down
+name: Circle down
 set: major
 description: Used to represent downwards navigation, or that something is below it.
 keywords:

--- a/polaris-icons/icons/CircleInformationMajor.yml
+++ b/polaris-icons/icons/CircleInformationMajor.yml
@@ -1,4 +1,4 @@
-name: circle information
+name: Circle information
 set: major
 description: Used to represent a hint, or draw attention to a piece of information.
 keywords:

--- a/polaris-icons/icons/CircleLeftMajor.yml
+++ b/polaris-icons/icons/CircleLeftMajor.yml
@@ -1,4 +1,4 @@
-name: circle left
+name: Circle left
 set: major
 description: Used to represent backwards naviagation, or that something is before it.
 keywords:

--- a/polaris-icons/icons/CircleMinusMajor.yml
+++ b/polaris-icons/icons/CircleMinusMajor.yml
@@ -1,4 +1,4 @@
-name: circle minus
+name: Circle minus
 set: major
 description: Used to represent an action to remove an item or resource, or decrease the quantity of an item or resource.
 keywords:

--- a/polaris-icons/icons/CircleMinusMinor.yml
+++ b/polaris-icons/icons/CircleMinusMinor.yml
@@ -1,4 +1,4 @@
-name: circle minus
+name: Circle minus
 set: minor
 description: Used to represent an action to remove an item or resource, or decrease the quantity of an item or resource.
 keywords:

--- a/polaris-icons/icons/CircleMinusOutlineMinor.yml
+++ b/polaris-icons/icons/CircleMinusOutlineMinor.yml
@@ -1,4 +1,4 @@
-name: circle minus outline
+name: Circle minus outline
 set: minor
 description: Used to represent an action to remove an item or resource, or decrease the quantity of an item or resource.
 keywords:

--- a/polaris-icons/icons/CirclePlusMajor.yml
+++ b/polaris-icons/icons/CirclePlusMajor.yml
@@ -1,4 +1,4 @@
-name: circle plus
+name: Circle plus
 set: major
 description: Similar to the plus icons, used to indicate adding something.
 keywords:

--- a/polaris-icons/icons/CirclePlusMinor.yml
+++ b/polaris-icons/icons/CirclePlusMinor.yml
@@ -1,4 +1,4 @@
-name: circle plus
+name: Circle plus
 set: minor
 description: Used to represent an action to add an item or resource, or increase the quantity of an item or resource.
 keywords:

--- a/polaris-icons/icons/CirclePlusOutlineMinor.yml
+++ b/polaris-icons/icons/CirclePlusOutlineMinor.yml
@@ -1,4 +1,4 @@
-name: circle plus outline
+name: Circle plus outline
 set: minor
 description: Used to denote the action of adding new content, like adding a new variant option name in the mobile app.
 keywords:

--- a/polaris-icons/icons/CircleRightMajor.yml
+++ b/polaris-icons/icons/CircleRightMajor.yml
@@ -1,4 +1,4 @@
-name: circle right
+name: Circle right
 set: major
 description: Used to represent forwards naviagation, or that something is after it.
 keywords:

--- a/polaris-icons/icons/CircleTickMajor.yml
+++ b/polaris-icons/icons/CircleTickMajor.yml
@@ -1,4 +1,4 @@
-name: circle tick
+name: Circle tick
 set: major
 description: Used to represent an action to approve or confirm.
 keywords:

--- a/polaris-icons/icons/CircleTickMinor.yml
+++ b/polaris-icons/icons/CircleTickMinor.yml
@@ -1,4 +1,4 @@
-name: circle tick
+name: Circle tick
 set: minor
 description: Used to represent an action to approve or confirm.
 keywords:

--- a/polaris-icons/icons/CircleTickOutlineMinor.yml
+++ b/polaris-icons/icons/CircleTickOutlineMinor.yml
@@ -1,4 +1,4 @@
-name: circle tick outline
+name: Circle tick outline
 set: minor
 description: Used to represent an action to approve or confirm.
 keywords:

--- a/polaris-icons/icons/CircleUpMajor.yml
+++ b/polaris-icons/icons/CircleUpMajor.yml
@@ -1,4 +1,4 @@
-name: circle up
+name: Circle up
 set: major
 description: Used to represent upwards naviagation, or that something is above it.
 keywords:

--- a/polaris-icons/icons/ClipboardMinor.yml
+++ b/polaris-icons/icons/ClipboardMinor.yml
@@ -1,4 +1,4 @@
-name: clipboard
+name: Clipboard
 set: minor
 description: Used to represent a clipboard, usually accompanying a copy action.
 keywords:

--- a/polaris-icons/icons/ClockMajor.yml
+++ b/polaris-icons/icons/ClockMajor.yml
@@ -1,4 +1,4 @@
-name: clock
+name: Clock
 set: major
 description: Used to represent a clock, or the time.
 keywords:

--- a/polaris-icons/icons/ClockMinor.yml
+++ b/polaris-icons/icons/ClockMinor.yml
@@ -1,4 +1,4 @@
-name: clock
+name: Clock
 set: minor
 description: Used to indicate time.
 keywords:

--- a/polaris-icons/icons/CodeMajor.yml
+++ b/polaris-icons/icons/CodeMajor.yml
@@ -1,4 +1,4 @@
-name: code
+name: Code
 set: major
 description: Used to represent programming.
 keywords:

--- a/polaris-icons/icons/CollectionsMajor.yml
+++ b/polaris-icons/icons/CollectionsMajor.yml
@@ -1,4 +1,4 @@
-name: collections
+name: Collections
 set: major
 description: Used to represent a collection of products.
 keywords:

--- a/polaris-icons/icons/ColorNoneMinor.yml
+++ b/polaris-icons/icons/ColorNoneMinor.yml
@@ -1,4 +1,4 @@
-name: color none
+name: Color none
 set: minor
 description: Used to represent a lack of color, or that a color is not allowed or available.
 keywords:

--- a/polaris-icons/icons/ColorsMajor.yml
+++ b/polaris-icons/icons/ColorsMajor.yml
@@ -1,4 +1,4 @@
-name: colors
+name: Colors
 set: major
 description: Used to represent a color swatch, or palette of colors.
 keywords:

--- a/polaris-icons/icons/Column1Major.yml
+++ b/polaris-icons/icons/Column1Major.yml
@@ -1,4 +1,4 @@
-name: column 1
+name: Column 1
 set: major
 description: Used to represent a 1 column layout.
 keywords:

--- a/polaris-icons/icons/ColumnWithTextMajor.yml
+++ b/polaris-icons/icons/ColumnWithTextMajor.yml
@@ -1,4 +1,4 @@
-name: column with text
+name: Column with text
 set: major
 description: Used to represent a layout option of two columns, each featuring an image and text.
 keywords:

--- a/polaris-icons/icons/Columns2Major.yml
+++ b/polaris-icons/icons/Columns2Major.yml
@@ -1,4 +1,4 @@
-name: columns 2
+name: Columns 2
 set: major
 description: Used to represent a 2 column layout.
 keywords:

--- a/polaris-icons/icons/Columns3Major.yml
+++ b/polaris-icons/icons/Columns3Major.yml
@@ -1,4 +1,4 @@
-name: columns 3
+name: Columns 3
 set: major
 description: Used to represent a 3 column layout.
 keywords:

--- a/polaris-icons/icons/Columns3Minor.yml
+++ b/polaris-icons/icons/Columns3Minor.yml
@@ -1,4 +1,4 @@
-name: columns 3
+name: Columns 3
 set: minor
 description: Used to represent a 3 column layout or an action to hide or show columns
 keywords:

--- a/polaris-icons/icons/ComposeMajor.yml
+++ b/polaris-icons/icons/ComposeMajor.yml
@@ -1,4 +1,4 @@
-name: compose
+name: Compose
 set: major
 description: Used to denote the action of composing a new message.
 keywords:

--- a/polaris-icons/icons/ConfettiMajor.yml
+++ b/polaris-icons/icons/ConfettiMajor.yml
@@ -1,4 +1,4 @@
-name: confetti
+name: Confetti
 set: major
 description: Used to represent a moment of celebration, or to call attention to something fun or new.
 keywords:

--- a/polaris-icons/icons/ConnectMinor.yml
+++ b/polaris-icons/icons/ConnectMinor.yml
@@ -1,4 +1,4 @@
-name: connect
+name: Connect
 set: minor
 description: Used to represent a connection between two items or resources.
 keywords:

--- a/polaris-icons/icons/ConversationMinor.yml
+++ b/polaris-icons/icons/ConversationMinor.yml
@@ -1,4 +1,4 @@
-name: conversation
+name: Conversation
 set: minor
 description: Used to give merchants an indication of comments attached to an order.
 keywords:

--- a/polaris-icons/icons/CreditCardCancelMajor.yml
+++ b/polaris-icons/icons/CreditCardCancelMajor.yml
@@ -1,4 +1,4 @@
-name: credit card cancel
+name: Credit card cancel
 set: major
 description: Used to represent a cancellation related to a charge
 keywords:

--- a/polaris-icons/icons/CreditCardMajor.yml
+++ b/polaris-icons/icons/CreditCardMajor.yml
@@ -1,4 +1,4 @@
-name: credit card
+name: Credit card
 set: major
 description: Used to represent a credit card.
 keywords:

--- a/polaris-icons/icons/CreditCardPercentMajor.yml
+++ b/polaris-icons/icons/CreditCardPercentMajor.yml
@@ -1,4 +1,4 @@
-name: credit card percent
+name: Credit card percent
 set: major
 description: Used to represent a credit card interest.
 keywords:

--- a/polaris-icons/icons/CreditCardSecureMajor.yml
+++ b/polaris-icons/icons/CreditCardSecureMajor.yml
@@ -1,4 +1,4 @@
-name: credit card secure
+name: Credit card secure
 set: major
 description: Used to represent a secured credit card.
 keywords:

--- a/polaris-icons/icons/CurrencyConvertMinor.yml
+++ b/polaris-icons/icons/CurrencyConvertMinor.yml
@@ -1,4 +1,4 @@
-name: currency convert
+name: Currency convert
 set: minor
 description: Used to represent currency conversion.
 keywords:

--- a/polaris-icons/icons/CustomerMinusMajor.yml
+++ b/polaris-icons/icons/CustomerMinusMajor.yml
@@ -1,4 +1,4 @@
-name: customer minus
+name: Customer minus
 set: major
 description: Used to represent removing a customer, or user.
 keywords:

--- a/polaris-icons/icons/CustomerPlusMajor.yml
+++ b/polaris-icons/icons/CustomerPlusMajor.yml
@@ -1,4 +1,4 @@
-name: customer plus
+name: Customer plus
 set: major
 description: Used to represent adding a customer, or user.
 keywords:

--- a/polaris-icons/icons/CustomersMajor.yml
+++ b/polaris-icons/icons/CustomersMajor.yml
@@ -1,4 +1,4 @@
-name: customers
+name: Customers
 set: major
 description: Used to represent a customer, or user.
 keywords:

--- a/polaris-icons/icons/CustomersMinor.yml
+++ b/polaris-icons/icons/CustomersMinor.yml
@@ -1,4 +1,4 @@
-name: customers
+name: Customers
 set: minor
 description: Used to represent a customer, or user.
 keywords:

--- a/polaris-icons/icons/DataVisualizationMajor.yml
+++ b/polaris-icons/icons/DataVisualizationMajor.yml
@@ -1,4 +1,4 @@
-name: data visualization
+name: Data visualization
 set: major
 description: Used to represent a presentation or graph.
 keywords:

--- a/polaris-icons/icons/DeleteMajor.yml
+++ b/polaris-icons/icons/DeleteMajor.yml
@@ -1,4 +1,4 @@
-name: delete
+name: Delete
 set: major
 description: Used to represent a trash can, or an action to remove or delete an item or resource.
 keywords:

--- a/polaris-icons/icons/DeleteMinor.yml
+++ b/polaris-icons/icons/DeleteMinor.yml
@@ -1,4 +1,4 @@
-name: delete
+name: Delete
 set: minor
 description: Used to denote a destructive action to delete an item.
 keywords:

--- a/polaris-icons/icons/DesktopMajor.yml
+++ b/polaris-icons/icons/DesktopMajor.yml
@@ -1,4 +1,4 @@
-name: desktop
+name: Desktop
 set: major
 description: Used to represent a large screen or desktop computer.
 keywords:

--- a/polaris-icons/icons/DetailedPopUpMajor.yml
+++ b/polaris-icons/icons/DetailedPopUpMajor.yml
@@ -1,4 +1,4 @@
-name: detailed pop up
+name: Detailed pop up
 set: major
 description: Used to represent the option to popup the content.
 keywords:

--- a/polaris-icons/icons/DiamondAlertMajor.yml
+++ b/polaris-icons/icons/DiamondAlertMajor.yml
@@ -1,4 +1,4 @@
-name: diamond alert
+name: Diamond alert
 set: major
 description: Used to alert merchants on information they should be aware of.
 keywords:

--- a/polaris-icons/icons/DigitalMediaReceiverMajor.yml
+++ b/polaris-icons/icons/DigitalMediaReceiverMajor.yml
@@ -1,4 +1,4 @@
-name: digital media receiver
+name: Digital media receiver
 set: major
 description: Used to represent a digital receiver or wireless network device.
 keywords:

--- a/polaris-icons/icons/DiscountAutomaticMajor.yml
+++ b/polaris-icons/icons/DiscountAutomaticMajor.yml
@@ -1,4 +1,4 @@
-name: discount automatic
+name: Discount automatic
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/DiscountCodeMajor.yml
+++ b/polaris-icons/icons/DiscountCodeMajor.yml
@@ -1,4 +1,4 @@
-name: discount code
+name: Discount code
 set: major
 description: Used to represent a discount code or coupon.
 keywords:

--- a/polaris-icons/icons/DiscountsMajor.yml
+++ b/polaris-icons/icons/DiscountsMajor.yml
@@ -1,4 +1,4 @@
-name: discounts
+name: Discounts
 set: major
 description: Used to represent a discount.
 keywords:

--- a/polaris-icons/icons/DiscountsMinor.yml
+++ b/polaris-icons/icons/DiscountsMinor.yml
@@ -1,4 +1,4 @@
-name: discounts
+name: Discounts
 set: minor
 description: Used to represent a discount.
 keywords:

--- a/polaris-icons/icons/DisputeMinor.yml
+++ b/polaris-icons/icons/DisputeMinor.yml
@@ -1,4 +1,4 @@
-name: dispute
+name: Dispute
 set: minor
 description: Used to represent a dispute or important conversation or notification.
 keywords:

--- a/polaris-icons/icons/DnsSettingsMajor.yml
+++ b/polaris-icons/icons/DnsSettingsMajor.yml
@@ -1,4 +1,4 @@
-name: dns settings
+name: Dns settings
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/DomainNewMajor.yml
+++ b/polaris-icons/icons/DomainNewMajor.yml
@@ -1,4 +1,4 @@
-name: domain new
+name: Domain new
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/DomainRedirectMinor.yml
+++ b/polaris-icons/icons/DomainRedirectMinor.yml
@@ -1,4 +1,4 @@
-name: domain redirect
+name: Domain redirect
 set: minor
 description: Used to represent a redirect domain.
 keywords:

--- a/polaris-icons/icons/DomainsMajor.yml
+++ b/polaris-icons/icons/DomainsMajor.yml
@@ -1,4 +1,4 @@
-name: domains
+name: Domains
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/DraftOrdersMajor.yml
+++ b/polaris-icons/icons/DraftOrdersMajor.yml
@@ -1,4 +1,4 @@
-name: draft orders
+name: Draft orders
 set: major
 description: Used to represent an order that is in a Draft state.
 keywords:

--- a/polaris-icons/icons/DragDropMajor.yml
+++ b/polaris-icons/icons/DragDropMajor.yml
@@ -1,4 +1,4 @@
-name: drag drop
+name: Drag drop
 set: major
 description: Used to represent drag and drop.
 keywords:

--- a/polaris-icons/icons/DragHandleMinor.yml
+++ b/polaris-icons/icons/DragHandleMinor.yml
@@ -1,4 +1,4 @@
-name: drag handle
+name: Drag handle
 set: minor
 description: Used to represent drag handles.
 keywords:

--- a/polaris-icons/icons/DropdownMinor.yml
+++ b/polaris-icons/icons/DropdownMinor.yml
@@ -1,4 +1,4 @@
-name: dropdown
+name: Dropdown
 set: minor
 description: Used to represent there is dropdown content
 keywords:

--- a/polaris-icons/icons/DuplicateMinor.yml
+++ b/polaris-icons/icons/DuplicateMinor.yml
@@ -1,4 +1,4 @@
-name: duplicate
+name: Duplicate
 set: minor
 description: Used to denote the action of duplicating orders, to save as (reports), and to copy content to clipboard like an address.
 keywords:

--- a/polaris-icons/icons/EditMajor.yml
+++ b/polaris-icons/icons/EditMajor.yml
@@ -1,4 +1,4 @@
-name: edit
+name: Edit
 set: major
 description: Used to represent an action to edit an item or resource.
 keywords:

--- a/polaris-icons/icons/EditMinor.yml
+++ b/polaris-icons/icons/EditMinor.yml
@@ -1,4 +1,4 @@
-name: edit
+name: Edit
 set: minor
 description: Used to represent the action of editing or modifying information.
 keywords:

--- a/polaris-icons/icons/EmailMajor.yml
+++ b/polaris-icons/icons/EmailMajor.yml
@@ -1,4 +1,4 @@
-name: email
+name: Email
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/EmailNewsletterMajor.yml
+++ b/polaris-icons/icons/EmailNewsletterMajor.yml
@@ -1,4 +1,4 @@
-name: email newsletter
+name: Email newsletter
 set: major
 description: Used to represent an opened email or letter.
 keywords:

--- a/polaris-icons/icons/EmbedMinor.yml
+++ b/polaris-icons/icons/EmbedMinor.yml
@@ -1,4 +1,4 @@
-name: embed
+name: Embed
 set: minor
 description: Used to represent an object embedded from a web resource.
 keywords:

--- a/polaris-icons/icons/EnableSelectionMinor.yml
+++ b/polaris-icons/icons/EnableSelectionMinor.yml
@@ -1,4 +1,4 @@
-name: enable selection
+name: Enable selection
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/EnvelopeMajor.yml
+++ b/polaris-icons/icons/EnvelopeMajor.yml
@@ -1,4 +1,4 @@
-name: envelope
+name: Envelope
 set: major
 description: Used to represent an envelope that merchants can use to ship orders to their customers.
 keywords:

--- a/polaris-icons/icons/ExchangeMajor.yml
+++ b/polaris-icons/icons/ExchangeMajor.yml
@@ -1,4 +1,4 @@
-name: exchange
+name: Exchange
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ExistingInventoryMajor.yml
+++ b/polaris-icons/icons/ExistingInventoryMajor.yml
@@ -1,4 +1,4 @@
-name: existing inventory
+name: Existing inventory
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ExitMajor.yml
+++ b/polaris-icons/icons/ExitMajor.yml
@@ -1,4 +1,4 @@
-name: exit
+name: Exit
 set: major
 description: Used to denote the action of exiting an app, channel, or workflow.
 keywords:

--- a/polaris-icons/icons/ExportMinor.yml
+++ b/polaris-icons/icons/ExportMinor.yml
@@ -1,4 +1,4 @@
-name: export
+name: Export
 set: minor
 description: Used to denote the action of exporting content.
 keywords:

--- a/polaris-icons/icons/ExternalMinor.yml
+++ b/polaris-icons/icons/ExternalMinor.yml
@@ -1,4 +1,4 @@
-name: external
+name: External
 set: minor
 description: Used to denote the action of navigating to an external resource.
 keywords:

--- a/polaris-icons/icons/ExternalSmallMinor.yml
+++ b/polaris-icons/icons/ExternalSmallMinor.yml
@@ -1,4 +1,4 @@
-name: external small
+name: External small
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/FaviconMajor.yml
+++ b/polaris-icons/icons/FaviconMajor.yml
@@ -1,4 +1,4 @@
-name: favicon
+name: Favicon
 set: major
 description: Used to represent a favicon.
 keywords:

--- a/polaris-icons/icons/FavoriteMajor.yml
+++ b/polaris-icons/icons/FavoriteMajor.yml
@@ -1,4 +1,4 @@
-name: favorite
+name: Favorite
 set: major
 description: Used to represent an action to favorite or save an item or resource.
 keywords:

--- a/polaris-icons/icons/FeaturedCollectionMajor.yml
+++ b/polaris-icons/icons/FeaturedCollectionMajor.yml
@@ -1,4 +1,4 @@
-name: featured collection
+name: Featured collection
 set: major
 description: Used to represent a featured or favorite collection.
 keywords:

--- a/polaris-icons/icons/FeaturedContentMajor.yml
+++ b/polaris-icons/icons/FeaturedContentMajor.yml
@@ -1,4 +1,4 @@
-name: featured content
+name: Featured content
 set: major
 description: Used to represent a featured or favorite page or content item.
 keywords:

--- a/polaris-icons/icons/FilterMajor.yml
+++ b/polaris-icons/icons/FilterMajor.yml
@@ -1,4 +1,4 @@
-name: filter
+name: Filter
 set: major
 description: Used to represent an action to filter a list of items or resources.
 keywords:

--- a/polaris-icons/icons/FinancesMajor.yml
+++ b/polaris-icons/icons/FinancesMajor.yml
@@ -1,4 +1,4 @@
-name: finances
+name: Finances
 set: major
 description: Used to represent the Finances section.
 keywords:

--- a/polaris-icons/icons/FinancesMinor.yml
+++ b/polaris-icons/icons/FinancesMinor.yml
@@ -1,4 +1,4 @@
-name: finances
+name: Finances
 set: minor
 description: Used to represent the Finances section.
 keywords:

--- a/polaris-icons/icons/FirstOrderMajor.yml
+++ b/polaris-icons/icons/FirstOrderMajor.yml
@@ -1,4 +1,4 @@
-name: first order
+name: First order
 set: major
 description: Used to represent a first order.
 keywords:

--- a/polaris-icons/icons/FirstVisitMajor.yml
+++ b/polaris-icons/icons/FirstVisitMajor.yml
@@ -1,4 +1,4 @@
-name: first visit
+name: First visit
 set: major
 description: Used to represent a first view or visitor.
 keywords:

--- a/polaris-icons/icons/FlagMajor.yml
+++ b/polaris-icons/icons/FlagMajor.yml
@@ -1,4 +1,4 @@
-name: flag
+name: Flag
 set: major
 description: Used to represent a flag.
 keywords:

--- a/polaris-icons/icons/FlipCameraMajor.yml
+++ b/polaris-icons/icons/FlipCameraMajor.yml
@@ -1,4 +1,4 @@
-name: flip camera
+name: Flip camera
 set: major
 description: Used to represent an action to flip a mobile phone camera.
 keywords:

--- a/polaris-icons/icons/FolderDownMajor.yml
+++ b/polaris-icons/icons/FolderDownMajor.yml
@@ -1,4 +1,4 @@
-name: folder down
+name: Folder down
 set: major
 description: Used to represent an action to download a folder.
 keywords:

--- a/polaris-icons/icons/FolderMajor.yml
+++ b/polaris-icons/icons/FolderMajor.yml
@@ -1,4 +1,4 @@
-name: folder
+name: Folder
 set: major
 description: Used to represent a folder.
 keywords:

--- a/polaris-icons/icons/FolderMinusMajor.yml
+++ b/polaris-icons/icons/FolderMinusMajor.yml
@@ -1,4 +1,4 @@
-name: folder minus
+name: Folder minus
 set: major
 description: Used to represent an action to remove a folder.
 keywords:

--- a/polaris-icons/icons/FolderPlusMajor.yml
+++ b/polaris-icons/icons/FolderPlusMajor.yml
@@ -1,4 +1,4 @@
-name: folder plus
+name: Folder plus
 set: major
 description: Used to represent an action to add a folder.
 keywords:

--- a/polaris-icons/icons/FolderUpMajor.yml
+++ b/polaris-icons/icons/FolderUpMajor.yml
@@ -1,4 +1,4 @@
-name: folder up
+name: Folder up
 set: major
 description: Used to represent an action to upload a folder.
 keywords:

--- a/polaris-icons/icons/FollowUpEmailMajor.yml
+++ b/polaris-icons/icons/FollowUpEmailMajor.yml
@@ -1,4 +1,4 @@
-name: follow up email
+name: Follow up email
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/FoodMajor.yml
+++ b/polaris-icons/icons/FoodMajor.yml
@@ -1,4 +1,4 @@
-name: food
+name: Food
 set: major
 description: Used as a navigation item in our emoji picker for the food category.
 keywords:

--- a/polaris-icons/icons/FooterMajor.yml
+++ b/polaris-icons/icons/FooterMajor.yml
@@ -1,4 +1,4 @@
-name: footer
+name: Footer
 set: major
 description: Used to represent the footer section of a component, page or layout.
 keywords:

--- a/polaris-icons/icons/FormsMajor.yml
+++ b/polaris-icons/icons/FormsMajor.yml
@@ -1,4 +1,4 @@
-name: forms
+name: Forms
 set: major
 description: Used to represent a text input for a form.
 keywords:

--- a/polaris-icons/icons/FraudProtectMajor.yml
+++ b/polaris-icons/icons/FraudProtectMajor.yml
@@ -1,4 +1,4 @@
-name: fraud protect
+name: Fraud protect
 set: major
 description: Used to represent that an order is protected by Fraud Protect from chargebacks due to fraud.
 keywords:

--- a/polaris-icons/icons/FraudProtectMinor.yml
+++ b/polaris-icons/icons/FraudProtectMinor.yml
@@ -1,4 +1,4 @@
-name: fraud protect
+name: Fraud protect
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/FraudProtectPendingMajor.yml
+++ b/polaris-icons/icons/FraudProtectPendingMajor.yml
@@ -1,4 +1,4 @@
-name: fraud protect pending
+name: Fraud protect pending
 set: major
 description: Used to represent that the Fraud Protect status is pending.
 keywords:

--- a/polaris-icons/icons/FraudProtectPendingMinor.yml
+++ b/polaris-icons/icons/FraudProtectPendingMinor.yml
@@ -1,4 +1,4 @@
-name: fraud protect pending
+name: Fraud protect pending
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/FraudProtectUnprotectedMajor.yml
+++ b/polaris-icons/icons/FraudProtectUnprotectedMajor.yml
@@ -1,4 +1,4 @@
-name: fraud protect unprotected
+name: Fraud protect unprotected
 set: major
 description: Used to represent that an order is not protected by Fraud Protect from chargebacks due to fraud.
 keywords:

--- a/polaris-icons/icons/FraudProtectUnprotectedMinor.yml
+++ b/polaris-icons/icons/FraudProtectUnprotectedMinor.yml
@@ -1,4 +1,4 @@
-name: fraud protect unprotected
+name: Fraud protect unprotected
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/GamesConsoleMajor.yml
+++ b/polaris-icons/icons/GamesConsoleMajor.yml
@@ -1,4 +1,4 @@
-name: games console
+name: Games console
 set: major
 description: Used to represent a console controller.
 keywords:

--- a/polaris-icons/icons/GiftCardMajor.yml
+++ b/polaris-icons/icons/GiftCardMajor.yml
@@ -1,4 +1,4 @@
-name: gift card
+name: Gift card
 set: major
 description: Used to represent a gift card or present.
 keywords:

--- a/polaris-icons/icons/GiftCardMinor.yml
+++ b/polaris-icons/icons/GiftCardMinor.yml
@@ -1,4 +1,4 @@
-name: gift card
+name: Gift card
 set: minor
 description: Used to represent a gift card or present.
 keywords:

--- a/polaris-icons/icons/GlobeMajor.yml
+++ b/polaris-icons/icons/GlobeMajor.yml
@@ -1,4 +1,4 @@
-name: globe
+name: Globe
 set: major
 description: Used to represent a globe.
 keywords:

--- a/polaris-icons/icons/GlobeMinor.yml
+++ b/polaris-icons/icons/GlobeMinor.yml
@@ -1,4 +1,4 @@
-name: globe
+name: Globe
 set: minor
 description: Used to represent a globe.
 keywords:

--- a/polaris-icons/icons/GrammarMajor.yml
+++ b/polaris-icons/icons/GrammarMajor.yml
@@ -1,4 +1,4 @@
-name: grammar
+name: Grammar
 set: major
 description: Used to represent correct grammar or a spell check.
 keywords:

--- a/polaris-icons/icons/HashtagMajor.yml
+++ b/polaris-icons/icons/HashtagMajor.yml
@@ -1,4 +1,4 @@
-name: hashtag
+name: Hashtag
 set: major
 description: Used to represent a hashtag.
 keywords:

--- a/polaris-icons/icons/HashtagMinor.yml
+++ b/polaris-icons/icons/HashtagMinor.yml
@@ -1,4 +1,4 @@
-name: hashtag
+name: Hashtag
 set: minor
 description: Used to represent a hashtag.
 keywords:

--- a/polaris-icons/icons/HeaderMajor.yml
+++ b/polaris-icons/icons/HeaderMajor.yml
@@ -1,4 +1,4 @@
-name: header
+name: Header
 set: major
 description: Used to represent the header section of a component, page or layout.
 keywords:

--- a/polaris-icons/icons/HeartMajor.yml
+++ b/polaris-icons/icons/HeartMajor.yml
@@ -1,4 +1,4 @@
-name: heart
+name: Heart
 set: major
 description: Used to represent a heart or an action to love or like something.
 keywords:

--- a/polaris-icons/icons/HideKeyboardMajor.yml
+++ b/polaris-icons/icons/HideKeyboardMajor.yml
@@ -1,4 +1,4 @@
-name: hide keyboard
+name: Hide keyboard
 set: major
 description: Used to represent an action to hide the keyboard on a mobile device.
 keywords:

--- a/polaris-icons/icons/HideMinor.yml
+++ b/polaris-icons/icons/HideMinor.yml
@@ -1,4 +1,4 @@
-name: hide
+name: Hide
 set: minor
 description: Used to represent an action to hide something, or to represent a hidden item or resource.
 keywords:

--- a/polaris-icons/icons/HintMajor.yml
+++ b/polaris-icons/icons/HintMajor.yml
@@ -1,4 +1,4 @@
-name: hint
+name: Hint
 set: major
 description: Used to represent a hint or idea.
 keywords:

--- a/polaris-icons/icons/HomeMajor.yml
+++ b/polaris-icons/icons/HomeMajor.yml
@@ -1,4 +1,4 @@
-name: home
+name: Home
 set: major
 description: Used to help direct merchants back to the admin home page.
 keywords:

--- a/polaris-icons/icons/HomeMinor.yml
+++ b/polaris-icons/icons/HomeMinor.yml
@@ -1,4 +1,4 @@
-name: home
+name: Home
 set: minor
 description: Used to help direct merchants back to the admin home page.
 keywords:

--- a/polaris-icons/icons/HorizontalDotsMinor.yml
+++ b/polaris-icons/icons/HorizontalDotsMinor.yml
@@ -1,4 +1,4 @@
-name: horizontal dots
+name: Horizontal dots
 set: minor
 description: Used to represent additional actions in areas where three or more actions are used.
 keywords:

--- a/polaris-icons/icons/ICON_TEMPLATES/IconNameSet.yml
+++ b/polaris-icons/icons/ICON_TEMPLATES/IconNameSet.yml
@@ -1,4 +1,4 @@
-name: name of the icon
+name: Name of the icon
 set: major or minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/IconsMajor.yml
+++ b/polaris-icons/icons/IconsMajor.yml
@@ -1,4 +1,4 @@
-name: icons
+name: Icons
 set: major
 description: Used to represent icons or shapes.
 keywords:

--- a/polaris-icons/icons/IllustrationMajor.yml
+++ b/polaris-icons/icons/IllustrationMajor.yml
@@ -1,4 +1,4 @@
-name: illustration
+name: Illustration
 set: major
 description: Used to represent an illustration, painting or brush.
 keywords:

--- a/polaris-icons/icons/ImageAltMajor.yml
+++ b/polaris-icons/icons/ImageAltMajor.yml
@@ -1,4 +1,4 @@
-name: image alt
+name: Image alt
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ImageAltMinor.yml
+++ b/polaris-icons/icons/ImageAltMinor.yml
@@ -1,4 +1,4 @@
-name: image alt
+name: Image alt
 set: minor
 description: Used to represent the alt text attribute used to describe the appearance and function of an image on a page.
 keywords:

--- a/polaris-icons/icons/ImageMajor.yml
+++ b/polaris-icons/icons/ImageMajor.yml
@@ -1,4 +1,4 @@
-name: image
+name: Image
 set: major
 description: Used to represent an image or placeholder.
 keywords:

--- a/polaris-icons/icons/ImageWithTextMajor.yml
+++ b/polaris-icons/icons/ImageWithTextMajor.yml
@@ -1,4 +1,4 @@
-name: image with text
+name: Image with text
 set: major
 description: Used to represent a layout option of a single column, featuring an image and text.
 keywords:

--- a/polaris-icons/icons/ImageWithTextOverlayMajor.yml
+++ b/polaris-icons/icons/ImageWithTextOverlayMajor.yml
@@ -1,4 +1,4 @@
-name: image with text overlay
+name: Image with text overlay
 set: major
 description: Used to represent a layout option of text overlaid on an image.
 keywords:

--- a/polaris-icons/icons/ImagesMajor.yml
+++ b/polaris-icons/icons/ImagesMajor.yml
@@ -1,4 +1,4 @@
-name: images
+name: Images
 set: major
 description: Used to represent multiple images.
 keywords:

--- a/polaris-icons/icons/ImportMinor.yml
+++ b/polaris-icons/icons/ImportMinor.yml
@@ -1,4 +1,4 @@
-name: import
+name: Import
 set: minor
 description: Used to denote the action of importing content.
 keywords:

--- a/polaris-icons/icons/ImportStoreMajor.yml
+++ b/polaris-icons/icons/ImportStoreMajor.yml
@@ -1,4 +1,4 @@
-name: import store
+name: Import store
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/IncomingMajor.yml
+++ b/polaris-icons/icons/IncomingMajor.yml
@@ -1,4 +1,4 @@
-name: incoming
+name: Incoming
 set: major
 description: Used to represent an incoming item or resource, or importing an item or resource.
 keywords:

--- a/polaris-icons/icons/InfoMinor.yml
+++ b/polaris-icons/icons/InfoMinor.yml
@@ -1,4 +1,4 @@
-name: info
+name: Info
 set: minor
 description: Used to represent a hint, or draw attention to a piece of information.
 keywords:

--- a/polaris-icons/icons/InstallMinor.yml
+++ b/polaris-icons/icons/InstallMinor.yml
@@ -1,4 +1,4 @@
-name: install
+name: Install
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/InventoryMajor.yml
+++ b/polaris-icons/icons/InventoryMajor.yml
@@ -1,4 +1,4 @@
-name: inventory
+name: Inventory
 set: major
 description: Used to represent inventory or a warehouse.
 keywords:

--- a/polaris-icons/icons/InviteMinor.yml
+++ b/polaris-icons/icons/InviteMinor.yml
@@ -1,4 +1,4 @@
-name: invite
+name: Invite
 set: minor
 description: Used to represent an email or letter.
 keywords:

--- a/polaris-icons/icons/IqMajor.yml
+++ b/polaris-icons/icons/IqMajor.yml
@@ -1,4 +1,4 @@
-name: iq
+name: Iq
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/JobsMajor.yml
+++ b/polaris-icons/icons/JobsMajor.yml
@@ -1,4 +1,4 @@
-name: jobs
+name: Jobs
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/KeyMajor.yml
+++ b/polaris-icons/icons/KeyMajor.yml
@@ -1,4 +1,4 @@
-name: key
+name: Key
 set: major
 description: Used to represent a key or security.
 keywords:

--- a/polaris-icons/icons/LabelPrinterMajor.yml
+++ b/polaris-icons/icons/LabelPrinterMajor.yml
@@ -1,4 +1,4 @@
-name: label printer
+name: Label printer
 set: major
 description: Used to represent a label printer (a special printer that prints 4x6 shipping labels on thermal sticker paper).
 keywords:

--- a/polaris-icons/icons/LandingPageMajor.yml
+++ b/polaris-icons/icons/LandingPageMajor.yml
@@ -1,4 +1,4 @@
-name: landing page
+name: Landing page
 set: major
 description: Used to represent a landing page or adding an item or resource to a page.
 keywords:

--- a/polaris-icons/icons/LanguageMinor.yml
+++ b/polaris-icons/icons/LanguageMinor.yml
@@ -1,4 +1,4 @@
-name: language
+name: Language
 set: minor
 description: Used to represent internationalization or multiple language options.
 keywords:

--- a/polaris-icons/icons/LegalMajor.yml
+++ b/polaris-icons/icons/LegalMajor.yml
@@ -1,4 +1,4 @@
-name: legal
+name: Legal
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/LinkMinor.yml
+++ b/polaris-icons/icons/LinkMinor.yml
@@ -1,4 +1,4 @@
-name: link
+name: Link
 set: minor
 description: Used to represent a link.
 keywords:

--- a/polaris-icons/icons/ListMajor.yml
+++ b/polaris-icons/icons/ListMajor.yml
@@ -1,4 +1,4 @@
-name: list
+name: List
 set: major
 description: Used to represent a list of items or resources, or a bulleted list.
 keywords:

--- a/polaris-icons/icons/LiveViewMajor.yml
+++ b/polaris-icons/icons/LiveViewMajor.yml
@@ -1,4 +1,4 @@
-name: live view
+name: Live view
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/LocationMajor.yml
+++ b/polaris-icons/icons/LocationMajor.yml
@@ -1,4 +1,4 @@
-name: location
+name: Location
 set: major
 description: Used to represent a location.
 keywords:

--- a/polaris-icons/icons/LocationsMinor.yml
+++ b/polaris-icons/icons/LocationsMinor.yml
@@ -1,4 +1,4 @@
-name: locations
+name: Locations
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/LockMajor.yml
+++ b/polaris-icons/icons/LockMajor.yml
@@ -1,4 +1,4 @@
-name: lock
+name: Lock
 set: major
 description: Used to represent a lock, a secure item or resource or that an option or setting is currently locked.
 keywords:

--- a/polaris-icons/icons/LockMinor.yml
+++ b/polaris-icons/icons/LockMinor.yml
@@ -1,4 +1,4 @@
-name: lock
+name: Lock
 set: minor
 description: Used to represent a lock, a secure item or resource or that an option or setting is currently locked.
 keywords:

--- a/polaris-icons/icons/LogOutMinor.yml
+++ b/polaris-icons/icons/LogOutMinor.yml
@@ -1,4 +1,4 @@
-name: log out
+name: Log out
 set: minor
 description: Used to denote the action of logging out of Shopify.
 keywords:

--- a/polaris-icons/icons/LogoBlockMajor.yml
+++ b/polaris-icons/icons/LogoBlockMajor.yml
@@ -1,4 +1,4 @@
-name: logo block
+name: Logo block
 set: major
 description: Used to represent a layout option of one or more logos.
 keywords:

--- a/polaris-icons/icons/ManagedStoreMajor.yml
+++ b/polaris-icons/icons/ManagedStoreMajor.yml
@@ -1,4 +1,4 @@
-name: managed store
+name: Managed store
 set: major
 description: Used to represent a managed or approved store.
 keywords:

--- a/polaris-icons/icons/MarkFulfilledMinor.yml
+++ b/polaris-icons/icons/MarkFulfilledMinor.yml
@@ -1,4 +1,4 @@
-name: mark fulfilled
+name: Mark fulfilled
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/MarkPaidMinor.yml
+++ b/polaris-icons/icons/MarkPaidMinor.yml
@@ -1,4 +1,4 @@
-name: mark paid
+name: Mark paid
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/MarketingMajor.yml
+++ b/polaris-icons/icons/MarketingMajor.yml
@@ -1,4 +1,4 @@
-name: marketing
+name: Marketing
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/MarketingMinor.yml
+++ b/polaris-icons/icons/MarketingMinor.yml
@@ -1,4 +1,4 @@
-name: marketing
+name: Marketing
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/MarketsMajor.yml
+++ b/polaris-icons/icons/MarketsMajor.yml
@@ -1,4 +1,4 @@
-name: markets
+name: Markets
 set: major
 description: Used to represent Markets, Shopify's international commerce product.
 keywords:

--- a/polaris-icons/icons/MaximizeMajor.yml
+++ b/polaris-icons/icons/MaximizeMajor.yml
@@ -1,4 +1,4 @@
-name: maximize
+name: Maximize
 set: major
 description: Used to represent an action to make an item, resource or view larger.
 keywords:

--- a/polaris-icons/icons/MaximizeMinor.yml
+++ b/polaris-icons/icons/MaximizeMinor.yml
@@ -1,4 +1,4 @@
-name: maximize
+name: Maximize
 set: minor
 description: Used to represent an action to make an item, resource or view larger.
 keywords:

--- a/polaris-icons/icons/MentionMajor.yml
+++ b/polaris-icons/icons/MentionMajor.yml
@@ -1,4 +1,4 @@
-name: mention
+name: Mention
 set: major
 description: Used to represent an action to mention someone.
 keywords:

--- a/polaris-icons/icons/MergeMinor.yml
+++ b/polaris-icons/icons/MergeMinor.yml
@@ -1,4 +1,4 @@
-name: merge
+name: Merge
 set: minor
 description: Used to represent merging of objects.
 keywords:

--- a/polaris-icons/icons/MicrophoneMajor.yml
+++ b/polaris-icons/icons/MicrophoneMajor.yml
@@ -1,4 +1,4 @@
-name: microphone
+name: Microphone
 set: major
 description: Used to represent a microphone.
 keywords:

--- a/polaris-icons/icons/MinimizeMajor.yml
+++ b/polaris-icons/icons/MinimizeMajor.yml
@@ -1,4 +1,4 @@
-name: minimize
+name: Minimize
 set: major
 description: Used to represent an action to make an item, resource or view smaller.
 keywords:

--- a/polaris-icons/icons/MinimizeMinor.yml
+++ b/polaris-icons/icons/MinimizeMinor.yml
@@ -1,4 +1,4 @@
-name: minimize
+name: Minimize
 set: minor
 description: Used to represent an action to make an item, resource or view smaller.
 keywords:

--- a/polaris-icons/icons/MinusMinor.yml
+++ b/polaris-icons/icons/MinusMinor.yml
@@ -1,4 +1,4 @@
-name: minus
+name: Minus
 set: minor
 description: Used to denote the action of removing an item.
 keywords:

--- a/polaris-icons/icons/MobileAcceptMajor.yml
+++ b/polaris-icons/icons/MobileAcceptMajor.yml
@@ -1,4 +1,4 @@
-name: mobile accept
+name: Mobile accept
 set: major
 description: Used to represent a confirm action. Most commonly used in the toolbar in an _edit_ context.
 keywords:

--- a/polaris-icons/icons/MobileBackArrowMajor.yml
+++ b/polaris-icons/icons/MobileBackArrowMajor.yml
@@ -1,4 +1,4 @@
-name: mobile back arrow
+name: Mobile back arrow
 set: major
 description: Used to represent backwards navigation.
 keywords:

--- a/polaris-icons/icons/MobileCancelMajor.yml
+++ b/polaris-icons/icons/MobileCancelMajor.yml
@@ -1,4 +1,4 @@
-name: mobile cancel
+name: Mobile cancel
 set: major
 description: Used to denote the action of cancelling a task or action and to close an overlay modal or bottom sheet.
 keywords:

--- a/polaris-icons/icons/MobileChevronMajor.yml
+++ b/polaris-icons/icons/MobileChevronMajor.yml
@@ -1,4 +1,4 @@
-name: mobile chevron
+name: Mobile chevron
 set: major
 description: Used to represent the back action commonly found in iOS.
 keywords:

--- a/polaris-icons/icons/MobileHamburgerMajor.yml
+++ b/polaris-icons/icons/MobileHamburgerMajor.yml
@@ -1,4 +1,4 @@
-name: mobile hamburger
+name: Mobile hamburger
 set: major
 description: Used to help direct merchants to navigation on mobile.
 keywords:

--- a/polaris-icons/icons/MobileHorizontalDotsMajor.yml
+++ b/polaris-icons/icons/MobileHorizontalDotsMajor.yml
@@ -1,4 +1,4 @@
-name: mobile horizontal dots
+name: Mobile horizontal dots
 set: major
 description: Used to represent an action to reveal a menu or more options.
 keywords:

--- a/polaris-icons/icons/MobileMajor.yml
+++ b/polaris-icons/icons/MobileMajor.yml
@@ -1,4 +1,4 @@
-name: mobile
+name: Mobile
 set: major
 description: Used to represent a mobile phone.
 keywords:

--- a/polaris-icons/icons/MobilePlusMajor.yml
+++ b/polaris-icons/icons/MobilePlusMajor.yml
@@ -1,4 +1,4 @@
-name: mobile plus
+name: Mobile plus
 set: major
 description: Used to represent an action to add an item or resource, or increase the quantity of an item or resource.
 keywords:

--- a/polaris-icons/icons/MobileVerticalDotsMajor.yml
+++ b/polaris-icons/icons/MobileVerticalDotsMajor.yml
@@ -1,4 +1,4 @@
-name: mobile vertical dots
+name: Mobile vertical dots
 set: major
 description: Used to represent an action to reveal a menu or more options.
 keywords:

--- a/polaris-icons/icons/MonerisMajor.yml
+++ b/polaris-icons/icons/MonerisMajor.yml
@@ -1,4 +1,4 @@
-name: moneris
+name: Moneris
 set: major
 description: Used to represent a handheld credit card reader.
 keywords:

--- a/polaris-icons/icons/NatureMajor.yml
+++ b/polaris-icons/icons/NatureMajor.yml
@@ -1,4 +1,4 @@
-name: nature
+name: Nature
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/NavigationMajor.yml
+++ b/polaris-icons/icons/NavigationMajor.yml
@@ -1,4 +1,4 @@
-name: navigation
+name: Navigation
 set: major
 description: Used to represent a compass or navigation.
 keywords:

--- a/polaris-icons/icons/NoteMajor.yml
+++ b/polaris-icons/icons/NoteMajor.yml
@@ -1,4 +1,4 @@
-name: note
+name: Note
 set: major
 description: Used to represent a document or note.
 keywords:

--- a/polaris-icons/icons/NoteMinor.yml
+++ b/polaris-icons/icons/NoteMinor.yml
@@ -1,4 +1,4 @@
-name: note
+name: Note
 set: minor
 description: Used to represent a document or note.
 keywords:

--- a/polaris-icons/icons/NotificationMajor.yml
+++ b/polaris-icons/icons/NotificationMajor.yml
@@ -1,4 +1,4 @@
-name: notification
+name: Notification
 set: major
 description: Used to represent a notification or alert.
 keywords:

--- a/polaris-icons/icons/OnlineStoreMajor.yml
+++ b/polaris-icons/icons/OnlineStoreMajor.yml
@@ -1,4 +1,4 @@
-name: online store
+name: Online store
 set: major
 description: Used to represent an online store.
 keywords:

--- a/polaris-icons/icons/OnlineStoreMinor.yml
+++ b/polaris-icons/icons/OnlineStoreMinor.yml
@@ -1,4 +1,4 @@
-name: online store
+name: Online store
 set: minor
 description: Used to represent an online store.
 keywords:

--- a/polaris-icons/icons/OrderStatusMinor.yml
+++ b/polaris-icons/icons/OrderStatusMinor.yml
@@ -1,4 +1,4 @@
-name: order status
+name: Order status
 set: minor
 description: Used to represent the activity of an inbox.
 keywords:

--- a/polaris-icons/icons/OrdersMajor.yml
+++ b/polaris-icons/icons/OrdersMajor.yml
@@ -1,4 +1,4 @@
-name: orders
+name: Orders
 set: major
 description: Used to represent an inbox or an item or resource arriving in an inbox.
 keywords:

--- a/polaris-icons/icons/OrdersMinor.yml
+++ b/polaris-icons/icons/OrdersMinor.yml
@@ -1,4 +1,4 @@
-name: orders
+name: Orders
 set: minor
 description: Used to represent an inbox or an item or resource arriving in an inbox.
 keywords:

--- a/polaris-icons/icons/OutgoingMajor.yml
+++ b/polaris-icons/icons/OutgoingMajor.yml
@@ -1,4 +1,4 @@
-name: outgoing
+name: Outgoing
 set: major
 description: Used to represent an outgoing item or resource, or exporting an item or resource.
 keywords:

--- a/polaris-icons/icons/PackageMajor.yml
+++ b/polaris-icons/icons/PackageMajor.yml
@@ -1,4 +1,4 @@
-name: package
+name: Package
 set: major
 description: Used to represent a package or box that merchants can ship their products in.
 keywords:

--- a/polaris-icons/icons/PageDownMajor.yml
+++ b/polaris-icons/icons/PageDownMajor.yml
@@ -1,4 +1,4 @@
-name: page down
+name: Page down
 set: major
 description: Used to represent an action to download a page or document.
 keywords:

--- a/polaris-icons/icons/PageMajor.yml
+++ b/polaris-icons/icons/PageMajor.yml
@@ -1,4 +1,4 @@
-name: page
+name: Page
 set: major
 description: Used to represent a blank page or document.
 keywords:

--- a/polaris-icons/icons/PageMinusMajor.yml
+++ b/polaris-icons/icons/PageMinusMajor.yml
@@ -1,4 +1,4 @@
-name: page minus
+name: Page minus
 set: major
 description: Used to represent an action to remove a page or document.
 keywords:

--- a/polaris-icons/icons/PagePlusMajor.yml
+++ b/polaris-icons/icons/PagePlusMajor.yml
@@ -1,4 +1,4 @@
-name: page plus
+name: Page plus
 set: major
 description: Used to represent an action to add a page or document.
 keywords:

--- a/polaris-icons/icons/PageUpMajor.yml
+++ b/polaris-icons/icons/PageUpMajor.yml
@@ -1,4 +1,4 @@
-name: page up
+name: Page up
 set: major
 description: Used to represent an action to upload a page or document.
 keywords:

--- a/polaris-icons/icons/PaginationEndMinor.yml
+++ b/polaris-icons/icons/PaginationEndMinor.yml
@@ -1,4 +1,4 @@
-name: pagination end
+name: Pagination end
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/PaginationStartMinor.yml
+++ b/polaris-icons/icons/PaginationStartMinor.yml
@@ -1,4 +1,4 @@
-name: pagination start
+name: Pagination start
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/PaintBrushMajor.yml
+++ b/polaris-icons/icons/PaintBrushMajor.yml
@@ -1,4 +1,4 @@
-name: paint brush
+name: Paint brush
 set: major
 description: Used to represent a paintbrush or an action to customize an item or resource.
 keywords:

--- a/polaris-icons/icons/PauseCircleMajor.yml
+++ b/polaris-icons/icons/PauseCircleMajor.yml
@@ -1,4 +1,4 @@
-name: pause circle
+name: Pause circle
 set: major
 description: Used to represent an action to pause something.
 keywords:

--- a/polaris-icons/icons/PauseMajor.yml
+++ b/polaris-icons/icons/PauseMajor.yml
@@ -1,4 +1,4 @@
-name: pause
+name: Pause
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/PauseMinor.yml
+++ b/polaris-icons/icons/PauseMinor.yml
@@ -1,4 +1,4 @@
-name: pause
+name: Pause
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/PaymentsMajor.yml
+++ b/polaris-icons/icons/PaymentsMajor.yml
@@ -1,4 +1,4 @@
-name: payments
+name: Payments
 set: major
 description: Used to represent a payment made by credit or debit card.
 keywords:

--- a/polaris-icons/icons/PhoneInMajor.yml
+++ b/polaris-icons/icons/PhoneInMajor.yml
@@ -1,4 +1,4 @@
-name: phone in
+name: Phone in
 set: major
 description: Used to represent an incoming phone call.
 keywords:

--- a/polaris-icons/icons/PhoneMajor.yml
+++ b/polaris-icons/icons/PhoneMajor.yml
@@ -1,4 +1,4 @@
-name: phone
+name: Phone
 set: major
 description: Used to represent a phone or phone call.
 keywords:

--- a/polaris-icons/icons/PhoneOutMajor.yml
+++ b/polaris-icons/icons/PhoneOutMajor.yml
@@ -1,4 +1,4 @@
-name: phone out
+name: Phone out
 set: major
 description: Used to represent an outgoing phone call.
 keywords:

--- a/polaris-icons/icons/PinMajor.yml
+++ b/polaris-icons/icons/PinMajor.yml
@@ -1,4 +1,4 @@
-name: pin
+name: Pin
 set: major
 description: Used to represent a pin or an action to pin or save something.
 keywords:

--- a/polaris-icons/icons/PinMinor.yml
+++ b/polaris-icons/icons/PinMinor.yml
@@ -1,4 +1,4 @@
-name: pin
+name: Pin
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/PlayCircleMajor.yml
+++ b/polaris-icons/icons/PlayCircleMajor.yml
@@ -1,4 +1,4 @@
-name: play circle
+name: Play circle
 set: major
 description: Used to represent an action to play or resume something.
 keywords:

--- a/polaris-icons/icons/PlayMajor.yml
+++ b/polaris-icons/icons/PlayMajor.yml
@@ -1,4 +1,4 @@
-name: play
+name: Play
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/PlayMinor.yml
+++ b/polaris-icons/icons/PlayMinor.yml
@@ -1,4 +1,4 @@
-name: play
+name: Play
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/PlusMinor.yml
+++ b/polaris-icons/icons/PlusMinor.yml
@@ -1,4 +1,4 @@
-name: plus
+name: Plus
 set: minor
 description: Used to denote the action of adding an item and zooming into a map.
 keywords:

--- a/polaris-icons/icons/PointOfSaleMajor.yml
+++ b/polaris-icons/icons/PointOfSaleMajor.yml
@@ -1,4 +1,4 @@
-name: point of sale
+name: Point of sale
 set: major
 description: Used to represent a point of sale or sales register.
 keywords:

--- a/polaris-icons/icons/PopularMajor.yml
+++ b/polaris-icons/icons/PopularMajor.yml
@@ -1,4 +1,4 @@
-name: popular
+name: Popular
 set: major
 description: Used to represent activity or something increasing in popularity.
 keywords:

--- a/polaris-icons/icons/PriceLookupMinor.yml
+++ b/polaris-icons/icons/PriceLookupMinor.yml
@@ -1,4 +1,4 @@
-name: price lookup
+name: Price lookup
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/PrintMajor.yml
+++ b/polaris-icons/icons/PrintMajor.yml
@@ -1,4 +1,4 @@
-name: print
+name: Print
 set: major
 description: Used to represent a printer or an action to print something.
 keywords:

--- a/polaris-icons/icons/PrintMinor.yml
+++ b/polaris-icons/icons/PrintMinor.yml
@@ -1,4 +1,4 @@
-name: print
+name: Print
 set: minor
 description: Used to denote the action of printing.
 keywords:

--- a/polaris-icons/icons/ProductReturnsMinor.yml
+++ b/polaris-icons/icons/ProductReturnsMinor.yml
@@ -1,4 +1,4 @@
-name: product returns
+name: Product returns
 set: minor
 description: Used to help direct merchants to returns page.
 keywords:

--- a/polaris-icons/icons/ProductsMajor.yml
+++ b/polaris-icons/icons/ProductsMajor.yml
@@ -1,4 +1,4 @@
-name: products
+name: Products
 set: major
 description: Used to represent products or a price tag.
 keywords:

--- a/polaris-icons/icons/ProductsMinor.yml
+++ b/polaris-icons/icons/ProductsMinor.yml
@@ -1,4 +1,4 @@
-name: products
+name: Products
 set: minor
 description: Used to represent products or a price tag.
 keywords:

--- a/polaris-icons/icons/ProfileMajor.yml
+++ b/polaris-icons/icons/ProfileMajor.yml
@@ -1,4 +1,4 @@
-name: profile
+name: Profile
 set: major
 description: Used to represent a staff member.
 keywords:

--- a/polaris-icons/icons/ProfileMinor.yml
+++ b/polaris-icons/icons/ProfileMinor.yml
@@ -1,4 +1,4 @@
-name: profile
+name: Profile
 set: minor
 description: Used to represent a staff member.
 keywords:

--- a/polaris-icons/icons/PromoteMinor.yml
+++ b/polaris-icons/icons/PromoteMinor.yml
@@ -1,4 +1,4 @@
-name: promote
+name: Promote
 set: minor
 description: Used to represent an action to open an external resource, or promote an item or resource.
 keywords:

--- a/polaris-icons/icons/QuestionMarkInverseMajor.yml
+++ b/polaris-icons/icons/QuestionMarkInverseMajor.yml
@@ -1,4 +1,4 @@
-name: question mark inverse
+name: Question mark inverse
 set: major
 description: Used to give merchants help or support for a feature.
 keywords:

--- a/polaris-icons/icons/QuestionMarkInverseMinor.yml
+++ b/polaris-icons/icons/QuestionMarkInverseMinor.yml
@@ -1,4 +1,4 @@
-name: question mark inverse
+name: Question mark inverse
 set: minor
 description: Used to give merchants help or support for a feature.
 keywords:

--- a/polaris-icons/icons/QuestionMarkMajor.yml
+++ b/polaris-icons/icons/QuestionMarkMajor.yml
@@ -1,4 +1,4 @@
-name: question mark
+name: Question mark
 set: major
 description: Used to give merchants help or support for a feature.
 keywords:

--- a/polaris-icons/icons/QuestionMarkMinor.yml
+++ b/polaris-icons/icons/QuestionMarkMinor.yml
@@ -1,4 +1,4 @@
-name: question mark
+name: Question mark
 set: minor
 description: Used to represent help, information or as an action to reveal more information about an item or resource.
 keywords:

--- a/polaris-icons/icons/QuickSaleMajor.yml
+++ b/polaris-icons/icons/QuickSaleMajor.yml
@@ -1,4 +1,4 @@
-name: quick sale
+name: Quick sale
 set: major
 description: Used to represent a quick checkout process or quick sale.
 keywords:

--- a/polaris-icons/icons/ReadTimeMinor.yml
+++ b/polaris-icons/icons/ReadTimeMinor.yml
@@ -1,4 +1,4 @@
-name: read time
+name: Read time
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ReceiptMajor.yml
+++ b/polaris-icons/icons/ReceiptMajor.yml
@@ -1,4 +1,4 @@
-name: receipt
+name: Receipt
 set: major
 description: Used to represent a sales receipt or invoice.
 keywords:

--- a/polaris-icons/icons/RecentSearchesMajor.yml
+++ b/polaris-icons/icons/RecentSearchesMajor.yml
@@ -1,4 +1,4 @@
-name: recent searches
+name: Recent searches
 set: major
 description: Used to represent recent searches or search history.
 keywords:

--- a/polaris-icons/icons/RedoMajor.yml
+++ b/polaris-icons/icons/RedoMajor.yml
@@ -1,4 +1,4 @@
-name: redo
+name: Redo
 set: major
 description: Used to indicate redoing an action after undoing it.
 keywords:

--- a/polaris-icons/icons/ReferralCodeMajor.yml
+++ b/polaris-icons/icons/ReferralCodeMajor.yml
@@ -1,4 +1,4 @@
-name: referral code
+name: Referral code
 set: major
 description: Used to represent a referral code’s usage status.
 keywords:

--- a/polaris-icons/icons/ReferralMajor.yml
+++ b/polaris-icons/icons/ReferralMajor.yml
@@ -1,4 +1,4 @@
-name: referral
+name: Referral
 set: major
 description: Used to represent the source of a referral.
 keywords:

--- a/polaris-icons/icons/RefreshMajor.yml
+++ b/polaris-icons/icons/RefreshMajor.yml
@@ -1,4 +1,4 @@
-name: refresh
+name: Refresh
 set: major
 description: Used to represent an action to refresh or sync an item or resource.
 keywords:

--- a/polaris-icons/icons/RefreshMinor.yml
+++ b/polaris-icons/icons/RefreshMinor.yml
@@ -1,4 +1,4 @@
-name: refresh
+name: Refresh
 set: minor
 description: Used to denote the action of resetting a customer’s account password on their customer page.
 keywords:

--- a/polaris-icons/icons/RefundMajor.yml
+++ b/polaris-icons/icons/RefundMajor.yml
@@ -1,4 +1,4 @@
-name: refund
+name: Refund
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/RefundMinor.yml
+++ b/polaris-icons/icons/RefundMinor.yml
@@ -1,4 +1,4 @@
-name: refund
+name: Refund
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/RemoveProductMajor.yml
+++ b/polaris-icons/icons/RemoveProductMajor.yml
@@ -1,4 +1,4 @@
-name: remove product
+name: Remove product
 set: major
 description: Used to represent an action to remove a product.
 keywords:

--- a/polaris-icons/icons/RepeatOrderMajor.yml
+++ b/polaris-icons/icons/RepeatOrderMajor.yml
@@ -1,4 +1,4 @@
-name: repeat order
+name: Repeat order
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ReplaceMajor.yml
+++ b/polaris-icons/icons/ReplaceMajor.yml
@@ -1,4 +1,4 @@
-name: replace
+name: Replace
 set: major
 description: Used to represent an action to replace an item or resource with another.
 keywords:

--- a/polaris-icons/icons/ReplayMinor.yml
+++ b/polaris-icons/icons/ReplayMinor.yml
@@ -1,4 +1,4 @@
-name: replay
+name: Replay
 set: minor
 description: Used to represent an action to replay or restart something.
 keywords:

--- a/polaris-icons/icons/ReportMinor.yml
+++ b/polaris-icons/icons/ReportMinor.yml
@@ -1,4 +1,4 @@
-name: report
+name: Report
 set: minor
 description: Used to represent analytics or a report.
 keywords:

--- a/polaris-icons/icons/ReportsMajor.yml
+++ b/polaris-icons/icons/ReportsMajor.yml
@@ -1,4 +1,4 @@
-name: reports
+name: Reports
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ResetMinor.yml
+++ b/polaris-icons/icons/ResetMinor.yml
@@ -1,4 +1,4 @@
-name: reset
+name: Reset
 set: minor
 description: Used to represent an action to reset or restart something.
 keywords:

--- a/polaris-icons/icons/ResourcesMajor.yml
+++ b/polaris-icons/icons/ResourcesMajor.yml
@@ -1,4 +1,4 @@
-name: resources
+name: Resources
 set: major
 description: Used to represent resources to learn more about a topic or feature.
 keywords:

--- a/polaris-icons/icons/ReturnMinor.yml
+++ b/polaris-icons/icons/ReturnMinor.yml
@@ -1,4 +1,4 @@
-name: return
+name: Return
 set: minor
 description: Used to represent an action to create a new line, sometimes referred to as a carriage return.
 keywords:

--- a/polaris-icons/icons/RiskMajor.yml
+++ b/polaris-icons/icons/RiskMajor.yml
@@ -1,4 +1,4 @@
-name: risk
+name: Risk
 set: major
 description: Used to represent elevated risk on a payment or order, usually the risk of credit card fraud.
 keywords:

--- a/polaris-icons/icons/RiskMinor.yml
+++ b/polaris-icons/icons/RiskMinor.yml
@@ -1,4 +1,4 @@
-name: risk
+name: Risk
 set: minor
 description: Used to represent risk associated with orders.
 keywords:

--- a/polaris-icons/icons/SandboxMajor.yml
+++ b/polaris-icons/icons/SandboxMajor.yml
@@ -1,4 +1,4 @@
-name: sandbox
+name: Sandbox
 set: major
 description: Used to represent a development store (feature exclusive to Shopify Plus Partners).
 keywords:

--- a/polaris-icons/icons/SaveMinor.yml
+++ b/polaris-icons/icons/SaveMinor.yml
@@ -1,4 +1,4 @@
-name: save
+name: Save
 set: minor
 description: Used to denote the action of saving.
 keywords:

--- a/polaris-icons/icons/SearchMajor.yml
+++ b/polaris-icons/icons/SearchMajor.yml
@@ -1,4 +1,4 @@
-name: search
+name: Search
 set: major
 description: Used to represent search or an action to search for an item or resource.
 keywords:

--- a/polaris-icons/icons/SearchMinor.yml
+++ b/polaris-icons/icons/SearchMinor.yml
@@ -1,4 +1,4 @@
-name: search
+name: Search
 set: minor
 description: Used to denote the action of searching throughout the admin.
 keywords:

--- a/polaris-icons/icons/SectionMajor.yml
+++ b/polaris-icons/icons/SectionMajor.yml
@@ -1,4 +1,4 @@
-name: section
+name: Section
 set: major
 description: Used to represent the middle section of a component, page or layout.
 keywords:

--- a/polaris-icons/icons/SecureMajor.yml
+++ b/polaris-icons/icons/SecureMajor.yml
@@ -1,4 +1,4 @@
-name: secure
+name: Secure
 set: major
 description: Used to represent a secure or protected item or resource, or than an item or resource can be trusted.
 keywords:

--- a/polaris-icons/icons/SelectMinor.yml
+++ b/polaris-icons/icons/SelectMinor.yml
@@ -1,4 +1,4 @@
-name: select
+name: Select
 set: minor
 description: Used to denote the action opening a select.
 keywords:

--- a/polaris-icons/icons/SendMajor.yml
+++ b/polaris-icons/icons/SendMajor.yml
@@ -1,4 +1,4 @@
-name: send
+name: Send
 set: major
 description: Used to represent an action to send a message, commonly used in a chat UI.
 keywords:

--- a/polaris-icons/icons/SettingsMajor.yml
+++ b/polaris-icons/icons/SettingsMajor.yml
@@ -1,4 +1,4 @@
-name: settings
+name: Settings
 set: major
 description: Used to represent settings or a configuration option.
 keywords:

--- a/polaris-icons/icons/SettingsMinor.yml
+++ b/polaris-icons/icons/SettingsMinor.yml
@@ -1,4 +1,4 @@
-name: settings
+name: Settings
 set: minor
 description: Used to represent settings or a configuration option.
 keywords:

--- a/polaris-icons/icons/ShareIosMinor.yml
+++ b/polaris-icons/icons/ShareIosMinor.yml
@@ -1,4 +1,4 @@
-name: share ios
+name: Share ios
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ShareMinor.yml
+++ b/polaris-icons/icons/ShareMinor.yml
@@ -1,4 +1,4 @@
-name: share
+name: Share
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ShipmentMajor.yml
+++ b/polaris-icons/icons/ShipmentMajor.yml
@@ -1,4 +1,4 @@
-name: shipment
+name: Shipment
 set: major
 description: Used to represent shipping-related events or actions such as shipping labels or tracking information.
 keywords:

--- a/polaris-icons/icons/ShopcodesMajor.yml
+++ b/polaris-icons/icons/ShopcodesMajor.yml
@@ -1,4 +1,4 @@
-name: shopcodes
+name: Shopcodes
 set: major
 description: Used to represent a QR code.
 keywords:

--- a/polaris-icons/icons/SidebarLeftMajor.yml
+++ b/polaris-icons/icons/SidebarLeftMajor.yml
@@ -1,4 +1,4 @@
-name: sidebar left
+name: Sidebar left
 set: major
 description: Used to represent the left section of a component, page or layout.
 keywords:

--- a/polaris-icons/icons/SidebarRightMajor.yml
+++ b/polaris-icons/icons/SidebarRightMajor.yml
@@ -1,4 +1,4 @@
-name: sidebar right
+name: Sidebar right
 set: major
 description: Used to represent the right section of a component, page or layout.
 keywords:

--- a/polaris-icons/icons/SlideshowMajor.yml
+++ b/polaris-icons/icons/SlideshowMajor.yml
@@ -1,4 +1,4 @@
-name: slideshow
+name: Slideshow
 set: major
 description: Used to represent a slideshow or series of images.
 keywords:

--- a/polaris-icons/icons/SmileyHappyMajor.yml
+++ b/polaris-icons/icons/SmileyHappyMajor.yml
@@ -1,4 +1,4 @@
-name: smiley happy
+name: Smiley happy
 set: major
 description: Used to represent a happy customer or user, a smiling face or a smiley emoji.
 keywords:

--- a/polaris-icons/icons/SmileyJoyMajor.yml
+++ b/polaris-icons/icons/SmileyJoyMajor.yml
@@ -1,4 +1,4 @@
-name: smiley joy
+name: Smiley joy
 set: major
 description: Used to represent a very happy customer or user, a smiling face or a smiley emoji.
 keywords:

--- a/polaris-icons/icons/SmileyNeutralMajor.yml
+++ b/polaris-icons/icons/SmileyNeutralMajor.yml
@@ -1,4 +1,4 @@
-name: smiley neutral
+name: Smiley neutral
 set: major
 description: Used to represent a neutral customer or user, a neutral face or a neutral emoji.
 keywords:

--- a/polaris-icons/icons/SmileySadMajor.yml
+++ b/polaris-icons/icons/SmileySadMajor.yml
@@ -1,4 +1,4 @@
-name: smiley sad
+name: Smiley sad
 set: major
 description: Used to represent a sad customer or user, a sad face or a sad emoji.
 keywords:

--- a/polaris-icons/icons/SocialAdMajor.yml
+++ b/polaris-icons/icons/SocialAdMajor.yml
@@ -1,4 +1,4 @@
-name: social ad
+name: Social ad
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/SocialPostMajor.yml
+++ b/polaris-icons/icons/SocialPostMajor.yml
@@ -1,4 +1,4 @@
-name: social post
+name: Social post
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/SoftPackMajor.yml
+++ b/polaris-icons/icons/SoftPackMajor.yml
@@ -1,4 +1,4 @@
-name: soft pack
+name: Soft pack
 set: major
 description: Used to represent a soft pack envelope (or bubble mailer) that merchants can use to ship orders to their customers.
 keywords:

--- a/polaris-icons/icons/SortAscendingMajor.yml
+++ b/polaris-icons/icons/SortAscendingMajor.yml
@@ -1,4 +1,4 @@
-name: sort ascending
+name: Sort ascending
 set: major
 description: Used to indicate that a list of items or resources has been sorted by ascending order.
 keywords:

--- a/polaris-icons/icons/SortDescendingMajor.yml
+++ b/polaris-icons/icons/SortDescendingMajor.yml
@@ -1,4 +1,4 @@
-name: sort descending
+name: Sort descending
 set: major
 description: Used to indicate that a list of items or resources has been sorted by descending order.
 keywords:

--- a/polaris-icons/icons/SortMinor.yml
+++ b/polaris-icons/icons/SortMinor.yml
@@ -1,4 +1,4 @@
-name: sort
+name: Sort
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/SoundMajor.yml
+++ b/polaris-icons/icons/SoundMajor.yml
@@ -1,4 +1,4 @@
-name: sound
+name: Sound
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/StarFilledMinor.yml
+++ b/polaris-icons/icons/StarFilledMinor.yml
@@ -1,4 +1,4 @@
-name: star filled
+name: Star filled
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/StarOutlineMinor.yml
+++ b/polaris-icons/icons/StarOutlineMinor.yml
@@ -1,4 +1,4 @@
-name: star outline
+name: Star outline
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/StoreMajor.yml
+++ b/polaris-icons/icons/StoreMajor.yml
@@ -1,4 +1,4 @@
-name: store
+name: Store
 set: major
 description: Used to represent a store or shop.
 keywords:

--- a/polaris-icons/icons/StoreMinor.yml
+++ b/polaris-icons/icons/StoreMinor.yml
@@ -1,4 +1,4 @@
-name: store
+name: Store
 set: minor
 description: Used to represent a store or shop.
 keywords:

--- a/polaris-icons/icons/StoreStatusMajor.yml
+++ b/polaris-icons/icons/StoreStatusMajor.yml
@@ -1,4 +1,4 @@
-name: store status
+name: Store status
 set: major
 description: Used to represent the activity of a shop or store.
 keywords:

--- a/polaris-icons/icons/TabletMajor.yml
+++ b/polaris-icons/icons/TabletMajor.yml
@@ -1,4 +1,4 @@
-name: tablet
+name: Tablet
 set: major
 description: Used to represent a tablet.
 keywords:

--- a/polaris-icons/icons/TapChipMajor.yml
+++ b/polaris-icons/icons/TapChipMajor.yml
@@ -1,4 +1,4 @@
-name: tap chip
+name: Tap chip
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TaxMajor.yml
+++ b/polaris-icons/icons/TaxMajor.yml
@@ -1,4 +1,4 @@
-name: tax
+name: Tax
 set: major
 description: Used to represent sales tax or a tax receipt.
 keywords:

--- a/polaris-icons/icons/TeamMajor.yml
+++ b/polaris-icons/icons/TeamMajor.yml
@@ -1,4 +1,4 @@
-name: team
+name: Team
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TemplateMajor.yml
+++ b/polaris-icons/icons/TemplateMajor.yml
@@ -1,4 +1,4 @@
-name: template
+name: Template
 set: major
 description: Used to represent a Shopify Theme Template.
 keywords:

--- a/polaris-icons/icons/TextAlignmentCenterMajor.yml
+++ b/polaris-icons/icons/TextAlignmentCenterMajor.yml
@@ -1,4 +1,4 @@
-name: text alignment center
+name: Text alignment center
 set: major
 description: Icon indicating alignment of text at the center
 keywords:

--- a/polaris-icons/icons/TextAlignmentLeftMajor.yml
+++ b/polaris-icons/icons/TextAlignmentLeftMajor.yml
@@ -1,4 +1,4 @@
-name: text alignment left
+name: Text alignment left
 set: major
 description: Icon indicating alignment of text on the left side
 keywords:

--- a/polaris-icons/icons/TextAlignmentRightMajor.yml
+++ b/polaris-icons/icons/TextAlignmentRightMajor.yml
@@ -1,4 +1,4 @@
-name: text alignment right
+name: Text alignment right
 set: major
 description: Icon indicating alignment of text on the right side
 keywords:

--- a/polaris-icons/icons/TextBlockMajor.yml
+++ b/polaris-icons/icons/TextBlockMajor.yml
@@ -1,4 +1,4 @@
-name: text block
+name: Text block
 set: major
 description: Used to represent a paragraph or block of text.
 keywords:

--- a/polaris-icons/icons/TextMajor.yml
+++ b/polaris-icons/icons/TextMajor.yml
@@ -1,4 +1,4 @@
-name: text
+name: Text
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ThemeEditMajor.yml
+++ b/polaris-icons/icons/ThemeEditMajor.yml
@@ -1,4 +1,4 @@
-name: theme edit
+name: Theme edit
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ThemeStoreMajor.yml
+++ b/polaris-icons/icons/ThemeStoreMajor.yml
@@ -1,4 +1,4 @@
-name: theme store
+name: Theme store
 set: major
 description: Used to represent the Shopify theme store.
 keywords:

--- a/polaris-icons/icons/ThemesMajor.yml
+++ b/polaris-icons/icons/ThemesMajor.yml
@@ -1,4 +1,4 @@
-name: themes
+name: Themes
 set: major
 description: Used to indicate free themes in the Shopify theme store.
 keywords:

--- a/polaris-icons/icons/ThumbsDownMajor.yml
+++ b/polaris-icons/icons/ThumbsDownMajor.yml
@@ -1,4 +1,4 @@
-name: thumbs down
+name: Thumbs down
 set: major
 description: Used to represent an action to dislike or disapprove of something.
 keywords:

--- a/polaris-icons/icons/ThumbsDownMinor.yml
+++ b/polaris-icons/icons/ThumbsDownMinor.yml
@@ -1,4 +1,4 @@
-name: thumbs down
+name: Thumbs down
 set: minor
 description: Used to represent an action to dislike or disapprove of something.
 keywords:

--- a/polaris-icons/icons/ThumbsUpMajor.yml
+++ b/polaris-icons/icons/ThumbsUpMajor.yml
@@ -1,4 +1,4 @@
-name: thumbs up
+name: Thumbs up
 set: major
 description: Used to represent an action to like or approve of something.
 keywords:

--- a/polaris-icons/icons/ThumbsUpMinor.yml
+++ b/polaris-icons/icons/ThumbsUpMinor.yml
@@ -1,4 +1,4 @@
-name: thumbs up
+name: Thumbs up
 set: minor
 description: Used to represent an action to like or approve of something.
 keywords:

--- a/polaris-icons/icons/TickMinor.yml
+++ b/polaris-icons/icons/TickMinor.yml
@@ -1,4 +1,4 @@
-name: tick
+name: Tick
 set: minor
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TickSmallMinor.yml
+++ b/polaris-icons/icons/TickSmallMinor.yml
@@ -1,4 +1,4 @@
-name: tick small
+name: Tick small
 set: minor
 description: Used to denote the action of checking a Polaris checkbox.
 keywords:

--- a/polaris-icons/icons/TimelineAttachmentMajor.yml
+++ b/polaris-icons/icons/TimelineAttachmentMajor.yml
@@ -1,4 +1,4 @@
-name: timeline attachment
+name: Timeline attachment
 set: major
 description: This icon denotes an attachment of any file to a timeline.
 keywords:

--- a/polaris-icons/icons/TipsMajor.yml
+++ b/polaris-icons/icons/TipsMajor.yml
@@ -1,4 +1,4 @@
-name: tips
+name: Tips
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TitleMinor.yml
+++ b/polaris-icons/icons/TitleMinor.yml
@@ -1,4 +1,4 @@
-name: title
+name: Title
 set: minor
 description: Used to represent a title or heading block appearing as a sub-element of a section, page or layout.
 keywords:

--- a/polaris-icons/icons/ToggleMinor.yml
+++ b/polaris-icons/icons/ToggleMinor.yml
@@ -1,4 +1,4 @@
-name: toggle
+name: Toggle
 set: minor
 description: Used to dennote something that can be toggled on and off.
 keywords:

--- a/polaris-icons/icons/ToolsMajor.yml
+++ b/polaris-icons/icons/ToolsMajor.yml
@@ -1,4 +1,4 @@
-name: tools
+name: Tools
 set: major
 description: Used to represent an action to customize an item or resource.
 keywords:

--- a/polaris-icons/icons/TransactionFeeDollarMajor.yml
+++ b/polaris-icons/icons/TransactionFeeDollarMajor.yml
@@ -1,4 +1,4 @@
-name: transaction fee (dollar)
+name: Transaction fee (dollar)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransactionFeeEuroMajor.yml
+++ b/polaris-icons/icons/TransactionFeeEuroMajor.yml
@@ -1,4 +1,4 @@
-name: transaction fee (euro)
+name: Transaction fee (euro)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransactionFeePoundMajor.yml
+++ b/polaris-icons/icons/TransactionFeePoundMajor.yml
@@ -1,4 +1,4 @@
-name: transaction fee (pound)
+name: Transaction fee (pound)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransactionFeeRupeeMajor.yml
+++ b/polaris-icons/icons/TransactionFeeRupeeMajor.yml
@@ -1,4 +1,4 @@
-name: transaction fee (rupee)
+name: Transaction fee (rupee)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransactionFeeYenMajor.yml
+++ b/polaris-icons/icons/TransactionFeeYenMajor.yml
@@ -1,4 +1,4 @@
-name: transaction fee (yen)
+name: Transaction fee (yen)
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransactionMajor.yml
+++ b/polaris-icons/icons/TransactionMajor.yml
@@ -1,4 +1,4 @@
-name: transaction
+name: Transaction
 set: major
 description: Used to represent an action to customize an item or resource.
 keywords:

--- a/polaris-icons/icons/TransferInMajor.yml
+++ b/polaris-icons/icons/TransferInMajor.yml
@@ -1,4 +1,4 @@
-name: transfer in
+name: Transfer in
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransferMajor.yml
+++ b/polaris-icons/icons/TransferMajor.yml
@@ -1,4 +1,4 @@
-name: transfer
+name: Transfer
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransferOutMajor.yml
+++ b/polaris-icons/icons/TransferOutMajor.yml
@@ -1,4 +1,4 @@
-name: transfer out
+name: Transfer out
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransferWithinShopifyMajor.yml
+++ b/polaris-icons/icons/TransferWithinShopifyMajor.yml
@@ -1,4 +1,4 @@
-name: transfer within shopify
+name: Transfer within shopify
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/TransportMajor.yml
+++ b/polaris-icons/icons/TransportMajor.yml
@@ -1,4 +1,4 @@
-name: transport
+name: Transport
 set: major
 description: Used as a navigation item in our emoji picker for the transport category.
 keywords:

--- a/polaris-icons/icons/TroubleshootMajor.yml
+++ b/polaris-icons/icons/TroubleshootMajor.yml
@@ -1,4 +1,4 @@
-name: troubleshoot
+name: Troubleshoot
 set: major
 description: Used to represent an action to troubleshoot or view troubleshooting information.
 keywords:

--- a/polaris-icons/icons/TypeMajor.yml
+++ b/polaris-icons/icons/TypeMajor.yml
@@ -1,4 +1,4 @@
-name: type
+name: Type
 set: major
 description: Used to represent a typeface or an action to change the properties of a typeface or body of text.
 keywords:

--- a/polaris-icons/icons/TypeMinor.yml
+++ b/polaris-icons/icons/TypeMinor.yml
@@ -1,4 +1,4 @@
-name: type
+name: Type
 set: minor
 description: Used to represent a typeface or an action to change the properties of a typeface or body of text.
 keywords:

--- a/polaris-icons/icons/UndoMajor.yml
+++ b/polaris-icons/icons/UndoMajor.yml
@@ -1,4 +1,4 @@
-name: undo
+name: Undo
 set: major
 description: Used to indicate undoing an action in an editor context.
 keywords:

--- a/polaris-icons/icons/UnfulfilledMajor.yml
+++ b/polaris-icons/icons/UnfulfilledMajor.yml
@@ -1,4 +1,4 @@
-name: unfulfilled
+name: Unfulfilled
 set: major
 description: Used to represent an empty inbox.
 keywords:

--- a/polaris-icons/icons/UnknownDeviceMajor.yml
+++ b/polaris-icons/icons/UnknownDeviceMajor.yml
@@ -1,4 +1,4 @@
-name: unknown device
+name: Unknown device
 set: major
 description: Used to represent an unknown device, item or resource.
 keywords:

--- a/polaris-icons/icons/UpdateInventoryMajor.yml
+++ b/polaris-icons/icons/UpdateInventoryMajor.yml
@@ -1,4 +1,4 @@
-name: update inventory
+name: Update inventory
 set: major
 description: Used to represent updated inventory at a warehouse.
 keywords:

--- a/polaris-icons/icons/UploadMajor.yml
+++ b/polaris-icons/icons/UploadMajor.yml
@@ -1,4 +1,4 @@
-name: upload
+name: Upload
 set: major
 description: Used to represent the ability to upload a file
 keywords:

--- a/polaris-icons/icons/VariantMajor.yml
+++ b/polaris-icons/icons/VariantMajor.yml
@@ -1,4 +1,4 @@
-name: variant
+name: Variant
 set: major
 description:
   # Icon type   | Example description

--- a/polaris-icons/icons/ViewMajor.yml
+++ b/polaris-icons/icons/ViewMajor.yml
@@ -1,4 +1,4 @@
-name: view
+name: View
 set: major
 description: Used to represent an action to view something, or to represent an openly viewable item or resource.
 keywords:

--- a/polaris-icons/icons/ViewMinor.yml
+++ b/polaris-icons/icons/ViewMinor.yml
@@ -1,4 +1,4 @@
-name: view
+name: View
 set: minor
 description: Used to denote the action of previewing an online store.
 keywords:

--- a/polaris-icons/icons/ViewportNarrowMajor.yml
+++ b/polaris-icons/icons/ViewportNarrowMajor.yml
@@ -1,4 +1,4 @@
-name: viewport narrow
+name: Viewport narrow
 set: major
 description: Used to represent an action to make a viewport, item or resource narrower.
 keywords:

--- a/polaris-icons/icons/ViewportWideMajor.yml
+++ b/polaris-icons/icons/ViewportWideMajor.yml
@@ -1,4 +1,4 @@
-name: viewport wide
+name: Viewport wide
 set: major
 description: Used to represent an action to make a viewport, item or resource wider.
 keywords:

--- a/polaris-icons/icons/VocabularyMajor.yml
+++ b/polaris-icons/icons/VocabularyMajor.yml
@@ -1,4 +1,4 @@
-name: vocabulary
+name: Vocabulary
 set: major
 description: Used to represent a book, dictionary or thesaurus.
 keywords:

--- a/polaris-icons/icons/WandMajor.yml
+++ b/polaris-icons/icons/WandMajor.yml
@@ -1,4 +1,4 @@
-name: wand
+name: Wand
 set: major
 description: Used to represent an action to perform an automatic process or series of processes.
 keywords:

--- a/polaris-icons/icons/WandMinor.yml
+++ b/polaris-icons/icons/WandMinor.yml
@@ -1,4 +1,4 @@
-name: wand
+name: Wand
 set: minor
 description: Used to represent an action to perform an automatic process or series of processes.
 keywords:

--- a/polaris-icons/icons/WearableMajor.yml
+++ b/polaris-icons/icons/WearableMajor.yml
@@ -1,4 +1,4 @@
-name: wearable
+name: Wearable
 set: major
 description: Used to represent a wearable device or wristwatch.
 keywords:

--- a/polaris-icons/icons/WholesaleMajor.yml
+++ b/polaris-icons/icons/WholesaleMajor.yml
@@ -1,4 +1,4 @@
-name: wholesale
+name: Wholesale
 set: major
 description: Used to represent a forklift or equipment used in a warehouse.
 keywords:

--- a/polaris-icons/icons/WifiMajor.yml
+++ b/polaris-icons/icons/WifiMajor.yml
@@ -1,4 +1,4 @@
-name: wifi
+name: Wifi
 set: major
 description:
   # Icon type   | Example description


### PR DESCRIPTION
Changes the casing of icons to start with an uppercase character. This will make the icon names render like any other word/sentence on the website.

<img width="479" alt="image" src="https://user-images.githubusercontent.com/875708/177201601-d515ad1a-cee6-4deb-99b3-8e6110a92a9c.png">

The keys in the metadata file/object are untouched, so this shouldn't be a breaking change.