### PR TITLE
Remove non existent examples frontmatter

### DIFF
--- a/polaris.shopify.com/content/components/modal.md
+++ b/polaris.shopify.com/content/components/modal.md
@@ -54,12 +54,6 @@ examples:
     title: Modal with activator ref
   - fileName: modal-without-an-activator-prop.tsx
     title: Modal without an activator prop
-  # - fileName: modal-warning.tsx
-  #   title: Warning modal
-  #   description: >-
-  #     Use to make it clear to the merchant that the action is potentially
-  #     dangerous. Only use this option when the merchant is about to perform an
-  #     action that can’t be undone or is difficult to undo.
 ---
 
 # Modal

--- a/polaris.shopify.com/content/components/pagination.md
+++ b/polaris.shopify.com/content/components/pagination.md
@@ -32,11 +32,6 @@ examples:
     description: >-
       Add a label between navigation buttons to provide more context of the
       content being viewed by the user.
-  # - fileName: pagination-infinite-scroll.tsx
-  #   title: Infinite scroll
-  #   description: >-
-  #     Use for lists longer than 25 items. In mobile apps it’s natural to scroll
-  #     to the bottom of the screen to load more items.
 ---
 
 # Pagination

--- a/polaris.shopify.com/content/components/popover.md
+++ b/polaris.shopify.com/content/components/popover.md
@@ -42,11 +42,6 @@ examples:
     description: >-
       Use to present merchants with a list that dynamically loads more items on
       scroll or arrow down.
-  # - fileName: popover-action-sheet.tsx
-  #   title: Action sheet
-  #   description: >-
-  #     Use when you have few actions that affects the whole page. Action sheets
-  #     doesn’t support icons or additional information.
 ---
 
 # Popover

--- a/polaris.shopify.com/content/components/radio-button.md
+++ b/polaris.shopify.com/content/components/radio-button.md
@@ -19,11 +19,6 @@ examples:
     description: >-
       Use radio buttons where merchants must make a single
       selection.
-  # - fileName: radio-button-toggle.tsx
-  #   title: Toggle
-  #   description: >-
-  #     Use toggles when merchants need to make a binary choice (on or
-  #     off).
 ---
 
 # Radio button

--- a/polaris.shopify.com/content/components/text-field.md
+++ b/polaris.shopify.com/content/components/text-field.md
@@ -115,12 +115,6 @@ examples:
       field. If inputting weight as a number and a separate unit of
       measurement, use a text field with a selector (like “kg” or “lb”) as a
       connected field.
-  # - fileName: text-field-with-icon-action.tsx
-  #   title: Text field with icon action
-  #   description: >-
-  #     Use to let merchants take an action within the text field.For example, tap
-  #     on a barcode icon to launch the camera and scan barcode for the barcode
-  #     field. This helps merchants simplify their input.
   - fileName: text-field-with-validation-error.tsx
     title: Text field with validation error
     description: >-

--- a/polaris.shopify.com/content/components/toast.md
+++ b/polaris.shopify.com/content/components/toast.md
@@ -29,23 +29,6 @@ examples:
   - fileName: toast-with-custom-duration.tsx
     title: Toast with custom duration
     description: Use to shorten or lengthen the default duration of 5000 milliseconds.
-  # - fileName: toast-with-action.tsx
-  #   title: Toast with action
-  #   description: >-
-  #     Use when a merchant has the ability to act on the message. For example, to
-  #     undo a change or retry an action.
-  # - fileName: toast-default.tsx
-  #   title: Default toast
-  #   description: >-
-  #     Use default toast for informative and neutral feedback.On iOS,
-  #     icons are available for cases where you want to re-inforce the
-  #     message.
-  # - fileName: toast-success.tsx
-  #   title: Success toast
-  #   description: >-
-  #     Use success toast to indicate that something was successful. For example,
-  #     a product was successfully updated.On iOS, icons are available
-  #     for cases where you want to re-inforce the message.
   - fileName: toast-error.tsx
     title: Error toast
     description: >-


### PR DESCRIPTION
These were removed in https://github.com/Shopify/polaris/pull/6536 and https://github.com/Shopify/polaris/pull/6549. This is some cleanup I missed.

- [x] Remove example frontmatter that does not have an example file
