### PR TITLE
Only run preversion step if on the release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    env:
+      isReleaseBranch: ${{ github.ref == 'refs/heads/changeset-release/main' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -24,10 +26,11 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Run preversion scripts
-        run: |
-          yarn preversion-packages
+        if: env.isReleaseBranch
+        run: yarn preversion-packages
 
       - name: Commit preversion updates
+        if: env.isReleaseBranch
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Apply preversion changes


### PR DESCRIPTION
This check will only run the preversion and git autocommit steps if we are on the release branch of `changeset-release/main`