### PR TITLE
Adding a "When to Contribute" table to the Contributing docs.

### DIFF
--- a/.changeset/hip-dolphins-compete.md
+++ b/.changeset/hip-dolphins-compete.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Added "when to contribute" table to Contributing docs

--- a/polaris.shopify.com/content/contributing/index.md
+++ b/polaris.shopify.com/content/contributing/index.md
@@ -11,11 +11,17 @@ Polaris thrives on contribution and community support. Anyone, regardless of dis
 
 ## Who can contribute
 
-Contribution to Polaris looks different depending on whether or not you work at Shopify. Shopifolk can contribute to any Polaris project, including the Figma UI Kit. Open source contributions are welcome for [Polaris React components](contributing/components) and their [documentation](/contributing/documentation).
+Contribution to Polaris looks different depending on whether you work at Shopify. Shopify employees can contribute to any Polaris project, including the Figma UI Kit. Open source contributions are welcome for [Polaris React components](contributing/components) and their [documentation](/contributing/documentation).
 
 ## When to contribute
 
-Figuring out what and when to contribute is not always simple, especially when deciding between adding something new to the system or going with an existing solution. Check out the [Designing with a system](/contributing/designing-with-a-system) and [When to contribute new patterns](/contributing/when-to-contribute-new-patterns) guides to help you make this decision.
+Figuring out what and when to contribute is not always simple, but it doesn't have to be! Here are some common scenarios for deciding when to contribute:
+
+| Use the System                                                               | Extend the system                                                                       | Build a custom solution                                                                         |     |     |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | --- | --- |
+| _When available resources can solve a design problem_                        | _When a change or addition can solve a shared problem_                                  | _When a unique problem requires a unique solution_                                              |     |     |
+| Read [ Designing with a system ](/contributing/designing-with-a-system)      | Read [ When to contribute new patterns ](/contributing/when-to-contribute-new-patterns) | Share ideas in [ #admin-ux ](https://shopify.slack.com/archives/C039ZAKQ5AA)(Shopify employees) |     |     |
+| [ Review App Design Guidelines ](https://shopify.dev/apps/design-guidelines) | [ Create GitHub issue ](https://github.com/Shopify/polaris/issues/new/choose)           | Build with Polaris [ tokens ](https://polaris.shopify.com/tokens/colors)                        |     |     |
 
 ## Where to get help
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHAT is this pull request doing?
This adds a table under #When to Contribute delineating how to use the system, extend the system, and choose to custom-build. FYI, this is the interim, "simple" fix to adhere to the markdown styling limitations, with the hope to replace this with a media-card design later.

Screenshot:
<img width="1573" alt="Screen Shot 2022-07-21 at 5 41 12 PM" src="https://user-images.githubusercontent.com/13204374/180327136-68bf14ea-15b0-4d95-ad11-52bcf39e8ec8.png">

