### PR TITLE
[IndexTable] Export selection types used in web

### DIFF
--- a/.changeset/curvy-pianos-attack.md
+++ b/.changeset/curvy-pianos-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add selection IndexTable type defintions

--- a/.changeset/curvy-pianos-attack.md
+++ b/.changeset/curvy-pianos-attack.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Add selection IndexTable type defintions
+Exported IndexTable constant and type definition

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -406,3 +406,7 @@ export {
   useRowSelected as useIndexTableRowSelected,
   useContainerScroll as useIndexTableContainerScroll,
 } from './utilities/index-table';
+export {
+  SELECT_ALL_ITEMS as INDEX_TABLE_SELECT_ALL_ITEMS,
+  SelectionType as IndexTableSelectionType,
+} from './utilities/index-provider';


### PR DESCRIPTION
### WHY are these changes introduced?

We have made a lot of updates to `web` to update all instances of the `polaris-next` IndexTable to the Polaris version. However, there are still multiple instances of components referencing the `SELECT_ALL_ITEMS` and `SelectionType` type definitions from the `polaris-next` IndexProvider. We currently don't export this from `polaris-react` and in order to finally remove the IndexTable/IndexProvider from the `polaris-next` codebase, we should export these from Polaris itself. 




### WHAT is this pull request doing?

This PR exports these two types, but namespaces them with the `IndexTable`/`INDEX_TABLE` prefix in order to allow developers to understand what the types pertain to.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
