### PR TITLE
[FooterHelp] Add content guideline for links in FooterHelp

### DIFF
--- a/.changeset/happy-keys-serve.md
+++ b/.changeset/happy-keys-serve.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Add content guideline for links in `FooterHelp`

--- a/polaris-react/src/components/FooterHelp/README.md
+++ b/polaris-react/src/components/FooterHelp/README.md
@@ -47,6 +47,10 @@ Links should be:
 
 Clearly labeled: Merchants shouldn’t need to guess where they’ll end up if they click on an action link. Never use “click here” as a link because it doesn’t set expectations about what’s next.
 
+Links should not be:
+
+Marked as external: Do not set the `external` prop on the `Link` component to force open a new tab.
+
 <!-- usagelist -->
 
 #### Do

--- a/polaris.shopify.com/content/components/footer-help.md
+++ b/polaris.shopify.com/content/components/footer-help.md
@@ -53,6 +53,10 @@ Links should be:
 
 Clearly labeled: Merchants shouldn’t need to guess where they’ll end up if they click on an action link. Never use “click here” as a link because it doesn’t set expectations about what’s next.
 
+Links should not be:
+
+Marked as external: Do not set the `external` prop on the `Link` component to force open a new tab.
+
 <!-- usagelist -->
 
 #### Do


### PR DESCRIPTION
### WHY are these changes introduced?

Per a discussion with @alex-page on whether links in `FooterHelp` should have the `external` prop applied, this change introduces a clear guideline on **not** including the `external` prop.

### WHAT is this pull request doing?

Adding a content guideline:

![](https://screenshot.click/12-40-te4j4-vfklc.png)

### 🎩 checklist

- 🚫 Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- 🚫 Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- 🚫 Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
