### PR TITLE
Remove unnecessary comments from markdown files

### DIFF
--- a/.changeset/long-spoons-kiss.md
+++ b/.changeset/long-spoons-kiss.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Removed comments and cleaned up markdown files

--- a/polaris-react/src/components/AccountConnection/README.md
+++ b/polaris-react/src/components/AccountConnection/README.md
@@ -52,7 +52,7 @@ merchants can connect to, followed by the word “account”. Write account conn
 - Mailchimp account
 - Instagram account
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -68,7 +68,7 @@ merchants can connect to, followed by the word “account”. Write account conn
 
 Clearly link to your terms and conditions and let merchants know about any additional costs of your service.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -85,7 +85,7 @@ Learn about terms, conditions, and payment details.
 
 Always use the verb Connect in the button of the account connection component. When merchants click or tap “Connect” it should open up your platform or service’s authorization page in a new browser window.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/AccountConnection/README.md
+++ b/polaris-react/src/components/AccountConnection/README.md
@@ -64,6 +64,8 @@ merchants can connect to, followed by the word “account”. Write account conn
 - Connect your Account
 - Instagram Account
 
+<!-- end -->
+
 ### Terms and conditions
 
 Clearly link to your terms and conditions and let merchants know about any additional costs of your service.

--- a/polaris-react/src/components/AccountConnection/README.md
+++ b/polaris-react/src/components/AccountConnection/README.md
@@ -52,7 +52,7 @@ merchants can connect to, followed by the word “account”. Write account conn
 - Mailchimp account
 - Instagram account
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -68,7 +68,7 @@ merchants can connect to, followed by the word “account”. Write account conn
 
 Clearly link to your terms and conditions and let merchants know about any additional costs of your service.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -85,7 +85,7 @@ Learn about terms, conditions, and payment details.
 
 Always use the verb Connect in the button of the account connection component. When merchants click or tap “Connect” it should open up your platform or service’s authorization page in a new browser window.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/ActionList/README.md
+++ b/polaris-react/src/components/ActionList/README.md
@@ -34,7 +34,7 @@ Actions lists should:
 
 Each item in an action list should be clear and predictable. Merchants should be able to anticipate what will happen when they click on an action item.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -48,7 +48,7 @@ Buy
 
 Each item in an action list should always lead with a strong verb that encourages action. To provide enough context use the {verb}+{noun} format unless the action is clear with a single verb.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -64,7 +64,7 @@ Each item in an action list should always lead with a strong verb that encourage
 
 Each item in an action list should be scannable avoiding unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/ActionList/README.md
+++ b/polaris-react/src/components/ActionList/README.md
@@ -34,7 +34,7 @@ Actions lists should:
 
 Each item in an action list should be clear and predictable. Merchants should be able to anticipate what will happen when they click on an action item.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -48,7 +48,7 @@ Buy
 
 Each item in an action list should always lead with a strong verb that encourages action. To provide enough context use the {verb}+{noun} format unless the action is clear with a single verb.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -64,7 +64,7 @@ Each item in an action list should always lead with a strong verb that encourage
 
 Each item in an action list should be scannable avoiding unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Autocomplete/README.md
+++ b/polaris-react/src/components/Autocomplete/README.md
@@ -911,7 +911,7 @@ The autocomplete list displays below the text field or other control by default 
 
 Autocomplete features can be challenging for merchants with visual, motor, and cognitive disabilities. Even when they’re built using best practices, these features can be difficult to use with some assistive technologies. Merchants should always be able to search, enter data, or perform other activities without relying on the autocomplete.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Autocomplete/README.md
+++ b/polaris-react/src/components/Autocomplete/README.md
@@ -911,7 +911,7 @@ The autocomplete list displays below the text field or other control by default 
 
 Autocomplete features can be challenging for merchants with visual, motor, and cognitive disabilities. Even when they’re built using best practices, these features can be difficult to use with some assistive technologies. Merchants should always be able to search, enter data, or perform other activities without relying on the autocomplete.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Badge/README.md
+++ b/polaris-react/src/components/Badge/README.md
@@ -61,7 +61,7 @@ The available badges for fulfillment status are:
 - Unfulfilled
 - Restocked
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Don’t
 

--- a/polaris-react/src/components/Badge/README.md
+++ b/polaris-react/src/components/Badge/README.md
@@ -61,7 +61,7 @@ The available badges for fulfillment status are:
 - Unfulfilled
 - Restocked
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Don’t
 

--- a/polaris-react/src/components/Banner/README.md
+++ b/polaris-react/src/components/Banner/README.md
@@ -80,7 +80,7 @@ Body content should:
 - Explain how to resolve the issue, particularly for warning and critical
   banners
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -101,7 +101,7 @@ Buttons and links should be:
   happen when they click a button. Never deceive merchants by mislabeling a
   button.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -117,7 +117,7 @@ Buy
   action. To provide enough context to merchants use the {verb}+{noun} format on
   buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -131,7 +131,7 @@ Try Apple Pay
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -147,7 +147,7 @@ Link text should:
 
 - Set the expectation of where merchants will be taken
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -162,7 +162,7 @@ Order
 - Use consistent content to label navigation. For example, if a navigational
   link leads to a page called Orders, label the link Orders.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -182,7 +182,7 @@ Body content should be:
   what actions are available to them (especially something new). Don’t use
   permissive language like “you can”.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -199,7 +199,7 @@ Now you can get performance data for all your sales channels.
 - Clear: use the verb “need” to help merchants understand when they’re required
   to do something.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -455,7 +455,7 @@ Always include [inline error](https://polaris.shopify.com/components/inline-erro
 
 To learn about creating helpful and accessible error message text, see the guidelines for [error messages](https://polaris.shopify.com/patterns/error-messages).
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Banner/README.md
+++ b/polaris-react/src/components/Banner/README.md
@@ -80,7 +80,7 @@ Body content should:
 - Explain how to resolve the issue, particularly for warning and critical
   banners
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -101,7 +101,7 @@ Buttons and links should be:
   happen when they click a button. Never deceive merchants by mislabeling a
   button.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -117,7 +117,7 @@ Buy
   action. To provide enough context to merchants use the {verb}+{noun} format on
   buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -131,7 +131,7 @@ Try Apple Pay
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -147,7 +147,7 @@ Link text should:
 
 - Set the expectation of where merchants will be taken
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -162,7 +162,7 @@ Order
 - Use consistent content to label navigation. For example, if a navigational
   link leads to a page called Orders, label the link Orders.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -182,7 +182,7 @@ Body content should be:
   what actions are available to them (especially something new). Don’t use
   permissive language like “you can”.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -199,7 +199,7 @@ Now you can get performance data for all your sales channels.
 - Clear: use the verb “need” to help merchants understand when they’re required
   to do something.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -455,7 +455,7 @@ Always include [inline error](https://polaris.shopify.com/components/inline-erro
 
 To learn about creating helpful and accessible error message text, see the guidelines for [error messages](https://polaris.shopify.com/patterns/error-messages).
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Button/README.md
+++ b/polaris-react/src/components/Button/README.md
@@ -356,7 +356,7 @@ To help support merchants who use speech activation software as well as sighted 
 
 When possible, give the button visible text that clearly conveys its purpose without the use of `accessibilityLabel`. When no additional content is needed, duplicating the button text with `accessibilityLabel` isn’t necessary.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -391,7 +391,7 @@ When you use the button component to create a link to an external resource:
 
 For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/link).
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Button/README.md
+++ b/polaris-react/src/components/Button/README.md
@@ -356,7 +356,7 @@ To help support merchants who use speech activation software as well as sighted 
 
 When possible, give the button visible text that clearly conveys its purpose without the use of `accessibilityLabel`. When no additional content is needed, duplicating the button text with `accessibilityLabel` isn’t necessary.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 
@@ -391,7 +391,7 @@ When you use the button component to create a link to an external resource:
 
 For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/link).
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/CalloutCard/README.md
+++ b/polaris-react/src/components/CalloutCard/README.md
@@ -58,7 +58,7 @@ Body content should be:
   what actions are available to them (especially something new). Don’t use
   permissive language like “you can”.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -75,7 +75,7 @@ Now you can get performance data for all your sales channels.
 - Clear: use the verb “need” to help merchants understand when they’re required
   to do something
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -95,7 +95,7 @@ Buttons should be:
 
 Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -111,7 +111,7 @@ Buy
   action. To provide enough context to merchants use the {verb}+{noun} format on
   buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -125,7 +125,7 @@ View your settings
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/CalloutCard/README.md
+++ b/polaris-react/src/components/CalloutCard/README.md
@@ -58,7 +58,7 @@ Body content should be:
   what actions are available to them (especially something new). Don’t use
   permissive language like “you can”.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -75,7 +75,7 @@ Now you can get performance data for all your sales channels.
 - Clear: use the verb “need” to help merchants understand when they’re required
   to do something
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -95,7 +95,7 @@ Buttons should be:
 
 Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -111,7 +111,7 @@ Buy
   action. To provide enough context to merchants use the {verb}+{noun} format on
   buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -125,7 +125,7 @@ View your settings
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Caption/README.md
+++ b/polaris-react/src/components/Caption/README.md
@@ -38,7 +38,7 @@ Caption text size is smaller than the recommended size for general reading. On w
 
 Captions are primarily used in [data visualizations](https://polaris.shopify.com/design/data-visualizations). Stick to a few words and don’t use this component for complete sentences or longer content.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Caption/README.md
+++ b/polaris-react/src/components/Caption/README.md
@@ -38,7 +38,7 @@ Caption text size is smaller than the recommended size for general reading. On w
 
 Captions are primarily used in [data visualizations](https://polaris.shopify.com/design/data-visualizations). Stick to a few words and don’t use this component for complete sentences or longer content.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Card/README.md
+++ b/polaris-react/src/components/Card/README.md
@@ -59,7 +59,7 @@ Body content should be:
   actions are available to them (especially something new). Don’t use permissive
   language like “you can”.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -76,7 +76,7 @@ Now you can get performance data for all your sales channels.
 - Clear: use the verb “need” to help merchants understand when they’re required
   to do something.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -97,7 +97,7 @@ Buttons should be:
 - Clear and predictable: merchants should be able to anticipate what will happen
   when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -115,7 +115,7 @@ Action-led: buttons should always lead with a strong verb that encourages
 action. To provide enough context to merchants use the {verb}+{noun} format on
 buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -131,7 +131,7 @@ buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
 Scannable: Avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Card/README.md
+++ b/polaris-react/src/components/Card/README.md
@@ -59,7 +59,7 @@ Body content should be:
   actions are available to them (especially something new). Don’t use permissive
   language like “you can”.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -76,7 +76,7 @@ Now you can get performance data for all your sales channels.
 - Clear: use the verb “need” to help merchants understand when they’re required
   to do something.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -97,7 +97,7 @@ Buttons should be:
 - Clear and predictable: merchants should be able to anticipate what will happen
   when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -115,7 +115,7 @@ Action-led: buttons should always lead with a strong verb that encourages
 action. To provide enough context to merchants use the {verb}+{noun} format on
 buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -131,7 +131,7 @@ buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
 Scannable: Avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Checkbox/README.md
+++ b/polaris-react/src/components/Checkbox/README.md
@@ -46,7 +46,7 @@ Lists that use checkboxes should:
 
 - Start with a capital letter
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 
@@ -64,7 +64,7 @@ Lists that use checkboxes should:
 
 - Not use commas or semicolons at the end of each line
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 
@@ -83,7 +83,7 @@ Lists that use checkboxes should:
 - In the rare case where the checkbox is asking merchants to agree to terms
   or service, use the first person
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Checkbox/README.md
+++ b/polaris-react/src/components/Checkbox/README.md
@@ -46,7 +46,7 @@ Lists that use checkboxes should:
 
 - Start with a capital letter
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -64,7 +64,7 @@ Lists that use checkboxes should:
 
 - Not use commas or semicolons at the end of each line
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -83,7 +83,7 @@ Lists that use checkboxes should:
 - In the rare case where the checkbox is asking merchants to agree to terms
   or service, use the first person
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/ChoiceList/README.md
+++ b/polaris-react/src/components/ChoiceList/README.md
@@ -46,7 +46,7 @@ List titles should:
 - Help merchants understand how the items in the list are grouped together, or
   should explain what kind of choice merchants are making
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -65,7 +65,7 @@ Pick one
 - It the title introduces the list, it should end with a colon
 - Should be written in sentence case
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -79,7 +79,7 @@ Shipping Options
 
 ### Not use colons
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 
@@ -99,7 +99,7 @@ Every item in a choice list should:
 - Not use commas or semicolons at the end of each line
 - Be written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/ChoiceList/README.md
+++ b/polaris-react/src/components/ChoiceList/README.md
@@ -46,7 +46,7 @@ List titles should:
 - Help merchants understand how the items in the list are grouped together, or
   should explain what kind of choice merchants are making
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -65,7 +65,7 @@ Pick one
 - It the title introduces the list, it should end with a colon
 - Should be written in sentence case
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -79,7 +79,7 @@ Shipping Options
 
 ### Not use colons
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -99,7 +99,7 @@ Every item in a choice list should:
 - Not use commas or semicolons at the end of each line
 - Be written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -803,7 +803,7 @@ The `Combobox` popover displays below the text field or other control by default
 
 `Combobox` features can be challenging for merchants with visual, motor, and cognitive disabilities. Even when they’re built using best practices, these features can be difficult to use with some assistive technologies. Merchants should always be able to search, enter data, or perform other activities without relying on the combobox.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Combobox/README.md
+++ b/polaris-react/src/components/Combobox/README.md
@@ -803,7 +803,7 @@ The `Combobox` popover displays below the text field or other control by default
 
 `Combobox` features can be challenging for merchants with visual, motor, and cognitive disabilities. Even when they’re built using best practices, these features can be difficult to use with some assistive technologies. Merchants should always be able to search, enter data, or perform other activities without relying on the combobox.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/ContextualSaveBar/README.md
+++ b/polaris-react/src/components/ContextualSaveBar/README.md
@@ -43,7 +43,7 @@ The standard message content is
 - “Unsaved changes” when editing existing content
 - “Unsaved {resource name}” when creating a new object
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -59,7 +59,7 @@ The standard message content is
 
 Actions in the contextual save bar component should consist of a strong verb that encourages action. They should not include a noun.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/ContextualSaveBar/README.md
+++ b/polaris-react/src/components/ContextualSaveBar/README.md
@@ -43,7 +43,7 @@ The standard message content is
 - “Unsaved changes” when editing existing content
 - “Unsaved {resource name}” when creating a new object
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -59,7 +59,7 @@ The standard message content is
 
 Actions in the contextual save bar component should consist of a strong verb that encourages action. They should not include a noun.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/DataTable/README.md
+++ b/polaris-react/src/components/DataTable/README.md
@@ -1014,7 +1014,7 @@ Headers should:
 - Include units of measurement symbols so they aren’t repeated throughout the columns
 - Use sentence case (first word capitalized, rest lowercase)
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -1052,7 +1052,7 @@ Native HTML tables provide a large amount of structural information to screen re
 
 Sortable tables use the `aria-sort` attribute to convey which columns are sortable (and in what direction). They also use `aria-label` on sorting buttons to convey what activating the button will do.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/DataTable/README.md
+++ b/polaris-react/src/components/DataTable/README.md
@@ -1014,7 +1014,7 @@ Headers should:
 - Include units of measurement symbols so they aren’t repeated throughout the columns
 - Use sentence case (first word capitalized, rest lowercase)
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -1052,7 +1052,7 @@ Native HTML tables provide a large amount of structural information to screen re
 
 Sortable tables use the `aria-sort` attribute to convey which columns are sortable (and in what direction). They also use `aria-label` on sorting buttons to convey what activating the button will do.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/DescriptionList/README.md
+++ b/polaris-react/src/components/DescriptionList/README.md
@@ -42,7 +42,7 @@ Terms should be:
 
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -60,7 +60,7 @@ Terms descriptions should be:
 
 - Directly related to the term they’re describing
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -80,7 +80,7 @@ Terms descriptions should be:
 - Conversational by using articles (the, a, an)
 - Written using plain language
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/DescriptionList/README.md
+++ b/polaris-react/src/components/DescriptionList/README.md
@@ -42,7 +42,7 @@ Terms should be:
 
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -60,7 +60,7 @@ Terms descriptions should be:
 
 - Directly related to the term they’re describing
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -80,7 +80,7 @@ Terms descriptions should be:
 - Conversational by using articles (the, a, an)
 - Written using plain language
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/DisplayText/README.md
+++ b/polaris-react/src/components/DisplayText/README.md
@@ -104,7 +104,7 @@ Although display text creates an interesting visual experience, it doesn’t rep
 
 By default, the display text component outputs text in an HTML paragraph (`<p>`). If a heading tag is needed for display text, use the `element` prop to set the heading level.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/DisplayText/README.md
+++ b/polaris-react/src/components/DisplayText/README.md
@@ -104,7 +104,7 @@ Although display text creates an interesting visual experience, it doesn’t rep
 
 By default, the display text component outputs text in an HTML paragraph (`<p>`). If a heading tag is needed for display text, use the `element` prop to set the heading level.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/EmptyState/README.md
+++ b/polaris-react/src/components/EmptyState/README.md
@@ -57,7 +57,7 @@ Empty state titles should:
 
 - Be action-oriented: encourage merchants to take the step required to activate the product or feature
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -87,7 +87,7 @@ They should be:
   happen when they click a button. Never deceive merchants by using misleading
   titles.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -105,7 +105,7 @@ They should be:
   action. To provide enough context to merchants use the {verb}+{noun} format on
   buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -121,7 +121,7 @@ They should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/EmptyState/README.md
+++ b/polaris-react/src/components/EmptyState/README.md
@@ -57,7 +57,7 @@ Empty state titles should:
 
 - Be action-oriented: encourage merchants to take the step required to activate the product or feature
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -87,7 +87,7 @@ They should be:
   happen when they click a button. Never deceive merchants by using misleading
   titles.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -105,7 +105,7 @@ They should be:
   action. To provide enough context to merchants use the {verb}+{noun} format on
   buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -121,7 +121,7 @@ They should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/ExceptionList/README.md
+++ b/polaris-react/src/components/ExceptionList/README.md
@@ -51,7 +51,7 @@ If placed next to an item in a [resource list](https://polaris.shopify.com/compo
 
 - Make the entire list item clickable because the exception list itself isn’t clickable
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/ExceptionList/README.md
+++ b/polaris-react/src/components/ExceptionList/README.md
@@ -24,14 +24,6 @@ The exception list component should:
 - Used sparingly, so that it has more impact and doesn’t add clutter
 - Only use an icon if it adds clarity to the content or helps merchants visualize the meaning
 
-<!-- improvement -->
-
-### Opportunity for improvement
-
-Exception lists aren’t clickable. If you have an idea that could make this component better, please [open an issue](https://github.com/shopify/polaris/issues).
-
-<!-- end -->
-
 ---
 
 ## Content guidelines
@@ -85,10 +77,6 @@ Use icons to add clarity or assist in visualizing the meaning
 ---
 
 ## Related components
-
-<!-- remove comment and adjust link when component is built -->
-
-<!-- * To display an error in a card or section, use the [contextual banner]() component -->
 
 - To display an error at the top of a page, or to indicate multiple errors in a form, use the [banner](https://polaris.shopify.com/components/banner) component
 - Exceptions lists are often used in the [resource list](https://polaris.shopify.com/components/resource-list) component to display conditional content

--- a/polaris-react/src/components/ExceptionList/README.md
+++ b/polaris-react/src/components/ExceptionList/README.md
@@ -51,7 +51,7 @@ If placed next to an item in a [resource list](https://polaris.shopify.com/compo
 
 - Make the entire list item clickable because the exception list itself isn’t clickable
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Filters/README.md
+++ b/polaris-react/src/components/Filters/README.md
@@ -64,7 +64,7 @@ The filters component should:
 
 The text field should be clearly labeled so it’s obvious to merchants what they should enter into the field.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -80,7 +80,7 @@ The text field should be clearly labeled so it’s obvious to merchants what the
 
 Use the name of the filter if the purpose of the name is clear on its own. For example, when you see a filter badge that reads **Fulfilled**, it’s intuitive that it falls under the Fulfillment status category.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -94,7 +94,7 @@ Use the name of the filter if the purpose of the name is clear on its own. For e
 
 If the filter name is ambiguous on its own, add a descriptive word related to the status. For example, **Low** doesn’t make sense out of context. Add the word “risk” so that merchants know it’s from the Risk category.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -108,7 +108,7 @@ If the filter name is ambiguous on its own, add a descriptive word related to th
 
 Group tags from the same category together.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -122,7 +122,7 @@ Group tags from the same category together.
 
 If all tag pills selected: truncate in the middle
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Filters/README.md
+++ b/polaris-react/src/components/Filters/README.md
@@ -64,7 +64,7 @@ The filters component should:
 
 The text field should be clearly labeled so it’s obvious to merchants what they should enter into the field.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -80,7 +80,7 @@ The text field should be clearly labeled so it’s obvious to merchants what the
 
 Use the name of the filter if the purpose of the name is clear on its own. For example, when you see a filter badge that reads **Fulfilled**, it’s intuitive that it falls under the Fulfillment status category.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -94,7 +94,7 @@ Use the name of the filter if the purpose of the name is clear on its own. For e
 
 If the filter name is ambiguous on its own, add a descriptive word related to the status. For example, **Low** doesn’t make sense out of context. Add the word “risk” so that merchants know it’s from the Risk category.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -108,7 +108,7 @@ If the filter name is ambiguous on its own, add a descriptive word related to th
 
 Group tags from the same category together.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -122,7 +122,7 @@ Group tags from the same category together.
 
 If all tag pills selected: truncate in the middle
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/FooterHelp/README.md
+++ b/polaris-react/src/components/FooterHelp/README.md
@@ -51,7 +51,7 @@ Links should not be:
 
 Marked as external: Do not set the `external` prop on the `Link` component to force open a new tab.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/FooterHelp/README.md
+++ b/polaris-react/src/components/FooterHelp/README.md
@@ -51,7 +51,7 @@ Links should not be:
 
 Marked as external: Do not set the `external` prop on the `Link` component to force open a new tab.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/FormLayout/README.md
+++ b/polaris-react/src/components/FormLayout/README.md
@@ -58,7 +58,7 @@ A label is a short description of a field. Labels are not help text, and they sh
 - Short and succinct (1–3 words)
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -70,7 +70,7 @@ A label is a short description of a field. Labels are not help text, and they sh
 
 <!-- end -->
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/FormLayout/README.md
+++ b/polaris-react/src/components/FormLayout/README.md
@@ -58,7 +58,7 @@ A label is a short description of a field. Labels are not help text, and they sh
 - Short and succinct (1–3 words)
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -70,7 +70,7 @@ A label is a short description of a field. Labels are not help text, and they sh
 
 <!-- end -->
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Heading/README.md
+++ b/polaris-react/src/components/Heading/README.md
@@ -63,7 +63,7 @@ Use the `element` prop to determine the specific HTML element that’s output fo
 
 Learn more about writing helpful [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings).
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Heading/README.md
+++ b/polaris-react/src/components/Heading/README.md
@@ -63,7 +63,7 @@ Use the `element` prop to determine the specific HTML element that’s output fo
 
 Learn more about writing helpful [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings).
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Icon/README.md
+++ b/polaris-react/src/components/Icon/README.md
@@ -97,7 +97,7 @@ Using icons can be a great help to merchants who have difficulties with reading,
 
 If the icon appears without text, then use the `accessibilityLabel` prop to give the icon a text alternative. This adds an `aria-label` that’s conveyed to screen reader users.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Icon/README.md
+++ b/polaris-react/src/components/Icon/README.md
@@ -97,7 +97,7 @@ Using icons can be a great help to merchants who have difficulties with reading,
 
 If the icon appears without text, then use the `accessibilityLabel` prop to give the icon a text alternative. This adds an `aria-label` that’s conveyed to screen reader users.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -1714,7 +1714,7 @@ Index tables should:
 
 - Identify the type of resource, usually with a heading
 
-  <!-- usage -->
+  <!-- dodont -->
 
   #### Do
 
@@ -1729,7 +1729,7 @@ Index tables should:
 
 - Indicate when not all members of a resource are being shown. For a card summarizing and linking to recently purchased products:
 
-  <!-- usage -->
+  <!-- dodont -->
 
   #### Do
 

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -1714,7 +1714,7 @@ Index tables should:
 
 - Identify the type of resource, usually with a heading
 
-  <!-- usagelist -->
+  <!-- usage -->
 
   #### Do
 
@@ -1729,7 +1729,7 @@ Index tables should:
 
 - Indicate when not all members of a resource are being shown. For a card summarizing and linking to recently purchased products:
 
-  <!-- usagelist -->
+  <!-- usage -->
 
   #### Do
 

--- a/polaris-react/src/components/IndexTable/README.md
+++ b/polaris-react/src/components/IndexTable/README.md
@@ -1663,11 +1663,7 @@ Using an index table in a project involves combining the following components an
 - [Filters](https://polaris.shopify.com/components/filters) (optional)
 - Pagination component (optional)
 
-<!-- hint -->
-
 The index table component provides the UI elements for list sorting, filtering, and pagination, but doesn’t provide the logic for these operations. When a sort option is changed, filter added, or second page requested, you’ll need to handle that event (including any network requests) and then update the component with new props.
-
-<!-- end -->
 
 ---
 

--- a/polaris-react/src/components/InlineError/README.md
+++ b/polaris-react/src/components/InlineError/README.md
@@ -42,7 +42,7 @@ Inline error messages should:
 - Be short and concise, no more than a single sentence
 - Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/InlineError/README.md
+++ b/polaris-react/src/components/InlineError/README.md
@@ -42,7 +42,7 @@ Inline error messages should:
 - Be short and concise, no more than a single sentence
 - Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/KeyboardKey/README.md
+++ b/polaris-react/src/components/KeyboardKey/README.md
@@ -67,7 +67,7 @@ Use to list a related set of keyboard shortcuts.
 
 The text of the keyboard key component is read by screen readers, but the visual formatting isn’t conveyed. Ensure that merchants are able to understand information about keyboard shortcuts without relying on the visual style of the component.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/KeyboardKey/README.md
+++ b/polaris-react/src/components/KeyboardKey/README.md
@@ -67,7 +67,7 @@ Use to list a related set of keyboard shortcuts.
 
 The text of the keyboard key component is read by screen readers, but the visual formatting isn’t conveyed. Ensure that merchants are able to understand information about keyboard shortcuts without relying on the visual style of the component.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Link/README.md
+++ b/polaris-react/src/components/Link/README.md
@@ -110,7 +110,7 @@ Use the `url` prop to give the link component a valid `href` value. This allows 
 
 The Link component is underlined to give interactive elements a shape. This allows links to not rely on color from being the only way users can tell if an element is interactive.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 
@@ -148,7 +148,7 @@ To provide consistency and clarity:
 - Use the same text for links that navigate to the same content
 - Use different text for links that navigate to different content
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 
@@ -164,7 +164,7 @@ To provide consistency and clarity:
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Link/README.md
+++ b/polaris-react/src/components/Link/README.md
@@ -110,7 +110,7 @@ Use the `url` prop to give the link component a valid `href` value. This allows 
 
 The Link component is underlined to give interactive elements a shape. This allows links to not rely on color from being the only way users can tell if an element is interactive.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -148,7 +148,7 @@ To provide consistency and clarity:
 - Use the same text for links that navigate to the same content
 - Use different text for links that navigate to different content
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -164,7 +164,7 @@ To provide consistency and clarity:
 
 <!-- end -->
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/List/README.md
+++ b/polaris-react/src/components/List/README.md
@@ -37,7 +37,7 @@ Every item in a list should:
 - Start with a capital letter
 - Not use commas or semicolons at the end of each line
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -55,7 +55,7 @@ Every item in a list should:
 
 - Be written in sentence case
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/List/README.md
+++ b/polaris-react/src/components/List/README.md
@@ -37,7 +37,7 @@ Every item in a list should:
 - Start with a capital letter
 - Not use commas or semicolons at the end of each line
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -55,7 +55,7 @@ Every item in a list should:
 
 - Be written in sentence case
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Listbox/README.md
+++ b/polaris-react/src/components/Listbox/README.md
@@ -42,7 +42,7 @@ Listboxes should:
 
 Each item in a `Listbox` should be clear and descriptive.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -162,7 +162,7 @@ The `Listbox` component is based on the [Aria 1.2 Listbox pattern](https://www.w
 It is important to not present interactive elements inside of list box options as they can interfere with navigation
 for assistive technology users.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Listbox/README.md
+++ b/polaris-react/src/components/Listbox/README.md
@@ -42,7 +42,7 @@ Listboxes should:
 
 Each item in a `Listbox` should be clear and descriptive.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -162,7 +162,7 @@ The `Listbox` component is based on the [Aria 1.2 Listbox pattern](https://www.w
 It is important to not present interactive elements inside of list box options as they can interfere with navigation
 for assistive technology users.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/MediaCard/README.md
+++ b/polaris-react/src/components/MediaCard/README.md
@@ -45,7 +45,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling merchants what actions are available to them, especially something new. Don’t use permissive language like “you can”.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -62,7 +62,7 @@ Now you can get performance data for all of your sales channels.
 - Clear: use the verb “need” to help merchants understand when they’re required
   to do something
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -82,7 +82,7 @@ Buttons should be:
 
 Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -98,7 +98,7 @@ Buy
   action. To provide enough context to merchants use the {verb}+{noun} format on
   buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -112,7 +112,7 @@ View your settings
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/MediaCard/README.md
+++ b/polaris-react/src/components/MediaCard/README.md
@@ -45,7 +45,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling merchants what actions are available to them, especially something new. Don’t use permissive language like “you can”.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -62,7 +62,7 @@ Now you can get performance data for all of your sales channels.
 - Clear: use the verb “need” to help merchants understand when they’re required
   to do something
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -82,7 +82,7 @@ Buttons should be:
 
 Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -98,7 +98,7 @@ Buy
   action. To provide enough context to merchants use the {verb}+{noun} format on
   buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -112,7 +112,7 @@ View your settings
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Modal/README.md
+++ b/polaris-react/src/components/Modal/README.md
@@ -53,7 +53,7 @@ Modal titles should:
 - Use a clear {verb}+{noun} question or statement
 - Follow the content guidelines for [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings)
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -75,7 +75,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling a merchant what actions are available to them (especially something new). Don’t use permissive language like "you can".
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -92,7 +92,7 @@ Body content should be:
 - Structured for merchant success: always put the most critical information first.
 - Clear: use the verb “need” to help merchants understand when they’re required to do something.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -110,7 +110,7 @@ Actions should be:
 
 - Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive a merchant by mislabeling an action.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -126,7 +126,7 @@ Actions should be:
 
 - Action-led: actions should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on actions except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -142,7 +142,7 @@ Actions should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -161,7 +161,7 @@ Tertiary actions should:
 - Only be used when the action requires the context of the content in the modal
 - Never be used to dismiss the modal
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -181,7 +181,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling a merchant what actions are available to them (especially something new). Don’t use permissive language like "you can".
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -196,7 +196,7 @@ Body content should be:
 - Structured for merchant success: always put the most critical information first.
 - Clear: use the verb “need” to help merchants understand when they’re required to do something.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Modal/README.md
+++ b/polaris-react/src/components/Modal/README.md
@@ -53,7 +53,7 @@ Modal titles should:
 - Use a clear {verb}+{noun} question or statement
 - Follow the content guidelines for [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings)
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -75,7 +75,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling a merchant what actions are available to them (especially something new). Don’t use permissive language like "you can".
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -92,7 +92,7 @@ Body content should be:
 - Structured for merchant success: always put the most critical information first.
 - Clear: use the verb “need” to help merchants understand when they’re required to do something.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -110,7 +110,7 @@ Actions should be:
 
 - Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive a merchant by mislabeling an action.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -126,7 +126,7 @@ Actions should be:
 
 - Action-led: actions should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on actions except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -142,7 +142,7 @@ Actions should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -161,7 +161,7 @@ Tertiary actions should:
 - Only be used when the action requires the context of the content in the modal
 - Never be used to dismiss the modal
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -181,7 +181,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling a merchant what actions are available to them (especially something new). Don’t use permissive language like "you can".
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -196,7 +196,7 @@ Body content should be:
 - Structured for merchant success: always put the most critical information first.
 - Clear: use the verb “need” to help merchants understand when they’re required to do something.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Navigation/README.md
+++ b/polaris-react/src/components/Navigation/README.md
@@ -45,7 +45,7 @@ Navigation should:
 
 - Use sentence case for primary and secondary navigation items
 
-  <!-- usage -->
+  <!-- dodont -->
 
   #### Do
 
@@ -59,7 +59,7 @@ Navigation should:
 
 - Use as few words as possible to describe each item label
 
-  <!-- usage -->
+  <!-- dodont -->
 
   #### Do
 
@@ -73,7 +73,7 @@ Navigation should:
 
 - Use all caps for section labels
 
-  <!-- usage -->
+  <!-- dodont -->
 
   #### Do
 

--- a/polaris-react/src/components/Navigation/README.md
+++ b/polaris-react/src/components/Navigation/README.md
@@ -45,7 +45,7 @@ Navigation should:
 
 - Use sentence case for primary and secondary navigation items
 
-  <!-- usagelist -->
+  <!-- usage -->
 
   #### Do
 
@@ -59,7 +59,7 @@ Navigation should:
 
 - Use as few words as possible to describe each item label
 
-  <!-- usagelist -->
+  <!-- usage -->
 
   #### Do
 
@@ -73,7 +73,7 @@ Navigation should:
 
 - Use all caps for section labels
 
-  <!-- usagelist -->
+  <!-- usage -->
 
   #### Do
 

--- a/polaris-react/src/components/OptionList/README.md
+++ b/polaris-react/src/components/OptionList/README.md
@@ -40,7 +40,7 @@ The option list component should:
 
 Each item in an option list should be clear and descriptive.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/OptionList/README.md
+++ b/polaris-react/src/components/OptionList/README.md
@@ -40,7 +40,7 @@ The option list component should:
 
 Each item in an option list should be clear and descriptive.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Page/README.md
+++ b/polaris-react/src/components/Page/README.md
@@ -69,7 +69,7 @@ Page header action labels should be:
 - Action-led: they should always lead with a strong verb that encourages
   action. To provide enough context to merchants, use the {verb}+{noun} format.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -87,7 +87,7 @@ Page header action labels should be:
 
   In the context of the orders list page:
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -103,7 +103,7 @@ Page header action labels should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Page/README.md
+++ b/polaris-react/src/components/Page/README.md
@@ -69,7 +69,7 @@ Page header action labels should be:
 - Action-led: they should always lead with a strong verb that encourages
   action. To provide enough context to merchants, use the {verb}+{noun} format.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -87,7 +87,7 @@ Page header action labels should be:
 
   In the context of the orders list page:
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -103,7 +103,7 @@ Page header action labels should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/PageActions/README.md
+++ b/polaris-react/src/components/PageActions/README.md
@@ -36,7 +36,7 @@ Buttons should be:
 
 - Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -52,7 +52,7 @@ Buttons should be:
 
 - Action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -68,7 +68,7 @@ Buttons should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/PageActions/README.md
+++ b/polaris-react/src/components/PageActions/README.md
@@ -36,7 +36,7 @@ Buttons should be:
 
 - Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -52,7 +52,7 @@ Buttons should be:
 
 - Action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -68,7 +68,7 @@ Buttons should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Popover/README.md
+++ b/polaris-react/src/components/Popover/README.md
@@ -46,7 +46,7 @@ If a popover contains actions, they should:
 
 - Be clear and predictable: merchants should be able to anticipate what will happen when they click on an action item. Never deceive merchants by mislabeling an action.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -62,7 +62,7 @@ If a popover contains actions, they should:
 
 - Be action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -80,7 +80,7 @@ If a popover contains actions, they should:
 
 - Be scannable, especially when the popover contains a list of actions or options. Avoid unnecessary words and articles such as “the”, “an”, or “a”.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -96,7 +96,7 @@ If the popover includes a series of navigational links, each item should:
 
 - Be concise but still give merchants enough information so they can easily find and accurately navigate to the path they want.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Popover/README.md
+++ b/polaris-react/src/components/Popover/README.md
@@ -46,7 +46,7 @@ If a popover contains actions, they should:
 
 - Be clear and predictable: merchants should be able to anticipate what will happen when they click on an action item. Never deceive merchants by mislabeling an action.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -62,7 +62,7 @@ If a popover contains actions, they should:
 
 - Be action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -80,7 +80,7 @@ If a popover contains actions, they should:
 
 - Be scannable, especially when the popover contains a list of actions or options. Avoid unnecessary words and articles such as “the”, “an”, or “a”.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -96,7 +96,7 @@ If the popover includes a series of navigational links, each item should:
 
 - Be concise but still give merchants enough information so they can easily find and accurately navigate to the path they want.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/RadioButton/README.md
+++ b/polaris-react/src/components/RadioButton/README.md
@@ -48,7 +48,7 @@ Radio button labels should:
 - Be introduced with a colon or a heading
 - Start with a capital letter
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -62,7 +62,7 @@ Radio button labels should:
 
 - Not end in punctuation if it’s a single sentence, word, or a fragment
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/RadioButton/README.md
+++ b/polaris-react/src/components/RadioButton/README.md
@@ -48,7 +48,7 @@ Radio button labels should:
 - Be introduced with a colon or a heading
 - Start with a capital letter
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -62,7 +62,7 @@ Radio button labels should:
 
 - Not end in punctuation if it’s a single sentence, word, or a fragment
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/RangeSlider/README.md
+++ b/polaris-react/src/components/RangeSlider/README.md
@@ -39,7 +39,7 @@ A label is a short description of the requested input. Labels are not instructio
 - Short and succinct (1–3 words)
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -58,7 +58,7 @@ A label is a short description of the requested input. Labels are not instructio
 Try to only ask for information that’s required. If you need to ask merchants
 to provide optional information, mark the field optional by placing the text “(optional)” at the end of the field’s label. Don’t mark required fields with asterisks.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -74,7 +74,7 @@ to provide optional information, mark the field optional by placing the text “
 
 Help text provides extra guidance or instruction to people filling out a form field. It can also be used to clarify how the information will be used. As with all form content, help text should be succinct and easy to read.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -94,7 +94,7 @@ Error messages should:
 - Be short and concise, no more than a single sentence
 - Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/RangeSlider/README.md
+++ b/polaris-react/src/components/RangeSlider/README.md
@@ -39,7 +39,7 @@ A label is a short description of the requested input. Labels are not instructio
 - Short and succinct (1–3 words)
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -58,7 +58,7 @@ A label is a short description of the requested input. Labels are not instructio
 Try to only ask for information that’s required. If you need to ask merchants
 to provide optional information, mark the field optional by placing the text “(optional)” at the end of the field’s label. Don’t mark required fields with asterisks.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -74,7 +74,7 @@ to provide optional information, mark the field optional by placing the text “
 
 Help text provides extra guidance or instruction to people filling out a form field. It can also be used to clarify how the information will be used. As with all form content, help text should be succinct and easy to read.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -94,7 +94,7 @@ Error messages should:
 - Be short and concise, no more than a single sentence
 - Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/ResourceList/README.md
+++ b/polaris-react/src/components/ResourceList/README.md
@@ -1275,7 +1275,7 @@ Resource lists should:
 
 - Identify the type of resource, usually with a heading
 
-  <!-- usage -->
+  <!-- dodont -->
 
   #### Do
 
@@ -1290,7 +1290,7 @@ Resource lists should:
 
 - Indicate when not all members of a resource are being shown. For a card summarizing and linking to recently purchased products:
 
-  <!-- usage -->
+  <!-- dodont -->
 
   #### Do
 

--- a/polaris-react/src/components/ResourceList/README.md
+++ b/polaris-react/src/components/ResourceList/README.md
@@ -1275,7 +1275,7 @@ Resource lists should:
 
 - Identify the type of resource, usually with a heading
 
-  <!-- usagelist -->
+  <!-- usage -->
 
   #### Do
 
@@ -1290,7 +1290,7 @@ Resource lists should:
 
 - Indicate when not all members of a resource are being shown. For a card summarizing and linking to recently purchased products:
 
-  <!-- usagelist -->
+  <!-- usage -->
 
   #### Do
 

--- a/polaris-react/src/components/Select/README.md
+++ b/polaris-react/src/components/Select/README.md
@@ -49,7 +49,7 @@ Labels should:
 - Be independent sentences. To support [internationalization](https://polaris.shopify.com/foundations/internationalization), they should not act as the first part of a sentence that is finished by the component’s options.
 - Be descriptive, not instructional. If the selection needs more explanation, use help text below the field.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -61,7 +61,7 @@ Labels should:
 
 <!-- end -->
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Select/README.md
+++ b/polaris-react/src/components/Select/README.md
@@ -49,7 +49,7 @@ Labels should:
 - Be independent sentences. To support [internationalization](https://polaris.shopify.com/foundations/internationalization), they should not act as the first part of a sentence that is finished by the component’s options.
 - Be descriptive, not instructional. If the selection needs more explanation, use help text below the field.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -61,7 +61,7 @@ Labels should:
 
 <!-- end -->
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/SettingToggle/README.md
+++ b/polaris-react/src/components/SettingToggle/README.md
@@ -56,7 +56,7 @@ For example, if the setting toggle is on, the button should say “Deactivate”
 allow merchants to turn it off. If the setting toggle is off, the button should
 say “Activate” to allow merchants to turn it on.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/SettingToggle/README.md
+++ b/polaris-react/src/components/SettingToggle/README.md
@@ -56,7 +56,7 @@ For example, if the setting toggle is on, the button should say “Deactivate”
 allow merchants to turn it off. If the setting toggle is off, the button should
 say “Activate” to allow merchants to turn it on.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/SkeletonBodyText/README.md
+++ b/polaris-react/src/components/SkeletonBodyText/README.md
@@ -31,7 +31,7 @@ Skeleton body text component should:
 
 Show static content that never changes on a page and use skeleton loading for dynamic content. Skeleton body text can sometimes be used to represent non-typographic content such as forms. Don’t use placeholder content that will change when the page fully loads.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/SkeletonBodyText/README.md
+++ b/polaris-react/src/components/SkeletonBodyText/README.md
@@ -31,7 +31,7 @@ Skeleton body text component should:
 
 Show static content that never changes on a page and use skeleton loading for dynamic content. Skeleton body text can sometimes be used to represent non-typographic content such as forms. Don’t use placeholder content that will change when the page fully loads.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/SkeletonDisplayText/README.md
+++ b/polaris-react/src/components/SkeletonDisplayText/README.md
@@ -30,7 +30,7 @@ Skeleton display text component should:
 
 Show static display text that that never changes on a page. For example, keep page titles, such as Products on the product list page, but use skeleton loading for page titles that change on the product details page.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -44,7 +44,7 @@ Use skeleton display text for static content or placeholder content for dynamic 
 
 <!-- end -->
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/SkeletonDisplayText/README.md
+++ b/polaris-react/src/components/SkeletonDisplayText/README.md
@@ -30,7 +30,7 @@ Skeleton display text component should:
 
 Show static display text that that never changes on a page. For example, keep page titles, such as Products on the product list page, but use skeleton loading for page titles that change on the product details page.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 
@@ -44,7 +44,7 @@ Use skeleton display text for static content or placeholder content for dynamic 
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/SkeletonPage/README.md
+++ b/polaris-react/src/components/SkeletonPage/README.md
@@ -30,7 +30,7 @@ Show page titles that never change for a page. For example, keep the title “Pr
 
 Secondary actions are always represented with skeleton content. You can change the number of skeleton actions that best represent the number of actions once loaded.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/SkeletonPage/README.md
+++ b/polaris-react/src/components/SkeletonPage/README.md
@@ -30,7 +30,7 @@ Show page titles that never change for a page. For example, keep the title “Pr
 
 Secondary actions are always represented with skeleton content. You can change the number of skeleton actions that best represent the number of actions once loaded.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Subheading/README.md
+++ b/polaris-react/src/components/Subheading/README.md
@@ -59,7 +59,7 @@ Use the `element` prop to determine the specific HTML element that’s output fo
 
 Learn more about writing helpful [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings).
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Subheading/README.md
+++ b/polaris-react/src/components/Subheading/README.md
@@ -59,7 +59,7 @@ Use the `element` prop to determine the specific HTML element that’s output fo
 
 Learn more about writing helpful [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings).
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/TextField/README.md
+++ b/polaris-react/src/components/TextField/README.md
@@ -830,7 +830,7 @@ When you provide help text via the `helpText` prop or an inline error message vi
 
 Use the `placeholder` prop to provide additional instructions. However, don’t rely on placeholders alone since the content isn’t always conveyed to all merchants.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/TextField/README.md
+++ b/polaris-react/src/components/TextField/README.md
@@ -830,7 +830,7 @@ When you provide help text via the `helpText` prop or an inline error message vi
 
 Use the `placeholder` prop to provide additional instructions. However, don’t rely on placeholders alone since the content isn’t always conveyed to all merchants.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/TextStyle/README.md
+++ b/polaris-react/src/components/TextStyle/README.md
@@ -97,7 +97,7 @@ Use to display inline snippets of code or code-like text.
 
 Don’t rely on text style alone to convey information to merchants. Ensure that text styles are used to enhance the information provided in text.
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/TextStyle/README.md
+++ b/polaris-react/src/components/TextStyle/README.md
@@ -97,7 +97,7 @@ Use to display inline snippets of code or code-like text.
 
 Don’t rely on text style alone to convey information to merchants. Ensure that text styles are used to enhance the information provided in text.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Toast/README.md
+++ b/polaris-react/src/components/Toast/README.md
@@ -55,7 +55,7 @@ Toast messages should be:
 - Short and affirmative
 - Written in the pattern of: noun + verb
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 
@@ -90,7 +90,7 @@ Action should:
 - Not have actions, like [Cancel], for dismissing toast. The [X] to dismiss is already included in the component.
 - Be used with a duration of at least 10,000 milliseconds for accessibility.
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/Toast/README.md
+++ b/polaris-react/src/components/Toast/README.md
@@ -55,7 +55,7 @@ Toast messages should be:
 - Short and affirmative
 - Written in the pattern of: noun + verb
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 
@@ -90,7 +90,7 @@ Action should:
 - Not have actions, like [Cancel], for dismissing toast. The [X] to dismiss is already included in the component.
 - Be used with a duration of at least 10,000 milliseconds for accessibility.
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Tooltip/README.md
+++ b/polaris-react/src/components/Tooltip/README.md
@@ -46,7 +46,7 @@ Tooltips should:
 - Be concise and scannable
 - Not be used to communicate error messages or important account information
 
-<!-- usageblock -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris-react/src/components/Tooltip/README.md
+++ b/polaris-react/src/components/Tooltip/README.md
@@ -46,7 +46,7 @@ Tooltips should:
 - Be concise and scannable
 - Not be used to communicate error messages or important account information
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/TopBar/README.md
+++ b/polaris-react/src/components/TopBar/README.md
@@ -54,7 +54,7 @@ The placeholder content for the search field should:
 - Always say "Search"
 - Never include an ellipsis
 
-<!-- usage -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris-react/src/components/TopBar/README.md
+++ b/polaris-react/src/components/TopBar/README.md
@@ -54,7 +54,7 @@ The placeholder content for the search field should:
 - Always say "Search"
 - Never include an ellipsis
 
-<!-- usagelist -->
+<!-- usage -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/account-connection.md
+++ b/polaris.shopify.com/content/components/account-connection.md
@@ -34,11 +34,8 @@ The account component should:
 - Be placed at the top of the Account page for the relevant sales channel
 - Identify the name of the platform or service merchants can connect to
 - Show whether the account is connected or disconnected so that merchants can easily connect or disconnect an account
-- Include a link to the relevant sales channel or platform terms and conditions,
-  including information about any charges or fees that merchants may incur by
-  using the channel or platform
-- Link to terms and conditions, which should open up on the sales channel
-  developer’s website in a new browser window
+- Include a link to the relevant sales channel or platform terms and conditions, including information about any charges or fees that merchants may incur by using the channel or platform
+- Link to terms and conditions, which should open up on the sales channel developer’s website in a new browser window
 
 ---
 
@@ -46,8 +43,7 @@ The account component should:
 
 ### Title
 
-The account connection title should be the name of the platform or service that
-merchants can connect to, followed by the word “account”. Write account connection titles in sentence case (capitalize the first word and proper nouns only).
+The account connection title should be the name of the platform or service that merchants can connect to, followed by the word “account”. Write account connection titles in sentence case (capitalize the first word and proper nouns only).
 
 #### For example:
 
@@ -55,7 +51,7 @@ merchants can connect to, followed by the word “account”. Write account conn
 - Mailchimp account
 - Instagram account
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -67,11 +63,13 @@ merchants can connect to, followed by the word “account”. Write account conn
 - Connect your Account
 - Instagram Account
 
+<!-- end -->
+
 ### Terms and conditions
 
 Clearly link to your terms and conditions and let merchants know about any additional costs of your service.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -88,7 +86,7 @@ Learn about terms, conditions, and payment details.
 
 Always use the verb Connect in the button of the account connection component. When merchants click or tap “Connect” it should open up your platform or service’s authorization page in a new browser window.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/action-list.md
+++ b/polaris.shopify.com/content/components/action-list.md
@@ -67,7 +67,7 @@ Actions lists should:
 
 Each item in an action list should be clear and predictable. Merchants should be able to anticipate what will happen when they click on an action item.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -81,7 +81,7 @@ Buy
 
 Each item in an action list should always lead with a strong verb that encourages action. To provide enough context use the {verb}+{noun} format unless the action is clear with a single verb.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -97,7 +97,7 @@ Each item in an action list should always lead with a strong verb that encourage
 
 Each item in an action list should be scannable avoiding unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/autocomplete.md
+++ b/polaris.shopify.com/content/components/autocomplete.md
@@ -83,7 +83,7 @@ The autocomplete list displays below the text field or other control by default 
 
 Autocomplete features can be challenging for merchants with visual, motor, and cognitive disabilities. Even when they’re built using best practices, these features can be difficult to use with some assistive technologies. Merchants should always be able to search, enter data, or perform other activities without relying on the autocomplete.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/avatar.md
+++ b/polaris.shopify.com/content/components/avatar.md
@@ -51,8 +51,7 @@ Avatars should be one of 4 sizes:
 
 Any time you use an image to communicate a concept on Shopify, it’s important to use descriptive [alt text](https://polaris.shopify.com/content/alternative-text). Doing this is important for [accessibility](https://polaris.shopify.com/foundations/accessibility) because it allows screen readers to describe what’s in the image to people who may not be able to see it.
 
-For avatars, we recommend using a format that describes what will show in the
-image:
+For avatars, we recommend using a format that describes what will show in the image:
 
 - `alt="Person’s name"` if the avatar represents a person
 - `alt="Business’s name"` if the avatar represents a business

--- a/polaris.shopify.com/content/components/badge.md
+++ b/polaris.shopify.com/content/components/badge.md
@@ -123,7 +123,7 @@ The available badges for fulfillment status are:
 - Unfulfilled
 - Restocked
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Don’t
 

--- a/polaris.shopify.com/content/components/banner.md
+++ b/polaris.shopify.com/content/components/banner.md
@@ -112,12 +112,9 @@ Banners should be placed in the appropriate context:
 
 Banners should:
 
-- Focus on a single theme, piece of information, or required action to avoid
-  overwhelming merchants.
-- Be concise and scannable—merchants shouldn’t need to spend a lot of time
-  figuring out what they need to know and do.
-- Be limited to a few important calls to action with no more than one primary
-  action.
+- Focus on a single theme, piece of information, or required action to avoid overwhelming merchants.
+- Be concise and scannable—merchants shouldn’t need to spend a lot of time figuring out what they need to know and do.
+- Be limited to a few important calls to action with no more than one primary action.
 - Not be used for marketing information or upsell—[use callout cards](https://polaris.shopify.com/components/callout-card) instead.
 
 To learn about writing helpful and accessible error message text, see the guidelines for [error messages](https://polaris.shopify.com/patterns/error-messages).
@@ -134,10 +131,9 @@ Body content should:
 - Clarify the benefit of the main task
 - Be written in sentence case and use appropriate punctuation
 - Avoid repeating the heading
-- Explain how to resolve the issue, particularly for warning and critical
-  banners
+- Explain how to resolve the issue, particularly for warning and critical banners
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -145,8 +141,7 @@ Your online store has a maximum of 20 themes. Delete unused themes to add more.
 
 #### Don’t
 
-You have reached your theme limit. Your online store has reached its maximum
-of 20 themes. To add more themes, delete themes you’re no longer using.
+You have reached your theme limit. Your online store has reached its maximum of 20 themes. To add more themes, delete themes you’re no longer using.
 
 <!-- end -->
 
@@ -154,11 +149,9 @@ of 20 themes. To add more themes, delete themes you’re no longer using.
 
 Buttons and links should be:
 
-- Clear and predictable: merchants should be able to anticipate what will
-  happen when they click a button. Never deceive merchants by mislabeling a
-  button.
+- Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -170,11 +163,9 @@ Buy
 
 <!-- end -->
 
-- Action-led: buttons should always lead with a strong verb that encourages
-  action. To provide enough context to merchants use the {verb}+{noun} format on
-  buttons except in the case of common actions like Save, Close, Cancel, or OK.
+- Action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -188,7 +179,7 @@ Try Apple Pay
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -204,7 +195,7 @@ Link text should:
 
 - Set the expectation of where merchants will be taken
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -216,10 +207,9 @@ Order
 
 <!-- end -->
 
-- Use consistent content to label navigation. For example, if a navigational
-  link leads to a page called Orders, label the link Orders.
+- Use consistent content to label navigation. For example, if a navigational link leads to a page called Orders, label the link Orders.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -235,11 +225,9 @@ Finance section
 
 Body content should be:
 
-- Actionable: start sentences with imperative verbs when telling merchants
-  what actions are available to them (especially something new). Don’t use
-  permissive language like “you can”.
+- Actionable: start sentences with imperative verbs when telling merchants what actions are available to them (especially something new). Don’t use permissive language like “you can”.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -251,22 +239,18 @@ Now you can get performance data for all your sales channels.
 
 <!-- end -->
 
-- Structured for merchant success: always put the most critical information
-  first.
-- Clear: use the verb “need” to help merchants understand when they’re required
-  to do something.
+- Structured for merchant success: always put the most critical information first.
+- Clear: use the verb “need” to help merchants understand when they’re required to do something.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-To buy a shipping label, you need to enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you need to enter the total weight of your shipment, including packaging.
 
 #### Don’t
 
-To buy a shipping label, you must enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you must enter the total weight of your shipment, including packaging.
 
 <!-- end -->
 
@@ -302,7 +286,7 @@ Always include [inline error](https://polaris.shopify.com/components/inline-erro
 
 To learn about creating helpful and accessible error message text, see the guidelines for [error messages](https://polaris.shopify.com/patterns/error-messages).
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/button-group.md
+++ b/polaris.shopify.com/content/components/button-group.md
@@ -48,11 +48,9 @@ Button groups should:
 - Only use buttons that follow the
   [best practices outlined in the button component](https://polaris.shopify.com/components/button#best-practices)
 - Group together calls to action that have a relationship
-- Be used with consideration that too many calls to action can cause merchants
-  to be unsure of what to do next
+- Be used with consideration that too many calls to action can cause merchants to be unsure of what to do next
 - Be thoughtful about how multiple buttons will look and work on small screens
-- Only be used in groups of up to six buttons if the buttons contain an icon
-  with no text
+- Only be used in groups of up to six buttons if the buttons contain an icon with no text
 
 ---
 

--- a/polaris.shopify.com/content/components/button.md
+++ b/polaris.shopify.com/content/components/button.md
@@ -133,10 +133,8 @@ Buttons should:
 
 - Be clearly and accurately labeled.
 - Lead with a strong, actionable verb.
-- Use established button colors appropriately. For example, only use a red
-  button for an action that’s difficult or impossible to undo.
-- Prioritize the most important actions. Too many calls to action can cause
-  confusion and make merchants unsure of what to do next.
+- Use established button colors appropriately. For example, only use a red button for an action that’s difficult or impossible to undo.
+- Prioritize the most important actions. Too many calls to action can cause confusion and make merchants unsure of what to do next.
 - Be positioned in consistent locations in the interface.
 
 ### Buttons versus links
@@ -194,7 +192,7 @@ To help support merchants who use speech activation software as well as sighted 
 
 When possible, give the button visible text that clearly conveys its purpose without the use of `accessibilityLabel`. When no additional content is needed, duplicating the button text with `accessibilityLabel` isn’t necessary.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -229,7 +227,7 @@ When you use the button component to create a link to an external resource:
 
 For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/link).
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/callout-card.md
+++ b/polaris.shopify.com/content/components/callout-card.md
@@ -52,8 +52,7 @@ Callout cards should:
 - Clearly articulate the benefit of the feature and what it does
 - Provide merchants with a clear call to action
 - Be targeted to merchants who will most benefit from the feature
-- Be dismissable so merchants can get rid of cards about features they’re not
-  interested in
+- Be dismissable so merchants can get rid of cards about features they’re not interested in
 - Use an illustration that helps to communicate the subject or merchant benefit
 
 ---
@@ -68,11 +67,9 @@ Callout card titles should follow the content guidelines for [headings and subhe
 
 Body content should be:
 
-- Actionable: start sentences with imperative verbs when telling merchants
-  what actions are available to them (especially something new). Don’t use
-  permissive language like “you can”.
+- Actionable: start sentences with imperative verbs when telling merchants what actions are available to them (especially something new). Don’t use permissive language like “you can”.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -84,22 +81,18 @@ Now you can get performance data for all your sales channels.
 
 <!-- end -->
 
-- Structured for merchant success: always put the most critical information
-  first
-- Clear: use the verb “need” to help merchants understand when they’re required
-  to do something
+- Structured for merchant success: always put the most critical information first
+- Clear: use the verb “need” to help merchants understand when they’re required to do something
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-To buy a shipping label, you need to enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you need to enter the total weight of your shipment, including packaging.
 
 #### Don’t
 
-To buy a shipping label, you must enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you must enter the total weight of your shipment, including packaging.
 
 <!-- end -->
 
@@ -109,7 +102,7 @@ Buttons should be:
 
 Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -121,11 +114,9 @@ Buy
 
 <!-- end -->
 
-- Action-led: buttons should always lead with a strong verb that encourages
-  action. To provide enough context to merchants use the {verb}+{noun} format on
-  buttons except in the case of common actions like Save, Close, Cancel, or OK.
+- Action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -139,7 +130,7 @@ View your settings
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/caption.md
+++ b/polaris.shopify.com/content/components/caption.md
@@ -44,7 +44,7 @@ Caption text size is smaller than the recommended size for general reading. On w
 
 Captions are primarily used in [data visualizations](https://polaris.shopify.com/design/data-visualizations). Stick to a few words and don’t use this component for complete sentences or longer content.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/card.md
+++ b/polaris.shopify.com/content/components/card.md
@@ -114,15 +114,10 @@ Cards are used to group similar concepts and tasks together to make Shopify easi
 Cards should:
 
 - Use headings that set clear expectations about the card’s purpose
-- Prioritize information so the content merchants most need to know comes
-  first
-- Stick to single user flows or break more complicated flows into multiple
-  sections
-- Avoid too many call-to-action buttons or links and only one primary call to
-  action per card
-- Use calls to action on the bottom of the card for next steps and use the
-  space in the upper right corner of the card for persistent, optional actions
-  (such as an Edit link)
+- Prioritize information so the content merchants most need to know comes first
+- Stick to single user flows or break more complicated flows into multiple sections
+- Avoid too many call-to-action buttons or links and only one primary call to action per card
+- Use calls to action on the bottom of the card for next steps and use the space in the upper right corner of the card for persistent, optional actions (such as an Edit link)
 
 ---
 
@@ -136,11 +131,9 @@ Card titles should follow the content guidelines for [headings and subheadings](
 
 Body content should be:
 
-- Actionable: start sentences with imperative verbs when telling merchants what
-  actions are available to them (especially something new). Don’t use permissive
-  language like “you can”.
+- Actionable: start sentences with imperative verbs when telling merchants what actions are available to them (especially something new). Don’t use permissive language like “you can”.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -152,22 +145,18 @@ Now you can get performance data for all your sales channels.
 
 <!-- end -->
 
-- Structured for merchant success: always put the most critical information
-  first.
-- Clear: use the verb “need” to help merchants understand when they’re required
-  to do something.
+- Structured for merchant success: always put the most critical information first.
+- Clear: use the verb “need” to help merchants understand when they’re required to do something.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-To buy a shipping label, you need to enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you need to enter the total weight of your shipment, including packaging.
 
 #### Don’t
 
-To buy a shipping label, you must enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you must enter the total weight of your shipment, including packaging.
 
 <!-- end -->
 
@@ -175,10 +164,9 @@ including packaging.
 
 Buttons should be:
 
-- Clear and predictable: merchants should be able to anticipate what will happen
-  when they click a button. Never deceive merchants by mislabeling a button.
+- Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -192,11 +180,9 @@ Buttons should be:
 
 <!-- end -->
 
-Action-led: buttons should always lead with a strong verb that encourages
-action. To provide enough context to merchants use the {verb}+{noun} format on
-buttons except in the case of common actions like Save, Close, Cancel, or OK.
+Action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -212,7 +198,7 @@ buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
 Scannable: Avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -228,23 +214,16 @@ Add a menu item
 
 Section titles should be:
 
-- Informative: they should label the type of content grouped in the body
-  content below
-- Like headings: follow the same content guidelines as when you’re writing
-  headings
+- Informative: they should label the type of content grouped in the body content below
+- Like headings: follow the same content guidelines as when you’re writing headings
 
 ### Action links
 
 Links should be:
 
-- Used for secondary or persistent actions: links should be used to represent
-  lower priority actions than buttons, or persistent actions that merchants may
-  take at any time (such as a persistent Edit link).
-- Clearly labeled: merchants should not need to guess where they’ll end up if
-  they click on an action link. Never use “click here” as a link because it
-  doesn’t set expectations about what’s next.
-- Similar to buttons: Follow the same content guidelines as when you’re writing
-  text for buttons.
+- Used for secondary or persistent actions: links should be used to represent lower priority actions than buttons, or persistent actions that merchants may take at any time (such as a persistent Edit link).
+- Clearly labeled: merchants should not need to guess where they’ll end up if they click on an action link. Never use “click here” as a link because it doesn’t set expectations about what’s next.
+- Similar to buttons: Follow the same content guidelines as when you’re writing text for buttons.
 
 ---
 
@@ -261,7 +240,7 @@ The required `title` prop gives the card a level 2 heading (`<h2>`). This helps 
 
 If you use the `subdued` prop on a card or section, make sure that the card or section `title` conveys the reason for using `subdued`. This ensures that merchants with low vision, including those who use screen readers, can identify that the content is inactive or less important.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/checkbox.md
+++ b/polaris.shopify.com/content/components/checkbox.md
@@ -32,16 +32,12 @@ Checkboxes are most commonly used to give merchants a way to make a range of sel
 
 Checkboxes should:
 
-- Work independently from each other: selecting one checkbox shouldn’t change
-  the selection status of another checkbox in the list. The exception is when a
-  checkbox is used to make a bulk selection of multiple items.
+- Work independently from each other: selecting one checkbox shouldn’t change the selection status of another checkbox in the list. The exception is when a checkbox is used to make a bulk selection of multiple items.
 - Be framed positively: for example, `Turn on notifications` instead of
   `Turn off notifications`
 - Always have a label when being used to toggling a setting on or off
-- Be listed according to a logical order, whether it’s alphabetical, numerical,
-  time-based, or some other clear system.
-- Link to more information or include a subtitle as required to provide more
-  explanation. Don’t rely on tooltips to explain a checkbox.
+- Be listed according to a logical order, whether it’s alphabetical, numerical, time-based, or some other clear system.
+- Link to more information or include a subtitle as required to provide more explanation. Don’t rely on tooltips to explain a checkbox.
 
 ---
 
@@ -53,7 +49,7 @@ Lists that use checkboxes should:
 
 - Start with a capital letter
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -71,7 +67,7 @@ Lists that use checkboxes should:
 
 - Not use commas or semicolons at the end of each line
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -87,10 +83,9 @@ Lists that use checkboxes should:
 
 <!-- end -->
 
-- In the rare case where the checkbox is asking merchants to agree to terms
-  or service, use the first person
+- In the rare case where the checkbox is asking merchants to agree to terms or service, use the first person
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/choice-list.md
+++ b/polaris.shopify.com/content/components/choice-list.md
@@ -54,8 +54,7 @@ examples:
 # Choice list
 
 A choice list lets you create a list of grouped radio buttons or checkboxes.
-Use this component if you need to group together a related list of interactive
-choices.
+Use this component if you need to group together a related list of interactive choices.
 
 ---
 
@@ -75,10 +74,9 @@ Choice lists should:
 
 List titles should:
 
-- Help merchants understand how the items in the list are grouped together, or
-  should explain what kind of choice merchants are making
+- Help merchants understand how the items in the list are grouped together, or should explain what kind of choice merchants are making
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -97,7 +95,7 @@ Pick one
 - It the title introduces the list, it should end with a colon
 - Should be written in sentence case
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -111,7 +109,7 @@ Shipping Options
 
 ### Not use colons
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -137,7 +135,7 @@ Every item in a choice list should:
 - Not use commas or semicolons at the end of each line
 - Be written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/collapsible.md
+++ b/polaris.shopify.com/content/components/collapsible.md
@@ -36,10 +36,8 @@ The collapsible component is used to put long sections of information under a bl
 
 The collapsible component should:
 
-- Be used for information that is lower priority or that merchants don’t need
-  to see all the time
-- Not be used to hide error messages or other critical information that requires
-  an immediate action
+- Be used for information that is lower priority or that merchants don’t need to see all the time
+- Not be used to hide error messages or other critical information that requires an immediate action
 
 ---
 

--- a/polaris.shopify.com/content/components/color-picker.md
+++ b/polaris.shopify.com/content/components/color-picker.md
@@ -36,7 +36,6 @@ The color picker is used to let merchants select a color visually. For example, 
 
 ## Best practices
 
-- Use the alpha slider if you want to allow merchants to be able to select a
-  transparent color
+- Use the alpha slider if you want to allow merchants to be able to select a transparent color
 
 ---

--- a/polaris.shopify.com/content/components/combobox.md
+++ b/polaris.shopify.com/content/components/combobox.md
@@ -108,7 +108,7 @@ The `Combobox` popover displays below the text field or other control by default
 
 `Combobox` features can be challenging for merchants with visual, motor, and cognitive disabilities. Even when they’re built using best practices, these features can be difficult to use with some assistive technologies. Merchants should always be able to search, enter data, or perform other activities without relying on the combobox.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/contextual-save-bar.md
+++ b/polaris.shopify.com/content/components/contextual-save-bar.md
@@ -64,7 +64,7 @@ The standard message content is
 - “Unsaved changes” when editing existing content
 - “Unsaved {resource name}” when creating a new object
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -80,7 +80,7 @@ The standard message content is
 
 Actions in the contextual save bar component should consist of a strong verb that encourages action. They should not include a noun.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/data-table.md
+++ b/polaris.shopify.com/content/components/data-table.md
@@ -88,7 +88,7 @@ Headers should:
 - Include units of measurement symbols so they aren’t repeated throughout the columns
 - Use sentence case (first word capitalized, rest lowercase)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -126,7 +126,7 @@ Native HTML tables provide a large amount of structural information to screen re
 
 Sortable tables use the `aria-sort` attribute to convey which columns are sortable (and in what direction). They also use `aria-label` on sorting buttons to convey what activating the button will do.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/date-picker.md
+++ b/polaris.shopify.com/content/components/date-picker.md
@@ -49,8 +49,7 @@ Date pickers should:
 
 - Use smart defaults and highlight common selections
 - Close after a single date is selected unless a range with a start and end date is required
-- Set the start date on first click or tap and the end date on second click or tap if a range
-  is required
+- Set the start date on first click or tap and the end date on second click or tap if a range is required
 - Not be used to enter a date that is many years in the future or the past
 - Follow [date format guidelines](https://polaris.shopify.com/content/grammar-and-mechanics#section-dates-numbers-and-addresses)
 

--- a/polaris.shopify.com/content/components/description-list.md
+++ b/polaris.shopify.com/content/components/description-list.md
@@ -22,8 +22,7 @@ examples:
 # Description list
 
 Description lists are a way to organize and explain related information.
-They’re particularly useful when you need to list and define terms such as in a
-glossary.
+They’re particularly useful when you need to list and define terms such as in a glossary.
 
 ---
 
@@ -33,9 +32,7 @@ Description lists should:
 
 - Contain terms and associated explanations, or descriptions for each term.
 - Provide information that isn’t action-oriented.
-- Not be an excuse for using unnecessarily complicated or jargon-filled
-  language. Generally, if merchants need a description list to understand the
-  language in Shopify, we should look for opportunities to simplify the language.
+- Not be an excuse for using unnecessarily complicated or jargon-filled language. Generally, if merchants need a description list to understand the language in Shopify, we should look for opportunities to simplify the language.
 - Not be used to upsell merchants on a feature or service.
 
 ---
@@ -48,7 +45,7 @@ Terms should be:
 
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -66,12 +63,11 @@ Terms descriptions should be:
 
 - Directly related to the term they’re describing
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Discount code: A series of numbers and/or letters that an online shopper may enter at checkout
-  to get a discount or special offer.
+- Discount code: A series of numbers and/or letters that an online shopper may enter at checkout to get a discount or special offer.
 
 #### Don’t
 
@@ -81,17 +77,15 @@ Terms descriptions should be:
 
 - Written to describe the merchant benefit or utility
 - No more than one or two short sentences in length
-- Written in sentence case with all appropriate punctuation, including ending
-  each sentence with a period
+- Written in sentence case with all appropriate punctuation, including ending each sentence with a period
 - Conversational by using articles (the, a, an)
 - Written using plain language
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Abandoned checkout: The details of a checkout that was started but not completed, including the
-  products added and the customer’s details.
+- Abandoned checkout: The details of a checkout that was started but not completed, including the products added and the customer’s details.
 
 #### Don’t
 

--- a/polaris.shopify.com/content/components/display-text.md
+++ b/polaris.shopify.com/content/components/display-text.md
@@ -53,12 +53,10 @@ Display styles make a bold visual statement. Use them to create impact when the 
 
 ## Best practices
 
-- Use when the primary goal of the page is communication rather than
-  interaction.
+- Use when the primary goal of the page is communication rather than interaction.
 - Use larger display text sizes when a page is focused around a single message.
   In these cases it may be paired with an illustration.
-- Use smaller display text to pair with larger text, or alone as part of more
-  complex data displays such as dashboards.
+- Use smaller display text to pair with larger text, or alone as part of more complex data displays such as dashboards.
 
 ---
 
@@ -68,8 +66,7 @@ Display styles make a bold visual statement. Use them to create impact when the 
 
 Display text should be:
 
-- Benefits-driven and focused on information that is most important to
-  merchants
+- Benefits-driven and focused on information that is most important to merchants
 - Concise and scannable:
   - Use simple, clear language that can be read at a glance
   - Keep display text content to a short sentence that’s just a few words in
@@ -87,7 +84,7 @@ Although display text creates an interesting visual experience, it doesn’t rep
 
 By default, the display text component outputs text in an HTML paragraph (`<p>`). If a heading tag is needed for display text, use the `element` prop to set the heading level.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/empty-state.md
+++ b/polaris.shopify.com/content/components/empty-state.md
@@ -46,20 +46,15 @@ Empty states are used when a list, table, or chart has no items or data to show.
 
 Empty states should:
 
-- Orient merchants by clearly explaining the benefit and utility of a product
-  or feature
-- Simplify a complicated experience by focusing on a few key features and
-  benefits
-- Use simple and clear language that empowers merchants to move their business
-  forward
-- Be encouraging and never make merchants feel unsuccessful or guilty because
-  they haven’t used a product or feature
+- Orient merchants by clearly explaining the benefit and utility of a product or feature
+- Simplify a complicated experience by focusing on a few key features and benefits
+- Use simple and clear language that empowers merchants to move their business forward
+- Be encouraging and never make merchants feel unsuccessful or guilty because they haven’t used a product or feature
 - Explain the steps merchants need to take to activate a product or feature
 - Use illustrations thoughtfully as outlined in our [illustration guidelines](https://polaris.shopify.com/design/illustrations)
 - Use only one primary call-to-action button
 - Provide extra spacing at the bottom of an empty state that is within content
-  (card, modal, or navigation) to match the image that was passed into the component
-  with a white space above it of 40px
+  (card, modal, or navigation) to match the image that was passed into the component with a white space above it of 40px
 
 ---
 
@@ -71,7 +66,7 @@ Empty state titles should:
 
 - Be action-oriented: encourage merchants to take the step required to activate the product or feature
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -97,11 +92,9 @@ Empty state subtitles act like body content. They should:
 Buttons are used for the most important actions you want merchants to take.
 They should be:
 
-- Clear and predictable: merchants should be able to anticipate what will
-  happen when they click a button. Never deceive merchants by using misleading
-  titles.
+- Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by using misleading titles.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -115,11 +108,9 @@ They should be:
 
 <!-- end -->
 
-- Action-led: buttons should always lead with a strong verb that encourages
-  action. To provide enough context to merchants use the {verb}+{noun} format on
-  buttons except in the case of common actions like Save, Close, Cancel, or OK.
+- Action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -135,7 +126,7 @@ They should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -150,8 +141,7 @@ They should be:
 ### Secondary action
 
 Secondary actions are used for less important actions such as “Learn more” or
-“Close” buttons. They should follow all the other content rules outlined for
-primary buttons.
+“Close” buttons. They should follow all the other content rules outlined for primary buttons.
 
 ---
 

--- a/polaris.shopify.com/content/components/exception-list.md
+++ b/polaris.shopify.com/content/components/exception-list.md
@@ -28,14 +28,6 @@ The exception list component should:
 - Used sparingly, so that it has more impact and doesn’t add clutter
 - Only use an icon if it adds clarity to the content or helps merchants visualize the meaning
 
-<!-- improvement -->
-
-### Opportunity for improvement
-
-Exception lists aren’t clickable. If you have an idea that could make this component better, please [open an issue](https://github.com/shopify/polaris/issues).
-
-<!-- end -->
-
 ---
 
 ## Content guidelines
@@ -55,7 +47,7 @@ If placed next to an item in a [resource list](https://polaris.shopify.com/compo
 
 - Make the entire list item clickable because the exception list itself isn’t clickable
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -70,10 +62,6 @@ If placed next to an item in a [resource list](https://polaris.shopify.com/compo
 ---
 
 ## Related components
-
-<!-- remove comment and adjust link when component is built -->
-
-<!-- * To display an error in a card or section, use the [contextual banner]() component -->
 
 - To display an error at the top of a page, or to indicate multiple errors in a form, use the [banner](https://polaris.shopify.com/components/banner) component
 - Exceptions lists are often used in the [resource list](https://polaris.shopify.com/components/resource-list) component to display conditional content

--- a/polaris.shopify.com/content/components/filters.md
+++ b/polaris.shopify.com/content/components/filters.md
@@ -83,7 +83,7 @@ The filters component should:
 
 The text field should be clearly labeled so it’s obvious to merchants what they should enter into the field.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -99,7 +99,7 @@ The text field should be clearly labeled so it’s obvious to merchants what the
 
 Use the name of the filter if the purpose of the name is clear on its own. For example, when you see a filter badge that reads **Fulfilled**, it’s intuitive that it falls under the Fulfillment status category.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -113,7 +113,7 @@ Use the name of the filter if the purpose of the name is clear on its own. For e
 
 If the filter name is ambiguous on its own, add a descriptive word related to the status. For example, **Low** doesn’t make sense out of context. Add the word “risk” so that merchants know it’s from the Risk category.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -127,7 +127,7 @@ If the filter name is ambiguous on its own, add a descriptive word related to th
 
 Group tags from the same category together.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -141,7 +141,7 @@ Group tags from the same category together.
 
 If all tag pills selected: truncate in the middle
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/footer-help.md
+++ b/polaris.shopify.com/content/components/footer-help.md
@@ -57,7 +57,7 @@ Links should not be:
 
 Marked as external: Do not set the `external` prop on the `Link` component to force open a new tab.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/form-layout.md
+++ b/polaris.shopify.com/content/components/form-layout.md
@@ -77,7 +77,7 @@ A label is a short description of a field. Labels are not help text, and they sh
 - Short and succinct (1–3 words)
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -89,7 +89,7 @@ A label is a short description of a field. Labels are not help text, and they sh
 
 <!-- end -->
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/heading.md
+++ b/polaris.shopify.com/content/components/heading.md
@@ -55,7 +55,7 @@ Use the `element` prop to determine the specific HTML element that’s output fo
 
 Learn more about writing helpful [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings).
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/icon.md
+++ b/polaris.shopify.com/content/components/icon.md
@@ -49,7 +49,7 @@ Using icons can be a great help to merchants who have difficulties with reading,
 
 If the icon appears without text, then use the `accessibilityLabel` prop to give the icon a text alternative. This adds an `aria-label` that’s conveyed to screen reader users.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/index-table.md
+++ b/polaris.shopify.com/content/components/index-table.md
@@ -110,11 +110,7 @@ Using an index table in a project involves combining the following components an
 - [Filters](https://polaris.shopify.com/components/filters) (optional)
 - Pagination component (optional)
 
-<!-- hint -->
-
 The index table component provides the UI elements for list sorting, filtering, and pagination, but doesn’t provide the logic for these operations. When a sort option is changed, filter added, or second page requested, you’ll need to handle that event (including any network requests) and then update the component with new props.
-
-<!-- end -->
 
 ---
 
@@ -161,7 +157,7 @@ Index tables should:
 
 - Identify the type of resource, usually with a heading
 
-  <!-- usagelist -->
+  <!-- dodont -->
 
   #### Do
 
@@ -176,7 +172,7 @@ Index tables should:
 
 - Indicate when not all members of a resource are being shown. For a card summarizing and linking to recently purchased products:
 
-  <!-- usagelist -->
+  <!-- dodont -->
 
   #### Do
 

--- a/polaris.shopify.com/content/components/inline-error.md
+++ b/polaris.shopify.com/content/components/inline-error.md
@@ -49,7 +49,7 @@ Inline error messages should:
 - Be short and concise, no more than a single sentence
 - Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/keyboard-key.md
+++ b/polaris.shopify.com/content/components/keyboard-key.md
@@ -59,7 +59,7 @@ The shortcut description should describe what action is taken when merchants tap
 
 The text of the keyboard key component is read by screen readers, but the visual formatting isn’t conveyed. Ensure that merchants are able to understand information about keyboard shortcuts without relying on the visual style of the component.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/link.md
+++ b/polaris.shopify.com/content/components/link.md
@@ -82,7 +82,7 @@ Use the `url` prop to give the link component a valid `href` value. This allows 
 
 The Link component is underlined to give interactive elements a shape. This allows links to not rely on color from being the only way users can tell if an element is interactive.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -120,7 +120,7 @@ To provide consistency and clarity:
 - Use the same text for links that navigate to the same content
 - Use different text for links that navigate to different content
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -136,7 +136,7 @@ To provide consistency and clarity:
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/list.md
+++ b/polaris.shopify.com/content/components/list.md
@@ -32,10 +32,8 @@ Lists display a set of related text-only content. Each list item begins with a b
 
 Lists should:
 
-- Break up chunks of related content to make the information easier for
-  merchants to scan
-- Be phrased consistently (try to start each item with a noun or a
-  verb and be consistent with each item)
+- Break up chunks of related content to make the information easier for merchants to scan
+- Be phrased consistently (try to start each item with a noun or a verb and be consistent with each item)
 - Not be used for lists where the entire item represents an action
 
 ---
@@ -49,7 +47,7 @@ Every item in a list should:
 - Start with a capital letter
 - Not use commas or semicolons at the end of each line
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -67,7 +65,7 @@ Every item in a list should:
 
 - Be written in sentence case
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/listbox.md
+++ b/polaris.shopify.com/content/components/listbox.md
@@ -59,7 +59,7 @@ Listboxes should:
 
 Each item in a `Listbox` should be clear and descriptive.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -90,10 +90,9 @@ Location picker
 
 The `Listbox` component is based on the [Aria 1.2 Listbox pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox).
 
-It is important to not present interactive elements inside of list box options as they can interfere with navigation
-for assistive technology users.
+It is important to not present interactive elements inside of list box options as they can interfere with navigation for assistive technology users.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/media-card.md
+++ b/polaris.shopify.com/content/components/media-card.md
@@ -72,7 +72,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling merchants what actions are available to them, especially something new. Don’t use permissive language like “you can”.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -84,22 +84,18 @@ Now you can get performance data for all of your sales channels.
 
 <!-- end -->
 
-- Structured for merchant success: always put the most critical information
-  first
-- Clear: use the verb “need” to help merchants understand when they’re required
-  to do something
+- Structured for merchant success: always put the most critical information first
+- Clear: use the verb “need” to help merchants understand when they’re required to do something
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-To buy a shipping label, you need to enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you need to enter the total weight of your shipment, including packaging.
 
 #### Don’t
 
-To buy a shipping label, you must enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you must enter the total weight of your shipment, including packaging.
 
 <!-- end -->
 
@@ -109,7 +105,7 @@ Buttons should be:
 
 Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -121,11 +117,9 @@ Buy
 
 <!-- end -->
 
-- Action-led: buttons should always lead with a strong verb that encourages
-  action. To provide enough context to merchants use the {verb}+{noun} format on
-  buttons except in the case of common actions like Save, Close, Cancel, or OK.
+- Action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -139,7 +133,7 @@ View your settings
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/modal.md
+++ b/polaris.shopify.com/content/components/modal.md
@@ -81,7 +81,7 @@ Modal titles should:
 - Use a clear {verb}+{noun} question or statement
 - Follow the content guidelines for [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -103,7 +103,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling a merchant what actions are available to them (especially something new). Don’t use permissive language like "you can".
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -120,7 +120,7 @@ Body content should be:
 - Structured for merchant success: always put the most critical information first.
 - Clear: use the verb “need” to help merchants understand when they’re required to do something.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -138,7 +138,7 @@ Actions should be:
 
 - Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive a merchant by mislabeling an action.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -154,7 +154,7 @@ Actions should be:
 
 - Action-led: actions should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on actions except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -170,7 +170,7 @@ Actions should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -189,7 +189,7 @@ Tertiary actions should:
 - Only be used when the action requires the context of the content in the modal
 - Never be used to dismiss the modal
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -209,7 +209,7 @@ Body content should be:
 
 - Actionable: start sentences with imperative verbs when telling a merchant what actions are available to them (especially something new). Don’t use permissive language like "you can".
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -224,7 +224,7 @@ Body content should be:
 - Structured for merchant success: always put the most critical information first.
 - Clear: use the verb “need” to help merchants understand when they’re required to do something.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/navigation.md
+++ b/polaris.shopify.com/content/components/navigation.md
@@ -88,7 +88,7 @@ Navigation should:
 
 - Use sentence case for primary and secondary navigation items
 
-  <!-- usagelist -->
+  <!-- dodont -->
 
   #### Do
 
@@ -102,7 +102,7 @@ Navigation should:
 
 - Use as few words as possible to describe each item label
 
-  <!-- usagelist -->
+  <!-- dodont -->
 
   #### Do
 
@@ -116,7 +116,7 @@ Navigation should:
 
 - Use all caps for section labels
 
-  <!-- usagelist -->
+  <!-- dodont -->
 
   #### Do
 

--- a/polaris.shopify.com/content/components/option-list.md
+++ b/polaris.shopify.com/content/components/option-list.md
@@ -40,9 +40,7 @@ The option list component lets you create a list of grouped items that merchants
 
 The option list component should:
 
-- Be placed on its own inside a container. Usually the container behaves like a
-  menu, as it does with [popover](https://polaris.shopify.com/components/popover). Don’t
-  place other components within the same container.
+- Be placed on its own inside a container. Usually the container behaves like a menu, as it does with [popover](https://polaris.shopify.com/components/popover). Don’t place other components within the same container.
 - Not be used when a [select component](https://polaris.shopify.com/components/select) will do.
 
 ---
@@ -53,7 +51,7 @@ The option list component should:
 
 Each item in an option list should be clear and descriptive.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/page-actions.md
+++ b/polaris.shopify.com/content/components/page-actions.md
@@ -49,7 +49,7 @@ Buttons should be:
 
 - Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive merchants by mislabeling a button.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -65,7 +65,7 @@ Buttons should be:
 
 - Action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -81,7 +81,7 @@ Buttons should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/page.md
+++ b/polaris.shopify.com/content/components/page.md
@@ -130,13 +130,11 @@ The content of each breadcrumb link should be the title of the page to which it 
 
 Page header action labels should be:
 
-- Clear and predictable: merchants should be able to anticipate what will
-  happen when they click a page action. Never deceive merchants by mislabeling an action.
+- Clear and predictable: merchants should be able to anticipate what will happen when they click a page action. Never deceive merchants by mislabeling an action.
 
-- Action-led: they should always lead with a strong verb that encourages
-  action. To provide enough context to merchants, use the {verb}+{noun} format.
+- Action-led: they should always lead with a strong verb that encourages action. To provide enough context to merchants, use the {verb}+{noun} format.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -154,7 +152,7 @@ Page header action labels should be:
 
   In the context of the orders list page:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -170,7 +168,7 @@ Page header action labels should be:
 
 - Scannable: avoid unnecessary words and articles such as the, an, or a.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/popover.md
+++ b/polaris.shopify.com/content/components/popover.md
@@ -67,7 +67,7 @@ If a popover contains actions, they should:
 
 - Be clear and predictable: merchants should be able to anticipate what will happen when they click on an action item. Never deceive merchants by mislabeling an action.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -83,7 +83,7 @@ If a popover contains actions, they should:
 
 - Be action-led: buttons should always lead with a strong verb that encourages action. To provide enough context to merchants use the {verb}+{noun} format on buttons except in the case of common actions like Save, Close, Cancel, or OK.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -101,7 +101,7 @@ If a popover contains actions, they should:
 
 - Be scannable, especially when the popover contains a list of actions or options. Avoid unnecessary words and articles such as “the”, “an”, or “a”.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -117,7 +117,7 @@ If the popover includes a series of navigational links, each item should:
 
 - Be concise but still give merchants enough information so they can easily find and accurately navigate to the path they want.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/radio-button.md
+++ b/polaris.shopify.com/content/components/radio-button.md
@@ -53,7 +53,7 @@ Radio button labels should:
 - Be introduced with a colon or a heading
 - Start with a capital letter
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -67,7 +67,7 @@ Radio button labels should:
 
 - Not end in punctuation if it’s a single sentence, word, or a fragment
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/range-slider.md
+++ b/polaris.shopify.com/content/components/range-slider.md
@@ -61,7 +61,7 @@ A label is a short description of the requested input. Labels are not instructio
 - Short and succinct (1–3 words)
 - Written in sentence case (the first word capitalized, the rest lowercase)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -77,10 +77,9 @@ A label is a short description of the requested input. Labels are not instructio
 
 ### Designating optional fields
 
-Try to only ask for information that’s required. If you need to ask merchants
-to provide optional information, mark the field optional by placing the text “(optional)” at the end of the field’s label. Don’t mark required fields with asterisks.
+Try to only ask for information that’s required. If you need to ask merchants to provide optional information, mark the field optional by placing the text “(optional)” at the end of the field’s label. Don’t mark required fields with asterisks.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -96,7 +95,7 @@ to provide optional information, mark the field optional by placing the text “
 
 Help text provides extra guidance or instruction to people filling out a form field. It can also be used to clarify how the information will be used. As with all form content, help text should be succinct and easy to read.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -116,7 +115,7 @@ Error messages should:
 - Be short and concise, no more than a single sentence
 - Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/resource-list.md
+++ b/polaris.shopify.com/content/components/resource-list.md
@@ -113,11 +113,7 @@ Using a resource list in a project involves combining the following components a
 - [Filters](https://polaris.shopify.com/components/filters) (optional)
 - Pagination component (optional)
 
-<!-- hint -->
-
 The resource list component provides the UI elements for list sorting, filtering, and pagination, but doesn’t provide the logic for these operations. When a sort option is changed, filter added, or second page requested, you’ll need to handle that event (including any network requests) and then update the component with new props.
-
-<!-- end -->
 
 ---
 
@@ -141,10 +137,6 @@ Because a details page displays all the content and actions for an individual re
 
 ![Schematic showing content from a details page being surfaced on a resource list](/images/components/resource-list/list-surfacing-show@2x.png)
 
-<!-- hint -->
-
-#### Hint
-
 #### A resource list isn’t a data table
 
 On wide screens, a resource list often looks like a table, especially if some content is aligned in columns. Despite this, resource lists and data tables have different purposes.
@@ -152,8 +144,6 @@ On wide screens, a resource list often looks like a table, especially if some co
 A data table is a form of data visualization. It works best to present highly structured data for comparison and analysis.
 
 If your use case is more about visualizing or analyzing data, use the [data table component](https://polaris.shopify.com/components/data-table). If your use case is more about finding and taking action on objects, use a resource list.
-
-<!-- end -->
 
 ---
 
@@ -182,7 +172,7 @@ Resource lists should:
 
 - Identify the type of resource, usually with a heading
 
-  <!-- usagelist -->
+  <!-- dodont -->
 
   #### Do
 
@@ -197,7 +187,7 @@ Resource lists should:
 
 - Indicate when not all members of a resource are being shown. For a card summarizing and linking to recently purchased products:
 
-  <!-- usagelist -->
+  <!-- dodont -->
 
   #### Do
 

--- a/polaris.shopify.com/content/components/scrollable.md
+++ b/polaris.shopify.com/content/components/scrollable.md
@@ -38,10 +38,8 @@ The scrollable component is a container for long form content, such as terms of 
 
 Scrollable containers should:
 
-- Be used when it’s helpful to provide an extra visual cue to let merchants
-  know that content exists below or above the fold
-- Only be used for length text such as terms of service or other legal
-  disclaimers and never for instructional or action-oriented text
+- Be used when it’s helpful to provide an extra visual cue to let merchants know that content exists below or above the fold
+- Only be used for length text such as terms of service or other legal disclaimers and never for instructional or action-oriented text
 
 ---
 

--- a/polaris.shopify.com/content/components/select.md
+++ b/polaris.shopify.com/content/components/select.md
@@ -85,7 +85,7 @@ Labels should:
 - Be independent sentences. To support [internationalization](https://polaris.shopify.com/foundations/internationalization), they should not act as the first part of a sentence that is finished by the component’s options.
 - Be descriptive, not instructional. If the selection needs more explanation, use help text below the field.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -97,7 +97,7 @@ Labels should:
 
 <!-- end -->
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/setting-toggle.md
+++ b/polaris.shopify.com/content/components/setting-toggle.md
@@ -33,11 +33,8 @@ Use to give merchants control over a feature or option that can be turned on or 
 Settings toggles should:
 
 - Include different body content for the activated and deactivated states.
-- Clearly indicate whether the setting is activated or deactivated and explain the
-  implications of the state of the setting to merchants. (“Automatic messages
-  are deactivated. Your customers won’t receive automatic shipping updates.”)
-- Clearly state when a setting or feature is not available and why. Provide
-  actionable steps for merchants to unlock the functionality.
+- Clearly indicate whether the setting is activated or deactivated and explain the implications of the state of the setting to merchants. (“Automatic messages are deactivated. Your customers won’t receive automatic shipping updates.”)
+- Clearly state when a setting or feature is not available and why. Provide actionable steps for merchants to unlock the functionality.
 
 ---
 
@@ -49,19 +46,16 @@ Toggle descriptions should:
 
 - Clearly indicate whether the setting is activated or deactivated
 - Explain the implications of the state of the setting to merchants
-  (“Automatic messages are deactivated. Your customers won’t receive automatic
-  shipping updates.”)
+  (“Automatic messages are deactivated. Your customers won’t receive automatic shipping updates.”)
 
 ### Primary button
 
 The primary buttons for the setting toggle should always say either “Activate” or
 “Deactivate” depending on whether the setting can be turned on or off.
 
-For example, if the setting toggle is on, the button should say “Deactivate” to
-allow merchants to turn it off. If the setting toggle is off, the button should
-say “Activate” to allow merchants to turn it on.
+For example, if the setting toggle is on, the button should say “Deactivate” to allow merchants to turn it off. If the setting toggle is off, the button should say “Activate” to allow merchants to turn it on.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/skeleton-body-text.md
+++ b/polaris.shopify.com/content/components/skeleton-body-text.md
@@ -43,7 +43,7 @@ Skeleton body text component should:
 
 Show static content that never changes on a page and use skeleton loading for dynamic content. Skeleton body text can sometimes be used to represent non-typographic content such as forms. Don’t use placeholder content that will change when the page fully loads.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/skeleton-display-text.md
+++ b/polaris.shopify.com/content/components/skeleton-display-text.md
@@ -44,7 +44,7 @@ Skeleton display text component should:
 
 Show static display text that that never changes on a page. For example, keep page titles, such as Products on the product list page, but use skeleton loading for page titles that change on the product details page.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -58,7 +58,7 @@ Use skeleton display text for static content or placeholder content for dynamic 
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/skeleton-page.md
+++ b/polaris.shopify.com/content/components/skeleton-page.md
@@ -41,7 +41,7 @@ Show page titles that never change for a page. For example, keep the title “Pr
 
 Secondary actions are always represented with skeleton content. You can change the number of skeleton actions that best represent the number of actions once loaded.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/subheading.md
+++ b/polaris.shopify.com/content/components/subheading.md
@@ -53,7 +53,7 @@ Use the `element` prop to determine the specific HTML element that’s output fo
 
 Learn more about writing helpful [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings).
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/text-field.md
+++ b/polaris.shopify.com/content/components/text-field.md
@@ -249,7 +249,7 @@ When you provide help text via the `helpText` prop or an inline error message vi
 
 Use the `placeholder` prop to provide additional instructions. However, don’t rely on placeholders alone since the content isn’t always conveyed to all merchants.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/text-style.md
+++ b/polaris.shopify.com/content/components/text-style.md
@@ -75,7 +75,7 @@ Text style should be:
 
 Don’t rely on text style alone to convey information to merchants. Ensure that text styles are used to enhance the information provided in text.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/toast.md
+++ b/polaris.shopify.com/content/components/toast.md
@@ -73,7 +73,7 @@ Toast messages should be:
 - Short and affirmative
 - Written in the pattern of: noun + verb
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -108,7 +108,7 @@ Action should:
 - Not have actions, like [Cancel], for dismissing toast. The [X] to dismiss is already included in the component.
 - Be used with a duration of at least 10,000 milliseconds for accessibility.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/tooltip.md
+++ b/polaris.shopify.com/content/components/tooltip.md
@@ -32,13 +32,10 @@ Tooltips should:
 
 - Provide useful, additional information or clarification.
 - Succinctly describe or expand on the element they point to.
-- Be provided for icon-only buttons or a button with an associated keyboard
-  shortcut.
-- Not be used to communicate critical information, including errors in forms or
-  other interaction feedback.
+- Be provided for icon-only buttons or a button with an associated keyboard shortcut.
+- Not be used to communicate critical information, including errors in forms or other interaction feedback.
 - Not contain any links or buttons.
-- Be used sparingly. If you’re building something that requires a lot of
-  tooltips, work on clarifying the design and the language in the experience.
+- Be used sparingly. If you’re building something that requires a lot of tooltips, work on clarifying the design and the language in the experience.
 
 ---
 
@@ -52,7 +49,7 @@ Tooltips should:
 - Be concise and scannable
 - Not be used to communicate error messages or important account information
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/components/top-bar.md
+++ b/polaris.shopify.com/content/components/top-bar.md
@@ -59,7 +59,7 @@ The placeholder content for the search field should:
 - Always say "Search"
 - Never include an ellipsis
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/content/accessible-and-inclusive-language.md
+++ b/polaris.shopify.com/content/foundations/content/accessible-and-inclusive-language.md
@@ -31,8 +31,6 @@ keywords:
 
 # Accessible and inclusive language
 
-<!-- keywords: inclusivity, inclusive content, inclusive language, word list -->
-
 Our mission is to make commerce better for _everyone_. Building products for everyone means creating inclusive content.
 
 The words we use have power. Writing for everyone, everywhere means that we don’t exclude or harm any of our merchants, even if these words have been normalized.
@@ -46,8 +44,6 @@ Test your content with a diverse audience by recruiting merchants from a variety
 ---
 
 ## Accessible content
-
-<!-- keywords: accessibility, accessible, a11y, disability, ableist, ableism -->
 
 Using anti-ableist language is just one part of making accessible content at Shopify. Ableist language is content that holds bias towards the nondisabled experience, or discriminates against the disabled community.
 
@@ -67,7 +63,7 @@ This language and narrative around people with disabilities can be othering and 
 
 Implies that disability is a less-desired or negative state.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -79,7 +75,7 @@ Accounts are disabled.
 
 <!-- end -->
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -96,7 +92,7 @@ Accounts are disabled.
 
 _Note: Because `disabled` is a valid state for HTML elements, usage of “disabled” is appropriate when talking about specific element states, just not overall feature functionality._
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -108,7 +104,7 @@ The checkbox is disabled.
 
 This language can imply that there’s something wrong with anyone outside of the majority.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -130,7 +126,7 @@ This language is often used to equate deafness or hearing impairment with ignora
 
 As a metaphor, this can equate lack of vision to ignorance. Only use the term when referencing the disability itself.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -148,7 +144,7 @@ As a metaphor, this can equate lack of vision to ignorance. Only use the term wh
 
 This language can stigmatize people with mental disabilities by using these words as modifiers for “unbelievable” or in a negative context.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -170,7 +166,7 @@ This language can stigmatize people with mental disabilities by using these word
 
 Handicap implies that the person is the issue, rather than the environment.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -187,7 +183,7 @@ Handicap implies that the person is the issue, rather than the environment.
 
 This term can reduce a person’s primary identity to using a wheelchair.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -204,7 +200,7 @@ This term can reduce a person’s primary identity to using a wheelchair.
 
 This phrasing implies that having a disability equates to suffering.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -223,8 +219,6 @@ When we write a task is “only a few steps”, or this should “just take a mi
 ---
 
 ## Anti-racist content
-
-<!-- keywords: anti-racist, racism, racist, race, racial -->
 
 Racist language expresses bias towards or against a particular race, or expresses the belief that some races are inferior to others. Always prioritize our merchants, partners, and buyers experience over perceived barriers to using anti-racist language.
 
@@ -249,7 +243,7 @@ Consider why you need to frame someone or something this way. What is “foreign
 
 These phrases come from laws meant to circumvent or disenfranchise Black people’s rights. These laws, or “grandfather clauses” originated in the Reconstruction era in the American South.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -267,7 +261,7 @@ These phrases come from laws meant to circumvent or disenfranchise Black people�
 
 A powwow is a celebration of heritage, art, and community held by Indigenous people, and should only be used to refer to actual powwows. Use other terms to refer to meetings and events that aren’t powwows.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -290,7 +284,7 @@ Indigenous communities use spirit animals as totems and guides. A spirit animal 
 
 These terms imply that “white is good” and “black is bad”.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -308,7 +302,7 @@ These terms imply that “white is good” and “black is bad”.
 
 These terms enforce the “white is good” and “black is bad” paradigm.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -324,7 +318,7 @@ These terms enforce the “white is good” and “black is bad” paradigm.
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -336,7 +330,7 @@ Learn how to secure a compromised account and reset blacklisted credentials.
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -352,7 +346,7 @@ Add no-reply[at]shopify.com to your email provider’s whitelist.
 
 This term originates from a dance contest where enslaved Black people competed for cake.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -368,7 +362,7 @@ It’s a cakewalk to file your taxes with our latest features.
 
 This term refers to communities and places that are predominantly white and that might make non-white people feel restricted or isolated. Avoid using this term except when referring to the named property in CSS.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -386,7 +380,7 @@ This term refers to communities and places that are predominantly white and that
 
 This phrase was used to stereotype Indigenous peoples as unintelligent, and shouldn’t be used due to its racist origins.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -402,7 +396,7 @@ Long time no see
 
 This metaphor refers to the lynching of Black people, and shouldn’t be used.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -417,8 +411,6 @@ This metaphor refers to the lynching of Black people, and shouldn’t be used.
 ---
 
 ## Ungendered content
-
-<!-- keywords: gender, gendered, ungendered, sex, gender identity, gender binary, they, gender-neutral, gender-inclusive, pronouns -->
 
 Gendered language is language biased towards a particular sex or gender. Language that relies on stereotypes, or makes broad assumptions about its audiences’ sex or gender identities is likely gendered.
 
@@ -447,7 +439,7 @@ Avoid the following words and phrases.
 
 These terms reinforce the idea that gender is binary.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -465,7 +457,7 @@ These terms reinforce the idea that gender is binary.
 
 This term can exclude people who aren’t men and reinforce the idea that positions of power are only for men. Use a word that’s gender-neutral and inclusive of all people.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -481,7 +473,7 @@ This term can exclude people who aren’t men and reinforce the idea that positi
 
 This term excludes people who aren’t men. Use a word that’s gender-neutral and inclusive of all people.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -498,7 +490,7 @@ This term excludes people who aren’t men. Use a word that’s gender-neutral a
 
 This word can exclude people who aren’t men. Use a word that’s gender-neutral and inclusive of all people.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -517,7 +509,7 @@ This word can exclude people who aren’t men. Use a word that’s gender-neutra
 
 This word can also exclude people who aren’t men.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -534,7 +526,7 @@ This word can also exclude people who aren’t men.
 
 These terms assume a binary gender which might not be the case. Consider how you use these terms and if they’re necessary in that particular context. If you’re listing genders, make sure to include all genders.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -552,7 +544,7 @@ These terms assume a binary gender which might not be the case. Consider how you
 
 These terms assume a binary gender which might not be the case. Consider how you use these terms and if they’re necessary in that particular context.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/content/actionable-language.md
+++ b/polaris.shopify.com/content/foundations/content/actionable-language.md
@@ -77,26 +77,25 @@ Merchants use Shopify to get things done. Content should be written and structur
 
 ## Headings and subheadings
 
-<!-- keywords: articles, conversational headings, conversational subheadings, sub-headings, microcopy headings, microcopy subheadings, microcopy sub-headings, heading capitalization, subheading capitalization, sub-heading capitalization, heading punctuation, punctuating headings -->
-
 Headings and subheadings are titles and subtitles that refer to sections of the interface.
 
 ### Basic structure
 
 Headings and subheadings should be:
 
-- Informative and descriptive:
+**Informative and descriptive:**
 
-  - Highlight the most important concept or piece of information for merchants
-  - Help merchants understand what they’ll find in the section below
+- Highlight the most important concept or piece of information for merchants
+- Help merchants understand what they’ll find in the section below
 
-- Concise and scannable:
-  - Use simple, clear language
-  - Keep headings to a single sentence
-  - Avoid using punctuation such as periods, commas, or semicolons
-  - Write in sentence case (capitalize the first word and proper nouns only)
+**Concise and scannable:**
 
-<!-- usagelist -->
+- Use simple, clear language
+- Keep headings to a single sentence
+- Avoid using punctuation such as periods, commas, or semicolons
+- Write in sentence case (capitalize the first word and proper nouns only)
+
+<!-- dodont -->
 
 #### Do
 
@@ -120,7 +119,7 @@ Whether or not to use articles (“the,” “a,” “an”) in headings and su
 
 For more conversational areas of the product, like Home cards, sell pages, and empty states, use articles. It makes the language more approachable and helps people to understand new, complex concepts.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -136,7 +135,7 @@ For more conversational areas of the product, like Home cards, sell pages, and e
 
 For labels, titles, and microcopy, avoid articles to keep content short and actionable. This increases readability and encourages immediate action.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -156,7 +155,7 @@ Start sentences with imperative verbs when telling merchants what actions they c
 
 When a merchant reads a sentence that starts with an imperative verb it should sound like they’re being instructed what to do. Don’t use permissive language like “you can.”
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -176,14 +175,11 @@ Add your first product and see how it looks in your store.
 
 <!--- keywords: buttons, button copy, button text, button content, links, actions, calls to action, call to actions, action-led, action led, scannable, articles, choose , select, choose vs select, select vs choose, need, must, need vs must, must vs need -->
 
-Buttons need to be clear and predictable. Merchants should be able to
-anticipate what will happen when they select a button. Never mislead
-someone by mislabeling a button.
+Buttons need to be clear and predictable. Merchants should be able to anticipate what will happen when they select a button. Never mislead someone by mislabeling a button.
 
-Buttons should always lead with a strong verb that encourages action.
-To provide enough context to merchants, use the {verb} + {noun} content formula on buttons except in the case of common actions like “Done,” “Close,” “Cancel,” or “OK.”
+Buttons should always lead with a strong verb that encourages action. To provide enough context to merchants, use the {verb} + {noun} content formula on buttons except in the case of common actions like “Done,” “Close,” “Cancel,” or “OK.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -201,7 +197,7 @@ To provide enough context to merchants, use the {verb} + {noun} content formula 
 
 Always write button text in sentence case, which means the first word is capitalized and the rest are lowercase (unless a term is a proper noun).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -215,7 +211,7 @@ Always write button text in sentence case, which means the first word is capital
 
 Avoid unnecessary words and articles such as “the,” “an,” or “a.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -231,11 +227,9 @@ Add a menu item
 
 ## Links
 
-Links need to be clear and predictable. Merchants should be able to
-anticipate what will happen when they select a link. Never mislead
-someone by mislabeling a link.
+Links need to be clear and predictable. Merchants should be able to anticipate what will happen when they select a link. Never mislead someone by mislabeling a link.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -257,7 +251,7 @@ Links in full sentences shouldn’t link the entire sentence, only the text that
 
 It’s better for [internationalization](/foundations/internationalization) to have only single terms or small parts of phrases linked. Linking a full phrase is problematic because the word order might change, which would break the link into two parts.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -275,7 +269,7 @@ It’s better for [internationalization](/foundations/internationalization) to h
 
 Links that aren’t in full sentences should use the {verb + noun} pattern and not be punctuated, with the exception of question marks.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -308,7 +302,7 @@ Confirmation titles should:
 - Avoid articles (the, a, an) to keep content short and actionable
 - Be written in sentence case (the first word is capitalized, and the rest is lowercase)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -331,7 +325,7 @@ Confirmation body content should:
 - Clearly explain if the action is irreversible or difficult to undo, using [plain language](https://polaris.shopify.com/content/product-content#write-for-a-grade-7-reading-level).
 - Be concise: use only one line of text. Don’t start the sentence with “Are you sure?”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -360,7 +354,7 @@ Before merchants can delete objects like collections, transfers, products, and v
 
 Primary action:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -376,7 +370,7 @@ Primary action:
 
 Secondary action:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -392,7 +386,7 @@ Secondary action:
 
 Primary action:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -406,7 +400,7 @@ Primary action:
 
 Secondary action:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -423,7 +417,7 @@ Secondary action:
 
 Primary action:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -438,7 +432,7 @@ Primary action:
 
 Secondary action:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -467,8 +461,6 @@ Directional language often indicates a lack of visual or content hierarchy. When
 
 ## Save vs. done
 
-<!-- keywords: save states, deferred save, deferred saving, saving in sheets, saving in modals, saving on a page, saving on pages, delayed saves, delayed saving, context bar copy, page actions, edit states, manage states -->
-
 Use “Save” when a change is saved immediately to a database and “Done” for [deferred saves](#deferred-saves).
 
 ### Saving immediately to a database
@@ -477,11 +469,9 @@ Use “Save” as the default for any action that saves immediately to a databas
 
 #### Saving using the context bar component
 
-When merchants make changes on a page they’re sometimes presented with a context bar at the top. This context bar displays a status message on the left to indicate the state of the changes,
-like “Unsaved discount.” Since the status message provides context around the action being taken, the button doesn’t need to follow the common {verb} + {noun} content formula. For example, [Save] instead of [Save product].
-In the context bar component, use the verb “Save”.
+When merchants make changes on a page they’re sometimes presented with a context bar at the top. This context bar displays a status message on the left to indicate the state of the changes, like “Unsaved discount.” Since the status message provides context around the action being taken, the button doesn’t need to follow the common {verb} + {noun} content formula. For example, [Save] instead of [Save product]. In the context bar component, use the verb “Save”.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -499,7 +489,7 @@ Use the verb “Save” in the context bar
 
 Status messages in the context bar should be descriptive and follow the {adjective} + {noun} content formula.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -518,7 +508,7 @@ Status messages in the context bar should be descriptive and follow the {adjecti
 
 Use the verb “Save” in modals and sheets when saving directly to the database.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -540,7 +530,7 @@ Use the {Save} + {noun} content formula when a save action doesn’t have the su
 
 For example, the action at the bottom of the Create discount page uses [Save discount]:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -563,7 +553,7 @@ Use the adjective “Done” for deferred saves. When the modal or sheet closes,
 
 Most deferred saves happen when confirming changes in Add, Edit, Manage, and Select modals and sheets.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -582,11 +572,9 @@ Most deferred saves happen when confirming changes in Add, Edit, Manage, and Sel
 
 ### Datepickers
 
-<!-- keywords: date pickers, datepicker copy, date picker copy, datepicker copy, datepicker copy, datepicker buttons, date picker buttons -->
-
 Use the adjective “Done” for datepickers.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -604,11 +592,9 @@ Use the adjective “Done” for datepickers.
 
 ## OK vs. accept
 
-<!-- keywords: confirmations okay, o.k., accept conditions, read only states -->
-
 Use the adjective “OK” when merchants need to confirm they’ve read something, but aren’t required to legally accept terms of service before continuing. For example, use “OK” when presenting a security notification in a modal or sheet.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -627,7 +613,7 @@ Use the adjective “OK” when merchants need to confirm they’ve read somethi
 
 Use the adjective “Accept” when terms of service require legal confirmation before merchants can continue.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -645,8 +631,6 @@ Accept
 
 ## Close vs. cancel
 
-<!-- keywords: exiting copy, exiting content, exiting modals, exiting screens, backing out of changes -->
-
 Use the back arrow button as the call to action for modals and screens when:
 
 - the content is in a view-only state
@@ -656,7 +640,7 @@ Don’t use “Close” as the call to action when there’s the option for merc
 - make any changes to the modal or screen
 - confirm they’ve read something or accept terms of service (see [OK vs. accept](#OK-accept))
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -672,7 +656,7 @@ Don’t use “Close” as the call to action when there’s the option for merc
 
 Use “Cancel” as the option for merchants to back out of any changes made on a page, modal, or sheet. When the cancel button is pressed, changes automatically get discarded. “Cancel” is often paired with “Save” and “Done” actions (and is always placed to the left).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -692,20 +676,16 @@ Use the verb “Cancel” as the action for merchants to back out of changes
 
 ## Select vs. choose
 
-<!-- keywords: pick -->
-
 Use the verb “select”:
 
-- When telling merchants to pick something from a limited number of options of
-  the same kind
-- When merchants need to make an easy or obvious decision that doesn’t require
-  deep reflection or analysis
+- When telling merchants to pick something from a limited number of options of the same kind
+- When merchants need to make an easy or obvious decision that doesn’t require deep reflection or analysis
 - For defined lists and dropdown menus
 - When merchants are given the option to pick from a list of already existing objects, like products
 
 Pair Select modals and screens with the “Done” call to action.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -722,12 +702,10 @@ Pair Select modals and screens with the “Done” call to action.
 
 Use the verb “choose” when:
 
-- Encouraging merchants to make a decision that is more subjective, strategic,
-  emotional, or open-ended
-- Merchants have to pick from a large inventory of items, like themes, or
-  options that require strategic decision making, like pricing plans
+- Encouraging merchants to make a decision that is more subjective, strategic, emotional, or open-ended
+- Merchants have to pick from a large inventory of items, like themes, or options that require strategic decision making, like pricing plans
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -748,11 +726,9 @@ Use the verb “choose” when:
 
 ## Edit vs. manage
 
-<!-- keywords: edit -->
-
 Use the verb “edit” when you can change the input of a field (letters, numbers, properties). Place as link text next to the field or area that is being edited. There’s no need for a noun unless it’s unclear what’s being edited.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -767,11 +743,9 @@ Use the verb “edit” when you can change the input of a field (letters, numbe
 
 <!-- end -->
 
-<!-- keywords: manage -->
-
 Use the verb “manage” at a higher level to convey that multiple actions can be done, or sections and settings can be updated. Pair this verb with a noun if it’s in a button or if it’s unclear what is being managed.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -790,11 +764,9 @@ Use the verb “manage” at a higher level to convey that multiple actions can 
 
 ## Change vs. switch
 
-<!-- keywords: change -->
-
 Use the verb “change” when merchants can replace an option, but not edit it. For example, they can change an image or theme, but the action doesn’t include editing its properties. Place as link text next to the field or area that is being changed. There’s no need for a noun unless it’s unclear what is being changed.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -807,11 +779,9 @@ Use the verb “change” when merchants can replace an option, but not edit it.
 
 <!-- end -->
 
-<!-- keywords: switch -->
-
 Use the verb “switch” when it’s important for merchants to know what they’re switching between, like users, accounts, locations, or modes. When the switch happens, the previous option is turned off, logged out, or deactivated. Always pair with a noun to prevent confusion.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -828,12 +798,9 @@ Use the verb “switch” when it’s important for merchants to know what they�
 
 ## Create vs. add
 
-<!-- keywords: new items, creation states, addition states, new objects -->
+Use the verb “create” when you’re encouraging merchants to generate something from scratch, like a collection.
 
-Use the verb “create” when you’re encouraging merchants to generate something
-from scratch, like a collection.
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -849,10 +816,9 @@ from scratch, like a collection.
 
 <!-- end -->
 
-Use the verb “add” when you’re encouraging merchants to bring something that
-already exists into Shopify, like a product.
+Use the verb “add” when you’re encouraging merchants to bring something that already exists into Shopify, like a product.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -870,13 +836,9 @@ already exists into Shopify, like a product.
 
 ## View vs. see
 
-<!-- keywords: viewing, view all, see all -->
+Use the verb “view” when you’re encouraging merchants to go to a specific page or section for more details, or to reveal more information. Use “view” in buttons, calls to action, and link text.
 
-Use the verb “view” when you’re encouraging merchants to go to a specific
-page or section for more details, or to reveal more information. Use “view” in
-buttons, calls to action, and link text.
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -895,10 +857,9 @@ buttons, calls to action, and link text.
 
 <!-- end -->
 
-Use the verb “see” in more general, conversational descriptions without a
-specific call to action.
+Use the verb “see” in more general, conversational descriptions without a specific call to action.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -916,22 +877,17 @@ specific call to action.
 
 ## Need vs. must
 
-<!-- keywords: required actions -->
+Use the verb “need” when you’re telling merchants something they’re required to do or should do.
 
-Use the verb “need” when you’re telling merchants something they’re required
-to do or should do.
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-To buy a shipping label, you need to enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you need to enter the total weight of your shipment, including packaging.
 
 #### Don’t
 
-To buy a shipping label, you must enter the total weight of your shipment,
-including packaging.
+To buy a shipping label, you must enter the total weight of your shipment, including packaging.
 
 <!-- end -->
 
@@ -939,12 +895,9 @@ including packaging.
 
 ## Export vs. download
 
-<!-- keywords: exporting, downloading -->
+Use “export” as the call to action when merchants needs to transfer data from Shopify and convert it into a different format.
 
-Use “export” as the call to action when merchants needs to transfer data from
-Shopify and convert it into a different format.
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -956,10 +909,9 @@ Shopify and convert it into a different format.
 
 <!-- end -->
 
-Use “download” as the call to action when merchants need to copy data (of the
-same format) from Shopify to a computer system.
+Use “download” as the call to action when merchants need to copy data (of the same format) from Shopify to a computer system.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -977,12 +929,9 @@ same format) from Shopify to a computer system.
 
 ## Import vs. upload
 
-<!-- keywords: importing, uploading -->
+Use “import” as the call to action when merchants need to transfer data and convert it into a different format so it can be used in Shopify.
 
-Use “import” as the call to action when merchants need to transfer data and
-convert it into a different format so it can be used in Shopify.
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -994,10 +943,9 @@ convert it into a different format so it can be used in Shopify.
 
 <!-- end -->
 
-Use “upload” as the call to action when merchants need to copy data of the same
-format from a computer system into Shopify.
+Use “upload” as the call to action when merchants need to copy data of the same format from a computer system into Shopify.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/content/alternative-text.md
+++ b/polaris.shopify.com/content/foundations/content/alternative-text.md
@@ -36,16 +36,11 @@ keywords:
 
 # Alternative text
 
-Shopify aims to provide an [inclusive experience](/foundations/accessibility).
-Alternative text (alt text) helps people with low or loss of vision use our
-products.
+Shopify aims to provide an [inclusive experience](/foundations/accessibility). Alternative text (alt text) helps people with low or loss of vision use our products.
 
-Generally, alt text is text replacement for an image and is often represented by
-the alt HTML element attribute, `alt=""`, but is also used in other scenarios.
+Generally, alt text is text replacement for an image and is often represented by the alt HTML element attribute, `alt=""`, but is also used in other scenarios.
 
-Screen readers announce alt text to explain images to people with low or loss of
-vision. Alt text is also displayed if images fail to download for some reason
-(for example, due to an unstable network connection).
+Screen readers announce alt text to explain images to people with low or loss of vision. Alt text is also displayed if images fail to download for some reason (for example, due to an unstable network connection).
 
 Alt text should:
 
@@ -57,27 +52,22 @@ Alt text should:
 
 ## Alt text for images
 
-<!-- keywords: img tags, image tags, image alternative text, img, empty alt text attribute -->
-
-All `<img>` tags need an alt text attribute, even if it’s empty. We need to let
-the screen reader know to ignore the image.
+All `<img>` tags need an alt text attribute, even if it’s empty. We need to let the screen reader know to ignore the image.
 
 Empty alt text attribute for images: `<img alt="" />`
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
-Use alt text when the image conveys valuable information, such as the ability to
-play a demonstration video.
+Use alt text when the image conveys valuable information, such as the ability to play a demonstration video.
 
 In this case, you would use:
 `<img alt="Watch a video on how the Shopify reports section works." />`
 
 #### Don’t
 
-Use alt text when the image doesn’t add clarity to the task. In this case, leave
-the alt text attribute empty: `alt=""`
+Use alt text when the image doesn’t add clarity to the task. In this case, leave the alt text attribute empty: `alt=""`
 
 <!-- end -->
 
@@ -85,32 +75,20 @@ the alt text attribute empty: `alt=""`
 
 ## Writing alt text
 
-<!-- keywords: plain text, alt text writing, alt text content, alt text copy -->
-
 Alt text should always be written in plain text.
 
-- Use the simplest words you can. Stuck on how to replace a complicated word?
-  Check this
-  [A-Z list of alternative words](https://www.plainenglish.co.uk/the-a-z-of-alternative-words.html)
-  or these
-  [plain language tips](/content/product-content#write-for-a-7-grade-reading-level).
-- Avoid needless words. If you take out a word, is the phrase just as easy to
-  understand? If yes, then cut that word.
-- Write concisely. Thinking about how to write for a small amount of space is a
-  good shortcut.
-- Write in the [active voice](/content/grammar-and-mechanics#basics). Only use
-  the passive voice if you want to hide who is doing the thing described.
+- Use the simplest words you can. Stuck on how to replace a complicated word? Check this [A-Z list of alternative words](https://www.plainenglish.co.uk/the-a-z-of-alternative-words.html) or these [plain language tips](/content/product-content#write-for-a-7-grade-reading-level).
+- Avoid needless words. If you take out a word, is the phrase just as easy to understand? If yes, then cut that word.
+- Write concisely. Thinking about how to write for a small amount of space is a good shortcut.
+- Write in the [active voice](/content/grammar-and-mechanics#basics). Only use the passive voice if you want to hide who is doing the thing described.
 
 ---
 
 ## Situations that need alt text
 
-<!-- keywords: examples of alt text, examples of alternative text, alternative text examples, icon alternative text, icon alt text, action alternative text, action alt text, button alternative text, button alt text, complex images, complex image alternative text, images alternative text, images alt text, alternative text for, alt text for -->
-
 ### Icons
 
-[Icons](/components/icon) that could be misinterpreted need an
-explanation, so use the `aria-label` attribute.
+[Icons](/components/icon) that could be misinterpreted need an explanation, so use the `aria-label` attribute.
 
 ```html
 <button aria-label="Close" onclick="myDialog.close()">X</button>
@@ -118,20 +96,20 @@ explanation, so use the `aria-label` attribute.
 
 ### Actions
 
-If space constraints require you to write calls to action without nouns, like
-“learn more” and “apply now”, give further indication of where merchants will
-be sent after they select.
+If space constraints require you to write calls to action without nouns, like “learn more” and “apply now”, give further indication of where merchants will be sent after they select.
 
-<!-- prettier-ignore -->
 ```html
-<a href="{cta-url}" aria-label="Learn more about opening an online store with Shopify">Learn more</a>
+<a
+  href="{cta-url}"
+  aria-label="Learn more about opening an online store with Shopify"
+  >Learn more</a
+>
 ```
 
 ### Complex images
 
 Images with a bit more complexity need more logic in the code.
 
-<!-- prettier-ignore -->
 ```html
 <div role="img" aria-labelledby="star_id">
   <img src="fullstar.png" alt="" />
@@ -145,47 +123,36 @@ Images with a bit more complexity need more logic in the code.
 
 ## Pronunciation and translation
 
-<!-- keywords: html lang attribute, html tag, speech synthesis tools, alternative text translation, alt text translation -->
+Not only are we striving to make interactions with our products pleasurable, we also want to try to make the listening experience for our merchants pleasant as well. The HTML lang attribute helps speech synthesis tools figure out pronunciation and translation tools figure out what rules to use.
 
-Not only are we striving to make interactions with our products pleasurable, we
-also want to try to make the listening experience for our merchants pleasant as
-well. The HTML lang attribute helps speech synthesis tools figure out
-pronunciation and translation tools figure out what rules to use.
-
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Indicate the language of the page. This example is for English.
 
-<!-- prettier-ignore -->
 ```html
-<html lang="en">
+<html lang="en"></html>
 ```
 
 #### Don’t
 
 Fail to indicate the language of the page.
 
-<!-- prettier-ignore -->
 ```html
-<html>
+<html></html>
 ```
 
 <!-- end -->
 
 Here’s a
-[standard list of language attributes](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
-that you can use in your document.
+[standard list of language attributes](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) that you can use in your document.
 
 ---
 
 ## SEO
 
-<!-- keywords: search engine optimization, searchability, keywords, key words -->
-
-Alt text is a good way to increase site searchability. This applies outside of
-Shopify’s admin.
+Alt text is a good way to increase site searchability. This applies outside of Shopify’s admin.
 
 - Use keywords (the words that people search for) logically
 - Never reduce the relevance or clarity of the alt text just to insert a keyword

--- a/polaris.shopify.com/content/foundations/content/grammar-and-mechanics.md
+++ b/polaris.shopify.com/content/foundations/content/grammar-and-mechanics.md
@@ -20,14 +20,11 @@ keywords:
 
 # Grammar and mechanics
 
-This guide is to help designers, developers, recruiters, UX-ers, product
-managers, support advisors, or anyone who writes public-facing text for Shopify.
+This guide is to help designers, developers, recruiters, UX-ers, product managers, support advisors, or anyone who writes public-facing text for Shopify.
 
 ---
 
 ## Basics
-
-<!-- keywords: active voice, passive voice, contractions, plain language, reading levels, past tense, your, referring to yourself , referring to Shopify, abbreviated words, abbreviating words, empathy -->
 
 ### Active voice
 
@@ -35,10 +32,9 @@ You should (almost) always write in the active voice:
 
 - Subject (person/thing acting) verb (the action) object (receives the action)
 
-Use the active voice if merchants need to do something. It should be clear
-that the subject is the one doing the action.
+Use the active voice if merchants need to do something. It should be clear that the subject is the one doing the action.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -54,20 +50,17 @@ Details were added to the product
 
 To tell if you’re using the passive voice, look out for:
 
-- When the object comes before the subject (“the item was purchased by the
-  customer”)
+- When the object comes before the subject (“the item was purchased by the customer”)
 - Past tense verbs (“was added,” “was created,” and so on)
 - Forms of the verb “to be” (“was,” “is,” “were,” and so on)
 
-You should almost always write in the active voice, but here’s when to use the
-passive voice:
+You should almost always write in the active voice, but here’s when to use the passive voice:
 
 - To avoid referring to yourself or Shopify
 - To make it clear that you didn’t personally take an action or make a decision
-- If the object (thing being done) is more important than the subject (person
-  doing the thing)
+- If the object (thing being done) is more important than the subject (person doing the thing)
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -83,12 +76,9 @@ Shopify creates and emails your invoices monthly to
 
 ### Contractions
 
-Contractions are abbreviated words. We use them to set a light and casual tone
-in the interface. The goal is to sound human, so avoid contracting verbs that
-sound awkward when you say them out loud, or have been phased out of modern day
-speech.
+Contractions are abbreviated words. We use them to set a light and casual tone in the interface. The goal is to sound human, so avoid contracting verbs that sound awkward when you say them out loud, or have been phased out of modern day speech.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -120,17 +110,14 @@ speech.
 
 ### Plain language
 
-Use words and language that our merchants use. Avoid jargon or technical
-terminology. Make sure each sentence has a single focus and keep them short. Aim
-for a Grade 7 reading level.
+Use words and language that our merchants use. Avoid jargon or technical terminology. Make sure each sentence has a single focus and keep them short. Aim for a Grade 7 reading level.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
 - We’ve made some changes to improve your store’s security
-- These products aren’t getting a lot of views, but visitors are adding them to
-  their carts
+- These products aren’t getting a lot of views, but visitors are adding them to their carts
 
 #### Don’t
 
@@ -143,18 +130,15 @@ for a Grade 7 reading level.
 
 ## Capitalization
 
-<!-- keywords: heading capitalization, proper nouns, product names, feature names, job titles, position titles, position names, roles, slashes, forward slashes, sentence case, title case, lowercase, lower case, uppercase, upper case, what words are capitalized?, trademarks, third party brands, third-party brands -->
-
 ### Headings
 
 Use sentence case for all headings:
 
 - Capitalize the first word of a heading
-- Capitalize proper or trademarked nouns (names of products, countries, or
-  people)
+- Capitalize proper or trademarked nouns (names of products, countries, or people)
 - Lowercase for everything else
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -168,11 +152,9 @@ Create Purchase Order
 
 ### Product and feature names
 
-In general, if a feature or product isn’t unique to Shopify, don’t capitalize it
-(such as blogs, navigation, pages). If it’s unique to Shopify and marketable as its
-own product, capitalize it (such as Shopify Payments, or Frenzy).
+In general, if a feature or product isn’t unique to Shopify, don’t capitalize it (such as blogs, navigation, pages). If it’s unique to Shopify and marketable as its own product, capitalize it (such as Shopify Payments, or Frenzy).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -190,20 +172,15 @@ own product, capitalize it (such as Shopify Payments, or Frenzy).
 
 ### Trademarks
 
-Respect the usage guidelines of any third-party intellectual property. For
-example, in US communications, Apple Pay requires you to include the trademark
-symbol (™) the first time Apple Pay appears in body copy.
+Respect the usage guidelines of any third-party intellectual property. For example, in US communications, Apple Pay requires you to include the trademark symbol (™) the first time Apple Pay appears in body copy.
 
-Review the third party’s brand usage guidelines to make sure you are using the
-company’s name and logo correctly.
+Review the third party’s brand usage guidelines to make sure you are using the company’s name and logo correctly.
 
 ### Job titles
 
-Job titles should be capitalized when they come before or after a person’s name. When
-referring to a job title without referencing a name, don’t capitalize the job
-title.
+Job titles should be capitalized when they come before or after a person’s name. When referring to a job title without referencing a name, don’t capitalize the job title.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -225,7 +202,7 @@ title.
 
 The first letter following a slash shouldn’t be capitalized.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -247,14 +224,11 @@ See the content guidelines for [headings and subheadings](/content/actionable-la
 
 ## Lists
 
-<!-- keywords: bulleted lists, numbered lists, dropdown menu lists, drop down menu lists, action lists, menu actions, menu nouns, nouns in a menu, nouns in menu, list capitalization, list punctuation, list help text, list descriptions, menu lists, list in a menu, list in a drop down, list in a dropdown, list in drop downs, list in dropdowns -->
-
 ### Bulleted
 
-Use a bulleted list when items are related but sequence or priority doesn’t
-matter.
+Use a bulleted list when items are related but sequence or priority doesn’t matter.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -278,7 +252,7 @@ Use Shopify payments to
 
 Use a numbered list when item sequence or priority does matter, such as step-by-step instructions.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -301,13 +275,11 @@ To set up Shopify Payments:
 
 #### Actions in a menu
 
-Menu lists give users a horizontal set of actions when space is limited. The
-order of actions is often based on logic such as most popular actions.
+Menu lists give users a horizontal set of actions when space is limited. The order of actions is often based on logic such as most popular actions.
 
-Actions in a menu follow a {verb}+{noun} pattern. If there’s enough context,
-only a verb might be required.
+Actions in a menu follow a {verb}+{noun} pattern. If there’s enough context, only a verb might be required.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -327,13 +299,11 @@ only a verb might be required.
 
 #### Nouns in a menu
 
-Menu lists give users a horizontal set of nouns when space is limited. The order
-of nouns is often based on logic such as most recent orders.
+Menu lists give users a horizontal set of nouns when space is limited. The order of nouns is often based on logic such as most recent orders.
 
-Nouns in a menu should be concise but still give the user enough information so
-they can easily find and accurately select the item they want.
+Nouns in a menu should be concise but still give the user enough information so they can easily find and accurately select the item they want.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -356,10 +326,9 @@ Select filter
 ### Capitalization
 
 - List items always start with a capital letter.
-- Capitalization and punctuation rules apply to both bulleted and numbered
-  lists.
+- Capitalization and punctuation rules apply to both bulleted and numbered lists.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -392,17 +361,13 @@ Company name
 
 ## Dates, numbers, and measurements
 
-<!-- keywords: date format, ordinal indicators, time, 12 hour clock, 12-hour clock, 24-hour clock, 24 hour clock, currency format, number format, phone number format, phone numbers format, numbers format, dates format, hyphens, en dashes, dashes, ranges, downward ranges, upward ranges, units of measurements, unit of measurement, time stamp, timezone -->
-
 These guidelines are for American English, which is the language we use as a base before translating to other languages. However, dates, numbers, and measurements may be formatted differently in other languages. You can use [helpers](https://github.com/Shopify/quilt) to ensure they are localized automatically.
 
 ### Date
 
-When possible, use the month’s full name, for example, October. If there are
-space constraints, use 3-letter abbreviations, for example, Oct. Don’t write
-dates numerically, for example, 07-02-14.
+When possible, use the month’s full name, for example, October. If there are space constraints, use 3-letter abbreviations, for example, Oct. Don’t write dates numerically, for example, 07-02-14.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -418,10 +383,9 @@ dates numerically, for example, 07-02-14.
 
 <!-- end -->
 
-Don’t use ordinal indicators, which are words representing position or rank in a
-sequential order (1st, 2nd, 3rd, and so on).
+Don’t use ordinal indicators, which are words representing position or rank in a sequential order (1st, 2nd, 3rd, and so on).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -436,11 +400,9 @@ January 23rd–April 1st
 ### Time:
 
 - Use the 12-hour clock, followed by am or pm.
-- Include a space after the last number. For example, “Your package will
-  arrive at 12:35 pm.” Adding the space helps with formatting for English-speaking markets outside of North America, so we use it for North American usage as well.
+- Include a space after the last number. For example, “Your package will arrive at 12:35 pm.” Adding the space helps with formatting for English-speaking markets outside of North America, so we use it for North American usage as well.
 - Use the browser time of the logged in user.
-- To show a time range, use an en dash and include the am/pm after both times,
-  for example, 3:00 pm–4:00 pm.
+- To show a time range, use an en dash and include the am/pm after both times, for example, 3:00 pm–4:00 pm.
 - If indicating both the date and time, separate them with the word “at” instead of a comma.
 
 #### Time zones
@@ -452,7 +414,7 @@ January 23rd–April 1st
 
 For all translations, the time format is automatically localized by the `Intl.DateTimeFormat` JavaScript object.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -466,7 +428,7 @@ Thursday, October 15, 2015 at 2:00 pm EDT
 
 Use consistent timestamp formats by following these examples:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -492,10 +454,9 @@ Use consistent timestamp formats by following these examples:
 
 ### Currency
 
-When including currency with a price, the currency comes after the dollar
-amount. Learn more about [formatting localized currency](/foundations/formatting-localized-currency).
+When including currency with a price, the currency comes after the dollar amount. Learn more about [formatting localized currency](/foundations/formatting-localized-currency).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -513,7 +474,7 @@ amount. Learn more about [formatting localized currency](/foundations/formatting
 
 In general, use numerals. If the number is below 10 and not integral to the sentence, spell it out in full.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -534,10 +495,9 @@ In general, use numerals. If the number is below 10 and not integral to the sent
 
 <!-- end -->
 
-Use commas for numbers with four or more digits. Whenever possible, don’t
-truncate numbers:
+Use commas for numbers with four or more digits. Whenever possible, don’t truncate numbers:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -553,10 +513,9 @@ truncate numbers:
 
 <!-- end -->
 
-Use hyphens when writing phone numbers. Don’t use brackets, spaces, periods, or
-plus signs:
+Use hyphens when writing phone numbers. Don’t use brackets, spaces, periods, or plus signs:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -574,7 +533,7 @@ plus signs:
 
 Use an en dash without a space on either side for number ranges:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -596,10 +555,9 @@ Use an en dash without a space on either side for number ranges:
 
 <!-- end -->
 
-Use “to” instead of an en dash if a number range is preceded by “from” in a
-phrase. Use “and” if a range is preceded by “between.”
+Use “to” instead of an en dash if a number range is preceded by “from” in a phrase. Use “and” if a range is preceded by “between.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -617,7 +575,7 @@ phrase. Use “and” if a range is preceded by “between.”
 
 For undefined upward ranges, use “and up” or “or more.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -633,7 +591,7 @@ For undefined upward ranges, use “and up” or “or more.”
 
 For downward ranges, be specific.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -649,7 +607,7 @@ $0.00–$49.99
 
 In all cases, include a space between the number and the unit.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -668,7 +626,7 @@ In all cases, include a space between the number and the unit.
 
 Never pluralize unit of measurement abbreviations.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -682,10 +640,9 @@ Never pluralize unit of measurement abbreviations.
 
 <!-- end -->
 
-When listing out multiple measurements in a row, put the unit of measurement at the end
-instead of after each number (and include a space).
+When listing out multiple measurements in a row, put the unit of measurement at the end instead of after each number (and include a space).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -699,7 +656,7 @@ instead of after each number (and include a space).
 
 For pricing by measurement, don’t add a space before or after a slash.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -715,7 +672,7 @@ For pricing by measurement, don’t add a space before or after a slash.
 
 For units of measurement, use decimals instead of fractions:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -742,31 +699,29 @@ Use the imperial system for the United States, Liberia, and Myanmar, and use the
 | **Distance**         | Metric          | kilometers    | km           |
 |                      | Imperial        | miles         | mi           |
 | **Image resolution** | Universal       | pixels        | px           |
-|                      | megapixels      | MP            |
-|                      | pixels per inch | ppi           |
-|                      | dots per inch   | dpi           |
+|                      | megapixels      | MP            |              |
+|                      | pixels per inch | ppi           |              |
+|                      | dots per inch   | dpi           |              |
 | **Length**           | Metric          | centimeters   | cm           |
-|                      | meters          | m             |
+|                      | meters          | m             |              |
 |                      | Imperial        | inches        | in           |
-|                      | feet            | ft            |
-|                      | yards           | yd            |
+|                      | feet            | ft            |              |
+|                      | yards           | yd            |              |
 | **Storage size**     | Universal       | kilobytes     | KB           |
-|                      | gigabytes       | GB            |
-|                      | terabytes       | TB            |
+|                      | gigabytes       | GB            |              |
+|                      | terabytes       | TB            |              |
 | **Volume**           | Metric          | centimeters   | ml           |
-|                      | litres          | L             |
+|                      | litres          | L             |              |
 |                      | Imperial        | fluid ounces  | fl oz        |
-|                      | gallons         | gal           |
+|                      | gallons         | gal           |              |
 | **Weight**           | Metric          | grams         | g            |
-|                      | kilograms       | kg            |
+|                      | kilograms       | kg            |              |
 |                      | Imperial        | ounces        | oz           |
-|                      | pounds          | lb            |
+|                      | pounds          | lb            |              |
 
 ---
 
 ## Addresses and places
-
-<!-- keywords: country, countries, provinces, states, country adjectives, abbreviated country, country punctuation, country abbreviations, address, address format, address line 1, address line 2, shipping address, delivery address -->
 
 ### Address
 
@@ -780,16 +735,13 @@ City
 Country            Province           Postal code
 ```
 
-Please note, “optional” in `Apartment, suite, etc. (optional)` means that the
-field is optional for customers to complete, but we should always include it in
-the form.
+Please note, “optional” in `Apartment, suite, etc. (optional)` means that the field is optional for customers to complete, but we should always include it in the form.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Use locale-specific alternatives for province and postal code, for example,
-  the US uses State and ZIP code
+- Use locale-specific alternatives for province and postal code, for example, the US uses State and ZIP code
 
 #### Don’t
 
@@ -802,7 +754,7 @@ the form.
 
 Use a nation’s proper name when referring to it as a noun.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -816,7 +768,7 @@ Your store must be located in the US.
 
 When using a country as an adjective (such as when referring to currency), use the abbreviated form without punctuation.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -830,23 +782,18 @@ U.S. currency
 
 Things to watch out for:
 
-- Don’t use colloquial forms of a nation or state name, for example, America instead of the
-  United States
-- Search online to see whether nations commonly use “the” before their name, for example, the
-  Philippines or the Falkland Islands
+- Don’t use colloquial forms of a nation or state name, for example, America instead of the United States
+- Search online to see whether nations commonly use “the” before their name, for example, the Philippines or the Falkland Islands
 
 ---
 
 ## Punctuation
 
-<!-- keywords: ampersands, apostrophes, omitted numbers, omitted letters, verb contractions, possessives, colons, commas, ellipses, truncation, truncating, exclamation marks, en-dashes, em-dashes, en dashes, em dashes, hyphens, periods, question marks, quotes, quoting, quotation marks, semicolons, semi colons, semi-colons, smart quotes, smart apostrophes -->
-
 ### Ampersands
 
-Don’t use ampersands (&). They attract attention to the least important part of
-the sentence. Spell out the word “and.”
+Don’t use ampersands (&). They attract attention to the least important part of the sentence. Spell out the word “and.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -868,14 +815,13 @@ Use apostrophes to represent omitted letters or numbers:
 
 Use apostrophes to form possessives:
 
-- Singular nouns: add _’s_, even if they end in _s_ (merchant’s,
-  bus’s)
+- Singular nouns: add _’s_, even if they end in _s_ (merchant’s, bus’s)
 - Plural nouns that don’t end in s: add _’s_ (women’s, men’s)
 - Plural nouns that end in s: add an apostrophe (boxes’, customers’)
 
 Don’t use apostrophes to form possessive pronouns such as hers or his.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -893,12 +839,11 @@ Don’t use apostrophes to form possessive pronouns such as hers or his.
 
 Always use apostrophes, not vertical (straight) quotes.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- <span style="font-size: 5rem; line-height: 0; vertical-align: bottom">’</span>
-  <kbd>option</kbd> + <kbd>shift</kbd> + <kbd>]</kbd>
+- <span style="font-size: 5rem; line-height: 0; vertical-align: bottom">’</span> <kbd>option</kbd> + <kbd>shift</kbd> + <kbd>]</kbd>
 
 #### Don’t
 
@@ -908,10 +853,9 @@ Always use apostrophes, not vertical (straight) quotes.
 
 ### Colons
 
-Avoid using colons in sentences. If you need to use one, don’t capitalize the
-first word after the colon unless it’s a proper noun.
+Avoid using colons in sentences. If you need to use one, don’t capitalize the first word after the colon unless it’s a proper noun.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -919,14 +863,13 @@ Your store accepts payments with GoCoin and Shopify Payments.
 
 #### Don’t
 
-Your store accepts payments with: GoCoin and Shopify Payments. Merchants store,
-womens clothing, customers credit cards
+Your store accepts payments with: GoCoin and Shopify Payments. Merchants store, womens clothing, customers credit cards
 
 <!-- end -->
 
 Don’t use colons to introduce radio buttons or checkboxes.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -940,7 +883,7 @@ If the customer abandons their checkout, send them an email reminder to complete
 
 Introduce bulleted lists with a colon.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -962,27 +905,23 @@ Correct the following payment information to continue.
 
 ### Commas
 
-Use the oxford comma (also known as the serial comma) in sentences. There should
-be a comma after every list of 3 or more items (unless you’re using a bulleted or numbered
-list).
+Use the oxford comma (also known as the serial comma) in sentences. There should be a comma after every list of 3 or more items (unless you’re using a bulleted or numbered list).
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
-Kit is an app that handles your online advertising, email marketing, and social
-media.
+Kit is an app that handles your online advertising, email marketing, and social media.
 
 #### Don’t
 
-Kit is an app that handles your online advertising, email marketing and social
-media.
+Kit is an app that handles your online advertising, email marketing and social media.
 
 <!-- end -->
 
 Don’t use commas to separate bulleted or numbered list items.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -1000,9 +939,7 @@ Don’t use commas to separate bulleted or numbered list items.
 
 ### Ellipses
 
-The ellipses (…) can be used in place of a missing piece of text (most commonly
-to show the deletion of words from a direct quotation). Avoid using ellipses in
-text.
+The ellipses (…) can be used in place of a missing piece of text (most commonly to show the deletion of words from a direct quotation). Avoid using ellipses in text.
 
 Use ellipses for:
 
@@ -1013,7 +950,7 @@ Don’t use ellipses for:
 - Placeholder copy
 - Trailing off a sentence
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1027,7 +964,7 @@ Start typing to search for files…
 
 Always use the ellipsis character, not three periods.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1041,22 +978,17 @@ Always use the ellipsis character, not three periods.
 
 #### Truncation
 
-Consider constraints of the space in the interface when deciding to use
-truncation. Think about what part of the string merchants needs most. It’s
-usually the beginning or end, which means you might have to truncate the middle
-of the string.
+Consider constraints of the space in the interface when deciding to use truncation. Think about what part of the string merchants needs most. It’s usually the beginning or end, which means you might have to truncate the middle of the string.
 
 #### Ellipses button component
 
-A button with an ellipsis icon (not the same as text) is used to expand more
-actions. It’s typically used in cards, or for horizontal sets of actions when
-space is limited.
+A button with an ellipsis icon (not the same as text) is used to expand more actions. It’s typically used in cards, or for horizontal sets of actions when space is limited.
 
 ### En-dashes and em-dashes
 
 Use an en dash with no spaces in between (–) for a fixed range of numbers
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1068,10 +1000,9 @@ Use an en dash with no spaces in between (–) for a fixed range of numbers
 
 <!-- end -->
 
-Use an em dash only if you can’t make your message clearer by splitting it into
-two sentences. Use an em dash without a space on either side (—).
+Use an em dash only if you can’t make your message clearer by splitting it into two sentences. Use an em dash without a space on either side (—).
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -1083,19 +1014,15 @@ Choose your theme’s design—colors, typography, and pictures—all in one pla
 
 <!-- end -->
 
-Depending on the font or appearance, you may want to include a hair space on
-either side of the en or em dash. HTML entity code for hair space is `&hairsp;`
-or `&#8202;`.
+Depending on the font or appearance, you may want to include a hair space on either side of the en or em dash. HTML entity code for hair space is `&hairsp;` or `&#8202;`.
 
-Tip: On Mac the keyboard shortcuts are option - for en dash and shift option -
-for em dash.
+Tip: On Mac the keyboard shortcuts are option - for en dash and shift option - for em dash.
 
 ### Exclamation marks
 
-Avoid exclamation marks—only use them for really really exciting things. If you
-absolutely have to, limit yourself to one exclamation mark per page.
+Avoid exclamation marks—only use them for really really exciting things. If you absolutely have to, limit yourself to one exclamation mark per page.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1111,10 +1038,9 @@ You’ve updated your product title!
 
 Use hyphens to:
 
-- Form compound modifiers: two words that combine to modify or describe the noun
-  that follows
+- Form compound modifiers: two words that combine to modify or describe the noun that follows
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1133,10 +1059,9 @@ Use hyphens to:
 
 <!-- end -->
 
-- Join prefixes and suffixes only if there are two vowels beside each other.
-  Never use hyphens in the words ecommerce and email.
+- Join prefixes and suffixes only if there are two vowels beside each other. Never use hyphens in the words ecommerce and email.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1153,13 +1078,11 @@ Use hyphens to:
 
 ### Periods
 
-Periods often end up in places they shouldn’t, and are omitted at strange times.
-In general, don’t use periods in interface copy unless it’s a full sentence
-description.
+Periods often end up in places they shouldn’t, and are omitted at strange times. In general, don’t use periods in interface copy unless it’s a full sentence description.
 
 When to use periods:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1183,16 +1106,14 @@ When to use periods:
 
 <!-- end -->
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Description example: Add this product to a collection so it’s easy to find in
-  your store.
+- Description example: Add this product to a collection so it’s easy to find in your store.
 - Placeholder example: Search products
 - Timeline example: \$50.41 USD was authorized.
-- Footer help box example: Learn more about
-  [products](https://help.shopify.com/manual/products)
+- Footer help box example: Learn more about [products](https://help.shopify.com/manual/products)
 
 #### Don’t
 
@@ -1205,12 +1126,11 @@ When to use periods:
 
 #### Periods for bulleted, numbered, and lists of links
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Use when a list item has two or more full sentences, then also add periods to
-  the whole list
+- Use when a list item has two or more full sentences, then also add periods to the whole list
 - Use for the description or helper text below a bulleted or numbered list item
 
 #### Don’t
@@ -1222,8 +1142,7 @@ When to use periods:
 
 ### Question marks
 
-Avoid question marks wherever possible. Reword into affirmative statements
-wherever you can, but there are exceptions:
+Avoid question marks wherever possible. Reword into affirmative statements wherever you can, but there are exceptions:
 
 It’s okay to use question marks if you don’t know the result of the question:
 
@@ -1235,7 +1154,7 @@ Don’t use question marks if:
 - It’s the only option available: “Reset password”
 - It’s an on/off option: “Show quantity box”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1256,7 +1175,7 @@ Use quotation marks to:
 
 When it’s helpful to the merchant, use quotation marks to indicate input that the merchant has provided, such as a product title or file name. Use this indication only when the input appears in running text.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1272,7 +1191,7 @@ When it’s helpful to the merchant, use quotation marks to indicate input that 
 
 In general, place commas and periods inside quotation marks. When working with literal strings like typed commands or merchant inputs, place punctuation outside the quotation marks.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1290,7 +1209,7 @@ In general, place commas and periods inside quotation marks. When working with l
 
 Always use smart (curly) quotes, not vertical (straight) quotes.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1305,9 +1224,7 @@ Always use smart (curly) quotes, not vertical (straight) quotes.
 
 #### Don’t
 
-- <span style="font-size: 5rem; line-height: 0; vertical-align: bottom">"</span>
-  or
-  <span style="font-size: 5rem; line-height: 0; vertical-align: bottom">'</span>
+- <span style="font-size: 5rem; line-height: 0; vertical-align: bottom">"</span> or <span style="font-size: 5rem; line-height: 0; vertical-align: bottom">'</span>
 
 <!-- end -->
 
@@ -1315,11 +1232,10 @@ Always use smart (curly) quotes, not vertical (straight) quotes.
 
 Avoid semicolons if possible. If you really need them, use semicolons to:
 
-- Connect two closely related ideas, as long as they are both independent
-  clauses (full sentences that could stand on their own).
+- Connect two closely related ideas, as long as they are both independent clauses (full sentences that could stand on their own).
 - Replace a comma or the word “and” between two closely related ideas.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -1335,15 +1251,11 @@ The unicorn was hungry; the grass was brown.
 
 ## Spelling and formatting
 
-<!-- keywords: american spelling, us spelling, u.s. spelling, usa spelling, english spelling, canadian spelling, bolding, spell check -->
-
 ### American spelling
 
-Use American spelling for all external-facing Shopify content. When in doubt,
-check the [Merriam-Webster dictionary](https://www.merriam-webster.com/) for the
-preferred spelling of specific terms.
+Use American spelling for all external-facing Shopify content. When in doubt, check the [Merriam-Webster dictionary](https://www.merriam-webster.com/) for the preferred spelling of specific terms.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1359,27 +1271,23 @@ preferred spelling of specific terms.
 
 <!-- end -->
 
-Tip: it’s easy to miss Canadian spelling. Switch your laptop language settings
-to American English and turn spell check on. It will highlight any Canadianisms
-you might have missed.
+Tip: it’s easy to miss Canadian spelling. Switch your laptop language settings to American English and turn spell check on. It will highlight any Canadianisms you might have missed.
 
 ### Bold
 
 When in doubt, don’t bold.
 
-Use bold sparingly and only where strong emphasis is required.
-Don’t use bold to create a heading or emphasize:
+Use bold sparingly and only where strong emphasis is required. Don’t use bold to create a heading or emphasize:
 
 - Proper nouns
 - Merchant input
 - Checkbox titles
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
-After your first sale, PayPal will email you at **merchant&#64;email.com** with
-instructions.
+After your first sale, PayPal will email you at **merchant&#64;email.com** with instructions.
 
 #### Don’t
 
@@ -1391,14 +1299,11 @@ Are you sure you want to delete **Sunset T-shirt**?
 
 ## You, we, and other personal pronouns
 
-<!-- keywords: addressing merchants, referring to shopify, talking about shopify, talking about merchants, messaging to merchants -->
-
 ### Addressing merchants
 
-Always refer to merchants as “you.” Don’t speak for merchants
-with phrases that use “I” or “my.”
+Always refer to merchants as “you.” Don’t speak for merchants with phrases that use “I” or “my.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1410,10 +1315,9 @@ Change your email address in My Profile.
 
 <!-- end -->
 
-In some cases (such as getting merchant consent or granting permissions) you
-should refer to merchants as “I.”
+In some cases (such as getting merchant consent or granting permissions) you should refer to merchants as “I.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -1426,11 +1330,9 @@ should refer to merchants as “I.”
 
 ### Referring to Shopify
 
-Always refer to Shopify as “we,” but avoid inserting Shopify into the content as
-much as possible (except when a human is taking action, such as reviewing a
-request).
+Always refer to Shopify as “we,” but avoid inserting Shopify into the content as much as possible (except when a human is taking action, such as reviewing a request).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/content/help-documentation.md
+++ b/polaris.shopify.com/content/foundations/content/help-documentation.md
@@ -31,12 +31,10 @@ keywords:
 
 # Help documentation
 
-After you build an app or other integration, writing help documentation will
-show merchants how to use it.
+After you build an app or other integration, writing help documentation will show merchants how to use it.
 
 These guidelines are based on our experience writing help documentation for the
-[Shopify Help Center](https://help.shopify.com/). They’re all intended to serve
-the same goal: to educate and empower Shopify merchants.
+[Shopify Help Center](https://help.shopify.com/). They’re all intended to serve the same goal: to educate and empower Shopify merchants.
 
 To include a link to help documentation in your app or channel, use the
 [Footer help](/components/footer-help) component.
@@ -45,15 +43,11 @@ To include a link to help documentation in your app or channel, use the
 
 ## Plan for your audience
 
-<!-- keywords: audience types, customer types, audience personas, customer personas, personas, audience expectations, writing for different audiences, writing for different personas, writing for different customers, new users, experienced users, technical users -->
-
-The way you write your help documentation should change depending on the type of
-audience and their expectations. Take some time to plan for your audience.
+The way you write your help documentation should change depending on the type of audience and their expectations. Take some time to plan for your audience.
 
 ### Audience types
 
-Write help documentation for its intended audience. For any given document, we
-can expect a wide spectrum of Shopify users as an audience:
+Write help documentation for its intended audience. For any given document, we can expect a wide spectrum of Shopify users as an audience:
 
 #### Prospective users
 
@@ -82,8 +76,7 @@ can expect a wide spectrum of Shopify users as an audience:
 
 ### Audience expectations
 
-Each of these different users will likely have different expectations for the
-same document. Let’s take a look at how that might play out:
+Each of these different users will likely have different expectations for the same document. Let’s take a look at how that might play out:
 
 #### Prospective users
 
@@ -114,55 +107,38 @@ same document. Let’s take a look at how that might play out:
 - Pointers to information sources
 
 This is just one way to imagine the variety of users that fit into our audience.
-However we imagine their skill level, our aim for documentation remains the
-same: to accommodate a wide range of users and their objectives. We can do this
-by presenting information in a way that’s inclusive of different skill levels,
-different learning styles, and different workflows.
+However we imagine their skill level, our aim for documentation remains the same: to accommodate a wide range of users and their objectives. We can do this by presenting information in a way that’s inclusive of different skill levels, different learning styles, and different workflows.
 
 ---
 
 ## Use headings to organize your document
 
-<!-- keywords: effective headings, low-level headings, low level headings, heading hierarchy, task-based headings, page-level headings, page level headings, topic-level headings, topic level headings -->
+Readers come to help documentation with different expectations and in different usage settings. For example:
 
-Readers come to help documentation with different expectations and in different
-usage settings. For example:
+- One might be working through a long, multi-stage setup process to connect a third-party app into her admin
+- Another might be using her tablet to check out the details of Shopify POS and see if it could be used at her cafe
+- Another might be trying to make a quick edit to his storefront in the half hour he has left before going to pick up his kids from school
 
-- One might be working through a long, multi-stage setup process to connect a
-  third-party app into her admin
-- Another might be using her tablet to check out the details of Shopify POS and
-  see if it could be used at her cafe
-- Another might be trying to make a quick edit to his storefront in the half
-  hour he has left before going to pick up his kids from school
-
-In all these different cases, the reader needs documentation that’s findable,
-usable, and relevant—in short, organized.
+In all these different cases, the reader needs documentation that’s findable, usable, and relevant—in short, organized.
 
 ### Effective headings
 
-Effective headings make it clear to readers which sections of a document are
-most relevant to their current tasks (findability). Headings also provide them
-with a good sense of progress while they move from one task to the next
+Effective headings make it clear to readers which sections of a document are most relevant to their current tasks (findability). Headings also provide them with a good sense of progress while they move from one task to the next
 (usability).
 
 ### Low-level headings
 
-As a general rule, the lower a heading is in the doc’s hierarchy, the more
-flexible you can be with its tone. For example, low-level headings can be longer
-and more specific, or less formal.
+As a general rule, the lower a heading is in the doc’s hierarchy, the more flexible you can be with its tone. For example, low-level headings can be longer and more specific, or less formal.
 
 ### Heading hierarchy
 
-Maintain the heading hierarchy throughout the doc, and don’t skip heading
-levels. For example, go directly from H1 to H2, then to H3, and so on. This
-helps the readers know where they are in the document, whether they’re going
-through a specific workflow or just scanning.
+Maintain the heading hierarchy throughout the doc, and don’t skip heading levels. For example, go directly from H1 to H2, then to H3, and so on. This helps the readers know where they are in the document, whether they’re going through a specific workflow or just scanning.
 
 ### Tips
 
 For page or topic-level headings, use short, gerund (ing-word) based statements.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -176,7 +152,7 @@ For page or topic-level headings, use short, gerund (ing-word) based statements.
 
 For task-based headings within the document, use verb stems / imperatives.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -190,7 +166,7 @@ For task-based headings within the document, use verb stems / imperatives.
 
 Avoid pronouns and articles in headings to keep them short.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -205,7 +181,7 @@ Avoid pronouns and articles in headings to keep them short.
 
 Avoid long strings of nouns in a heading.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -221,7 +197,7 @@ Avoid long strings of nouns in a heading.
 
 Keep the key descriptors close to the front of a heading so it’s easier to scan quickly. For example, avoid starting the heading with “How to” or “To.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -235,7 +211,7 @@ Keep the key descriptors close to the front of a heading so it’s easier to sca
 
 Try to keep parallel grammatical structure between headings of the same level.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -247,11 +223,9 @@ Try to keep parallel grammatical structure between headings of the same level.
 
 <!-- end -->
 
-In most cases, headings should be statements rather than questions. Save
-question-style headings for FAQs or low-level headings that address specific
-functions.
+In most cases, headings should be statements rather than questions. Save question-style headings for FAQs or low-level headings that address specific functions.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -263,11 +237,9 @@ functions.
 
 <!-- end -->
 
-Use sentence case for all headings, but no periods at the end. Format and
-capitalize interface elements or buttons in the way they appear in the Shopify
-admin.
+Use sentence case for all headings, but no periods at the end. Format and capitalize interface elements or buttons in the way they appear in the Shopify admin.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -279,20 +251,17 @@ admin.
 
 <!-- end -->
 
-Use parallel structure in lists, headings, and pretty much everywhere else to
-encourage comprehension and recall.
+Use parallel structure in lists, headings, and pretty much everywhere else to encourage comprehension and recall.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Adding products to your store, Deleting products from your store, Editing
-  products in your store
+- Adding products to your store, Deleting products from your store, Editing products in your store
 
 #### Don’t
 
-- Add products to your store, How to delete products from your store, Edit a
-  product in your store
+- Add products to your store, How to delete products from your store, Edit a product in your store
 
 <!-- end -->
 
@@ -300,51 +269,33 @@ encourage comprehension and recall.
 
 ## Document tasks
 
-<!-- keywords: task-oriented, task oriented, writing introductions, writing numbered steps, steps, start at, lists, short lists, actionable language -->
-
 ### Be task-oriented
 
-Most help documentation is task-oriented: it’s designed to guide readers through
-the steps they need to follow to complete a task. The best documentation will
-save readers time by helping them complete their tasks quickly. The way that you
-present information has a big impact on how useful it will be to your readers.
+Most help documentation is task-oriented: it’s designed to guide readers through the steps they need to follow to complete a task. The best documentation will save readers time by helping them complete their tasks quickly. The way that you present information has a big impact on how useful it will be to your readers.
 
 ### Use introductions
 
-In most cases, a document shouldn’t start with a set of instructions. Instead,
-offer context with an introductory comment or define a key concept about the
-topic. Decide what information readers need before they scan the instructions.
+In most cases, a document shouldn’t start with a set of instructions. Instead, offer context with an introductory comment or define a key concept about the topic. Decide what information readers need before they scan the instructions.
 This is also true for the document’s subsections.
 
 ### Use numbered steps
 
-Divide up the instructions in a way that reflects how the reader might think of
-the task. Use numbered steps for each part of the task. This helps to hold your
-reader’s attention, and makes it easier for them to switch between a help
-document and Shopify to complete the task.
+Divide up the instructions in a way that reflects how the reader might think of the task. Use numbered steps for each part of the task. This helps to hold your reader’s attention, and makes it easier for them to switch between a help document and Shopify to complete the task.
 
 ### Start at the beginning of a workflow
 
-Make sure that the instructions for major tasks in a longer document can stand
-alone. If the instructions for a task pick up abruptly where an earlier task
-left off, then the readers who begin at that point might struggle to figure out
-the workflow. Start documenting each task at the beginning of the workflow
-required to complete it.
+Make sure that the instructions for major tasks in a longer document can stand alone. If the instructions for a task pick up abruptly where an earlier task left off, then the readers who begin at that point might struggle to figure out the workflow. Start documenting each task at the beginning of the workflow required to complete it.
 
 ### Use short lists
 
-In general, use short lists (either numbered steps or bullets), which are easier
-to read than long lists. If you have a task or a list that needs more than ten
-items, then break it up into two or more lists, each with their own subheading.
+In general, use short lists (either numbered steps or bullets), which are easier to read than long lists. If you have a task or a list that needs more than ten items, then break it up into two or more lists, each with their own subheading.
 
 ### Make tasks actionable
 
-Tell the user what they can do with your product, not what it can do. This means
-structuring documentation around user actions rather than product features.
-Readers aren’t there to read a spec: they want to keep their businesses up and
-running.
+Tell the user what they can do with your product, not what it can do. This means structuring documentation around user actions rather than product features.
+Readers aren’t there to read a spec: they want to keep their businesses up and running.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -359,7 +310,7 @@ running.
 In general, avoid grouping multiple actions together in a single numbered step.
 Each step should include only one or two user actions.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -375,7 +326,7 @@ Each step should include only one or two user actions.
 
 Avoid telling the user to “find” or “locate” something in a task.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -387,12 +338,11 @@ Avoid telling the user to “find” or “locate” something in a task.
 
 <!-- end -->
 
-Use the action word “select” when you’re telling the reader to pick something
-from a set number of choices (like from a list or dropdown menu), and use
+Use the action word “select” when you’re telling the reader to pick something from a set number of choices (like from a list or dropdown menu), and use
 “choose” when you’re telling the reader to make a choice that’s more open-ended
 (like “Choose what kind of store you want to open”).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -404,11 +354,9 @@ from a set number of choices (like from a list or dropdown menu), and use
 
 <!-- end -->
 
-Use consistent phrasing when referring to the reader’s choice. Use the most
-direct “If you want to” instead of more formal options such as “If you would
-like to” or “If you wish to.”
+Use consistent phrasing when referring to the reader’s choice. Use the most direct “If you want to” instead of more formal options such as “If you would like to” or “If you wish to.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -422,7 +370,7 @@ like to” or “If you wish to.”
 
 Avoid using “desired” in place of the more direct “want.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -438,14 +386,9 @@ Avoid using “desired” in place of the more direct “want.”
 
 ## Structure conditional statements
 
-<!-- keywords: if statements, if then, if, then statements -->
+For conditional cases, start the step with “if” so the reader doesn’t have to read the whole sentence only to find out that the condition does not apply to them. It often helps to add a “then” to help the reader identify the condition and the outcome.
 
-For conditional cases, start the step with “if” so the reader doesn’t have to
-read the whole sentence only to find out that the condition does not apply to
-them. It often helps to add a “then” to help the reader identify the condition
-and the outcome.
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -461,27 +404,20 @@ and the outcome.
 
 ## Clarify results of actions
 
-<!-- keywords: steps, step by step, step-by-step, tasks, ordering tasks -->
-
-Show results of actions in the same step as the task and be clear about where in
-the flow the reader is.
+Show results of actions in the same step as the task and be clear about where in the flow the reader is.
 
 ### Put actions and results in the same step
 
-If you need to mention the results of a user action, then do it in the same
-numbered step that describes that action (don’t use a separate numbered step).
-In general, omit results statements unless the result is surprising or
-unexpected.
+If you need to mention the results of a user action, then do it in the same numbered step that describes that action (don’t use a separate numbered step).
+In general, omit results statements unless the result is surprising or unexpected.
 
 ### Mention earlier steps to reinforce order of tasks
 
 You can refer to an earlier step to reinforce the order of the steps.
 
-For progress within a series of steps, use the phrase “When you’ve” or “After
-you’ve.” Avoid using “Once you’ve.”
+For progress within a series of steps, use the phrase “When you’ve” or “After you’ve.” Avoid using “Once you’ve.”
 
-For progress between tasks, begin a section with “Now that you’ve” or “After
-you’ve” (referring back to the previous action or step).
+For progress between tasks, begin a section with “Now that you’ve” or “After you’ve” (referring back to the previous action or step).
 
 ### Use “make sure” and “confirm” for important tasks
 
@@ -489,14 +425,13 @@ When asking the reader to confirm something, use:
 
 - “Make sure” in cases where there’s still a related important task (instead of
   “check that” or “verify that”).
-- “Confirm” in cases where the reader has already been told to do something, and
-  you’re now reminding them.
+- “Confirm” in cases where the reader has already been told to do something, and you’re now reminding them.
 
 ### Tips
 
 For instructions, use the command form of the verb.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -510,12 +445,11 @@ For instructions, use the command form of the verb.
 
 Limit the future tense to cases that actually refer to the future.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Choose an end date. After this date, the boosted post will revert to a regular
-  post.
+- Choose an end date. After this date, the boosted post will revert to a regular post.
 
 #### Don’t
 
@@ -527,78 +461,56 @@ Limit the future tense to cases that actually refer to the future.
 
 ## Use screenshots for clarity
 
-<!-- keywords: images in help documentation, help documentation images, screen shots, screenshots -->
-
-Screenshots help visual learners understand complex tasks and add context to the
-tasks you’re documenting. Use them wisely.
+Screenshots help visual learners understand complex tasks and add context to the tasks you’re documenting. Use them wisely.
 
 ### Use screenshots for complex tasks
 
-In general, don’t use a screenshot to illustrate every step in a task. Instead,
-save screenshots for places where the interface is complicated.
+In general, don’t use a screenshot to illustrate every step in a task. Instead, save screenshots for places where the interface is complicated.
 
 ### Make screenshots with equal margins
 
-When highlighting an area of a screenshot, try to show an equal amount of space
-around the area that you want the reader to focus on.
+When highlighting an area of a screenshot, try to show an equal amount of space around the area that you want the reader to focus on.
 
 ### Use consistent images in a workflow
 
 Tell a story by being consistent with details in screenshots within a document.
-For example, you could follow a single order and keep the details the same from
-one screenshot to the next.
+For example, you could follow a single order and keep the details the same from one screenshot to the next.
 
 ---
 
 ## Teach through documentation
 
-<!-- keywords: educational, educating, teaching, explain apps, describe apps, educate about apps, merchant education, educational opportunity, educational opportunities -->
-
-Documentation is an opportunity for education. Building context, making
-instructions clear, and encouraging learning are key.
+Documentation is an opportunity for education. Building context, making instructions clear, and encouraging learning are key.
 
 ### Link to next steps
 
-Offer links to the next steps. Choose the next steps based on reader profiles
-and feedback.
+Offer links to the next steps. Choose the next steps based on reader profiles and feedback.
 
 ### Encourage learning
 
-Encourage the reader to learn more. Explain the benefits of the feature in the
-introduction of your document.
+Encourage the reader to learn more. Explain the benefits of the feature in the introduction of your document.
 
 ### Make the first tasks easier
 
-Where you can, give the readers “early wins.” Make the first step or two of the
-task short and easy.
+Where you can, give the readers “early wins.” Make the first step or two of the task short and easy.
 
 ### Build context
 
-Connect the current task to readers’ wider knowledge: other parts of Shopify,
-the store-building process, and even the business-building process.
+Connect the current task to readers’ wider knowledge: other parts of Shopify, the store-building process, and even the business-building process.
 
 ### Try not to repeat information on the same page
 
-In most cases, avoid repeating information on a page. You might need to repeat
-important points to make sure the reader notices them. For example, you might
-repeat a warning from the document’s introduction within a set of instructions.
+In most cases, avoid repeating information on a page. You might need to repeat important points to make sure the reader notices them. For example, you might repeat a warning from the document’s introduction within a set of instructions.
 
 ---
 
 ## Use the right tone
 
-<!-- keywords: instructional tone, help tone, help docs voice and tone, help documentation voice and tone -->
-
-Think of the context that the reader is in and what they might be feeling and
-thinking while they’re reading your documentation. This perspective will help
-you pick what type of tone to apply.
+Think of the context that the reader is in and what they might be feeling and thinking while they’re reading your documentation. This perspective will help you pick what type of tone to apply.
 
 ### Instructional tone
 
-Most people don’t want to spend time reading documentation. They want to learn
-what they need to know, and then move on. The language in documentation needs to
-be short, to the point, and task-oriented. That doesn’t mean your writing needs
-to be terse or dry.
+Most people don’t want to spend time reading documentation. They want to learn what they need to know, and then move on. The language in documentation needs to be short, to the point, and task-oriented. That doesn’t mean your writing needs to be terse or dry.
 
 ### Lighter tone
 
@@ -606,22 +518,17 @@ In general, you can begin a document using a lighter tone.
 
 ### Informal tone
 
-When you introduce a task, an informal tone can help draw the reader in, offer
-context, and encourage the reader to keep going. You can also use a more
-informal tone when introducing sub-tasks, to give the reader a break from the
-instructions.
+When you introduce a task, an informal tone can help draw the reader in, offer context, and encourage the reader to keep going. You can also use a more informal tone when introducing sub-tasks, to give the reader a break from the instructions.
 
 ### Direct tone
 
-For actions and tasks, aim for a much more direct tone. Keep your tone
-approachable by using contractions (for example _can’t_, _it’s_) to link
-directions and results.
+For actions and tasks, aim for a much more direct tone. Keep your tone approachable by using contractions (for example _can’t_, _it’s_) to link directions and results.
 
 ### Tips
 
 Use contractions.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -635,7 +542,7 @@ Use contractions.
 
 Address the reader or user as “you.”
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -649,26 +556,17 @@ Address the reader or user as “you.”
 
 Keep tone in check by avoiding the following:
 
-- Sounding patronizing, chummy, cheery, childish, or otherwise inappropriate in
-  an attempt to seem informal and relatable.
-- Colloquialisms, jokes, sarcasm, jargon, and slang. Avoid anything that’s too
-  culturally specific.
-- Anything that causes the user to pause or hesitate, unless you explicitly want
-  them to.
+- Sounding patronizing, chummy, cheery, childish, or otherwise inappropriate in an attempt to seem informal and relatable.
+- Colloquialisms, jokes, sarcasm, jargon, and slang. Avoid anything that’s too culturally specific.
+- Anything that causes the user to pause or hesitate, unless you explicitly want them to.
 
 ---
 
 ## Use the active voice
 
-<!-- keywords: passive voice, plain language, informal language, less formal language, informal writing, less formal writing, informal content, less formal content -->
+Use the active voice as much as possible, which generally sounds less formal than the passive voice. This means writing what merchants do, instead of what is being done by merchants. But in cases where the passive voice sounds more natural than the active voice, use passive voice (like with verbs such as “publish” or “assign” and with nouns like “discount”).
 
-Use the active voice as much as possible, which generally sounds less formal
-than the passive voice. This means writing what merchants do, instead of
-what is being done by merchants. But in cases where the passive voice
-sounds more natural than the active voice, use passive voice (like
-with verbs such as “publish” or “assign” and with nouns like “discount”).
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -684,18 +582,13 @@ with verbs such as “publish” or “assign” and with nouns like “discount
 
 ## Improve readability
 
-<!-- keywords: prose, sentence flow, flowing -->
-
-It’s important that the sentences you put together flow. Changing things up and
-knowing when things should be combined or separated will improve prose. Reading
-sentences that flow helps reader comprehension.
+It’s important that the sentences you put together flow. Changing things up and knowing when things should be combined or separated will improve prose. Reading sentences that flow helps reader comprehension.
 
 ### Avoid choppy writing
 
-Use linking adverbs, conjunctions, and prepositions liberally to avoid choppy
-writing.
+Use linking adverbs, conjunctions, and prepositions liberally to avoid choppy writing.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -709,12 +602,8 @@ writing.
 
 ### Change up sentence structures
 
-Vary your sentence structure, especially in longer paragraphs. Try not to use
-more than two phrases with a “To x, do y” structure in a row—this gets
-repetitive and can cause the reader to lose interest. To break it up, add a
-short declarative sentence, if possible.
+Vary your sentence structure, especially in longer paragraphs. Try not to use more than two phrases with a “To x, do y” structure in a row—this gets repetitive and can cause the reader to lose interest. To break it up, add a short declarative sentence, if possible.
 
 ### Break up complicated chunks
 
-Use conjunctions (a word that joins words or groups of words) to break up
-complicated passages.
+Use conjunctions (a word that joins words or groups of words) to break up complicated passages.

--- a/polaris.shopify.com/content/foundations/content/merchant-to-customer.md
+++ b/polaris.shopify.com/content/foundations/content/merchant-to-customer.md
@@ -68,7 +68,7 @@ Too much personality is inappropriate for some stores. Customers aren’t going 
 
 Keep in mind that some content, such as emails, can be personalized by merchants. You’re providing a default for them to work from.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -95,7 +95,7 @@ Whoops! Houston, we have a problem!
 
 Avoid technical or ecommerce terms. Customers are interested in their order and their delivery, not in inventory and fulfillment. They might want to sign up for news and exclusive offers, but not marketing emails.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -113,7 +113,7 @@ Avoid technical or ecommerce terms. Customers are interested in their order and 
 
 It’s important that any purchase flow is efficient. Use short, easy-to-understand words and phrases. For example:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -131,7 +131,7 @@ It’s important that any purchase flow is efficient. Use short, easy-to-underst
 
 But remember that clear beats short. Don’t use content that can be interpreted in different ways. For example, does “bi-weekly” mean twice a week or every two weeks? It’s clearer to say “Every 2 weeks.” Using more words is okay if it provides clarity.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -169,7 +169,7 @@ In the Shopify admin and Point-of-Sale (POS), a customer appears on the Customer
 
 Word usage to use/avoid:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/content/naming.md
+++ b/polaris.shopify.com/content/foundations/content/naming.md
@@ -1,6 +1,5 @@
 ---
-name: Naming
-keywords:
+name: Naming keywords:
   - names
   - caps
   - capitalizations
@@ -21,8 +20,7 @@ keywords:
 
 # Naming
 
-The names we give our products and features teach merchants how to use Shopify
-and how to find the things they need to run their business.
+The names we give our products and features teach merchants how to use Shopify and how to find the things they need to run their business.
 
 ---
 
@@ -38,22 +36,18 @@ Shopify. A well-chosen name will:
 - Differentiate Shopify from other products
 - Clarify where a product or feature fits into our brand system
 
-The naming process involves collaboration. Include different disciplines and
-people with different subject matter expertise in the creation of a name.
+The naming process involves collaboration. Include different disciplines and people with different subject matter expertise in the creation of a name.
 
 ---
 
 ## Does it need a branded name?
 
 Most features don’t need an official, branded name. For example, order entry is
-a feature that’s referred to descriptively and so doesn’t need to be
-capitalized. When choosing what to call a feature, pick words that describe what
-the feature does or represents. If there’s room, add extra context for merchants
-by describing the feature instead of using only the feature name.
+a feature that’s referred to descriptively and so doesn’t need to be capitalized. When choosing what to call a feature, pick words that describe what the feature does or represents. If there’s room, add extra context for merchants by describing the feature instead of using only the feature name.
 
 Avoid capitalizing descriptive feature names.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -65,10 +59,9 @@ Avoid capitalizing descriptive feature names.
 
 <!-- end -->
 
-If there‘s room, describe the feature instead of defaulting to only using the
-name.
+If there‘s room, describe the feature instead of defaulting to only using the name.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -82,33 +75,23 @@ name.
 
 ### Using “Shopify”
 
-Only Shopify can use the word “Shopify” in a name. The word “Shopify” can’t be
-used to name third-party products.
+Only Shopify can use the word “Shopify” in a name. The word “Shopify” can’t be used to name third-party products.
 
 It’s important we use the word “Shopify” consistently, and sparingly. Don’t use
-“Shopify” in a name unless there’s a lack of surrounding context and we want its
-target audience to know it’s associated with Shopify.
+“Shopify” in a name unless there’s a lack of surrounding context and we want its target audience to know it’s associated with Shopify.
 
-Adding “Shopify” doesn’t add clarity in the context of other Shopify products
-and features. For example, merchants often confuse Shopify Shipping with the
-other shipping features, like shipping settings, carrier calculated shipping
-rates, shipping labels, and shipping zones. Our support staff have to refer to
-the Shopify Plan by its cost because the general name doesn’t distinguish it
-from the other plans.
+Adding “Shopify” doesn’t add clarity in the context of other Shopify products and features. For example, merchants often confuse Shopify Shipping with the other shipping features, like shipping settings, carrier calculated shipping other, shipping labels, and shipping zones. Our support staff have to refer to the Shopify Plan by its cost because the general name doesn’t distinguish it ratesthe other plans.
 
 Use “Shopify” in front of a name when a product:
 
-- Is or will become a separate product or platform and we need to associate it
-  with Shopify
+- Is or will become a separate product or platform and we need to associate it with Shopify
 - Should be differentiated from other, similar products in the industry
 - Doesn’t justify an
-  [evocative name](/content/naming#section-descriptive-vs-evocative-names), but
-  still needs to associated with Shopify
+  [evocative name](/content/naming#section-descriptive-vs-evocative-names), but still needs to associated with Shopify
 
-Don’t use “Shopify” in a name for built in functionality features, like fraud
-analysis or importing products.
+Don’t use “Shopify” in a name for built in functionality features, like fraud analysis or importing products. analysis
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -124,11 +107,7 @@ analysis or importing products.
 
 <!-- end -->
 
-Shopify makes apps that merchants can add to their Shopify admin. It’s okay to
-say “Built by Shopify” or “Made by Shopify” after the app name. Once you’ve
-picked the format that works for the design, use it consistently.
-
-<!-- usagelist -->
+Shopify makes apps that merchants can add to their Shopify admin. It’s okay to say “Built by Shopify” or “Made by Shopify” after the app name. Once you’ve sayked the format that works for the design, use it consistently. pickedodont -->
 
 #### Do
 
@@ -144,10 +123,9 @@ picked the format that works for the design, use it consistently.
 
 <!-- end -->
 
-Apps that aren’t built by Shopify should not use the word “Shopify” in their
-name or say “for Shopify” after the name.
+Apps that aren’t built by Shopify should not use the word “Shopify” in their name or say “for Shopify” after the name.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -165,23 +143,12 @@ name or say “for Shopify” after the name.
 
 ## Descriptive vs evocative names
 
-There are two types of approaches to naming, the descriptive approach, or the
-evocative approach. Descriptive names are concrete, while evocative can be more
-abstract. Descriptive names are merchant friendly, and the most common. Features
-should always have descriptive names. Standalone products that require
-independent branding can use evocative names. Third-party apps and channels
-should have their own branded names and should never use the word “Shopify” in
-the name.
-
-If you’re a Shopify employee and are looking to trademark an evocative name, ask
-the legal department for help.
+There are two types of approaches to naming, the descriptive approach, or the evocative approach. Descriptive names are concrete, while evocative can be more abstract. Descriptive names are merchant friendly, and the most common. Features should always have descriptive names. Standalone products that require independent branding can use evocative names. Third-party apps and channels should have their own branded names and should never use the word “Shopify” in the name. the
+If you’re a Shopify employee and are looking to trademark an evocative name, ask the legal department for help.
 
 ### Descriptive names
 
-Features and products connected to Shopify’s main product offering should have
-names that reveal something about their purpose. Avoid jargon and make sure the
-name you pick won’t get confused with similar names or terms.
-
+Features and products connected to Shopify’s main product offering should have names that reveal something about their purpose. Avoid jargon and make sure the name you pick won’t get confused with similar names or terms. name
 Reserve evocative naming conventions for standalone products like Kit, and
 Frenzy.
 
@@ -193,10 +160,7 @@ Descriptive names should:
 - Make sense in marketing materials
 - Align with brand
 
-If it’s a default feature (merchants don’t have to sign up or opt in to use it),
-don’t [capitalize](/content/naming#section-general-guidelines) it.
-
-<!-- usagelist -->
+If it’s a default feature (merchants don’t have to sign up or opt in to use it), don’t [capitalize](/content/naming#section-general-guidelines) it. don- dodont -->
 
 #### Do
 
@@ -212,10 +176,9 @@ don’t [capitalize](/content/naming#section-general-guidelines) it.
 
 <!-- end -->
 
-Avoid jargon and give merchants a hint about the actions they’ll be able to take
-when they interact with the product or feature.
+Avoid jargon and give merchants a hint about the actions they’ll be able to take when they interact with the product or feature.
 
-<!-- usagelist -->
+<!-- dodont --> when
 
 #### Do
 
@@ -234,19 +197,10 @@ when they interact with the product or feature.
 
 ### Evocative names
 
-Standalone products use evocative names to position us in the industry. These
-unique and bold naming conventions can help with branding or recall, but don’t
-always help people understand the experience. They’re better for standalone
-products, and not for experiences that are part of Shopify’s main product
-offering.
+Standalone products use evocative names to position us in the industry. These unique and bold naming conventions can help with branding or recall, but don’ unique help people understand the experience. They’re better for standalone products, and not for experiences that are part of Shopify’s main product uniq always
+Sometimes Shopify acquires a product or service that already has a unique, branded name. Even though it may become more tied to Shopify, it can keep its name to maintain its brand identity. This also helps maintain the context audiences already have about the product, like in the case of Kit.
 
-Sometimes Shopify acquires a product or service that already has a unique,
-branded name. Even though it may become more tied to Shopify, it can keep its
-name to maintain its brand identity. This also helps maintain the context
-audiences already have about the product, like in the case of Kit.
-
-Certain standalone names use the word “Shopify” because it differentiates the
-product from similar ones in the industry, like Shopify Pay in comparison to
+Certain standalone names use the word “Shopify” because it differentiates the product from similar ones in the industry, like Shopify Pay in comparison to
 Apple Pay, or Android Pay. For more details, see the
 [guidelines for using “Shopify” in a name](/content/naming#section-does-it-need-a-branded-name-).
 
@@ -257,11 +211,9 @@ Evocative names should:
 - Reflect the concept it represents
 - Make sense when used in marketing materials
 
-If you work at Shopify and want to trademark a name, talk to the legal
-department. It’s easier to trademark unique or made-up name. These names have
-stronger identities, but it’s not always clear what they do.
+If you work at Shopify and want to trademark a name, talk to the legal department. It’s easier to trademark unique or made-up name. These names have stronger identities, but it’s not always clear what they do.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -277,11 +229,9 @@ stronger identities, but it’s not always clear what they do.
 
 <!-- end -->
 
-Some evocative names can be more descriptive, although they’re harder to
-trademark if they use common terminology. Not all evocative names need to be
-trademarked.
+Some evocative names can be more descriptive, although they’re harder to trademark if they use common terminology. Not all evocative names need t trademarked.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -295,10 +245,9 @@ trademarked.
 
 <!-- end -->
 
-If you’re creating a website or product for an existing brand, maintain its
-brand identity and keep “Shopify” out of the name.
+If you’re creating a website or product for an existing brand, maintain its brand identity and keep “Shopify” out of the name.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -315,16 +264,13 @@ brand identity and keep “Shopify” out of the name.
 
 ## Shopify products and features
 
-An off-brand and unclear name can confuse your audience. It can also feel
-disconnected from the rest of Shopify.
+An off-brand and unclear name can confuse your audience. It can also feel disconnected from the rest of Shopify.
 
 A good product or feature name should:
 
 - Help merchants understand what the experience represents
-- Fit into the information architecture of the product or website in which it
-  belongs
-- Make sense when compared to other products, features, websites, or events in
-  the same market
+- Fit into the information architecture of the product or website in which it belongs
+- Make sense when compared to other products, features, websites, or events in the same market
 - Avoid any negative or weird connotations
 
 There are two types of approaches to naming, the
@@ -332,22 +278,11 @@ There are two types of approaches to naming, the
 
 ### Referring to Shopify and areas in the admin
 
-Use consistent and easy to understand descriptions when referring to locations
-in product, especially in
-[help documentation](/content/help-documentation#navigation). Descriptive
-feature names aren’t [capitalized](/content/naming#section-general-guidelines),
-but when providing steps in a workflow, it’s okay to capitalize the page name,
-for example, “Go to the Products page”. Note that the page name is capitalized,
-but “page” isn’t.
+Use consistent and easy to understand descriptions when referring to locations in product, especially in
+[help documentation](/content/help-documentation#navigation). Descriptive feature names aren’t [capitalized](/content/naming#section-general-guidel featuren providing steps in a workflow, it’s okay to capitalize the page name, for example, “Go to the Products page”. Note that the page name is capitalized, but “page” isn’t. forn referring to Shopify’s main product offering, use “Shopify”. The only exception is when you need to differentiate it from another product, like the butile app, or expl fornpify admin”.
 
-When referring to Shopify’s main product offering, use “Shopify”. The only
-exception is when you need to differentiate it from another product, like the
-mobile app, or explain a task specific to the admin. In these cases, you can use
-“Shopify admin”.
+A good description can: exception mobileease adoption of the product area
 
-A good description can:
-
-- Increase adoption of the product area
 - Help establish a mental model for merchants
 - Clarify where the area fits into the product system
 - Help support staff and merchants understand each other when communicating
@@ -361,13 +296,12 @@ A good description should:
 
 Use consistent descriptions when referring to areas in the Shopify admin.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
 - The customer list is found on the Customers page.
-- When a new customer places an order with your store, their name and
-  information are automatically added to your customer list.
+- When a new customer places an order with your store, their name and information are automatically added to your customer list.
 
 #### Don’t
 
@@ -376,10 +310,9 @@ Use consistent descriptions when referring to areas in the Shopify admin.
 
 <!-- end -->
 
-Merchants call our main product offering “Shopify”, so we use that same
-terminology.
+Merchants call our main product offering “Shopify”, so we use that same terminology. terminology
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -392,11 +325,10 @@ terminology.
 
 <!-- end -->
 
-Top-level marketing content is created for audiences who have little context
-about Shopify. Since they may not know about specific Shopify products, we use
+Top-level marketing content is created for audiences who have little context about Shopify. Since they may not know about specific Shopify products, we use
 “Shopify” here too.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -415,7 +347,7 @@ about Shopify. Since they may not know about specific Shopify products, we use
 For app names in areas with surrounding context, like in the app store or on the
 Apps page in the Shopify admin, don’t add the word “app” to the end of the name.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -429,10 +361,9 @@ Apps page in the Shopify admin, don’t add the word “app” to the end of the
 
 <!-- end -->
 
-For app names without surrounding context, like in search in the Shopify admin,
-or on a home card, add “app” so merchants know what it is.
+For app names without surrounding context, like in search in the Shopify admin, or on a home card, add “app” so merchants know what it is.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -447,7 +378,7 @@ or on a home card, add “app” so merchants know what it is.
 When writing about channels, make it clear to merchants that they are interacting with
 a channel through Shopify, and not through the other company.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -459,10 +390,9 @@ a channel through Shopify, and not through the other company.
 
 <!-- end -->
 
-If “channel” is used somewhere in surrounding content, it’s okay to drop it for
-titles and button copy.
+If “channel” is used somewhere in surrounding content, it’s okay to drop it for titles and button copy. titles
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -474,14 +404,10 @@ titles and button copy.
 
 <!-- end -->
 
-Not every channel is a sales channel. For example, BuzzFeed is a marketing
-outreach channel and Facebook is a sales and marketing channel. Clarify channel
-types when you have room, otherwise default to channel. If there’s surrounding
-context, you can drop channel altogether.
-
+Not every channel is a sales channel. For example, BuzzFeed is a marketing outreach channel and Facebook is a sales and marketing channel. Clarify ch outreachen you have room, otherwise default to channel. If there’s surrounding context, you can drop channel altogether. context
 If there’s surrounding context, drop the word channel from the name.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -495,7 +421,7 @@ If there’s surrounding context, drop the word channel from the name.
 
 If there’s room for a description, explain the channel type.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -511,14 +437,11 @@ If there’s room for a description, explain the channel type.
 
 ## General guidelines
 
-In general, capitalize evocative names and don’t capitalize feature names. Avoid
-acronyms, and think about how your audience will interpret a name.
+In general, capitalize evocative names and don’t capitalize feature names. Avoid acronyms, and think about how your audience will interpret a name.
 
 ### Capitalization
 
-Don’t capitalize default features. Default features are built into Shopify and
-merchants don’t have to sign up, add, or opt in to use them. Analytics and
-discounts are examples of default features.
+Don’t capitalize default features. Default features are built into Shopify and merchants don’t have to sign up, add, or opt in to use them. Analytics and discounts are examples of default features.
 
 Capitalizing names should only happen:
 
@@ -527,7 +450,7 @@ Capitalizing names should only happen:
 - When we want to try and claim specific words (think Tweet or Pin)
 - For names listed in top level navigation, like Products
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -553,7 +476,7 @@ Names shouldn’t be capitalized if they:
 - Include common, familiar words
 - Are default features
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -573,24 +496,17 @@ Names shouldn’t be capitalized if they:
 
 ### Acronyms and abbreviations
 
-An acronym is a word formed from parts of an existing compound term. For
-example, “rich text editor” could be written as “RTE”. An abbreviation is a
-shortened form of a written word or phrase used in place of the whole word or
-phrase. “Amt” is an abbreviation for “amount”.
+An acronym is a word formed from parts of an existing compound term. For example, “rich text editor” could be written as “RTE”. An abbreviation i exampleed form of a written word or phrase used in place of the whole word or phrase. “Amt” is an abbreviation for “amount”.
 
 Our stance on acronyms:
 
 - Avoid creating acronyms.
-- Acronyms take longer to understand and might reduce adoption of a product,
-  feature, or concept.
-- Acronyms are like inside jokes—people who understand the acronym feel included
-  in the meaning, but people who don’t feel left out and confused.
-- If you have to use an acronym, spell it out the first time you use it and
-  follow with the acronym in brackets.
-- Internationally understood acronyms and abbreviations are acceptable, like the
-  word “app” or “SEO”.
+- Acronyms take longer to understand and might reduce adoption of a product, feature, or concept.
+- Acronyms are like inside jokes—people who understand the acronym feel included in the meaning, but people who don’t feel left out and confused.
+- If you have to use an acronym, spell it out the first time you use it and follow with the acronym in brackets.
+- Internationally understood acronyms and abbreviations are acceptable, like the word “app” or “SEO”.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -610,11 +526,9 @@ Our stance on acronyms:
 
 <!-- end -->
 
-Avoid using Internet slang acronyms in Shopify products and when creating new,
-branded names. These acronyms are exclusive to certain online communities and
-are not approachable for everyday merchants.
+Avoid using Internet slang acronyms in Shopify products and when creating new, branded names. These acronyms are exclusive to certain online communities and branded approachable for everyday merchants.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -626,10 +540,9 @@ are not approachable for everyday merchants.
 
 <!-- end -->
 
-Internationally understood acronyms and abbreviations are acceptable. Some of
-these include time zone, tax, barcode, weight, and size abbreviations.
+Internationally understood acronyms and abbreviations are acceptable. Some of these include time zone, tax, barcode, weight, and size abbreviations.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -667,10 +580,9 @@ these include time zone, tax, barcode, weight, and size abbreviations.
 
 <!-- end -->
 
-When using a country as an adjective (such as when referring to currency), you
-may use an abbreviated form without punctuation.
+When using a country as an adjective (such as when referring to currency), you may use an abbreviated form without punctuation.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -684,14 +596,7 @@ may use an abbreviated form without punctuation.
 
 ### Similar names
 
-Being an ecommerce platform has its naming challenges. For example, a lot of
-feature names could include the word “shipping” or “pay”. Think merchant-first
-and be descriptive to differentiate the name. Picture what it’s like to have
-conversations with merchants about similar names like Shopify Payments and
-Shopify Pay, or around our pricing plans to identify names that might be
-confusing.
-
-Before naming a new product or feature:
+Being an ecommerce platform has its naming challenges. For example, a lot of feature names could include the word “shipping” or “pay”. Think merchant-first and be descriptive to differentiate the name. Picture what it’s like to have conversations with merchants about similar names like Shopify Payments and conversationsor around our pricing plans to identify names that might be confusing. confusingming a new product or feature:
 
 - Conduct an audit of existing names to narrow down your naming choices
 - Ask the support team to see if they think it’ll conflict with another name
@@ -699,24 +604,20 @@ Before naming a new product or feature:
 
 ### Localization and translation
 
-Names may not translate directly to other languages. Identify if you need to
-create a separate name, or if a direct translation will do.
+Names may not translate directly to other languages. Identify if you need to create a separate name, or if a direct translation will do.
 
-Before confirming a name, check with people who work in translation and
-localization to find out if:
+Before confirming a name, check with people who work in translation and createzation to find out if:
 
 - There are cultural considerations
-- A different name for a different location would have a positive impact for
-  brand
+- A different name for a different location would have a positive impac localization
+  Some already existing names are different depending where you’re from. For
+  example, in North America, people say, “I’ll send you a text.” In India and
+  Nordic countries, people say, “I’ll SMS you.” Do your research and find out what
+  people call things in everyday conversations.
 
-Some already existing names are different depending where you’re from. For
-example, in North America, people say, “I’ll send you a text.” In India and
-Nordic countries, people say, “I’ll SMS you.” Do your research and find out what
-people call things in everyday conversations.
+Use “text message” when writing for North American audiences. example
 
-Use “text message” when writing for North American audiences.
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -730,7 +631,7 @@ Use “text message” when writing for North American audiences.
 
 Use SMS when writing for Indian and Nordic audiences.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -744,21 +645,9 @@ Use SMS when writing for Indian and Nordic audiences.
 
 ### Initials
 
-In languages that use logographic characters, like Japanese, name initials can
-have different meanings. For example, in Japanese a name like Chikako (周子)
-Ishikawa (石川) means “neighborhood stone” (周石) in initials. Check with the
-localization and translation team before writing something in short form in
-another language.
+In languages that use logographic characters, like Japanese, name initials can have different meanings. For example, in Japanese a name like Chikako (周子) havekawa (石川) means “neighborhood stone” (周石) in initials. Check with the localization and translation team before writing something in short form in another language. localization anotheriding negative connotat anotheriding
+Some words or terms have unintended negative connotations for some audiences. Do some research to avoid associating offensive words or phrases with your product or feature name. somet by: orSaying it out loud
 
-### Avoiding negative connotations
-
-Some words or terms have unintended negative connotations for some audiences. Do
-some research to avoid associating offensive words or phrases with your product
-or feature name.
-
-Start by:
-
-- Saying it out loud
 - Getting people outside of your team to look at the name with a new perspective
 - Doing a Google search to see if it surfaces with another meaning
 
@@ -767,12 +656,7 @@ Start by:
 ## Components
 
 Be strategic and consistent when naming
-[components](/components/get-started#navigation). It makes it easier to create
-and build products and features for Shopify when people can switch between
-implementations and see the same names represented throughout. For example, we
-should use the same name across Rails, React, and Figma. It’s okay if each
-implementation has its own spelling convention. For example, “Account
-connection” in documentation and in Figma layer names, but
+[components](/components/get-started#navigation). It makes it easier to create and build products and features for Shopify when people can switch between implementations and see the same names represented throughout. For example implementationssame name across Rails, React, and Figma. It’s okay if each implementation has its own spelling convention. For example, “Account andnection” in documentation and in Figma layer names, but
 “ui_account_connection” in Rails, and “AccountConnection” in React.
 
 A good component name can:
@@ -787,10 +671,9 @@ Component names in documentation should:
 - Avoid jargon so different disciplines understand its function
 - Be written in singular, not plural, format
 
-In documentation we write out the name without any punctuation and use sentence
-case, meaning, the first word is capitalized and the rest is lowercase.
+In documentation we write out the name without any punctuation and use sentence case, meaning, the first word is capitalized and the rest is lowercase. case
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -804,10 +687,9 @@ case, meaning, the first word is capitalized and the rest is lowercase.
 
 <!-- end -->
 
-In code, we use the same name as the documentation, but can alter the spelling
-convention to suit the implementation.
+In code, we use the same name as the documentation, but can alter the spelling convention to suit the implementation. convention
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -821,10 +703,9 @@ convention to suit the implementation.
 
 <!-- end -->
 
-For subcomponents, the same rules apply. In documentation, write out the name
-with a space between words, and use sentence case.
+For subcomponents, the same rules apply. In documentation, write out the name with a space between words, and use sentence case. with
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -838,7 +719,7 @@ with a space between words, and use sentence case.
 
 For subcomponents in the code, use a period in place of the space.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -852,7 +733,7 @@ For subcomponents in the code, use a period in place of the space.
 
 For all components, use American spelling:
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -866,8 +747,7 @@ For all components, use American spelling:
 
 <!-- end -->
 
-There is an exception: the Labelled component uses the British spelling,
-following the `aria-labelledby` attribute as per the [ARIA specification](https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby) itself.
+There is an exception: the Labelled component uses the British spelling, following the `aria-labelledby` attribute as per the [ARIA specification](https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby) itself.
 
 ---
 
@@ -885,7 +765,7 @@ Product area icons should:
 
 - Only be used to symbolize their specific product area or function
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -903,7 +783,7 @@ Product area icons should:
 
 Functional icons not tied to product areas should represent a clear action.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -920,7 +800,7 @@ Icons with more than one function should be named to:
 - Represent their purpose
 - Describe how they look
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/content/naming.md
+++ b/polaris.shopify.com/content/foundations/content/naming.md
@@ -1,5 +1,6 @@
 ---
-name: Naming keywords:
+name: Naming
+keywords:
   - names
   - caps
   - capitalizations

--- a/polaris.shopify.com/content/foundations/content/product-content.md
+++ b/polaris.shopify.com/content/foundations/content/product-content.md
@@ -1,6 +1,5 @@
 ---
-name: Product content
-keywords:
+name: Product content keywords:
   - content standards
   - content guidelines
   - content strategy practices
@@ -29,98 +28,42 @@ keywords:
 
 # Product content
 
-Thoughtful, consistent interface content is a core element of a well-designed
-user experience.
+Thoughtful, consistent interface content is a core element of a well-designed user experience.
 
-Our content standards will help you understand how to think strategically about
-the language in your products and apps. They’ll also give you clear, tactical
-suggestions designed to help you use language to craft better experiences.
-
-[Each component](/components/get-started) also includes content guidelines about
-how to write for specific interface elements.
-
----
+Our content standards will help you understand how to think strategically about the language in your products and apps. They’ll also give you clear, tactical thegestions designed to help you use language to craft better experiences. suggestionsnent](/components/get-started) also includes content guidelines about suggestionsnentr specific interface elements. how how
 
 ## Respond to merchant needs
 
-<!-- keywords: real merchants, language, empathy -->
+Not everyone is a confident writer, but everyone can improve their content by making sure it responds to the needs of their audience. Keep in mind that rea makingn Shopify every day to run their businesses. The product, feature, or app you’re building can make a big difference to the people using it. Take some t making relyse plain language youpify merchants are busy people who may be running their online business in youition to having a full-time job, managing their family life, and doing a million other things. They’re also located all over the world, have varying youels of literacy, and some m toopify using plain language doesn’t mean dumbing content down. It’s millionaking sure language is straightforward and communicates concepts as millionntly as possible. As a benchmark, we consider plain language to be a U addition
+If you create content for Shopify’s other audiences, such as [merchant’s cu million toopifys aboutte short sentences (no more than 15–20 words). efficientlyngs and bullets to make your content easier to scan. aboutte jargon and always choose a short, simple word over a long and complicated o levelspsidioms and phrases with indirect or ironic meanings.
 
-Not everyone is a confident writer, but everyone can improve their content by
-making sure it responds to the needs of their audience. Keep in mind that real people
-rely on Shopify every day to run their businesses. The product, feature, or app
-you’re building can make a big difference to the people using it. Take some time
-to learn about who they are, what they need, and the language they use.
-
----
-
-## Use plain language
-
-<!-- keywords: literacy, english as a first language, english as a second language, esl, short sentences, using headings, using bullets, scannable, jargon, idioms, terminology, industry standard, repeated words, small screens -->
-
-Shopify merchants are busy people who may be running their online business in
-addition to having a full-time job, managing their family life, and doing a
-million other things. They’re also located all over the world, have varying
-levels of literacy, and some may not speak English as their first language. Some content can be translated poorly and can be misinterpreted.
-
-Writing using plain language doesn’t mean dumbing content down. It’s
-about making sure language is straightforward and communicates concepts as
-efficiently as possible. As a benchmark, we consider plain language to be a United States grade 7 reading level. Grade reading level can be checked using apps like http://www.hemingwayapp.com/ or https://readable.com/.
-
-If you create content for Shopify’s other audiences, such as [merchant’s customers](/content/merchant-to-customer), the same plain language guidelines apply. Some reading level exceptions can be made for audiences with a high level of subject matter expertise in an area, like partner developers. Keep in mind that we still aim to keep technical content readable by other UX disciplines who want to learn about technical subjects, or for those who speak English as a second language.
-
-### Tips
-
-- Write short sentences (no more than 15–20 words).
-- Use headings and bullets to make your content easier to scan.
-- Avoid jargon and always choose a short, simple word over a long and
-  complicated one.
-- Avoid idioms and phrases with indirect or ironic meanings.
-- Only use industry-standard terminology when you have reason to believe it will
-  improve understanding. Spend time researching what words people use,
-  rather than defaulting to what corporations call things.
+- Only use industry-standard terminology when you have reason to believe it will improve understanding. Spend time researching what words people use, rather than defaulting to what corporations call things.
 - Edit unnecessary or repeated words.
-- Write for small screens first. Constraints can help you focus on the most
-  important message.
-- Read your content out loud. If you get tripped up or it doesn’t sound like
-  something a human would say, your content needs to be edited.
+- Write for small screens first. Constraints can help you focus on the most important message.
+- Read your content out loud. If you get tripped up or it doesn’t sound like something a human would say, your content needs to be edited.
 
 ---
 
 ## Encourage action
 
-<!-- keywords: content structure, actionable language, writing action, button copy, prioritizing tasks, call to action -->
-
-People use Shopify to get things done, whether they’re managing a store, or making a purchase. Content should be written and structured
-to help the reader understand and take the most important actions.
+People use Shopify to get things done, whether they’re managing a store, or making a purchase. Content should be written and structured to help the reader understand and take the most important actions.
 
 ### Tips
 
-- Calls to action on buttons and links should start with a strong verb that
-  describes the action a person will take when they click.
-- Always prioritize the most important information and task — don’t make people
-  dig to find what they care about.
-- Break down complicated tasks into steps that help people focus on one thing
-  at a time.
-- Use the [active voice](/content/grammar-and-mechanics#basics) to clarify the
-  subject and the action.
+- Calls to action on buttons and links should start with a strong verb that describes the action a person will take when they click.
+- Always prioritize the most important information and task — don’t make people dig to find what they care about. toBreak down complicated tasks into steps that help people focus on one thing at a time.
+- Use the [active voice](/content/grammar-and-mechanics#basics) to clarify the subject and the action.
 
 ---
 
 ## Be consistent
 
-<!-- keywords: consistency in copy, consistent copy, consistent nouns, consistent verbs, writing consistently, write consistently, synonyms, plain language, word list, merchant words, merchant language, merchant terms -->
-
-To help your audience understand key concepts and actions they can take, use
-consistent nouns (words used to identify people, places, or things) and verbs
+To help your audience understand key concepts and actions they can take, use consistent nouns (words used to identify people, places, or things) and verbs
 (action words) wherever possible.
 
 ### Tips
 
-- Get in the habit of making a list of all the most important verbs and nouns in
-  the experience you’re building.
-- Look at your word list. Does each word clearly describe the object or action
-  it represents in the simplest way possible?
+- Get in the habit of making a list of all the most important verbs and nouns in the experience you’re building.
+- Look at your word list. Does each word clearly describe the object or action it represents in the simplest way possible?
 - Does your language reflect how people think and the words they use?
-- Identify synonyms (a word or phrase that means exactly or nearly the same as
-  another word or phrase in the same language), and eliminate them. Each
-  important object and action should have a single word to represent it.
+- Identify synonyms (a word or phrase that means exactly or nearly the same as another word or phrase in the same language), and eliminate them. Each important object and action should have a single word to represent it.

--- a/polaris.shopify.com/content/foundations/content/product-content.md
+++ b/polaris.shopify.com/content/foundations/content/product-content.md
@@ -1,5 +1,6 @@
 ---
-name: Product content keywords:
+name: Product content
+keywords:
   - content standards
   - content guidelines
   - content strategy practices

--- a/polaris.shopify.com/content/foundations/content/release-notes.md
+++ b/polaris.shopify.com/content/foundations/content/release-notes.md
@@ -100,7 +100,7 @@ The Shopify mobile app now uses {x} to do {y}.
 
 Releases should always be specific enough to avoid general or generic messaging.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -151,7 +151,7 @@ Bug fix: Swapping from one store and into another no longer causes the app to cr
 
 For everyday fixes and updates, specify what was changed in a simple way.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -165,7 +165,7 @@ For everyday fixes and updates, specify what was changed in a simple way.
 
 For infrastructure updates, explain the merchant benefit.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -179,7 +179,7 @@ For infrastructure updates, explain the merchant benefit.
 
 For technical updates, be specific but keep the language simple.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -193,7 +193,7 @@ For technical updates, be specific but keep the language simple.
 
 Avoid humour.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/content/voice-and-tone.md
+++ b/polaris.shopify.com/content/foundations/content/voice-and-tone.md
@@ -14,14 +14,11 @@ keywords:
 
 # Voice and tone
 
-Learn how to apply Shopify’s voice and choose the right tone, no matter what
-product, feature, or app you’re building.
+Learn how to apply Shopify’s voice and choose the right tone, no matter what product, feature, or app you’re building.
 
 ---
 
 ## What are voice and tone?
-
-<!-- keywords: difference between voice and tone, what is voice, what is tone, what does voice mean?, what does tone mean? -->
 
 Shopify’s voice is a reflection of who we are. We should always sound like
 Shopify.
@@ -45,8 +42,6 @@ You'll find more specific guidelines on how to adapt your tone to different situ
 ---
 
 ## Voice guidelines
-
-<!-- keywords: confident not arrogant, empathetic not overprotective, transparent not blunt, what is shopifys voice, what is shopify’s voice, what does shopify sound like, sound like, shopifys personality, shopify’s personality, voice writing, confident, empathetic, transparent, not arrogant, not overprotective, not blunt, arrogant, overprotective, blunt -->
 
 As Shopify’s voice, we should always:
 
@@ -77,8 +72,6 @@ As Shopify’s voice, we should always:
 
 ## Adapting tone by situation
 
-<!-- keywords: tone examples, error message tone, tone of an error messages, positive tones, neutral tones, negative tones, change in tones, changing tones, tone of messages, message tones, tone guidelines -->
-
 Our tone adapts to the context. We’ll use certain voice attributes more or less based on the situation.
 
 Often people frame tone guidance around adapting to the emotional state of the audience. The reality is we never know a person’s emotional state. Even when things seem the most positive, we can’t be sure.
@@ -89,7 +82,7 @@ While it’s helpful to consider how your audience is likely to feel, don’t as
 
 When everything is working as it should, our goal is to give people what they need to get work done, without getting in the way or drawing attention to ourselves. We want the audience to know what something is or that something has happened as expected.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -105,7 +98,7 @@ Use overly complicated or intimidating language.
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -130,7 +123,7 @@ Some people will want to be guided step-by-step through the process, while other
 
 Remember, they may have sought this out specifically or we may have recommended it to them, so don’t assume that they want or need to use it.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -146,7 +139,7 @@ _Create a new campaign and you could double your sales this holiday season._
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -170,7 +163,7 @@ In this case, our job is to help people understand what happened so that they ca
 
 Read the [error message guidelines](https://polaris.shopify.com/patterns/error-messages) for more detailed guidance.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -186,7 +179,7 @@ _Bad request, forbidden, fatal, expectation failed, unresolved, invalid_
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -208,7 +201,7 @@ There are situations where we want to acknowledge that someone completed a compl
 
 While we don’t need to celebrate the accomplishment, we should recognize that they put in the time and effort. Depending on the level of effort, these may be simple confirmations or more active recognition that they completed something difficult.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -224,7 +217,7 @@ _Congrats! You set up your single login for Shopify._
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -246,7 +239,7 @@ These are situations when we want to keep people moving along a desired path. In
 
 We don’t want to be too overzealous or action-driven here—it’s more about helping people understand the next step and giving them the context they need to take it.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -262,7 +255,7 @@ _You’re just a few steps away from receiving your first order._
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -280,7 +273,7 @@ In this case, there’s a serious risk of damaging trust and hurting our relatio
 
 Read the [error message guidelines](https://polaris.shopify.com/patterns/error-messages) for more detailed guidance.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -296,7 +289,7 @@ _Today’s sales data might not be accurate, but don’t worry—it’s just tem
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -306,7 +299,7 @@ _All systems are now fully operational. We recognize and apologize for the stres
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -322,7 +315,7 @@ It’s exciting to launch a new feature or update, but always consider the audie
 
 When you’re announcing something new, focus on educating and explaining what it is, what it’s used for, and what the user can expect.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -342,7 +335,7 @@ _It’s never been easier to customize the fonts, colors, and styles of Buy Butt
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -360,7 +353,7 @@ Let audiences know that we understand that it’s an important moment and we’r
 
 Remember, this is about celebrating their accomplishments, not ours. Launching something new? You probably don’t need to celebrate with them. Read our guidance around [announcing new features and updates](#announcing-features).
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -376,7 +369,7 @@ _You set up your payment providers, congrats!_
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/design/colors.md
+++ b/polaris.shopify.com/content/foundations/design/colors.md
@@ -10,17 +10,11 @@ keywords:
 
 Our color system builds on the recognition of the Shopify brand colors to make the admin interface more usable.
 
-<!-- showcasecontent -->
-
 ![Diagram showcasing layers of color of various hues](/images/foundations/design/colors/color-intro@2x.png)
-
-<!-- end -->
 
 ---
 
 ## Principles
-
-<!-- keywords: color principles, accessible colors, focus attention, communication -->
 
 ### Communication is key
 
@@ -38,17 +32,9 @@ The color system is designed within the HSLuv color space to generate themes tha
 
 ## Color roles
 
-<!-- keywords: color roles, palette scss, color scheme, color names, color sass, sass colors, hex colors -->
-
-<!-- showcasecontent -->
-
 ![Diagram of colors representing the new Polaris color system](/images/foundations/design/colors/color-roles@2x.png)
 
 We define colors based on the role they play in the interface. There are 10 color roles, which we use to generate the values of all the color variants in the palette.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Diagram presenting color variants in a user interface](/images/foundations/design/colors/color-variants@2x.png)
 
@@ -56,15 +42,9 @@ We define colors based on the role they play in the interface. There are 10 colo
 
 Color variants are variables that apply color to the UI, and their values are generated from the color roles. Color variants are available as tokens.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Diagram presenting a color naming pattern for the color token Border Success Subdued](/images/foundations/design/colors/color-variant-naming@2x.png)
 
 Variants share a naming pattern that references their color role, the interaction state they define, and any UI elements they’re linked to.
-
-<!-- end -->
 
 ---
 
@@ -72,17 +52,11 @@ Variants share a naming pattern that references their color role, the interactio
 
 How the color roles relate to the variants, and how they’re applied across the interface.
 
-<!-- centeredcontent -->
-
 ![Diagram presenting the surface color role, with mainly white and gray colors](/images/foundations/design/colors/color-role-surface@2x.png)
 
 ### Surface
 
 Surface colors affect surfaces of components, such as page, card, sheet, and popover.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Diagram presenting the on surface color role, with mainly black and darker gray colors](/images/foundations/design/colors/color-role-onsurface@2x.png)
 
@@ -90,19 +64,11 @@ Surface colors affect surfaces of components, such as page, card, sheet, and pop
 
 Apply on-surface colors to elements that appear on neutral surfaces, usually borders, secondary icons, and text elements.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Diagram presenting the primary color role, with mainly green colors](/images/foundations/design/colors/color-role-primary@2x.png)
 
 ### Primary
 
 Use primary colors for primary actions like buttons, icons and text on navigation and tabs, and for the background in navigation and tab interactive states.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Diagram presenting the secondary color role, with mainly white and gray colors](/images/foundations/design/colors/color-role-secondary@2x.png)
 
@@ -110,19 +76,11 @@ Use primary colors for primary actions like buttons, icons and text on navigatio
 
 Use secondary colors for secondary and tertiary buttons and the background of form elements.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Diagram presenting the interactive color role, with mainly blue colors](/images/foundations/design/colors/color-role-interactive@2x.png)
 
 ### Interactive
 
 Use interactive colors for things like links, focus indicators, and selected interactive states.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Diagram presenting the success color role, with mainly green colors](/images/foundations/design/colors/color-role-success@2x.png)
 
@@ -130,19 +88,11 @@ Use interactive colors for things like links, focus indicators, and selected int
 
 Success colors indicate something positive, like the success of a merchant action or to illustrate growth.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Diagram presenting the warning color role, with mainly yellow and orange colors](/images/foundations/design/colors/color-role-warning@2x.png)
 
 ### Warning
 
 Warning colors let the merchant know they need to take action, and are applied to badges, banners, and exception lists.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Diagram presenting the critical color role, with mainly red colors](/images/foundations/design/colors/color-role-critical@2x.png)
 
@@ -150,24 +100,14 @@ Warning colors let the merchant know they need to take action, and are applied t
 
 Critical colors are for destructive interactive elements, errors, and critical events that require immediate action.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Diagram presenting the highlight color role, with mainly cyan and teal colors](/images/foundations/design/colors/color-role-highlight@2x.png)
 
 ### Highlight
 
 Highlight colors indicate important elements that don’t require immediate action. They’re used with informational banners and badges, indicators that draw attention to new information, loading or progress bars, and data visualization.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Diagram presenting the decorative color role, with a variety of colors like yellow, turquoise and rose](/images/foundations/design/colors/color-role-decorative@2x.png)
 
 ### Decorative
 
 Decorative colors are for expressive communications that assert the Shopify brand presence.
-
-<!-- end -->

--- a/polaris.shopify.com/content/foundations/design/data-visualizations.md
+++ b/polaris.shopify.com/content/foundations/design/data-visualizations.md
@@ -6,57 +6,40 @@ keywords:
 
 # Data visualizations
 
-Visualizations surface patterns in data, and provide immediate answers to a
-single, specific question.
+Visualizations surface patterns in data, and provide immediate answers to a single, specific question.
 
-This section outlines data visualization practices at Shopify and how to
-leverage them.
+This section outlines data visualization practices at Shopify and how to leverage them.
 
 ---
 
 ## Data visualizations at Shopify
 
-<!-- keywords: data visualization process, data process, data styles, data formats, data integrity, data accuracy, trustful data, data trust, data presentations -->
+The data visualization process always begins with a set of data, a question, and analysis of the data to find the answer. Each visualization should focus on answering a single question about the dataset. For example, “What are my sales over time?”
 
-The data visualization process always begins with a set of data, a question, and
-analysis of the data to find the answer. Each visualization should focus on
-answering a single question about the dataset. For example, “What are my sales
-over time?”
-
-By maintaining consistent styles and formats for our data visualizations, we
-ensure that data is presented in a truthful and accurate manner to maintain
-integrity with merchants.
+By maintaining consistent styles and formats for our data visualizations, we ensure that data is presented in a truthful and accurate manner to maintain integrity with merchants.
 
 ---
 
 ## Guidelines
 
-<!-- keywords: data visualization guidelines, data visualization standards, data points, datapoints, real data points -->
-
 Data visualization should be approached by:
 
 ### Solving a problem
 
-Have a clear question that needs to be answered. If multiple answers to multiple
-questions are illustrated in a visualization, it will become over complicated
-and hard to understand.
+Have a clear question that needs to be answered. If multiple answers to multiple questions are illustrated in a visualization, it will become over complicated and hard to understand.
 
 ### Testing with real data
 
-Testing with real data will reveal the effectiveness of the visualization. Also
-test when there are a few data points (one or two) or many data points (100 or more).
+Testing with real data will reveal the effectiveness of the visualization. Also test when there are a few data points (one or two) or many data points (100 or more).
 
 ### Scaling by number of datapoints
 
-Think about how the visualization will scale with more or fewer data points. Look
-out for cases where data is sparse (mostly zero) or spiky (some values are much
+Think about how the visualization will scale with more or fewer data points. Look out for cases where data is sparse (mostly zero) or spiky (some values are much
 larger than others).
 
 ---
 
 ## Five core traits
-
-<!-- keywords: data visualization guidelines, evaluating data visualizations, accuracy, data granularity, intuitiveness, engagement, focus -->
 
 An effective data visualization strikes the right balance between the five core traits: accuracy, intuitiveness, engagement, focus, and data granularity. It’s important to be intentional about which of these you focus on, and which are less important, in order to answer your specific question in the best way for your target audience. Understanding these traits help you choose between the many ways to visualize data by giving you a language for evaluating a visualization's effectiveness.
 
@@ -84,64 +67,58 @@ Data granularity is about the level of detail of the data set presented in the v
 
 ## Axis and labelling conventions
 
-<!-- keywords: quantitative data, 2 axis, axis labelling, labelling axis, axis labels -->
+All standard charts that show quantitative data have 2 axes that should be labeled for clarity.
 
-All standard charts that show quantitative data have 2 axes that should be
-labeled for clarity.
-
-- Labelling should be outside and separate from the data area. This ensures the
-  user understands the range of the data without taking focus away from the
-  data.
-- Ensure that all labels are clear and accurate in what they represent. Use
-  simple and short language.
+- Labelling should be outside and separate from the data area. This ensures the user understands the range of the data without taking focus away from the data.
+- Ensure that all labels are clear and accurate in what they represent. Use simple and short language.
 
 ---
 
 ## Granular guidelines
 
-<!-- keywords: axis guidelines, axis lines, axis label conventions, skipping labels, x-axis labels, y-axis labels, ticks, x-axis abbreviations, axis label abbreviations, chart abbreviations, graph abbreviations, y-axis abbreviations, x-axis conventions, y-axis conventions -->
-
 ### Axis lines
 
 Axis lines should be used as a guideline to show quantitative data, yet be unobtrusive.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Ensure axis lines only appear where the data appears.
+
 ![A light grey chart with axis lines](/images/foundations/design/data-visualizations/do/ensure-axis-lines-only-appear-where-data-appears@2x.png)
 
 #### Don’t
 
 Use bleeding axis lines to the edge of the screen.
+
 ![A chart with axis lines filling the screen](/images/foundations/design/data-visualizations/dont/use-bleeding-axis-lines-to-the-edge-of-the-screen@2x.png)
 
 <!-- end -->
 
 ### Skipping labels
 
-Labelling the tick marks on both the y-axis and x-axis helps the visualization
-become more clear in what it represents.
+Labelling the tick marks on both the y-axis and x-axis helps the visualization become more clear in what it represents.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Skip labels in regular intervals.
+
 ![A bar chart plotting time using 12am, 8am, 12pm, and 8pm](/images/foundations/design/data-visualizations/do/skip-labels-in-regular-intervals@2x.png)
 
 #### Don’t
 
 Try to squeeze all labels together.
+
 ![A chart plotting time with too many axis labels](/images/foundations/design/data-visualizations/dont/squeeze-all-labels-together@2x.png)
 
 <!-- end -->
 
 ### X-axis Abbreviations
 
-Shopify uses standard abbreviations for months and weekdays in order to reduce
-clutter in visualizations.
+Shopify uses standard abbreviations for months and weekdays in order to reduce clutter in visualizations.
 
 - Use 12 hour format for time, with lowercase letters (12am, 6pm)
 - Use the first three letters for days of the week (Sun, Mon)
@@ -149,16 +126,18 @@ clutter in visualizations.
 - For specific days, use the format ‘day + month’ (10 Apr, 11 Apr)
 - For specific months, use the format month + year (Apr 2011, May 2017)
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Use standard abbreviations for labeling.
+
 ![A chart showing the days of the week abbreviated to Mon, Tues, and so on](/images/foundations/design/data-visualizations/do/use-standard-abbreviations-for-labeling2@2x.png)
 
 #### Don’t
 
 Slant labels to make them fit.
+
 ![A chart with labels slanted at a 45 degree angle](/images/foundations/design/data-visualizations/dont/slant-labels-to-make-them-fit2@2x.png)
 
 <!-- end -->
@@ -167,16 +146,18 @@ Slant labels to make them fit.
 
 Shopify uses standard monetary abbreviations for the y-axis to reduce clutter.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Abbreviate using ‘k’ for thousand, ‘b’ for billion.
+
 ![A chart with a y-axis representing a thousand dollars as “$1.0k”](/images/foundations/design/data-visualizations/do/abbreviate-using-k-for-thousand-b-for-billion-and-include-the-unit@2x.png)
 
 #### Don’t
 
 Go over 3 numeric characters, 1 decimal, or 1 letter.
+
 ![A chart with a y-axis that represents the value of a thousand and one dollars as “$1.001k”](/images/foundations/design/data-visualizations/dont/go-over-3-numeric-characters-1-decimal-and-1-single-letter@2x.png)
 
 <!-- end -->
@@ -185,16 +166,18 @@ Go over 3 numeric characters, 1 decimal, or 1 letter.
 
 Labels should be clear and concise.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Center all labels on the bar and the tick mark.
+
 ![A bar chart with the abbreviated days of the week centered on the ticks which are centered on the bars that they represent](/images/foundations/design/data-visualizations/do/center-all-labels-with-the-bar-and-tick2@2x.png)
 
 #### Don’t
 
 Use decimals on the x-axis labels.
+
 ![A bar chart plotting numbers with decimals on the x-axis](/images/foundations/design/data-visualizations/dont/use-decimals-on-x-axis-labels2@2x.png)
 
 <!-- end -->
@@ -203,11 +186,12 @@ Use decimals on the x-axis labels.
 
 Labels should be clear and concise.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Left align labels and keep them above y-axis lines.
+
 ![A chart with a dollar value on the y-axis that’s aligned to the left and raised slightly from the grey axis](/images/foundations/design/data-visualizations/do/left-align-labels-and-keep-them-slightly-above-the-y-axis-lines@2x.png)
 
 <!-- end -->
@@ -216,64 +200,37 @@ Left align labels and keep them above y-axis lines.
 
 ## Color palettes
 
-<!-- keywords: data visualization colors, data colors, multiseries data colors -->
-
-Color in data visualization has a very specific meaning. The data visualization
-color palette provides specific colors that can be used alone or in a group,
-depending on the intent.
-
-<!-- floatedcontent -->
+Color in data visualization has a very specific meaning. The data visualization color palette provides specific colors that can be used alone or in a group, depending on the intent.
 
 ### Single data series
 
-Use when there is a single data series. For example, a bar chart, column chart,
-or a single line chart.
+Use when there is a single data series. For example, a bar chart, column chart, or a single line chart.
+
 ![A line graph with y-axis and x-axis labels and a single purple line plotting data](/images/foundations/design/data-visualizations/single-data-series@2x.png)
-
-<!-- end -->
-
-<!-- floatedcontent -->
 
 ![A line chart with 2 different colors comparing current values to a past value](/images/foundations/design/data-visualizations/single-comparison-to-past@2x.png)
 
 ### Single comparison to past
 
-This is used when the data set is being compared to to its past values. For
-example, total sales by month, this year, compared to last year. In this case,
-the current value will be purple and the past value will be grey.
-
-<!-- end -->
-
-<!-- floatedcontent -->
+This is used when the data set is being compared to to its past values. For example, total sales by month, this year, compared to last year. In this case, the current value will be purple and the past value will be grey.
 
 ### Multiseries data
 
-Used when there are multiple data sets to compare. For example, a multiseries
-line chart. Go down the list as the number of datasets increase.
+Used when there are multiple data sets to compare. For example, a multiseries line chart. Go down the list as the number of datasets increase.
+
 ![A line chart with multiple data points represented by different colors](/images/foundations/design/data-visualizations/multiseries-data@2x.png)
-
-<!-- end -->
-
-<!-- floatedcontent -->
 
 ![One example of an upward trend in percentage sales represented in gren and another example of a downward trend in](/images/foundations/design/data-visualizations/biased-charts@2x.png)
 
 ### Biased
 
-Used when certain data need is displayed in a negative or positive light. For
-example, showing positive or negative change relative to a reference value.
-
-<!-- end -->
+Used when certain data need is displayed in a negative or positive light. For example, showing positive or negative change relative to a reference value.
 
 ---
 
 ## Horizontal bar charts
 
-<!-- keywords: horizontal bar graphs, bar graphs, bar positioning, bar colors, bar chart labels, bar graph labels -->
-
-Bar charts are used for comparing discrete categories. Use a bar chart when
-there is a constraint to the number of data points that can appear on the
-visualization, otherwise it becomes hard to scale.
+Bar charts are used for comparing discrete categories. Use a bar chart when there is a constraint to the number of data points that can appear on the visualization, otherwise it becomes hard to scale.
 
 ### Best used for
 
@@ -285,20 +242,20 @@ When the number of data points can exceed 6. In this case, use a table.
 
 ### Bar chart labels
 
-Label each bar with what it’s displaying, as well as the value. For more best
-practices, visit axis and label conventions.
+Label each bar with what it’s displaying, as well as the value. For more best practices, visit axis and label conventions.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
-Include a label on each bar. If the bar is too small, include it outside of the
-bar.
+Include a label on each bar. If the bar is too small, include it outside of the bar.
+
 ![A horizontal bar chart with 2 dollar values within the bar and the lowest value outside of the bar to the right](/images/foundations/design/data-visualizations/do/include-a-label-on-each-bar-if-the-bar-is-too-small-include-it-outside-of-the-bar@2x.png)
 
 #### Do
 
 Include a label on top of each bar to display what data it’s showing.
+
 ![A horizontal bar chart displaying the country represented by each bar](/images/foundations/design/data-visualizations/do/include-a-label-on-top-of-each-bar-to-display-what-data-it-is-showing@2x.png)
 
 <!-- end -->
@@ -307,38 +264,35 @@ Include a label on top of each bar to display what data it’s showing.
 
 Use one color for all bars.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Give negative bars 60% opacity.
+
 ![A horizontal bar chart with solid purple positive bars and purple negative bars set to 60% opacity](/images/foundations/design/data-visualizations/do/give-negative-bars-60-opacity@2x.png)
 
 #### Don’t
 
 Use multiple colors for the bars.
+
 ![A horizontal bar chart using a different color for each bar](/images/foundations/design/data-visualizations/dont/use-multiple-colors-for-the-bars@2x.png)
 
 <!-- end -->
 
 ### Bar positioning
 
-Make sure the bars are proportional in width, roughly twice the size of the
-space between the bars.
+Make sure the bars are proportional in width, roughly twice the size of the space between the bars.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Make the width of each bar about twice as wide as the space between them.
 
-<!-- ![](data-viz/do/findthese) -->
-
 #### Don’t
 
 Make the bars too skinny.
-
-<!-- ![](data-viz/dont/findthese) -->
 
 <!-- end -->
 
@@ -346,11 +300,7 @@ Make the bars too skinny.
 
 ## Vertical column charts
 
-<!-- keywords: vertical bar graphs, vertical bar charts, bar graphs, bar positioning, bar colors, bar chart labels, bar graph labels, graph interactions, data visualization interactions, graph interactivity -->
-
-Column charts are used to show change over time, trends, and individual data
-points. Use column charts for when the number of data points is fewer than 30, or
-else use a line chart.
+Column charts are used to show change over time, trends, and individual data points. Use column charts for when the number of data points is fewer than 30, or else use a line chart.
 
 ### Best used for
 
@@ -359,58 +309,58 @@ else use a line chart.
 
 ### Don’t use
 
-When the number of data points can exceed 31. In this case, use a
-[line chart](/design/data-visualizations#line-charts).
+When the number of data points can exceed 31. In this case, use a [line chart](/design/data-visualizations#line-charts).
 
 ### Color
 
 All bars should be the same color.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Use one color for all bars.
+
 ![A bar chart showing a data trend with the same bar color](/images/foundations/design/data-visualizations/do/use-one-color-for-all-bars@2x.png)
 
 #### Don’t
 
 Use multiple colors for the bars.
+
 ![A bar chart showing the same data point with different colors](/images/foundations/design/data-visualizations/dont/use-multiple-colors-for-the-bars2@2x.png)
 
 <!-- end -->
 
 ### Bar positioning
 
-Make sure the bars are proportional in width, roughly twice the size of the
-space between the bars.
+Make sure the bars are proportional in width, roughly twice the size of the space between the bars.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Make the width of each bar about twice as wide as the space between them.
+
 ![A bar chart properly formatted with spaces half the size of each bar](/images/foundations/design/data-visualizations/do/make-the-width-of-each-bar-about-twice-the-space-between-them@2x.png)
 
 #### Don’t
 
 Make the bars too skinny.
+
 ![A bar chart with spaces 4 times larger than the bar itself](/images/foundations/design/data-visualizations/dont/make-the-bars-too-skinny@2x.png)
 
 <!-- end -->
 
 ### Interactivity
 
-Include some interactivity on the bars upon hover since users will be looking at
-individual data points. The top line of the tooltip should follow x-axis
-abbreviation and labelling guidelines, while the bottom line tooltip should
-follow y-axis abbreviation and labelling guidelines.
+Include some interactivity on the bars upon hover since users will be looking at individual data points. The top line of the tooltip should follow x-axis abbreviation and labelling guidelines, while the bottom line tooltip should follow y-axis abbreviation and labelling guidelines.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Include tooltips for x-axis and y-axis values.
+
 ![A bar chart with a tool tip on a bar displaying the date axis point and the dollar value axis point](/images/foundations/design/data-visualizations/do/include-tooltips-with-both-the-x-axis-value-and-y-axis-value@2x.png)
 
 <!-- end -->
@@ -419,11 +369,7 @@ Include tooltips for x-axis and y-axis values.
 
 ## Line charts
 
-<!-- keywords: connecting data points, data series, line graphs -->
-
-A line chart is created by connecting a series of data points together with a
-line. Line charts are good to show change over time, comparisons, and trends.
-Use line charts when the number of data points is more than 30.
+A line chart is created by connecting a series of data points together with a line. Line charts are good to show change over time, comparisons, and trends. Use line charts when the number of data points is more than 30.
 
 ### Best used for
 
@@ -433,30 +379,26 @@ Use line charts when the number of data points is more than 30.
 
 ### Axis and labelling
 
-Set up the chart area using the
-[axis and labelling guidelines](/design/data-visualizations#axis-and-labelling-conventions)
+Set up the chart area using the [axis and labelling guidelines](/design/data-visualizations#axis-and-labelling-conventions)
 
 ---
 
 ## Multiline charts
 
-<!-- keywords: number of lines in line chart, number of lines in line graph, line graph legend -->
+Line graphs work well when multiple datasets need to be compared. Use the [color palette](/design/colors#color-palette) to select colors.
 
-Line graphs work well when multiple datasets need to be compared. Use the
-[color palette](/design/colors#color-palette) to select colors.
-
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Use contrasting color and include a legend.
+
 ![A line chart with 2 lines using purple and teal to represent the years 2015 and 2016](/images/foundations/design/data-visualizations/do/use-contrasting-colors-and-include-a-legend@2x.png)
 
 #### Don’t
 
-<!-- Label each line with a legend. Label the lines on the actual visualization. -->
-
 Use more than 4 lines.
+
 ![A line chart with 4 lines of different colors](/images/foundations/design/data-visualizations/dont/use-more-than-4-lines-try-to-stick-to-2-lines@2x.png)
 
 <!-- end -->
@@ -465,11 +407,7 @@ Use more than 4 lines.
 
 ## Display metrics
 
-<!-- keywords: quantifiable measures, single values, metric units, metric scope, metric movements, metric colors -->
-
-A display metric is a quantifiable measure that is used to track and display the
-status of a specific process. Examples include a sum, an average, or a movement
-in a positive or negative direction.
+A display metric is a quantifiable measure that is used to track and display the status of a specific process. Examples include a sum, an average, or a movement in a positive or negative direction.
 
 ### Best used for
 
@@ -477,35 +415,36 @@ Showing a single value with a base unit.
 
 ### Units
 
-Metrics should be paired with their base unit in close proximity to the number.
-Use concise and clear language for metrics.
+Metrics should be paired with their base unit in close proximity to the number. Use concise and clear language for metrics.
 
 ### Scope
 
 Metrics should be scoped to indicate the timeline of the data.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Include a dimension of time to scope the value.
+
 ![Diagram showing “sales this week” with a numeric dollar value](/images/foundations/design/data-visualizations/do/include-a-dimension-of-time-to-scope-the-value@2x.png)
 
 <!-- end -->
 
 ### Movement
 
-If needed, consider including a comparison indicator, such as comparison to the
-previous time or average.
+If needed, consider including a comparison indicator, such as comparison to the previous time or average.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Use green for positive movement.
+
 ![Diagram of green being used to signify an upward trend in data](/images/foundations/design/data-visualizations/do/use-green-to-signify-positive-movement@2x.png)
 
 Use red for negative movement.
+
 ![Diagram of red being used to signify a downward trend in data](/images/foundations/design/data-visualizations/do/use-red-to-signify-negative-movement@2x.png)
 
 <!-- end -->
@@ -514,12 +453,7 @@ Use red for negative movement.
 
 ## Tables
 
-<!-- keywords: tables, charts, discrete data, table filtering, chart filtering, table ordering, chart ordering, table alignment, column alignment, vertical alignment, row highlighting, table highlighting, chart highlighting, table colors, chart colors, table totals, chart toals -->
-
-A table is a good way to showcase a large amount of information which has a
-variety of columns and data to show for each entity. A table should be used when
-multiple metrics and categories need to be presented together, and accurate
-lookup of the data values is more important that showing patterns in the data.
+A table is a good way to showcase a large amount of information which has a variety of columns and data to show for each entity. A table should be used when multiple metrics and categories need to be presented together, and accurate lookup of the data values is more important that showing patterns in the data.
 
 ### Best used for
 
@@ -529,52 +463,54 @@ lookup of the data values is more important that showing patterns in the data.
 
 ### Alignment
 
-Consistent vertical alignment is essential for fast visual comparison between
-values in a table.
+Consistent vertical alignment is essential for fast visual comparison between values in a table.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Left align non-numeric values and right align numeric values.
+
 ![A table showing product inventory with product names aligned to the left and numbers aligned to the right](/images/foundations/design/data-visualizations/do/left-align-non-numeric-values-and-right-align-numeric-values@2x.png)
 
 #### Don’t
 
 Center column headers.
+
 ![A table showing product inventory data with headers, numbers, and titles centered](/images/foundations/design/data-visualizations/dont/center-align-columns@2x.png)
 
 <!-- end -->
 
 ### Separation
 
-In order to reduce clutter and non-data ink, we prefer to subtly separate each
-row.
+In order to reduce clutter and non-data ink, we prefer to subtly separate each row.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Use light lines to indicate separation between rows.
+
 ![A table with three rows separated by light grey lines](/images/foundations/design/data-visualizations/do/separate-rows-with-dividing-lines@2x.png)
 
 #### Don’t
 
 Highlight every other row to indicate separation.
+
 ![A table with a white background and grey lines using a darker grey every other row](/images/foundations/design/data-visualizations/dont/separate-rows-by-highlighting-every-other-row@2x.png)
 
 <!-- end -->
 
 ### Totals
 
-Totals allow merchants to understand the data holistically and should be easy to
-find.
+Totals allow merchants to understand the data holistically and should be easy to find.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
 Place totals as the first row beneath the headers, and bold the text.
+
 ![A diagram showing individual product sales underneath the total sales in bold type](/images/foundations/design/data-visualizations/do/place-bold-totals-in-the-first-row@2x.png)
 
 <!-- end -->
@@ -595,7 +531,7 @@ Others might simply have trouble understanding data presented in a chart or grap
 
 To support the needs of different merchants, always provide multiple formats for data visualizations.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -611,7 +547,7 @@ Provide data visualizations in only one format.
 
 Color is critical for visualization, but can cause issues for merchants with color blindness and low vision. Color should be used in a way that supports the interpretation of visual information for all merchants, including those with visual issues.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/design/design.md
+++ b/polaris.shopify.com/content/foundations/design/design.md
@@ -8,11 +8,7 @@ keywords:
 
 # Design
 
-<!-- keywords: design, new design, new polaris, changes, changing, update, design language -->
-
 These are the principles that shape how we design all the experiences across the Shopify admin.
-
-<!-- showcasecontent -->
 
 ![Design of Polaris for Admin, showcasing an admin interface and a mobile view](/images/foundations/design/design-intro@2x.png)
 
@@ -35,5 +31,3 @@ Being intentional about when the Shopify brand comes forward, and when it takes 
 ### Familiarity across experiences
 
 Defined patterns and guidelines help us design a wide variety of experiences that still always feel&nbsp;like&nbsp;Shopify.
-
-<!-- end -->

--- a/polaris.shopify.com/content/foundations/design/icons.md
+++ b/polaris.shopify.com/content/foundations/design/icons.md
@@ -23,17 +23,11 @@ keywords:
 
 Icons in the Shopify admin act as visual aids to help merchants complete tasks. They’re simple, informative, and build on the visual language of the design system.
 
-<!-- showcasecontent -->
-
 ![A collection of various icons used in the Shopify Admin.](/images/foundations/design/icons/icons-intro@2x.png)
-
-<!-- end -->
 
 ---
 
 ## Principles
-
-<!-- keywords: icon principles, icons, how to use icons -->
 
 ### Simple over detailed
 
@@ -51,17 +45,11 @@ The design of an icon communicates tone, much like the content it’s paired wit
 
 ## Creating icons
 
-<!-- showcasecontent -->
-
 ![Five icons in order: a trash can to represent a delete action, a cogwheel to represent settings, a spyglass to represent search, a pin to represent location and a bell to represent notifications.](/images/foundations/design/icons/icons-established@2x.png)
 
 ### Use established icons
 
 Icons that have been used for a long time worldwide have a higher chance of being recognized and understood quickly. Don’t reinvent an icon that’s already been accepted as the convention. There are global, established conventions for concepts like “delete,” “settings,” and “search.” These symbols are effective, and don’t need to be redefined.
-
-<!-- end -->
-
-<!-- showcasecontent -->
 
 ![An icon of a cogwheel that represents Store, Product, and global settings.](/images/foundations/design/icons/icons-limit-variations@2x.png)
 
@@ -69,17 +57,11 @@ Icons that have been used for a long time worldwide have a higher chance of bein
 
 Use a single icon to represent variations of the same concept. Shipping settings, store settings, account settings, and any new settings should use the cog icon. Don’t create a custom icon for each of these concepts—it bloats the icon library and makes it difficult for merchants to create strong connections around a concept.
 
-<!-- end -->
-<!-- showcasecontent -->
-
 ![Various icons paired with text, notably the icon of a house with the word "Home", the icon of a computer with the word "Desktop" and an icon of an arrow pointing up and another pointing down with the word "Sort".](/images/foundations/design/icons/icons-pairing@2x.png)
 
 ### Pair icons with text
 
 The purpose of an icon is to clarify the content by providing a visual cue and improve legibility and scannability of the user interface. In general, icons should be placed near a label or title. Never use an icon to replace a name of a product or feature—the rare exception being an icon that’s a universally understood action, like the trash can icon that represents deletions.
-
-<!-- end -->
-<!-- showcasecontent -->
 
 ![Five icons representing the currency of different countries: a dollar, a euro, a british pound, an indian rupee and a japanese yen.](/images/foundations/design/icons/icons-internationalization@2x.png)
 
@@ -87,13 +69,9 @@ The purpose of an icon is to clarify the content by providing a visual cue and i
 
 Whenever possible, use a universally recognized icon. However, there will be times where only a locally understood icon will work to communicate a concept. When deciding what symbol should be used, check that it will be understood at a glance by people from different cultures and&nbsp;backgrounds.
 
-<!-- end -->
-
 ---
 
 ## When to use icons
-
-<!-- keywords: icon use cases, navigation icons, page header icons, section title icons, banner icons, inline icons, action icons -->
 
 Icons are powerful visual helpers and should be used with care. Overuse quickly results in user interfaces that are visually overwhelming or distracting.
 Icons are commonly used:
@@ -110,11 +88,7 @@ To browse a list of all available icons, visit the [polaris-icons](https://polar
 
 ## System icons
 
-<!-- keywords: icon sizing, icon sizes, minor icons, major icons, small icons, navigation icons, button icons -->
-
 System icons help merchants find their way around and shouldn’t be ornamental. They’re smaller than spot icons because they’re always applied in product experiences where it’s important that they complement the user experience and not overpower it. They should represent a specific action, object, or concept.
-
-<!-- centeredcontent -->
 
 ![Icons in a navigation menu.](/images/foundations/design/icons/icons-system-20@2x.png)
 
@@ -127,10 +101,6 @@ Major system icons are:
 - 20×20 in size
 - Within a 20×20 bounding box
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Smaller icons in a drop-down menu](/images/foundations/design/icons/icons-system-16@2x.png)
 
 ### Minor icons—16×16
@@ -142,15 +112,9 @@ Minor system icons are:
 - 16×16 in size
 - Within a 20×20 bounding box
 
-<!-- end -->
-
 ---
 
 ## Spot icons
-
-<!-- keywords: large icons, spot icons -->
-
-<!-- showcasecontent -->
 
 ![Larger, spot icons of a spyglass for a "results not found" error, an upwards arrow for a file upload card, and an exclamation point for a "page not found" error.](/images/foundations/design/icons/icons-spot@2x.png)
 
@@ -159,5 +123,3 @@ Spot icons reinforce messaging in product experiences that are seen more than on
 - Bigger than system icons and have a stronger stroke weight to add visual balance to the layout
 - 60×60 in size
 - Within a 60×60 bounding box
-
-<!-- end -->

--- a/polaris.shopify.com/content/foundations/design/illustrations.md
+++ b/polaris.shopify.com/content/foundations/design/illustrations.md
@@ -9,17 +9,11 @@ keywords:
 
 The Shopify admin uses a precise illustration style to help merchants quickly and clearly understand how things work across every experience.
 
-<!-- showcasecontent -->
-
 ![The illustration of a chair, in simples straight lines, followed by a version with curves and some color, followed by a final version with filled shapes and shadows.](/images/foundations/design/illustrations/illustrations-intro@2x.png)
-
-<!-- end -->
 
 ---
 
 ## Principles
-
-<!-- keywords: illustration guidelines, illustration principles, be useful, be consistent, be considerate, be focused -->
 
 ### Always be useful
 
@@ -41,29 +35,17 @@ Each illustration conveys one thing. The story is easy to understand, so merchan
 
 ## Elements of style
 
-<!-- keywords: illustration background color, illustration transparency, illustration blending modes, illustration elements, illustration scaling, style, illustration style -->
-
-<!-- showcasecontent -->
-
 ![A color palette and illustrations using the color palette](/images/foundations/design/illustrations/illustrations-color@2x.png)
 
 ### Color
 
 Illustrations use a special set of colors designed to work well in the places where they show up. The palette is limited: individual illustrations use whites, grays, and two or three colors each. Colors are also less saturated than the surrounding UI, so they don’t distract from core interactions.
 
-<!-- end -->
-
-<!-- showcasecontent -->
-
 ![Illustrations of a flag, a teapot, a leaf, and various profiles of people of different ethnicities.](/images/foundations/design/illustrations/illustrations-shape@2x.png)
 
 ### Shape
 
 Objects have realistic proportions so they’re easy to recognize. Simple geometric shapes with rounded corners build images that are clear and approachable. Representations of people use more organic shapes.
-
-<!-- end -->
-
-<!-- showcasecontent -->
 
 ![An illustration of a laptop and an illustration of shipping boxes separated on a white background](/images/foundations/design/illustrations/illustrations-space@2x.png)
 
@@ -73,10 +55,6 @@ The perspective is flat and two-dimensional so the entire area of the illustrati
 
 Each illustration has negative space around it so it feels balanced in the place it lives, and so its visual weight is the same as other illustrations that live in the same places.
 
-<!-- end -->
-
-<!-- showcasecontent -->
-
 ![An stylized illustration of a chair with red lines defining its angles, next to an illustration of the profile of a person, with red lines to emphasize where curves are used.](/images/foundations/design/illustrations/illustrations-line@2x.png)
 
 ### Line
@@ -85,27 +63,17 @@ Line makes and arranges shapes in the space. All illustrations have smooth lines
 
 Intersecting and continuous lines are a key element of the admin illustration style, but they aren’t forced. They make a simple illustration feel elegant and visually interesting without being distracting.
 
-<!-- end -->
-
-<!-- showcasecontent -->
-
 ![An intricate illustration of a shipping label, followed by an illustration of a sheet with a list of users, followed by a very simple illustration of an URL address bar.](/images/foundations/design/illustrations/illustrations-detail@2x.png)
 
 ### Detail
 
 Illustrations need some detail to make sense, but too much can be noisy. They have the minimum amount of detail necessary to make them feel realistic but still simple. Fine details are rarely smaller than 4px in height or width.
 
-<!-- end -->
-
 ---
 
 ## Where illustrations live
 
-<!-- keywords: illustration use cases, where to use illustrations, empty states, on-boarding, announcements, progress indicators, common places for illustations, signs to use an illustration -->
-
 There are places where illustrations always appear, and places where they’re used only sometimes.
-
-<!-- showcasecontent -->
 
 ![An illustration of scissors cutting a coupon to indicate a page for discount code administration that has no discount codes saved.](/images/foundations/design/illustrations/illustrations-empty-states@2x.png)
 
@@ -113,18 +81,11 @@ There are places where illustrations always appear, and places where they’re u
 
 Merchants see an empty state illustration the first time they access a new part of the experience, before they’ve had the chance to do anything there yet. It introduces what they can do here, and sets expectations for what’s ahead.
 
-<!-- end -->
-<!-- showcasecontent -->
-
 ![An admin homecard with a small illustration next to some text describing how to customize a theme.](/images/foundations/design/illustrations/illustrations-onboarding@2x.png)
 
 ### Onboarding
 
 Onboarding tasks help new merchants set up their store. Illustrations frame what each task is for. And by changing in appearance, they reinforce when a task is complete.
-
-<!-- end -->
-
-<!-- showcasecontent -->
 
 ![An illustration celebrating a store anniversary.](/images/foundations/design/illustrations/illustrations-announcements@2x.png)
 
@@ -132,13 +93,8 @@ Onboarding tasks help new merchants set up their store. Illustrations frame what
 
 Announcements let merchants know about something that might help their business. When the announcement celebrates a major merchant milestone or introduces an important product, illustration helps make it special or noticeable.
 
-<!-- end -->
-<!-- showcasecontent -->
-
 ![An illustration next to a card talking about Shopify Payments.](/images/foundations/design/illustrations/illustrations-spot@2x.png)
 
 ### Spot illustrations
 
 In some rare instances, unique spot illustrations can be used to achieve a specific goal, like to draw attention to something important on a busy page, or to explain a technical concept.
-
-<!-- end -->

--- a/polaris.shopify.com/content/foundations/design/interaction-states.md
+++ b/polaris.shopify.com/content/foundations/design/interaction-states.md
@@ -17,17 +17,11 @@ keywords:
 
 Interaction states communicate the status of an element in the interface, establish confidence once an action is taken, and suggest the ability (or inability) to interact with the element.
 
-<!-- showcasecontent -->
-
 ![A collection of buttons in different states](/images/foundations/design/interaction-states/interaction-states-intro@2x.png)
-
-<!-- end -->
 
 ---
 
 ## Principles
-
-<!-- keywords: interaction states guidelines, interaction states principles, be subtle but obvious, be consistent -->
 
 ### Be subtle, but clear
 
@@ -40,8 +34,6 @@ Consistent treatments for interaction feedback create recognizable patterns. If 
 ---
 
 ## Designing interaction states
-
-<!-- keywords: interaction states use cases, where to use interaction states, signifiers, affordance, a11y, accessibility, behavior  -->
 
 Keep in mind that merchants interact with interfaces differently depending which input device they’re using. Devices they may be using include:
 
@@ -60,31 +52,17 @@ To learn more, check out the [accessibility guidelines](/foundations/accessibili
 
 Provide merchants with cues as to what the interface will do if they interact with it. By using signifiers we set expectations about what components can do, which creates a more intuitive interface that’s easier to use. The types of signifiers include:
 
-<!-- centeredcontent -->
-
 ![A "sort" button in a default state.](/images/foundations/design/interaction-states/interaction-states-explicit@2x.png)
 
 **Explicit**, where content directs merchants to do the intended action, such as “Sort” or “Save.”
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![An "edit" button with its underline appearing when the mouse hovers above it.](/images/foundations/design/interaction-states/interaction-states-hidden@2x.png)
 
 **Hidden**, where the clue isn’t revealed until the merchant interacts with it, such as hovering or using tab navigation to see if a button is clickable.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![A "print packing slip" button that is grayed out and inactive.](/images/foundations/design/interaction-states/interaction-states-negative@2x.png)
 
 **Negative**, where the action appears inactive (like the button is grayed out and doesn’t respond to hover) because it isn’t available for the merchant to use.
-
-<!-- end -->
-
-<!-- showcasecontent -->
 
 ![A toast component, a button with a spinner component and a text field component with an error message.](/images/foundations/design/interaction-states/interaction-states-behavior@2x.png)
 
@@ -95,5 +73,3 @@ Provide merchants with cues as to what the interface will do if they interact wi
 **For non-disruptive feedback** on the outcome of an action, use the [toast](https://polaris.shopify.com/components/toast) component.
 
 **For an unsuccessful completion** that requires the merchant to take action, provide information about what prevented the action from completing successfully and what the merchant can do to fix the problem. For example, use the validation error state of the [text field](https://polaris.shopify.com/components/text-field) component.
-
-<!-- end -->

--- a/polaris.shopify.com/content/foundations/design/sounds.md
+++ b/polaris.shopify.com/content/foundations/design/sounds.md
@@ -10,11 +10,7 @@ keywords:
 
 We use sound to communicate information and to enhance how merchants experience the Shopify admin. Sound patterns make interactions easier and more predictable.
 
-<!-- showcasecontent -->
-
 ![Visual representation of sound waves as concentric circles](/images/foundations/design/sounds/sound-intro@2x.png)
-
-<!-- end -->
 
 ---
 
@@ -22,31 +18,21 @@ We use sound to communicate information and to enhance how merchants experience 
 
 ### Selectively urgent
 
-<!-- keywords: sound urgency, sound guide, duration, volume, alert sound -->
-
 The duration, volume, and character of a sound should all be dictated by the level of urgency of an event. For example, an alert indicating that a customer is struggling to complete checkout requires more urgent attention and immediate action. An alert indicating that a customer has arrived at a storefront is informative, but doesn’t require immediate action. The sounds used during these events should be customized to reflect the differences in urgency.
 
 ### Avoid annoying repetition
-
-<!-- keywords: repetition, informative sounds, annoying sounds -->
 
 Some sounds occur many times per day. While appealing on first listen, a sound may become irritating after ten, and unbearable after a hundred. Merchants that hear a sound repeatedly may quickly grow tired of it. **Our sounds should be informative and not annoying.** When possible, use data to determine how often a sound is triggered.
 
 ### Distinct and succinct
 
-<!-- keywords: clean sound, convey information, distorted sounds -->
-
 Merchants are likely to hear our sounds in a variety of contexts. Clean, focused, and succinct sounds convey information better than muffled or distorted sounds.
 
 ### Test across devices
 
-<!-- keywords: device sounds, mobile sounds, desktop sounds, small speaker sounds -->
-
 While you may be testing your designs using headphones or loudspeakers that reveal the audible frequency spectrum clearly, a smartphone speaker will affect the quality of the sound. Smaller speakers are more susceptible to distortion. Sounds on mobile devices should be played at lower levels than on a desktop computer or laptop. Test sounds on a variety of devices and volume&nbsp;levels.
 
 ### Think beyond sound
-
-<!-- keywords: deaf, deafness, hard of hearing, hearing loss, auditory disability, auditory disabilities -->
 
 Some people can’t rely on sound to receive cues or notifications. Merchants may have a disability that affects hearing or auditory processing. Depending on the merchant’s preferences and technologies, they may receive sound cues through haptic or visual feedback, but don’t assume that they’ll be able to perceive sound. Always include an alternative method to convey information, like text-based notifications or visual changes in the interface.
 
@@ -54,15 +40,11 @@ Some people can’t rely on sound to receive cues or notifications. Merchants ma
 
 ## When to use sound
 
-<!-- keywords: too many sounds, unnecessary sounds, quality of product, turn off sounds -->
-
 Sounds in our product help convey information. There’s an important balance between having too many sounds and not enough. Useful and well-planned sounds will help with merchant understanding. Unnecessary sounds will reduce the perceived quality of our product.
 
 Even though merchants might miss important information if they turn off their sound, we should always provide the option for them to do so.
 
 ### Common sound events
-
-<!-- keywords: immediate attention, confirmation sound, statement of failure, augment user experience -->
 
 - For an event that requires a merchant’s immediate attention, use an alert to encourage them to pause their workflow and take care of things.
 - For something that’s useful for a merchant to do, but not necessarily immediately, use a notification.

--- a/polaris.shopify.com/content/foundations/design/spacing.md
+++ b/polaris.shopify.com/content/foundations/design/spacing.md
@@ -32,23 +32,15 @@ Beyond mathematical precision, spacing also reacts to the objects it surrounds, 
 
 All spacing for components and typography is done in increments of 4 pixels. This forms the basic unit of measurement for spacing.
 
-<!-- centeredcontent -->
-
 ![The mobile interface of the Shopify admin on a 4 pixel grid.](/images/foundations/design/spacing/spacing-4px-grid@2x.png)
 
 ### 4px grid
 
 Typography doesn’t use a traditional baseline grid. Instead, line heights are set in increments of 4px and spacing is measured from the edges of the text boxes.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![A profile card component on a 4 pixel grid with text placed vertically at 20 pixel intervals](/images/foundations/design/spacing/spacing-20px-elements@2x.png)
 
 Many components are sized in increments of 20px to match the line height of body text. This makes it easy to create harmonious arrangements of components and&nbsp;text.
-
-<!-- end -->
 
 ---
 
@@ -67,41 +59,25 @@ When applying spacing in CSS, use these [spacing tokens](/tokens/spacing).
 
 Various components within Polaris enable automatic spacing between elements:
 
-<!-- centeredcontent -->
-
 ![Several paragraphs of text with space in between, with their edges and spacing highlighted](/images/foundations/design/spacing/spacing-text-container@2x.png)
 
 Use the [text container](/components/text-container) component to wrap and automatically add the correct spacing between a set of paragraphs, lists, or other textual components.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![A text label, text value and badge arranged in a row, with their edges and spacing highlighted](/images/foundations/design/spacing/spacing-stack@2x.png)
 
 The [stack](/components/stack) component can be used to arrange arbitrary components in a horizontal row or vertical stack with space in between. It accepts the same values as the Sass spacing function to control spacing between the items.
 
-<!-- end -->
-
 ---
 
 ## How to choose spacing
-
-<!-- showcasecontent -->
 
 Use less space between small components, or components that share a close functional&nbsp;relationship.
 
 ![Two text fields showing spacing within and between them](/images/foundations/design/spacing/spacing-less-space@2x.png)
 
-<!-- end -->
-
-<!-- showcasecontent -->
-
 Use less space between small components, or components that share a close functional&nbsp;relationship.
 
 ![Detail of a screen from Shopify admin, showing space between the page header and cards, between the cards, and the space around the layout](/images/foundations/design/spacing/spacing-more-space@2x.png)
-
-<!-- end -->
 
 Coordinate small and large values, along with structural components (like Home cards), to create visual groupings of related things. This helps merchants understand the interface and more easily find what they’re looking for.
 For screens with specialized layouts, adjust overall spacing based on the density of the content. For example, a simple login screen on desktop display has more room to breathe, so more space can be used.
@@ -112,27 +88,17 @@ For screens with specialized layouts, adjust overall spacing based on the densit
 
 The most common spacing sizes are used throughout Polaris for admin as follows:
 
-<!-- centeredcontent -->
-
 ![Space between icon and text in buttons and list items](/images/foundations/design/spacing/spacing-extra-tight@2x.png)
 
 **4px** (`extra-tight`) between icon and text.
 
 The [button](/components/button) component has this spacing built in.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Two buttons in a row, with annotation showing the space between](/images/foundations/design/spacing/spacing-tight@2x.png)
 
 **8px** (`tight`) between icon and text.
 
 The [button group](/components/button-group) component has this spacing built in.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![A form showing horizontal and vertical space between text fields](/images/foundations/design/spacing/spacing-base-forms@2x.png)
 
@@ -142,27 +108,15 @@ The [button group](/components/button-group) component has this spacing built in
 
 The [form layout](/components/form-layout) component has this spacing built in.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Detail of a card component from a large screen display, showing padding on the top, sides and between card sections](/images/foundations/design/spacing/spacing-loose-forms@2x.png)
 
 **20px** (`loose`) padding in cards.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Detail of a card on a small screen, showing reduced side padding](/images/foundations/design/spacing/spacing-loose-mobile@2x.png)
 
 **16px** (`base`) side padding on small screen.
 
 The [card](/components/card) component has this built in.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Detail of a screen from the Shopify admin, showing horizontal and vertical spacing between cards](/images/foundations/design/spacing/spacing-loose-between-cards@2x.png)
 
@@ -172,31 +126,19 @@ The The [card](/components/card) component automatically adds vertical space bet
 
 For horizontal spacing, use the [layout](/components/layout) component to create multi-column layouts.
 
-<!-- end -->
-
 ---
 
 ## Adjustments and exceptions
 
 In cases where minute alignment adjustments are necessary, some exceptions apply:
 
-<!-- centeredcontent -->
-
 ![Closeup of a badge component, showing how its internal padding can be arbitrary, but its height is a multiple of 4px and the text within is vertically centered](/images/foundations/design/spacing/spacing-exception-badge@2x.png)
 
 When text is vertically centered inside a component, the top and bottom padding can be any size.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Three buttons in a row, showing how their width depends on their text content](/images/foundations/design/spacing/spacing-text-width@2x.png)
 
 Allow the length of text to determine the width of components and where they fall horizontally when placed in a row.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Diagram of a button with optical adjustment for an icon](/images/foundations/design/spacing/spacing-optical-adjustment@2x.png)
 
@@ -206,15 +148,13 @@ Sometimes an element is larger than it appears. Spacing based on the invisible e
 
 Without optical adjustment, the disclosure icon appears too far from the right edge of the button. After optical correction, the perceived spacing is more balanced.
 
-<!-- end -->
-
 ---
 
 ## Touch targets
 
 Merchants can more easily perform a task on mobile when interactive elements follow the recommended touch target sizes and spacing guidelines. Make sure that there’s enough space between links, buttons, and inputs prevents accidental actions. Note: touch target sizes differ across iOS (44px) and Android (48dpi).
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/design/typography.md
+++ b/polaris.shopify.com/content/foundations/design/typography.md
@@ -28,23 +28,13 @@ To make things accessible to audiences with different eyesight constraints, acro
 
 ## Font sizes
 
-<!-- keywords: type scales, typographic scales, display x-large, display large, display regular, display medium, display small, font size -->
-
 We use the typographic scale to communicate visual hierarchy in text.
-
-<!-- typescale -->
-
-<!-- end -->
 
 ---
 
 ## Formatting
 
-<!-- keywords: strong, bold, subdued, greyed-out, grayed-out, grey text, gray text, font weight, text weight -->
-
 Along with the typographic scale, sometimes additional formatting is necessary to illuminate the distinction between smaller-scale relationships. Different formatting styles can be implemented using the text style component.
-
-<!-- centeredcontent -->
 
 ![Diagram presenting text that is left aligned](/images/foundations/design/typography/type-left-align@2x.png)
 
@@ -52,19 +42,11 @@ Along with the typographic scale, sometimes additional formatting is necessary t
 
 By default, text is left aligned. Exceptions to this rule include text in tables, and the centered text we use in empty states.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Diagram presenting text that is emphasised by being bold](/images/foundations/design/typography/type-strong@2x.png)
 
 ### Strong
 
 Use this style sparingly and only where strong emphasis is required. In interfaces, strong should be seldom used to enhance visual hierarchy.
-
-<!-- end -->
-
-<!-- centeredcontent -->
 
 ![Diagram presenting text that is underlined](/images/foundations/design/typography/type-underline@2x.png)
 
@@ -72,23 +54,15 @@ Use this style sparingly and only where strong emphasis is required. In interfac
 
 Underline styles are exclusively for text links. Don’t use underline for things like adding emphasis to text within body copy.
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Diagram presenting text that is subdued in a lighter gray color](/images/foundations/design/typography/type-subdued@2x.png)
 
 ### Subdued
 
 The subdued style lets you de-emphasize content, and you can use it across all font sizes. Mostly it should be used in contrast to other un-subdued text, vs. on its own. However you can use Subdued with standalone text that’s non-actionable or less important.
 
-<!-- end -->
-
 ---
 
 ## Display styles
-
-<!-- showcasecontent -->
 
 ### PageHeading
 
@@ -96,19 +70,11 @@ PageHeading is reserved for the title of a screen.
 
 ![An interface showing the title of a page before its contents](/images/foundations/design/typography/type-pageheading@2x.png)
 
-<!-- end -->
-
-<!-- showcasecontent -->
-
 ### Display
 
 Display is for titling various interface elements, such as empty states and modals.
 
 ![An empty state and a modal with large display headings](/images/foundations/design/typography/type-display@2x.png)
-
-<!-- end -->
-
-<!-- showcasecontent -->
 
 ### Heading
 
@@ -116,19 +82,11 @@ Heading should always be used for titles of top-level sections of a screen. If t
 
 ![Two interface cards with headings](/images/foundations/design/typography/type-heading@2x.png)
 
-<!-- end -->
-
-<!-- showcasecontent -->
-
 ### Subheading
 
 If a top-level section of a screen has subsections, use the Subheading style for titling those subsections. Subheading should never appear as the first element in a card. Only use with titles (vs. sections of content).
 
 ![An interface card titled with a large heading text size followed by a smaller subheading](/images/foundations/design/typography/type-subheading@2x.png)
-
-<!-- end -->
-
-<!-- showcasecontent -->
 
 ### Caption
 
@@ -136,29 +94,20 @@ Caption is for providing details in places where content is compact and space is
 
 ![A line chart with small, caption-sized labels](/images/foundations/design/typography/type-caption@2x.png)
 
-<!-- end -->
-
 ---
 
 ## Font stack
 
-<!-- keywords: font-family, webfont, system font -->
-
 We use a font stack that adapts to the operating system it runs on, like macOS, iOS, Windows, Android or Linux distributions.
 
-<!-- showcasecontent -->
-
 ![A diagram showing a selection of default iOS, Mac, Windows, Android and Linux fonts](/images/foundations/design/typography/type-fontstack@2x.png)
-
-<!-- end -->
 
 - Apple devices will display [San Francisco](https://developer.apple.com/fonts/)
 - Android devices will display
   [Roboto](https://material.io/guidelines/resources/roboto-noto-fonts.html)
 - Devices running Windows will display
   [Segoe UI](https://en.wikipedia.org/wiki/Segoe#Segoe_UI)
-- Machines running Linux will display the default sans-serif font for any
-  running distribution
+- Machines running Linux will display the default sans-serif font for any running distribution
 
 This font-stack makes sure all browsers can load platform-specific fonts:
 
@@ -202,9 +151,7 @@ textarea {
 
 ## Mobile considerations
 
-<!-- keywords: mobile typography, native typography, mobile fonts, iOS typography, Android typography, mobile type scale, native type scale -->
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/foundations/accessibility.md
+++ b/polaris.shopify.com/content/foundations/foundations/accessibility.md
@@ -24,14 +24,11 @@ Making commerce better for everyone means caring deeply about making quality pro
 - A beautiful and functional design
 - Consistent and useful [copy](/content/product-content)
 - Principles of
-  [universal design](https://en.wikipedia.org/wiki/Universal_design) and
-  inclusivity
+  [universal design](https://en.wikipedia.org/wiki/Universal_design) and inclusivity
 
 ---
 
 ## Usable for everyone
-
-<!-- keywords: vision trouble, visual impairments, color blind, hearing trouble, physical disabilities, physical functioning difficulty, cognitive disabilities, people with disabilities, persons with disabilities, limited vision, loss of vision, low vision, disability, disabilities, diverse, diversity, inclusivity, inclusive experiences, deaf, deafness, blind, blindness, dexterity, mobility, cognitive, learning disability, learning disabilities, speech -->
 
 It’s important that Shopify products—and [Partner](https://www.shopify.ca/partners) products—are usable and useful to everyone.
 
@@ -46,10 +43,7 @@ In the United States, as many as 1 in 4 adults has at least 1 disability [Source
 
 ## Building inclusive experiences
 
-<!-- keywords: accessible markup, accessible mark up, accessible code, alternative text, alt text, accesibility feedback, accessible components, inclusivity, assistive tech, assistive technology, wcag, web content accessibility guidelines -->
-
-Using our [components](/components/get-started) is a way to improve
-accessibility and consistency when building products for Shopify.
+Using our [components](/components/get-started) is a way to improve accessibility and consistency when building products for Shopify.
 
 - The component library in this style guide includes code we can use across applications
 - This component code includes accessible markup
@@ -63,7 +57,7 @@ Many accessibility features come free in the components. But, it’s important t
 
 Don’t programmatically move focus to new content without merchant input. Polaris components that use controls to display overlays, such as modals and popovers, manage focus automatically.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -126,5 +120,4 @@ For more information, see the following resources:
 ### Feedback
 
 Sometimes, building accessible and inclusive experiences can be difficult. If we’ve made any mistakes in this style guide, please
-[reach out by creating a GitHub issue](https://github.com/Shopify/polaris-react/issues)
-and help us make it better.
+[reach out by creating a GitHub issue](https://github.com/Shopify/polaris-react/issues) and help us make it better.

--- a/polaris.shopify.com/content/foundations/foundations/experience-values.md
+++ b/polaris.shopify.com/content/foundations/foundations/experience-values.md
@@ -36,7 +36,7 @@ These values are at the heart of how we build experiences at Shopify. They’re 
 
 ---
 
-## Our approach <!-- nav:skipsection -->
+## Our approach
 
 The best part of this shared set of values is the conversations they enable. They are fantastic lenses through which to view, critique, and improve our work.
 

--- a/polaris.shopify.com/content/foundations/foundations/formatting-localized-currency.md
+++ b/polaris.shopify.com/content/foundations/foundations/formatting-localized-currency.md
@@ -90,7 +90,7 @@ Because CLDR formatting is limited, these guidelines will help you choose the ap
 
 #### Store currency
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -127,7 +127,7 @@ This example illustrates the use of short format for non-total amounts and expli
 
 Always place the negative symbol before the currency and amount in either format.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/foundations/internationalization.md
+++ b/polaris.shopify.com/content/foundations/foundations/internationalization.md
@@ -27,7 +27,7 @@ We aim to build one experience that works for all merchants in all of our market
 
 ---
 
-## Definitions <!-- nav:skipsection -->
+## Definitions
 
 ### Internationalization
 
@@ -52,7 +52,7 @@ French-France (fr-FR); French-Canada (fr-CA); Portuguese-Brazil (pt-BR). Note th
 
 When interfaces are localized, the content will often expand in length. In most languages, text is up to 50% longer on average than English. Some non-Latin languages, such as Japanese, take up more vertical space. For character-based languages, text wrapping and line breaking can’t always rely on spaces to separate words. Your interface needs to be flexible enough to accommodate language-specific formatting and text expansion without changing its context of use.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -68,7 +68,7 @@ Don’t rely on responsive stacking alone. It can often change the hierarchy of 
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -97,7 +97,7 @@ Avoid using narrow columns in smaller components. Ensure the right amount of pad
 
 Word order can change dramatically in translation. If the layout and functionality of your interface is dependent on a certain word order, it’s likely to break when localized.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -113,7 +113,7 @@ Don’t place elements with a fixed position inside a sentence. The order of thi
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Do
 
@@ -142,21 +142,13 @@ Don’t use full phrases as links. Word order changes might break the link into 
 
 Merchants in each locale have different cultural sensibilities. Use visuals, content, and interface formats that are useful and meaningful to merchants in all parts of the world.
 
-<!-- centeredcontent -->
-
 ![Good example of icon usage](/images/foundations/foundations/internationalization/icons-meaning@2x.png)
 
 When possible, use universally known icons. Be mindful of when you use country-specific icons and where they are surfaced. Find out more about [icons](/foundations/design/icons).
 
-<!-- end -->
-
-<!-- centeredcontent -->
-
 ![Bad example of text fields](/images/foundations/foundations/internationalization/colors-cultural-context@2x.png)
 
 Be mindful of using colors to represent meaning. Colors can hold discrete connotations in different cultures. For example, in North America, green is used to indicate success and red for failure, as opposed to China, where red symbolizes prosperity and good fortune.
-
-<!-- end -->
 
 ### Tips
 

--- a/polaris.shopify.com/content/foundations/patterns/error-messages.md
+++ b/polaris.shopify.com/content/foundations/patterns/error-messages.md
@@ -11,13 +11,11 @@ keywords:
 
 # Error messages
 
-Error messages can be scary. Make errors visible to merchants, easy to
-understand, and helpful.
+Error messages can be scary. Make errors visible to merchants, easy to understand, and helpful.
 
 Error messages should:
 
-- Tell merchants what happened. If there’s a solution, explain it. If possible,
-  offer a one-click fix with a button. If there’s
+- Tell merchants what happened. If there’s a solution, explain it. If possible, offer a one-click fix with a button. If there’s
   [no solution](#errors-without-solutions), give troubleshooting instructions.
 - Be placed close to the source of the problem.
 - Communicate severity using the appropriate [color](#colors) and
@@ -28,19 +26,15 @@ Error messages should:
   [numbers and dates](/content/grammar-and-mechanics#section-dates-numbers-and-addresses).
 - Be brief.
 
-Good design can reduce the need for error messages by preventing them in the
-first place.
+Good design can reduce the need for error messages by preventing them in the first place.
 
 ---
 
 ## Error message types
 
-Think about the scope of the error when selecting a message type. Is something
-wrong with the entire application, with the entire current screen, or with a
-specific element on the screen?
+Think about the scope of the error when selecting a message type. Is something wrong with the entire application, with the entire current screen, or with a specific element on the screen?
 
-If the cause of the error is visible and the error just happened, show the error
-message immediately and as close to the source of the problem as possible.
+If the cause of the error is visible and the error just happened, show the error message immediately and as close to the source of the problem as possible.
 
 ### [Text field validation error](#form-validation)
 
@@ -119,21 +113,15 @@ Use when:
 
 ## Error colors
 
-Red is the scariest error color. Only use red for critical messages that
-merchants need to deal with immediately to avoid harm to their business. For
-example, if merchants don’t act on the message right away, they might lose
-money or their store might be suspended.
+Red is the scariest error color. Only use red for critical messages that merchants need to deal with immediately to avoid harm to their business. For example, if merchants don’t act on the message right away, they might lose money or their store might be suspended.
 
-Yellow error messages still demand attention, but are more appropriate for
-messages that are part of a daily workflow.
+Yellow error messages still demand attention, but are more appropriate for messages that are part of a daily workflow.
 
 ### Red (critical)
 
 Use critical messages to:
 
-- Bring attention to urgent tasks. If not dealt with immediately, merchants'
-  businesses will be noticeably impacted, like an account being suspended or
-  money being lost.
+- Bring attention to urgent tasks. If not dealt with immediately, merchants' businesses will be noticeably impacted, like an account being suspended or money being lost.
 
 Examples of critical message types:
 
@@ -142,7 +130,7 @@ Examples of critical message types:
 - Review an order for fraud
 - Fix a problem that’s preventing payment from being processed
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -154,10 +142,9 @@ Examples of critical message types:
 
 <!-- end -->
 
-The one exception to using red is in form validation errors because this is a
-standard convention merchants are used to seeing outside of Shopify.
+The one exception to using red is in form validation errors because this is a standard convention merchants are used to seeing outside of Shopify.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -173,10 +160,8 @@ standard convention merchants are used to seeing outside of Shopify.
 
 Use warning messages to:
 
-- Help merchants fix issues so they can complete a common workflow or continue
-  to the next step
-- Notify merchants about upcoming expirations or pending requests that, if not
-  dealt with soon, could lead to problems in the future
+- Help merchants fix issues so they can complete a common workflow or continue to the next step
+- Notify merchants about upcoming expirations or pending requests that, if not dealt with soon, could lead to problems in the future
 
 Examples of warning message types:
 
@@ -187,7 +172,7 @@ Examples of warning message types:
 - Changing a setting might have unintended consequences. See
   [settings warning](#settings-warning).
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -207,7 +192,7 @@ Examples of warning message types:
 
 Although error toast is still available, we discourage its use. Toast messages are too short to adequately explain what went wrong and how to fix the problem. Because the toast component appears at the bottom of the screen and disappears after 3 seconds, it can easily be missed. Reserve toast for errors not caused by merchants, like a connection issue. Always try to use a banner to inform merchants about persistent errors.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Don’t
 
@@ -215,13 +200,10 @@ Although error toast is still available, we discourage its use. Toast messages a
 
 ### Don’t use modals for errors
 
-Modal dialogs are a good way to ask merchants to confirm a
-destructive action, but not to tell them an error has occurred.
-Modals block merchants until a decision is made, which is
-likely to make merchants feel pressured. Most errors don’t need
-to block access to the rest of the feature.
+Modal dialogs are a good way to ask merchants to confirm a destructive action, but not to tell them an error has occurred.
+Modals block merchants until a decision is made, which is likely to make merchants feel pressured. Most errors don’t need to block access to the rest of the feature.
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Don’t
 
@@ -229,15 +211,13 @@ to block access to the rest of the feature.
 
 ### Avoid using [home notifications](#home-notifications) for errors
 
-Home notification errors are for high-priority tasks that merchants
-must complete immediately to continue using Shopify or prevent
+Home notification errors are for high-priority tasks that merchants must complete immediately to continue using Shopify or prevent
 a negative impact to their business, like losing money.
-One exception is errors for features that don‘t have a
-dedicated details page.
+One exception is errors for features that don‘t have a dedicated details page.
 
 <!-- end -->
 
-<!-- usageblock -->
+<!-- dodont -->
 
 #### Don’t
 
@@ -259,9 +239,7 @@ Use when:
 Don’t use when:
 
 - It takes
-  [more than a full second](https://developers.google.com/web/fundamentals/performance/rail#ux)
-  to validate input and display a message. If there’s a lag before a validation
-  message appears, merchants might shift their attention and miss the error.
+  [more than a full second](https://developers.google.com/web/fundamentals/performance/rail#ux) to validate input and display a message. If there’s a lag before a validation message appears, merchants might shift their attention and miss the error.
   Either find a way to improve the validation speed, or rely on the
   [validation after form submission](#validate-on-submit).
 - The field is empty. Merchants might tab through a form before filling it out, and errors on empty fields can cause confusion and frustration.
@@ -280,12 +258,9 @@ Don’t use when:
 
 **Usage**
 
-Do an initial validation check as soon as merchants finish typing in the
-field.
+Do an initial validation check as soon as merchants finish typing in the field.
 
-Merchants can be considered to be finished typing only when keyboard focus
-moves away from the field and there is at least one character in the field. This
-helps avoid marking the field as not valid before merchants are really done typing.
+Merchants can be considered to be finished typing only when keyboard focus moves away from the field and there is at least one character in the field. This helps avoid marking the field as not valid before merchants are really done typing.
 
 ![Initial validation check with purple border](/images/foundations/patterns/error-messages/text-field-validation-purple-incorrect-input@2x.png)
 
@@ -297,13 +272,11 @@ Once a field has an error, complete validation checks after each keystroke.
 
 ![Text field validation with cursor by incorrect semi colon](/images/foundations/patterns/error-messages/text-field-validation-cursor@2x.png)
 
-Remove the error message as soon as the input becomes valid so merchants can
-immediately tell they fixed the issue.
+Remove the error message as soon as the input becomes valid so merchants can immediately tell they fixed the issue.
 
 ![Text field validation with purple border](/images/foundations/patterns/error-messages/text-field-validation-purple-border-cursor@2x.png)
 
-If the validation process is less than a second but not instant, show a spinner
-on the field to indicate validation progress.
+If the validation process is less than a second but not instant, show a spinner on the field to indicate validation progress.
 
 ![Text field validation in loading state with spinner](/images/foundations/patterns/error-messages/text-field-validation-loading@2x.png)
 
@@ -311,24 +284,15 @@ on the field to indicate validation progress.
 
 ## Validate on submit
 
-Validate on submit is triggered when merchants press the form’s submit
-
-button. The submit button is often \[Save\], but can be another call to action.
+Validate on submit is triggered when merchants press the form’s submit button. The submit button is often \[Save\], but can be another call to action.
 
 Use when:
 
-- Not all fields can be validated while merchants are typing. When a form is used
-  for saving data, always validate on submit and validate text fields while
-  typing. For example, if merchants never interact with a required text field,
-  there’s no change to mark it as not valid until they press the submit button.
-  The same applies to form controls other than text fields, such as radio
-  buttons, and selects.
+- Not all fields can be validated while merchants are typing. When a form is used for saving data, always validate on submit and validate text fields while typing. For example, if merchants never interact with a required text field, there’s no change to mark it as not valid until they press the submit button. The same applies to form controls other than text fields, such as radio buttons, and selects.
 
 Don’t use when:
 
-- A form doesn’t have specific validation requirements, or the form doesn’t save
-  data. For example, a search form that returns no results should display an
-  empty state, rather than a validation error.
+- A form doesn’t have specific validation requirements, or the form doesn’t save data. For example, a search form that returns no results should display an empty state, rather than a validation error.
 
 ### Component
 
@@ -360,13 +324,9 @@ Individual field error messages:
 
 ![Red form validation banner](/images/foundations/patterns/error-messages/validation-banner-red@2x.png)
 
-Rather than pointing out that there are {x} number of errors, be more
-descriptive. Explain that in order to save or continue, {x} number of fields
-need to be changed. For the bullet point instructions, see if you can word them
-to be more actionable, for example, “Add a discount code,“ instead of “Discount
-can’t be blank.“
+Rather than pointing out that there are {x} number of errors, be more descriptive. Explain that in order to save or continue, {x} number of fields need to be changed. For the bullet point instructions, see if you can word them to be more actionable, for example, “Add a discount code,“ instead of “Discount can’t be blank.“
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -407,16 +367,13 @@ If the form submission has multiple errors:
 Use:
 
 - To help merchants prevent potential mistakes
-- When form input is valid, but you want to warn merchants of a consequence
-  they might not be expecting
+- When form input is valid, but you want to warn merchants of a consequence they might not be expecting
 
 Don’t use:
 
 - For actual error states
 
-Tip: Explore ways to prevent the warning message from showing at all. Look for
-opportunities to add help text or other contextual information to surface or
-highlight potential risks or consequences of taking, or not taking, the action.
+Tip: Explore ways to prevent the warning message from showing at all. Look for opportunities to add help text or other contextual information to surface or highlight potential risks or consequences of taking, or not taking, the action.
 
 ### Component
 
@@ -444,13 +401,11 @@ Use when:
 - An error applies to the entire screen
 - The error is far down the page and it’s critical that they see the message
 - [A form was submitted with fields that are not valid](#form-validation)
-- If the error was delayed, for example, an action was taken and the error
-  doesn’t immediately appear in context
+- If the error was delayed, for example, an action was taken and the error doesn’t immediately appear in context
 
 Don’t use when:
 
-- It’s possible to place the banner [in context] because the source of the error
-  is in view and the event that triggered the action just happened
+- It’s possible to place the banner [in context] because the source of the error is in view and the event that triggered the action just happened
 
 For multiple error guidelines, see [validate on submit](#validate-on-submit)
 
@@ -461,7 +416,7 @@ Page-level banner errors should explain:
 - Why it happened
 - What to do next
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -493,13 +448,9 @@ Body content should:
 Calls to action should:
 
 - Be action-led (verb+noun format)
-- Aim for a one-click fix. If the error can be fixed via a single
-  button or menu, offer that action directly in the error message.
-- Open a dedicated error-correction view for more complex problems
-  such as reviewing a risky order or editing an unverified
-  customer address.
-- Provide a link to documentation for information that may be
-  valuable but can’t fit in a brief error message.
+- Aim for a one-click fix. If the error can be fixed via a single button or menu, offer that action directly in the error message.
+- Open a dedicated error-correction view for more complex problems such as reviewing a risky order or editing an unverified customer address.
+- Provide a link to documentation for information that may be valuable but can’t fit in a brief error message.
 
 ![Page level warning banner](/images/foundations/patterns/error-messages/page-level-warning-banner@2x.png)
 
@@ -507,18 +458,14 @@ Calls to action should:
 
 Use when:
 
-- Merchants are engaged in a task flow and you want to warn them about potential
-  issues with the task at hand, or inform them something has gone wrong
-- Directing merchants to a page with multiple sections and you want to visibly
-  call out the section with the error
+- Merchants are engaged in a task flow and you want to warn them about potential issues with the task at hand, or inform them something has gone wrong
+- Directing merchants to a page with multiple sections and you want to visibly call out the section with the error
 
 Don’t use when:
 
 - An error applies to the entire screen.
-- The error is far down the page and it’s critical that merchants see the
-  message.
-- If the error was delayed. For example, an action was taken and the error
-  doesn’t immediately appear in context. In these cases, use the
+- The error is far down the page and it’s critical that merchants see the message.
+- If the error was delayed. For example, an action was taken and the error doesn’t immediately appear in context. In these cases, use the
   [page-level banner](#page-level-banners)
 
 ### Component
@@ -546,9 +493,7 @@ Don’t use when:
 
 Use when:
 
-- Items in a list are in a noteworthy state that you want to make merchants
-  aware of, like a status, or piece of information (like a high risk order)
-  that’s directly relevant to the information it’s connected to
+- Items in a list are in a noteworthy state that you want to make merchants aware of, like a status, or piece of information (like a high risk order) that’s directly relevant to the information it’s connected to
 
 Example:
 
@@ -586,19 +531,15 @@ Content should:
 
 ## Home notifications
 
-Home notifications are primarily used to prevent merchants from losing money or
-help them continue using Shopify if they don’t act on the error message
-instructions immediately.
+Home notifications are primarily used to prevent merchants from losing money or help them continue using Shopify if they don’t act on the error message instructions immediately.
 
 Use for:
 
 - High-priority tasks that must be completed immediately to continue using
   Shopify or avoid losing money.
-- Important enough tasks that we wouldn’t want merchants to navigate to another
-  place in Shopify to find it, or stumble upon while completing another task.
+- Important enough tasks that we wouldn’t want merchants to navigate to another place in Shopify to find it, or stumble upon while completing another task.
 - Errors for features that don’t have a dedicated details page. For example, before
-  Shopify Capital had a details page, related status messages were temporarily
-  surfaced in Home.
+  Shopify Capital had a details page, related status messages were temporarily surfaced in Home.
 
 Don’t use for:
 
@@ -615,15 +556,13 @@ Don’t use for:
 
 ### Warning home notifications
 
-Warning home notifications are pre-emptive. They let merchants know that their
-finances will be impacted if action isn’t taken in a couple days or more, or
-that an action can be taken to make money sooner.
+Warning home notifications are pre-emptive. They let merchants know that their finances will be impacted if action isn’t taken in a couple days or more, or that an action can be taken to make money sooner.
 
 - Financing request is pending
 - Warn about upcoming expiration
 - Pending status, like with Shopify Capital application status
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -653,7 +592,7 @@ Critical home notifications can be used for these message types:
 - Payment processing issues
 - Payment authorizations expiring that day
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -669,10 +608,7 @@ Critical home notifications can be used for these message types:
 
 ## Admin unavailable errors
 
-Sometimes the admin can’t be displayed due to a network issue, browser
-limitation, connection problem, or server issue. 400 and 500 series errors fall
-in this category. In these cases, always explain what went wrong and provide
-merchants with a troubleshooting step, like refreshing the page.
+Sometimes the admin can’t be displayed due to a network issue, browser limitation, connection problem, or server issue. 400 and 500 series errors fall in this category. In these cases, always explain what went wrong and provide merchants with a troubleshooting step, like refreshing the page.
 
 Use when:
 
@@ -682,7 +618,7 @@ Don’t use when:
 
 - The error can be placed in context, close to the source of the problem
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -696,7 +632,7 @@ Don’t use when:
 
 Don’t use internal language in error messages and avoid using question formats.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -726,11 +662,7 @@ Headings should:
 
 ## Errors without solutions
 
-When a service issue occurs in Shopify or is caused by a third party, we don’t
-always have a solution to offer to merchants. In these cases, always explain
-what went wrong so they can attempt to troubleshoot. If available,
-provide them with a troubleshooting step, like refreshing the page or
-returning at a later time.
+When a service issue occurs in Shopify or is caused by a third party, we don’t always have a solution to offer to merchants. In these cases, always explain what went wrong so they can attempt to troubleshoot. If available, provide them with a troubleshooting step, like refreshing the page or returning at a later time.
 
 Use when:
 
@@ -742,7 +674,7 @@ Don’t use when:
 
 - There’s literally any solution we can offer to merchants
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -751,12 +683,11 @@ Don’t use when:
 
 #### Don’t
 
-- Don’t use the “Something went wrong. Please try again in a few minutes.”
-  message when there’s any option to offer more context.
+- Don’t use the “Something went wrong. Please try again in a few minutes.” message when there’s any option to offer more context.
 
 <!-- end -->
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -775,38 +706,29 @@ Don’t use when:
 
 ## Voice and tone
 
-<!-- keywords: please -->
+These content guidelines are based on common copy mistakes. Avoid sounding overly apologetic, too technical, or hyperbolic. Keep Shopify out of the conversation unless Shopify was the cause of the error. Don’t downplay the error by telling merchants not to worry or by adding humor to a negative situation.
 
-These content guidelines are based on common copy mistakes. Avoid sounding
-overly apologetic, too technical, or hyperbolic. Keep Shopify out of the
-conversation unless Shopify was the cause of the error. Don’t downplay the error
-by telling merchants not to worry or by adding humor to a negative situation.
+Avoid the word “please” so it’s not overused throughout the admin. Don’t downplay serious problems.
 
-Avoid the word “please” so it’s not overused throughout the admin. Don’t
-downplay serious problems.
-
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Some of today’s sales data isn’t updated yet. This will be fixed soon. Your
-  data is safe, and your actual sales are not affected.
+- Some of today’s sales data isn’t updated yet. This will be fixed soon. Your data is safe, and your actual sales are not affected.
 
 #### Don’t
 
-- Today’s sales data **might** not be accurate, but **please don’t worry—it’s
-  just temporary**.
+- Today’s sales data **might** not be accurate, but **please don’t worry—it’s just temporary**.
 
 <!-- end -->
 
 Don’t use scary, technical words in error messages.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Product weight can’t be negative. Change the product weight to be 0 or higher
-  and try again.
+- Product weight can’t be negative. Change the product weight to be 0 or higher and try again.
 
 #### Don’t
 
@@ -816,14 +738,13 @@ Don’t use scary, technical words in error messages.
 
 Error messages are not the place for hyperbole or injecting personality.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
 - High risk of fraud detected
 
-Before fulfilling this order or capturing payment, review the Risk Analysis and
-determine if this order is fraudulent.
+Before fulfilling this order or capturing payment, review the Risk Analysis and determine if this order is fraudulent.
 
 #### Don’t
 
@@ -836,37 +757,30 @@ Analysis to make sure the order is safe!
 
 Don’t use internal Shopify terms. Only include the information merchants need.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
 - There’s a problem loading this page
 
-There’s a technical problem with Shopify that has prevented this page from
-loading. Try reloading this page or going to another page in Shopify. If that
-doesn’t work, visit our status page for updates and try again later.
+There’s a technical problem with Shopify that has prevented this page from loading. Try reloading this page or going to another page in Shopify. If that doesn’t work, visit our status page for updates and try again later.
 
 #### Don’t
 
-- There’s a technical problem with Shopify that has prevented this page from
-  loading. **Our operation engineers are aware of this problem and are working
-  hard to get it solved**.
+- There’s a technical problem with Shopify that has prevented this page from loading. **Our operation engineers are aware of this problem and are working hard to get it solved**.
 
 <!-- end -->
 
-Keep Shopify out of the conversation. Focus on the information merchants need
-to complete their task efficiently.
+Keep Shopify out of the conversation. Focus on the information merchants need to complete their task efficiently.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
-- Before you can view earnings from your store, you need to complete your
-  account setup. [Complete account setup]
+- Before you can view earnings from your store, you need to complete your account setup. [Complete account setup]
 
 #### Don’t
 
-- Before **we** can provide you with earnings from your store, **we** need some
-  additional information. [Complete account setup]
+- Before **we** can provide you with earnings from your store, **we** need some additional information. [Complete account setup]
 
 <!-- end -->

--- a/polaris.shopify.com/content/foundations/patterns/home-cards.md
+++ b/polaris.shopify.com/content/foundations/patterns/home-cards.md
@@ -109,7 +109,7 @@ The tone changes depending on the context or situation of a card, but it should 
 
 ### Positive situation
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -134,7 +134,7 @@ _Fulfill them from your Orders page!_
 
 ### Neutral situation
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -157,7 +157,7 @@ _It’s easy to apply and it’ll help your business grow!_
 
 ### Negative situation
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/content/foundations/patterns/page-layouts.md
+++ b/polaris.shopify.com/content/foundations/patterns/page-layouts.md
@@ -19,18 +19,15 @@ Layout patterns provide common ways to arrange the content of a screen.
 
 A screen is the entire user interface (UI) of an application at a given time.
 
-A typical Polaris screen consists of several layers. The app frame makes up the
-outer layer. Within that are the page component and a layout component.
+A typical Polaris screen consists of several layers. The app frame makes up the outer layer. Within that are the page component and a layout component.
 
-The layout component arranges containers like cards and banners in a way that’s
-responsive across all screen sizes.
+The layout component arranges containers like cards and banners in a way that’s responsive across all screen sizes.
 
 ### App frame
 
 ![Screen from the Shopify admin, highlighting the top bar with logo, search and profile menu, and the navigation sidebar on the left](/images/foundations/patterns/page-layouts/app-frame-diagram@2x.png)
 
-The app frame is the outer UI of the application. It holds global features like
-top-level navigation and search.
+The app frame is the outer UI of the application. It holds global features like top-level navigation and search.
 
 ### Page component
 
@@ -45,16 +42,13 @@ The [page component](/components/page):
 Page component variations:
 
 - Full width. Use this for wide content like lists and tables.
-- Single-column. Use this narrow variant to focus the page on a single
-  transaction, like filling out a form.
+- Single-column. Use this narrow variant to focus the page on a single transaction, like filling out a form.
 
 ### Layout component
 
 ![Admin screen highlighting a typical layout](/images/foundations/patterns/page-layouts/page-layout-diagram@2x.png)
 
-Within the page, the [layout component](/components/layout) groups the
-content into sections. Sections control how the content flows into columns. Each
-section can be:
+Within the page, the [layout component](/components/layout) groups the content into sections. Sections control how the content flows into columns. Each section can be:
 
 - Full-width
 - Primary (2/3 width)
@@ -65,33 +59,26 @@ section can be:
 
 ![Screen highlighting a layout with: page-level banner up top, primary and secondary sections in the middle, and footer actions below](/images/foundations/patterns/page-layouts/cards-in-layout-diagram@2x.png)
 
-Place page-level [banners](/components/banner) in a full-width section
-at the top of the page.
+Place page-level [banners](/components/banner) in a full-width section at the top of the page.
 
-Stack [cards](/components/card) in sections to separate the screen’s
-main content into meaningful groups.
+Stack [cards](/components/card) in sections to separate the screen’s main content into meaningful groups.
 
 For screens that represent an individual resource like a product or order, place
-[page actions](/components/page-actions) in a full-width section at
-the bottom of the page.
+[page actions](/components/page-actions) in a full-width section at the bottom of the page.
 
 For pages that don’t have footer actions, the
-[footer help component](/components/footer-help) can offer a
-link to documentation about the current screen.
+[footer help component](/components/footer-help) can offer a link to documentation about the current screen.
 
 ### Layout in a card
 
 ![Diagram showing the anatomy of a card component, showing the card title and header actions at the top, two sections in the middle, and footer below](/images/foundations/patterns/page-layouts/card-layout-diagram@2x.png)
 
-[Cards](/components/card) have a similar structure to the page as a
-whole.
+[Cards](/components/card) have a similar structure to the page as a whole.
 
 - Cards often have a header, with a title and card-level actions on the right.
 - Cards can have footer actions.
-- Complex cards can be split into sections. Card sections are automatically
-  separated with a divider.
-- Sections often have a subheader with a title on the left and section-level
-  actions on the right.
+- Complex cards can be split into sections. Card sections are automatically separated with a divider.
+- Sections often have a subheader with a title on the left and section-level actions on the right.
 
 For more details, including when to use header and footer actions, see the
 [card component](/components/card).
@@ -100,11 +87,9 @@ For more details, including when to use header and footer actions, see the
 
 ## Specialty screen types
 
-The structure described above applies to most screens in the Shopify admin, but
-other types of screens exist.
+The structure described above applies to most screens in the Shopify admin, but other types of screens exist.
 
-**Embedded Shopify apps**, including sales channels, are contained within the
-normal app frame. However, they display the [page component](/components/page) differently.
+**Embedded Shopify apps**, including sales channels, are contained within the normal app frame. However, they display the [page component](/components/page) differently.
 
 ![Typical embedded app settings screen, showing the embedded page header with app icon and breadcrumb.](/images/foundations/patterns/page-layouts/embedded-page-diagram@2x.png)
 
@@ -112,9 +97,7 @@ normal app frame. However, they display the [page component](/components/page) d
 
 ![Shopify Capital sell screen. The standard app frame and page components contain a layout with a large illustration and introductory heading. This is followed by side-by-side cards with different offers, and a grid of selling points.](/images/foundations/patterns/page-layouts/sell-screen@2x.png)
 
-**Immersive editors** are for complex, interactive editing tasks. Immersive
-editors often show a live preview of what’s being worked on with tools for
-making changes arranged around the edges.
+**Immersive editors** are for complex, interactive editing tasks. Immersive editors often show a live preview of what’s being worked on with tools for making changes arranged around the edges.
 
 ![Shopify theme editor screen, with specialized top bar and side bar offering edit controls, and a preview of the online store website in the middle](/images/foundations/patterns/page-layouts/theme-editor-screen@2x.png)
 
@@ -122,15 +105,13 @@ making changes arranged around the edges.
 
 ## Standard page layouts
 
-The following patterns describe common ways to arrange content within the app
-frame and below the page header.
+The following patterns describe common ways to arrange content within the app frame and below the page header.
 
 ### Single column, wide
 
 ![Generic customers list screen, showing how a wider layout can fit more content about each customer](/images/foundations/patterns/page-layouts/page-frame-wide@2x.png)
 
-Use this layout for wide list or table views that benefit from more horizontal
-space.
+Use this layout for wide list or table views that benefit from more horizontal space.
 
 - Set the page component to full width
 - Use one or more basic layout sections
@@ -149,8 +130,7 @@ space.
 
 ![Example screen showing a complex form in a narrow layout](/images/foundations/patterns/page-layouts/page-frame-narrow@2x.png)
 
-Use this layout to focus merchant attention on a screen dedicated to a single
-task, like filling out a form.
+Use this layout to focus merchant attention on a screen dedicated to a single task, like filling out a form.
 
 - Set the page component to single column (narrow) mode
 - Use one or more basic layout sections
@@ -169,15 +149,13 @@ task, like filling out a form.
 Primary/secondary layouts split content into a main column and a secondary one.
 The main column is usually on the left, but can be on the right.
 
-The most common use of the primary/secondary layout is for showing the details
-for an individual object, such as an order or product.
+The most common use of the primary/secondary layout is for showing the details for an individual object, such as an order or product.
 
 ![Product details page, with cards for product title, description and images in the left, primary column, and cards for publishing to sales channels and product tags in the secondary column](/images/foundations/patterns/page-layouts/page-layout-details@2x.png)
 
 - Set the page component to its default width.
 - Place the most important content in a primary column.
-- Place other content in the secondary column. Content here should be
-  navigational, less frequently used, or not essential.
+- Place other content in the secondary column. Content here should be navigational, less frequently used, or not essential.
 
 ```jsx
 <Page title="Details page">
@@ -190,8 +168,7 @@ for an individual object, such as an order or product.
 </Page>
 ```
 
-Another use of this layout is for a focused task where a summary is helpful,
-such as purchasing shipping labels for an order.
+Another use of this layout is for a focused task where a summary is helpful, such as purchasing shipping labels for an order.
 
 ![Create shipping labels screen, with configuration for the labels in the left, primary column, and summary with “Buy shipping labels” button in the secondary column](/images/foundations/patterns/page-layouts/page-layout-task-with-summary@2x.png)
 
@@ -214,12 +191,9 @@ such as purchasing shipping labels for an order.
 
 ![General settings page, with annotated sections for “Store details” and “Store address” visible](/images/foundations/patterns/page-layouts/page-layout-annotated@2x.png)
 
-Annotated layouts group the content of the page into distinct sections that are
-only loosely related. This layout makes it easier to scan the page for a
-particular section.
+Annotated layouts group the content of the page into distinct sections that are only loosely related. This layout makes it easier to scan the page for a particular section.
 
-Use this layout for settings screens. Don’t use this layout when merchants
-need to navigate to more than one section to complete their task.
+Use this layout for settings screens. Don’t use this layout when merchants need to navigate to more than one section to complete their task.
 
 - Set the page component to its default width.
 - Use an annotated layout section for each independent topic on the page.
@@ -246,43 +220,33 @@ need to navigate to more than one section to complete their task.
 
 ### Custom page layouts
 
-Most screens in the Shopify admin use one of these layouts, but they aren’t the
-only ones you can use in Polaris. The following layouts are also possible:
+Most screens in the Shopify admin use one of these layouts, but they aren’t the only ones you can use in Polaris. The following layouts are also possible:
 
 - Multi-column list
 - Grid of equals
 - Masonry layout
 
 To achieve these and other layouts, create one or more custom layout components.
-Think of layout components a set of “shelves” into which other components can be
-placed.
+Think of layout components a set of “shelves” into which other components can be placed.
 
 ---
 
 ## Small-scale layout
 
-The [stack](/components/stack) component is useful for small-scale
-layout. It lets you arrange arbitrary components in a horizontal row or vertical
-stack. It’s also a useful component for applying
+The [stack](/components/stack) component is useful for small-scale layout. It lets you arrange arbitrary components in a horizontal row or vertical stack. It’s also a useful component for applying
 [standard spacing](/design/spacing).
 
 ![A text label, text value and badge arranged in a row with space between](/images/foundations/patterns/page-layouts/stack-horizontal@2x.png)
 
-Stacks work especially well for a row of components where one item needs to grow
-to fill the available space. When space becomes constrained, the content will
-wrap by default.
+Stacks work especially well for a row of components where one item needs to grow to fill the available space. When space becomes constrained, the content will wrap by default.
 
 ![A custom heading on the left (labeled “fill”) and UI control pushed to the right (labeled “auto”)](/images/foundations/patterns/page-layouts/stack-with-fill@2x.png)
 
 ### Custom small-scale layouts
 
-You’re more likely to need a custom small-scale layout than a custom page
-layout. If the desired layout can’t be easily achieved using a single stack
-component, create a custom layout.
+You’re more likely to need a custom small-scale layout than a custom page layout. If the desired layout can’t be easily achieved using a single stack component, create a custom layout.
 
-Custom small-scale layouts can often be done as part of a functional component,
-such as the timeline input shown here. It’s also possible to create dedicated
-small-scale layout components if the layout needs to be reusable.
+Custom small-scale layouts can often be done as part of a functional component, such as the timeline input shown here. It’s also possible to create dedicated small-scale layout components if the layout needs to be reusable.
 
 ![A row of UI elements on a wide screen, showing one element pushing two others to the right. A second state of the same element is shown on a narrower screen. The two smaller elements have wrapped below the first, creating a new row. Now one element stretches to fill the row and pushes last element to the end.](/images/foundations/patterns/page-layouts/layout-small-scale-custom@2x.png)
 
@@ -295,19 +259,12 @@ Organizing actions is as important as organizing content.
 If an action applies to the entire page:
 
 - Place it in the page header as a primary or secondary action
-- Use the [page actions](/components/page-actions) component for
-  page-level delete and save actions
+- Use the [page actions](/components/page-actions) component for page-level delete and save actions
 
-If an action applies to something more specific, place it at the level of the
-content it affects. For example, if an action applies to the contents of a card:
+If an action applies to something more specific, place it at the level of the content it affects. For example, if an action applies to the contents of a card:
 
-- Use card header actions for less important actions, or those that don’t
-  benefit from reviewing the contents of the card. For example, merchants may
-  want to add items to a card containing a long list.
-- Use card footer actions for a card’s most important actions, or actions that
-  benefit from reviewing the contents of the card. For example, merchants
-  should review the contents of a shipment before cancelling or adding tracking
-  information.
+- Use card header actions for less important actions, or those that don’t benefit from reviewing the contents of the card. For example, merchants may want to add items to a card containing a long list.
+- Use card footer actions for a card’s most important actions, or actions that benefit from reviewing the contents of the card. For example, merchants should review the contents of a shipment before cancelling or adding tracking information.
 
 ---
 
@@ -315,6 +272,4 @@ content it affects. For example, if an action applies to the contents of a card:
 
 Always consider the full range of screen sizes when designing layouts.
 
-If a page has become complex, overloaded with content, or hard to navigate by
-scrolling on a phone, it can be broken up into a core page and secondary pages
-accessible via navigation.
+If a page has become complex, overloaded with content, or hard to navigate by scrolling on a phone, it can be broken up into a core page and secondary pages accessible via navigation.

--- a/polaris.shopify.com/content/foundations/patterns/text-fields.md
+++ b/polaris.shopify.com/content/foundations/patterns/text-fields.md
@@ -22,7 +22,7 @@ Field labels act as a title for the text field. Labels should typically be short
 
 ![field-label-highlighted](/images/foundations/patterns/text-fields/field-label-highlighted@2x.png)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -36,7 +36,7 @@ Field labels act as a title for the text field. Labels should typically be short
 
 Edge case: When a text field isn’t part of a form and is placed individually on a page (like a comment field), then you can write the field label as a call to action. For example, “Leave a comment”. This is because there’s no surrounding context and using “Comment” alone could be confusing.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -82,7 +82,7 @@ Best practices:
 
 ![help-text](/images/foundations/patterns/text-fields/help-text@2x.png)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -136,7 +136,7 @@ Modeled text inputs are text field inputs that require text to be formatted in a
 - If there’s not enough room to include both an instructional call to action and an example, then include only the example
 - Use the word “Example” followed by a colon to introduce the example (instead of e.g.)
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -184,7 +184,7 @@ If the text field label isn’t clear about where the user can find the informat
 
 Don’t use placeholder text for free input titles, names, and descriptions; use help text instead.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -204,7 +204,7 @@ Don’t use placeholder text for codes or tracking numbers; use help text instea
 
 Choose clear names for the field label, and don’t repeat it in the help text if possible. Instead, offer context that will help the user understand and complete the task quickly.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -239,7 +239,7 @@ Multiline inputs hold things like product and collection descriptions, notes abo
 
 We usually don’t know what will go in multiline fields, so providing example text isn’t helpful. Instead, include help text that explains how the text will be used and who can view it.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 
@@ -257,7 +257,7 @@ Don’t use placeholder text for comments and notes; use help text instead. Comm
 
 Some comments and notes are not visible to customers, but some are. In the help text, describe clearly who will be able to view the note.
 
-<!-- usagelist -->
+<!-- dodont -->
 
 #### Do
 

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -219,7 +219,7 @@ button {
 }
 
 // Legacy CSS hacks to work with content from old site (used in markdown files)
-.usage-list {
+.usage {
   margin: 1.25rem 0 2rem;
   font-size: var(--font-size-200);
   gap: 1rem;
@@ -236,7 +236,7 @@ button {
     gap: 1rem;
   }
 
-  .usage-list-part {
+  .usage-part {
     position: relative;
     flex: 1;
     background: var(--surface-subdued);
@@ -289,44 +289,6 @@ button {
     h3 {
       font-size: var(--font-size-300);
       color: var(--text);
-    }
-  }
-
-  &.usage-block {
-    .usage-list-part {
-      padding-top: 1.75rem;
-
-      h4 {
-        display: none;
-      }
-
-      li,
-      p {
-        background-image: url(/images/icon-do.svg);
-        background-repeat: no-repeat;
-        background-position: left 0.15rem;
-        padding-left: 34px;
-        background-size: auto 1.25rem;
-        letter-spacing: var(--letter-spacing-200);
-        list-style: none;
-        margin-left: 0;
-      }
-
-      li:before {
-        display: none;
-      }
-
-      &[data-type="dont"] {
-        li,
-        p {
-          background-image: url(/images/icon-dont.svg);
-        }
-
-        li > p {
-          background: none;
-          padding-left: 0;
-        }
-      }
     }
   }
 }

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -219,16 +219,12 @@ button {
 }
 
 // Legacy CSS hacks to work with content from old site (used in markdown files)
-.usage {
+.dodont {
   margin: 1.25rem 0 2rem;
   font-size: var(--font-size-200);
   gap: 1rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
-
-  + .usage-list {
-    margin-top: -1rem;
-  }
 
   @media screen and (max-width: $breakpointMobile) {
     display: flex;
@@ -236,17 +232,13 @@ button {
     gap: 1rem;
   }
 
-  .usage-part {
+  .dodont-part {
     position: relative;
     flex: 1;
     background: var(--surface-subdued);
     padding: 0.25rem 1.25rem;
     border-radius: var(--border-radius-400);
     overflow: hidden;
-
-    &:empty {
-      display: none;
-    }
 
     h4:first-child {
       background-image: url(/images/icon-do.svg);

--- a/polaris.shopify.com/src/utils/markdown.mjs
+++ b/polaris.shopify.com/src/utils/markdown.mjs
@@ -23,13 +23,12 @@ export const parseMarkdown = (inputMarkdown) => {
 
   let markdown = readmeSection;
 
-  // Add some custom HTML to <!-- usagelist --> and <!-- usageblock --> tags
-  const usageListRegex = /<!-- (usagelist|usageblock) -->(.*?)<!-- end -->/gis;
-  if (markdown.match(usageListRegex)) {
-    markdown = markdown.replaceAll(usageListRegex, (match) => {
+  // Add some custom HTML to <!-- dodont --> tags
+  const dodontRegex = /<!-- (dodont) -->(.*?)<!-- end -->/gis;
+  if (markdown.match(dodontRegex)) {
+    markdown = markdown.replaceAll(dodontRegex, (match) => {
       const matchWithoutComments = match
-        .replace(/^<!-- usagelist -->/, "")
-        .replace(/^<!-- usageblock -->/, "")
+        .replace(/^<!-- dodont -->/, "")
         .replace(/<!-- end -->$/, "");
 
       let i = 0;
@@ -39,7 +38,7 @@ export const parseMarkdown = (inputMarkdown) => {
           if (i === 1) {
             const type = match.startsWith("#### Don") ? "dont" : "do";
 
-            return `</div><div class="usage-list-part" data-type="${type}">\n\n#### ${captured}`;
+            return `</div><div class="dodont-part" data-type="${type}">\n\n#### ${captured}`;
           }
           i++;
           return match;
@@ -48,9 +47,7 @@ export const parseMarkdown = (inputMarkdown) => {
 
       const type = match.trim().startsWith("#### Don") ? "dont" : "do";
 
-      return `<div class="usage-list${
-        match.includes("usageblock") ? " usage-block" : ""
-      }"><div class="usage-list-part" data-type="${type}">${matchWithColumns}</div></div>`;
+      return `<div class="dodont"><div class="dodont-part" data-type="${type}">${matchWithColumns}</div></div>`;
     });
   }
 


### PR DESCRIPTION
- [x] Replaced `<!-- usagelist` and `<!-- usageblock` with `<!-- dodont`
- [x] Simplified CSS and logic for `<!-- dodont`
- [x] Removed `<!-- keywords: `
- [x] Removed `<!-- showcasecontent`
- [x] Removed `<!-- centeredcontent`
- [x] Removed `<!-- hint`
- [x] Removed 80 character line break from markdown files