### PR TITLE
[Banner] Fix missing period typo in Warning banners description

### DIFF
--- a/.changeset/dirty-walls-yell.md
+++ b/.changeset/dirty-walls-yell.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix missing period typo in Warning banners description

--- a/polaris.shopify.com/content/components/banner.md
+++ b/polaris.shopify.com/content/components/banner.md
@@ -56,7 +56,7 @@ examples:
     title: Warning banners
     description: >-
       Use to display information that needs attention or that merchants need to
-      take action onSeeing these banners can be stressful for merchants so be
+      take action on. Seeing these banners can be stressful for merchants so be
       cautious about using them
   - fileName: banner-critical.tsx
     title: Critical banners


### PR DESCRIPTION
Fixing a missing period type in the `Warning banners` description.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Noticed a typo while reading Polaris documentation.

<!--
  Context about the problem that’s being addressed.
-->

Adds a missing period and trailing space between two sentences.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
