### PR TITLE
[Buttons] Return onClick handler implicitly instead of calling it

### DIFF
--- a/.changeset/poor-dragons-return.md
+++ b/.changeset/poor-dragons-return.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+fix explicit onClick handler bug

--- a/polaris-react/src/utilities/use-disable-interaction.ts
+++ b/polaris-react/src/utilities/use-disable-interaction.ts
@@ -24,12 +24,14 @@ export function useDisableClick(disabled?: boolean, handleClick?: () => void) {
       if (disabled) {
         event.preventDefault();
         event.stopPropagation();
-      } else {
-        handleClick && handleClick();
       }
     },
-    [disabled, handleClick],
+    [disabled],
   );
+
+  if (!disabled) {
+    return handleClick;
+  }
 
   return handleClickWrapper;
 }
@@ -43,12 +45,14 @@ export function useDisableKeyboard(
       if (disabled && (event?.key === ' ' || event.key === 'Enter')) {
         event.preventDefault();
         event.stopPropagation();
-      } else {
-        handleKeyDown && handleKeyDown(event);
       }
     },
-    [disabled, handleKeyDown],
+    [disabled],
   );
+
+  if (!disabled) {
+    return handleKeyDown;
+  }
 
   return handleKeyDownWrapper;
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

- A bug that was caught by various teams:
 > The Button has lost the ability to stop porpagation on click. Previously, events were passed implicitly, but now they fail to do so due to explicitly calling the handleClick [callback in use-disable-interaction.ts](https://github.com/Shopify/polaris/blob/f7a84090231a09ce5f79f05ccb863c8723b5f0f8/polaris-react/src/utilities/use-disable-interaction.ts#L28).

Fixes https://github.com/Shopify/polaris/issues/6798

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Returns the original `onClick` event function implicitly

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

- [Demo using the snapshot release](https://codesandbox.io/s/button-click-0-0-0-snapshot-release-20220805173531-yt92pm?file=/App.js)
- Notice how `handleClick()` is not called in the hook

