### PR TITLE
Clean up scripts

### DIFF
--- a/.changeset/odd-carpets-film.md
+++ b/.changeset/odd-carpets-film.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Adjust some of the internal scripts so they are simpler

--- a/polaris-react/scripts/readme-update-version.js
+++ b/polaris-react/scripts/readme-update-version.js
@@ -5,9 +5,11 @@ const {execSync} = require('child_process');
 const {writeFileSync, readFileSync} = require('fs');
 
 const {version: newVersion} = require('../package.json');
-const {semverRegExp, readmes} = require('../scripts/utilities');
+const {semverRegExp} = require('../scripts/utilities');
 
 const root = resolve(__dirname, '..');
+
+export const readmes = Object.freeze(['README.md', 'src/components/README.md']);
 
 console.log(`🆕 Updating version in ${readmes.join(', ')}...`);
 readmes

--- a/polaris-react/scripts/utilities/index.js
+++ b/polaris-react/scripts/utilities/index.js
@@ -1,5 +1,3 @@
-const {readmes} = require('./readmes');
 const {semverRegExp} = require('./semver-reg-exp');
 
-module.exports.readmes = readmes;
 module.exports.semverRegExp = semverRegExp;

--- a/polaris-react/scripts/utilities/readmes.js
+++ b/polaris-react/scripts/utilities/readmes.js
@@ -1,2 +1,0 @@
-const readmes = Object.freeze(['README.md', 'src/components/README.md']);
-module.exports.readmes = readmes;

--- a/polaris-react/tests/readme-update-version.test.js
+++ b/polaris-react/tests/readme-update-version.test.js
@@ -1,7 +1,8 @@
 const path = require('path');
 const fs = require('fs');
 
-const {semverRegExp, readmes} = require('../scripts/utilities');
+const {semverRegExp} = require('../scripts/utilities');
+const {readmes} = require('../scripts/readme-update-version');
 
 describe('readme-update-version', () => {
   it('matches 4 semver numbers in READMEs', () => {

--- a/polaris-react/tests/setup/matchers/props.ts
+++ b/polaris-react/tests/setup/matchers/props.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import type {Node} from '@shopify/react-testing';
 
 export function toBeDisabled(received: Node<any>) {
@@ -8,8 +7,8 @@ export function toBeDisabled(received: Node<any>) {
     pass,
     message() {
       return pass
-        ? chalk.green(`Expected component not to be disabled, but it was.`)
-        : chalk.red(`Expected component to be disabled, but it wasn't.`);
+        ? 'Expected component not to be disabled, but it was.'
+        : "Expected component to be disabled, but it wasn't.";
     },
   };
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When removing `markdown` storybook magic I noticed a couple of clean ups that could happen to reduce deps and snowflake files.