### PR TITLE
[TextField] Fix: cross browser input number decimal separator spec

### DIFF
--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -577,7 +577,7 @@ export function TextField({
 
   function handleKeyPress(event: React.KeyboardEvent) {
     const {key, which} = event;
-    const numbersSpec = /[\d.eE+-]$/;
+    const numbersSpec = /[\d.,eE+-]$/;
     if (type !== 'number' || which === Key.Enter || numbersSpec.test(key)) {
       return;
     }


### PR DESCRIPTION
Browsers may display decimal numbers in a numeric input field differently depending on the lang attribute. But in polaris, at the moment, only the input of decimal numbers separated by a dot is supported.

There is a problem when I pass the number **1.5** to the value parameter, as in the example below:

```jsx
<TextField type="number" value={1.5} />
```

Then the browser will display an input with a value of **1,5**. The user, when trying to change the value, cannot do this because he initially saw the comma symbol and trying to enter it will not be able to do it.
