### PR TITLE
[Combobox][Listbox.Option] Fixed click event bubbling causing Popover close

### DIFF
--- a/.changeset/warm-clocks-jog.md
+++ b/.changeset/warm-clocks-jog.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Fixed `Listbox.Option` click event bubbling causing close of `Popover` in `Combobox`

--- a/polaris-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/polaris-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -651,6 +651,9 @@ export function WithAction() {
           ellipsis: true,
           helpText: 'Help text',
           icon: CirclePlusMinor,
+          onAction: () => {
+            console.log('actionBefore clicked!');
+          },
         }}
         options={options}
         selected={selectedOptions}
@@ -743,6 +746,9 @@ export function WithWrappingAction() {
           helpText: 'Help text',
           icon: CirclePlusMinor,
           wrapOverflow: true,
+          onAction: () => {
+            console.log('actionBefore clicked!');
+          },
         }}
         options={options}
         selected={selectedOptions}
@@ -828,6 +834,9 @@ export function WithDestructiveAction() {
           content: 'Destructive action',
           destructive: true,
           icon: DeleteMinor,
+          onAction: () => {
+            console.log('actionBefore clicked!');
+          },
         }}
         options={options}
         selected={selectedOptions}

--- a/polaris-react/src/components/Autocomplete/Autocomplete.tsx
+++ b/polaris-react/src/components/Autocomplete/Autocomplete.tsx
@@ -151,6 +151,11 @@ export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
 
   const updateSelection = useCallback(
     (newSelection: string) => {
+      if (actionBefore && newSelection === actionBefore.content) {
+        actionBefore.onAction && actionBefore.onAction();
+        return;
+      }
+
       if (allowMultiple) {
         if (selected.includes(newSelection)) {
           onSelect(selected.filter((option) => option !== newSelection));
@@ -161,7 +166,7 @@ export const Autocomplete: React.FunctionComponent<AutocompleteProps> & {
         onSelect([newSelection]);
       }
     },
-    [allowMultiple, onSelect, selected],
+    [allowMultiple, onSelect, selected, actionBefore],
   );
 
   const actionMarkup = actionBefore && <MappedAction {...actionBefore} />;

--- a/polaris-react/src/components/Combobox/Combobox.tsx
+++ b/polaris-react/src/components/Combobox/Combobox.tsx
@@ -50,19 +50,15 @@ export function Combobox({
   const [textFieldLabelId, setTextFieldLabelId] = useState<string>();
   const [listboxId, setListboxId] = useState<string>();
   const [textFieldFocused, setTextFieldFocused] = useState<boolean>(false);
-  const [disableCloseOnSelect, setDisableCloseOnSelect] = useState(false);
   const shouldOpen = Boolean(!popoverActive && Children.count(children) > 0);
   const ref = useRef<PopoverPublicAPI | null>(null);
 
   const handleClose = useCallback(() => {
-    // only deactive popover if not creating a new option
-    if (!disableCloseOnSelect) {
-      setPopoverActive(false);
-      onClose?.();
-    }
+    setPopoverActive(false);
+    onClose?.();
 
     setActiveOptionId(undefined);
-  }, [disableCloseOnSelect, onClose]);
+  }, [onClose]);
 
   const handleOpen = useCallback(() => {
     setPopoverActive(true);
@@ -74,12 +70,10 @@ export function Combobox({
       handleClose();
       setActiveOptionId(undefined);
       return;
-    } else {
-      setDisableCloseOnSelect(true);
     }
 
     ref.current?.forceUpdatePosition();
-  }, [allowMultiple, handleClose, setDisableCloseOnSelect]);
+  }, [allowMultiple, handleClose]);
 
   const handleFocus = useCallback(() => {
     if (shouldOpen) {

--- a/polaris-react/src/components/Combobox/Combobox.tsx
+++ b/polaris-react/src/components/Combobox/Combobox.tsx
@@ -88,11 +88,10 @@ export function Combobox({
   }, [shouldOpen, handleOpen]);
 
   const handleBlur = useCallback(() => {
-    setDisableCloseOnSelect(false);
     if (popoverActive) {
       handleClose();
     }
-  }, [popoverActive, handleClose, setDisableCloseOnSelect]);
+  }, [popoverActive, handleClose]);
 
   const textFieldContextValue: ComboboxTextFieldType = useMemo(
     () => ({

--- a/polaris-react/src/components/Listbox/Listbox.stories.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.stories.tsx
@@ -1,7 +1,16 @@
-import React from 'react';
+import React, {useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Icon, Listbox, Stack} from '@shopify/polaris';
-import {CirclePlusMinor} from '@shopify/polaris-icons';
+import {
+  Card,
+  EmptySearchResult,
+  Scrollable,
+  TextField,
+  Icon,
+  Listbox,
+  Stack,
+  AutoSelection,
+} from '@shopify/polaris';
+import {CirclePlusMinor, SearchMinor} from '@shopify/polaris-icons';
 
 export default {
   component: Listbox,
@@ -23,7 +32,7 @@ export function WithLoading() {
       <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
       <Listbox.Option value="UniqueValue-2">Item 2</Listbox.Option>
       <Listbox.Option value="UniqueValue-3">Item 3</Listbox.Option>
-      <Listbox.Loading />
+      <Listbox.Loading accessibilityLabel="loading example" />
     </Listbox>
   );
 }
@@ -62,5 +71,279 @@ export function WithCustomElement() {
       </Listbox.Option>
       <Listbox.Loading accessibilityLabel="items are loading" />
     </Listbox>
+  );
+}
+
+export function WithSearch() {
+  interface CustomerSegment {
+    id: string;
+    label: string;
+    value: string;
+  }
+
+  const actionValue = '__ACTION__';
+
+  const segments: CustomerSegment[] = [
+    {
+      label: 'All customers',
+      id: 'gid://shopify/CustomerSegment/1',
+      value: '0',
+    },
+    {
+      label: 'VIP customers',
+      id: 'gid://shopify/CustomerSegment/2',
+      value: '1',
+    },
+    {
+      label: 'New customers',
+      id: 'gid://shopify/CustomerSegment/3',
+      value: '2',
+    },
+    {
+      label: 'Abandoned carts - last 30 days',
+      id: 'gid://shopify/CustomerSegment/4',
+      value: '3',
+    },
+    {
+      label: 'Wholesale customers',
+      id: 'gid://shopify/CustomerSegment/5',
+      value: '4',
+    },
+    {
+      label: 'Email subscribers',
+      id: 'gid://shopify/CustomerSegment/6',
+      value: '5',
+    },
+    {
+      label: 'From New York',
+      id: 'gid://shopify/CustomerSegment/7',
+      value: '6',
+    },
+    {
+      label: 'Repeat buyers',
+      id: 'gid://shopify/CustomerSegment/8',
+      value: '7',
+    },
+    {
+      label: 'First time buyers',
+      id: 'gid://shopify/CustomerSegment/9',
+      value: '8',
+    },
+    {
+      label: 'From Canada',
+      id: 'gid://shopify/CustomerSegment/10',
+      value: '9',
+    },
+    {
+      label: 'Bought in last 60 days',
+      id: 'gid://shopify/CustomerSegment/11',
+      value: '10',
+    },
+    {
+      label: 'Bought last BFCM',
+      id: 'gid://shopify/CustomerSegment/12',
+      value: '11',
+    },
+  ];
+
+  const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
+    (_, index) => ({
+      label: `Other customers ${index + 13}`,
+      id: `gid://shopify/CustomerSegment/${index + 13}`,
+      value: `${index + 12}`,
+    }),
+  );
+
+  segments.push(...lazyLoadSegments);
+
+  const interval = 25;
+
+  const [showFooterAction, setShowFooterAction] = useState(true);
+  const [query, setQuery] = useState('');
+  const [lazyLoading, setLazyLoading] = useState(false);
+  const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
+  const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
+  const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
+  const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
+  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
+    [],
+  );
+
+  const handleClickShowAll = () => {
+    setShowFooterAction(false);
+    setVisibleOptionIndex(segments.length);
+  };
+
+  const handleFilterSegments = (query: string) => {
+    const nextFilteredSegments = segments.filter((segment: CustomerSegment) => {
+      return segment.label
+        .toLocaleLowerCase()
+        .includes(query.toLocaleLowerCase().trim());
+    });
+
+    setFilteredSegments(nextFilteredSegments);
+  };
+
+  const handleQueryChange = (query: string) => {
+    setQuery(query);
+
+    if (query.length >= 2) handleFilterSegments(query);
+  };
+
+  const handleQueryClear = () => {
+    handleQueryChange('');
+  };
+
+  const handleResetVisibleOptionIndex = () => {
+    setVisibleOptionIndex(interval);
+  };
+
+  const handleSegmentSelect = (segmentIndex: string) => {
+    if (segmentIndex === actionValue) {
+      return handleClickShowAll();
+    }
+
+    setSelectedSegmentIndex(Number(segmentIndex));
+  };
+
+  const handleActiveOptionChange = (_: string, domId: string) => {
+    setActiveOptionId(domId);
+  };
+
+  /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
+
+  const handleLazyLoadSegments = () => {
+    if (willLoadMoreResults && !showFooterAction) {
+      setLazyLoading(true);
+
+      const options = query ? filteredSegments : segments;
+
+      setTimeout(() => {
+        const remainingOptionCount = options.length - visibleOptionIndex;
+        const nextVisibleOptionIndex =
+          remainingOptionCount >= interval
+            ? visibleOptionIndex + interval
+            : visibleOptionIndex + remainingOptionCount;
+
+        setLazyLoading(false);
+        setVisibleOptionIndex(nextVisibleOptionIndex);
+
+        if (remainingOptionCount <= interval) {
+          setWillLoadMoreResults(false);
+        }
+      }, 1000);
+    }
+  };
+
+  const listboxId = 'SearchableListbox';
+
+  const textFieldMarkup = (
+    <div style={{padding: '12px'}}>
+      <TextField
+        focused={showFooterAction}
+        clearButton
+        labelHidden
+        label="Customer segments"
+        placeholder="Search segments"
+        autoComplete="off"
+        value={query}
+        prefix={<Icon source={SearchMinor} />}
+        ariaActiveDescendant={activeOptionId}
+        ariaControls={listboxId}
+        onChange={handleQueryChange}
+        onClearButtonClick={handleQueryClear}
+      />
+    </div>
+  );
+
+  const segmentOptions = query ? filteredSegments : segments;
+
+  const segmentList =
+    segmentOptions.length > 0
+      ? segmentOptions
+          .slice(0, visibleOptionIndex)
+          .map(({label, id, value}) => {
+            const selected = segments[selectedSegmentIndex].value === value;
+
+            return (
+              <Listbox.Option key={id} value={value} selected={selected}>
+                <Listbox.TextOption selected={selected}>
+                  {label}
+                </Listbox.TextOption>
+              </Listbox.Option>
+            );
+          })
+      : null;
+
+  const showAllMarkup = showFooterAction ? (
+    <Listbox.Action value={actionValue}>
+      <span style={{color: 'var(--p-interactive)'}}>Show all 111 segments</span>
+    </Listbox.Action>
+  ) : null;
+
+  const lazyLoadingMarkup = lazyLoading ? (
+    <Listbox.Loading
+      accessibilityLabel={`${
+        query ? 'Filtering' : 'Loading'
+      } customer segments`}
+    />
+  ) : null;
+
+  const noResultsMarkup =
+    segmentOptions.length === 0 ? (
+      <EmptySearchResult
+        title=""
+        description={`No segments found matching "${query}"`}
+      />
+    ) : null;
+
+  const listboxMarkup = (
+    <Listbox
+      enableKeyboardControl
+      autoSelection={AutoSelection.FirstSelected}
+      accessibilityLabel="Search for and select a customer segment"
+      customListId={listboxId}
+      onSelect={handleSegmentSelect}
+      onActiveOptionChange={handleActiveOptionChange}
+    >
+      {segmentList}
+      {showAllMarkup}
+      {noResultsMarkup}
+      {lazyLoadingMarkup}
+    </Listbox>
+  );
+
+  return (
+    <Card>
+      <div
+        style={{
+          alignItems: 'stretch',
+          borderTop: '1px solid #DFE3E8',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'stretch',
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          overflow: 'hidden',
+        }}
+      >
+        {textFieldMarkup}
+
+        <Scrollable
+          shadow
+          style={{
+            position: 'relative',
+            height: '292px',
+            padding: 'var(--p-space-2) 0',
+            borderBottomLeftRadius: 'var(--p-border-radius-2)',
+            borderBottomRightRadius: 'var(--p-border-radius-2)',
+          }}
+          onScrolledToBottom={handleLazyLoadSegments}
+        >
+          {listboxMarkup}
+        </Scrollable>
+      </div>
+    </Card>
   );
 }

--- a/polaris-react/src/components/Listbox/components/Option/Option.tsx
+++ b/polaris-react/src/components/Listbox/components/Option/Option.tsx
@@ -47,6 +47,7 @@ export const Option = memo(function Option({
   const handleOptionSelect = useCallback(
     (event: React.MouseEvent | React.KeyboardEvent) => {
       event.preventDefault();
+      event.stopPropagation();
       onAction && onAction();
       if (listItemRef.current && !onAction) {
         onOptionSelect({

--- a/polaris-react/src/components/Listbox/components/Option/tests/Option.test.tsx
+++ b/polaris-react/src/components/Listbox/components/Option/tests/Option.test.tsx
@@ -68,7 +68,10 @@ describe('Option', () => {
     });
     const domId = optionElement?.prop('id');
 
-    optionElement!.trigger('onClick', {preventDefault: () => {}});
+    optionElement!.trigger('onClick', {
+      preventDefault: () => {},
+      stopPropagation: () => {},
+    });
 
     expect(onOptionSelectSpy).toHaveBeenCalledTimes(1);
     expect(onOptionSelectSpy).toHaveBeenCalledWith({
@@ -138,9 +141,10 @@ describe('Option', () => {
       },
     );
 
-    option
-      .find('li', {role: 'option'})!
-      .trigger('onMouseDown', {preventDefault: preventDefaultSpy});
+    option.find('li', {role: 'option'})!.trigger('onMouseDown', {
+      preventDefault: preventDefaultSpy,
+      stopPropagation: () => {},
+    });
 
     expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
   });
@@ -318,7 +322,10 @@ describe('Option', () => {
         .find('li', {
           role: 'option',
         })!
-        .trigger('onClick', {preventDefault: () => {}});
+        .trigger('onClick', {
+          preventDefault: () => {},
+          stopPropagation: () => {},
+        });
 
       expect(onActionSpy).toHaveBeenCalled();
     });
@@ -343,7 +350,10 @@ describe('Option', () => {
         .find('li', {
           role: 'option',
         })!
-        .trigger('onClick', {preventDefault: () => {}});
+        .trigger('onClick', {
+          preventDefault: () => {},
+          stopPropagation: () => {},
+        });
 
       expect(onOptionSelectSpy).not.toHaveBeenCalled();
     });

--- a/polaris-react/src/components/Popover/Popover.stories.tsx
+++ b/polaris-react/src/components/Popover/Popover.stories.tsx
@@ -352,10 +352,6 @@ export function WithSearchableListbox() {
     handleQueryChange('');
   };
 
-  const handleResetVisibleOptionIndex = () => {
-    setVisibleOptionIndex(interval);
-  };
-
   const handleOpenPicker = () => {
     setPickerOpen(true);
   };
@@ -363,7 +359,6 @@ export function WithSearchableListbox() {
   const handleClosePicker = () => {
     setPickerOpen(false);
     handleQueryChange('');
-    handleResetVisibleOptionIndex();
   };
 
   const handleSegmentSelect = (segmentIndex: string) => {

--- a/polaris-react/src/components/Popover/Popover.stories.tsx
+++ b/polaris-react/src/components/Popover/Popover.stories.tsx
@@ -9,8 +9,17 @@ import {
   Popover,
   ResourceList,
   Select,
+  Listbox,
   TextField,
+  Icon,
+  Link,
+  Heading,
+  AutoSelection,
+  Scrollable,
+  EmptySearchResult,
+  DisplayText,
 } from '@shopify/polaris';
+import {SearchMinor} from '@shopify/polaris-icons';
 
 export default {
   component: Popover,
@@ -221,3 +230,332 @@ export function WithLazyLoadedList() {
       .join('');
   }
 }
+
+export function WithSearchableListbox() {
+  interface CustomerSegment {
+    id: string;
+    label: string;
+    value: string;
+  }
+
+  const actionValue = '__ACTION__';
+
+  const segments: CustomerSegment[] = [
+    {
+      label: 'All customers',
+      id: 'gid://shopify/CustomerSegment/1',
+      value: '0',
+    },
+    {
+      label: 'VIP customers',
+      id: 'gid://shopify/CustomerSegment/2',
+      value: '1',
+    },
+    {
+      label: 'New customers',
+      id: 'gid://shopify/CustomerSegment/3',
+      value: '2',
+    },
+    {
+      label: 'Abandoned carts - last 30 days',
+      id: 'gid://shopify/CustomerSegment/4',
+      value: '3',
+    },
+    {
+      label: 'Wholesale customers',
+      id: 'gid://shopify/CustomerSegment/5',
+      value: '4',
+    },
+    {
+      label: 'Email subscribers',
+      id: 'gid://shopify/CustomerSegment/6',
+      value: '5',
+    },
+    {
+      label: 'From New York',
+      id: 'gid://shopify/CustomerSegment/7',
+      value: '6',
+    },
+    {
+      label: 'Repeat buyers',
+      id: 'gid://shopify/CustomerSegment/8',
+      value: '7',
+    },
+    {
+      label: 'First time buyers',
+      id: 'gid://shopify/CustomerSegment/9',
+      value: '8',
+    },
+    {
+      label: 'From Canada',
+      id: 'gid://shopify/CustomerSegment/10',
+      value: '9',
+    },
+    {
+      label: 'Bought in last 60 days',
+      id: 'gid://shopify/CustomerSegment/11',
+      value: '10',
+    },
+    {
+      label: 'Bought last BFCM',
+      id: 'gid://shopify/CustomerSegment/12',
+      value: '11',
+    },
+  ];
+
+  const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
+    (_, index) => ({
+      label: `Other customers ${index + 13}`,
+      id: `gid://shopify/CustomerSegment/${index + 13}`,
+      value: `${index + 12}`,
+    }),
+  );
+
+  segments.push(...lazyLoadSegments);
+
+  const interval = 25;
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [showFooterAction, setShowFooterAction] = useState(true);
+  const [query, setQuery] = useState('');
+  const [lazyLoading, setLazyLoading] = useState(false);
+  const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
+  const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
+  const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
+  const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
+  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
+    [],
+  );
+
+  const handleClickShowAll = () => {
+    setShowFooterAction(false);
+    setVisibleOptionIndex(interval);
+  };
+
+  const handleFilterSegments = (query: string) => {
+    const nextFilteredSegments = segments.filter((segment: CustomerSegment) => {
+      return segment.label
+        .toLocaleLowerCase()
+        .includes(query.toLocaleLowerCase().trim());
+    });
+
+    setFilteredSegments(nextFilteredSegments);
+  };
+
+  const handleQueryChange = (query: string) => {
+    setQuery(query);
+
+    if (query.length >= 2) handleFilterSegments(query);
+  };
+
+  const handleQueryClear = () => {
+    handleQueryChange('');
+  };
+
+  const handleResetVisibleOptionIndex = () => {
+    setVisibleOptionIndex(interval);
+  };
+
+  const handleOpenPicker = () => {
+    setPickerOpen(true);
+  };
+
+  const handleClosePicker = () => {
+    setPickerOpen(false);
+    handleQueryChange('');
+    handleResetVisibleOptionIndex();
+  };
+
+  const handleSegmentSelect = (segmentIndex: string) => {
+    if (segmentIndex === actionValue) {
+      return handleClickShowAll();
+    }
+
+    setSelectedSegmentIndex(Number(segmentIndex));
+    handleClosePicker();
+  };
+
+  const handleActiveOptionChange = (_: string, domId: string) => {
+    setActiveOptionId(domId);
+  };
+
+  /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
+
+  const handleLazyLoadSegments = () => {
+    if (willLoadMoreResults && !showFooterAction) {
+      setLazyLoading(true);
+
+      const options = query ? filteredSegments : segments;
+
+      setTimeout(() => {
+        const remainingOptionCount = options.length - visibleOptionIndex;
+        const nextVisibleOptionIndex =
+          remainingOptionCount >= interval
+            ? visibleOptionIndex + interval
+            : visibleOptionIndex + remainingOptionCount;
+
+        setLazyLoading(false);
+        setVisibleOptionIndex(nextVisibleOptionIndex);
+
+        if (remainingOptionCount <= interval) {
+          setWillLoadMoreResults(false);
+        }
+      }, 1000);
+    }
+  };
+
+  const listboxId = 'SearchableListboxInPopover';
+
+  /* Your app's feature/context specific activator here */
+  const activator = (
+    <div
+      style={{
+        fontSize: 'var(--p-font-size-7)',
+        color: 'var(--p-text)',
+        borderBottom: '1px dashed var(--p-border)',
+      }}
+    >
+      <Link monochrome removeUnderline onClick={handleOpenPicker}>
+        <DisplayText element="h1">
+          {segments[selectedSegmentIndex].label}
+        </DisplayText>
+      </Link>
+    </div>
+  );
+
+  const textFieldMarkup = (
+    <div style={{padding: '12px'}}>
+      <StopPropagation>
+        <TextField
+          focused={showFooterAction}
+          clearButton
+          labelHidden
+          label="Customer segments"
+          placeholder="Search segments"
+          autoComplete="off"
+          value={query}
+          prefix={<Icon source={SearchMinor} />}
+          ariaActiveDescendant={activeOptionId}
+          ariaControls={listboxId}
+          onChange={handleQueryChange}
+          onClearButtonClick={handleQueryClear}
+        />
+      </StopPropagation>
+    </div>
+  );
+
+  const segmentOptions = query ? filteredSegments : segments;
+
+  const segmentList =
+    segmentOptions.length > 0
+      ? segmentOptions
+          .slice(0, visibleOptionIndex)
+          .map(({label, id, value}) => {
+            const selected = segments[selectedSegmentIndex].id === id;
+
+            return (
+              <Listbox.Option key={id} value={value} selected={selected}>
+                <Listbox.TextOption selected={selected}>
+                  {label}
+                </Listbox.TextOption>
+              </Listbox.Option>
+            );
+          })
+      : null;
+
+  const showAllMarkup = showFooterAction ? (
+    <Listbox.Action value={actionValue}>
+      <span style={{color: 'var(--p-interactive)'}}>Show all 111 segments</span>
+    </Listbox.Action>
+  ) : null;
+
+  const lazyLoadingMarkup = lazyLoading ? (
+    <Listbox.Loading
+      accessibilityLabel={`${
+        query ? 'Filtering' : 'Loading'
+      } customer segments`}
+    />
+  ) : null;
+
+  const noResultsMarkup =
+    segmentOptions.length === 0 ? (
+      <EmptySearchResult
+        title=""
+        description={`No segments found matching "${query}"`}
+      />
+    ) : null;
+
+  const listboxMarkup = (
+    <Listbox
+      enableKeyboardControl
+      autoSelection={AutoSelection.FirstSelected}
+      accessibilityLabel="Search for and select a customer segment"
+      customListId={listboxId}
+      onSelect={handleSegmentSelect}
+      onActiveOptionChange={handleActiveOptionChange}
+    >
+      {segmentList}
+      {showAllMarkup}
+      {noResultsMarkup}
+      {lazyLoadingMarkup}
+    </Listbox>
+  );
+
+  return (
+    <div style={{height: '400px'}}>
+      <Popover
+        active={pickerOpen}
+        activator={activator}
+        ariaHaspopup="listbox"
+        preferredAlignment="left"
+        autofocusTarget="first-node"
+        onClose={handleClosePicker}
+      >
+        <Popover.Pane fixed>
+          <div
+            style={{
+              alignItems: 'stretch',
+              borderTop: '1px solid #DFE3E8',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'stretch',
+              position: 'relative',
+              width: '100%',
+              height: '100%',
+              overflow: 'hidden',
+            }}
+          >
+            {textFieldMarkup}
+
+            <Scrollable
+              shadow
+              style={{
+                position: 'relative',
+                width: '310px',
+                height: '292px',
+                padding: 'var(--p-space-2) 0',
+                borderBottomLeftRadius: 'var(--p-border-radius-2)',
+                borderBottomRightRadius: 'var(--p-border-radius-2)',
+              }}
+              onScrolledToBottom={handleLazyLoadSegments}
+            >
+              {listboxMarkup}
+            </Scrollable>
+          </div>
+        </Popover.Pane>
+      </Popover>
+    </div>
+  );
+}
+
+const StopPropagation = ({children}: React.PropsWithChildren<any>) => {
+  const stopEventPropagation = (event: React.MouseEvent | React.TouchEvent) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <div onClick={stopEventPropagation} onTouchStart={stopEventPropagation}>
+      {children}
+    </div>
+  );
+};

--- a/polaris-react/src/components/Sheet/Sheet.stories.tsx
+++ b/polaris-react/src/components/Sheet/Sheet.stories.tsx
@@ -9,8 +9,16 @@ import {
   Page,
   Scrollable,
   Sheet,
+  EmptySearchResult,
+  Listbox,
+  TextField,
+  TextContainer,
+  TextStyle,
+  Subheading,
+  Icon,
+  AutoSelection,
 } from '@shopify/polaris';
-import {MobileCancelMajor} from '@shopify/polaris-icons';
+import {MobileCancelMajor, SearchMinor} from '@shopify/polaris-icons';
 
 export default {
   component: Sheet,
@@ -77,7 +85,7 @@ export function Default() {
           content: 'Manage sales channels',
         },
       ]
-    : null;
+    : undefined;
 
   return (
     <Page narrowWidth>
@@ -150,3 +158,375 @@ export function Default() {
     </Page>
   );
 }
+
+export function WithSearchableListbox() {
+  const actionValue = '__ACTION__';
+
+  interface CustomerSegment {
+    id: string;
+    label: string;
+    value: string;
+  }
+
+  const segments: CustomerSegment[] = [
+    {
+      label: 'All customers',
+      id: 'gid://shopify/CustomerSegment/1',
+      value: '0',
+    },
+    {
+      label: 'VIP customers',
+      id: 'gid://shopify/CustomerSegment/2',
+      value: '1',
+    },
+    {
+      label: 'New customers',
+      id: 'gid://shopify/CustomerSegment/3',
+      value: '2',
+    },
+    {
+      label: 'Abandoned carts - last 30 days',
+      id: 'gid://shopify/CustomerSegment/4',
+      value: '3',
+    },
+    {
+      label: 'Wholesale customers',
+      id: 'gid://shopify/CustomerSegment/5',
+      value: '4',
+    },
+    {
+      label: 'Email subscribers',
+      id: 'gid://shopify/CustomerSegment/6',
+      value: '5',
+    },
+    {
+      label: 'From New York',
+      id: 'gid://shopify/CustomerSegment/7',
+      value: '6',
+    },
+    {
+      label: 'Repeat buyers',
+      id: 'gid://shopify/CustomerSegment/8',
+      value: '7',
+    },
+    {
+      label: 'First time buyers',
+      id: 'gid://shopify/CustomerSegment/9',
+      value: '8',
+    },
+    {
+      label: 'From Canada',
+      id: 'gid://shopify/CustomerSegment/10',
+      value: '9',
+    },
+    {
+      label: 'Bought in last 60 days',
+      id: 'gid://shopify/CustomerSegment/11',
+      value: '10',
+    },
+    {
+      label: 'Bought last BFCM',
+      id: 'gid://shopify/CustomerSegment/12',
+      value: '11',
+    },
+  ];
+
+  const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
+    (_, index) => ({
+      label: `Other customers ${index + 13}`,
+      id: `gid://shopify/CustomerSegment/${index + 13}`,
+      value: `${index + 12}`,
+    }),
+  );
+
+  segments.push(...lazyLoadSegments);
+
+  const interval = 25;
+  const [sheetOpen, setSheetOpen] = useState(true);
+  const [showFooterAction, setShowFooterAction] = useState(true);
+  const [query, setQuery] = useState('');
+  const [lazyLoading, setLazyLoading] = useState(false);
+  const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
+  const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
+  const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
+  const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
+  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
+    [],
+  );
+
+  const handleClickShowAll = () => {
+    setShowFooterAction(false);
+    setVisibleOptionIndex(segments.length);
+  };
+
+  const handleFilterSegments = (query: string) => {
+    const nextFilteredSegments = segments.filter((segment) => {
+      return segment.label
+        .toLocaleLowerCase()
+        .includes(query.toLocaleLowerCase().trim());
+    });
+
+    setFilteredSegments(nextFilteredSegments);
+  };
+
+  const handleQueryChange = (query: string) => {
+    setQuery(query);
+
+    if (query.length >= 2) handleFilterSegments(query);
+  };
+
+  const handleQueryClear = () => {
+    handleQueryChange('');
+  };
+
+  const handleResetVisibleOptionIndex = () => {
+    setVisibleOptionIndex(interval);
+  };
+
+  const handleOpenSheet = () => {
+    setSheetOpen(true);
+  };
+
+  const handleCloseSheet = () => {
+    setSheetOpen(false);
+    handleQueryChange('');
+    handleResetVisibleOptionIndex();
+  };
+
+  const handleSegmentSelect = (segmentIndex: string) => {
+    if (segmentIndex === actionValue) {
+      return handleClickShowAll();
+    }
+
+    setSelectedSegmentIndex(Number(segmentIndex));
+    handleCloseSheet();
+  };
+
+  const handleActiveOptionChange = (_: string, domId: string) => {
+    setActiveOptionId(domId);
+  };
+
+  /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
+
+  const handleLazyLoadSegments = () => {
+    if (willLoadMoreResults && !showFooterAction) {
+      setLazyLoading(true);
+
+      const options = query ? filteredSegments : segments;
+
+      setTimeout(() => {
+        const remainingOptionCount = options.length - visibleOptionIndex;
+        const nextVisibleOptionIndex =
+          remainingOptionCount >= interval
+            ? visibleOptionIndex + interval
+            : visibleOptionIndex + remainingOptionCount;
+
+        setLazyLoading(false);
+        setVisibleOptionIndex(nextVisibleOptionIndex);
+
+        if (remainingOptionCount <= interval) {
+          setWillLoadMoreResults(false);
+        }
+      }, 1000);
+    }
+  };
+
+  const listboxId = 'SearchableListboxInSheet';
+
+  /* Your app's feature/context specific activator here */
+  const activator = (
+    <Button onClick={handleOpenSheet}>
+      {segments[selectedSegmentIndex].label}
+    </Button>
+  );
+
+  const textFieldMarkup = (
+    <div
+      style={{
+        padding: 'var(--p-space-4) var(--p-space-2)',
+        position: 'sticky',
+        zIndex: 'var(--p-z-12)',
+        width: '100%',
+        background: 'var(--p-surface)',
+      }}
+    >
+      <StopPropagation>
+        <TextField
+          focused={showFooterAction}
+          clearButton
+          labelHidden
+          label="Customer segments"
+          placeholder="Search segments"
+          autoComplete="off"
+          value={query}
+          prefix={<Icon source={SearchMinor} />}
+          ariaActiveDescendant={activeOptionId}
+          ariaControls={listboxId}
+          onChange={handleQueryChange}
+          onClearButtonClick={handleQueryClear}
+        />
+      </StopPropagation>
+    </div>
+  );
+
+  const segmentOptions = query ? filteredSegments : segments;
+
+  const segmentList =
+    segmentOptions.length > 0
+      ? segmentOptions
+          .slice(0, visibleOptionIndex)
+          .map(({label, id, value}) => {
+            const selected = segments[selectedSegmentIndex].id === id;
+
+            return (
+              <Listbox.Option key={id} value={value} selected={selected}>
+                <Listbox.TextOption selected={selected}>
+                  {label}
+                </Listbox.TextOption>
+              </Listbox.Option>
+            );
+          })
+      : null;
+
+  const showAllMarkup = showFooterAction ? (
+    <Listbox.Action value={actionValue}>
+      <span style={{color: 'var(--p-interactive)'}}>Show all 111 segments</span>
+    </Listbox.Action>
+  ) : null;
+
+  const lazyLoadingMarkup = lazyLoading ? (
+    <Listbox.Loading
+      accessibilityLabel={`${
+        query ? 'Filtering' : 'Loading'
+      } customer segments`}
+    />
+  ) : null;
+
+  const noResultsMarkup =
+    segmentOptions.length === 0 ? (
+      <EmptySearchResult
+        title=""
+        description={`No segments found matching "${query}"`}
+      />
+    ) : null;
+
+  const listboxMarkup = (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <Listbox
+        enableKeyboardControl
+        autoSelection={AutoSelection.FirstSelected}
+        accessibilityLabel="Search for and select a customer segment"
+        customListId={listboxId}
+        onSelect={handleSegmentSelect}
+        onActiveOptionChange={handleActiveOptionChange}
+      >
+        {segmentList}
+        {showAllMarkup}
+        {noResultsMarkup}
+        {lazyLoadingMarkup}
+      </Listbox>
+    </div>
+  );
+
+  return (
+    <div style={{height: '265px'}}>
+      {activator}
+      <Sheet
+        open={sheetOpen}
+        accessibilityLabel="Flow action"
+        onClose={handleCloseSheet}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <div
+            style={{
+              alignItems: 'flex-start',
+              borderBottom: '1px solid #DFE3E8',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'space-between',
+              width: '100%',
+              padding: 'var(--p-space-4)',
+            }}
+          >
+            <div
+              style={{
+                alignItems: 'center',
+                display: 'flex',
+                justifyContent: 'space-between',
+                width: '100%',
+                marginBottom: 'var(--p-space-2)',
+              }}
+            >
+              <TextStyle variation="subdued">
+                <Subheading>Action</Subheading>
+              </TextStyle>
+              <Button
+                accessibilityLabel="Cancel"
+                icon={MobileCancelMajor}
+                onClick={handleCloseSheet}
+                plain
+              />
+            </div>
+            <TextContainer>
+              <Heading>Look up customer segmentation membership</Heading>
+              <TextStyle variation="subdued">
+                Look up whether a customer is included in a segment.
+              </TextStyle>
+            </TextContainer>
+          </div>
+          <div
+            style={{
+              alignItems: 'stretch',
+              borderTop: '1px solid #DFE3E8',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'stretch',
+              position: 'relative',
+              width: '100%',
+              height: '100%',
+              overflow: 'hidden',
+            }}
+          >
+            {textFieldMarkup}
+
+            <Scrollable
+              shadow
+              style={{
+                position: 'relative',
+                width: '100%',
+                height: '292px',
+                padding: 'var(--p-space-2) 0',
+              }}
+              onScrolledToBottom={handleLazyLoadSegments}
+            >
+              {listboxMarkup}
+            </Scrollable>
+          </div>
+        </div>
+      </Sheet>
+    </div>
+  );
+}
+
+const StopPropagation = ({children}: React.PropsWithChildren<any>) => {
+  const stopEventPropagation = (event: React.MouseEvent | React.TouchEvent) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <div onClick={stopEventPropagation} onTouchStart={stopEventPropagation}>
+      {children}
+    </div>
+  );
+};

--- a/polaris.shopify.com/pages/examples/autocomplete-with-action.tsx
+++ b/polaris.shopify.com/pages/examples/autocomplete-with-action.tsx
@@ -81,6 +81,9 @@ function AutocompleteActionBeforeExample() {
           ellipsis: true,
           helpText: 'Help text',
           icon: CirclePlusMinor,
+          onAction: () => {
+            console.log('actionBefore clicked!');
+          },
         }}
         options={options}
         selected={selectedOptions}

--- a/polaris.shopify.com/pages/examples/autocomplete-with-destructive-action.tsx
+++ b/polaris.shopify.com/pages/examples/autocomplete-with-destructive-action.tsx
@@ -76,6 +76,9 @@ function AutocompleteActionBeforeExample() {
           content: 'Destructive action',
           destructive: true,
           icon: DeleteMinor,
+          onAction: () => {
+            console.log('actionBefore clicked!');
+          },
         }}
         options={options}
         selected={selectedOptions}

--- a/polaris.shopify.com/pages/examples/autocomplete-with-wrapping-action.tsx
+++ b/polaris.shopify.com/pages/examples/autocomplete-with-wrapping-action.tsx
@@ -83,6 +83,9 @@ function AutocompleteActionBeforeExample() {
           helpText: 'Help text',
           icon: CirclePlusMinor,
           wrapOverflow: true,
+          onAction: () => {
+            console.log('actionBefore clicked!');
+          },
         }}
         options={options}
         selected={selectedOptions}

--- a/polaris.shopify.com/pages/examples/combobox-with-manual-selection.tsx
+++ b/polaris.shopify.com/pages/examples/combobox-with-manual-selection.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   TextContainer,
   Stack,
+  AutoSelection,
 } from '@shopify/polaris';
 import {SearchMinor} from '@shopify/polaris-icons';
 import {useState, useCallback, useMemo} from 'react';
@@ -112,7 +113,9 @@ function MultiComboboxExample() {
         }
       >
         {optionsMarkup ? (
-          <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
+          <Listbox autoSelection="NONE" onSelect={updateSelection}>
+            {optionsMarkup}
+          </Listbox>
         ) : null}
       </Combobox>
       <TextContainer>

--- a/polaris.shopify.com/pages/examples/listbox-with-search.tsx
+++ b/polaris.shopify.com/pages/examples/listbox-with-search.tsx
@@ -90,8 +90,8 @@ const segments: CustomerSegment[] = [
 
 const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
   (_, index) => ({
-    label: `Other customers ${index + 12}`,
-    id: `gid://shopify/CustomerSegment/${index + 12}`,
+    label: `Other customers ${index + 13}`,
+    id: `gid://shopify/CustomerSegment/${index + 13}`,
     value: `${index + 12}`,
   }),
 );

--- a/polaris.shopify.com/pages/examples/listbox-with-search.tsx
+++ b/polaris.shopify.com/pages/examples/listbox-with-search.tsx
@@ -17,15 +17,9 @@ import {SearchMinor} from '@shopify/polaris-icons';
 
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-interface CustomerSegment {
-  id: string;
-  label: string;
-  value: string;
-}
-
 const actionValue = '__ACTION__';
 
-const segments: CustomerSegment[] = [
+const segments = [
   {
     label: 'All customers',
     id: 'gid://shopify/CustomerSegment/1',
@@ -88,13 +82,11 @@ const segments: CustomerSegment[] = [
   },
 ];
 
-const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
-  (_, index) => ({
-    label: `Other customers ${index + 13}`,
-    id: `gid://shopify/CustomerSegment/${index + 13}`,
-    value: `${index + 12}`,
-  }),
-);
+const lazyLoadSegments = Array.from(Array(100)).map((_, index) => ({
+  label: `Other customers ${index + 13}`,
+  id: `gid://shopify/CustomerSegment/${index + 13}`,
+  value: `${index + 12}`,
+}));
 
 segments.push(...lazyLoadSegments);
 
@@ -108,17 +100,15 @@ function ListboxWithSearchExample() {
   const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
   const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
   const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
-  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
-    [],
-  );
+  const [filteredSegments, setFilteredSegments] = useState([]);
 
   const handleClickShowAll = () => {
     setShowFooterAction(false);
     setVisibleOptionIndex(segments.length);
   };
 
-  const handleFilterSegments = (query: string) => {
-    const nextFilteredSegments = segments.filter((segment: CustomerSegment) => {
+  const handleFilterSegments = (query) => {
+    const nextFilteredSegments = segments.filter((segment) => {
       return segment.label
         .toLocaleLowerCase()
         .includes(query.toLocaleLowerCase().trim());
@@ -127,7 +117,7 @@ function ListboxWithSearchExample() {
     setFilteredSegments(nextFilteredSegments);
   };
 
-  const handleQueryChange = (query: string) => {
+  const handleQueryChange = (query) => {
     setQuery(query);
 
     if (query.length >= 2) handleFilterSegments(query);
@@ -141,7 +131,7 @@ function ListboxWithSearchExample() {
     setVisibleOptionIndex(interval);
   };
 
-  const handleSegmentSelect = (segmentIndex: string) => {
+  const handleSegmentSelect = (segmentIndex) => {
     if (segmentIndex === actionValue) {
       return handleClickShowAll();
     }
@@ -149,7 +139,7 @@ function ListboxWithSearchExample() {
     setSelectedSegmentIndex(Number(segmentIndex));
   };
 
-  const handleActiveOptionChange = (_: string, domId: string) => {
+  const handleActiveOptionChange = (_, domId) => {
     setActiveOptionId(domId);
   };
 

--- a/polaris.shopify.com/pages/examples/popover-with-searchable-listbox.tsx
+++ b/polaris.shopify.com/pages/examples/popover-with-searchable-listbox.tsx
@@ -126,10 +126,6 @@ function PopoverWithSearchableListboxExample() {
     handleQueryChange('');
   };
 
-  const handleResetVisibleOptionIndex = () => {
-    setVisibleOptionIndex(interval);
-  };
-
   const handleOpenPicker = () => {
     setPickerOpen(true);
   };
@@ -137,7 +133,6 @@ function PopoverWithSearchableListboxExample() {
   const handleClosePicker = () => {
     setPickerOpen(false);
     handleQueryChange('');
-    handleResetVisibleOptionIndex();
   };
 
   const handleSegmentSelect = (segmentIndex: string) => {

--- a/polaris.shopify.com/pages/examples/popover-with-searchable-listbox.tsx
+++ b/polaris.shopify.com/pages/examples/popover-with-searchable-listbox.tsx
@@ -10,21 +10,14 @@ import {
   Scrollable,
   EmptySearchResult,
   DisplayText,
-  Button,
 } from '@shopify/polaris';
 import {SearchMinor} from '@shopify/polaris-icons';
 
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-interface CustomerSegment {
-  id: string;
-  label: string;
-  value: string;
-}
-
 const actionValue = '__ACTION__';
 
-const segments: CustomerSegment[] = [
+const segments = [
   {
     label: 'All customers',
     id: 'gid://shopify/CustomerSegment/1',
@@ -87,13 +80,11 @@ const segments: CustomerSegment[] = [
   },
 ];
 
-const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
-  (_, index) => ({
-    label: `Other customers ${index + 13}`,
-    id: `gid://shopify/CustomerSegment/${index + 13}`,
-    value: `${index + 12}`,
-  }),
-);
+const lazyLoadSegments = Array.from(Array(100)).map((_, index) => ({
+  label: `Other customers ${index + 13}`,
+  id: `gid://shopify/CustomerSegment/${index + 13}`,
+  value: `${index + 12}`,
+}));
 
 segments.push(...lazyLoadSegments);
 
@@ -108,9 +99,7 @@ function PopoverWithSearchableListboxExample() {
   const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
   const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
   const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
-  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
-    [],
-  );
+  const [filteredSegments, setFilteredSegments] = useState([]);
 
   const handleClickShowAll = () => {
     setShowFooterAction(false);
@@ -118,7 +107,7 @@ function PopoverWithSearchableListboxExample() {
   };
 
   const handleFilterSegments = (query: string) => {
-    const nextFilteredSegments = segments.filter((segment: CustomerSegment) => {
+    const nextFilteredSegments = segments.filter((segment) => {
       return segment.label
         .toLocaleLowerCase()
         .includes(query.toLocaleLowerCase().trim());

--- a/polaris.shopify.com/pages/examples/popover-with-searchable-listbox.tsx
+++ b/polaris.shopify.com/pages/examples/popover-with-searchable-listbox.tsx
@@ -89,8 +89,8 @@ const segments: CustomerSegment[] = [
 
 const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
   (_, index) => ({
-    label: `Other customers ${index + 12}`,
-    id: `gid://shopify/CustomerSegment/${index + 12}`,
+    label: `Other customers ${index + 13}`,
+    id: `gid://shopify/CustomerSegment/${index + 13}`,
     value: `${index + 12}`,
   }),
 );
@@ -114,7 +114,7 @@ function PopoverWithSearchableListboxExample() {
 
   const handleClickShowAll = () => {
     setShowFooterAction(false);
-    setVisibleOptionIndex(segments.length);
+    setVisibleOptionIndex(interval);
   };
 
   const handleFilterSegments = (query: string) => {

--- a/polaris.shopify.com/pages/examples/sheet-with-searchable-listbox.tsx
+++ b/polaris.shopify.com/pages/examples/sheet-with-searchable-listbox.tsx
@@ -92,8 +92,8 @@ const segments: CustomerSegment[] = [
 
 const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
   (_, index) => ({
-    label: `Other customers ${index + 12}`,
-    id: `gid://shopify/CustomerSegment/${index + 12}`,
+    label: `Other customers ${index + 13}`,
+    id: `gid://shopify/CustomerSegment/${index + 13}`,
     value: `${index + 12}`,
   }),
 );

--- a/polaris.shopify.com/pages/examples/sheet-with-searchable-listbox.tsx
+++ b/polaris.shopify.com/pages/examples/sheet-with-searchable-listbox.tsx
@@ -19,15 +19,9 @@ import {MobileCancelMajor, SearchMinor} from '@shopify/polaris-icons';
 
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-interface CustomerSegment {
-  id: string;
-  label: string;
-  value: string;
-}
-
 const actionValue = '__ACTION__';
 
-const segments: CustomerSegment[] = [
+const segments = [
   {
     label: 'All customers',
     id: 'gid://shopify/CustomerSegment/1',
@@ -90,13 +84,11 @@ const segments: CustomerSegment[] = [
   },
 ];
 
-const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
-  (_, index) => ({
-    label: `Other customers ${index + 13}`,
-    id: `gid://shopify/CustomerSegment/${index + 13}`,
-    value: `${index + 12}`,
-  }),
-);
+const lazyLoadSegments = Array.from(Array(100)).map((_, index) => ({
+  label: `Other customers ${index + 13}`,
+  id: `gid://shopify/CustomerSegment/${index + 13}`,
+  value: `${index + 12}`,
+}));
 
 segments.push(...lazyLoadSegments);
 
@@ -111,9 +103,7 @@ function SheetWithSearchableListboxExample() {
   const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
   const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
   const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
-  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
-    [],
-  );
+  const [filteredSegments, setFilteredSegments] = useState([]);
 
   const handleClickShowAll = () => {
     setShowFooterAction(false);
@@ -121,7 +111,7 @@ function SheetWithSearchableListboxExample() {
   };
 
   const handleFilterSegments = (query: string) => {
-    const nextFilteredSegments = segments.filter((segment: CustomerSegment) => {
+    const nextFilteredSegments = segments.filter((segment) => {
       return segment.label
         .toLocaleLowerCase()
         .includes(query.toLocaleLowerCase().trim());


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

It's a common pattern in the admin for `Combobox` to include a `Listbox.Action` to enable creation of new options. Because propagation of the click event on `Listbox.Option` is not stopped, when a `Listbox` is rendered in a `Popover`, like a `Combobox`, the `Popover` closes unexpectedly. `Combobox` currently has a hack to prevent this, but it's also a problem for searchable listbox implementations. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR: 

- Stops propagation of the click event on `Listbox.Option` to prevent unwanted bubbling
- Removes the workaround for the bug in `Combobox`
- Fixes the `Autocomplete` `actionBefore` prop's `onAction` callback never being called when provided
- Adds the Listbox with search example and the Sheet/Popover with searchable listbox examples to Storybook
- Fixes the duplicate key React console error in the searchable listbox examples

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

- You can tophat `web` using [this Spinstance](https://shop1.shopify.test-listbox-bug-fix.chloe-rice.us.spin.dev/admin/products/1)
  OR
- Tophat the `Popover` "With searchable listbox" example in Storybook ([PR deploy](https://5d559397bae39100201eedc1-nefjqtdvzc.chromatic.com/?path=/story/all-components-popover--with-searchable-listbox), [Production example](https://polaris.shopify.com/components/popover)

I tested in `web` to ensure no regressions with this [Spinstance](https://shop1.shopify.test-listbox-bug-fix.chloe-rice.us.spin.dev/admin). There are no `Autocomplete` instances using `actionBefore`, which is probably why that bug was never caught. Tested several autocompletes, comboboxes, and listboxes, including the the "Browse all" action in the Product details OrganizationCard Type combobox. All work as expected and/or as in production. 


<!--
  Give as much information as needed to experiment with the component
  in the playground.


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>
-->

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
