### PR TITLE
[Typography foundations] Refactor `display` variants to `heading2xl-4xl`

### DIFF
--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -67,21 +67,6 @@
   font-weight: var(--p-font-weight-bold);
 }
 
-.displaySm {
-  font-size: var(--p-font-size-500);
-  line-height: var(--p-font-line-height-5);
-}
-
-.displayMd {
-  font-size: var(--p-font-size-600);
-  line-height: var(--p-font-line-height-6);
-}
-
-.displayLg {
-  font-size: var(--p-font-size-700);
-  line-height: var(--p-font-line-height-7);
-}
-
 .headingSm {
   font-size: var(--p-font-size-75);
   line-height: var(--p-font-line-height-1);
@@ -100,6 +85,21 @@
 .headingXl {
   font-size: var(--p-font-size-300);
   line-height: var(--p-font-line-height-3);
+}
+
+.heading2xl {
+  font-size: var(--p-font-size-500);
+  line-height: var(--p-font-line-height-5);
+}
+
+.heading3xl {
+  font-size: var(--p-font-size-600);
+  line-height: var(--p-font-line-height-6);
+}
+
+.heading4xl {
+  font-size: var(--p-font-size-700);
+  line-height: var(--p-font-line-height-7);
 }
 
 .bodySm {

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -7,13 +7,13 @@ import styles from './Text.scss';
 type Element = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
 
 type Variant =
-  | 'displaySm'
-  | 'displayMd'
-  | 'displayLg'
   | 'headingSm'
   | 'headingMd'
   | 'headingLg'
   | 'headingXl'
+  | 'heading2xl'
+  | 'heading3xl'
+  | 'heading4xl'
   | 'bodySm'
   | 'bodyMd'
   | 'bodyLg';
@@ -25,13 +25,13 @@ type FontWeight = 'regular' | 'medium' | 'semibold' | 'bold';
 type Color = 'success' | 'critical' | 'warning' | 'subdued';
 
 const VariantFontWeightMapping: {[V in Variant]: FontWeight} = {
-  displaySm: 'semibold',
-  displayMd: 'semibold',
-  displayLg: 'bold',
   headingSm: 'bold',
   headingMd: 'semibold',
   headingLg: 'semibold',
   headingXl: 'semibold',
+  heading2xl: 'semibold',
+  heading3xl: 'semibold',
+  heading4xl: 'bold',
   bodySm: 'regular',
   bodyMd: 'regular',
   bodyLg: 'regular',


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #6724.

Display variants were intended to give clarity on how to apply type but ended up causing more confusion.

### WHAT is this pull request doing?

Refactors the `displaySm`, `displayMd`, and `displayLg` variants to `heading2xl`, `heading3xl`, and `heading4xl`.

[Storybook url](https://5d559397bae39100201eedc1-voipjrdlby.chromatic.com/?path=/story/playground-playground--playground).
Screenshot:
    <details>
      <summary>Updated Text component variants</summary>
      <img src="https://user-images.githubusercontent.com/26749317/180433610-3af5f7da-b4d8-47fd-a039-0c41fda2fde4.png" alt="Updated Text component variants">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Stack, Text} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Stack vertical>
        <Text as="h1" variant="heading4xl">
          Heading4xl variant
        </Text>
        <Text as="h2" variant="heading3xl">
          Heading3xl variant
        </Text>
        <Text as="h3" variant="heading2xl">
          Heading2xl variant
        </Text>
        <Text as="h4" variant="headingXl">
          HeadingXl variant
        </Text>
        <Text as="h5" variant="headingLg">
          HeadingLg variant
        </Text>
        <Text as="h6" variant="headingMd">
          HeadingMd variant
        </Text>
        <Text as="h6" variant="headingSm">
          HeadingSm variant
        </Text>
        <Text as="p" variant="bodyLg">
          BodyLg variant
        </Text>
        <Text as="p" variant="bodyMd">
          BodyMd variant
        </Text>
        <Text as="p" variant="bodySm">
          BodySm variant
        </Text>
      </Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
