### PR TITLE
Update references to polaris-icons repo

### DIFF
--- a/.changeset/quick-owls-joke.md
+++ b/.changeset/quick-owls-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': patch
+---
+
+Update GitHub repo references in package.json

--- a/polaris-icons/package.json
+++ b/polaris-icons/package.json
@@ -43,11 +43,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Shopify/polaris-icons.git",
-    "directory": "packages/polaris-icons"
+    "url": "git+https://github.com/Shopify/polaris.git",
+    "directory": "polaris-icons"
   },
   "bugs": {
-    "url": "https://github.com/shopify/polaris-icons/issues"
+    "url": "https://github.com/shopify/polaris/issues"
   },
   "homepage": "https://polaris.shopify.com/icons",
   "devDependencies": {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When the code was moved from the Shopify/polaris-icons repo to Shopify/polaris icons in #5657, these references should have been updated.

Among other things, the broken links prevent Dependabot from surfacing the changelog on upgrade PRs.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

It updates the references to point to Shopify/polaris, instead of Shopify/polaris-icons
