### PR TITLE
[polaris.shopify.com] Minor improvements to contributing page

### DIFF
--- a/.changeset/tricky-paws-hope.md
+++ b/.changeset/tricky-paws-hope.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Improve layout of contribution guidelines so that its width is consistent between pages

--- a/polaris.shopify.com/src/data/navItems.ts
+++ b/polaris.shopify.com/src/data/navItems.ts
@@ -251,6 +251,10 @@ export const contributingNavItems = [
     title: "Contributing to Polaris",
     children: [
       {
+        title: "Introduction",
+        url: "/contributing",
+      },
+      {
         title: "Components",
         url: "/contributing/components",
       },

--- a/polaris.shopify.com/src/pages/contributing/[doc].tsx
+++ b/polaris.shopify.com/src/pages/contributing/[doc].tsx
@@ -3,7 +3,6 @@ import fs from "fs";
 import path from "path";
 import glob from "glob";
 
-import Container from "../../components/Container";
 import Layout from "../../components/Layout";
 import Longform from "../../components/Longform";
 import Markdown from "../../components/Markdown";
@@ -21,15 +20,13 @@ const contributingDirectory = path.join(process.cwd(), "content/contributing");
 
 const Contributing: NextPage<Props> = ({ readme, title }: Props) => {
   return (
-    <Container>
-      <Layout navItems={contributingNavItems}>
-        <PageMeta title={title} />
+    <Layout navItems={contributingNavItems}>
+      <PageMeta title={title} />
 
-        <Longform>
-          <Markdown text={readme} />
-        </Longform>
-      </Layout>
-    </Container>
+      <Longform>
+        <Markdown text={readme} />
+      </Longform>
+    </Layout>
   );
 };
 

--- a/polaris.shopify.com/src/pages/contributing/index.tsx
+++ b/polaris.shopify.com/src/pages/contributing/index.tsx
@@ -16,11 +16,7 @@ interface Props {
 
 const Contributing: NextPage<Props> = ({ readme }) => {
   return (
-    <Layout
-      title="Contributing to Polaris"
-      navItems={contributingNavItems}
-      showTOC={false}
-    >
+    <Layout title="Contributing to Polaris" navItems={contributingNavItems}>
       <PageMeta title="Contributing to Polaris" />
 
       <Longform>


### PR DESCRIPTION
### Make the page layout consistent:
✅ The page wrapper now has the same width across all pages.

✅ The TOC is now visible on all pages. This is consistent with all the other pages on the site. This also reduces the width of the article itself which makes the line length appropriate for readability ([a11y guidelines](https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length)). 

### Link to overview
✅ There was no way to get back to find the "overview" (`/contributing`) page in the side nav. I found this confusing. This adds an item to the nav called "Introduction". What do you think? "Overview"?

Before:

<img width="281" alt="image" src="https://user-images.githubusercontent.com/875708/179174387-dbcc9d84-6c00-410a-8a23-00a6689ab386.png">

After:

<img width="249" alt="image" src="https://user-images.githubusercontent.com/875708/179174429-d284165c-42af-4d41-b7db-e3815e95ba2a.png">

Related to #6430