### PR TITLE
Fix component links across repos

### DIFF
--- a/.changeset/beige-seals-trade.md
+++ b/.changeset/beige-seals-trade.md
@@ -1,0 +1,7 @@
+---
+'@shopify/polaris-icons': patch
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Update component links so they no longer hit the redirect

--- a/documentation/guides/migrating-from-v5-to-v6.md
+++ b/documentation/guides/migrating-from-v5-to-v6.md
@@ -9,7 +9,7 @@ In v5 Polaris contained two design languages that could be toggled using the `ne
 In v6, you no longer need to configure `AppProvider` to opt into new styles, and legacy theme configuration has been removed:
 
 - `AppProvider`'s `features` prop no longer accepts a `newDesignLanguage` key.
-- `AppProvider`'s `theme` prop no longer accepts theming using the `topBar` key. Instead control theming using the new color config that gets passed through to [`ThemeProvider`](https://polaris.shopify.com/components/structure/theme-provider).
+- `AppProvider`'s `theme` prop no longer accepts theming using the `topBar` key. Instead control theming using the new color config that gets passed through to [`ThemeProvider`](https://polaris.shopify.com/components/theme-provider).
 - `AppProvider`'s `theme` prop expects its `frameOffset` to be specified as a string including a unit instead of a number in pixels, to allow for non-pixel based sizing.
 
 ```diff

--- a/polaris-icons/README.md
+++ b/polaris-icons/README.md
@@ -8,7 +8,7 @@ Browse and search Polaris icons: <https://polaris-icons.shopify.com>.
 
 ## Getting started
 
-Although it’s possible to use this package directly, we recommend using the icons in this package through [Polaris React](https://github.com/Shopify/polaris-react) in combination with the [`Icon`](https://polaris.shopify.com/components/images-and-icons/icon) component.
+Although it’s possible to use this package directly, we recommend using the icons in this package through [Polaris React](https://github.com/Shopify/polaris-react) in combination with the [`Icon`](https://polaris.shopify.com/components/icon) component.
 
 ## Installation
 
@@ -29,7 +29,7 @@ Although it’s possible to use this package directly, we recommend using the ic
 
 ## Usage
 
-Import the [`Icon`](https://polaris.shopify.com/components/images-and-icons/icon) component from Polaris React and any icon from Polaris icons into your project.
+Import the [`Icon`](https://polaris.shopify.com/components/icon) component from Polaris React and any icon from Polaris icons into your project.
 
 1. Import the icon component from Polaris React:
 

--- a/polaris-react/CHANGELOG.md
+++ b/polaris-react/CHANGELOG.md
@@ -1264,9 +1264,9 @@ For instructions on updating from v5 to v6, see our [migration guide](https://gi
 
 ## 4.18.0
 
-- Added [`MediaCard`](https://polaris.shopify.com/components/structure/video-card) and [`VideoThumbnail`](https://polaris.shopify.com/components/images-and-icons/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
-- Added [`VideoThumbnail`](https://polaris.shopify.com/components/images-and-icons/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
-- Added utilities for parsing video duration (https://polaris.shopify.com/components/images-and-icons/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
+- Added [`MediaCard`](https://polaris.shopify.com/components/video-card) and [`VideoThumbnail`](https://polaris.shopify.com/components/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
+- Added [`VideoThumbnail`](https://polaris.shopify.com/components/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
+- Added utilities for parsing video duration (https://polaris.shopify.com/components/video-thumbnail) ([#2725](https://github.com/Shopify/polaris-react/pull/2725))
 - Updated polaris-tokens to use new font stack ([#2906](https://github.com/Shopify/polaris-react/pull/2906))
 
 ## 4.17.1
@@ -1698,7 +1698,7 @@ For instructions on updating from v3 to v4, see our [migration guide](https://gi
 - Removed support for `<Icon untrusted>`. Passing a string into `source` will now always load an untrusted icon, you don’t need that additional property. ([#1604](https://github.com/Shopify/polaris-react/pull/1604)).
 - Removed `Navigation.UserMenu`. Use `TopBar.UserMenu` instead. ([#1599](https://github.com/Shopify/polaris-react/pull/1599))
 - Made `title` a required prop on `ChoiceList` to improve accessibility. It can be hidden with `titleHidden`. ([#1575](https://github.com/Shopify/polaris-react/pull/1575))
-- Made `i18n` a required prop on `AppProvider`. [Usage instructions](https://polaris.shopify.com/components/structure/app-provider#using-translations) are included in the `AppProvider` docs. ([#1530](https://github.com/Shopify/polaris-react/pull/1530))
+- Made `i18n` a required prop on `AppProvider`. [Usage instructions](https://polaris.shopify.com/components/app-provider#using-translations) are included in the `AppProvider` docs. ([#1530](https://github.com/Shopify/polaris-react/pull/1530))
 - Upgraded `react` and `react-dom` peer-dependencies to 16.8.6 to enable the use of hooks ([#1525](https://github.com/Shopify/polaris-react/pull/1525))
 - Changed the import method for React to use default imports. Applications consuming Polaris using TypeScript must enable [`esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop) in `tsconfig.json`. ([#1523](https://github.com/Shopify/polaris-react/pull/1523))
 - Removed `LinkLikeComponent` type export. Use `AppProviderProps['linkComponent']` instead. ([#1864](https://github.com/Shopify/polaris-react/pull/1864))
@@ -2266,37 +2266,37 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 
 We’ve released a suite of new components that, when combined, form the application frame of a stand-alone (or non-embedded) Polaris app.
 
-#### [Frame](https://polaris.shopify.com/components/structure/frame)
+#### [Frame](https://polaris.shopify.com/components/frame)
 
 The frame component, while not visible in the user interface itself, provides the structure for any non-embedded application. It wraps the main elements and houses the following components:
 
-- primary [navigation](https://polaris.shopify.com/components/navigation/navigation)
-- [top bar](https://polaris.shopify.com/components/structure/top-bar)
-- [toast](https://polaris.shopify.com/components/feedback-indicators/toast)
-- [loading](https://polaris.shopify.com/components/feedback-indicators/loading)
-- [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar)
+- primary [navigation](https://polaris.shopify.com/components/navigation)
+- [top bar](https://polaris.shopify.com/components/top-bar)
+- [toast](https://polaris.shopify.com/components/toast)
+- [loading](https://polaris.shopify.com/components/loading)
+- [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar)
 
-#### [Navigation](https://polaris.shopify.com/components/navigation/navigation)
+#### [Navigation](https://polaris.shopify.com/components/navigation)
 
-The navigation component is used to display the primary navigation in the sidebar of the [frame](https://polaris.shopify.com/components/structure/frame) of any non-embedded application. Navigation includes a list of links that merchants use to move between sections of the application.
+The navigation component is used to display the primary navigation in the sidebar of the [frame](https://polaris.shopify.com/components/frame) of any non-embedded application. Navigation includes a list of links that merchants use to move between sections of the application.
 
-#### [TopBar](https://polaris.shopify.com/components/structure/top-bar)
+#### [TopBar](https://polaris.shopify.com/components/top-bar)
 
-The top bar component is always visible at the top of a non-embedded application. Its logo and color can be customized using the [app provider](https://polaris.shopify.com/components/structure/app-provider) component to reflect an application’s brand. Merchants can use it to search an application, access menus, and navigate by clicking on the logo.
+The top bar component is always visible at the top of a non-embedded application. Its logo and color can be customized using the [app provider](https://polaris.shopify.com/components/app-provider) component to reflect an application’s brand. Merchants can use it to search an application, access menus, and navigate by clicking on the logo.
 
-#### [Toast](https://polaris.shopify.com/components/feedback-indicators/toast)
+#### [Toast](https://polaris.shopify.com/components/toast)
 
 The toast component is a non-disruptive message that appears at the bottom of the interface to provide quick, at-a-glance feedback on the outcome of an action.
 
-#### [Loading](https://polaris.shopify.com/components/feedback-indicators/loading)
+#### [Loading](https://polaris.shopify.com/components/loading)
 
 The loading component is used to indicate to merchants that a page is loading or an upload is processing.
 
-#### [ContextualSaveBar](https://polaris.shopify.com/components/forms/contextual-save-bar)
+#### [ContextualSaveBar](https://polaris.shopify.com/components/contextual-save-bar)
 
 The contextual save bar tells merchants their options once they have made changes to a form on the page. This component is also shown while creating a new object like a product or customer. Merchants can use this component to save or discard their work.
 
-#### [Autocomplete](https://polaris.shopify.com/components/forms/autocomplete)
+#### [Autocomplete](https://polaris.shopify.com/components/autocomplete)
 
 The autocomplete component is an input field that provides selectable suggestions as a merchant types into it. It allows merchants to quickly search through and select from large collections of options.
 
@@ -2516,7 +2516,7 @@ Use `withRef` with `compose` to forwardRefs to a component.
 - Added examples for iOS and Android `Avatar`
 - Added `Stepper` component
 
-#### [InlineError](https://polaris.shopify.com/components/forms/inline-error)
+#### [InlineError](https://polaris.shopify.com/components/inline-error)
 
 Use inline errors to describe custom form inputs or form groups when invalid.
 
@@ -2555,7 +2555,7 @@ Use inline errors to describe custom form inputs or form groups when invalid.
 
 ## 2.3.0
 
-#### [Option list](https://polaris.shopify.com/components/lists-and-tables/option-list)
+#### [Option list](https://polaris.shopify.com/components/option-list)
 
 Use `OptionList` to present a group of selectable items outside of the context of a `Form`.
 
@@ -2580,7 +2580,7 @@ Use `OptionList` to present a group of selectable items outside of the context o
 
 ## 2.2.0
 
-#### [Range slider](https://polaris.shopify.com/components/forms/range-slider)
+#### [Range slider](https://polaris.shopify.com/components/range-slider)
 
 Use `RangeSlider` to select a number value between a min and max range.
 
@@ -2608,7 +2608,7 @@ Use `RangeSlider` to select a number value between a min and max range.
 
 ## 2.1.0
 
-#### [Exception list](https://polaris.shopify.com/components/lists-and-tables/exception-list)
+#### [Exception list](https://polaris.shopify.com/components/exception-list)
 
 Use Exception lists to draw the merchant’s attention to important information that adds extra context to a task.
 
@@ -2650,7 +2650,7 @@ We’re removing support for React 15 in order to make full use of some of the n
 
 Upgrade your app to the latest version of React.
 
-#### [App provider](https://polaris.shopify.com/components/structure/app-provider)
+#### [App provider](https://polaris.shopify.com/components/app-provider)
 
 The `AppProvider` component is now required in your app for Polaris components to function properly.
 
@@ -2658,7 +2658,7 @@ The `AppProvider` component is now required in your app for Polaris components t
 
 Wrap your app in the `AppProvider` component.
 
-#### [Collapsible](https://polaris.shopify.com/components/behavior/collapsible) component requires an `id` prop
+#### [Collapsible](https://polaris.shopify.com/components/collapsible) component requires an `id` prop
 
 For accessibility reasons, the `id` prop is now required on the `Collapsible` component.
 
@@ -2674,7 +2674,7 @@ The `EmbeddedApp` component has been removed. The `AppProvider` component now ac
 
 Use the `AppProvider` component with the `apiKey` and `shopOrigin` props.
 
-#### [Resource list](https://polaris.shopify.com/components/lists-and-tables/resource-list#navigation)
+#### [Resource list](https://polaris.shopify.com/components/resource-list#navigation)
 
 Shopify is organized around objects that represent a merchant’s business, such as customers, products, and orders. Each individual order, for example, is given a dedicated page that can be linked to. In Shopify, we call these types of objects resources.
 
@@ -2734,23 +2734,23 @@ If you’re using VS Code, here are the exact search / replace instructions to f
 - replace `\bcolor\(([a-z-]+), ([a-z-]+)\)` with `color('$1', '$2')`
 - replace `\bcolor\(([a-z-]+), ([a-z-]+), (.*)\)` with `color('$1', '$2', $3)`
 
-#### [Data table](https://polaris.shopify.com/components/lists-and-tables/data-table)
+#### [Data table](https://polaris.shopify.com/components/data-table)
 
 Since launching Polaris components, we’ve had many people ask why we didn’t include tables. While we have been moving away from using tables for comparisons that aren’t tabular data (resource lists, for example), we recognize that there are still cases to use them.
 
 The data table component is our answer to those cases. While data visualizations represents part of a data set, data tables are used to organize and display all the information from a data set, allowing merchants view details from the entire set. This helps merchants compare and analyze all the data in a unified way.
 
-#### [Drop zone](https://polaris.shopify.com/components/actions/drop-zone#navigation)
+#### [Drop zone](https://polaris.shopify.com/components/drop-zone#navigation)
 
 Currently we have several different interfaces for uploading files across Shopify, which leads to a lack of consistency and some missing features and capabilities. To solve this problem, we’re releasing a new drop zone component.
 
 This new component allows merchants to upload files by dragging and dropping them into an area on a page. The component handles file type validation, dropping onto the window, and more, meaning more ease of use for merchants.
 
-#### [Modal](https://polaris.shopify.com/components/overlays/modal#navigation)
+#### [Modal](https://polaris.shopify.com/components/modal#navigation)
 
 In the original Polaris React, the modal component was only available to embedded apps. No longer. Our new modal component is universal in that it can be used in either stand-alone or embedded apps, and will handle the correct behavior for you.
 
-#### [App provider](https://polaris.shopify.com/components/structure/app-provider#navigation)
+#### [App provider](https://polaris.shopify.com/components/app-provider#navigation)
 
 The app provider is a required component that enables sharing global app config with the components in Polaris. This is used for the internationalization of strings in Polaris components, as well as set other configuration such as a custom link component that all the Polaris components will use. This unlocks new ways for us to share configuration at an app level and have the components react to that configuration.
 

--- a/polaris-react/src/components/AccountConnection/README.md
+++ b/polaris-react/src/components/AccountConnection/README.md
@@ -144,4 +144,4 @@ function AccountConnectionExample() {
 
 ## Accessibility
 
-See accessibility guidance for the [setting toggle component](https://polaris.shopify.com/components/actions/setting-toggle) to turn connections on and off.
+See accessibility guidance for the [setting toggle component](https://polaris.shopify.com/components/setting-toggle) to turn connections on and off.

--- a/polaris-react/src/components/ActionList/README.md
+++ b/polaris-react/src/components/ActionList/README.md
@@ -15,7 +15,7 @@ keywords:
 
 # Action list
 
-Action lists render a list of actions or selectable options. This component is usually placed inside a [popover container](https://polaris.shopify.com/components/overlays/popover) to create a dropdown menu or to let merchants select from a list of options.
+Action lists render a list of actions or selectable options. This component is usually placed inside a [popover container](https://polaris.shopify.com/components/popover) to create a dropdown menu or to let merchants select from a list of options.
 
 ---
 
@@ -397,14 +397,14 @@ function ActionListWithPrefixSuffixExample() {
 
 ## Related components
 
-- To combine more than one button in a single layout, [use the button group component](https://polaris.shopify.com/components/actions/button-group)
-- To display a list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list)
+- To combine more than one button in a single layout, [use the button group component](https://polaris.shopify.com/components/button-group)
+- To display a list of related content, [use the list component](https://polaris.shopify.com/components/list)
 
 ---
 
 ## Accessibility
 
-Items in an action list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users. Each item is implemented as a [button](https://polaris.shopify.com/components/actions/button).
+Items in an action list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users. Each item is implemented as a [button](https://polaris.shopify.com/components/button).
 
 ### Keyboard support
 

--- a/polaris-react/src/components/AppProvider/README.md
+++ b/polaris-react/src/components/AppProvider/README.md
@@ -93,7 +93,7 @@ AppProvider works by default without any additional options passed to it.
 
 ### With i18n
 
-With an `i18n`, `AppProvider` will provide these translations to polaris components. See [using translations](https://polaris.shopify.com/components/structure/app-provider#using-translations)
+With an `i18n`, `AppProvider` will provide these translations to polaris components. See [using translations](https://polaris.shopify.com/components/app-provider#using-translations)
 
 ```jsx
 <AppProvider
@@ -200,7 +200,7 @@ function AppProviderLinkExample() {
 
 ### With color scheme
 
-With a `colorScheme`, the app provider component will set the root color scheme for the App (such as: light or dark).For `colorScheme` configuration, see the [CustomProperties](https://polaris.shopify.com/components/structure/custom-properties) component documentation.
+With a `colorScheme`, the app provider component will set the root color scheme for the App (such as: light or dark).For `colorScheme` configuration, see the [CustomProperties](https://polaris.shopify.com/components/custom-properties) component documentation.
 
 ```jsx
 function AppProviderThemeExample() {

--- a/polaris-react/src/components/Autocomplete/README.md
+++ b/polaris-react/src/components/Autocomplete/README.md
@@ -28,7 +28,7 @@ The autocomplete component should:
 
 ## Content guidelines
 
-The input field for autocomplete should follow the [content guidelines](https://polaris.shopify.com/components/forms/text-field) for text fields.
+The input field for autocomplete should follow the [content guidelines](https://polaris.shopify.com/components/text-field) for text fields.
 
 ---
 
@@ -895,9 +895,9 @@ function AutocompleteActionBeforeExample() {
 
 ## Related components
 
-- For an input field without suggested options, [use the text field component](https://polaris.shopify.com/components/forms/text-field)
-- For a list of selectable options not linked to an input field, [use the option list component](https://polaris.shopify.com/components/lists-and-tables/option-list)
-- For a text field that triggers a popover, [use the combo box component](https://polaris.shopify.com/components/forms/combobox)
+- For an input field without suggested options, [use the text field component](https://polaris.shopify.com/components/text-field)
+- For a list of selectable options not linked to an input field, [use the option list component](https://polaris.shopify.com/components/option-list)
+- For a text field that triggers a popover, [use the combo box component](https://polaris.shopify.com/components/combobox)
 
 ---
 

--- a/polaris-react/src/components/Avatar/README.md
+++ b/polaris-react/src/components/Avatar/README.md
@@ -115,7 +115,7 @@ Use a `square` shape when the avatar represents a non-person entity like an app,
 
 ## Related components
 
-- To show a thumbnail for an object rather than a person or business, [use the thumbnail component](https://polaris.shopify.com/components/images-and-icons/thumbnail)
+- To show a thumbnail for an object rather than a person or business, [use the thumbnail component](https://polaris.shopify.com/components/thumbnail)
 
 ---
 

--- a/polaris-react/src/components/Badge/README.md
+++ b/polaris-react/src/components/Badge/README.md
@@ -185,10 +185,10 @@ Use when the status and progress accessibilityLabels are not appropriate to a gi
 
 ## Related components
 
-- To represent an interactive list of categories provided by merchants, [use tags](https://polaris.shopify.com/components/forms/tag)
+- To represent an interactive list of categories provided by merchants, [use tags](https://polaris.shopify.com/components/tag)
 
 ---
 
 ## Accessibility
 
-Badges that convey information with icons or color include text provided by the [visually hidden component](https://polaris.shopify.com/components/titles-and-text/visually-hidden#navigation). This text is read out by assistive technologies like screen readers so that merchants with vision issues can access the meaning of the badge in context.
+Badges that convey information with icons or color include text provided by the [visually hidden component](https://polaris.shopify.com/components/visually-hidden#navigation). This text is read out by assistive technologies like screen readers so that merchants with vision issues can access the meaning of the badge in context.

--- a/polaris-react/src/components/Banner/README.md
+++ b/polaris-react/src/components/Banner/README.md
@@ -65,7 +65,7 @@ Banners should:
   figuring out what they need to know and do.
 - Be limited to a few important calls to action with no more than one primary
   action.
-- Not be used for marketing information or upsell—[use callout cards](https://polaris.shopify.com/components/structure/callout-card) instead.
+- Not be used for marketing information or upsell—[use callout cards](https://polaris.shopify.com/components/callout-card) instead.
 
 To learn about writing helpful and accessible error message text, see the guidelines for [error messages](https://polaris.shopify.com/patterns/error-messages).
 
@@ -431,8 +431,8 @@ Banners inside of cards render with less spacing and a pared-back design to fit 
 
 ## Related components
 
-- To inform merchants about a new feature or opportunity, [use callout cards](https://polaris.shopify.com/components/structure/callout-card)
-- To group similar concepts together in the interface, [use a card](https://polaris.shopify.com/components/structure/card)
+- To inform merchants about a new feature or opportunity, [use callout cards](https://polaris.shopify.com/components/callout-card)
+- To group similar concepts together in the interface, [use a card](https://polaris.shopify.com/components/card)
 
 ---
 
@@ -455,7 +455,7 @@ When merchants submit long or complex forms with errors, use a critical banner t
 
 #### Inline errors
 
-Always include [inline error](https://polaris.shopify.com/components/forms/inline-error) messages for specific form fields so that merchants know what to do in context as they correct their mistakes.
+Always include [inline error](https://polaris.shopify.com/components/inline-error) messages for specific form fields so that merchants know what to do in context as they correct their mistakes.
 
 To learn about creating helpful and accessible error message text, see the guidelines for [error messages](https://polaris.shopify.com/patterns/error-messages).
 

--- a/polaris-react/src/components/Button/README.md
+++ b/polaris-react/src/components/Button/README.md
@@ -32,7 +32,7 @@ keywords:
 
 Buttons are used primarily for actions, such as “Add”, “Close”, “Cancel”, or “Save”. Plain buttons, which look similar to links, are used for less important or less commonly used actions, such as “view shipping settings”.
 
-For navigational actions that appear within or directly following a sentence, use the [link component](https://polaris.shopify.com/components/navigation/link).
+For navigational actions that appear within or directly following a sentence, use the [link component](https://polaris.shopify.com/components/link).
 
 ---
 
@@ -329,8 +329,8 @@ Use when a button has been pressed and the associated action is in progress.
 
 ## Related components
 
-- To combine or lay out multiple buttons, [use the button group component](https://polaris.shopify.com/components/actions/button-group)
-- For navigational actions that appear within or directly following a sentence, use the [link component](https://polaris.shopify.com/components/navigation/link)
+- To combine or lay out multiple buttons, [use the button group component](https://polaris.shopify.com/components/button-group)
+- For navigational actions that appear within or directly following a sentence, use the [link component](https://polaris.shopify.com/components/link)
 
 ---
 
@@ -347,7 +347,7 @@ Buttons can have different states that are visually and programmatically conveye
 
 Merchants generally expect buttons to submit data or take action, and for links to navigate. If navigation is required for the button component, use the `url` prop. The control will output an anchor styled as a button, instead of a button in HTML, to help convey this difference.
 
-For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/navigation/link).
+For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/link).
 
 ### Labeling
 
@@ -395,7 +395,7 @@ When you use the button component to create a link to an external resource:
 - Use the `icon` prop to add the `external` icon to the button
 - Use the `accessibilityLabel` prop to include the warning about opening a new tab in the button text for non-visual screen reader users
 
-For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/navigation/link).
+For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/link).
 
 <!-- usageblock -->
 

--- a/polaris-react/src/components/ButtonGroup/README.md
+++ b/polaris-react/src/components/ButtonGroup/README.md
@@ -36,7 +36,7 @@ Button group displays multiple related actions stacked or in a horizontal row to
 Button groups should:
 
 - Only use buttons that follow the
-  [best practices outlined in the button component](https://polaris.shopify.com/components/actions/button#best-practices)
+  [best practices outlined in the button component](https://polaris.shopify.com/components/button#best-practices)
 - Group together calls to action that have a relationship
 - Be used with consideration that too many calls to action can cause merchants
   to be unsure of what to do next
@@ -93,5 +93,5 @@ Use to emphasize several buttons as a thematically-related set among other contr
 
 ## Related components
 
-- To learn how to use individual buttons, [use the button component](https://polaris.shopify.com/components/actions/button)
-- To embed an action or navigation into a line of text, [use the link component](https://polaris.shopify.com/components/navigation/link)
+- To learn how to use individual buttons, [use the button component](https://polaris.shopify.com/components/button)
+- To embed an action or navigation into a line of text, [use the link component](https://polaris.shopify.com/components/link)

--- a/polaris-react/src/components/CalloutCard/README.md
+++ b/polaris-react/src/components/CalloutCard/README.md
@@ -192,9 +192,9 @@ Make all callout cards dismissible so merchants can get rid of cards about featu
 
 ## Related components
 
-- To group similar concepts and tasks together, [use the card component](https://polaris.shopify.com/components/structure/card)
-- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/structure/layout)
-- To explain a feature that merchants haven’t tried yet, [use the empty state component](https://polaris.shopify.com/components/structure/empty-state)
+- To group similar concepts and tasks together, [use the card component](https://polaris.shopify.com/components/card)
+- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/layout)
+- To explain a feature that merchants haven’t tried yet, [use the empty state component](https://polaris.shopify.com/components/empty-state)
 
 ---
 

--- a/polaris-react/src/components/Card/README.md
+++ b/polaris-react/src/components/Card/README.md
@@ -582,8 +582,8 @@ Use when you need further control over the spacing of your card sections.
 
 ## Related components
 
-- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/structure/layout)
-- To highlight a Shopify feature, [use the callout card component](https://polaris.shopify.com/components/structure/callout-card)
+- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/layout)
+- To highlight a Shopify feature, [use the callout card component](https://polaris.shopify.com/components/callout-card)
 
 ---
 

--- a/polaris-react/src/components/Checkbox/README.md
+++ b/polaris-react/src/components/Checkbox/README.md
@@ -126,9 +126,9 @@ function CheckboxExample() {
 
 ## Related components
 
-- To present a list of options where merchants can only make a single choice, [use the radio button component](https://polaris.shopify.com/components/forms/radio-button)
-- To display a list of related content, [use the choice list component](https://polaris.shopify.com/components/forms/choice-list)
-- To create an ungrouped list, [use the content list component](https://polaris.shopify.com/components/lists-and-tables/list)
+- To present a list of options where merchants can only make a single choice, [use the radio button component](https://polaris.shopify.com/components/radio-button)
+- To display a list of related content, [use the choice list component](https://polaris.shopify.com/components/choice-list)
+- To create an ungrouped list, [use the content list component](https://polaris.shopify.com/components/list)
 
 ---
 

--- a/polaris-react/src/components/ChoiceList/README.md
+++ b/polaris-react/src/components/ChoiceList/README.md
@@ -364,12 +364,12 @@ function SingleOrMultuChoiceListWithChildrenContextWhenSelectedExample() {
 
 ## Related components
 
-- To present a long list of radio buttons or when space is constrained, [use the select component](https://polaris.shopify.com/components/forms/select)
-- To build a group of radio buttons or checkboxes with a custom layout, use the [radio button component](https://polaris.shopify.com/components/forms/radio-button) or [checkbox component](https://polaris.shopify.com/components/forms/checkbox)
-- To display a simple, non-interactive list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list)
+- To present a long list of radio buttons or when space is constrained, [use the select component](https://polaris.shopify.com/components/select)
+- To build a group of radio buttons or checkboxes with a custom layout, use the [radio button component](https://polaris.shopify.com/components/radio-button) or [checkbox component](https://polaris.shopify.com/components/checkbox)
+- To display a simple, non-interactive list of related content, [use the list component](https://polaris.shopify.com/components/list)
 
 ---
 
 ## Accessibility
 
-The choice list component uses the accessibility features of the [checkbox](https://polaris.shopify.com/components/forms/checkbox) and [radio button](https://polaris.shopify.com/components/forms/radio-button) components.
+The choice list component uses the accessibility features of the [checkbox](https://polaris.shopify.com/components/checkbox) and [radio button](https://polaris.shopify.com/components/radio-button) components.

--- a/polaris-react/src/components/Collapsible/README.md
+++ b/polaris-react/src/components/Collapsible/README.md
@@ -45,7 +45,7 @@ The collapsible component should:
 
 ## Content guidelines
 
-Collapsible containers are cards with expandable and collapsible functionality, and should follow the content guidelines for [cards](https://polaris.shopify.com/components/structure/card#section-content-guidelines).
+Collapsible containers are cards with expandable and collapsible functionality, and should follow the content guidelines for [cards](https://polaris.shopify.com/components/card#section-content-guidelines).
 
 ---
 
@@ -101,14 +101,14 @@ function CollapsibleExample() {
 
 ## Related components
 
-- To control a collapsible component, use the [button](https://polaris.shopify.com/components/actions/button) component
-- To put long sections of information in a container that allows for scrolling, [use the scrollable component](https://polaris.shopify.com/components/behavior/scrollable)
+- To control a collapsible component, use the [button](https://polaris.shopify.com/components/button) component
+- To put long sections of information in a container that allows for scrolling, [use the scrollable component](https://polaris.shopify.com/components/scrollable)
 
 ---
 
 ## Accessibility
 
-Use the collapsible component in conjunction with a [button](https://polaris.shopify.com/components/actions/button). Place the collapsible content immediately after the button that controls it, so merchants with vision or attention issues can easily discover what content is being affected.
+Use the collapsible component in conjunction with a [button](https://polaris.shopify.com/components/button). Place the collapsible content immediately after the button that controls it, so merchants with vision or attention issues can easily discover what content is being affected.
 
 - Use the required `id` prop of the collapsible component to give the content a unique `id` value
 - Use the `ariaExpanded` prop on the button component to add an `aria-expanded` attribute, which conveys the expanded or collapsed state to screen reader users

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -26,7 +26,7 @@ A combobox is made up of the following:
 1. **TextField**: A text input that activates a popover displaying a list of options. As merchants type in the text field, the list of options is filtered by the input value. Options replace or add to the input value when selected.
 2. **Popover**: An overlay containing a list of options.
 3. **Listbox**: A list of options to filter and select or deselect.
-4. **Listbox.Option**: The individual options to select or deselect. Check out the [listbox component documentation](https://polaris.shopify.com/components/forms/listbox) to learn how to compose it with various content.
+4. **Listbox.Option**: The individual options to select or deselect. Check out the [listbox component documentation](https://polaris.shopify.com/components/listbox) to learn how to compose it with various content.
 
 ---
 
@@ -43,7 +43,7 @@ The `Combobox` component should:
 
 ## Content guidelines
 
-The input field for `Combobox` should follow the [content guidelines](https://polaris.shopify.com/components/forms/text-field) for text fields.
+The input field for `Combobox` should follow the [content guidelines](https://polaris.shopify.com/components/text-field) for text fields.
 
 ---
 
@@ -788,8 +788,8 @@ function LoadingAutocompleteExample() {
 
 ## Related components
 
-- For an input field without suggested options, [use the text field component](https://polaris.shopify.com/components/forms/text-field)
-- For a list of selectable options not linked to an input field, [use the list box component](https://polaris.shopify.com/components/lists-and-tables/listbox)
+- For an input field without suggested options, [use the text field component](https://polaris.shopify.com/components/text-field)
+- For a list of selectable options not linked to an input field, [use the list box component](https://polaris.shopify.com/components/listbox)
 
 ---
 
@@ -797,7 +797,7 @@ function LoadingAutocompleteExample() {
 
 ### Structure
 
-The `Combobox` component is based on the [ARIA 1.2 combobox pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#combobox). It is a combination of a single-line `TextField` and a `Popover`. The current implementation expects a [`Listbox`](https://polaris.shopify.com/components/lists-and-tables/listbox) component to be used.
+The `Combobox` component is based on the [ARIA 1.2 combobox pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#combobox). It is a combination of a single-line `TextField` and a `Popover`. The current implementation expects a [`Listbox`](https://polaris.shopify.com/components/listbox) component to be used.
 
 The `Combobox` popover displays below the text field or other control by default so it is easy for merchants to discover and use. However, you can change the position with the `preferredPosition` prop.
 

--- a/polaris-react/src/components/ContextualSaveBar/README.md
+++ b/polaris-react/src/components/ContextualSaveBar/README.md
@@ -19,7 +19,7 @@ The contextual save bar tells merchants their options once they have made change
 
 ## Required components
 
-The contextual save bar component must be wrapped in the [frame](https://polaris.shopify.com/components/structure/frame) component.
+The contextual save bar component must be wrapped in the [frame](https://polaris.shopify.com/components/frame) component.
 
 ---
 
@@ -30,7 +30,7 @@ The contextual save bar component should:
 - Become visible when a form on the page has unsaved changes
 - Be used to save or discard in-progress changes
 - Provide brief and helpful context on the nature of in-progress changes
-- Save all changes on the page. Avoid scenarios where multiple forms on a single page can be edited at the same time. If specific sections of a page need to be independently editable, use an Edit button to launch a [modal dialog](https://polaris.shopify.com/components/overlays/modal) for each section where changes can be made and saved.
+- Save all changes on the page. Avoid scenarios where multiple forms on a single page can be edited at the same time. If specific sections of a page need to be independently editable, use an Edit button to launch a [modal dialog](https://polaris.shopify.com/components/modal) for each section where changes can be made and saved.
 
 ---
 
@@ -194,6 +194,6 @@ Use the fullWidth flag when you want to remove the default max-width set on the 
 
 ## Related components
 
-- To wrap your entire application, [use the frame component](https://polaris.shopify.com/components/structure/frame)
-- To build the outer wrapper of a page, including page title and associated actions, [use the page component](https://polaris.shopify.com/components/structure/page)
-- To wrap form elements and handle the submission of a form, [use the form component](https://polaris.shopify.com/components/forms/form)
+- To wrap your entire application, [use the frame component](https://polaris.shopify.com/components/frame)
+- To build the outer wrapper of a page, including page title and associated actions, [use the page component](https://polaris.shopify.com/components/page)
+- To wrap form elements and handle the submission of a form, [use the form component](https://polaris.shopify.com/components/form)

--- a/polaris-react/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/polaris-react/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -91,7 +91,7 @@ describe('<ContextualSaveBar />', () => {
       expect(() => {
         mount(<ContextualSaveBar {...props} />);
       }).toThrow(
-        'No Frame context was provided. Your component must be wrapped in a <Frame> component. See https://polaris.shopify.com/components/structure/frame for implementation instructions.',
+        'No Frame context was provided. Your component must be wrapped in a <Frame> component. See https://polaris.shopify.com/components/frame for implementation instructions.',
       );
     });
   });

--- a/polaris-react/src/components/CustomProperties/README.md
+++ b/polaris-react/src/components/CustomProperties/README.md
@@ -12,7 +12,7 @@ omitAppProvider: true
 
 # Custom Properties
 
-Use the custom properties component to share global theme settings throughout the hierarchy of your application. Custom properties is included by default as a child of the [app provider component](https://polaris.shopify.com/components/structure/app-provider) but can be used independently to apply a base color scheme to its children.
+Use the custom properties component to share global theme settings throughout the hierarchy of your application. Custom properties is included by default as a child of the [app provider component](https://polaris.shopify.com/components/app-provider) but can be used independently to apply a base color scheme to its children.
 
 ---
 
@@ -115,4 +115,4 @@ The CustomProperties component uses [CSS custom properties](https://developer.mo
 
 ## Related components
 
-- To share global settings throughout the hierarchy of your application, [use the app provider component](https://polaris.shopify.com/components/structure/app-provider)
+- To share global settings throughout the hierarchy of your application, [use the app provider component](https://polaris.shopify.com/components/app-provider)

--- a/polaris-react/src/components/DataTable/README.md
+++ b/polaris-react/src/components/DataTable/README.md
@@ -1040,7 +1040,7 @@ Keep decimals consistent. For example, don’t use 3 decimals in one row and 2 i
 
 ## Related components
 
-- To create an actionable list of related items that link to details pages, such as a list of customers, use the [resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list).
+- To create an actionable list of related items that link to details pages, such as a list of customers, use the [resource list component](https://polaris.shopify.com/components/resource-list).
 
 ---
 
@@ -1060,7 +1060,7 @@ Use tables for tabular data.
 
 #### Don’t
 
-Use tables for layout. For a table-like layout that doesn’t use table HTML elements, use the [resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list).
+Use tables for layout. For a table-like layout that doesn’t use table HTML elements, use the [resource list component](https://polaris.shopify.com/components/resource-list).
 
 <!-- end -->
 

--- a/polaris-react/src/components/DatePicker/README.md
+++ b/polaris-react/src/components/DatePicker/README.md
@@ -210,7 +210,7 @@ function DatePickerExample() {
 
 Some users might find interacting with date pickers to be challenging. When you use the date picker component, always give users the option to enter the date using a text field component as well.
 
-If you use the date picker within a [popover component](/components/overlays/popover), then use a button to trigger the popover instead of displaying the popover when the text input gets focus. This gives users more control over their experience.
+If you use the date picker within a [popover component](/components/popover), then use a button to trigger the popover instead of displaying the popover when the text input gets focus. This gives users more control over their experience.
 
 ### Keyboard support
 

--- a/polaris-react/src/components/DescriptionList/README.md
+++ b/polaris-react/src/components/DescriptionList/README.md
@@ -133,7 +133,7 @@ Use when you need to present merchants with a list of items or terms alongside d
 
 ## Related components
 
-- To create a list of actions or navigation, [use the action list component](https://polaris.shopify.com/components/actions/action-list).
+- To create a list of actions or navigation, [use the action list component](https://polaris.shopify.com/components/action-list).
 
 ---
 

--- a/polaris-react/src/components/DisplayText/README.md
+++ b/polaris-react/src/components/DisplayText/README.md
@@ -118,6 +118,6 @@ Use display text to create visual interest along with a meaningful heading struc
 
 #### Don’t
 
-Use display text in place of standard headings. Use the [heading component](https://polaris.shopify.com/components/titles-and-text/heading) and [subheading component](https://polaris.shopify.com/components/titles-and-text/subheading) to provide structure.
+Use display text in place of standard headings. Use the [heading component](https://polaris.shopify.com/components/heading) and [subheading component](https://polaris.shopify.com/components/subheading) to provide structure.
 
 <!-- end -->

--- a/polaris-react/src/components/DropZone/README.md
+++ b/polaris-react/src/components/DropZone/README.md
@@ -28,7 +28,7 @@ Drop zones should:
 
 - Inform merchants when the file(s) can’t be uploaded:
   - When possible, use validation errors on drag to detect and explain things like file size limits or file types accepted.
-  - Use the [banner component](https://polaris.shopify.com/components/feedback-indicators/banner) with a critical status to communicate errors that happen on the server.
+  - Use the [banner component](https://polaris.shopify.com/components/banner) with a critical status to communicate errors that happen on the server.
 - Provide feedback once the file(s) have been dropped and uploading begins.
 - For convenience, allow files to be dropped anywhere on the page by enabling `dropOnPage`.
 - Provide a file upload button to allow merchants to select files for upload in a traditional way. Do this by using the `DropZone.FileUpload` subcomponent.
@@ -61,7 +61,7 @@ Server-side upload errors give feedback after file submission.
 
 Upload error messages should:
 
-- Be displayed as a [banner](https://polaris.shopify.com/components/feedback-indicators/banner) with a critical status
+- Be displayed as a [banner](https://polaris.shopify.com/components/banner) with a critical status
 - Show the name of the file(s) that were not uploaded successfully
 - Describe why the file(s) couldn’t be uploaded and what merchants should change to upload their file successfully, as seen below
 
@@ -577,8 +577,8 @@ Use file upload with the drop zone component to let merchants select files for u
 
 ## Related components
 
-- To provide context to upload errors when they occur, use the [banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
-- To provide feedback during file upload, use the [spinner component](https://polaris.shopify.com/components/feedback-indicators/spinner)
+- To provide context to upload errors when they occur, use the [banner component](https://polaris.shopify.com/components/banner)
+- To provide feedback during file upload, use the [spinner component](https://polaris.shopify.com/components/spinner)
 
 ---
 

--- a/polaris-react/src/components/EmptyState/README.md
+++ b/polaris-react/src/components/EmptyState/README.md
@@ -214,8 +214,8 @@ Use to provide additional but non-critical context for a new product or feature.
 ## Related components
 
 - To learn more about illustrations for empty states, [read the illustration guidelines](https://polaris.shopify.com/design/illustrations)
-- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/structure/layout)
-- To highlight a Shopify feature, [use the callout card component](https://polaris.shopify.com/components/structure/callout-card)
+- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/layout)
+- To highlight a Shopify feature, [use the callout card component](https://polaris.shopify.com/components/callout-card)
 
 ---
 

--- a/polaris-react/src/components/ExceptionList/README.md
+++ b/polaris-react/src/components/ExceptionList/README.md
@@ -47,7 +47,7 @@ For error states, exception lists should:
 
 - Either tell merchants how to solve the problem or be attached to an item that lets merchants fix the problem
 
-If placed next to an item in a [resource list](https://polaris.shopify.com/components/lists-and-tables/resource-list), exceptions lists should:
+If placed next to an item in a [resource list](https://polaris.shopify.com/components/resource-list), exceptions lists should:
 
 - Make the entire list item clickable because the exception list itself isn’t clickable
 
@@ -90,8 +90,8 @@ Use icons to add clarity or assist in visualizing the meaning
 
 <!-- * To display an error in a card or section, use the [contextual banner]() component -->
 
-- To display an error at the top of a page, or to indicate multiple errors in a form, use the [banner](https://polaris.shopify.com/components/feedback-indicators/banner) component
-- Exceptions lists are often used in the [resource list](https://polaris.shopify.com/components/lists-and-tables/resource-list) component to display conditional content
+- To display an error at the top of a page, or to indicate multiple errors in a form, use the [banner](https://polaris.shopify.com/components/banner) component
+- Exceptions lists are often used in the [resource list](https://polaris.shopify.com/components/resource-list) component to display conditional content
 
 ---
 

--- a/polaris-react/src/components/Filters/README.md
+++ b/polaris-react/src/components/Filters/README.md
@@ -21,7 +21,7 @@ Merchants use filters to:
 - filter by typing into a text field
 - filter by selecting filters or promoted filters
 
-The way that merchants interact with filters depends on the components that you decide to incorporate. In its simplest form, filters includes a text field and a set of filters, which can be displayed in different ways. For example, you could show promoted filters and a More button that opens a [sheet](https://polaris.shopify.com/components/overlays/sheet) containing more filters. What the filters are and how they’re exposed to merchants is flexible.
+The way that merchants interact with filters depends on the components that you decide to incorporate. In its simplest form, filters includes a text field and a set of filters, which can be displayed in different ways. For example, you could show promoted filters and a More button that opens a [sheet](https://polaris.shopify.com/components/sheet) containing more filters. What the filters are and how they’re exposed to merchants is flexible.
 
 ---
 
@@ -29,11 +29,11 @@ The way that merchants interact with filters depends on the components that you 
 
 The filters component relies on the accessibility features of multiple other components:
 
-- [Text field](https://polaris.shopify.com/components/forms/text-field)
-- [Button](https://polaris.shopify.com/components/actions/button)
-- [Popover](https://polaris.shopify.com/components/overlays/popover)
-- [Sheet](https://polaris.shopify.com/components/overlays/sheet)
-- [Collapsible](https://polaris.shopify.com/components/behavior/collapsible)
+- [Text field](https://polaris.shopify.com/components/text-field)
+- [Button](https://polaris.shopify.com/components/button)
+- [Popover](https://polaris.shopify.com/components/popover)
+- [Sheet](https://polaris.shopify.com/components/sheet)
+- [Collapsible](https://polaris.shopify.com/components/collapsible)
 
 ### Maintain accessibility with custom features
 

--- a/polaris-react/src/components/FooterHelp/README.md
+++ b/polaris-react/src/components/FooterHelp/README.md
@@ -86,5 +86,5 @@ Use to direct merchants to more information related to the product or feature th
 
 ## Related components and documentation
 
-- To learn how to embed a link in a piece of text, [use the link component](https://polaris.shopify.com/components/navigation/link)
+- To learn how to embed a link in a piece of text, [use the link component](https://polaris.shopify.com/components/link)
 - To learn how to provide support for an app, [use the guide on supporting your app](https://help.shopify.com/en/api/app-store/being-successful-in-the-app-store/supporting-your-app)

--- a/polaris-react/src/components/Form/README.md
+++ b/polaris-react/src/components/Form/README.md
@@ -115,8 +115,8 @@ function FormWithoutNativeValidationExample() {
 
 ## Related components
 
-- To arrange fields within a form using standard spacing, [use the form layout component](https://polaris.shopify.com/components/forms/form-layout)
-- To see all of the components that make up a form, [visit the form section](https://polaris.shopify.com/components/forms/checkbox#navigation) of the component library
+- To arrange fields within a form using standard spacing, [use the form layout component](https://polaris.shopify.com/components/form-layout)
+- To see all of the components that make up a form, [visit the form section](https://polaris.shopify.com/components/checkbox#navigation) of the component library
 
 ---
 

--- a/polaris-react/src/components/FormLayout/README.md
+++ b/polaris-react/src/components/FormLayout/README.md
@@ -158,4 +158,4 @@ For very short inputs, the width of the inputs may be reduced in order to fit mo
 
 ## Related components
 
-- To arrange the largest sections of a page, [use the layout component](https://polaris.shopify.com/components/structure/layout)
+- To arrange the largest sections of a page, [use the layout component](https://polaris.shopify.com/components/layout)

--- a/polaris-react/src/components/Frame/README.md
+++ b/polaris-react/src/components/Frame/README.md
@@ -21,7 +21,7 @@ omitAppProvider: true
 
 # Frame
 
-The frame component, while not visible in the user interface itself, provides the structure for an application. It wraps the main elements and houses the primary [navigation](https://polaris.shopify.com/components/navigation/navigation), [top bar](https://polaris.shopify.com/components/structure/top-bar), [toast](https://polaris.shopify.com/components/feedback-indicators/toast), and [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) components.
+The frame component, while not visible in the user interface itself, provides the structure for an application. It wraps the main elements and houses the primary [navigation](https://polaris.shopify.com/components/navigation), [top bar](https://polaris.shopify.com/components/top-bar), [toast](https://polaris.shopify.com/components/toast), and [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar) components.
 
 ---
 
@@ -29,11 +29,11 @@ The frame component, while not visible in the user interface itself, provides th
 
 For the best experience when creating an application frame, use the following components:
 
-- [Top bar](https://polaris.shopify.com/components/structure/top-bar)
-- [Navigation](https://polaris.shopify.com/components/navigation/navigation)
-- [Contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar)
-- [Toast](https://polaris.shopify.com/components/feedback-indicators/toast)
-- [Loading](https://polaris.shopify.com/components/feedback-indicators/loading)
+- [Top bar](https://polaris.shopify.com/components/top-bar)
+- [Navigation](https://polaris.shopify.com/components/navigation)
+- [Contextual save bar](https://polaris.shopify.com/components/contextual-save-bar)
+- [Toast](https://polaris.shopify.com/components/toast)
+- [Loading](https://polaris.shopify.com/components/loading)
 
 ---
 
@@ -721,8 +721,8 @@ function FrameExample() {
 
 ## Related components
 
-- To display the navigation component on small screens, to provide search and a user menu, or to style the [frame](https://polaris.shopify.com/components/structure/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/structure/top-bar) component.
-- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/structure/navigation) component.
-- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) component.
-- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
-- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/feedback-indicators/loading) component.
+- To display the navigation component on small screens, to provide search and a user menu, or to style the [frame](https://polaris.shopify.com/components/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/top-bar) component.
+- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/navigation) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/loading) component.

--- a/polaris-react/src/components/FullscreenBar/README.md
+++ b/polaris-react/src/components/FullscreenBar/README.md
@@ -111,5 +111,5 @@ function FullscreenBarExample() {
 
 ## Related components
 
-- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
-- To indicate to merchants that a page is loading or an upload is processing, use the [loading](https://polaris.shopify.com/components/feedback-indicators/loading) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing, use the [loading](https://polaris.shopify.com/components/loading) component.

--- a/polaris-react/src/components/Grid/README.md
+++ b/polaris-react/src/components/Grid/README.md
@@ -143,5 +143,5 @@ Use to create a layout that can be customized at specific breakpoints.
 
 ## Related components
 
-- To lay out a set of smaller components in a row, [use the stack component](https://polaris.shopify.com/components/structure/stack)
-- To lay out form fields, [use the form layout component](https://polaris.shopify.com/components/forms/form-layout)
+- To lay out a set of smaller components in a row, [use the stack component](https://polaris.shopify.com/components/stack)
+- To lay out form fields, [use the form layout component](https://polaris.shopify.com/components/form-layout)

--- a/polaris-react/src/components/Heading/README.md
+++ b/polaris-react/src/components/Heading/README.md
@@ -23,7 +23,7 @@ keywords:
 
 # Heading
 
-Headings are used as the titles of each major section of a page in the interface. For example, [card components](https://polaris.shopify.com/components/structure/card) generally use headings as their title.
+Headings are used as the titles of each major section of a page in the interface. For example, [card components](https://polaris.shopify.com/components/card) generally use headings as their title.
 
 ---
 
@@ -57,7 +57,7 @@ Use for the title of each top-level page section.
 
 ## Related components
 
-- To break up a section with a heading into sub-sections, [use the subheading component](https://polaris.shopify.com/components/titles-and-text/subheading)
+- To break up a section with a heading into sub-sections, [use the subheading component](https://polaris.shopify.com/components/subheading)
 
 ---
 

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -34,9 +34,9 @@ An index table displays a collection of objects of the same type, like orders or
 
 Index tables can also:
 
-- Support [customized index rows and columns](https://polaris.shopify.com/components/lists-and-tables/resource-item)
+- Support [customized index rows and columns](https://polaris.shopify.com/components/resource-item)
 - Include bulk actions so merchants can act on multiple objects at once
-- Support sorting and [filtering](https://polaris.shopify.com/components/lists-and-tables/filters) of long lists
+- Support sorting and [filtering](https://polaris.shopify.com/components/filters) of long lists
 - Be paired with pagination to make long lists digestible
 
 ---
@@ -1660,7 +1660,7 @@ Using an index table in a project involves combining the following components an
 - IndexTable
 - [IndexTableRow](#index-table-row)
 - [IndexTableCell](#index-table-cell)
-- [Filters](https://polaris.shopify.com/components/lists-and-tables/filters) (optional)
+- [Filters](https://polaris.shopify.com/components/filters) (optional)
 - Pagination component (optional)
 
 <!-- hint -->
@@ -1696,11 +1696,11 @@ Because a details page displays all the content and actions for an individual re
 Index tables should:
 
 - Have items that perform an action when clicked. The action should navigate to the resource’s details page or otherwise provide more detail about the item.
-- [Customize the content and layout](https://polaris.shopify.com/components/lists-and-tables/resource-item) of their items rows to surface information to support merchants’ needs.
+- [Customize the content and layout](https://polaris.shopify.com/components/resource-item) of their items rows to surface information to support merchants’ needs.
 - Support sorting if the list can be long, and especially if different merchant tasks benefit from different sort orders.
-- Support [filtering](https://polaris.shopify.com/components/lists-and-tables/filters) if the list can be long.
+- Support [filtering](https://polaris.shopify.com/components/filters) if the list can be long.
 - Paginate when the current list contains more than 50 items.
-- Use the [skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) component on initial page load for the rest of the page if the loading prop is true and items are processing.
+- Use the [skeleton page](https://polaris.shopify.com/components/skeleton-page) component on initial page load for the rest of the page if the loading prop is true and items are processing.
 
 Index tables can optionally:
 
@@ -1743,7 +1743,7 @@ Index tables should:
 
 - Follow the verb + noun formula for bulk actions
 
-- Follow the [content guidelines for filter options and applied filters](https://polaris.shopify.com/components/lists-and-tables/filters#section-content-guidelines)
+- Follow the [content guidelines for filter options and applied filters](https://polaris.shopify.com/components/filters#section-content-guidelines)
 
 ---
 
@@ -1781,6 +1781,6 @@ An `IndexTableCell` is used to render a single cell within an `IndexTableRow`
 
 ## Related components
 
-- To create an actionable list of related items that link to details pages, such as a list of customers, use the [resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list)
-- To present structured data for comparison and analysis, like when helping merchants to gain insights or review analytics, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table)
-- To display a simple list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list)
+- To create an actionable list of related items that link to details pages, such as a list of customers, use the [resource list component](https://polaris.shopify.com/components/resource-list)
+- To present structured data for comparison and analysis, like when helping merchants to gain insights or review analytics, use the [data table component](https://polaris.shopify.com/components/data-table)
+- To display a simple list of related content, [use the list component](https://polaris.shopify.com/components/list)

--- a/polaris-react/src/components/InlineError/README.md
+++ b/polaris-react/src/components/InlineError/README.md
@@ -74,7 +74,7 @@ Use when the merchant has entered information that is not valid into multiple fi
 
 ## Related components
 
-- To create a list of exceptions that describe a resource, [use the exception list component](https://polaris.shopify.com/components/lists-and-tables/exception-list)
+- To create a list of exceptions that describe a resource, [use the exception list component](https://polaris.shopify.com/components/exception-list)
 
 ---
 

--- a/polaris-react/src/components/KeyboardKey/README.md
+++ b/polaris-react/src/components/KeyboardKey/README.md
@@ -59,7 +59,7 @@ Use to list a related set of keyboard shortcuts.
 
 ## Related components
 
-- To add a tooltip for a button with an associated keyboard shortcut, [use the tooltip component](https://polaris.shopify.com/components/overlays/tooltip)
+- To add a tooltip for a button with an associated keyboard shortcut, [use the tooltip component](https://polaris.shopify.com/components/tooltip)
 
 ---
 

--- a/polaris-react/src/components/Layout/README.md
+++ b/polaris-react/src/components/Layout/README.md
@@ -42,7 +42,7 @@ The content that appears in the layout component comes from cards and annotated 
 
 ### Cards
 
-Content from cards should follow the content guidelines for [cards](https://polaris.shopify.com/components/structure/card#section-content-guidelines).
+Content from cards should follow the content guidelines for [cards](https://polaris.shopify.com/components/card#section-content-guidelines).
 
 ### Annotated section titles
 
@@ -531,6 +531,6 @@ Use for settings pages that need a banner or other content at the top.
 
 ## Related components
 
-- To visually group content in a layout section, [use the card component](https://polaris.shopify.com/components/structure/card)
-- To lay out a set of smaller components in a row, [use the stack component](https://polaris.shopify.com/components/structure/stack)
-- To lay out form fields, [use the form layout component](https://polaris.shopify.com/components/forms/form-layout)
+- To visually group content in a layout section, [use the card component](https://polaris.shopify.com/components/card)
+- To lay out a set of smaller components in a row, [use the stack component](https://polaris.shopify.com/components/stack)
+- To lay out form fields, [use the form layout component](https://polaris.shopify.com/components/form-layout)

--- a/polaris-react/src/components/Link/README.md
+++ b/polaris-react/src/components/Link/README.md
@@ -25,7 +25,7 @@ keywords:
 
 Links take users to another place, and usually appear within or directly following a sentence.
 
-For actions that aren’t related to navigation, use the [button component](https://polaris.shopify.com/components/actions/button).
+For actions that aren’t related to navigation, use the [button component](https://polaris.shopify.com/components/button).
 
 ---
 
@@ -100,7 +100,7 @@ Use for text links that should open in a new browser tab (or window, depending o
 
 ## Related components
 
-- For actions that don’t appear within or directly following a sentence, use the [button component](https://polaris.shopify.com/components/actions/button)
+- For actions that don’t appear within or directly following a sentence, use the [button component](https://polaris.shopify.com/components/button)
 
 ---
 
@@ -135,7 +135,7 @@ The Link component is underlined to give interactive elements a shape. This allo
 
 ### Submitting data
 
-Merchants generally expect links to navigate, and not to submit data or take action. If you need a component that doesn’t have a URL associated with it, then use the [button component](https://polaris.shopify.com/components/actions/button) instead.
+Merchants generally expect links to navigate, and not to submit data or take action. If you need a component that doesn’t have a URL associated with it, then use the [button component](https://polaris.shopify.com/components/button) instead.
 
 ### Labeling
 

--- a/polaris-react/src/components/List/README.md
+++ b/polaris-react/src/components/List/README.md
@@ -109,9 +109,9 @@ Use for a text-only list of related items when an inherent order, priority, or s
 
 ## Related components
 
-- To create a list of checkboxes or radio buttons, [use the choice list component](https://polaris.shopify.com/components/forms/choice-list)
-- To present a collection of objects of the same type such as customers, products, or orders, [use the resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list)
-- When text labels for each item are useful for describing the content, [use the Description List component](https://polaris.shopify.com/components/lists-and-tables/description-list)
+- To create a list of checkboxes or radio buttons, [use the choice list component](https://polaris.shopify.com/components/choice-list)
+- To present a collection of objects of the same type such as customers, products, or orders, [use the resource list component](https://polaris.shopify.com/components/resource-list)
+- When text labels for each item are useful for describing the content, [use the Description List component](https://polaris.shopify.com/components/description-list)
 
 ---
 
@@ -119,4 +119,4 @@ Use for a text-only list of related items when an inherent order, priority, or s
 
 The list component outputs list items (`<li>`) inside a list wrapper (`<ul>` for bullet lists or `<ol>` for numbered lists). By default, list items are conveyed as a group of related elements to assistive technology users.
 
-To group items for layout only, consider using the [stack component](https://polaris.shopify.com/components/structure/stack).
+To group items for layout only, consider using the [stack component](https://polaris.shopify.com/components/stack).

--- a/polaris-react/src/components/Listbox/README.md
+++ b/polaris-react/src/components/Listbox/README.md
@@ -148,8 +148,8 @@ function ListboxWithCustomElementExample() {
 
 ## Related components
 
-- For a text field and popover container, [use the combobox component](https://polaris.shopify.com/components/forms/combobox)
-- [Autocomplete](https://polaris.shopify.com/components/forms/autocomplete) can be used as a convenience wrapper in lieu of Combobox and Listbox.
+- For a text field and popover container, [use the combobox component](https://polaris.shopify.com/components/combobox)
+- [Autocomplete](https://polaris.shopify.com/components/autocomplete) can be used as a convenience wrapper in lieu of Combobox and Listbox.
 
 ---
 

--- a/polaris-react/src/components/Loading/README.md
+++ b/polaris-react/src/components/Loading/README.md
@@ -32,7 +32,7 @@ Use to indicate that the page is loading.
 
 ## Required components
 
-The loading component must be wrapped in the [frame](https://polaris.shopify.com/components/structure/frame) component.
+The loading component must be wrapped in the [frame](https://polaris.shopify.com/components/frame) component.
 
 ---
 
@@ -49,9 +49,9 @@ The loading component should:
 
 ## Related components
 
-- To indicate that an action has been received, use the [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner)
-- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) component.
-- To better represent loading content, use [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) along with [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) components.
+- To indicate that an action has been received, use the [Spinner](https://polaris.shopify.com/components/spinner)
+- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](https://polaris.shopify.com/components/progress-bar) component.
+- To better represent loading content, use [Skeleton page](https://polaris.shopify.com/components/skeleton-page) along with [Skeleton body text](https://polaris.shopify.com/components/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/skeleton-display-text) components.
 
 ---
 

--- a/polaris-react/src/components/MediaCard/README.md
+++ b/polaris-react/src/components/MediaCard/README.md
@@ -278,10 +278,10 @@ Use when vertical screen space is not limited or when the video card is the page
 
 ## Related components
 
-- To create a video card, [use the video thumbnail component](https://polaris.shopify.com/components/images-and-icons/video-thumbnail)
-- To group similar concepts and tasks together, [use the card component](https://polaris.shopify.com/components/structure/card)
-- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/structure/layout)
-- To explain a feature that merchants haven’t tried yet, [use the empty state component](https://polaris.shopify.com/components/structure/empty-state)
+- To create a video card, [use the video thumbnail component](https://polaris.shopify.com/components/video-thumbnail)
+- To group similar concepts and tasks together, [use the card component](https://polaris.shopify.com/components/card)
+- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/layout)
+- To explain a feature that merchants haven’t tried yet, [use the empty state component](https://polaris.shopify.com/components/empty-state)
 
 ---
 

--- a/polaris-react/src/components/Modal/README.md
+++ b/polaris-react/src/components/Modal/README.md
@@ -742,9 +742,9 @@ function ModalExample() {
 
 ## Related components
 
-- To present large amounts of additional information or actions that don’t require confirmation, [use the collapsible component](https://polaris.shopify.com/components/behavior/collapsible) to expand content in place within the page
-- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](https://polaris.shopify.com/components/overlays/popover)
-- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
+- To present large amounts of additional information or actions that don’t require confirmation, [use the collapsible component](https://polaris.shopify.com/components/collapsible) to expand content in place within the page
+- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](https://polaris.shopify.com/components/popover)
+- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](https://polaris.shopify.com/components/banner)
 
 ---
 

--- a/polaris-react/src/components/Navigation/README.md
+++ b/polaris-react/src/components/Navigation/README.md
@@ -14,13 +14,13 @@ keywords:
 
 # Navigation
 
-The navigation component is used to display the primary navigation in the sidebar of the [frame](https://polaris.shopify.com/components/structure/frame) of an application. Navigation includes a list of links that merchants use to move between sections of the application.
+The navigation component is used to display the primary navigation in the sidebar of the [frame](https://polaris.shopify.com/components/frame) of an application. Navigation includes a list of links that merchants use to move between sections of the application.
 
 ---
 
 ## Required components
 
-The navigation component must be passed to the [frame](https://polaris.shopify.com/components/structure/frame) component. The mobile version of the navigation component appears in the [top bar](https://polaris.shopify.com/components/structure/top-bar) component.
+The navigation component must be passed to the [frame](https://polaris.shopify.com/components/frame) component. The mobile version of the navigation component appears in the [top bar](https://polaris.shopify.com/components/top-bar) component.
 
 ---
 
@@ -157,13 +157,13 @@ The content of the navigation component consists of navigation items. Each item 
 
 #### Properties
 
-| Prop               | Type                                                                               | Description                                                                                                                                             |
-| ------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| url                | string                                                                             | A location for the navigation item to navigate to when clicked                                                                                          |
-| accessibilityLabel | string                                                                             | A visually hidden label for screen readers to understand the content of a navigation item                                                               |
-| icon               | IconProps['source']                                                                | An icon to be displayed next to the navigation. Please prefer minor icons here. If a major icon has to be used, set the `shouldResizeIcon` prop to true |
-| onClick()          | function                                                                           | A callback function to handle clicking on a navigation item                                                                                             |
-| tooltip            | [TooltipProps](https://polaris.shopify.com/components/overlays/tooltip#navigation) | Options for displaying a tooltip when you hover over the action button                                                                                  |
+| Prop               | Type                                                                      | Description                                                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| url                | string                                                                    | A location for the navigation item to navigate to when clicked                                                                                          |
+| accessibilityLabel | string                                                                    | A visually hidden label for screen readers to understand the content of a navigation item                                                               |
+| icon               | IconProps['source']                                                       | An icon to be displayed next to the navigation. Please prefer minor icons here. If a major icon has to be used, set the `shouldResizeIcon` prop to true |
+| onClick()          | function                                                                  | A callback function to handle clicking on a navigation item                                                                                             |
+| tooltip            | [TooltipProps](https://polaris.shopify.com/components/tooltip#navigation) | Options for displaying a tooltip when you hover over the action button                                                                                  |
 
 <a name="type-action"></a>
 
@@ -190,12 +190,12 @@ Action allows a complementary icon-only action to render next to the section tit
 
 #### Action properties
 
-| Prop               | Type                                                                               | Description                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| icon               | IconProps['source']                                                                | An icon to be displayed as the content of the action                               |
-| accessibilityLabel | string                                                                             | A visually hidden label for screen readers to understand the content of the action |
-| onClick()          | function                                                                           | A callback function to handle clicking on the action                               |
-| tooltip            | [TooltipProps](https://polaris.shopify.com/components/overlays/tooltip#navigation) | Options for displaying a tooltip when you hover over the action button             |
+| Prop               | Type                                                                      | Description                                                                        |
+| ------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| icon               | IconProps['source']                                                       | An icon to be displayed as the content of the action                               |
+| accessibilityLabel | string                                                                    | A visually hidden label for screen readers to understand the content of the action |
+| onClick()          | function                                                                  | A callback function to handle clicking on the action                               |
+| tooltip            | [TooltipProps](https://polaris.shopify.com/components/tooltip#navigation) | Options for displaying a tooltip when you hover over the action button             |
 
 ---
 
@@ -203,7 +203,7 @@ Action allows a complementary icon-only action to render next to the section tit
 
 ### Basic navigation
 
-Use to present a navigation menu in the [frame](https://polaris.shopify.com/components/structure/frame).
+Use to present a navigation menu in the [frame](https://polaris.shopify.com/components/frame).
 
 ```jsx
 <Frame>
@@ -734,10 +734,10 @@ This example shows how to use the shouldResizeIcon prop when using Major icons
 
 ## Related components
 
-- To provide the structure for the navigation component, including the left sidebar and the top bar use the [frame](https://polaris.shopify.com/components/structure/frame) component.
-- To display the navigation component on small screens, to provide search and a user menu, or to theme the [frame](https://polaris.shopify.com/components/structure/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/structure/top-bar) component.
-- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) component.
-- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
-- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/feedback-indicators/loading) component.
-- To alternate among related views within the same context, use the [tabs](https://polaris.shopify.com/components/navigation/tabs) component.
-- To embed a single action or link within a larger span of text, use the [link](https://polaris.shopify.com/components/navigation/link) component.
+- To provide the structure for the navigation component, including the left sidebar and the top bar use the [frame](https://polaris.shopify.com/components/frame) component.
+- To display the navigation component on small screens, to provide search and a user menu, or to theme the [frame](https://polaris.shopify.com/components/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/top-bar) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/loading) component.
+- To alternate among related views within the same context, use the [tabs](https://polaris.shopify.com/components/tabs) component.
+- To embed a single action or link within a larger span of text, use the [link](https://polaris.shopify.com/components/link) component.

--- a/polaris-react/src/components/OptionList/README.md
+++ b/polaris-react/src/components/OptionList/README.md
@@ -19,7 +19,7 @@ The option list component lets you create a list of grouped items that
 merchants can pick from. This can include single selection or multiple selection
 of options. Option list usually appears in a popover, and sometimes in a modal
 or a sidebar. Option lists are styled differently than
-[choice lists](https://polaris.shopify.com/components/forms/choice-list) and should not be used within a form, but as a standalone menu.
+[choice lists](https://polaris.shopify.com/components/choice-list) and should not be used within a form, but as a standalone menu.
 
 ---
 
@@ -28,9 +28,9 @@ or a sidebar. Option lists are styled differently than
 The option list component should:
 
 - Be placed on its own inside a container. Usually the container behaves like a
-  menu, as it does with [popover](https://polaris.shopify.com/components/overlays/popover). Don’t
+  menu, as it does with [popover](https://polaris.shopify.com/components/popover). Don’t
   place other components within the same container.
-- Not be used when a [select component](https://polaris.shopify.com/components/forms/select) will do.
+- Not be used when a [select component](https://polaris.shopify.com/components/select) will do.
 
 ---
 
@@ -205,11 +205,11 @@ function OptionListInPopoverExample() {
 ## Related components
 
 - To render a list of actions,
-  [use the action list component](https://polaris.shopify.com/components/actions/action-list)
+  [use the action list component](https://polaris.shopify.com/components/action-list)
 - To create a list of grouped radio buttons or checkboxes,
-  [use the choice list component](https://polaris.shopify.com/components/forms/choice-list)
+  [use the choice list component](https://polaris.shopify.com/components/choice-list)
 - For a basic version of option list as a single choice menu,
-  [use the select component](https://polaris.shopify.com/components/forms/select)
+  [use the select component](https://polaris.shopify.com/components/select)
 
 ---
 
@@ -217,7 +217,7 @@ function OptionListInPopoverExample() {
 
 Items in an option list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users.
 
-Controls in simple option lists are [buttons](https://polaris.shopify.com/components/actions/button), and controls in multiple option lists are [checkboxes](https://polaris.shopify.com/components/forms/checkbox).
+Controls in simple option lists are [buttons](https://polaris.shopify.com/components/button), and controls in multiple option lists are [checkboxes](https://polaris.shopify.com/components/checkbox).
 
 If you customize the option list, you can provide ARIA roles that fit the context. These roles must be valid according to the [W3C ARIA specification](https://www.w3.org/TR/wai-aria-1.1/) to be conveyed correctly to screen reader users.
 

--- a/polaris-react/src/components/Page/README.md
+++ b/polaris-react/src/components/Page/README.md
@@ -439,6 +439,6 @@ Use when the page needs visual separation between the page header and the conten
 
 ## Related components
 
-- To lay out the content within a page, use the [layout component](https://polaris.shopify.com/components/structure/layout)
-- To add pagination within the context of a list or other page content, use the [pagination component](https://polaris.shopify.com/components/navigation/pagination)
-- To add primary and secondary calls to action at the bottom of a page, see the [page actions component](https://polaris.shopify.com/components/structure/page-actions)
+- To lay out the content within a page, use the [layout component](https://polaris.shopify.com/components/layout)
+- To add pagination within the context of a list or other page content, use the [pagination component](https://polaris.shopify.com/components/pagination)
+- To add primary and secondary calls to action at the bottom of a page, see the [page actions component](https://polaris.shopify.com/components/page-actions)

--- a/polaris-react/src/components/PageActions/README.md
+++ b/polaris-react/src/components/PageActions/README.md
@@ -166,6 +166,6 @@ Use to create a custom secondary action.
 
 ## Related components
 
-- To add actions to the top of a page, see the [page component’s](https://polaris.shopify.com/components/structure/page) action props
-- To create a call to action within the context of other page content, use the [button component](https://polaris.shopify.com/components/actions/button)
-- To let merchants move through a collection of items that spans multiple pages, see the [pagination component](https://polaris.shopify.com/components/navigation/pagination)
+- To add actions to the top of a page, see the [page component’s](https://polaris.shopify.com/components/page) action props
+- To create a call to action within the context of other page content, use the [button component](https://polaris.shopify.com/components/button)
+- To let merchants move through a collection of items that spans multiple pages, see the [pagination component](https://polaris.shopify.com/components/pagination)

--- a/polaris-react/src/components/Pagination/README.md
+++ b/polaris-react/src/components/Pagination/README.md
@@ -47,7 +47,7 @@ Web pagination should:
 iOS and Android pagination should:
 
 - Start loading items when merchants are close to the bottom, roughly 5 items from the end
-- Show [a spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) below the list to indicate that items have been requested
+- Show [a spinner](https://polaris.shopify.com/components/spinner) below the list to indicate that items have been requested
 
 ---
 
@@ -115,8 +115,8 @@ Add a label between navigation buttons to provide more context of the content be
 
 ## Related components
 
-- To see how pagination is used on a page, see the [page component](https://polaris.shopify.com/components/structure/page)
-- To add primary and secondary calls to action at the bottom of a page, see the [page actions component](https://polaris.shopify.com/components/structure/page-actions)
-- The [resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list) is often combined with pagination to handle long lists of resources such as orders or customers
-- To create stand-alone navigational links or calls to action, use the [button component](https://polaris.shopify.com/components/actions/button)
-- To embed actions or pathways to more information within a sentence, use the [link component](https://polaris.shopify.com/components/navigation/link)
+- To see how pagination is used on a page, see the [page component](https://polaris.shopify.com/components/page)
+- To add primary and secondary calls to action at the bottom of a page, see the [page actions component](https://polaris.shopify.com/components/page-actions)
+- The [resource list component](https://polaris.shopify.com/components/resource-list) is often combined with pagination to handle long lists of resources such as orders or customers
+- To create stand-alone navigational links or calls to action, use the [button component](https://polaris.shopify.com/components/button)
+- To embed actions or pathways to more information within a sentence, use the [link component](https://polaris.shopify.com/components/link)

--- a/polaris-react/src/components/Popover/README.md
+++ b/polaris-react/src/components/Popover/README.md
@@ -355,16 +355,16 @@ function PopoverLazyLoadExample() {
 
 ## Related components
 
-- To put a list of actions in a popover, [use the action list component](https://polaris.shopify.com/components/actions/action-list)
-- To let merchants select simple options from a list, [use the select component](https://polaris.shopify.com/components/forms/select)
+- To put a list of actions in a popover, [use the action list component](https://polaris.shopify.com/components/action-list)
+- To let merchants select simple options from a list, [use the select component](https://polaris.shopify.com/components/select)
 
 ---
 
 ## Accessibility
 
-Popovers usually contain an [option list](https://polaris.shopify.com/components/lists-and-tables/option-list) or an [action list](https://polaris.shopify.com/components/actions/action-list), but can also contain other controls or content.
+Popovers usually contain an [option list](https://polaris.shopify.com/components/option-list) or an [action list](https://polaris.shopify.com/components/action-list), but can also contain other controls or content.
 
-To assist screen readers with sending focus to an [action list](https://polaris.shopify.com/components/actions/action-list), pass `autofocusTarget='first-node'` to `Popover`. This will avoid known issues a screen reader may have with keyboard support once focus is moved off the activator.
+To assist screen readers with sending focus to an [action list](https://polaris.shopify.com/components/action-list), pass `autofocusTarget='first-node'` to `Popover`. This will avoid known issues a screen reader may have with keyboard support once focus is moved off the activator.
 
 Web browsers assign a default value of 'menu' to the `aria-haspopup` role. You can use the prop `ariaHaspopup` to specify a value. Screen readers may fail to send focus to the `Popover` content when they expect the content to be adjacent to the element with `aria-haspopup` in the DOM tree. In this scenario, it is recommended not to provide the `ariaHaspopup` prop.
 

--- a/polaris-react/src/components/ProgressBar/README.md
+++ b/polaris-react/src/components/ProgressBar/README.md
@@ -20,7 +20,7 @@ The progress bar component is used to visually represent the completion of a tas
 Progress bar components should:
 
 - Give merchants an indication of how much of the task has completed and how much is left.
-- Not be used for entire page loads. In this case, use the [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) component.
+- Not be used for entire page loads. In this case, use the [Skeleton page](https://polaris.shopify.com/components/skeleton-page) component.
 
 ---
 
@@ -66,5 +66,5 @@ Use the animated prop when you want to show a static progress bar.
 
 ## Related components
 
-- For tasks with a short load time, use the [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) component
-- For full page loads, use the [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) component
+- For tasks with a short load time, use the [Spinner](https://polaris.shopify.com/components/spinner) component
+- For full page loads, use the [Skeleton page](https://polaris.shopify.com/components/skeleton-page) component

--- a/polaris-react/src/components/RadioButton/README.md
+++ b/polaris-react/src/components/RadioButton/README.md
@@ -133,10 +133,10 @@ function RadioButtonExample() {
 
 ## Related components
 
-- To make simple lists of radio buttons easier to build, [use the choice list component](https://polaris.shopify.com/components/forms/choice-list)
-- For long lists of options, [consider the select component](https://polaris.shopify.com/components/forms/select) to avoid overwhelming merchants
-- To present merchants with a list of checkboxes, [use the choice list component](https://polaris.shopify.com/components/forms/choice-list) with the “allow multiple” option
-- To display non-interactive list of related content, [use the content list component](https://polaris.shopify.com/components/lists-and-tables/list)
+- To make simple lists of radio buttons easier to build, [use the choice list component](https://polaris.shopify.com/components/choice-list)
+- For long lists of options, [consider the select component](https://polaris.shopify.com/components/select) to avoid overwhelming merchants
+- To present merchants with a list of checkboxes, [use the choice list component](https://polaris.shopify.com/components/choice-list) with the “allow multiple” option
+- To display non-interactive list of related content, [use the content list component](https://polaris.shopify.com/components/list)
 
 ---
 

--- a/polaris-react/src/components/RangeSlider/README.md
+++ b/polaris-react/src/components/RangeSlider/README.md
@@ -356,7 +356,7 @@ function DualThumbRangeSliderExample() {
 
 ## Related components
 
-- To collect a number value as a text input, [use the text field component](https://polaris.shopify.com/components/forms/text-field)
+- To collect a number value as a text input, [use the text field component](https://polaris.shopify.com/components/text-field)
 
 ---
 

--- a/polaris-react/src/components/ResourceItem/README.md
+++ b/polaris-react/src/components/ResourceItem/README.md
@@ -80,7 +80,7 @@ function ResourceItemExample() {
 
 ### Item with media
 
-The media element can hold an [avatar](https://polaris.shopify.com/components/images-and-icons/avatar), [thumbnail](https://polaris.shopify.com/components/images-and-icons/thumbnail), or other small-format graphic.
+The media element can hold an [avatar](https://polaris.shopify.com/components/avatar), [thumbnail](https://polaris.shopify.com/components/thumbnail), or other small-format graphic.
 
 ```jsx
 <Card>
@@ -215,7 +215,7 @@ Use to adjust the vertical alignment of item content.
 
 ## Required components
 
-The resource item component must be wrapped in the [resource list](https://polaris.shopify.com/components/lists-and-tables/resource-list) component.
+The resource item component must be wrapped in the [resource list](https://polaris.shopify.com/components/resource-list) component.
 
 ---
 
@@ -246,7 +246,7 @@ Resource items should:
 
 Resource items can optionally:
 
-- Provide [shortcut actions](https://polaris.shopify.com/components/lists-and-tables/resource-list#study-custom-item-shortcut-actions) for quick access to frequent actions from the resource’s details page.
+- Provide [shortcut actions](https://polaris.shopify.com/components/resource-list#study-custom-item-shortcut-actions) for quick access to frequent actions from the resource’s details page.
 
 ---
 
@@ -257,10 +257,10 @@ Resource items should:
 - Present the information that merchants need to find the items that they’re looking for.
 - Support merchant tasks for the particular type of resource.
 - Avoid colons.
-- [Shortcut actions](https://polaris.shopify.com/components/lists-and-tables/resource-list#study-custom-item-shortcut-actions) don’t need to follow the full verb + noun formula for buttons.
+- [Shortcut actions](https://polaris.shopify.com/components/resource-list#study-custom-item-shortcut-actions) don’t need to follow the full verb + noun formula for buttons.
 
 ---
 
 ## Related components
 
-To display a simple list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list).
+To display a simple list of related content, [use the list component](https://polaris.shopify.com/components/list).

--- a/polaris-react/src/components/ResourceList/README.md
+++ b/polaris-react/src/components/ResourceList/README.md
@@ -31,9 +31,9 @@ A resource list displays a collection of objects of the same type, like products
 
 Resource lists can also:
 
-- Support [customized list items](https://polaris.shopify.com/components/lists-and-tables/resource-item)
+- Support [customized list items](https://polaris.shopify.com/components/resource-item)
 - Include bulk actions so merchants can act on multiple objects at once
-- Support sorting and [filtering](https://polaris.shopify.com/components/lists-and-tables/filters) of long lists
+- Support sorting and [filtering](https://polaris.shopify.com/components/filters) of long lists
 - Be paired with pagination to make long lists digestible
 
 ---
@@ -422,7 +422,7 @@ function ResourceListWithTotalItemsCount() {
 
 ### Resource list with sorting
 
-Allows merchants to change the way the list is sorted by selecting one of several options from a [Select](https://polaris.shopify.com/components/forms/select) control.
+Allows merchants to change the way the list is sorted by selecting one of several options from a [Select](https://polaris.shopify.com/components/select) control.
 
 ```jsx
 function ResourceListWithSortingExample() {
@@ -1202,8 +1202,8 @@ function ResourceListExample() {
 Using a resource list in a project involves combining the following components and subcomponents:
 
 - ResourceList
-- [ResourceItem](https://polaris.shopify.com/components/lists-and-tables/resource-item) or a customized list item
-- [Filters](https://polaris.shopify.com/components/lists-and-tables/filters) (optional)
+- [ResourceItem](https://polaris.shopify.com/components/resource-item) or a customized list item
+- [Filters](https://polaris.shopify.com/components/filters) (optional)
 - Pagination component (optional)
 
 <!-- hint -->
@@ -1248,7 +1248,7 @@ On wide screens, a resource list often looks like a table, especially if some co
 
 A data table is a form of data visualization. It works best to present highly structured data for comparison and analysis.
 
-If your use case is more about visualizing or analyzing data, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table). If your use case is more about finding and taking action on objects, use a resource list.
+If your use case is more about visualizing or analyzing data, use the [data table component](https://polaris.shopify.com/components/data-table). If your use case is more about finding and taking action on objects, use a resource list.
 
 <!-- end -->
 
@@ -1261,11 +1261,11 @@ Resource lists can live in many places in Shopify. You could include a short res
 Resource lists should:
 
 - Have items that perform an action when clicked. The action should navigate to the resource’s details page or otherwise provide more detail about the item.
-- [Customize the content and layout](https://polaris.shopify.com/components/lists-and-tables/resource-item) of their list items to support merchants’ needs.
+- [Customize the content and layout](https://polaris.shopify.com/components/resource-item) of their list items to support merchants’ needs.
 - Support sorting if the list can be long, and especially if different merchant tasks benefit from different sort orders.
-- Support [filtering](https://polaris.shopify.com/components/lists-and-tables/filters) if the list can be long.
+- Support [filtering](https://polaris.shopify.com/components/filters) if the list can be long.
 - Paginate when the current list contains more than 50 items.
-- Use the [skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) component on initial page load for the rest of the page if the loading prop is true and items are processing.
+- Use the [skeleton page](https://polaris.shopify.com/components/skeleton-page) component on initial page load for the rest of the page if the loading prop is true and items are processing.
 
 Resource lists can optionally:
 
@@ -1308,11 +1308,11 @@ Resource lists should:
 
 - Follow the verb + noun formula for bulk actions
 
-- Follow the [content guidelines for filter options and applied filters](https://polaris.shopify.com/components/lists-and-tables/filters#section-content-guidelines)
+- Follow the [content guidelines for filter options and applied filters](https://polaris.shopify.com/components/filters#section-content-guidelines)
 
 ---
 
 ## Related components
 
-- To present structured data for comparison and analysis, like when helping merchants to gain insights or review analytics, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table)
-- To display a simple list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list)
+- To present structured data for comparison and analysis, like when helping merchants to gain insights or review analytics, use the [data table component](https://polaris.shopify.com/components/data-table)
+- To display a simple list of related content, [use the list component](https://polaris.shopify.com/components/list)

--- a/polaris-react/src/components/Scrollable/README.md
+++ b/polaris-react/src/components/Scrollable/README.md
@@ -34,7 +34,7 @@ Scrollable containers should:
 
 ## Content guidelines
 
-Scrollable containers are cards with scrolling functionality, and should follow the [content guidelines](https://polaris.shopify.com/components/structure/card#section-content-guidelines) for cards.
+Scrollable containers are cards with scrolling functionality, and should follow the [content guidelines](https://polaris.shopify.com/components/card#section-content-guidelines) for cards.
 
 ---
 
@@ -355,4 +355,4 @@ Use when you need to programmatically scroll a child component into view in the 
 
 ## Related components
 
-- To put long sections of information under a block that merchants can expand or collapse, [use the collapsible component](https://polaris.shopify.com/components/behavior/collapsible)
+- To put long sections of information under a block that merchants can expand or collapse, [use the collapsible component](https://polaris.shopify.com/components/collapsible)

--- a/polaris-react/src/components/Select/README.md
+++ b/polaris-react/src/components/Select/README.md
@@ -232,7 +232,7 @@ To render an invalid select and its validation error separately:
 
 - Set a unique identifier to the select component `id` prop
 - Set a boolean to the select component `error` prop
-- Use an [inline error component](https://polaris.shopify.com/components/forms/inline-error) to describe the invalid select input and set its `fieldID` prop to the same unique identifier used for the text field `id`
+- Use an [inline error component](https://polaris.shopify.com/components/inline-error) to describe the invalid select input and set its `fieldID` prop to the same unique identifier used for the text field `id`
 
 ```jsx
 function SeparateValidationErrorExample() {
@@ -301,5 +301,5 @@ function SeparateValidationErrorExample() {
 
 ## Related components
 
-- To let merchants select one option from a list with less than 4 options, use [the choice list component](https://polaris.shopify.com/components/forms/choice-list)
-- To create a select where merchants can make multiple selections, or to allow advanced formatting of option text, use an [option list](https://polaris.shopify.com/components/lists-and-tables/option-list) inside a [popover](https://polaris.shopify.com/components/overlays/popover)
+- To let merchants select one option from a list with less than 4 options, use [the choice list component](https://polaris.shopify.com/components/choice-list)
+- To create a select where merchants can make multiple selections, or to allow advanced formatting of option text, use an [option list](https://polaris.shopify.com/components/option-list) inside a [popover](https://polaris.shopify.com/components/popover)

--- a/polaris-react/src/components/SettingToggle/README.md
+++ b/polaris-react/src/components/SettingToggle/README.md
@@ -107,7 +107,7 @@ function SettingToggleExample() {
 
 ## Related components
 
-- To let merchants connect or disconnect third-party services and apps, [use the account connection component](https://polaris.shopify.com/components/actions/account-connection)
+- To let merchants connect or disconnect third-party services and apps, [use the account connection component](https://polaris.shopify.com/components/account-connection)
 
 ---
 
@@ -116,4 +116,4 @@ function SettingToggleExample() {
 The setting toggle component is implemented as an HTML `<button>` with the `switch` [ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role).
 The components passed as children will automatically be wrapped in a label element describing the `<button>`. Enabling and disabling the SettingToggle with update the `aria-checked` attribute to `"true"` or `"false"`.
 
-To learn more about button accessibility, see the [button component](https://polaris.shopify.com/components/actions/button).
+To learn more about button accessibility, see the [button component](https://polaris.shopify.com/components/button).

--- a/polaris-react/src/components/Sheet/README.md
+++ b/polaris-react/src/components/Sheet/README.md
@@ -206,5 +206,5 @@ function SheetExample() {
 
 ## Related components
 
-- To offer an action before merchants can go to the next step in the flow, use the [modal component](https://polaris.shopify.com/components/overlays/modal)
-- To present a small amount of content or a menu of actions in a non-blocking overlay, use the [popover component](https://polaris.shopify.com/components/overlays/popover)
+- To offer an action before merchants can go to the next step in the flow, use the [modal component](https://polaris.shopify.com/components/modal)
+- To present a small amount of content or a menu of actions in a non-blocking overlay, use the [popover component](https://polaris.shopify.com/components/popover)

--- a/polaris-react/src/components/SkeletonBodyText/README.md
+++ b/polaris-react/src/components/SkeletonBodyText/README.md
@@ -19,8 +19,8 @@ Skeleton body text is used to provide a low fidelity representation of content b
 
 Skeleton body text component should:
 
-- Be used with [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) when page content loads all at once. Together, these components give merchants an indication of what the page layout will be once loaded.
-- Be used on its own, inside any content container component (like a [card](https://polaris.shopify.com/components/structure/card)), and when content loads after the main page load.
+- Be used with [Skeleton page](https://polaris.shopify.com/components/skeleton-page) when page content loads all at once. Together, these components give merchants an indication of what the page layout will be once loaded.
+- Be used on its own, inside any content container component (like a [card](https://polaris.shopify.com/components/card)), and when content loads after the main page load.
 - Try to match the number of lines to the content being loaded so it gives an accurate representation.
 
 ---
@@ -69,5 +69,5 @@ Use this component to represent a short, single line of text, like a timestamp.
 
 ## Related components
 
-- Use this component with [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) and [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) to represent the content of a page while it’s loading.
-- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) or [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) component.
+- Use this component with [Skeleton page](https://polaris.shopify.com/components/skeleton-page) and [Skeleton display text](https://polaris.shopify.com/components/skeleton-display-text) to represent the content of a page while it’s loading.
+- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/progress-bar) or [Spinner](https://polaris.shopify.com/components/spinner) component.

--- a/polaris-react/src/components/SkeletonDisplayText/README.md
+++ b/polaris-react/src/components/SkeletonDisplayText/README.md
@@ -90,5 +90,5 @@ Use this component to represent small display text such as content headings.
 
 ## Related components
 
-- Use this component with [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) and [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) to represent the content of a page before it’s loaded.
-- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) or [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) component.
+- Use this component with [Skeleton page](https://polaris.shopify.com/components/skeleton-page) and [Skeleton body text](https://polaris.shopify.com/components/skeleton-body-text) to represent the content of a page before it’s loaded.
+- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/progress-bar) or [Spinner](https://polaris.shopify.com/components/spinner) component.

--- a/polaris-react/src/components/SkeletonPage/README.md
+++ b/polaris-react/src/components/SkeletonPage/README.md
@@ -154,5 +154,5 @@ Use this component to compose a loading version of a page where the page title a
 
 ## Related components
 
-- Use the [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) components to represent blocks of content.
-- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) or [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) component.
+- Use the [Skeleton body text](https://polaris.shopify.com/components/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/skeleton-display-text) components to represent blocks of content.
+- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/progress-bar) or [Spinner](https://polaris.shopify.com/components/spinner) component.

--- a/polaris-react/src/components/SkeletonTabs/README.md
+++ b/polaris-react/src/components/SkeletonTabs/README.md
@@ -43,4 +43,4 @@ Skeleton tabs component should:
 
 ## Related components
 
-- Use this component with [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) and [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) to represent the content of a page before it’s loaded.
+- Use this component with [Skeleton page](https://polaris.shopify.com/components/skeleton-page) and [Skeleton body text](https://polaris.shopify.com/components/skeleton-body-text) to represent the content of a page before it’s loaded.

--- a/polaris-react/src/components/SkeletonThumbnail/README.md
+++ b/polaris-react/src/components/SkeletonThumbnail/README.md
@@ -61,4 +61,4 @@ Use this component to represent extra small thumbnails.
 
 ## Related components
 
-- Use this component with [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) to represent the content of a card while it’s loading.
+- Use this component with [Skeleton display text](https://polaris.shopify.com/components/skeleton-display-text) to represent the content of a card while it’s loading.

--- a/polaris-react/src/components/Spinner/README.md
+++ b/polaris-react/src/components/Spinner/README.md
@@ -148,5 +148,5 @@ Spinner accessibility label should:
 
 ## Related components
 
-- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) component.
-- To better represent loading content, use [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) along with [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) components.
+- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](https://polaris.shopify.com/components/progress-bar) component.
+- To better represent loading content, use [Skeleton page](https://polaris.shopify.com/components/skeleton-page) along with [Skeleton body text](https://polaris.shopify.com/components/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/skeleton-display-text) components.

--- a/polaris-react/src/components/Stack/README.md
+++ b/polaris-react/src/components/Stack/README.md
@@ -153,10 +153,10 @@ The stack component will treat multiple elements wrapped in a stack item compone
 
 ## Related components
 
-- To create the large-scale structure of pages, [use the layout component](https://polaris.shopify.com/components/structure/layout)
+- To create the large-scale structure of pages, [use the layout component](https://polaris.shopify.com/components/layout)
 
 ---
 
 ## Accessibility
 
-The stack component is for alignment only and doesn’t provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](https://polaris.shopify.com/components/lists-and-tables/list).
+The stack component is for alignment only and doesn’t provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](https://polaris.shopify.com/components/list).

--- a/polaris-react/src/components/Subheading/README.md
+++ b/polaris-react/src/components/Subheading/README.md
@@ -29,7 +29,7 @@ Subheadings should:
 
 - Be used to explain and clearly label logical groups in existing sections of a page
 - Not be used without a parent heading
-- Not be used in tables or list items, such as for the primary content in a [resource list](https://polaris.shopify.com/components/lists-and-tables/resource-list)
+- Not be used in tables or list items, such as for the primary content in a [resource list](https://polaris.shopify.com/components/resource-list)
 
 ---
 
@@ -53,7 +53,7 @@ Used for the title of any sub-sections in top-level page sections.
 
 ## Related components
 
-- To break up major sections of a page with a title, [use the heading component](https://polaris.shopify.com/components/titles-and-text/heading)
+- To break up major sections of a page with a title, [use the heading component](https://polaris.shopify.com/components/heading)
 
 ---
 

--- a/polaris-react/src/components/Tag/README.md
+++ b/polaris-react/src/components/Tag/README.md
@@ -139,8 +139,8 @@ function RemovableTagWithLinkExample() {
 
 ## Related components
 
-- To show the status of an object, [use the badge component](https://polaris.shopify.com/components/images-and-icons/badge)
-- To add and remove tags, [use the text field component](https://polaris.shopify.com/components/forms/text-field)
+- To show the status of an object, [use the badge component](https://polaris.shopify.com/components/badge)
+- To add and remove tags, [use the text field component](https://polaris.shopify.com/components/text-field)
 
 ---
 

--- a/polaris-react/src/components/TextContainer/README.md
+++ b/polaris-react/src/components/TextContainer/README.md
@@ -85,4 +85,4 @@ Use the loose spacing option to separate concepts that are independent of each o
 
 ## Related components
 
-- For more layout variations, or if you’re looking to vertically space components other than text, use [Stack](https://polaris.shopify.com/components/structure/stack).
+- For more layout variations, or if you’re looking to vertically space components other than text, use [Stack](https://polaris.shopify.com/components/stack).

--- a/polaris-react/src/components/TextField/README.md
+++ b/polaris-react/src/components/TextField/README.md
@@ -430,7 +430,7 @@ function VerticalContent() {
 
 Use when a text field and several related fields make up a logical unit.
 
-If inputting weight as a number and a separate unit of measurement, use a text field with a [select dropdown menu](https://polaris.shopify.com/components/forms/select) (for example “kg”, “lb”) as a connected field.
+If inputting weight as a number and a separate unit of measurement, use a text field with a [select dropdown menu](https://polaris.shopify.com/components/select) (for example “kg”, “lb”) as a connected field.
 
 ```jsx
 function ConnectedFieldsExample() {
@@ -501,7 +501,7 @@ To render an invalid text field and its validation error separately:
 
 - Set a unique identifier on the text field component `id` prop
 - Set a boolean on the text field component `error` prop
-- Use an [inline error component](https://polaris.shopify.com/components/forms/inline-error) to describe the invalid text field input, and set its `fieldID` prop to be the same unique indentifier as the text field component’s `id`
+- Use an [inline error component](https://polaris.shopify.com/components/inline-error) to describe the invalid text field input, and set its `fieldID` prop to be the same unique indentifier as the text field component’s `id`
 
 ```jsx
 function SeparateValidationErrorExample() {
@@ -808,9 +808,9 @@ function TextFieldWithSuggestionExample() {
 
 ## Related components
 
-- To lay out the elements in a responsive form, [use the form layout component](https://polaris.shopify.com/components/forms/form-layout)
-- To describe an invalid form input with a separate validation error, [use the inline error component](https://polaris.shopify.com/components/forms/inline-error)
-- It’s common to [use a select component](https://polaris.shopify.com/components/forms/select) connected to the left or right of a text field.
+- To lay out the elements in a responsive form, [use the form layout component](https://polaris.shopify.com/components/form-layout)
+- To describe an invalid form input with a separate validation error, [use the inline error component](https://polaris.shopify.com/components/inline-error)
+- It’s common to [use a select component](https://polaris.shopify.com/components/select) connected to the left or right of a text field.
 
 ---
 

--- a/polaris-react/src/components/Thumbnail/README.md
+++ b/polaris-react/src/components/Thumbnail/README.md
@@ -115,4 +115,4 @@ Use to render an icon inside of thumbnail.
 
 ## Related components
 
-- To present a thumbnail representation of an individual or business in the interface, [use the avatar component](https://polaris.shopify.com/components/images-and-icons/avatar)
+- To present a thumbnail representation of an individual or business in the interface, [use the avatar component](https://polaris.shopify.com/components/avatar)

--- a/polaris-react/src/components/Toast/README.md
+++ b/polaris-react/src/components/Toast/README.md
@@ -30,7 +30,7 @@ The toast component is a non-disruptive message that appears at the bottom of th
 
 ## Required components
 
-The toast component must be wrapped in the [frame](https://polaris.shopify.com/components/structure/frame) component.
+The toast component must be wrapped in the [frame](https://polaris.shopify.com/components/frame) component.
 
 ---
 
@@ -285,8 +285,8 @@ function ErrorToastExample() {
 
 ## Related components
 
-- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](https://polaris.shopify.com/components/overlays/popover)
-- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
+- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](https://polaris.shopify.com/components/popover)
+- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](https://polaris.shopify.com/components/banner)
 
 ---
 

--- a/polaris-react/src/components/Tooltip/README.md
+++ b/polaris-react/src/components/Tooltip/README.md
@@ -102,4 +102,4 @@ Use when the tooltip overlays interactive elements when active, for example a fo
 
 ## Related components
 
-- To make helpful content more visible to merchants, use the help text portions of form components such as [text fields](https://polaris.shopify.com/components/forms/text-field), [footer help](https://polaris.shopify.com/components/navigation/footer-help), or [an inline link to help](https://polaris.shopify.com/components/navigation/link)
+- To make helpful content more visible to merchants, use the help text portions of form components such as [text fields](https://polaris.shopify.com/components/text-field), [footer help](https://polaris.shopify.com/components/footer-help), or [an inline link to help](https://polaris.shopify.com/components/link)

--- a/polaris-react/src/components/TopBar/README.md
+++ b/polaris-react/src/components/TopBar/README.md
@@ -19,13 +19,13 @@ keywords:
 
 # Top bar
 
-The top bar is a header component that allows merchants to search, access menus, and navigate by clicking on the logo. It’s always visible at the top of interfaces like Shopify or Shopify Plus. Third-party apps that use the top bar can customize the color to match their brand using the [app provider](https://polaris.shopify.com/components/structure/app-provider) component and are required to use their own logo.
+The top bar is a header component that allows merchants to search, access menus, and navigate by clicking on the logo. It’s always visible at the top of interfaces like Shopify or Shopify Plus. Third-party apps that use the top bar can customize the color to match their brand using the [app provider](https://polaris.shopify.com/components/app-provider) component and are required to use their own logo.
 
 ---
 
 ## Required components
 
-The top bar component must be passed to the [frame](https://polaris.shopify.com/components/structure/frame) component.
+The top bar component must be passed to the [frame](https://polaris.shopify.com/components/frame) component.
 
 ---
 
@@ -34,10 +34,10 @@ The top bar component must be passed to the [frame](https://polaris.shopify.com/
 The top bar component should:
 
 - Not provide global navigation for an application
-  - Use the [navigation component](https://polaris.shopify.com/components/structure/navigation) instead
+  - Use the [navigation component](https://polaris.shopify.com/components/navigation) instead
 - Include search to help merchants find resources and navigate an application
 - Include a user menu component to indicate the logged-in merchant and provide them with global actions
-- Provide a color through the [app provider](https://polaris.shopify.com/components/structure/app-provider) component to style the background
+- Provide a color through the [app provider](https://polaris.shopify.com/components/app-provider) component to style the background
 - The global menu text should contrast with the rest of the top bar and pass the minimum contrast ratio of the WCAG 2.0 guidelines
 - Use an SVG file for the logo
 - Use a logo that passes the minimum contrast ratio of the WCAG 2.0 guidelines when compared to the top bar background color
@@ -351,8 +351,8 @@ function TopBarExample() {
 
 ## Related components
 
-- To provide the structure for the top bar component, as well as the primary navigation use the [frame](https://polaris.shopify.com/components/structure/frame) component.
-- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/structure/navigation) component.
-- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) component.
-- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
-- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/feedback-indicators/loading) component.
+- To provide the structure for the top bar component, as well as the primary navigation use the [frame](https://polaris.shopify.com/components/frame) component.
+- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/navigation) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/loading) component.

--- a/polaris-react/src/components/VideoThumbnail/README.md
+++ b/polaris-react/src/components/VideoThumbnail/README.md
@@ -81,13 +81,13 @@ Use to indicate the video’s play progress in relation to its duration.
 
 ## Required components
 
-- The video thumbnail should be wrapped in the [media card](https://polaris.shopify.com/components/structure/media-card) component.
+- The video thumbnail should be wrapped in the [media card](https://polaris.shopify.com/components/media-card) component.
 
 ---
 
 ## Related components
 
-- To present a small visual anchor for an object, [use the thumbnail component](https://polaris.shopify.com/components/images-and-icons/thumbnail)
+- To present a small visual anchor for an object, [use the thumbnail component](https://polaris.shopify.com/components/thumbnail)
 
 ---
 

--- a/polaris-react/src/utilities/errors.ts
+++ b/polaris-react/src/utilities/errors.ts
@@ -3,7 +3,7 @@ export class MissingAppProviderError extends Error {
     super(
       `${
         message ? `${message} ` : message
-      }Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.`,
+      }Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.`,
     );
     this.name = 'MissingAppProviderError';
   }

--- a/polaris-react/src/utilities/focus-manager/tests/hooks.test.tsx
+++ b/polaris-react/src/utilities/focus-manager/tests/hooks.test.tsx
@@ -39,7 +39,7 @@ describe('useFocusManager', () => {
         </UniqueIdFactoryContext.Provider>,
       );
     expect(attemptMount).toThrow(
-      'No FocusManager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+      'No FocusManager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
     );
   });
 });

--- a/polaris-react/src/utilities/frame/hooks.ts
+++ b/polaris-react/src/utilities/frame/hooks.ts
@@ -7,7 +7,7 @@ export function useFrame() {
 
   if (!frame) {
     throw new Error(
-      'No Frame context was provided. Your component must be wrapped in a <Frame> component. See https://polaris.shopify.com/components/structure/frame for implementation instructions.',
+      'No Frame context was provided. Your component must be wrapped in a <Frame> component. See https://polaris.shopify.com/components/frame for implementation instructions.',
     );
   }
 

--- a/polaris-react/src/utilities/frame/tests/hooks.test.tsx
+++ b/polaris-react/src/utilities/frame/tests/hooks.test.tsx
@@ -27,7 +27,7 @@ describe('useFrame', () => {
   it('throws an error if context is not set', () => {
     const fn = () => mount(<Component />);
     expect(fn).toThrow(
-      'No Frame context was provided. Your component must be wrapped in a <Frame> component. See https://polaris.shopify.com/components/structure/frame for implementation instructions.',
+      'No Frame context was provided. Your component must be wrapped in a <Frame> component. See https://polaris.shopify.com/components/frame for implementation instructions.',
     );
   });
 });

--- a/polaris-react/src/utilities/i18n/tests/hooks.test.tsx
+++ b/polaris-react/src/utilities/i18n/tests/hooks.test.tsx
@@ -27,7 +27,7 @@ describe('useI18n', () => {
   it('throws an error if context is not set', () => {
     const attemptMount = () => mount(<Component />);
     expect(attemptMount).toThrow(
-      'No i18n was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+      'No i18n was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
     );
   });
 });

--- a/polaris-react/src/utilities/media-query/hooks.tsx
+++ b/polaris-react/src/utilities/media-query/hooks.tsx
@@ -7,7 +7,7 @@ export function useMediaQuery() {
 
   if (!mediaQuery) {
     throw new Error(
-      'No mediaQuery was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+      'No mediaQuery was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
     );
   }
 

--- a/polaris-react/src/utilities/media-query/tests/hooks.test.tsx
+++ b/polaris-react/src/utilities/media-query/tests/hooks.test.tsx
@@ -27,7 +27,7 @@ describe('useMediaQuery', () => {
   it('throws an error if context is not set', () => {
     const attemptMount = () => mount(<Component />);
     expect(attemptMount).toThrow(
-      'No mediaQuery was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+      'No mediaQuery was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
     );
   });
 });

--- a/polaris-react/src/utilities/portals/hooks.ts
+++ b/polaris-react/src/utilities/portals/hooks.ts
@@ -7,7 +7,7 @@ export function usePortalsManager() {
 
   if (!portalsManager) {
     throw new Error(
-      'No portals manager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+      'No portals manager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
     );
   }
 

--- a/polaris-react/src/utilities/portals/tests/hooks.test.tsx
+++ b/polaris-react/src/utilities/portals/tests/hooks.test.tsx
@@ -29,7 +29,7 @@ describe('usePortalsManager', () => {
   it('throws an error if context is not set', () => {
     const attemptMount = () => mount(<Component />);
     expect(attemptMount).toThrow(
-      'No portals manager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+      'No portals manager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
     );
   });
 });

--- a/polaris-react/src/utilities/scroll-lock-manager/tests/hooks.test.tsx
+++ b/polaris-react/src/utilities/scroll-lock-manager/tests/hooks.test.tsx
@@ -29,7 +29,7 @@ describe('useScrollLockManager', () => {
   it('throws an error if context is not set', () => {
     const attemptMount = () => mount(<Component />);
     expect(attemptMount).toThrow(
-      'No ScrollLockManager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+      'No ScrollLockManager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
     );
   });
 });

--- a/polaris-react/src/utilities/sticky-manager/tests/hooks.test.tsx
+++ b/polaris-react/src/utilities/sticky-manager/tests/hooks.test.tsx
@@ -29,7 +29,7 @@ describe('useStickyManager', () => {
   it('throws an error if context is not set', () => {
     const attemptMount = () => mount(<Component />);
     expect(attemptMount).toThrow(
-      'No StickyManager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+      'No StickyManager was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
     );
   });
 });

--- a/polaris.shopify.com/content/components/date-picker.md
+++ b/polaris.shopify.com/content/components/date-picker.md
@@ -60,7 +60,7 @@ Date pickers should:
 
 Some users might find interacting with date pickers to be challenging. When you use the date picker component, always give users the option to enter the date using a text field component as well.
 
-If you use the date picker within a [popover component](/components/overlays/popover), then use a button to trigger the popover instead of displaying the popover when the text input gets focus. This gives users more control over their experience.
+If you use the date picker within a [popover component](/components/popover), then use a button to trigger the popover instead of displaying the popover when the text input gets focus. This gives users more control over their experience.
 
 ### Keyboard support
 

--- a/polaris.shopify.com/content/foundations/content/alternative-text.md
+++ b/polaris.shopify.com/content/foundations/content/alternative-text.md
@@ -109,7 +109,7 @@ Alt text should always be written in plain text.
 
 ### Icons
 
-[Icons](/components/images-and-icons/icon) that could be misinterpreted need an
+[Icons](/components/icon) that could be misinterpreted need an
 explanation, so use the `aria-label` attribute.
 
 ```html

--- a/polaris.shopify.com/content/foundations/content/help-documentation.md
+++ b/polaris.shopify.com/content/foundations/content/help-documentation.md
@@ -39,7 +39,7 @@ These guidelines are based on our experience writing help documentation for the
 the same goal: to educate and empower Shopify merchants.
 
 To include a link to help documentation in your app or channel, use the
-[Footer help](/components/navigation/footer-help) component.
+[Footer help](/components/footer-help) component.
 
 ---
 

--- a/polaris.shopify.com/content/foundations/content/voice-and-tone.md
+++ b/polaris.shopify.com/content/foundations/content/voice-and-tone.md
@@ -212,7 +212,7 @@ While we don’t need to celebrate the accomplishment, we should recognize that 
 
 #### Do
 
-If this is a task people do regularly, make it clear that the step is complete in a simple and non-intrusive way, like a [toast](/components/feedback-indicators/toast). Consider ways to confirm completion without words or messaging.
+If this is a task people do regularly, make it clear that the step is complete in a simple and non-intrusive way, like a [toast](/components/toast). Consider ways to confirm completion without words or messaging.
 
 _Product saved_
 

--- a/polaris.shopify.com/content/foundations/design/spacing.md
+++ b/polaris.shopify.com/content/foundations/design/spacing.md
@@ -71,7 +71,7 @@ Various components within Polaris enable automatic spacing between elements:
 
 ![Several paragraphs of text with space in between, with their edges and spacing highlighted](/public_images/design/spacing/spacing-text-container@2x.png)
 
-Use the [text container](/components/titles-and-text/text-container) component to wrap and automatically add the correct spacing between a set of paragraphs, lists, or other textual components.
+Use the [text container](/components/text-container) component to wrap and automatically add the correct spacing between a set of paragraphs, lists, or other textual components.
 
 <!-- end -->
 
@@ -79,7 +79,7 @@ Use the [text container](/components/titles-and-text/text-container) component t
 
 ![A text label, text value and badge arranged in a row, with their edges and spacing highlighted](/public_images/design/spacing/spacing-stack@2x.png)
 
-The [stack](/components/structure/stack) component can be used to arrange arbitrary components in a horizontal row or vertical stack with space in between. It accepts the same values as the Sass spacing function to control spacing between the items.
+The [stack](/components/stack) component can be used to arrange arbitrary components in a horizontal row or vertical stack with space in between. It accepts the same values as the Sass spacing function to control spacing between the items.
 
 <!-- end -->
 
@@ -118,7 +118,7 @@ The most common spacing sizes are used throughout Polaris for admin as follows:
 
 **4px** (`extra-tight`) between icon and text.
 
-The [button](/components/actions/button) component has this spacing built in.
+The [button](/components/button) component has this spacing built in.
 
 <!-- end -->
 
@@ -128,7 +128,7 @@ The [button](/components/actions/button) component has this spacing built in.
 
 **8px** (`tight`) between icon and text.
 
-The [button group](/components/actions/button-group) component has this spacing built in.
+The [button group](/components/button-group) component has this spacing built in.
 
 <!-- end -->
 
@@ -140,7 +140,7 @@ The [button group](/components/actions/button-group) component has this spacing 
 
 **16px** (`base`) vertically, **20px** (`loose`) horizontally.
 
-The [form layout](/components/forms/form-layout) component has this spacing built in.
+The [form layout](/components/form-layout) component has this spacing built in.
 
 <!-- end -->
 
@@ -158,7 +158,7 @@ The [form layout](/components/forms/form-layout) component has this spacing buil
 
 **16px** (`base`) side padding on small screen.
 
-The [card](/components/structure/card) component has this built in.
+The [card](/components/card) component has this built in.
 
 <!-- end -->
 
@@ -168,7 +168,7 @@ The [card](/components/structure/card) component has this built in.
 
 **20px** (`loose`) between cards
 
-The The [card](/components/structure/card) component automatically adds vertical space between it and any preceding card.
+The The [card](/components/card) component automatically adds vertical space between it and any preceding card.
 
 For horizontal spacing, use the [layout](/components/layout) component to create multi-column layouts.
 

--- a/polaris.shopify.com/content/foundations/patterns/loading.md
+++ b/polaris.shopify.com/content/foundations/patterns/loading.md
@@ -51,7 +51,7 @@ The content that is visible in the viewport is the content that merchants will l
 
 ### Limit page content
 
-Pages with a lot of content take longer to load. By limiting the page to meaningful content that merchants will need, we can speed up the loading and declutter the page. Use progressive disclosure to give merchants more content when they need it, and use [pagination](/components/navigation/pagination) to limit long lists. Remember to prefetch the data so that it's readily available.
+Pages with a lot of content take longer to load. By limiting the page to meaningful content that merchants will need, we can speed up the loading and declutter the page. Use progressive disclosure to give merchants more content when they need it, and use [pagination](/components/pagination) to limit long lists. Remember to prefetch the data so that it's readily available.
 
 ## Make good use of time
 
@@ -77,7 +77,7 @@ Controls can often be rendered active even when the data behind it hasn’t fini
 
 ### Give hints with recognizable placeholders
 
-Placeholders let merchants anticipate content type and location. Use placeholders for visually distinct elements, such as lists, images, controls, text, and data visualizations. This is the most important job [skeleton content](/components/feedback-indicators/skeleton-body-text) can do. Don’t use placeholders for content that could be rendered.
+Placeholders let merchants anticipate content type and location. Use placeholders for visually distinct elements, such as lists, images, controls, text, and data visualizations. This is the most important job [skeleton content](/components/skeleton-body-text) can do. Don’t use placeholders for content that could be rendered.
 
 Avoid details in the placeholder that may not appear. We don't want to draw attention to it and set false expectations.
 

--- a/polaris.shopify.com/content/foundations/patterns/page-layouts.md
+++ b/polaris.shopify.com/content/foundations/patterns/page-layouts.md
@@ -45,14 +45,10 @@ top-level navigation and search.
 
 ![Screen highlighting the top of the page content and the side margins of the page](/public_images/layout-page/page-frame-diagram@2x.png)
 
-<<<<<<< Updated upstream
 </div>
 </div>
 
-The [page component](/components/structure/page):
-=======
 The [page component](/components/page):
->>>>>>> Stashed changes
 
 - Acts as a container for the content of each specific page
 - Controls the horizontal margins of the content area
@@ -71,14 +67,10 @@ Page component variations:
 
 ![Admin screen highlighting a typical layout](/public_images/layout-page/page-layout-diagram@2x.png)
 
-<<<<<<< Updated upstream
 </div>
 </div>
 
-Within the page, the [layout component](/components/structure/layout) groups the
-=======
 Within the page, the [layout component](/components/layout) groups the
->>>>>>> Stashed changes
 content into sections. Sections control how the content flows into columns. Each
 section can be:
 
@@ -94,14 +86,10 @@ section can be:
 
 ![Screen highlighting a layout with: page-level banner up top, primary and secondary sections in the middle, and footer actions below](/public_images/layout-page/cards-in-layout-diagram@2x.png)
 
-<<<<<<< Updated upstream
 </div>
 </div>
 
-Place page-level [banners](/components/feedback-indicators/banner) in a full-width section
-=======
 Place page-level [banners](/components/banner) in a full-width section
->>>>>>> Stashed changes
 at the top of the page.
 
 Stack [cards](/components/card) in sections to separate the screen’s
@@ -122,14 +110,10 @@ link to documentation about the current screen.
 
 ![Diagram showing the anatomy of a card component, showing the card title and header actions at the top, two sections in the middle, and footer below](/public_images/layout-page/card-layout-diagram@2x.png)
 
-<<<<<<< Updated upstream
 </div>
 </div>
 
-[Cards](/components/structure/card) have a similar structure to the page as a
-=======
 [Cards](/components/card) have a similar structure to the page as a
->>>>>>> Stashed changes
 whole.
 
 - Cards often have a header, with a title and card-level actions on the right.

--- a/polaris.shopify.com/content/foundations/patterns/page-layouts.md
+++ b/polaris.shopify.com/content/foundations/patterns/page-layouts.md
@@ -45,10 +45,14 @@ top-level navigation and search.
 
 ![Screen highlighting the top of the page content and the side margins of the page](/public_images/layout-page/page-frame-diagram@2x.png)
 
+<<<<<<< Updated upstream
 </div>
 </div>
 
 The [page component](/components/structure/page):
+=======
+The [page component](/components/page):
+>>>>>>> Stashed changes
 
 - Acts as a container for the content of each specific page
 - Controls the horizontal margins of the content area
@@ -67,10 +71,14 @@ Page component variations:
 
 ![Admin screen highlighting a typical layout](/public_images/layout-page/page-layout-diagram@2x.png)
 
+<<<<<<< Updated upstream
 </div>
 </div>
 
 Within the page, the [layout component](/components/structure/layout) groups the
+=======
+Within the page, the [layout component](/components/layout) groups the
+>>>>>>> Stashed changes
 content into sections. Sections control how the content flows into columns. Each
 section can be:
 
@@ -86,21 +94,25 @@ section can be:
 
 ![Screen highlighting a layout with: page-level banner up top, primary and secondary sections in the middle, and footer actions below](/public_images/layout-page/cards-in-layout-diagram@2x.png)
 
+<<<<<<< Updated upstream
 </div>
 </div>
 
 Place page-level [banners](/components/feedback-indicators/banner) in a full-width section
+=======
+Place page-level [banners](/components/banner) in a full-width section
+>>>>>>> Stashed changes
 at the top of the page.
 
-Stack [cards](/components/structure/card) in sections to separate the screen’s
+Stack [cards](/components/card) in sections to separate the screen’s
 main content into meaningful groups.
 
 For screens that represent an individual resource like a product or order, place
-[page actions](/components/structure/page-actions) in a full-width section at
+[page actions](/components/page-actions) in a full-width section at
 the bottom of the page.
 
 For pages that don’t have footer actions, the
-[footer help component](/components/navigation/footer-help) can offer a
+[footer help component](/components/footer-help) can offer a
 link to documentation about the current screen.
 
 ### Layout in a card
@@ -110,10 +122,14 @@ link to documentation about the current screen.
 
 ![Diagram showing the anatomy of a card component, showing the card title and header actions at the top, two sections in the middle, and footer below](/public_images/layout-page/card-layout-diagram@2x.png)
 
+<<<<<<< Updated upstream
 </div>
 </div>
 
 [Cards](/components/structure/card) have a similar structure to the page as a
+=======
+[Cards](/components/card) have a similar structure to the page as a
+>>>>>>> Stashed changes
 whole.
 
 - Cards often have a header, with a title and card-level actions on the right.
@@ -124,7 +140,7 @@ whole.
   actions on the right.
 
 For more details, including when to use header and footer actions, see the
-[card component](/components/structure/card).
+[card component](/components/card).
 
 ---
 
@@ -134,7 +150,7 @@ The structure described above applies to most screens in the Shopify admin, but
 other types of screens exist.
 
 **Embedded Shopify apps**, including sales channels, are contained within the
-normal app frame. However, they display the [page component](/components/structure/page) differently.
+normal app frame. However, they display the [page component](/components/page) differently.
 
 <div class="Spacing">
 <div class="Image Image--radius">
@@ -339,7 +355,7 @@ placed.
 
 ## Small-scale layout
 
-The [stack](/components/structure/stack) component is useful for small-scale
+The [stack](/components/stack) component is useful for small-scale
 layout. It lets you arrange arbitrary components in a horizontal row or vertical
 stack. It’s also a useful component for applying
 [standard spacing](/design/spacing).
@@ -391,7 +407,7 @@ Organizing actions is as important as organizing content.
 If an action applies to the entire page:
 
 - Place it in the page header as a primary or secondary action
-- Use the [page actions](/components/structure/page-actions) component for
+- Use the [page actions](/components/page-actions) component for
   page-level delete and save actions
 
 If an action applies to something more specific, place it at the level of the


### PR DESCRIPTION
- [x] Replace all `/[category]/[component-name]` links with `/[component-name]`

@martenbjork I know you did this in `polaris.shopify.com` I want to make sure the content is aligned for a final check before removal.