### PR TITLE
[Icon] Clarify circle and diamond alert icon descriptions

### DIFF
--- a/.changeset/tough-melons-deliver.md
+++ b/.changeset/tough-melons-deliver.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris-icons': major
+'@shopify/polaris-icons': minor
 ---
 
 Making the descriptions and use cases for diamond and circle alert icons clearer.

--- a/.changeset/tough-melons-deliver.md
+++ b/.changeset/tough-melons-deliver.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': major
+---
+
+Making the descriptions and use cases for diamond and circle alert icons clearer.

--- a/polaris-icons/icons/CircleAlertMajor.yml
+++ b/polaris-icons/icons/CircleAlertMajor.yml
@@ -1,6 +1,6 @@
 name: Circle alert
 set: major
-description: Used to give merchants more information about something they should be aware of.
+description: Used to alert merchants of a critical error.
 keywords:
   - attention
   - alert

--- a/polaris-icons/icons/CircleAlertMajor.yml
+++ b/polaris-icons/icons/CircleAlertMajor.yml
@@ -1,6 +1,6 @@
 name: Circle alert
 set: major
-description: Used to alert merchants of a critical error.
+description: Used to alert merchants of a warning message.
 keywords:
   - attention
   - alert

--- a/polaris-icons/icons/DiamondAlertMajor.yml
+++ b/polaris-icons/icons/DiamondAlertMajor.yml
@@ -1,10 +1,14 @@
 name: Diamond alert
 set: major
-description: Used to alert merchants on information they should be aware of.
+description: Used to alert merchants of a critical error.
 keywords:
   - alert
   - attention
   - critical
+  - diamond
+  - error
+  - exclamation
+  - bang
 authors:
   - Jesse Bennett-Chamberlain
 version: 1


### PR DESCRIPTION
### WHY are these changes introduced?

The description / use case for the circle alert icon is not clear or distinguishable from the description for the diamond alert icon. It should be clear that the circle alert is for warning messages and the diamond alert is for critical errors.

### WHAT is this pull request doing?

This PR...

* changes the description of the circle alert icon from
![screenshot](https://screenshot.click/08-22-2i4gd-gkj9e.png)
`Used to give merchants more information about something they should be aware of.`
to
`Used to alert merchants of a warning message.`

* changes the description of the diamond alert icon from
![screenshot](https://screenshot.click/08-21-8w4mj-d0ei3.png)
`Used to alert merchants on information they should be aware of.`
to
`Used to alert merchants of a critical error.`

* adds a few keywords to the diamond alert icon keyword list