### PR TITLE
[IndexTable] Fix bulk actions on small screens

### DIFF
--- a/.changeset/nasty-pianos-shout.md
+++ b/.changeset/nasty-pianos-shout.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fix bulk actions not visible on IndexTable on small screens
+Fixed `IndexTable` bulk action visibility on small screens

--- a/.changeset/nasty-pianos-shout.md
+++ b/.changeset/nasty-pianos-shout.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix bulk actions not visible on IndexTable on small screens

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -104,6 +104,7 @@ function IndexTableBase({
   const [stickyWrapper, setStickyWrapper] = useState<HTMLElement | null>(null);
   const [hideScrollContainer, setHideScrollContainer] =
     useState<boolean>(false);
+  const [smallScreen, setSmallScreen] = useState(isSmallScreen());
 
   const tableHeadings = useRef<HTMLElement[]>([]);
   const stickyTableHeadings = useRef<HTMLElement[]>([]);
@@ -250,6 +251,13 @@ function IndexTableBase({
     handleCanScrollRight();
   }, [handleCanScrollRight]);
 
+  const handleIsSmallScreen = useCallback(() => {
+    const newSmallScreen = isSmallScreen();
+    if (smallScreen !== newSmallScreen) {
+      setSmallScreen(newSmallScreen);
+    }
+  }, [smallScreen]);
+
   const handleResize = useCallback(() => {
     // hide the scrollbar when resizing
     scrollBarElement.current?.style.setProperty(
@@ -260,7 +268,13 @@ function IndexTableBase({
     resizeTableHeadings();
     debounceResizeTableScrollbar();
     handleCanScrollRight();
-  }, [debounceResizeTableScrollbar, resizeTableHeadings, handleCanScrollRight]);
+    handleIsSmallScreen();
+  }, [
+    resizeTableHeadings,
+    debounceResizeTableScrollbar,
+    handleCanScrollRight,
+    handleIsSmallScreen,
+  ]);
 
   const handleScrollContainerScroll = useCallback(
     (canScrollLeft, canScrollRight) => {
@@ -467,7 +481,7 @@ function IndexTableBase({
             <div className={bulkActionClassNames} data-condensed={condensed}>
               {loadingMarkup}
               <BulkActions
-                smallScreen={condensed}
+                smallScreen={smallScreen}
                 label={i18n.translate('Polaris.IndexTable.selected', {
                   selectedItemsCount: selectedItemsCountLabel,
                 })}

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -252,10 +252,7 @@ function IndexTableBase({
   }, [handleCanScrollRight]);
 
   const handleIsSmallScreen = useCallback(() => {
-    const newSmallScreen = isSmallScreen();
-    if (smallScreen !== newSmallScreen) {
-      setSmallScreen(newSmallScreen);
-    }
+    setSmallScreen(smallScreen);
   }, [smallScreen]);
 
   const handleResize = useCallback(() => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #6405 
Fixes #4156
Fixes #5598

(it's the same bug, it is duplicated)


### WHAT is this pull request doing?

It copies the mechanism on `ResourceList` to keep the bulk actions visible on all screen sizes. 

Previous
![](https://screenshot.click/11-43-3ewqb-5wqjp.png)

Fixed
![](https://screenshot.click/11-45-u8szj-q54g2.png)

Does not affect bigger screens
![](https://screenshot.click/11-46-waohq-hppjm.png)
