### PR TITLE
Update a link in the icon contribution docs

### DIFF
--- a/.changeset/honest-goats-help.md
+++ b/.changeset/honest-goats-help.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris-icons': patch
+'polaris.shopify.com': patch
+---
+
+In the Vault documentation, the link for "propose an update" pre-populates a new github issue with some labels and subject line, etc.Updating the link here to mirror what's on this Vault page— https://vault.shopify.io/pages/17259-Polaris-Icons

--- a/polaris-icons/CONTRIBUTING.md
+++ b/polaris-icons/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you can’t find the icons you need, you can [propose new icons](https://gith
 
 ## Proposing updates to existing icons
 
-If you notice existing icons that are out-of-date or need improvements, you can [propose an update](https://github.com/Shopify/polaris/issues/new) to these icons.
+If you notice existing icons that are out-of-date or need improvements, you can [propose an update](https://github.com/Shopify/polaris-icons/issues/new?assignees=%40shopify%2Ficon-guild&labels=Update%2CProposal&template=propose-updates-to-existing-icons.md&title=%5BProposal%5D+Update+%3Cicon+names%3E) to these icons.
 
 ## Deprecation guidelines
 


### PR DESCRIPTION
### WHY are these changes introduced?

In the Icon contribution docs, there's a link to propose a change to an icon. Currently, it just opens a generic Github Issue. However, in [the Vault documentation](https://vault.shopify.io/pages/17259-Polaris-Icons), the Github issue is pre-populated with helpful metadata. This PR makes the Github docs aligned to the Vault docs on this topic.

### WHAT is this pull request doing?

On the [contributing.md page](https://github.com/Shopify/polaris/blob/main/polaris-icons/CONTRIBUTING.md#proposing-updates-to-existing-icons)
Just updates the link for Proposing Updates to Existing Icons
from— https://github.com/Shopify/polaris/issues/new
to— https://github.com/Shopify/polaris-icons/issues/new?assignees=%40shopify%2Ficon-guild&labels=Update%2CProposal&template=propose-updates-to-existing-icons.md&title=%5BProposal%5D+Update+%3Cicon+names%3E

@martenbjork, I hope I did it right here 😄 

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
