### PR TITLE
Add <SearchableListbox /> component

### DIFF
--- a/.changeset/cold-toys-greet.md
+++ b/.changeset/cold-toys-greet.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add <SearchableListbox /> to components

--- a/polaris-react/.storybook/polaris-readme-loader.js
+++ b/polaris-react/.storybook/polaris-readme-loader.js
@@ -127,6 +127,7 @@ import {
   ResourceItem,
   ResourceList,
   ResourcePicker,
+  SearchableListbox,
   Scrollable,
   ScrollLock,
   Select,

--- a/polaris-react/src/components/SearchableListbox/README.md
+++ b/polaris-react/src/components/SearchableListbox/README.md
@@ -23,7 +23,7 @@ A SearchableListbox is a vertical, searchable list of interactive, customisable 
 A SearchableListbox is composed of:
 
 1. **Activator node**: Customisable activator to toggle popover containing list items
-2. **Search field**: Textfield for performing serach that can be toggled via the `showSearch` prop
+2. **Search field**: Textfield for performing search that can be toggled via the `showSearch` prop
 3. **List items:** Customisable options inside the list that users can select or deselect
 4. **Footer action:** Optional footer action placed below the list that can be used for actions such as list expansion
 
@@ -35,6 +35,7 @@ SearchableListboxes should:
 
 - Have clear activator node that toggles popover, and content that indicates selected list item
 - Limit the number of list items displayed at once; use the `footerAction` prop for list expansion
+- Be passed all search related props if `showSearch` prop is true
 - Indicate search empty state to user when search value doesn't match any results
 - Show loading state to user when list data is being generated
 
@@ -68,10 +69,6 @@ function BaseExample() {
         </Button>
       }
       open={open}
-      showSearch={false}
-      searchValue=""
-      searchEmptyStateMessage="No results found"
-      searchLabel="Search"
       listItems={[
         {value: '1', children: 'option 1', selected: true},
         {value: '2', children: 'option 2'},
@@ -79,7 +76,6 @@ function BaseExample() {
       onClose={() => {
         setOpen(false);
       }}
-      onSearch={() => {}}
       onOptionSelect={(value) => {
         console.log(value);
         setOpen(false);
@@ -172,15 +168,10 @@ function LoadingExample() {
       }
       open={open}
       loading
-      showSearch={false}
-      searchValue=""
-      searchEmptyStateMessage="No results found"
-      searchLabel="Search"
       listItems={[]}
       onClose={() => {
         setOpen(false);
       }}
-      onSearch={() => {}}
       onOptionSelect={(value) => {
         console.log(value);
         setOpen(false);
@@ -219,15 +210,10 @@ function FooterActionExample() {
         </Button>
       }
       open={open}
-      showSearch={false}
-      searchValue=""
-      searchEmptyStateMessage="No results found"
-      searchLabel="Search"
       listItems={listItems}
       onClose={() => {
         setOpen(false);
       }}
-      onSearch={() => {}}
       onOptionSelect={(value) => {
         console.log(value);
         setOpen(false);
@@ -280,10 +266,6 @@ function CustomOptionExample() {
         </Button>
       }
       open={open}
-      showSearch={false}
-      searchValue=""
-      searchEmptyStateMessage="No results found"
-      searchLabel="Search"
       listItems={[
         {
           value: '1',
@@ -315,7 +297,6 @@ function CustomOptionExample() {
       onClose={() => {
         setOpen(false);
       }}
-      onSearch={() => {}}
       onOptionSelect={(value) => {
         console.log(value);
         setOpen(false);

--- a/polaris-react/src/components/SearchableListbox/README.md
+++ b/polaris-react/src/components/SearchableListbox/README.md
@@ -1,0 +1,326 @@
+---
+name: SearchableListbox
+category: Lists and tables
+keywords:
+  - searchable list
+  - list with search
+  - listbox
+  - list box
+  - interactive list
+  - list
+  - search
+  - textfield
+---
+
+# SearchableListbox
+
+A SearchableListbox is a vertical, searchable list of interactive, customisable options
+
+---
+
+## Anatomy
+
+A SearchableListbox is composed of:
+
+1. **Activator node**: Customisable activator to toggle popover containing list items
+2. **Search field**: Textfield for performing serach that can be toggled via the `showSearch` prop
+3. **List items:** Customisable options inside the list that users can select or deselect
+4. **Footer action:** Optional footer action placed below the list that can be used for actions such as list expansion
+
+---
+
+## Best practices
+
+SearchableListboxes should:
+
+- Have clear activator node that toggles popover, and content that indicates selected list item
+- Limit the number of list items displayed at once; use the `footerAction` prop for list expansion
+- Indicate search empty state to user when search value doesn't match any results
+- Show loading state to user when list data is being generated
+
+---
+
+## Examples
+
+### Basic SearchableListbox
+
+Basic implementation
+
+```jsx
+function BaseExample() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <SearchableListbox
+      activatorNode={
+        <Button
+          plain
+          monochrome
+          removeUnderline
+          size="large"
+          textAlign="left"
+          disclosure="down"
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          Option 1
+        </Button>
+      }
+      open={open}
+      showSearch={false}
+      searchValue=""
+      searchEmptyStateMessage="No results found"
+      searchLabel="Search"
+      listItems={[
+        {value: '1', children: 'option 1', selected: true},
+        {value: '2', children: 'option 2'},
+      ]}
+      onClose={() => {
+        setOpen(false);
+      }}
+      onSearch={() => {}}
+      onOptionSelect={(value) => {
+        console.log(value);
+        setOpen(false);
+      }}
+    />
+  );
+}
+```
+
+### SearchableListbox with search enabled
+
+```jsx
+function ExampleWithSearch() {
+  const [open, setOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const initialListItems = [
+    {value: 'option 1', children: <span>option 1</span>, selected: true},
+    {value: 'choice 2', children: <span>choice 2</span>},
+  ];
+  const [listItems, setListItems] = useState(initialListItems);
+
+  const handleSearch = (searchTerm) => {
+    setSearchValue(searchTerm);
+
+    const nextListItems = searchTerm
+      ? listItems.filter(({value}) => value.includes(searchTerm))
+      : initialListItems;
+    setListItems(nextListItems);
+  };
+
+  return (
+    <SearchableListbox
+      activatorNode={
+        <Button
+          plain
+          monochrome
+          removeUnderline
+          size="large"
+          textAlign="left"
+          disclosure="down"
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          Option 1
+        </Button>
+      }
+      open={open}
+      showSearch
+      searchValue={searchValue}
+      searchEmptyStateMessage="No results found"
+      searchLabel="Search"
+      listItems={listItems}
+      onClose={() => {
+        setOpen(false);
+        setSearchValue('');
+      }}
+      onSearch={handleSearch}
+      onOptionSelect={(value) => {
+        console.log(value);
+        setOpen(false);
+      }}
+    />
+  );
+}
+```
+
+### SearchableListbox in loading state
+
+```jsx
+function LoadingExample() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <SearchableListbox
+      activatorNode={
+        <Button
+          plain
+          monochrome
+          removeUnderline
+          size="large"
+          textAlign="left"
+          disclosure="down"
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          Option 1
+        </Button>
+      }
+      open={open}
+      loading
+      showSearch={false}
+      searchValue=""
+      searchEmptyStateMessage="No results found"
+      searchLabel="Search"
+      listItems={[]}
+      onClose={() => {
+        setOpen(false);
+      }}
+      onSearch={() => {}}
+      onOptionSelect={(value) => {
+        console.log(value);
+        setOpen(false);
+      }}
+    />
+  );
+}
+```
+
+### SearchableListbox with Footer Action
+
+```jsx
+function FooterActionExample() {
+  const [open, setOpen] = useState(false);
+  const [listItems, setListItems] = useState([
+    {value: 'option 1', children: 'option 1', selected: true},
+    {value: 'option 2', children: 'option 2'},
+  ]);
+  const [infiniteScrollEnabled, setInfiniteScrollEnabled] = useState(false);
+
+  return (
+    <SearchableListbox
+      activatorNode={
+        <Button
+          plain
+          monochrome
+          removeUnderline
+          size="large"
+          textAlign="left"
+          disclosure="down"
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          Option 1
+        </Button>
+      }
+      open={open}
+      showSearch={false}
+      searchValue=""
+      searchEmptyStateMessage="No results found"
+      searchLabel="Search"
+      listItems={listItems}
+      onClose={() => {
+        setOpen(false);
+      }}
+      onSearch={() => {}}
+      onOptionSelect={(value) => {
+        console.log(value);
+        setOpen(false);
+      }}
+      footerAction={
+        infiniteScrollEnabled ? undefined : (
+          <Button
+            plain
+            removeUnderline
+            textAlign="left"
+            onClick={() => {
+              setInfiniteScrollEnabled(true);
+              setListItems([
+                ...listItems,
+                {value: 'option 3', children: 'option 3'},
+                {value: 'option 4', children: 'option 4'},
+              ]);
+            }}
+          >
+            Show all
+          </Button>
+        )
+      }
+    />
+  );
+}
+```
+
+### SearchableListbox with custom list options
+
+```jsx
+function CustomOptionExample() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <SearchableListbox
+      activatorNode={
+        <Button
+          plain
+          monochrome
+          removeUnderline
+          size="large"
+          textAlign="left"
+          disclosure="down"
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          Option 1
+        </Button>
+      }
+      open={open}
+      showSearch={false}
+      searchValue=""
+      searchEmptyStateMessage="No results found"
+      searchLabel="Search"
+      listItems={[
+        {
+          value: '1',
+          children: (
+            <Stack wrap={false} alignment="leading">
+              <Stack.Item fill>
+                <Stack vertical spacing="extraTight">
+                  <span>option 1</span>
+                </Stack>
+              </Stack.Item>
+            </Stack>
+          ),
+          selected: true,
+        },
+        {
+          value: '2',
+          children: (
+            <Stack wrap={false} alignment="leading">
+              <Stack.Item fill>
+                <Stack vertical spacing="extraTight">
+                  <span>option 2</span>
+                </Stack>
+              </Stack.Item>
+              <Badge status="info">Draft</Badge>
+            </Stack>
+          ),
+        },
+      ]}
+      onClose={() => {
+        setOpen(false);
+      }}
+      onSearch={() => {}}
+      onOptionSelect={(value) => {
+        console.log(value);
+        setOpen(false);
+      }}
+    />
+  );
+}
+```

--- a/polaris-react/src/components/SearchableListbox/SearchableListbox.scss
+++ b/polaris-react/src/components/SearchableListbox/SearchableListbox.scss
@@ -1,11 +1,7 @@
 .SearchFieldWrapper {
-  padding: var(--p-space-4) var(--p-space-4) var(--p-space-2) var(--p-space-4);
+  padding: var(--p-space-4);
 }
 
 .ListBoxWrapper {
-  padding: var(--p-space-1) 0 var(--p-space-2);
-}
-
-.FooterActionWrapper {
-  padding: 0 var(--p-space-4) var(--p-space-4);
+  padding: var(--p-space-1) 0;
 }

--- a/polaris-react/src/components/SearchableListbox/SearchableListbox.scss
+++ b/polaris-react/src/components/SearchableListbox/SearchableListbox.scss
@@ -1,0 +1,11 @@
+.SearchFieldWrapper {
+  padding: var(--p-space-4) var(--p-space-4) var(--p-space-2) var(--p-space-4);
+}
+
+.ListBoxWrapper {
+  padding: var(--p-space-1) 0 var(--p-space-2);
+}
+
+.FooterActionWrapper {
+  padding: 0 var(--p-space-4) var(--p-space-4);
+}

--- a/polaris-react/src/components/SearchableListbox/SearchableListbox.tsx
+++ b/polaris-react/src/components/SearchableListbox/SearchableListbox.tsx
@@ -1,0 +1,120 @@
+import React, {useState, ReactNode, ReactElement} from 'react';
+
+import {Popover} from '../Popover';
+import {Scrollable} from '../Scrollable';
+import {AutoSelection, Listbox} from '../Listbox';
+import {useUniqueId} from '../../utilities/unique-id';
+
+import {StopPropagation, Search, SearchEmptyState} from './components';
+import styles from './SearchableListbox.scss';
+
+export interface SearchableListItem {
+  children: string | ReactNode;
+  value: string;
+  selected?: boolean;
+}
+
+export interface SearchableListboxProps {
+  activatorNode: ReactElement;
+  open: boolean;
+  showSearch: boolean;
+  searchValue: string;
+  searchEmptyStateMessage: string;
+  searchLabel: string;
+  searchPlaceholder?: string;
+  listItems?: SearchableListItem[];
+  loading?: boolean;
+  loadingAccessibilityLabel?: string;
+  footerAction?: ReactElement;
+  onClose(): void;
+  onSearch(search: string): void;
+  onOptionSelect(selected: string): void;
+  onScrolledToBottom?(): void;
+}
+
+export function SearchableListbox({
+  activatorNode,
+  open,
+  showSearch,
+  searchValue,
+  searchLabel,
+  searchPlaceholder,
+  searchEmptyStateMessage,
+  loading,
+  loadingAccessibilityLabel,
+  listItems,
+  footerAction,
+  onClose,
+  onOptionSelect,
+  onSearch,
+  onScrolledToBottom,
+}: SearchableListboxProps) {
+  const [activeOptionDomId, setActiveOptionDomId] = useState<string>();
+  const listId = useUniqueId('SearchableListbox');
+
+  const showEmptyState = !loading && !listItems?.length;
+
+  const handleActiveOptionChange = (_: string, domId: string) => {
+    setActiveOptionDomId(domId);
+  };
+
+  return (
+    <Popover
+      preferredAlignment="left"
+      activator={activatorNode}
+      active={open}
+      onClose={onClose}
+    >
+      {showSearch && (
+        <Popover.Pane fixed>
+          <div className={styles.SearchFieldWrapper}>
+            <StopPropagation>
+              <Search
+                activeOptionDomId={activeOptionDomId}
+                label={searchLabel}
+                value={searchValue}
+                placeholder={searchPlaceholder}
+                listId={listId}
+                onSearch={onSearch}
+              />
+            </StopPropagation>
+          </div>
+        </Popover.Pane>
+      )}
+      {showEmptyState ? (
+        <SearchEmptyState message={searchEmptyStateMessage} />
+      ) : (
+        <Scrollable shadow onScrolledToBottom={onScrolledToBottom}>
+          <div className={styles.ListBoxWrapper}>
+            <Listbox
+              autoSelection={AutoSelection.None}
+              onSelect={onOptionSelect}
+              customListId={listId}
+              onActiveOptionChange={handleActiveOptionChange}
+            >
+              {listItems?.map(({children, value, selected}) => {
+                return (
+                  <Listbox.Option value={value} selected={selected} key={value}>
+                    <Listbox.TextOption selected={selected}>
+                      {children}
+                    </Listbox.TextOption>
+                  </Listbox.Option>
+                );
+              })}
+              {loading && (
+                <Listbox.Loading
+                  accessibilityLabel={loadingAccessibilityLabel || ''}
+                />
+              )}
+            </Listbox>
+          </div>
+          {!loading && footerAction && (
+            <div className={styles.FooterActionWrapper}>
+              <StopPropagation>{footerAction}</StopPropagation>
+            </div>
+          )}
+        </Scrollable>
+      )}
+    </Popover>
+  );
+}

--- a/polaris-react/src/components/SearchableListbox/SearchableListbox.tsx
+++ b/polaris-react/src/components/SearchableListbox/SearchableListbox.tsx
@@ -17,17 +17,17 @@ export interface SearchableListItem {
 export interface SearchableListboxProps {
   activatorNode: ReactElement;
   open: boolean;
-  showSearch: boolean;
-  searchValue: string;
-  searchEmptyStateMessage: string;
-  searchLabel: string;
-  searchPlaceholder?: string;
   listItems?: SearchableListItem[];
   loading?: boolean;
   loadingAccessibilityLabel?: string;
   footerAction?: ReactElement;
+  showSearch?: boolean;
+  searchValue?: string;
+  searchEmptyStateMessage?: string;
+  searchLabel?: string;
+  searchPlaceholder?: string;
+  onSearch?(search: string): void;
   onClose(): void;
-  onSearch(search: string): void;
   onOptionSelect(selected: string): void;
   onScrolledToBottom?(): void;
 }
@@ -35,11 +35,11 @@ export interface SearchableListboxProps {
 export function SearchableListbox({
   activatorNode,
   open,
-  showSearch,
-  searchValue,
-  searchLabel,
-  searchPlaceholder,
-  searchEmptyStateMessage,
+  showSearch = false,
+  searchValue = '',
+  searchLabel = '',
+  searchPlaceholder = '',
+  searchEmptyStateMessage = '',
   loading,
   loadingAccessibilityLabel,
   listItems,
@@ -52,7 +52,8 @@ export function SearchableListbox({
   const [activeOptionDomId, setActiveOptionDomId] = useState<string>();
   const listId = useUniqueId('SearchableListbox');
 
-  const showEmptyState = !loading && !listItems?.length;
+  const showSearchField = showSearch && onSearch;
+  const showEmptyState = showSearchField && !loading && !listItems?.length;
 
   const handleActiveOptionChange = (_: string, domId: string) => {
     setActiveOptionDomId(domId);
@@ -65,7 +66,7 @@ export function SearchableListbox({
       active={open}
       onClose={onClose}
     >
-      {showSearch && (
+      {showSearchField && (
         <Popover.Pane fixed>
           <div className={styles.SearchFieldWrapper}>
             <StopPropagation>
@@ -87,6 +88,7 @@ export function SearchableListbox({
         <Scrollable shadow onScrolledToBottom={onScrolledToBottom}>
           <div className={styles.ListBoxWrapper}>
             <Listbox
+              enableKeyboardControl
               autoSelection={AutoSelection.None}
               onSelect={onOptionSelect}
               customListId={listId}
@@ -106,13 +108,13 @@ export function SearchableListbox({
                   accessibilityLabel={loadingAccessibilityLabel || ''}
                 />
               )}
+              {!loading && footerAction && (
+                <Listbox.Action value="Footer action">
+                  <StopPropagation>{footerAction}</StopPropagation>
+                </Listbox.Action>
+              )}
             </Listbox>
           </div>
-          {!loading && footerAction && (
-            <div className={styles.FooterActionWrapper}>
-              <StopPropagation>{footerAction}</StopPropagation>
-            </div>
-          )}
         </Scrollable>
       )}
     </Popover>

--- a/polaris-react/src/components/SearchableListbox/components/Search/Search.tsx
+++ b/polaris-react/src/components/SearchableListbox/components/Search/Search.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {SearchMinor} from '@shopify/polaris-icons';
+
+import {TextField} from '../../../TextField';
+import {Icon} from '../../../Icon';
+
+interface Props {
+  value: string;
+  label: string;
+  placeholder?: string;
+  listId: string;
+  activeOptionDomId?: string;
+  onSearch: (search: string) => void;
+}
+
+export function Search({
+  value,
+  label,
+  placeholder,
+  listId,
+  activeOptionDomId,
+  onSearch,
+}: Props) {
+  return (
+    <TextField
+      labelHidden
+      clearButton
+      autoComplete="off"
+      label={label}
+      value={value}
+      placeholder={placeholder}
+      ariaActiveDescendant={activeOptionDomId}
+      ariaControls={listId}
+      ariaOwns={listId}
+      onChange={onSearch}
+      onClearButtonClick={() => onSearch('')}
+      prefix={<Icon source={SearchMinor} />}
+    />
+  );
+}

--- a/polaris-react/src/components/SearchableListbox/components/Search/index.ts
+++ b/polaris-react/src/components/SearchableListbox/components/Search/index.ts
@@ -1,0 +1,1 @@
+export {Search} from './Search';

--- a/polaris-react/src/components/SearchableListbox/components/Search/tests/Search.test.tsx
+++ b/polaris-react/src/components/SearchableListbox/components/Search/tests/Search.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {SearchMinor} from '@shopify/polaris-icons';
+import {mountWithApp} from 'tests/utilities';
+
+import {Search} from '../Search';
+import {TextField} from '../../../../TextField';
+import {Icon} from '../../../../Icon';
+import {noop} from '../../../tests/utilities';
+
+const mockProps = {
+  value: '',
+  label: 'Search',
+  listId: 'customId',
+  onSearch: noop,
+};
+
+describe('<Search />', () => {
+  it('renders <TextField /> with default props and aria attributes', () => {
+    const listId = 'my-id';
+    const activeOptionId = 'active-option-id';
+    const search = mountWithApp(
+      <Search
+        {...mockProps}
+        listId={listId}
+        activeOptionDomId={activeOptionId}
+      />,
+    );
+
+    expect(search).toContainReactComponent(TextField, {
+      labelHidden: true,
+      clearButton: true,
+      autoComplete: 'off',
+      label: 'Search',
+      value: '',
+      ariaOwns: listId,
+      ariaControls: listId,
+      ariaActiveDescendant: activeOptionId,
+    });
+
+    expect(search.find(TextField)).toContainReactComponent(Icon, {
+      source: SearchMinor,
+    });
+  });
+
+  it('renders <TextField />  with value', () => {
+    const value = 'test';
+    const search = mountWithApp(<Search {...mockProps} value={value} />);
+
+    expect(search).toContainReactComponent(TextField, {
+      value,
+    });
+  });
+
+  it('renders <TextField />  with placeholder', () => {
+    const placeholder = 'test';
+    const search = mountWithApp(
+      <Search {...mockProps} placeholder={placeholder} />,
+    );
+
+    expect(search).toContainReactComponent(TextField, {
+      placeholder,
+    });
+  });
+
+  it('triggers onSearch on text field change', () => {
+    const value = 'test';
+    const onSearchSpy = jest.fn();
+    const search = mountWithApp(
+      <Search {...mockProps} onSearch={onSearchSpy} />,
+    );
+
+    search.find(TextField)!.trigger('onChange', value);
+
+    expect(onSearchSpy).toHaveBeenCalledWith(value);
+  });
+
+  it('triggers onSearch with empty value onClearButtonClick', () => {
+    const onSearchSpy = jest.fn();
+    const search = mountWithApp(
+      <Search {...mockProps} value="value" onSearch={onSearchSpy} />,
+    );
+
+    search.find(TextField)!.trigger('onClearButtonClick', 'textfieldId');
+
+    expect(onSearchSpy).toHaveBeenCalledWith('');
+  });
+});

--- a/polaris-react/src/components/SearchableListbox/components/SearchEmptyState/SearchEmptyState.scss
+++ b/polaris-react/src/components/SearchableListbox/components/SearchEmptyState/SearchEmptyState.scss
@@ -1,0 +1,4 @@
+.EmptyState {
+  text-align: center;
+  padding: var(--p-space-4) 0;
+}

--- a/polaris-react/src/components/SearchableListbox/components/SearchEmptyState/SearchEmptyState.tsx
+++ b/polaris-react/src/components/SearchableListbox/components/SearchEmptyState/SearchEmptyState.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import {TextStyle} from '../../../TextStyle';
+
+import styles from './SearchEmptyState.scss';
+
+interface Props {
+  message: string;
+}
+
+export function SearchEmptyState({message}: Props) {
+  return (
+    <div className={styles.EmptyState}>
+      <TextStyle variation="subdued">{message}</TextStyle>
+    </div>
+  );
+}

--- a/polaris-react/src/components/SearchableListbox/components/SearchEmptyState/index.ts
+++ b/polaris-react/src/components/SearchableListbox/components/SearchEmptyState/index.ts
@@ -1,0 +1,1 @@
+export {SearchEmptyState} from './SearchEmptyState';

--- a/polaris-react/src/components/SearchableListbox/components/SearchEmptyState/tests/SearchEmptyState.test.tsx
+++ b/polaris-react/src/components/SearchableListbox/components/SearchEmptyState/tests/SearchEmptyState.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {TextStyle} from '../../../../TextStyle';
+import {SearchEmptyState} from '../SearchEmptyState';
+
+describe('<SearchEmptyState />', () => {
+  it('renders subdued <TextStyle /> with message', () => {
+    const mockMessage = "it's empty";
+    const searchEmptyState = mountWithApp(
+      <SearchEmptyState message={mockMessage} />,
+    );
+
+    expect(searchEmptyState).toContainReactComponent(TextStyle, {
+      variation: 'subdued',
+      children: mockMessage,
+    });
+  });
+});

--- a/polaris-react/src/components/SearchableListbox/components/StopPropagation/StopPropagation.tsx
+++ b/polaris-react/src/components/SearchableListbox/components/StopPropagation/StopPropagation.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const StopPropagation = ({children}: React.PropsWithChildren<any>) => {
+  const stopEventPropagation = (event: React.MouseEvent | React.TouchEvent) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <div onClick={stopEventPropagation} onTouchStart={stopEventPropagation}>
+      {children}
+    </div>
+  );
+};

--- a/polaris-react/src/components/SearchableListbox/components/StopPropagation/index.ts
+++ b/polaris-react/src/components/SearchableListbox/components/StopPropagation/index.ts
@@ -1,0 +1,1 @@
+export {StopPropagation} from './StopPropagation';

--- a/polaris-react/src/components/SearchableListbox/components/StopPropagation/tests/StopPropagation.test.tsx
+++ b/polaris-react/src/components/SearchableListbox/components/StopPropagation/tests/StopPropagation.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {StopPropagation} from '../StopPropagation';
+
+const FakeComponent = ({
+  bubbleEventSpy,
+  withStopPropagation = true,
+}: {
+  bubbleEventSpy: (position: string) => void;
+  withStopPropagation?: boolean;
+}) => {
+  const handleClick = (position: string) => {
+    bubbleEventSpy(position);
+  };
+
+  const handleInnerClick = () => {
+    handleClick('inner');
+  };
+
+  const button = (
+    <button
+      type="button"
+      id="my-button"
+      onTouchStart={handleInnerClick}
+      onClick={handleInnerClick}
+    >
+      My button
+    </button>
+  );
+
+  return (
+    <div onClick={() => handleClick('outer')}>
+      {withStopPropagation ? (
+        <StopPropagation>{button}</StopPropagation>
+      ) : (
+        button
+      )}
+    </div>
+  );
+};
+
+describe('<StopPropagation />', () => {
+  it.each(['click', 'touchstart'])(
+    'stops propagation of %s event if <StopPropagation /> is present',
+    (event) => {
+      const clickSpy = jest.fn();
+      const searchWrapper = mountWithApp(
+        <FakeComponent bubbleEventSpy={clickSpy} />,
+      );
+
+      searchWrapper
+        .find('button', {id: 'my-button'})!
+        .domNode!.dispatchEvent(new Event(event, {bubbles: true}));
+
+      expect(clickSpy).toHaveBeenCalledWith('inner');
+      expect(clickSpy).not.toHaveBeenCalledWith('outer');
+    },
+  );
+
+  it("doesn't stop propagation of click event if <StopPropagation /> isn't present", () => {
+    const clickSpy = jest.fn();
+    const searchWrapper = mountWithApp(
+      <FakeComponent bubbleEventSpy={clickSpy} withStopPropagation={false} />,
+    );
+
+    searchWrapper
+      .find('button', {id: 'my-button'})!
+      .domNode!.dispatchEvent(new Event('click', {bubbles: true}));
+
+    expect(clickSpy).toHaveBeenCalledWith('inner');
+    expect(clickSpy).toHaveBeenCalledWith('outer');
+  });
+});

--- a/polaris-react/src/components/SearchableListbox/components/index.ts
+++ b/polaris-react/src/components/SearchableListbox/components/index.ts
@@ -1,0 +1,3 @@
+export {StopPropagation} from './StopPropagation';
+export {Search} from './Search';
+export {SearchEmptyState} from './SearchEmptyState';

--- a/polaris-react/src/components/SearchableListbox/index.ts
+++ b/polaris-react/src/components/SearchableListbox/index.ts
@@ -1,0 +1,1 @@
+export * from './SearchableListbox';

--- a/polaris-react/src/components/SearchableListbox/tests/SearchableListbox.test.tsx
+++ b/polaris-react/src/components/SearchableListbox/tests/SearchableListbox.test.tsx
@@ -1,0 +1,326 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {useUniqueId} from '../../../utilities/unique-id';
+import {AutoSelection, Listbox} from '../../Listbox';
+import {Popover} from '../../Popover';
+import {Scrollable} from '../../Scrollable';
+import {Search, StopPropagation, SearchEmptyState} from '../components';
+import {SearchableListbox} from '../SearchableListbox';
+
+import {noop} from './utilities';
+
+jest.mock('../../../utilities/unique-id', () => ({
+  ...jest.requireActual('../../../utilities/unique-id'),
+  useUniqueId: jest.fn(),
+}));
+const useUniqueIdMock = useUniqueId as jest.Mock;
+
+const mockProps = {
+  activatorNode: <span>Activator</span>,
+  open: true,
+  searchValue: '',
+  searchLabel: '',
+  searchEmptyStateMessage: '',
+  onClose: noop,
+  onOptionSelect: noop,
+  onSearch: noop,
+  showSearch: false,
+  loading: false,
+};
+
+describe('<SearchableListbox />', () => {
+  it('renders <Popover /> with base props', () => {
+    const searchableListbox = mountWithApp(
+      <SearchableListbox {...mockProps} />,
+    );
+
+    expect(searchableListbox).toContainReactComponent(Popover, {
+      preferredAlignment: 'left',
+      active: true,
+      onClose: expect.any(Function),
+    });
+  });
+
+  it.each([true, false])(
+    'renders <Popover /> with active prop based on open prop',
+    (open) => {
+      const searchableListbox = mountWithApp(
+        <SearchableListbox {...mockProps} open={open} />,
+      );
+
+      expect(searchableListbox).toContainReactComponent(Popover, {
+        active: open,
+      });
+    },
+  );
+
+  it('triggers onClose', () => {
+    const onCloseSpy = jest.fn();
+    const searchableListbox = mountWithApp(
+      <SearchableListbox {...mockProps} onClose={onCloseSpy} />,
+    );
+
+    searchableListbox.find(Popover)!.trigger('onClose');
+
+    expect(onCloseSpy).toHaveBeenCalled();
+  });
+
+  it('renders activatorNode', () => {
+    const activator = <button type="button">Activator button</button>;
+    const searchableListbox = mountWithApp(
+      <SearchableListbox {...mockProps} activatorNode={activator} />,
+    );
+
+    expect(searchableListbox).toContainReactComponent('button', {
+      type: 'button',
+      children: 'Activator button',
+    });
+  });
+
+  describe('listItems', () => {
+    it('renders <ListBox /> with a listId', () => {
+      const onOptionSelectSpy = jest.fn();
+
+      const mockCustomListId = 'SearchableListbox';
+      useUniqueIdMock.mockReturnValue(mockCustomListId);
+
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          listItems={getMockListItems()}
+          onOptionSelect={onOptionSelectSpy}
+        />,
+      );
+
+      expect(searchableListbox).toContainReactComponent(Listbox, {
+        onSelect: onOptionSelectSpy,
+        autoSelection: AutoSelection.None,
+        customListId: mockCustomListId,
+      });
+    });
+
+    it('renders <ListBox.Option /> and <ListBox.TextOption />', () => {
+      const listItems = getMockListItems();
+      const searchableListbox = mountWithApp(
+        <SearchableListbox {...mockProps} listItems={listItems} />,
+      );
+
+      const [listItem] = listItems;
+
+      expect(searchableListbox).toContainReactComponent(Listbox.Option, {
+        value: listItem.value,
+        selected: listItem.selected,
+      });
+      expect(searchableListbox).toContainReactComponent(Listbox.TextOption, {
+        selected: listItem.selected,
+        children: listItem.children,
+      });
+    });
+
+    it('calls onScrolledToBottom from <Scrollable />', () => {
+      const onScrolledToBottomSpy = jest.fn();
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          open
+          onScrolledToBottom={onScrolledToBottomSpy}
+          listItems={getMockListItems()}
+        />,
+      );
+
+      searchableListbox
+        .find(Popover)
+        ?.find(Scrollable, {onScrolledToBottom: onScrolledToBottomSpy})!
+        .trigger('onScrolledToBottom');
+
+      expect(onScrolledToBottomSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('search', () => {
+    it('hides <Search /> and fixed <Popover.Pane /> if showSearch is false', () => {
+      const searchableListbox = mountWithApp(
+        <SearchableListbox {...mockProps} showSearch={false} />,
+      );
+
+      expect(searchableListbox).not.toContainReactComponent(Popover.Pane, {
+        fixed: true,
+      });
+      expect(searchableListbox).not.toContainReactComponent(Search);
+    });
+
+    it('renders <Search /> in fixed <Popover.Pane /> and <StopPropagation /> with a listId', () => {
+      const placeholder = 'placeholder';
+      const value = 'value';
+
+      const mockCustomListId = 'SearchableListbox';
+      useUniqueIdMock.mockReturnValue(mockCustomListId);
+
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          showSearch
+          searchPlaceholder={placeholder}
+          searchValue={value}
+        />,
+      );
+
+      expect(
+        searchableListbox
+          .find(Popover.Pane, {fixed: true})!
+          .find(StopPropagation),
+      ).toContainReactComponent(Search, {
+        value,
+        placeholder,
+        listId: mockCustomListId,
+      });
+    });
+
+    it('sets activeOptionDomId of <Search /> onActiveOptionChange', () => {
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          showSearch
+          listItems={getMockListItems(2)}
+        />,
+      );
+
+      const nextOptionId = 'my-option-id';
+      searchableListbox
+        .find(Listbox)!
+        .trigger('onActiveOptionChange', '', nextOptionId);
+
+      expect(searchableListbox).toContainReactComponent(Search, {
+        activeOptionDomId: nextOptionId,
+      });
+    });
+
+    it('triggers onSearch', () => {
+      const value = 'test';
+      const onSearchSpy = jest.fn();
+      const searchableListbox = mountWithApp(
+        <SearchableListbox {...mockProps} showSearch onSearch={onSearchSpy} />,
+      );
+
+      searchableListbox.find(Search)!.trigger('onSearch', value);
+
+      expect(onSearchSpy).toHaveBeenCalledWith(value);
+    });
+  });
+
+  describe('<Listbox.Loading />', () => {
+    it('renders with accessibility label when loading', () => {
+      const label = 'loading spinner';
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          loading
+          loadingAccessibilityLabel={label}
+        />,
+      );
+
+      expect(searchableListbox).toContainReactComponent(Listbox.Loading, {
+        accessibilityLabel: label,
+      });
+    });
+
+    it("doesn't render if not loading", () => {
+      const searchableListbox = mountWithApp(
+        <SearchableListbox {...mockProps} loading={false} />,
+      );
+
+      expect(searchableListbox).not.toContainReactComponent(Listbox.Loading);
+    });
+  });
+
+  describe('footer action', () => {
+    it('renders inside <StopPropagation /> when not loading and listItems exist', () => {
+      const mockFooterAction = <p>action</p>;
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          loading={false}
+          footerAction={mockFooterAction}
+          listItems={getMockListItems()}
+        />,
+      );
+
+      expect(searchableListbox.find(Popover.Pane)).toContainReactComponent(
+        StopPropagation,
+        {
+          children: mockFooterAction,
+        },
+      );
+    });
+
+    it("doesn't render if loading", () => {
+      const mockFooterAction = <p>action</p>;
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          loading
+          footerAction={mockFooterAction}
+          listItems={getMockListItems()}
+        />,
+      );
+
+      expect(searchableListbox).not.toContainReactComponent('p', {
+        children: mockFooterAction,
+      });
+    });
+  });
+
+  describe('empty state', () => {
+    it.each([undefined, []])(
+      'renders <SearchEmptyState /> with emptyStateMessage when not loading and list items is %s',
+      (listItems) => {
+        const mockEmptyStateMessage = 'empty';
+        const searchableListbox = mountWithApp(
+          <SearchableListbox
+            {...mockProps}
+            loading={false}
+            listItems={listItems}
+            searchEmptyStateMessage={mockEmptyStateMessage}
+          />,
+        );
+
+        expect(searchableListbox).toContainReactComponent(SearchEmptyState, {
+          message: mockEmptyStateMessage,
+        });
+      },
+    );
+
+    it("doesn't render <SearchEmptyState /> when loading", () => {
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          loading
+          listItems={getMockListItems()}
+        />,
+      );
+
+      expect(searchableListbox).not.toContainReactComponent(SearchEmptyState);
+    });
+
+    it("doesn't render <SearchEmptyState /> when listItems exist", () => {
+      const searchableListbox = mountWithApp(
+        <SearchableListbox
+          {...mockProps}
+          listItems={getMockListItems()}
+          loading={false}
+        />,
+      );
+
+      expect(searchableListbox).not.toContainReactComponent(SearchEmptyState);
+    });
+  });
+});
+
+function getMockListItems(count = 1, selected = false) {
+  return [...Array(count)].map((_, index) => ({
+    value: `list item ${index}`,
+    children: <p>{`Item ${index}`}</p>,
+    selected,
+  }));
+}

--- a/polaris-react/src/components/SearchableListbox/tests/SearchableListbox.test.tsx
+++ b/polaris-react/src/components/SearchableListbox/tests/SearchableListbox.test.tsx
@@ -19,13 +19,8 @@ const useUniqueIdMock = useUniqueId as jest.Mock;
 const mockProps = {
   activatorNode: <span>Activator</span>,
   open: true,
-  searchValue: '',
-  searchLabel: '',
-  searchEmptyStateMessage: '',
   onClose: noop,
   onOptionSelect: noop,
-  onSearch: noop,
-  showSearch: false,
   loading: false,
 };
 
@@ -141,7 +136,22 @@ describe('<SearchableListbox />', () => {
   describe('search', () => {
     it('hides <Search /> and fixed <Popover.Pane /> if showSearch is false', () => {
       const searchableListbox = mountWithApp(
-        <SearchableListbox {...mockProps} showSearch={false} />,
+        <SearchableListbox
+          {...mockProps}
+          showSearch={false}
+          onSearch={() => {}}
+        />,
+      );
+
+      expect(searchableListbox).not.toContainReactComponent(Popover.Pane, {
+        fixed: true,
+      });
+      expect(searchableListbox).not.toContainReactComponent(Search);
+    });
+
+    it('hides <Search /> and fixed <Popover.Pane /> if onSearch is undefined', () => {
+      const searchableListbox = mountWithApp(
+        <SearchableListbox {...mockProps} showSearch onSearch={undefined} />,
       );
 
       expect(searchableListbox).not.toContainReactComponent(Popover.Pane, {
@@ -161,8 +171,10 @@ describe('<SearchableListbox />', () => {
         <SearchableListbox
           {...mockProps}
           showSearch
+          onSearch={() => {}}
           searchPlaceholder={placeholder}
           searchValue={value}
+          searchEmptyStateMessage="no results found"
         />,
       );
 
@@ -182,6 +194,10 @@ describe('<SearchableListbox />', () => {
         <SearchableListbox
           {...mockProps}
           showSearch
+          onSearch={() => {}}
+          searchPlaceholder="placeholder"
+          searchValue=""
+          searchEmptyStateMessage="no results found"
           listItems={getMockListItems(2)}
         />,
       );
@@ -200,7 +216,14 @@ describe('<SearchableListbox />', () => {
       const value = 'test';
       const onSearchSpy = jest.fn();
       const searchableListbox = mountWithApp(
-        <SearchableListbox {...mockProps} showSearch onSearch={onSearchSpy} />,
+        <SearchableListbox
+          {...mockProps}
+          showSearch
+          onSearch={onSearchSpy}
+          searchPlaceholder="placeholder"
+          searchValue=""
+          searchEmptyStateMessage="no results found"
+        />,
       );
 
       searchableListbox.find(Search)!.trigger('onSearch', value);
@@ -246,12 +269,11 @@ describe('<SearchableListbox />', () => {
         />,
       );
 
-      expect(searchableListbox.find(Popover.Pane)).toContainReactComponent(
-        StopPropagation,
-        {
-          children: mockFooterAction,
-        },
-      );
+      expect(
+        searchableListbox.find(Listbox.Action, {value: 'Footer action'}),
+      ).toContainReactComponent(StopPropagation, {
+        children: mockFooterAction,
+      });
     });
 
     it("doesn't render if loading", () => {
@@ -273,7 +295,7 @@ describe('<SearchableListbox />', () => {
 
   describe('empty state', () => {
     it.each([undefined, []])(
-      'renders <SearchEmptyState /> with emptyStateMessage when not loading and list items is %s',
+      'renders <SearchEmptyState /> with emptyStateMessage when showSearch is true, loading is false, and list items is %s',
       (listItems) => {
         const mockEmptyStateMessage = 'empty';
         const searchableListbox = mountWithApp(
@@ -281,6 +303,10 @@ describe('<SearchableListbox />', () => {
             {...mockProps}
             loading={false}
             listItems={listItems}
+            showSearch
+            onSearch={() => {}}
+            searchPlaceholder="placeholder"
+            searchValue=""
             searchEmptyStateMessage={mockEmptyStateMessage}
           />,
         );
@@ -296,6 +322,11 @@ describe('<SearchableListbox />', () => {
         <SearchableListbox
           {...mockProps}
           loading
+          showSearch
+          onSearch={() => {}}
+          searchPlaceholder="placeholder"
+          searchValue=""
+          searchEmptyStateMessage="no results found"
           listItems={getMockListItems()}
         />,
       );
@@ -308,6 +339,11 @@ describe('<SearchableListbox />', () => {
         <SearchableListbox
           {...mockProps}
           listItems={getMockListItems()}
+          showSearch
+          onSearch={() => {}}
+          searchPlaceholder="placeholder"
+          searchValue=""
+          searchEmptyStateMessage="no results found"
           loading={false}
         />,
       );

--- a/polaris-react/src/components/SearchableListbox/tests/utilities.ts
+++ b/polaris-react/src/components/SearchableListbox/tests/utilities.ts
@@ -1,0 +1,1 @@
+export function noop() {}

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -290,6 +290,12 @@ export type {ResourceItemProps} from './components/ResourceItem';
 export {ResourceList} from './components/ResourceList';
 export type {ResourceListProps} from './components/ResourceList';
 
+export {
+  SearchableListbox,
+  type SearchableListboxProps,
+  type SearchableListItem,
+} from './components/SearchableListbox';
+
 export {Scrollable} from './components/Scrollable';
 export type {ScrollableProps} from './components/Scrollable';
 

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -290,10 +290,10 @@ export type {ResourceItemProps} from './components/ResourceItem';
 export {ResourceList} from './components/ResourceList';
 export type {ResourceListProps} from './components/ResourceList';
 
-export {
-  SearchableListbox,
-  type SearchableListboxProps,
-  type SearchableListItem,
+export {SearchableListbox} from './components/SearchableListbox';
+export type {
+  SearchableListboxProps,
+  SearchableListItem,
 } from './components/SearchableListbox';
 
 export {Scrollable} from './components/Scrollable';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->


### WHY are these changes introduced?

- This component's goal is to provide a consistent `searchable list in a popover` experience to multiple consumers spanning from internal admin commerce objects to non-admin 1P apps. This consistent UI composition will help us accomplish a unified UX across our organisation, but also, provide a useful and (imo) common component pattern to the public.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Adds a new component, `<SearchableListbox />` to `src/components`

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

- Instead of a playground, please check out this branch, run storybook (`yarn && yarn dev`), and find the `SearchableListbox` folder in the left nav, and play around with the different examples.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
