### PR TITLE
Rename metaTokens to metadata

### DIFF
--- a/polaris-for-vscode/src/server.ts
+++ b/polaris-for-vscode/src/server.ts
@@ -1,4 +1,4 @@
-import {createVar, metaTokens, MetaTokenGroup} from '@shopify/polaris-tokens';
+import {createVar, metadata, MetadataGroup} from '@shopify/polaris-tokens';
 import {
   createConnection,
   TextDocuments,
@@ -12,7 +12,7 @@ import {
 } from 'vscode-languageserver/node';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 
-const {legacy, ...restTokenGroups} = metaTokens;
+const {legacy, ...restTokenGroups} = metadata;
 
 const groupedCompletionItemTokenGroups = restTokenGroups;
 
@@ -27,7 +27,7 @@ type GroupedCompletionItems = {
  */
 const groupedCompletionItems = Object.fromEntries(
   Object.entries(groupedCompletionItemTokenGroups).map(
-    ([groupedCompletionItemsKey, tokenGroup]: [string, MetaTokenGroup]) => {
+    ([groupedCompletionItemsKey, tokenGroup]: [string, MetadataGroup]) => {
       const groupedCompletionItemProperties: CompletionItem[] = Object.entries(
         tokenGroup,
       ).map(

--- a/polaris-tokens/README.md
+++ b/polaris-tokens/README.md
@@ -27,10 +27,10 @@ import {tokens} from '@shopify/polaris-tokens';
 console.log(tokens.colors.background); // 'rgba(246, 246, 247, 1)'
 
 // Tokens with metadata
-import {metaTokens} from '@shopify/polaris-tokens';
+import {metadata} from '@shopify/polaris-tokens';
 
-console.log(metaTokens.colors.background.value); // 'rgba(246, 246, 247, 1)'
-console.log(metaTokens.colors.background.description); // 'For use as a background color, in components such as Page and Frame backgrounds.'
+console.log(metadata.colors.background.value); // 'rgba(246, 246, 247, 1)'
+console.log(metadata.colors.background.description); // 'For use as a background color, in components such as Page and Frame backgrounds.'
 ```
 
 #### CSS

--- a/polaris-tokens/scripts/index.ts
+++ b/polaris-tokens/scripts/index.ts
@@ -1,4 +1,4 @@
-import {metaTokens} from '../src';
+import {metadata} from '../src';
 
 import {toTokenValues} from './toTokenValues';
 import {toJSON} from './toJSON';
@@ -7,9 +7,9 @@ import {toStyleSheet} from './toStyleSheet';
 
 (async () => {
   await Promise.all([
-    toTokenValues(metaTokens),
-    toJSON(metaTokens),
-    toMediaConditions(metaTokens.breakpoints),
-    toStyleSheet(metaTokens),
+    toTokenValues(metadata),
+    toJSON(metadata),
+    toMediaConditions(metadata.breakpoints),
+    toStyleSheet(metadata),
   ]);
 })();

--- a/polaris-tokens/scripts/toJSON.ts
+++ b/polaris-tokens/scripts/toJSON.ts
@@ -1,19 +1,19 @@
 import fs from 'fs';
 import path from 'path';
 
-import {MetaTokens, TokenGroup} from '../src';
+import {Metadata, MetadataGroup} from '../src';
 
 const outputDir = path.join(__dirname, '../dist/json');
 
-export async function toJSON(metaTokens: MetaTokens) {
+export async function toJSON(metadata: Metadata) {
   if (!fs.existsSync(outputDir)) {
     await fs.promises.mkdir(outputDir, {recursive: true});
   }
 
-  for (const entry of Object.entries(metaTokens)) {
+  for (const entry of Object.entries(metadata)) {
     const [tokenGroupName, tokenGroup] = entry as [
-      keyof MetaTokens,
-      TokenGroup,
+      keyof Metadata,
+      MetadataGroup,
     ];
     const filePath = path.join(outputDir, `${tokenGroupName}.json`);
 

--- a/polaris-tokens/scripts/toStyleSheet.ts
+++ b/polaris-tokens/scripts/toStyleSheet.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import {MetaTokens, MetaTokenGroup} from '../src';
+import {Metadata, MetadataGroup} from '../src';
 
 const cssOutputDir = path.join(__dirname, '../dist/css');
 const sassOutputDir = path.join(__dirname, '../dist/scss');
@@ -12,16 +12,16 @@ const sassOutputPath = path.join(sassOutputDir, 'styles.scss');
  * Creates static CSS custom properties.
  * Note: These values don't vary by color-scheme.
  */
-export function getStaticCustomProperties(metaTokens: MetaTokens) {
-  return Object.entries(metaTokens)
+export function getStaticCustomProperties(metadata: Metadata) {
+  return Object.entries(metadata)
     .map(([_, tokenGroup]) => getCustomProperties(tokenGroup))
     .join('');
 }
 
 /**
- * Creates CSS custom properties for a given metaTokens object.
+ * Creates CSS custom properties for a given metadata object.
  */
-export function getCustomProperties(tokenGroup: MetaTokenGroup) {
+export function getCustomProperties(tokenGroup: MetadataGroup) {
   return Object.entries(tokenGroup)
     .map(([token, {value}]) =>
       token.startsWith('keyframes')
@@ -34,14 +34,14 @@ export function getCustomProperties(tokenGroup: MetaTokenGroup) {
 /**
  * Concatenates the `keyframes` token-group into a single string.
  */
-export function getKeyframes(motion: MetaTokenGroup) {
+export function getKeyframes(motion: MetadataGroup) {
   return Object.entries(motion)
     .filter(([token]) => token.startsWith('keyframes'))
     .map(([token, {value}]) => `@keyframes p-${token}${value}`)
     .join('');
 }
 
-export async function toStyleSheet(metaTokens: MetaTokens) {
+export async function toStyleSheet(metadata: Metadata) {
   if (!fs.existsSync(cssOutputDir)) {
     await fs.promises.mkdir(cssOutputDir, {recursive: true});
   }
@@ -50,8 +50,8 @@ export async function toStyleSheet(metaTokens: MetaTokens) {
   }
 
   const styles = `
-  :root{color-scheme:light;${getStaticCustomProperties(metaTokens)}}
-  ${getKeyframes(metaTokens.motion)}
+  :root{color-scheme:light;${getStaticCustomProperties(metadata)}}
+  ${getKeyframes(metadata.motion)}
 `;
 
   await fs.promises.writeFile(cssOutputPath, styles);

--- a/polaris-tokens/scripts/toTokenValues.ts
+++ b/polaris-tokens/scripts/toTokenValues.ts
@@ -2,19 +2,19 @@ import fs from 'fs';
 import path from 'path';
 
 import {removeMetadata} from '../src';
-import type {Entry, Entries, MetaTokens, Tokens} from '../src/types';
+import type {Entry, Entries, Metadata, Tokens} from '../src/types';
 
 const outputDir = path.join(__dirname, '../build');
 const outputFile = path.join(outputDir, 'index.ts');
 
-export async function toTokenValues(metaTokens: MetaTokens) {
+export async function toTokenValues(metadata: Metadata) {
   if (!fs.existsSync(outputDir)) {
     await fs.promises.mkdir(outputDir);
   }
 
-  const tokensEntries: Entries<Tokens> = Object.entries(metaTokens).map(
+  const tokensEntries: Entries<Tokens> = Object.entries(metadata).map(
     (entry): Entry<Tokens> => {
-      const [tokenGroupName, tokenGroup] = entry as Entry<MetaTokens>;
+      const [tokenGroupName, tokenGroup] = entry as Entry<Metadata>;
 
       return [tokenGroupName, removeMetadata(tokenGroup)];
     },
@@ -32,6 +32,8 @@ export async function toTokenValues(metaTokens: MetaTokens) {
   );
 }
 
-function createExport(entry: [string, {[key: string]: unknown}]) {
+function createExport(
+  entry: [string, {[key: string]: unknown}] | Entry<Tokens>,
+) {
   return `export const ${entry[0]} = ${JSON.stringify(entry[1])} as const;`;
 }

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -1,9 +1,9 @@
-export * from './metaTokens';
+export * from './metadata';
 export * from './utilities';
 export type {
-  MetaTokenGroup,
-  MetaTokenProperties,
-  MetaTokens,
   TokenGroup,
   Tokens,
+  MetadataProperties,
+  MetadataGroup,
+  Metadata,
 } from './types';

--- a/polaris-tokens/src/metadata.ts
+++ b/polaris-tokens/src/metadata.ts
@@ -1,4 +1,4 @@
-import type {Exact, MetaTokens} from './types';
+import type {Exact, Metadata} from './types';
 import {tokensToRems} from './utilities';
 import {breakpoints} from './token-groups/breakpoints';
 import {depth} from './token-groups/depth';
@@ -10,7 +10,7 @@ import {spacing} from './token-groups/spacing';
 import {typography} from './token-groups/typography';
 import {zIndex} from './token-groups/zIndex';
 
-export const metaTokens = createMetaTokens({
+export const metadata = createMetadata({
   breakpoints: tokensToRems(breakpoints),
   colors,
   depth,
@@ -23,9 +23,9 @@ export const metaTokens = createMetaTokens({
 });
 
 /**
- * Identity function that simply returns the provided tokens, but additionally
- * validates the input matches the `Tokens` type exactly and infers all members.
+ * Identity function that simply returns the provided tokens with metadata, but additionally
+ * validates the input matches the `Metadata` type exactly and infers all members.
  */
-export function createMetaTokens<T extends Exact<MetaTokens, T>>(tokens: T) {
-  return tokens;
+export function createMetadata<T extends Exact<Metadata, T>>(metadata: T) {
+  return metadata;
 }

--- a/polaris-tokens/src/types.ts
+++ b/polaris-tokens/src/types.ts
@@ -1,36 +1,36 @@
 export type Entry<T> = [keyof T, T[keyof T]];
 export type Entries<T> = Entry<T>[];
 
-export interface MetaTokenProperties {
+export interface MetadataProperties {
   description?: string;
   value: string;
 }
 
-export interface MetaTokenGroup {
-  [token: string]: MetaTokenProperties;
+export interface MetadataGroup {
+  [token: string]: MetadataProperties;
+}
+
+export interface Metadata {
+  breakpoints: MetadataGroup;
+  colors: MetadataGroup;
+  depth: MetadataGroup;
+  legacy: MetadataGroup;
+  motion: MetadataGroup;
+  shape: MetadataGroup;
+  spacing: MetadataGroup;
+  typography: MetadataGroup;
+  zIndex: MetadataGroup;
 }
 
 export interface TokenGroup {
   [token: string]: string;
 }
 
-export interface MetaTokens {
-  breakpoints: MetaTokenGroup;
-  colors: MetaTokenGroup;
-  depth: MetaTokenGroup;
-  legacy: MetaTokenGroup;
-  motion: MetaTokenGroup;
-  shape: MetaTokenGroup;
-  spacing: MetaTokenGroup;
-  typography: MetaTokenGroup;
-  zIndex: MetaTokenGroup;
-}
-
 export type Tokens = {
-  [Property in keyof MetaTokens]: TokenGroup;
+  [Property in keyof MetadataGroup]: TokenGroup;
 };
 
-export type ExtractValues<T extends MetaTokenGroup> = {
+export type ExtractValues<T extends MetadataGroup> = {
   [K in keyof T]: T[K]['value'];
 };
 

--- a/polaris-tokens/src/utilities.ts
+++ b/polaris-tokens/src/utilities.ts
@@ -2,7 +2,7 @@ import type {
   Entry,
   Exact,
   ExtractValues,
-  MetaTokenGroup,
+  MetadataGroup,
   Tokens,
   TokenGroup,
 } from './types';
@@ -83,9 +83,7 @@ export function rem(value: string) {
   );
 }
 
-export function tokensToRems<T extends Exact<MetaTokenGroup, T>>(
-  tokenGroup: T,
-) {
+export function tokensToRems<T extends Exact<MetadataGroup, T>>(tokenGroup: T) {
   return Object.fromEntries(
     Object.entries(tokenGroup).map(([token, properties]) => [
       token,
@@ -125,12 +123,12 @@ export function getCustomPropertyNames(tokens: Tokens) {
     .flat();
 }
 
-export function removeMetadata<T extends Exact<MetaTokenGroup, T>>(
+export function removeMetadata<T extends Exact<MetadataGroup, T>>(
   tokenGroup: T,
 ) {
   return Object.fromEntries(
     Object.entries(tokenGroup).map((entry): Entry<TokenGroup> => {
-      const [tokenName, {value}] = entry as Entry<MetaTokenGroup>;
+      const [tokenName, {value}] = entry as Entry<MetadataGroup>;
 
       return [tokenName, value];
     }),

--- a/polaris.shopify.com/src/components/TokensPage/TokensPage.tsx
+++ b/polaris.shopify.com/src/components/TokensPage/TokensPage.tsx
@@ -1,8 +1,5 @@
 import styles from "./TokensPage.module.scss";
-import {
-  MetaTokenGroup,
-  metaTokens as allTokens,
-} from "@shopify/polaris-tokens";
+import { MetadataGroup, metadata as allTokens } from "@shopify/polaris-tokens";
 import Container from "../Container";
 import { TokenPropertiesWithName } from "../../types";
 import TokenList from "../TokenList";
@@ -60,7 +57,7 @@ const navItems: NavItem[] = [
 
 function tokensToFilteredArray(
   filter: string,
-  tokenGroup: MetaTokenGroup
+  tokenGroup: MetadataGroup
 ): TokenPropertiesWithName[] {
   return Object.entries(tokenGroup)
     .filter(([name]) => {

--- a/polaris.shopify.com/src/pages/api/v0/tokens/[tokens].tsx
+++ b/polaris.shopify.com/src/pages/api/v0/tokens/[tokens].tsx
@@ -1,7 +1,7 @@
-import { Tokens, TokenGroup, createVar, tokens } from "@shopify/polaris-tokens";
+import { createVar, tokens, TokenGroup } from "@shopify/polaris-tokens";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-type TokenGroupKey = keyof Tokens;
+type TokenGroupKey = keyof typeof tokens;
 
 export const tokenGroupKeys = Object.keys(tokens) as TokenGroupKey[];
 

--- a/polaris.shopify.com/src/types.ts
+++ b/polaris.shopify.com/src/types.ts
@@ -1,4 +1,4 @@
-import { MetaTokenProperties } from "@shopify/polaris-tokens";
+import { MetadataProperties } from "@shopify/polaris-tokens";
 import { Icon } from "@shopify/polaris-icons/metadata";
 
 export type MarkdownFile = {
@@ -7,7 +7,7 @@ export type MarkdownFile = {
   readme: string;
 };
 
-export interface TokenPropertiesWithName extends MetaTokenProperties {
+export interface TokenPropertiesWithName extends MetadataProperties {
   name: string;
 }
 

--- a/polaris.shopify.com/src/utils/search.ts
+++ b/polaris.shopify.com/src/utils/search.ts
@@ -5,7 +5,7 @@ import {
   SearchResultCategory,
   Status,
 } from "../types";
-import { metaTokens, MetaTokenProperties } from "@shopify/polaris-tokens";
+import { metadata, MetadataProperties } from "@shopify/polaris-tokens";
 import Fuse from "fuse.js";
 import { slugify, stripMarkdownLinks } from "./various";
 import iconMetadata from "@shopify/polaris-icons/metadata";
@@ -20,8 +20,7 @@ const MAX_RESULTS: { [key in SearchResultCategory]: number } = {
   icons: 9,
 };
 
-const { colors, depth, motion, shape, spacing, typography, zIndex } =
-  metaTokens;
+const { colors, depth, motion, shape, spacing, typography, zIndex } = metadata;
 
 let results: SearchResults = [];
 
@@ -60,7 +59,7 @@ const tokenGroups = {
 };
 Object.entries(tokenGroups).forEach(([groupSlug, tokenGroup]) => {
   Object.entries(tokenGroup).forEach(
-    ([tokenName, tokenProperties]: [string, MetaTokenProperties]) => {
+    ([tokenName, tokenProperties]: [string, MetadataProperties]) => {
       results.push({
         id: slugify(`tokens ${tokenName}`),
         category: "tokens",


### PR DESCRIPTION
### WHY are these changes introduced?

The `metaTokens` name was a bit confusing. This renames the `metaTokens` export in `@shopify/polaris-tokens` to `metadata` which better aligns with the metadata export in the icons package.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Renames the metaTokens` export to `metadata`

```diff
- import {metaTokens} from '@shopify/polaris-tokens';
+ import {metadata} from '@shopify/polaris-tokens';
```

Renames associated metadata types

- `MetaTokens` to `Metadata`
- `MetaTokenGroup` to `MetadataGroup`
- `MetaTokenProperties` to `MetadataProperties`