### PR TITLE
[polaris.shopify.com] Fix up mobile padding

### DIFF
--- a/.changeset/spotty-hornets-sneeze.md
+++ b/.changeset/spotty-hornets-sneeze.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix mobile padding on mobile devices

--- a/polaris.shopify.com/src/components/Layout/Layout.module.scss
+++ b/polaris.shopify.com/src/components/Layout/Layout.module.scss
@@ -17,10 +17,6 @@
   @media screen and (max-width: $breakpointTablet) {
     display: block;
   }
-
-  @media screen and (max-width: $breakpointMobile) {
-    padding: 0;
-  }
 }
 
 .Nav {

--- a/polaris.shopify.com/src/pages/contributing/[doc].tsx
+++ b/polaris.shopify.com/src/pages/contributing/[doc].tsx
@@ -3,7 +3,6 @@ import fs from "fs";
 import path from "path";
 import glob from "glob";
 
-import Container from "../../components/Container";
 import Layout from "../../components/Layout";
 import Longform from "../../components/Longform";
 import Markdown from "../../components/Markdown";
@@ -21,15 +20,13 @@ const contributingDirectory = path.join(process.cwd(), "content/contributing");
 
 const Contributing: NextPage<Props> = ({ readme, title }: Props) => {
   return (
-    <Container>
-      <Layout navItems={contributingNavItems}>
-        <PageMeta title={title} />
+    <Layout navItems={contributingNavItems}>
+      <PageMeta title={title} />
 
-        <Longform>
-          <Markdown text={readme} />
-        </Longform>
-      </Layout>
-    </Container>
+      <Longform>
+        <Markdown text={readme} />
+      </Longform>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
Fixes a regression in `Layout` that was introduced in #6430.

Before:

<img width="253" alt="image" src="https://user-images.githubusercontent.com/875708/179170677-8ec37725-0951-4e78-8bab-a211b38cf5b2.png">

After:

<img width="248" alt="image" src="https://user-images.githubusercontent.com/875708/179170820-82b5b992-c191-4fb1-be95-1c99e716909f.png">