### PR TITLE
[polaris.shopify.com] Fix link color

### DIFF
--- a/.changeset/olive-walls-sneeze.md
+++ b/.changeset/olive-walls-sneeze.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed an issue which accidentally made links be the same colors as regular text

--- a/polaris.shopify.com/src/components/Header/Header.module.scss
+++ b/polaris.shopify.com/src/components/Header/Header.module.scss
@@ -79,7 +79,7 @@
 .Logo {
   display: flex;
   align-items: center;
-  color: var(--text-inherit);
+  color: inherit;
   gap: 0.7rem;
   font-weight: var(--font-weight-500);
   font-size: var(--font-size-100);

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -116,7 +116,6 @@ html {
   * {
     margin: 0;
     padding: 0;
-    color: inherit;
     font-family: inherit;
     font-weight: inherit;
     font-size: 100%;


### PR DESCRIPTION
Fixed an issue which accidentally made links be the same colors as regular text.

Closes #6712.

Before:

<img width="463" alt="image" src="https://user-images.githubusercontent.com/875708/180243406-a228894f-6ec0-42eb-92f9-5cbb3cbd1f55.png">

After:

<img width="465" alt="image" src="https://user-images.githubusercontent.com/875708/180243483-29d3acbe-54db-43ac-88dc-9891383eeb91.png">
