### PR TITLE
Remove en page generation

### DIFF
--- a/polaris.shopify.com/next.config.js
+++ b/polaris.shopify.com/next.config.js
@@ -8,10 +8,6 @@ const nextConfig = {
   experimental: {
     scrollRestoration: true,
   },
-  i18n: {
-    locales: ["en"],
-    defaultLocale: "en",
-  },
   async headers() {
     return [
       {

--- a/polaris.shopify.com/src/pages/_document.tsx
+++ b/polaris.shopify.com/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
The current approach was generating pages for multiple locales. We only support one, so we should set the lang in the `_document`. See the [custom document docs](https://nextjs.org/docs/advanced-features/custom-document)