### PR TITLE
Add icon id for the icon metadata

### DIFF
--- a/.changeset/early-coins-look.md
+++ b/.changeset/early-coins-look.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': minor
+---
+
+Added id to the metadata value to reduce need to transform objects

--- a/polaris-icons/rollup.config.mjs
+++ b/polaris-icons/rollup.config.mjs
@@ -36,7 +36,10 @@ iconPaths.forEach((filename) => {
     .replace(`${iconBasePath}/`, '')
     .replace('.yml', '');
 
-  iconMetadata[exportName] = iconData;
+  iconMetadata[exportName] = {
+    id: exportName,
+    ...iconData,
+  };
   iconExports.push(
     `export {default as ${exportName}} from '../icons/${exportName}.svg';`,
   );


### PR DESCRIPTION
- [x] No breaking changes to the object structure
- [x] Users can still use the ID to look up the data they need
- [x] id is now available if needed but users don't need to transform the object to merge the key and value