### PR TITLE
[polaris.shopify.com] Home page: "Polaris for VS Code" section looses background on smaller breakpoints

### DIFF
--- a/.changeset/pink-turkeys-guess.md
+++ b/.changeset/pink-turkeys-guess.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed home page "Polaris for Vs Code" section background on smaller breakpoints

--- a/polaris.shopify.com/src/components/HomePage/HomePage.module.scss
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.module.scss
@@ -303,8 +303,7 @@ $video-filter: hue-rotate(130deg) brightness(75%) contrast(1.2) saturate(1.2)
   @media screen and (max-width: $breakpointDesktop) {
     display: flex;
     flex-direction: column-reverse;
-    background: transparent;
-    padding: 0;
+    padding: 2rem 1.25rem;
     gap: 2rem;
 
     .Text {

--- a/polaris.shopify.com/src/components/HomePage/HomePage.tsx
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.tsx
@@ -189,51 +189,47 @@ function HomePage({}: Props) {
 
         <div className={className(styles.Step, styles.PowerUps)}>
           <Container>
-            <div className={styles.Blocks}>
-              <div className={styles.Block}>
-                <div className={styles.PolarisForVSCode}>
-                  <div className={styles.Text}>
-                    <h3>Polaris for VS Code</h3>
-                    <p className={styles.Description}>
-                      Automatic autocompletion for Polaris tokens, right inside
-                      your favorite code editor.
-                    </p>
-                    <Links
-                      links={[
-                        {
-                          icon: "install",
-                          label: "Get the extension",
-                          url: "https://marketplace.visualstudio.com/items?itemName=Shopify.polaris-for-vscode",
-                        },
-                      ]}
-                    />
-                  </div>
-
-                  {useMotion ? (
-                    <div className={styles.Video}>
-                      <video
-                        muted
-                        loop
-                        autoPlay
-                        playsInline
-                        width="2250"
-                        height="1440"
-                      >
-                        <source src="/images/vscode.mp4" type="video/mp4" />
-                      </video>
-                    </div>
-                  ) : (
-                    <div className={styles.Poster}>
-                      <Image
-                        width="2250"
-                        height="1440"
-                        src="/images/vscode.jpg"
-                        alt="Screen shot of the Polaris VS Code extension actively autocompleting the value of a background CSS rule with the surface success design token."
-                      />
-                    </div>
-                  )}
-                </div>
+            <div className={styles.PolarisForVSCode}>
+              <div className={styles.Text}>
+                <h3>Polaris for VS Code</h3>
+                <p className={styles.Description}>
+                  Automatic autocompletion for Polaris tokens, right inside your
+                  favorite code editor.
+                </p>
+                <Links
+                  links={[
+                    {
+                      icon: "install",
+                      label: "Get the extension",
+                      url: "https://marketplace.visualstudio.com/items?itemName=Shopify.polaris-for-vscode",
+                    },
+                  ]}
+                />
               </div>
+
+              {useMotion ? (
+                <div className={styles.Video}>
+                  <video
+                    muted
+                    loop
+                    autoPlay
+                    playsInline
+                    width="2250"
+                    height="1440"
+                  >
+                    <source src="/images/vscode.mp4" type="video/mp4" />
+                  </video>
+                </div>
+              ) : (
+                <div className={styles.Poster}>
+                  <Image
+                    width="2250"
+                    height="1440"
+                    src="/images/vscode.jpg"
+                    alt="Screen shot of the Polaris VS Code extension actively autocompleting the value of a background CSS rule with the surface success design token."
+                  />
+                </div>
+              )}
             </div>
           </Container>
         </div>

--- a/polaris.shopify.com/src/components/HomePage/HomePage.tsx
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.tsx
@@ -189,47 +189,51 @@ function HomePage({}: Props) {
 
         <div className={className(styles.Step, styles.PowerUps)}>
           <Container>
-            <div className={styles.PolarisForVSCode}>
-              <div className={styles.Text}>
-                <h3>Polaris for VS Code</h3>
-                <p className={styles.Description}>
-                  Automatic autocompletion for Polaris tokens, right inside your
-                  favorite code editor.
-                </p>
-                <Links
-                  links={[
-                    {
-                      icon: "install",
-                      label: "Get the extension",
-                      url: "https://marketplace.visualstudio.com/items?itemName=Shopify.polaris-for-vscode",
-                    },
-                  ]}
-                />
-              </div>
+            <div className={styles.Blocks}>
+              <div className={styles.Block}>
+                <div className={styles.PolarisForVSCode}>
+                  <div className={styles.Text}>
+                    <h3>Polaris for VS Code</h3>
+                    <p className={styles.Description}>
+                      Automatic autocompletion for Polaris tokens, right inside
+                      your favorite code editor.
+                    </p>
+                    <Links
+                      links={[
+                        {
+                          icon: "install",
+                          label: "Get the extension",
+                          url: "https://marketplace.visualstudio.com/items?itemName=Shopify.polaris-for-vscode",
+                        },
+                      ]}
+                    />
+                  </div>
 
-              {useMotion ? (
-                <div className={styles.Video}>
-                  <video
-                    muted
-                    loop
-                    autoPlay
-                    playsInline
-                    width="2250"
-                    height="1440"
-                  >
-                    <source src="/images/vscode.mp4" type="video/mp4" />
-                  </video>
+                  {useMotion ? (
+                    <div className={styles.Video}>
+                      <video
+                        muted
+                        loop
+                        autoPlay
+                        playsInline
+                        width="2250"
+                        height="1440"
+                      >
+                        <source src="/images/vscode.mp4" type="video/mp4" />
+                      </video>
+                    </div>
+                  ) : (
+                    <div className={styles.Poster}>
+                      <Image
+                        width="2250"
+                        height="1440"
+                        src="/images/vscode.jpg"
+                        alt="Screen shot of the Polaris VS Code extension actively autocompleting the value of a background CSS rule with the surface success design token."
+                      />
+                    </div>
+                  )}
                 </div>
-              ) : (
-                <div className={styles.Poster}>
-                  <Image
-                    width="2250"
-                    height="1440"
-                    src="/images/vscode.jpg"
-                    alt="Screen shot of the Polaris VS Code extension actively autocompleting the value of a background CSS rule with the surface success design token."
-                  />
-                </div>
-              )}
+              </div>
             </div>
           </Container>
         </div>


### PR DESCRIPTION
Fixes Polaris VS Code section on the homepage.

**Before**
Subdued background was not showing up in mobile and desktop breakpoints. 

https://user-images.githubusercontent.com/97708939/179819855-a62753a4-096d-481a-83e2-7d2789225967.mp4

**After**
Subdued background is showing up and is consistent with other sections. 

https://user-images.githubusercontent.com/97708939/179820210-6f4cbfbb-3c96-4b77-85d8-4076f6bc0b13.mp4
