### PR TITLE
[polari.shopify.com] Fix issue that caused site search to re-open

### DIFF
--- a/.changeset/chatty-seahorses-raise.md
+++ b/.changeset/chatty-seahorses-raise.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixes an issue which caused the site search to re-open once dismissed.

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
@@ -186,7 +186,7 @@ function GlobalSearch() {
                   aria-controls="search-results"
                   aria-expanded={searchResultsCount > 0}
                   aria-activedescendant={currentItemId}
-                  onKeyDown={handleKeyboardNavigation}
+                  onKeyUp={handleKeyboardNavigation}
                   autoComplete="off"
                   autoCorrect="off"
                   autoCapitalize="off"


### PR DESCRIPTION
Changes the event handler for the global search. It fixes a pesky focus bug, but makes the search feel a tiny bit less snappy which we can address later.

> OK, I've narrow this one down to this:
> 
> - When you press enter, the keydown event closes the modal and returns focus to the previously focused element (a11y best practice)
> - The onkeyup event immediately fires on that element causing the modal to re-open
> 
> You can prove this by manually setting the focus on the dark mode switcher, then opening the global search using the / key. When you press enter on a result, the search will disappear (onkeydown), focus will return to the dark mode switcher, and the site will switch to light/dark mode (onkeyup).

Fixes #6638