### PR TITLE
[polaris.shopify.com] Fix background color of code examples

### DIFF
--- a/.changeset/tricky-wasps-perform.md
+++ b/.changeset/tricky-wasps-perform.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix mobile padding on mobile devices

--- a/.changeset/tricky-wasps-perform.md
+++ b/.changeset/tricky-wasps-perform.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-Fix mobile padding on mobile devices
+Fix background color of inline code examples

--- a/polaris.shopify.com/src/components/Longform/Longform.module.scss
+++ b/polaris.shopify.com/src/components/Longform/Longform.module.scss
@@ -138,7 +138,7 @@
     font-family: var(--font-family-mono);
     font-size: var(--font-size-100);
     padding: 1rem;
-    background: var(--surface-code-dark);
+    background: var(--surface-code-block);
     color: #fff;
     border-radius: var(--border-radius-500);
     overflow: auto;
@@ -156,10 +156,10 @@
   }
 
   code {
-    font-family: monospace;
+    font-family: var(--font-family-mono);
     font-size: var(--font-size-300);
     font-weight: var(--font-weight-500);
-    background: var(--surface-code-light);
+    background: var(--surface-code-inline);
     border-radius: var(--border-radius-300);
     padding: 0.15rem 0.25rem;
   }

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -28,8 +28,7 @@ body {
   --font-family-mono: "SF Mono", SFMono-Regular, ui-monospace,
     "DejaVu Sans Mono", Menlo, Consolas, monospace;
 
-  --surface-code-light: #eaeaea;
-  --surface-code-dark: #2e2e30;
+  --surface-code-block: #2e2e30;
 
   // Based on: https://type-scale.com/?size=16&scale=1.125&text=A%20Visual%20Type%20Scale&font=Poppins&fontweight=400&bodyfont=body_font_default&bodyfontweight=400&lineheight=1.75&backgroundcolor=%23ffffff&fontcolor=%23000000&preview=false
   --font-size-50: 0.75rem;
@@ -159,6 +158,7 @@ body,
   --surface-subdued: #f7f7f7;
   --surface-information: #dcf5f0;
   --surface-warning: #ffeceb;
+  --surface-code-inline: #eaeaea;
   --primary: #008060;
   --border-color: #dedede;
   --border-color-light: #ededed;
@@ -183,6 +183,7 @@ body,
   --surface-warning: #4c250f;
   --surface: #202021;
   --surface-subdued: #2e2e30;
+  --surface-code-inline: #3b3b3c;
   --primary: #1aab87;
   --border-color: #555;
   --border-color-light: #343434;


### PR DESCRIPTION
I shipped a foolish change without considering dark mode enough:
 
Before:

<img width="847" alt="image" src="https://user-images.githubusercontent.com/875708/179171860-31bae241-19fb-494f-b6c4-4b03730ed682.png">

After:

<img width="835" alt="image" src="https://user-images.githubusercontent.com/875708/179172015-4e9561c4-3175-4b10-a0a6-b1487e64a586.png">


