### PR TITLE
[polaris.shopify.com] Improve examples browsing experience

### DIFF
--- a/.changeset/twelve-games-fly.md
+++ b/.changeset/twelve-games-fly.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Improved examples browsing experience so that it's easier to see all examples at the same time.

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
@@ -44,7 +44,7 @@
   transition: opacity 0.1s linear;
 
   .CodeExample:hover & {
-    opacity: 0.5;
+    opacity: 0.75;
 
     &:hover {
       opacity: 1;
@@ -65,7 +65,7 @@
 .Code {
   font-family: var(--font-family-mono);
   white-space: pre-wrap;
-  padding: 0.5rem 0.66rem;
+  padding: 0.85rem 1rem;
   font-size: 14px;
   line-height: 1.6;
   overflow: auto;
@@ -77,6 +77,7 @@
 .CodeExample.minimalist .Code {
   font-size: var(--font-size-50);
   line-height: 1.45;
+  padding: 0.5rem 0.66rem;
 }
 
 .LineNumber {

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
@@ -4,6 +4,7 @@
   border-radius: var(--border-radius-400);
   max-width: calc(100vw - 1.5rem);
   cursor: text;
+  overflow: hidden;
 
   @include dark-mode {
     box-shadow: var(--card-shadow);
@@ -36,7 +37,7 @@
 
 .CopyButton {
   position: absolute;
-  padding: 0.5rem;
+  padding: 0.75rem;
   background: transparent;
   opacity: 0.2;
   border-radius: var(--border-radius-200);
@@ -63,11 +64,14 @@
 
 .Code {
   font-family: var(--font-family-mono);
-  white-space: pre;
+  white-space: pre-wrap;
   padding: 0.5rem 0.66rem;
   font-size: 14px;
   line-height: 1.6;
   overflow: auto;
+  max-height: 50vh;
+
+  @include custom-scrollbars;
 }
 
 .CodeExample.minimalist .Code {

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
@@ -16,7 +16,10 @@ function CodeExample({ minimalist, children }: Props) {
 
   return (
     <div
-      className={className(styles.CodeExample, minimalist && styles.minimalist)}
+      className={className(
+        styles.CodeExample,
+        minimalist ? styles.minimalist : "dark-mode"
+      )}
     >
       <div className={styles.CopyButtonWrapper}>
         <Tooltip

--- a/polaris.shopify.com/src/components/Examples/Examples.module.scss
+++ b/polaris.shopify.com/src/components/Examples/Examples.module.scss
@@ -15,6 +15,7 @@
     border-radius: var(--border-radius-400);
     font-size: var(--font-size-100);
     line-height: 1.33;
+    color: var(--text-strong);
 
     &:hover {
       box-shadow: var(--card-shadow-hover);

--- a/polaris.shopify.com/src/components/Examples/Examples.module.scss
+++ b/polaris.shopify.com/src/components/Examples/Examples.module.scss
@@ -23,7 +23,10 @@
 
     &[aria-selected="true"] {
       background: var(--search-highlight-color);
-    }
+      &:focus {
+        box-shadow: var(--focus-outline);
+      }
+    }  
   }
 }
 

--- a/polaris.shopify.com/src/components/Examples/Examples.module.scss
+++ b/polaris.shopify.com/src/components/Examples/Examples.module.scss
@@ -1,64 +1,33 @@
-.SelectContainer {
-  position: relative;
-  display: inline-block;
-  width: 100%;
+.Examples {
+  display: flex;
+  flex-wrap: wrap;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
 
-  select {
-    width: 100%;
-    height: 2.5rem;
-    line-height: 2.5rem;
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
-    background-color: var(--surface-subdued);
-    color: var(--text);
-    border-radius: var(--border-radius-500);
-    font-size: var(--font-size-400);
-    box-shadow: 0 0 0 1px var(--border-color);
+  button {
+    padding: 0.6rem 0.85rem;
+    text-align: left;
+    display: flex;
+    align-items: flex-start;
+    background: transparent;
+    box-shadow: var(--card-shadow);
+    border-radius: var(--border-radius-400);
+    font-size: var(--font-size-100);
+    line-height: 1.33;
 
-    &:focus-visible {
-      box-shadow: var(--focus-outline);
+    &:hover {
+      box-shadow: var(--card-shadow-hover);
+    }
+
+    &[aria-selected="true"] {
+      background: var(--search-highlight-color);
     }
   }
 }
 
-.SelectIcon {
-  pointer-events: none;
-  position: absolute;
-  top: calc(50% + 2px);
-  right: 1rem;
-  transform: translateY(-50%);
-  z-index: 1;
-
-  svg {
-    height: 1.2rem;
-    width: 1.2rem;
-  }
-}
-
-.Buttons {
-  margin-top: 3rem;
-  margin-bottom: 0.5rem;
-  display: flex;
-  justify-content: space-between;
-}
-
-.Button {
-  padding: 0.25rem 0.5rem;
-  border-radius: var(--border-radius-400);
-  font-size: var(--font-size-100);
-  background-color: var(--surface-subdued);
-  color: var(--text);
-  min-width: 40px;
-  box-shadow: var(--card-shadow);
-}
-
-.Button:not(.ButtonSelected) {
-  background: transparent;
-  box-shadow: none;
-}
-
 .ExampleFrame {
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
   background: #fafafa;
   border-radius: var(--border-radius-400);
   overflow: hidden;

--- a/polaris.shopify.com/src/components/Examples/Examples.module.scss
+++ b/polaris.shopify.com/src/components/Examples/Examples.module.scss
@@ -1,4 +1,4 @@
-.Examples {
+.ExamplesList {
   display: flex;
   flex-wrap: wrap;
   grid-template-columns: 1fr 1fr 1fr 1fr;
@@ -32,6 +32,17 @@
   border-radius: var(--border-radius-400);
   overflow: hidden;
   box-shadow: var(--card-shadow);
+
+  .Buttons {
+    display: flex;
+    justify-content: flex-end;
+    border-top: var(--border);
+    color: var(--text-link);
+
+    button {
+      padding: 0.75rem 1rem;
+    }
+  }
 }
 
 .SandboxButton {

--- a/polaris.shopify.com/src/components/Examples/Examples.tsx
+++ b/polaris.shopify.com/src/components/Examples/Examples.tsx
@@ -51,7 +51,7 @@ const Examples = (props: Props) => {
         onChange={setSelectedIndex}
       >
         <Tab.List>
-          <div className={styles.Examples}>
+          <div className={styles.ExamplesList}>
             {examples.map((example) => {
               return (
                 <Tab key={example.fileName}>
@@ -61,7 +61,6 @@ const Examples = (props: Props) => {
             })}
           </div>
         </Tab.List>
-
         <Tab.Panels>
           {examples.map(({ fileName, description, code }) => {
             const exampleUrl = `/examples/${fileName.replace(".tsx", "")}`;
@@ -77,7 +76,14 @@ const Examples = (props: Props) => {
                     onLoad={handleExampleLoad}
                     ref={iframeRef}
                   />
+                  <div className={styles.Buttons}>
+                    <CodesandboxButton
+                      className={styles.CodesandboxButton}
+                      code={code}
+                    />
+                  </div>
                 </div>
+
                 <CodeExample language="typescript">{code}</CodeExample>
               </Tab.Panel>
             );

--- a/polaris.shopify.com/src/components/Examples/Examples.tsx
+++ b/polaris.shopify.com/src/components/Examples/Examples.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, useEffect, useRef, useState } from "react";
 import styles from "./Examples.module.scss";
 import CodesandboxButton from "../CodesandboxButton";
 import CodeExample from "../CodeExample";
-import Select from "../Select";
+import { Tab } from "@headlessui/react";
 
 export type Example = {
   code: string;
@@ -17,19 +17,7 @@ interface Props {
 
 const Examples = (props: Props) => {
   const { examples } = props;
-  const [currentIndex, setIndex] = useState(0);
-  const [showPreview, setShowPreview] = useState(true);
-  const {
-    code = "",
-    description,
-    fileName = "",
-  } = examples[currentIndex] || {};
-  const exampleUrl = `/examples/${fileName.replace(".tsx", "")}`;
-  const handleSelection = (ev: ChangeEvent<HTMLSelectElement>) => {
-    const value = ev.target.value;
-
-    setIndex(parseInt(value, 10));
-  };
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
   const [iframeHeight, setIframeHeight] = useState("400px");
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -50,65 +38,52 @@ const Examples = (props: Props) => {
   };
 
   useEffect(() => {
-    setIndex(0);
-    setShowPreview(true);
+    setSelectedIndex(0);
   }, [examples]);
-
-  if (!examples?.length || !examples[currentIndex]) {
-    return null;
-  }
-
-  const options = examples.map(({ title }, index) => {
-    return { label: title, value: String(index) };
-  });
 
   return (
     <>
       <h2 id="examples">Examples</h2>
-      <Select
-        labelHidden
-        label="Component example"
-        id="Component-Example-Select"
-        options={options}
-        selected={options[currentIndex].value}
-        onChange={handleSelection}
-      />
-      {description ? <p>{description}</p> : null}
 
-      <div className={styles.Buttons}>
-        <div>
-          <button
-            className={`${styles.Button} ${
-              showPreview ? styles.ButtonSelected : ""
-            }`}
-            onClick={() => setShowPreview(true)}
-          >
-            Preview
-          </button>
-          <button
-            className={`${styles.Button} ${
-              showPreview ? "" : styles.ButtonSelected
-            }`}
-            onClick={() => setShowPreview(false)}
-          >
-            Code
-          </button>
-        </div>
-        <CodesandboxButton className={styles.SandboxButton} code={code} />
-      </div>
-      {showPreview ? (
-        <div className={styles.ExampleFrame}>
-          <iframe
-            src={exampleUrl}
-            height={iframeHeight}
-            width="100%"
-            onLoad={handleExampleLoad}
-            ref={iframeRef}
-          />
-        </div>
-      ) : (
-        <CodeExample language="typescript">{code}</CodeExample>
-      )}
+      <Tab.Group
+        defaultIndex={0}
+        selectedIndex={selectedIndex}
+        onChange={setSelectedIndex}
+      >
+        <Tab.List>
+          <div className={styles.Examples}>
+            {examples.map((example) => {
+              return (
+                <Tab key={example.fileName}>
+                  <span>{example.title}</span>
+                </Tab>
+              );
+            })}
+          </div>
+        </Tab.List>
+
+        <Tab.Panels>
+          {examples.map(({ fileName, description, code }) => {
+            const exampleUrl = `/examples/${fileName.replace(".tsx", "")}`;
+
+            return (
+              <Tab.Panel key={fileName}>
+                {description ? <p>{description}</p> : null}
+                <div className={styles.ExampleFrame}>
+                  <iframe
+                    src={exampleUrl}
+                    height={iframeHeight}
+                    width="100%"
+                    onLoad={handleExampleLoad}
+                    ref={iframeRef}
+                  />
+                </div>
+                <CodeExample language="typescript">{code}</CodeExample>
+              </Tab.Panel>
+            );
+          })}
+        </Tab.Panels>
+      </Tab.Group>
     </>
   );
 };

--- a/polaris.shopify.com/src/components/Examples/Examples.tsx
+++ b/polaris.shopify.com/src/components/Examples/Examples.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "./Examples.module.scss";
 import CodesandboxButton from "../CodesandboxButton";
 import CodeExample from "../CodeExample";


### PR DESCRIPTION
A few easy wins for the examples browsing experience 🚀 The examples experience will keep on evolving (towards a full playground) but in the mean time, this PR contains some nice improvements:

- No more select. Just list the examples on the page. Much easier to scan. (Using HeadlessUI's tab component for accessibility.)
- Show preview and code simultaneously. Removes the awkward tabs and reduces context switching.

Fixes #6424
Fixes #6425

<img width="927" alt="image" src="https://user-images.githubusercontent.com/875708/179805049-0f9e096c-518c-48e3-b96c-5cabe0efb39d.png">