### PR TITLE
[icons] fix broken polaris icons website links

### DIFF
--- a/.changeset/sixty-mirrors-add.md
+++ b/.changeset/sixty-mirrors-add.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris-icons': patch
+'polaris.shopify.com': patch
+---
+
+Update polaris icons website url

--- a/polaris-icons/CONTRIBUTING.md
+++ b/polaris-icons/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Polaris icons contribution guidelines
 
-This repository is the place to contribute changes to icons and <https://polaris-icons.shopify.com>.
+This repository is the place to contribute changes to icons and <https://polaris.shopify.com/icons>.
 
 - [Code of conduct](#code-of-conduct)
 - [Icon sets and design guidelines](#icon-sets-and-design-guidelines)

--- a/polaris-icons/package.json
+++ b/polaris-icons/package.json
@@ -49,7 +49,7 @@
   "bugs": {
     "url": "https://github.com/shopify/polaris-icons/issues"
   },
-  "homepage": "https://polaris-icons.shopify.com/",
+  "homepage": "https://polaris.shopify.com/icons",
   "devDependencies": {
     "@svgr/core": "^4.3.3",
     "glob": "^7.1.6",

--- a/polaris.shopify.com/content/contributing/icons.md
+++ b/polaris.shopify.com/content/contributing/icons.md
@@ -18,7 +18,7 @@ table goes here
 
 ## Detailed steps
 
-Before proposing a new icon, search the [icon explorer](https://polaris-icons.shopify.com/). If the icon you're looking for isn't included, create a proposal for the new icon and work with your team to add it. Any additions or changes should also be reflected in the [Figma UI Kit](/contributing/figma-ui-kit).
+Before proposing a new icon, search the [icon explorer](https://polaris.shopify.com/icons). If the icon you're looking for isn't included, create a proposal for the new icon and work with your team to add it. Any additions or changes should also be reflected in the [Figma UI Kit](/contributing/figma-ui-kit).
 
 ### How to contribute
 


### PR DESCRIPTION
For example this link on the live docs website: https://polaris.shopify.com/foundations/design/icons#when-to-use-icons