### PR TITLE
[DataTable] Fix dom validation error, focus states and icon shimmering.

### DIFF
--- a/.changeset/odd-games-cough.md
+++ b/.changeset/odd-games-cough.md
@@ -1,0 +1,12 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+---
+
+## '@shopify/polaris': patch
+
+- Updates `DataTable` to fix console warning about improperly nested HTML
+- Updates `DataTable` to ensure focus states remain on the same header element when switching between sticky and regular header.
+- Improves `DataTable` tooltip when using `truncate` prop.

--- a/.changeset/odd-games-cough.md
+++ b/.changeset/odd-games-cough.md
@@ -7,6 +7,6 @@
 
 ## '@shopify/polaris': patch
 
-- Updates `DataTable` to fix console warning about improperly nested HTML
-- Updates `DataTable` to ensure focus states remain on the same header element when switching between sticky and regular header.
-- Improves `DataTable` tooltip when using `truncate` prop.
+- Updated `DataTable` to fix console warning about improperly nested HTML
+- Updated `DataTable` to ensure focus states remain on the same header element when switching between sticky and regular header.
+- Improved `DataTable` tooltip when using `truncate` prop.

--- a/polaris-react/src/components/DataTable/DataTable.scss
+++ b/polaris-react/src/components/DataTable/DataTable.scss
@@ -12,7 +12,7 @@
     align-items: center;
     justify-content: center;
     width: 100%;
-    padding: var(--p-space-4) var(--p-space-2);
+    padding: var(--p-space-4) var(--p-space-2) 0;
 
     @media #{$p-breakpoints-md-up} {
       justify-content: flex-end;
@@ -165,8 +165,7 @@
   display: flex;
   align-self: flex-end;
   opacity: 0;
-  transition: opacity var(--p-duration-200) var(--p-ease),
-    fill var(--p-duration-200) var(--p-ease);
+  transition: opacity var(--p-duration-200) var(--p-ease);
 }
 
 .Heading {
@@ -176,7 +175,7 @@
   display: inline-flex;
   justify-content: flex-end;
   align-items: baseline;
-  @include recolor-icon(var(--p-icon));
+  @include recolor-icon(var(--p-icon-disabled));
   color: var(--p-text);
   transition: color var(--p-duration-200) var(--p-ease);
   cursor: pointer;
@@ -187,7 +186,7 @@
     visibility: hidden;
   }
 
-  .StickyHeaderEnabled [data-sticky-active] .StickyTable & {
+  .StickyHeaderEnabled [data-sticky-active] .StickyHeaderWrapper & {
     visibility: visible;
   }
 
@@ -200,15 +199,10 @@
   }
 
   &:hover {
-    @include recolor-icon(var(--p-interactive-hovered));
     color: var(--p-interactive-hovered);
 
     .Icon {
       opacity: 1;
-
-      svg {
-        fill: var(--p-icon-disabled);
-      }
     }
   }
 
@@ -233,6 +227,11 @@
 .Cell-sorted {
   .Icon {
     opacity: 1;
+    @include recolor-icon(var(--p-icon));
+  }
+
+  &:hover {
+    @include recolor-icon(var(--p-interactive-hovered));
   }
 
   .Heading:focus:not(:active) {
@@ -285,7 +284,7 @@
 }
 
 .StickyHeaderEnabled {
-  .StickyTable {
+  .StickyHeaderWrapper {
     position: relative;
     top: 0;
     left: 0;
@@ -294,7 +293,7 @@
     z-index: var(--p-z-1);
   }
 
-  .StickyTableHeader {
+  .StickyHeaderInner {
     position: absolute;
     display: flex;
     flex-direction: column;
@@ -302,20 +301,17 @@
     overflow: hidden;
     border-spacing: 0;
 
-    &:not(.StickyTableHeader-isSticky) {
+    &:not(.StickyHeaderInner-isSticky) {
       top: -9999px;
       left: -9999px;
     }
   }
 
-  .StickyTableColumnHeader-isScrolling {
-    box-shadow: 1px 1px 0 0 var(--p-border-divider),
-      1px 0 1px 1px rgba(63, 63, 68, 0.05), 1px 0 3px 0 rgba(63, 63, 68, 0.15);
-  }
-
-  .StickyTableHeadingsRow {
+  .StickyHeaderTable {
+    border-collapse: collapse;
+    display: block;
     overflow-x: auto;
-    background-color: var(--p-surface);
+    width: 100%;
     scrollbar-width: none;
 
     &::-webkit-scrollbar {
@@ -325,7 +321,16 @@
     }
   }
 
-  .StickyTableHeader-isSticky {
+  .StickyTableColumnHeader-isScrolling {
+    box-shadow: 1px 1px 0 0 var(--p-border-divider),
+      1px 0 1px 1px rgba(63, 63, 68, 0.05), 1px 0 3px 0 rgba(63, 63, 68, 0.15);
+  }
+
+  .StickyTableHeadingsRow {
+    background-color: var(--p-surface);
+  }
+
+  .StickyHeaderInner-isSticky {
     visibility: visible;
     background-color: var(--p-surface);
     box-shadow: var(--p-shadow-base);
@@ -337,11 +342,13 @@
   background: var(--p-surface);
   z-index: 3;
   border-spacing: 0;
+  left: 0;
   @media #{$p-breakpoints-md-down} {
     z-index: 1;
   }
 
-  &.separate th {
+  &.separate:is(table) th,
+  &.separate:is(th) {
     border-right: var(--p-border-divider);
   }
 }

--- a/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
+++ b/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
@@ -64,13 +64,16 @@ export function Cell({
   const numeric = contentType === 'numeric';
 
   const [showTooltip, setShowTooltip] = useState(false);
+  const [tooltipContent, setTooltipContent] = useState('');
 
   function setTooltip(ref: HTMLTableCellElement | null) {
     if (!ref) {
       return;
     }
-    if (ref.scrollWidth > ref.offsetWidth && inFixedFirstColumn) {
+    // Since the cell can accept any React node, we'll only show a tooltip when the cell content has an innerText
+    if (ref.scrollWidth > ref.offsetWidth && ref.innerText) {
       setShowTooltip(true);
+      setTooltipContent(ref.innerText);
     }
   }
 
@@ -118,7 +121,12 @@ export function Cell({
     </span>
   );
 
-  const focusable = inFixedFirstColumn || !(hasFixedFirstColumn && firstColumn);
+  const focusable = !(
+    stickyHeadingCell &&
+    hasFixedFirstColumn &&
+    firstColumn &&
+    !inFixedFirstColumn
+  );
 
   const sortableHeadingContent = (
     <button
@@ -177,7 +185,7 @@ export function Cell({
       }}
     >
       {showTooltip ? (
-        <Tooltip content={content}>
+        <Tooltip content={tooltipContent}>
           <span className={styles.TooltipContent}>{content}</span>
         </Tooltip>
       ) : (

--- a/polaris-react/src/components/DataTable/components/Navigation/Navigation.tsx
+++ b/polaris-react/src/components/DataTable/components/Navigation/Navigation.tsx
@@ -14,6 +14,7 @@ export interface NavigationProps {
   fixedFirstColumn?: boolean;
   navigateTableLeft?(): void;
   navigateTableRight?(): void;
+  setRef?: (ref: HTMLDivElement | null) => void;
 }
 
 export function Navigation({
@@ -23,6 +24,7 @@ export function Navigation({
   navigateTableLeft,
   navigateTableRight,
   fixedFirstColumn,
+  setRef = () => {},
 }: NavigationProps) {
   const i18n = useI18n();
 
@@ -47,7 +49,7 @@ export function Navigation({
   );
 
   return (
-    <div className={styles.Navigation}>
+    <div className={styles.Navigation} ref={setRef}>
       <Button
         plain
         icon={ChevronLeftMinor}

--- a/polaris.shopify.com/content/components/data-table.md
+++ b/polaris.shopify.com/content/components/data-table.md
@@ -43,6 +43,9 @@ examples:
   - fileName: data-table-with-sticky-header-enabled.tsx
     title: Data table with sticky header enabled
     description: Use as a broad example that includes most props available to data table.
+  - fileName: data-table-with-fixed-first-column-enabled.tsx
+    title: Data table with fixed first column enabled
+    description: Use to fix the first column when horizontal scrolling becomes necessary. Keeps the context of the row as the user scrolls.
 ---
 
 # Data table

--- a/polaris.shopify.com/src/pages/examples/data-table-with-fixed-first-column.tsx
+++ b/polaris.shopify.com/src/pages/examples/data-table-with-fixed-first-column.tsx
@@ -1,0 +1,296 @@
+import { Link, Page, Card, DataTable } from "@shopify/polaris";
+import { useState, useCallback } from "react";
+import { withPolarisExample } from "../../components/PolarisExamplePage";
+
+function DataTableWithFixedFirstColumnExample() {
+  const rows = [
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="emerald-silk-gown"
+      >
+        Emerald Silk Gown
+      </Link>,
+      "$875.00",
+      124689,
+      140,
+      "$121,500.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="mauve-cashmere-scarf"
+      >
+        Mauve Cashmere Scarf
+      </Link>,
+      "$230.00",
+      124533,
+      83,
+      "$19,090.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="navy-merino-wool"
+      >
+        Navy Merino Wool Blazer with khaki chinos and yellow belt
+      </Link>,
+      "$445.00",
+      124518,
+      32,
+      "$14,240.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="emerald-silk-gown"
+      >
+        Emerald Silk Gown
+      </Link>,
+      "$875.00",
+      124689,
+      140,
+      "$121,500.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="mauve-cashmere-scarf"
+      >
+        Mauve Cashmere Scarf
+      </Link>,
+      "$230.00",
+      124533,
+      83,
+      "$19,090.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="navy-merino-wool"
+      >
+        Navy Merino Wool Blazer with khaki chinos and yellow belt
+      </Link>,
+      "$445.00",
+      124518,
+      32,
+      "$14,240.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="emerald-silk-gown"
+      >
+        Emerald Silk Gown
+      </Link>,
+      "$875.00",
+      124689,
+      140,
+      "$121,500.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="mauve-cashmere-scarf"
+      >
+        Mauve Cashmere Scarf
+      </Link>,
+      "$230.00",
+      124533,
+      83,
+      "$19,090.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="navy-merino-wool"
+      >
+        Navy Merino Wool Blazer with khaki chinos and yellow belt
+      </Link>,
+      "$445.00",
+      124518,
+      32,
+      "$14,240.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="emerald-silk-gown"
+      >
+        Emerald Silk Gown
+      </Link>,
+      "$875.00",
+      124689,
+      140,
+      "$121,500.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="mauve-cashmere-scarf"
+      >
+        Mauve Cashmere Scarf
+      </Link>,
+      "$230.00",
+      124533,
+      83,
+      "$19,090.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="navy-merino-wool"
+      >
+        Navy Merino Wool Blazer with khaki chinos and yellow belt
+      </Link>,
+      "$445.00",
+      124518,
+      32,
+      "$14,240.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="emerald-silk-gown"
+      >
+        Emerald Silk Gown
+      </Link>,
+      "$875.00",
+      124689,
+      140,
+      "$121,500.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="mauve-cashmere-scarf"
+      >
+        Mauve Cashmere Scarf
+      </Link>,
+      "$230.00",
+      124533,
+      83,
+      "$19,090.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="navy-merino-wool"
+      >
+        Navy Merino Wool Blazer with khaki chinos and yellow belt
+      </Link>,
+      "$445.00",
+      124518,
+      32,
+      "$14,240.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="emerald-silk-gown"
+      >
+        Emerald Silk Gown
+      </Link>,
+      "$875.00",
+      124689,
+      140,
+      "$121,500.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="mauve-cashmere-scarf"
+      >
+        Mauve Cashmere Scarf
+      </Link>,
+      "$230.00",
+      124533,
+      83,
+      "$19,090.00",
+    ],
+    [
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="navy-merino-wool"
+      >
+        Navy Merino Wool Blazer with khaki chinos and yellow belt
+      </Link>,
+      "$445.00",
+      124518,
+      32,
+      "$14,240.00",
+    ],
+  ];
+  const [sortedRows, setSortedRows] = useState<any[]>(rows);
+
+  return (
+    <Page title="Sales by product">
+      <Card>
+        <DataTable
+          columnContentTypes={[
+            "text",
+            "numeric",
+            "numeric",
+            "numeric",
+            "numeric",
+          ]}
+          headings={[
+            "Product",
+            "Price",
+            "SKU Number",
+            "Net quantity",
+            "Net sales",
+          ]}
+          rows={sortedRows}
+          totals={["", "", "", 255, "$155,830.00"]}
+          sortable={[true, true, false, false, true]}
+          defaultSortDirection="descending"
+          initialSortColumnIndex={4}
+          onSort={(index, direction) => {
+            setSortedRows(
+              [...rows].sort((rowA, rowB) => {
+                const amountA = rowA[index]?.props?.children
+                  ? rowA[index]?.props?.children
+                  : parseFloat(rowA[index].substring(1));
+                const amountB = rowB[index]?.props?.children
+                  ? rowB[index]?.props?.children
+                  : parseFloat(rowB[index].substring(1));
+
+                return (
+                  direction === "descending"
+                    ? amountA > amountB
+                    : amountB > amountA
+                )
+                  ? 1
+                  : -1;
+              })
+            );
+          }}
+          footerContent={`Showing ${sortedRows.length} of ${sortedRows.length} results`}
+          stickyHeader
+          hasFixedFirstColumn
+        />
+      </Card>
+    </Page>
+  );
+}
+
+export default withPolarisExample(DataTableWithFixedFirstColumnExample);


### PR DESCRIPTION
> **Note**
> This is a second attempt at merging https://github.com/Shopify/polaris/pull/6532 which was previously [reverted](https://github.com/Shopify/polaris/pull/6720) as it contained a prop change that should have not been merged. Copying the complete description of the original PR to make it easier for reviewers to get context. The PR is exactly the same with the the exception of the prop name change being removed.

### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris/issues/6585

- Updates `DataTable` to fix console warning about improperly nested HTML ([previously reviewed](https://github.com/Shopify/polaris/pull/6532))
- Updates `DataTable` to fix shimmering icon hover state. ([previously reviewed](https://github.com/Shopify/polaris/pull/6532))
- Updates `DataTable` to ensure focus states remain on the same header element when switching between sticky and regular header when using `fixedFirstColumn` ([previously reviewed](https://github.com/Shopify/polaris/pull/6532))
- Improves `DataTable` tooltip when using `truncate` prop. ([previously reviewed](https://github.com/Shopify/polaris/pull/6532))
- Adds example for Data Table with fixed first column to polaris.shopify.com 

Related: https://github.com/Shopify/core-issues/issues/40678, https://github.com/Shopify/core-issues/issues/40809

### WHAT is this pull request doing?

#### Fix shimmering icon

<details>
      <summary>Before and After Video</summary>
      
##### Before

https://user-images.githubusercontent.com/4960217/178086283-e2931baa-dc11-4010-8f99-1854c7e17415.mp4

##### After

https://user-images.githubusercontent.com/4960217/178085907-79861323-368a-4b2b-8cfa-999a12607d73.mp4

</details>

#### Keep focus state on sticky header with fixed first column

<details>
      <summary>Before and After Video</summary>
      
##### Before

https://user-images.githubusercontent.com/4960217/178086264-911589d7-6c7f-4011-b0b9-fafab3878098.mp4

##### After

https://user-images.githubusercontent.com/4960217/178085950-4526c854-4174-4cb7-ba0f-5b7f84825e14.mp4

</details>

#### Ensuring tooltips on overflow won't contain any `<a>` tags when using `Link` component.

<details>
      <summary>Before and After Video</summary>
      
##### Before

https://user-images.githubusercontent.com/4960217/178086212-fb62f403-8e6b-4225-8f90-95308e221549.mp4

##### After

https://user-images.githubusercontent.com/4960217/178085989-e2477f77-7c59-4635-8cb8-e87118aa9a03.mp4

</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Card, Link, Page, DataTable} from '../src';

function FullDataTableExample() {
  const [sortedRows, setSortedRows] = useState(null);

  const initiallySortedRows = [
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="emerald-silk-gown"
      >
        Emerald Silk Gown
      </Link>,
      '$875.00',
      124689,
      140,
      '$121,500.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="mauve-cashmere-scarf"
      >
        Mauve Cashmere Scarf
      </Link>,
      '$230.00',
      124533,
      83,
      '$19,090.00',
      124689,
      140,
      '$121,500.00',
    ],
    [
      <Link
        removeUnderline
        url="https://www.example.com"
        key="navy-merino-wool"
      >
        Navy Merino Wool Blazer with khaki chinos and yellow belt
      </Link>,
      '$445.00',
      124518,
      32,
      '$14,240.00',
      124689,
      140,
      '$121,500.00',
    ],
  ];

  const rows = sortedRows ? sortedRows : initiallySortedRows;
  const handleSort = useCallback(
    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
    [rows],
  );

  return (
    <Page title="Sales by product">
      <Card>
        <DataTable
          columnContentTypes={[
            'text',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
          ]}
          headings={[
            'Product',
            'Price',
            'SKU Number',
            'Net quantity',
            'Net sales',
            'SKU Number',
            'Net quantity',
            'Net sales',
          ]}
          rows={rows}
          totals={['', '', '', 255, '$155,830.00', '', 255, '$155,830.00']}
          sortable={[true, true, false, false, true]}
          defaultSortDirection="descending"
          initialSortColumnIndex={4}
          onSort={handleSort}
          // footerContent={`Showing ${rows.length} of ${rows.length} results`}
          stickyHeader
          hasFixedFirstColumn
          truncate
        />
      </Card>
    </Page>
  );

  function sortCurrency(rows, index, direction) {
    return [...rows].sort((rowA, rowB) => {
      const amountA = parseFloat(rowA[index].substring(1));
      const amountB = parseFloat(rowB[index].substring(1));

      return direction === 'descending' ? amountB - amountA : amountA - amountB;
    });
  }
}

export function Playground() {
  return <FullDataTableExample />;
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide


