### PR TITLE
[polaris.shopify.com] Fix background color of code examples

### DIFF
--- a/.changeset/silly-melons-visit.md
+++ b/.changeset/silly-melons-visit.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix background colors of code examples

--- a/polaris.shopify.com/src/components/Longform/Longform.module.scss
+++ b/polaris.shopify.com/src/components/Longform/Longform.module.scss
@@ -138,13 +138,17 @@
     font-family: var(--font-family-mono);
     font-size: var(--font-size-100);
     padding: 1rem;
-    background: var(--surface-code);
+    background: var(--surface-code-dark);
     color: #fff;
     border-radius: var(--border-radius-500);
     overflow: auto;
     white-space: pre-wrap;
     min-width: 0;
     margin-top: 0.5rem;
+
+    code {
+      background: transparent;
+    }
 
     p {
       margin: 0;
@@ -155,7 +159,7 @@
     font-family: monospace;
     font-size: var(--font-size-300);
     font-weight: var(--font-weight-500);
-    background: var(--surface-code);
+    background: var(--surface-code-light);
     border-radius: var(--border-radius-300);
     padding: 0.15rem 0.25rem;
   }

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -28,6 +28,9 @@ body {
   --font-family-mono: "SF Mono", SFMono-Regular, ui-monospace,
     "DejaVu Sans Mono", Menlo, Consolas, monospace;
 
+  --surface-code-light: #eaeaea;
+  --surface-code-dark: #2e2e30;
+
   // Based on: https://type-scale.com/?size=16&scale=1.125&text=A%20Visual%20Type%20Scale&font=Poppins&fontweight=400&bodyfont=body_font_default&bodyfontweight=400&lineheight=1.75&backgroundcolor=%23ffffff&fontcolor=%23000000&preview=false
   --font-size-50: 0.75rem;
   --font-size-100: 0.85rem;
@@ -156,7 +159,6 @@ body,
   --surface-subdued: #f7f7f7;
   --surface-information: #dcf5f0;
   --surface-warning: #ffeceb;
-  --surface-code: #e7e7e7;
   --primary: #008060;
   --border-color: #dedede;
   --border-color-light: #ededed;
@@ -181,7 +183,6 @@ body,
   --surface-warning: #4c250f;
   --surface: #202021;
   --surface-subdued: #2e2e30;
-  --surface-code: #3a3a3a;
   --primary: #1aab87;
   --border-color: #555;
   --border-color-light: #343434;


### PR DESCRIPTION
#6430 introduced a new background color for inline code examples `like this one`. However, this broke multi-line code examples. This PR fixes the issue so that both designs are supported.

Thanks @jbalsas for filing a very thorough bug report that helped us debug this quickly! 🔥 

Before:

<img width="846" alt="Screen Shot 2022-07-14 at 12 52 08 PM" src="https://user-images.githubusercontent.com/875708/178967231-a3f54096-d41e-4285-adc0-cb073a8d1d00.png">

After:

<img width="852" alt="Screen Shot 2022-07-14 at 12 52 11 PM" src="https://user-images.githubusercontent.com/875708/178967251-5fa1c62b-c9c1-4364-9fc1-f57adf0236c8.png">

