### PR TITLE
[IndexTable] Update headings style and add sortable functionality.

### DIFF
--- a/.changeset/gold-dots-tickle.md
+++ b/.changeset/gold-dots-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Update IndexTable heading appearance and surface sorting ability in headings

--- a/polaris-react/locales/cs.json
+++ b/polaris-react/locales/cs.json
@@ -299,7 +299,8 @@
       "undo": "Vrátit zpět",
       "selectAllItems": "Vybrat vše typu {resourceNamePlural} ({itemsLength} a více)",
       "selectItem": "Vybrat: {resourceName}",
-      "selectButtonText": "Vybrat"
+      "selectButtonText": "Vybrat",
+      "sortAccessibilityLabel": "seřadit {direction} podle"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/da.json
+++ b/polaris-react/locales/da.json
@@ -297,7 +297,8 @@
       "undo": "Fortryd",
       "selectAllItems": "Vælg alle {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Vælg {resourceName}",
-      "selectButtonText": "Vælg"
+      "selectButtonText": "Vælg",
+      "sortAccessibilityLabel": "sortér {direction} efter"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/de.json
+++ b/polaris-react/locales/de.json
@@ -297,7 +297,8 @@
       "undo": "Rückgängig machen",
       "selectAllItems": "Alle {itemsLength}+ {resourceNamePlural} auswählen",
       "selectItem": "{resourceName} auswählen",
-      "selectButtonText": "Auswählen"
+      "selectButtonText": "Auswählen",
+      "sortAccessibilityLabel": "von {direction} sortieren nach"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -179,7 +179,8 @@
       "undo": "Undo",
       "selectAllItems": "Select all {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Select {resourceName}",
-      "selectButtonText": "Select"
+      "selectButtonText": "Select",
+      "sortAccessibilityLabel": "sort {direction} by"
     },
     "Loading": {
       "label": "Page loading bar"

--- a/polaris-react/locales/es.json
+++ b/polaris-react/locales/es.json
@@ -298,7 +298,8 @@
       "undo": "Deshacer",
       "selectAllItems": "Seleccionar los más de {itemsLength} recursos de {resourceNamePlural}",
       "selectItem": "Seleccionar {resourceName}",
-      "selectButtonText": "Seleccionar"
+      "selectButtonText": "Seleccionar",
+      "sortAccessibilityLabel": "ordenar {direction} por"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/fi.json
+++ b/polaris-react/locales/fi.json
@@ -297,7 +297,8 @@
       "undo": "Peru",
       "selectAllItems": "Valitse kaikki {itemsLength} ja {resourceNamePlural}",
       "selectItem": "Valitse {resourceName}",
-      "selectButtonText": "Valitse"
+      "selectButtonText": "Valitse",
+      "sortAccessibilityLabel": "lajittele {direction}:"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/fr.json
+++ b/polaris-react/locales/fr.json
@@ -298,7 +298,8 @@
       "undo": "Annuler",
       "selectAllItems": "Sélectionner la totalité des {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Sélectionner {resourceName}",
-      "selectButtonText": "Sélectionner"
+      "selectButtonText": "Sélectionner",
+      "sortAccessibilityLabel": "trier {direction} par"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/it.json
+++ b/polaris-react/locales/it.json
@@ -298,7 +298,8 @@
       "undo": "Annulla",
       "selectAllItems": "Seleziona tutti i {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Seleziona {resourceName}",
-      "selectButtonText": "Seleziona"
+      "selectButtonText": "Seleziona",
+      "sortAccessibilityLabel": "ordina {direction} per"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/ja.json
+++ b/polaris-react/locales/ja.json
@@ -297,7 +297,8 @@
       "undo": "元に戻す",
       "selectAllItems": "すべての{itemsLength}+{resourceNamePlural}を選択する",
       "selectItem": "{resourceName}を選択する",
-      "selectButtonText": "選択"
+      "selectButtonText": "選択",
+      "sortAccessibilityLabel": "で{direction}を並び替える"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/ko.json
+++ b/polaris-react/locales/ko.json
@@ -297,7 +297,8 @@
       "undo": "실행 취소",
       "selectAllItems": "길이가 {itemsLength} 이상인 모든 {resourceNamePlural} 선택",
       "selectItem": "{resourceName} 선택",
-      "selectButtonText": "선택"
+      "selectButtonText": "선택",
+      "sortAccessibilityLabel": "{direction} 정렬 기준"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/nb.json
+++ b/polaris-react/locales/nb.json
@@ -297,7 +297,8 @@
       "undo": "Angre",
       "selectAllItems": "Velg alle {itemsLength} {resourceNamePlural}",
       "selectItem": "Velg {resourceName}",
-      "selectButtonText": "Velg"
+      "selectButtonText": "Velg",
+      "sortAccessibilityLabel": "sortere {direction} etter"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/nb.json
+++ b/polaris-react/locales/nb.json
@@ -298,7 +298,7 @@
       "selectAllItems": "Velg alle {itemsLength} {resourceNamePlural}",
       "selectItem": "Velg {resourceName}",
       "selectButtonText": "Velg",
-      "sortAccessibilityLabel": "sortere {direction} etter"
+      "sortAccessibilityLabel": "sorter {direction} etter"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/nl.json
+++ b/polaris-react/locales/nl.json
@@ -297,7 +297,8 @@
       "undo": "Ongedaan maken",
       "selectAllItems": "Alle {itemsLength}+ {resourceNamePlural} selecteren",
       "selectItem": "{resourceName} selecteren",
-      "selectButtonText": "Selecteren"
+      "selectButtonText": "Selecteren",
+      "sortAccessibilityLabel": "sorteer {direction} op"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/nl.json
+++ b/polaris-react/locales/nl.json
@@ -298,7 +298,7 @@
       "selectAllItems": "Alle {itemsLength}+ {resourceNamePlural} selecteren",
       "selectItem": "{resourceName} selecteren",
       "selectButtonText": "Selecteren",
-      "sortAccessibilityLabel": "sorteer {direction} op"
+      "sortAccessibilityLabel": "{direction} sorteren op"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/pl.json
+++ b/polaris-react/locales/pl.json
@@ -299,7 +299,8 @@
       "undo": "Cofnij",
       "selectAllItems": "Wybierz wszystkie {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Wybierz {resourceName}",
-      "selectButtonText": "Wybierz"
+      "selectButtonText": "Wybierz",
+      "sortAccessibilityLabel": "sortuj {direction} według"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/pt-BR.json
+++ b/polaris-react/locales/pt-BR.json
@@ -298,7 +298,8 @@
       "undo": "Desfazer",
       "selectAllItems": "Selecionar todos os {resourceNamePlural} maiores que {itemsLength}",
       "selectItem": "Selecionar {resourceName}",
-      "selectButtonText": "Selecionar"
+      "selectButtonText": "Selecionar",
+      "sortAccessibilityLabel": "ordenar {direction} por"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/pt-PT.json
+++ b/polaris-react/locales/pt-PT.json
@@ -298,7 +298,8 @@
       "undo": "Anular",
       "selectAllItems": "Selecionar todos os itens de {resourceNamePlural} de {itemsLength}+",
       "selectItem": "Selecionar {resourceName}",
-      "selectButtonText": "Selecionar"
+      "selectButtonText": "Selecionar",
+      "sortAccessibilityLabel": "ordenar {direction} por"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/sv.json
+++ b/polaris-react/locales/sv.json
@@ -297,7 +297,8 @@
       "undo": "Ångra",
       "selectAllItems": "Välj alla {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Välj {resourceName}",
-      "selectButtonText": "Välj"
+      "selectButtonText": "Välj",
+      "sortAccessibilityLabel": "sortera {direction} efter"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/th.json
+++ b/polaris-react/locales/th.json
@@ -297,7 +297,8 @@
       "undo": "เลิกทำ",
       "selectAllItems": "เลือก {resourceNamePlural} ทั้ง {itemsLength}+ รายการ",
       "selectItem": "เลือก {resourceName}",
-      "selectButtonText": "เลือก"
+      "selectButtonText": "เลือก",
+      "sortAccessibilityLabel": "จัดเรียง {direction} ตาม"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/tr.json
+++ b/polaris-react/locales/tr.json
@@ -298,7 +298,7 @@
       "selectAllItems": "Şunların tümünü seç: {itemsLength}+ {resourceNamePlural}",
       "selectItem": "{resourceName} kaynağını seç",
       "selectButtonText": "Seç",
-      "sortAccessibilityLabel": "{direction} tarafı şuna göre sırala:"
+      "sortAccessibilityLabel": "{direction} öğesini şuna göre sırala:"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/tr.json
+++ b/polaris-react/locales/tr.json
@@ -297,7 +297,8 @@
       "undo": "Geri al",
       "selectAllItems": "Şunların tümünü seç: {itemsLength}+ {resourceNamePlural}",
       "selectItem": "{resourceName} kaynağını seç",
-      "selectButtonText": "Seç"
+      "selectButtonText": "Seç",
+      "sortAccessibilityLabel": "{direction} tarafı şuna göre sırala:"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/vi.json
+++ b/polaris-react/locales/vi.json
@@ -297,7 +297,8 @@
       "undo": "Hoàn tác",
       "selectAllItems": "Chọn tất cả {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Chọn {resourceName}",
-      "selectButtonText": "Chọn"
+      "selectButtonText": "Chọn",
+      "sortAccessibilityLabel": "sắp xếp {direction} theo"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/zh-CN.json
+++ b/polaris-react/locales/zh-CN.json
@@ -297,7 +297,8 @@
       "undo": "撤销",
       "selectAllItems": "选择所有 {itemsLength}+ 个 {resourceNamePlural}",
       "selectItem": "选择 {resourceName}",
-      "selectButtonText": "选择"
+      "selectButtonText": "选择",
+      "sortAccessibilityLabel": "向 {direction} 排序"
     },
     "Page": {
       "Header": {

--- a/polaris-react/locales/zh-TW.json
+++ b/polaris-react/locales/zh-TW.json
@@ -297,7 +297,8 @@
       "undo": "復原",
       "selectAllItems": "選取全部 {itemsLength} + {resourceNamePlural}",
       "selectItem": "選取 {resourceName}",
-      "selectButtonText": "選取"
+      "selectButtonText": "選取",
+      "sortAccessibilityLabel": "向 {direction} 排序，依據"
     },
     "Page": {
       "Header": {

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -201,6 +201,36 @@ $loading-panel-height: 53px;
   width: var(--p-space-5);
 }
 
+.TableHeadingSortButton {
+  background: none;
+  padding: 0;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: var(--p-font-weight-medium);
+  color: var(--p-text-subdued);
+  font-size: var(--p-font-size-1);
+
+  &:hover,
+  &:focus {
+    .TableHeadingSortIcon {
+      opacity: 1;
+    }
+  }
+}
+
+.TableHeadingSortIcon {
+  order: 1;
+  opacity: 0;
+  transition: var(--p-ease) var(--p-duration-150) opacity;
+}
+
+.TableHeadingSortIcon-visible {
+  opacity: 1;
+}
+
 .ColumnHeaderCheckboxWrapper {
   display: flex;
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -12,6 +12,7 @@ $breakpoint-small: 458px;
   --pc-index-table-loading-panel: 37;
   position: relative;
   overflow: hidden;
+  border-radius: inherit;
 }
 
 .LoadingContainer-enter {
@@ -177,7 +178,6 @@ $loading-panel-height: 53px;
 
 .TableHeading {
   background: var(--p-surface-subdued);
-  box-shadow: 0 1px var(--p-divider) inset;
   padding: var(--p-space-2) var(--p-space-4);
   text-align: left;
   font-weight: var(--p-font-weight-medium);

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -12,7 +12,6 @@ $breakpoint-small: 458px;
   --pc-index-table-loading-panel: 37;
   position: relative;
   overflow: hidden;
-  border-radius: inherit;
 }
 
 .LoadingContainer-enter {
@@ -177,9 +176,13 @@ $loading-panel-height: 53px;
 }
 
 .TableHeading {
-  padding: var(--p-space-4);
+  background: var(--p-surface-subdued);
+  box-shadow: 0 1px var(--p-divider) inset;
+  padding: var(--p-space-2) var(--p-space-4);
   text-align: left;
   font-weight: var(--p-font-weight-medium);
+  color: var(--p-text-subdued);
+  font-size: var(--p-font-size-1);
   white-space: nowrap;
   border: 0;
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -177,7 +177,6 @@ $loading-panel-height: 53px;
 }
 
 .TableHeading {
-  background: var(--p-surface-subdued);
   padding: var(--p-space-2) var(--p-space-4);
   text-align: left;
   font-weight: var(--p-font-weight-medium);
@@ -185,6 +184,10 @@ $loading-panel-height: 53px;
   font-size: var(--p-font-size-1);
   white-space: nowrap;
   border: 0;
+}
+
+.TableHeading-sortable {
+  background: var(--p-surface-subdued);
 }
 
 .TableHeading-flush {

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1403,12 +1403,10 @@ export function WithSortableHeadings() {
     setSortIndex(index);
     setSortDirection(direction);
     const newSortedRows = sortRows(rows, index, direction);
-    console.log({newSortedRows});
     setSortedRows(newSortedRows);
   }
 
   function sortRows(localRows, index, direction) {
-    console.log(index, direction);
     return [...localRows].sort((a, b) => {
       const key = index === 0 ? 'name' : 'location';
       if (a[key] < b[key]) {

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1407,12 +1407,12 @@ export function WithSortableHeadings() {
   }
 
   function sortRows(localRows, index, direction) {
-    return [...localRows].sort((a, b) => {
+    return [...localRows].sort((rowA, rowB) => {
       const key = index === 0 ? 'name' : 'location';
-      if (a[key] < b[key]) {
+      if (rowA[key] < rowB[key]) {
         return direction === 'descending' ? -1 : 1;
       }
-      if (a[key] > b[key]) {
+      if (rowA[key] > rowB[key]) {
         return direction === 'descending' ? 1 : -1;
       }
       return 0;

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1347,6 +1347,85 @@ export function WithAllOfItsElements() {
   }
 }
 
+export function WithSortableHeadings() {
+  const [sortIndex, setSortIndex] = useState(0);
+  const [sortDirection, setSortDirection] = useState('ascending');
+
+  const customers = [
+    {
+      id: '3411',
+      url: 'customers/341',
+      name: 'Mae Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$2,400',
+    },
+    {
+      id: '2561',
+      url: 'customers/256',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+  ];
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(customers);
+
+  function handleClickSortHeading(index, direction) {
+    setSortIndex(index);
+    setSortDirection(direction);
+  }
+
+  const rowMarkup = customers.map(
+    ({id, name, location, orders, amountSpent}, index) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <TextStyle variation="strong">{name}</TextStyle>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{location}</IndexTable.Cell>
+        <IndexTable.Cell>{orders}</IndexTable.Cell>
+        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <Card>
+      <IndexTable
+        resourceName={resourceName}
+        itemCount={customers.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {title: 'Name'},
+          {title: 'Location'},
+          {title: 'Order count'},
+          {title: 'Amount spent'},
+        ]}
+        sortable={[true, false, false, true]}
+        sortDirection={sortDirection}
+        sortColumnIndex={sortIndex}
+        onSort={handleClickSortHeading}
+      >
+        {rowMarkup}
+      </IndexTable>
+    </Card>
+  );
+}
+
 export function SmallScreenWithAllOfItsElements() {
   const customers = [
     {

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1349,9 +1349,9 @@ export function WithAllOfItsElements() {
 
 export function WithSortableHeadings() {
   const [sortIndex, setSortIndex] = useState(0);
-  const [sortDirection, setSortDirection] = useState('ascending');
+  const [sortDirection, setSortDirection] = useState('descending');
 
-  const customers = [
+  const initialRows = [
     {
       id: '3411',
       url: 'customers/341',
@@ -1368,21 +1368,60 @@ export function WithSortableHeadings() {
       orders: 30,
       amountSpent: '$140',
     },
+    {
+      id: '1245',
+      url: 'customers/123',
+      name: 'Anne-Marie Johnson',
+      location: 'Portland, USA',
+      orders: 10,
+      amountSpent: '$250',
+    },
+    {
+      id: '8741',
+      url: 'customers/543',
+      name: 'Bradley Stevens',
+      location: 'Hialeah, USA',
+      orders: 5,
+      amountSpent: '$26',
+    },
   ];
+  const [sortedRows, setSortedRows] = useState(
+    sortRows(initialRows, sortIndex, sortDirection),
+  );
+
   const resourceName = {
     singular: 'customer',
     plural: 'customers',
   };
 
+  const rows = sortedRows ?? initialRows;
+
   const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
+    useIndexResourceState(rows);
 
   function handleClickSortHeading(index, direction) {
     setSortIndex(index);
     setSortDirection(direction);
+    const newSortedRows = sortRows(rows, index, direction);
+    console.log({newSortedRows});
+    setSortedRows(newSortedRows);
   }
 
-  const rowMarkup = customers.map(
+  function sortRows(localRows, index, direction) {
+    console.log(index, direction);
+    return [...localRows].sort((a, b) => {
+      const key = index === 0 ? 'name' : 'location';
+      if (a[key] < b[key]) {
+        return direction === 'descending' ? -1 : 1;
+      }
+      if (a[key] > b[key]) {
+        return direction === 'descending' ? 1 : -1;
+      }
+      return 0;
+    });
+  }
+
+  const rowMarkup = rows.map(
     ({id, name, location, orders, amountSpent}, index) => (
       <IndexTable.Row
         id={id}
@@ -1393,9 +1432,9 @@ export function WithSortableHeadings() {
         <IndexTable.Cell>
           <TextStyle variation="strong">{name}</TextStyle>
         </IndexTable.Cell>
-        <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>
         <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
+        <IndexTable.Cell>{location}</IndexTable.Cell>
       </IndexTable.Row>
     ),
   );
@@ -1404,16 +1443,16 @@ export function WithSortableHeadings() {
     <Card>
       <IndexTable
         resourceName={resourceName}
-        itemCount={customers.length}
+        itemCount={rows.length}
         selectedItemsCount={
           allResourcesSelected ? 'All' : selectedResources.length
         }
         onSelectionChange={handleSelectionChange}
         headings={[
           {title: 'Name'},
-          {title: 'Location'},
           {title: 'Order count'},
           {title: 'Amount spent'},
+          {title: 'Location'},
         ]}
         sortable={[true, false, false, true]}
         sortDirection={sortDirection}

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -1,5 +1,9 @@
 import React, {useRef, useState, useEffect, useCallback, useMemo} from 'react';
-import {EnableSelectionMinor} from '@shopify/polaris-icons';
+import {
+  EnableSelectionMinor,
+  SortAscendingMajor,
+  SortDescendingMajor,
+} from '@shopify/polaris-icons';
 import {CSSTransition} from 'react-transition-group';
 import {tokens} from '@shopify/polaris-tokens';
 
@@ -11,11 +15,13 @@ import {Checkbox as PolarisCheckbox} from '../Checkbox';
 import {EmptySearchResult} from '../EmptySearchResult';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
+import {Icon} from '../Icon';
 import {Stack} from '../Stack';
 import {Sticky} from '../Sticky';
 import {Spinner} from '../Spinner';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {Button} from '../Button';
+import {UnstyledButton} from '../UnstyledButton';
 import {BulkActions, BulkActionsProps} from '../BulkActions';
 import {classNames} from '../../utilities/css';
 import {
@@ -35,10 +41,13 @@ import styles from './IndexTable.scss';
 
 export interface IndexTableHeading {
   title: string;
+  id?: string;
   flush?: boolean;
   new?: boolean;
   hidden?: boolean;
 }
+
+export type IndexTableSortDirection = 'ascending' | 'descending';
 
 export interface IndexTableBaseProps {
   headings: NonEmptyArray<IndexTableHeading>;
@@ -50,6 +59,21 @@ export interface IndexTableBaseProps {
   paginatedSelectAllActionText?: string;
   lastColumnSticky?: boolean;
   selectable?: boolean;
+  /** List of booleans, which maps to whether sorting is enabled or not for each column. Defaults to false for all columns.  */
+  sortable?: boolean[];
+  /**
+   * The direction to sort the table rows on first click or keypress of a sortable column heading. Defaults to ascending.
+   * @default 'ascending'
+   */
+  defaultSortDirection?: IndexTableSortDirection;
+  /** The current sorting direction. */
+  sortDirection?: IndexTableSortDirection;
+  /**
+   * The index of the heading that the table rows are sorted by.
+   */
+  sortColumnIndex?: number;
+  /** Callback fired on click or keypress of a sortable column heading. */
+  onSort?(headingIndex: number, direction: IndexTableSortDirection): void;
 }
 
 export interface TableHeadingRect {
@@ -71,6 +95,11 @@ function IndexTableBase({
   sort,
   paginatedSelectAllActionText,
   lastColumnSticky = false,
+  sortable,
+  sortDirection,
+  defaultSortDirection = 'descending',
+  sortColumnIndex,
+  onSort,
   ...restProps
 }: IndexTableBaseProps) {
   const {
@@ -385,7 +414,7 @@ function IndexTableBase({
 
         {selectable && (
           <div className={styles['StickyTableHeading-second-scrolling']}>
-            {renderHeadingContent(headings[0])}
+            {renderHeadingContent(headings[0], 0)}
           </div>
         )}
 
@@ -394,7 +423,7 @@ function IndexTableBase({
             className={styles.FirstStickyHeaderElement}
             ref={firstStickyHeaderElement}
           >
-            {renderHeadingContent(headings[0])}
+            {renderHeadingContent(headings[0], 0)}
           </div>
         )}
       </Stack>
@@ -677,7 +706,7 @@ function IndexTableBase({
         data-index-table-heading
         style={stickyPositioningStyle}
       >
-        {renderHeadingContent(heading)}
+        {renderHeadingContent(heading, index)}
       </th>
     );
 
@@ -718,7 +747,14 @@ function IndexTableBase({
     );
   }
 
-  function renderHeadingContent(heading: IndexTableHeading) {
+  function handleSortHeadingClick(
+    index: number,
+    direction: IndexTableSortDirection,
+  ) {
+    onSort?.(index, direction);
+  }
+
+  function renderHeadingContent(heading: IndexTableHeading, index: number) {
     let headingContent;
 
     if (heading.new) {
@@ -735,6 +771,49 @@ function IndexTableBase({
     } else {
       headingContent = heading.title;
     }
+    if (sortable?.[index]) {
+      const isCurrentlySorted = index === sortColumnIndex;
+      const isAscending = sortDirection === 'ascending';
+      let newDirection: IndexTableSortDirection = defaultSortDirection;
+      let source =
+        defaultSortDirection === 'ascending'
+          ? SortAscendingMajor
+          : SortDescendingMajor;
+      if (isCurrentlySorted) {
+        newDirection = isAscending ? 'descending' : 'ascending';
+        source =
+          sortDirection === 'ascending'
+            ? SortAscendingMajor
+            : SortDescendingMajor;
+      }
+
+      const sortAccessibilityLabel = i18n.translate(
+        'Polaris.IndexTable.sortAccessibilityLabel',
+        {direction: newDirection},
+      );
+
+      const iconMarkup = (
+        <span
+          className={classNames(
+            styles.TableHeadingSortIcon,
+            isCurrentlySorted && styles['TableHeadingSortIcon-visible'],
+          )}
+        >
+          <Icon source={source} accessibilityLabel={sortAccessibilityLabel} />
+        </span>
+      );
+
+      return (
+        <UnstyledButton
+          onClick={() => handleSortHeadingClick(index, newDirection)}
+          className={styles.TableHeadingSortButton}
+        >
+          {iconMarkup}
+
+          {headingContent}
+        </UnstyledButton>
+      );
+    }
     return headingContent;
   }
 
@@ -749,7 +828,7 @@ function IndexTableBase({
         ? {minWidth: tableHeadingRects.current[position].offsetWidth}
         : undefined;
 
-    const headingContent = renderHeadingContent(heading);
+    const headingContent = renderHeadingContent(heading, index);
     const stickyHeadingClassName = classNames(
       styles.TableHeading,
       index === 0 && styles['StickyTableHeading-second'],

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -63,7 +63,7 @@ export interface IndexTableBaseProps {
   sortable?: boolean[];
   /**
    * The direction to sort the table rows on first click or keypress of a sortable column heading. Defaults to ascending.
-   * @default 'ascending'
+   * @default 'descending'
    */
   defaultSortDirection?: IndexTableSortDirection;
   /** The current sorting direction. */

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -685,6 +685,8 @@ function IndexTableBase({
     const isLast = index === headings.length - 1;
     const headingContentClassName = classNames(
       styles.TableHeading,
+      sortable?.some((value) => value === true) &&
+        styles['TableHeading-sortable'],
       isSecond && styles['TableHeading-second'],
       isLast && !heading.hidden && styles['TableHeading-last'],
       !selectable && styles['TableHeading-unselectable'],


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/70689
Fixes https://github.com/Shopify/web/issues/70690

Our IndexTables are sortable across the admin, but there is no way of showing the current sorted state within an IndexTable currently, which could cause confusion for merchants. We also want to tighten up the appearance of the IndexTable to coincide with our efforts to unify the index filtering and searching experience.

### WHAT is this pull request doing?

<img width="1460" alt="A mockup of the new IndexTable heading UI, showing a more condensed view with a subdued background, and the ability to show the sorting state in a heading cell." src="https://user-images.githubusercontent.com/2562596/184341995-3613465f-b923-41f2-b85e-f3b04d994038.png">

This PR does two things that are related to the IndexTable headings. Firstly, it tightens up the density of the headings by shrinking the vertical padding of a heading, shrinking the font size down to 12px, and also adds in a `--p-surface-subdued` background color with `--p-text-subdued` font color to the heading.

Secondly, it adds the ability to show the sorting state of an IndexTable and controlling the sorting state by interacting with a sortable IndexTable heading. The logic introduced here mirrors the logic recently introduced for the DataTable for how that allows for sorting.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

- Clone this branch locally.
- Visit the new "With Sortable Headings" story in the IndexTable 
- Confirm that the Name and Location columns are now sortable through the heading
- Confirm that the other columns function as before with no additional sortable functionality

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
