### PR TITLE
[Icons] Added Plan icons, major + minor

### DIFF
--- a/.changeset/eight-buttons-listen.md
+++ b/.changeset/eight-buttons-listen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': minor
+---
+
+Added PlanMajor and PlanMinor icons, which are for use on the Settings sheet for Plan

--- a/polaris-icons/icons/PlanMajor.svg
+++ b/polaris-icons/icons/PlanMajor.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" focusable="false" aria-hidden="true"><path d="M11 1a2 2 0 0 0-2 2v3H7a2 2 0 0 0-2 2v3H3a2 2 0 0 0-2 2v3c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2h-6Zm0 2h5v3h-5V3ZM7 8h5v3H7V8Zm-4 5h5v3H3v-3Z" fill=""/></svg>

--- a/polaris-icons/icons/PlanMajor.svg
+++ b/polaris-icons/icons/PlanMajor.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" focusable="false" aria-hidden="true"><path d="M11 1a2 2 0 0 0-2 2v3H7a2 2 0 0 0-2 2v3H3a2 2 0 0 0-2 2v3c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2h-6Zm0 2h5v3h-5V3ZM7 8h5v3H7V8Zm-4 5h5v3H3v-3Z" fill=""/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M11 1a2 2 0 0 0-2 2v3H7a2 2 0 0 0-2 2v3H3a2 2 0 0 0-2 2v3c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2h-6Zm0 2h5v3h-5V3ZM7 8h5v3H7V8Zm-4 5h5v3H3v-3Z" fill="#5C5F62"/></svg>

--- a/polaris-icons/icons/PlanMajor.yml
+++ b/polaris-icons/icons/PlanMajor.yml
@@ -1,6 +1,6 @@
 name: Plans
 set: major
-description: Wayfinding  | Used to help direct merchants to the Plan page in Settings.
+description: Wayfinding | Used to help direct merchants to the Plan page in Settings.
 keywords:
   - Plan
   - Plans

--- a/polaris-icons/icons/PlanMajor.yml
+++ b/polaris-icons/icons/PlanMajor.yml
@@ -1,0 +1,16 @@
+name: Plans
+set: major
+description: Wayfinding  | Used to help direct merchants to the Plan page in Settings.
+keywords:
+  - Plan
+  - Plans
+  - Steps
+  - Levels
+  - Stairs
+  - Staircase
+authors:
+  - David Goligorsky
+version: 1
+date_added: 2022-07-15
+date_modified: 2022-07-15
+exclusive_use: For "Plan" in the settings nav

--- a/polaris-icons/icons/PlanMinor.svg
+++ b/polaris-icons/icons/PlanMinor.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" focusable="false" aria-hidden="true"><path d="M11 3a2 2 0 0 0-2 2v2H8a2 2 0 0 0-2 2v2H5a2 2 0 0 0-2 2v2c0 1.1.9 2 2 2h10a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-4Zm0 2h4v2h-4V5ZM8 9h4v2H8V9Zm-3 4h4v2H5v-2Z" fill=""/></svg>

--- a/polaris-icons/icons/PlanMinor.svg
+++ b/polaris-icons/icons/PlanMinor.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" focusable="false" aria-hidden="true"><path d="M11 3a2 2 0 0 0-2 2v2H8a2 2 0 0 0-2 2v2H5a2 2 0 0 0-2 2v2c0 1.1.9 2 2 2h10a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-4Zm0 2h4v2h-4V5ZM8 9h4v2H8V9Zm-3 4h4v2H5v-2Z" fill=""/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M11 3a2 2 0 0 0-2 2v2H8a2 2 0 0 0-2 2v2H5a2 2 0 0 0-2 2v2c0 1.1.9 2 2 2h10a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-4Zm0 2h4v2h-4V5ZM8 9h4v2H8V9Zm-3 4h4v2H5v-2Z" fill="#5C5F62"/></svg>

--- a/polaris-icons/icons/PlanMinor.yml
+++ b/polaris-icons/icons/PlanMinor.yml
@@ -1,0 +1,16 @@
+name: Plans
+set: minor
+description: Wayfinding  | Minor icon used to help direct merchants to the Plan page in Settings.
+keywords:
+  - Plan
+  - Plans
+  - Steps
+  - Levels
+  - Stairs
+  - Staircase
+authors:
+  - David Goligorsky
+version: 1
+date_added: 2022-07-15
+date_modified: 2022-07-15
+exclusive_use:

--- a/polaris-icons/icons/PlanMinor.yml
+++ b/polaris-icons/icons/PlanMinor.yml
@@ -1,6 +1,6 @@
 name: Plans
 set: minor
-description: Wayfinding  | Minor icon used to help direct merchants to the Plan page in Settings.
+description: Wayfinding | Minor icon used to help direct merchants to the Plan page in Settings.
 keywords:
   - Plan
   - Plans


### PR DESCRIPTION
### WHY are these changes introduced?

This PR addresses Issue #6501 
The new Plan icon will replace the use of the wallet (`BalanceMajor`) icon for the Plan tab in the Settings page nav.

### WHAT is this pull request doing?

This PR adds **major** and **minor** `svg` and `yml` files for this new Plan icon to `polaris/polaris-icons/icons`

**Question**—— The `svg` files include the properties `focusable="false" aria-hidden="true"` — Should this be baked in the svg?

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
