### PR TITLE
[WIP] [Modal] Trigger CloseButton pressed state on backdrop click

### DIFF
--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -90,6 +90,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   fullScreen,
 }: ModalProps) {
   const [iframeHeight, setIframeHeight] = useState(IFRAME_LOADING_HEIGHT);
+  const [backdropClicked, setBackdropClicked] = useState(false);
 
   const headerId = useUniqueId('modal-header');
   const activatorRef = useRef<HTMLDivElement>(null);
@@ -135,6 +136,11 @@ export const Modal: React.FunctionComponent<ModalProps> & {
     },
     [onIFrameLoad],
   );
+
+  const handleBackdropOnClick = () => {
+    setBackdropClicked(true);
+    onClose();
+  };
 
   if (open) {
     const footerMarkup =
@@ -196,7 +202,12 @@ export const Modal: React.FunctionComponent<ModalProps> & {
         limitHeight={limitHeight}
         fullScreen={fullScreen}
       >
-        <Header titleHidden={titleHidden} id={headerId} onClose={onClose}>
+        <Header
+          id={headerId}
+          titleHidden={titleHidden}
+          backdropClicked={backdropClicked}
+          onClose={onClose}
+        >
           {title}
         </Header>
         <div className={styles.BodyWrapper}>{bodyMarkup}</div>
@@ -204,7 +215,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       </Dialog>
     );
 
-    backdrop = <Backdrop onClick={onClose} />;
+    backdrop = <Backdrop onClick={handleBackdropOnClick} />;
   }
 
   const animated = !instant;

--- a/polaris-react/src/components/Modal/components/CloseButton/CloseButton.scss
+++ b/polaris-react/src/components/Modal/components/CloseButton/CloseButton.scss
@@ -25,3 +25,7 @@
     margin: var(--p-space-2);
   }
 }
+
+.BackdropClicked {
+  background: var(--p-surface-pressed);
+}

--- a/polaris-react/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/polaris-react/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -9,10 +9,15 @@ import styles from './CloseButton.scss';
 
 export interface CloseButtonProps {
   titleHidden?: boolean;
+  backdropClicked: boolean;
   onClick(): void;
 }
 
-export function CloseButton({titleHidden = false, onClick}: CloseButtonProps) {
+export function CloseButton({
+  titleHidden = false,
+  backdropClicked,
+  onClick,
+}: CloseButtonProps) {
   const i18n = useI18n();
 
   return (
@@ -20,6 +25,7 @@ export function CloseButton({titleHidden = false, onClick}: CloseButtonProps) {
       onClick={onClick}
       className={classNames(
         styles.CloseButton,
+        backdropClicked && styles.BackdropClicked,
         titleHidden && styles.titleHidden,
       )}
       aria-label={i18n.translate('Polaris.Common.close')}

--- a/polaris-react/src/components/Modal/components/Header/Header.tsx
+++ b/polaris-react/src/components/Modal/components/Header/Header.tsx
@@ -8,11 +8,18 @@ import styles from './Header.scss';
 export interface HeaderProps {
   id: string;
   titleHidden: boolean;
+  backdropClicked: boolean;
   children?: React.ReactNode;
   onClose(): void;
 }
 
-export function Header({id, titleHidden, children, onClose}: HeaderProps) {
+export function Header({
+  id,
+  titleHidden,
+  backdropClicked,
+  children,
+  onClose,
+}: HeaderProps) {
   return (
     <div
       className={titleHidden || !children ? styles.titleHidden : styles.Header}
@@ -22,7 +29,11 @@ export function Header({id, titleHidden, children, onClose}: HeaderProps) {
           {children}
         </DisplayText>
       </div>
-      <CloseButton titleHidden={titleHidden} onClick={onClose} />
+      <CloseButton
+        titleHidden={titleHidden}
+        backdropClicked={backdropClicked}
+        onClick={onClose}
+      />
     </div>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This is current a work in progress. I'm exploring different solutions to Shopify/shopify/issues/361647. Before this PR moves out of draft stage, I'll need to confirm with the Polaris team if this is desired or not.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
