### PR TITLE
[polaris.shopify.com] Fix tooltip bug

### DIFF
--- a/.changeset/strong-lemons-hammer.md
+++ b/.changeset/strong-lemons-hammer.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix tooltip layout bug

--- a/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
+++ b/polaris.shopify.com/src/components/Tooltip/Tooltip.module.scss
@@ -40,8 +40,7 @@
     filter: drop-shadow(0 5px 20px rgba(0, 0, 0, 0.5));
   }
 
-  &[data-placement="bottom"] {
-    content: "";
+  &[data-placement="bottom"]:after {
     top: -5px;
     bottom: auto;
     transform: rotate(135deg);


### PR DESCRIPTION
LOL, I accidentally shipped the silliest bug 🤪

<img width="327" alt="Screen Shot 2022-07-05 at 10 58 06 AM" src="https://user-images.githubusercontent.com/875708/177291631-59e9e97d-ce56-48e9-9c3b-96fe589288a3.png">

After this fix:

<img width="332" alt="image" src="https://user-images.githubusercontent.com/875708/177291865-e7cb9a04-9cf2-4bdc-afd1-5f586f0f8853.png">
