### PR TITLE
[Typography foundations] Update text alignment

### DIFF
--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -19,6 +19,10 @@
   @include visually-hidden;
 }
 
+.inherit {
+  text-align: inherit;
+}
+
 .start {
   text-align: start;
 }

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -19,10 +19,6 @@
   @include visually-hidden;
 }
 
-.inherit {
-  text-align: inherit;
-}
-
 .start {
   text-align: start;
 }

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -18,7 +18,7 @@ type Variant =
   | 'bodyMd'
   | 'bodyLg';
 
-type Alignment = 'inherit' | 'start' | 'center' | 'end' | 'justify';
+type Alignment = 'start' | 'center' | 'end' | 'justify';
 
 type FontWeight = 'regular' | 'medium' | 'semibold' | 'bold';
 
@@ -57,7 +57,7 @@ export interface TextProps {
 }
 
 export const Text = ({
-  alignment = 'inherit',
+  alignment,
   as,
   children,
   color,
@@ -72,7 +72,7 @@ export const Text = ({
     styles.root,
     styles[variant],
     fontWeight ? styles[fontWeight] : styles[VariantFontWeightMapping[variant]],
-    (alignment !== 'inherit' || truncate) && styles.block,
+    (alignment || truncate) && styles.block,
     alignment && styles[alignment],
     color && styles[color],
     truncate && styles.truncate,

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -72,6 +72,7 @@ export const Text = ({
     styles.root,
     styles[variant],
     fontWeight ? styles[fontWeight] : styles[VariantFontWeightMapping[variant]],
+    (alignment !== 'inherit' || truncate) && styles.block,
     alignment && styles[alignment],
     color && styles[color],
     truncate && styles.truncate,


### PR DESCRIPTION
### WHAT is this pull request doing?

- Default alignment of Text component is set to `inherit`
- `block` style is only applied when alignment or truncate is set (ignores default)
- Without setting alignment or truncate, users can use span elements to apply `inline` styling

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Text} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Text as="span" variant="headingSm">
        Hello World inline
      </Text>
      <Text as="h1" variant="headingSm" alignment="start">
        Hello World block
      </Text>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
