### PR TITLE
[polaris.shopify.com] Add support for tooltips that point up

### DIFF
--- a/.changeset/stupid-cherries-press.md
+++ b/.changeset/stupid-cherries-press.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix the direction of Tooltip's arrow. Now supports pointing upwards as well.

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
@@ -23,7 +23,6 @@ function CodeExample({ minimalist, children }: Props) {
       <div className={styles.CopyButtonWrapper}>
         <Tooltip
           ariaLabel="Copy to clipboard"
-          placement="top"
           renderContent={() => (
             <div className={styles.IconToolTip}>
               <p>{didJustCopy ? "Copied" : "Copy"}</p>

--- a/polaris.shopify.com/src/components/IconGrid/IconGrid.tsx
+++ b/polaris.shopify.com/src/components/IconGrid/IconGrid.tsx
@@ -42,7 +42,6 @@ function IconGridItem({
     >
       <Tooltip
         ariaLabel={icon.description}
-        placement="top"
         renderContent={() => (
           <div>
             <p>

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -152,7 +152,6 @@ function TokenListItem({
                 <div className={styles.TokenClipboard}>
                   <Tooltip
                     ariaLabel="Copy to clipboard"
-                    placement="top"
                     renderContent={() => (
                       <div className={styles.TokenToolTip}>
                         <p>{didJustCopy ? "Copied!" : "Copy to clipboard"}</p>

--- a/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
+++ b/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
@@ -41,7 +41,6 @@
   }
 
   &[data-placement="bottom"] {
-    &::after {
       content: "";
       top: -5px;
       bottom: auto;

--- a/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
+++ b/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
@@ -41,10 +41,9 @@
   }
 
   &[data-placement="bottom"] {
-      content: "";
-      top: -5px;
-      bottom: auto;
-      transform: rotate(135deg);
-    }
+    content: "";
+    top: -5px;
+    bottom: auto;
+    transform: rotate(135deg);
   }
 }

--- a/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
+++ b/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
@@ -2,7 +2,7 @@
 
 .Tooltip {
   pointer-events: none;
-  max-width: 300px;
+  max-width: 240px;
   z-index: 2;
   filter: drop-shadow(0 5px 20px rgba(0, 0, 0, 0.1));
 
@@ -38,5 +38,14 @@
 
   @include dark-mode {
     filter: drop-shadow(0 5px 20px rgba(0, 0, 0, 0.5));
+  }
+
+  &[data-placement="bottom"] {
+    &::after {
+      content: "";
+      top: -5px;
+      bottom: auto;
+      transform: rotate(135deg);
+    }
   }
 }

--- a/polaris.shopify.com/src/components/Tooltip/Tooltip.tsx
+++ b/polaris.shopify.com/src/components/Tooltip/Tooltip.tsx
@@ -17,25 +17,20 @@ import styles from "./Tooltip.module.scss";
 interface Props {
   ariaLabel: string;
   renderContent: () => React.ReactNode;
-  placement?: Placement;
   children: JSX.Element;
 }
 
-export const Tooltip = ({
-  children,
-  ariaLabel,
-  renderContent,
-  placement = "right",
-}: Props) => {
+export const Tooltip = ({ children, ariaLabel, renderContent }: Props) => {
   const [open, setOpen] = useState(false);
 
-  const { x, y, reference, floating, strategy, context } = useFloating({
-    placement,
-    open,
-    onOpenChange: setOpen,
-    middleware: [offset(5), flip(), shift({ padding: 8 })],
-    whileElementsMounted: autoUpdate,
-  });
+  const { x, y, reference, floating, strategy, context, placement } =
+    useFloating({
+      placement: "top",
+      open,
+      onOpenChange: setOpen,
+      middleware: [offset(5), flip(), shift({ padding: 8 })],
+      whileElementsMounted: autoUpdate,
+    });
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     useHover(context),
@@ -61,6 +56,7 @@ export const Tooltip = ({
               left: x ?? "",
             },
           })}
+          data-placement={placement}
           aria-label={ariaLabel}
         >
           <div className={styles.Content}>{renderContent()}</div>


### PR DESCRIPTION
Tooltips default to pointing down:

<img width="265" alt="image" src="https://user-images.githubusercontent.com/875708/177216298-ac44b599-5b67-4e08-8d8a-d291eba07c1d.png">

But can point up when needed:

<img width="285" alt="image" src="https://user-images.githubusercontent.com/875708/177216258-eaba6217-134d-4d7c-bfa1-b96ef23582a5.png">

Closes #6478