### PR TITLE
Use set versions for workspace package dependencies

### DIFF
--- a/.changeset/curly-paws-ring.md
+++ b/.changeset/curly-paws-ring.md
@@ -1,0 +1,8 @@
+---
+'polaris-for-figma': patch
+'polaris-for-vscode': patch
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Use exact versions for Polaris workspace dependencies.

--- a/polaris-for-figma/package.json
+++ b/polaris-for-figma/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
-    "@shopify/polaris": "*",
+    "@shopify/polaris": "^9.20.0",
     "antd": "^4.20.4",
     "lodash": "^4.17.15",
     "react": "^16.0.0",

--- a/polaris-for-vscode/package.json
+++ b/polaris-for-vscode/package.json
@@ -42,7 +42,7 @@
     "vscode-languageserver-textdocument": "^1.0.4"
   },
   "devDependencies": {
-    "@shopify/polaris-tokens": "*",
+    "@shopify/polaris-tokens": "^5.5.0",
     "@types/glob": "^7.2.0",
     "@types/node": "14.x",
     "@types/vscode": "^1.64.0",

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -63,8 +63,8 @@
     "version": "node ./scripts/readme-update-version"
   },
   "dependencies": {
-    "@shopify/polaris-icons": "*",
-    "@shopify/polaris-tokens": "*",
+    "@shopify/polaris-icons": "^5.0.0",
+    "@shopify/polaris-tokens": "^5.5.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "@types/react-transition-group": "^4.4.2",

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -21,9 +21,9 @@
   "dependencies": {
     "@floating-ui/react-dom-interactions": "^0.6.1",
     "@headlessui/react": "^1.6.5",
-    "@shopify/polaris": "*",
-    "@shopify/polaris-icons": "*",
-    "@shopify/polaris-tokens": "*",
+    "@shopify/polaris": "^9.20.0",
+    "@shopify/polaris-icons": "^5.0.0",
+    "@shopify/polaris-tokens": "^5.5.0",
     "codesandbox": "^2.2.3",
     "fuse.js": "^6.5.3",
     "glob": "^7.1.6",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6666

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Sets the workspace package dependencies to specific versions rather than the `*` version wildcard.

These specific versions should be automatically updated and bumped when using `changeset version` on release 🤖 🚀 