### PR TITLE
[Datatable] Sync fixed first column row height with main table

### DIFF
--- a/.changeset/bright-mails-do.md
+++ b/.changeset/bright-mails-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[Datatable] Fix alignment issue with fixed first column when a cell is empty

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -212,10 +212,15 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     const firstColumn = rows.map((row) => row.slice(0, 1));
     const firstHeading = headings.slice(0, 1);
     const firstTotal = totals?.slice(0, 1);
+    const tableHeaderRows = this.table.current?.children[0].childNodes;
     const tableBodyRows = this.table.current?.children[1].childNodes;
-    const rowHeights: number[] = [];
+    const headerRowHeights: number[] = [];
+    const bodyRowHeights: number[] = [];
+    tableHeaderRows?.forEach((row: HTMLTableRowElement) => {
+      headerRowHeights.push(row.clientHeight);
+    });
     tableBodyRows?.forEach((row: HTMLTableRowElement) => {
-      rowHeights.push(row.clientHeight);
+      bodyRowHeights.push(row.clientHeight);
     });
 
     const fixedFirstColumnMarkup = condensed && fixedFirstColumn && (
@@ -227,7 +232,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
         style={{maxWidth: `${columnVisibilityData[0].rightEdge}px`}}
       >
         <thead>
-          <tr>
+          <tr style={{height: `${headerRowHeights[0]}px`}}>
             {firstHeading.map((heading, index) =>
               this.renderHeading({
                 heading,
@@ -238,7 +243,9 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
             )}
           </tr>
           {totals && !showTotalsInFooter && (
-            <tr>{firstTotal?.map(this.renderTotals)}</tr>
+            <tr style={{height: `${headerRowHeights[1]}px`}}>
+              {firstTotal?.map(this.renderTotals)}
+            </tr>
           )}
         </thead>
         <tbody>
@@ -247,7 +254,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
               row,
               index,
               inFixedFirstColumn: true,
-              rowHeights,
+              rowHeights: bodyRowHeights,
             }),
           )}
         </tbody>

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -31,6 +31,17 @@ export type TableData = string | number | React.ReactNode;
 
 export type ColumnContentType = 'text' | 'numeric';
 
+const getRowClientHeights = (rows: NodeList | undefined) => {
+  const heights: number[] = [];
+  if (!rows) {
+    return heights;
+  }
+  rows.forEach((row: HTMLTableRowElement) => {
+    heights.push(row.clientHeight);
+  });
+  return heights;
+};
+
 export interface DataTableProps {
   /** List of data types, which determines content alignment for each column. Data types are "text," which aligns left, or "numeric," which aligns right. */
   columnContentTypes: ColumnContentType[];
@@ -214,14 +225,8 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     const firstTotal = totals?.slice(0, 1);
     const tableHeaderRows = this.table.current?.children[0].childNodes;
     const tableBodyRows = this.table.current?.children[1].childNodes;
-    const headerRowHeights: number[] = [];
-    const bodyRowHeights: number[] = [];
-    tableHeaderRows?.forEach((row: HTMLTableRowElement) => {
-      headerRowHeights.push(row.clientHeight);
-    });
-    tableBodyRows?.forEach((row: HTMLTableRowElement) => {
-      bodyRowHeights.push(row.clientHeight);
-    });
+    const headerRowHeights: number[] = getRowClientHeights(tableHeaderRows);
+    const bodyRowHeights: number[] = getRowClientHeights(tableBodyRows);
 
     const fixedFirstColumnMarkup = condensed && fixedFirstColumn && (
       <table

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -212,6 +212,11 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     const firstColumn = rows.map((row) => row.slice(0, 1));
     const firstHeading = headings.slice(0, 1);
     const firstTotal = totals?.slice(0, 1);
+    const tableBodyRows = this.table.current?.children[1].childNodes;
+    const rowHeights: number[] = [];
+    tableBodyRows?.forEach((row: HTMLTableRowElement) => {
+      rowHeights.push(row.clientHeight);
+    });
 
     const fixedFirstColumnMarkup = condensed && fixedFirstColumn && (
       <table
@@ -238,7 +243,12 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
         </thead>
         <tbody>
           {firstColumn.map((row, index) =>
-            this.defaultRenderRow({row, index, inFixedFirstColumn: true}),
+            this.defaultRenderRow({
+              row,
+              index,
+              inFixedFirstColumn: true,
+              rowHeights,
+            }),
           )}
         </tbody>
         {totals && showTotalsInFooter && (
@@ -812,10 +822,12 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     row,
     index,
     inFixedFirstColumn,
+    rowHeights,
   }: {
     row: TableData[];
     index: number;
     inFixedFirstColumn: boolean;
+    rowHeights?: number[];
   }) => {
     const {
       columnContentTypes,
@@ -835,6 +847,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
         className={className}
         onMouseEnter={this.handleHover(index)}
         onMouseLeave={this.handleHover()}
+        style={rowHeights ? {height: `${rowHeights[index]}px`} : {}}
       >
         {row.map((content: CellProps['content'], cellIndex: number) => {
           const hovered = index === this.state.rowHovered;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Addresses in part: https://github.com/Shopify/core-issues/issues/41725

If there is a row of data that is empty in the first first column, it will become misaligned with the rest of the column. 

![image](https://user-images.githubusercontent.com/90475486/179603518-76ff520f-b8d1-45e6-bc7a-f3df7e4827f5.png)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR checks the height of the rows in the table body, and applies that to the rows of the fixed first column so they always stay in sync and aligned.

To 🎩 reports in Analytics, use this [Spin URL](https://shop1.shopify.testing.jeremy-ludwig.us.spin.dev/admin/reports/sessions_attributed_to_marketing?since=-7d&until=today) which has a snapshot release of Polaris with these changes.

After:
![image](https://user-images.githubusercontent.com/90475486/179603781-45aceb39-ca2c-4c7e-8e23-595b17a1fa12.png)


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Card, Link, Page, DataTable} from '../src';

function FullDataTableExample() {
  const [sortedRows, setSortedRows] = useState(null);

  const initiallySortedRows = [
    ['', '$875.00', 124689, 140, '$121,500.00', 124689, 140, '$121,500.00'],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
  ];

  const rows = sortedRows ? sortedRows : initiallySortedRows;
  const handleSort = useCallback(
    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
    [rows],
  );

  return (
    <Page title="Sales by product">
      <Card>
        <DataTable
          columnContentTypes={[
            'text',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
          ]}
          headings={[
            'Product',
            'Price',
            'SKU Number',
            'Net quantity',
            'Net sales',
            'SKU Number',
            'Net quantity',
            'Net sales',
          ]}
          rows={rows}
          totals={['', '', '', 255, '$155,830.00', '', 255, '$155,830.00']}
          sortable={[true, true, false, false, true]}
          defaultSortDirection="descending"
          initialSortColumnIndex={4}
          onSort={handleSort}
          // footerContent={`Showing ${rows.length} of ${rows.length} results`}
          stickyHeader
          fixedFirstColumn
          // truncate
        />
      </Card>
    </Page>
  );

  function sortCurrency(rows, index, direction) {
    return [...rows].sort((rowA, rowB) => {
      const amountA = parseFloat(rowA[index].substring(1));
      const amountB = parseFloat(rowB[index].substring(1));

      return direction === 'descending' ? amountB - amountA : amountA - amountB;
    });
  }
}

export function Playground() {
  return <FullDataTableExample />;
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
