### PR TITLE
Update CSS version in readme

### DIFF
--- a/.changeset/short-planets-cross.md
+++ b/.changeset/short-planets-cross.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Update stylesheet url in Readme

--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -33,7 +33,7 @@ Otherwise include the CSS in your HTML. We suggest copying the styles file into 
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/@shopify/polaris@9.8.0/build/esm/styles.css"
+  href="https://unpkg.com/@shopify/polaris@9.20.0/build/esm/styles.css"
 />
 ```
 


### PR DESCRIPTION
The `polaris-react` CSS that was published to the CDN was broken for a few versions. It didn't contain the tokens / CSS Custom Properties which caused the layout to break. See #6650.

- 9.8.0: Missing tokens in `:root` https://unpkg.com/@shopify/polaris@9.8.0/build/esm/styles.css
- 9.20.0: Tokens are back in `:root` https://unpkg.com/@shopify/polaris@9.20.0/build/esm/styles.css

This PR updates the readme so that it points to a newer, fixed version of the CSS file.