### PR TITLE
[Typography foundations] Add fontweight to Text variants

### DIFF
--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -68,7 +68,7 @@
 }
 
 .displaySm {
-  font-size: var(--p-font-size-75);
+  font-size: var(--p-font-size-500);
   line-height: var(--p-font-line-height-5);
 }
 
@@ -79,7 +79,6 @@
 
 .displayLg {
   font-size: var(--p-font-size-700);
-  font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-font-line-height-7);
 }
 

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -24,6 +24,19 @@ type FontWeight = 'regular' | 'medium' | 'semibold' | 'bold';
 
 type Color = 'success' | 'critical' | 'warning' | 'subdued';
 
+const VariantFontWeightMapping: {[V in Variant]: FontWeight} = {
+  displaySm: 'semibold',
+  displayMd: 'semibold',
+  displayLg: 'bold',
+  headingSm: 'bold',
+  headingMd: 'semibold',
+  headingLg: 'semibold',
+  headingXl: 'semibold',
+  bodySm: 'regular',
+  bodyMd: 'regular',
+  bodyLg: 'regular',
+};
+
 export interface TextProps {
   /** Adjust horizontal alignment of text */
   alignment?: Alignment;
@@ -48,7 +61,7 @@ export const Text = ({
   as,
   children,
   color,
-  fontWeight = 'regular',
+  fontWeight,
   truncate = false,
   variant,
   visuallyHidden = false,
@@ -58,7 +71,7 @@ export const Text = ({
   const className = classNames(
     styles.root,
     styles[variant],
-    fontWeight && styles[fontWeight],
+    fontWeight ? styles[fontWeight] : styles[VariantFontWeightMapping[variant]],
     (alignment || truncate) && styles.block,
     alignment && styles[alignment],
     color && styles[color],


### PR DESCRIPTION
### WHY are these changes introduced?

`Text` variants didn't have default font weights mentioned in this [Figma](https://www.figma.com/file/lywHPxKoSsqzhQyasj6VON/Typography-foundations?node-id=1046%3A61571).

### WHAT is this pull request doing?

Adds default font weights to all the text style variants.
Also fixes the `font-size` for `displaySm` variant.

[Storybook URL](https://5d559397bae39100201eedc1-mcqsmzjcpg.chromatic.com/?path=/story/playground-playground--playground).
    <details>
      <summary>Screenshot of all variants (with font weight override examples)</summary>
      <img src="https://user-images.githubusercontent.com/26749317/180062274-a0bfb43c-d6fe-4cf7-aa77-095fef991554.png" alt="Text style variant font weights">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Stack, Text} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Stack vertical>
        <Text as="span" variant="displayLg">
          Display lg variant — bold
        </Text>
        <Text as="span" variant="displayMd">
          Display md variant — semibold
        </Text>
        <Text as="span" variant="displaySm">
          Display sm variant — semibold
        </Text>
        <Text as="h1" variant="headingXl">
          Heading xl variant — semibold
        </Text>
        <Text as="h2" variant="headingLg">
          Heading lg variant — semibold
        </Text>
        <Text as="h3" variant="headingMd">
          Heading md variant — semibold
        </Text>
        <Text as="h4" variant="headingSm">
          Heading sm variant — bold
        </Text>
        <Text as="p" variant="bodyLg">
          Body lg variant — regular
        </Text>
        <Text as="p" variant="bodyMd">
          Body md variant — regular
        </Text>
        <Text as="p" variant="bodySm">
          Body sm variant — regular
        </Text>
      </Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
