### PR TITLE
[TextField] Fix: multiline TextField focus problem

### DIFF
--- a/.changeset/silver-papayas-relax.md
+++ b/.changeset/silver-papayas-relax.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fix multiline TextField focus problem
+Fixed `TextField` `focused` prop not working when `multiline` is `true`

--- a/.changeset/silver-papayas-relax.md
+++ b/.changeset/silver-papayas-relax.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix multiline TextField focus problem

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -242,10 +242,10 @@ export function TextField({
   const spinnerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const input = inputRef.current;
+    const input = multiline ? textAreaRef.current : inputRef.current;
     if (!input || focused === undefined) return;
     focused ? input.focus() : input.blur();
-  }, [focused, verticalContent]);
+  }, [focused, verticalContent, multiline]);
 
   useEffect(() => {
     const input = inputRef.current;

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -290,6 +290,20 @@ describe('<TextField />', () => {
 
       expect(document.activeElement).not.toBe(element.find('input')!.domNode);
     });
+
+    it('multiline input is in focus state if focused is true', () => {
+      const element = mountWithApp(
+        <TextField
+          label="MultiLineTextField"
+          onChange={noop}
+          autoComplete="off"
+          focused
+          multiline={3}
+        />,
+      );
+
+      expect(document.activeElement).toBe(element.find('textarea')!.domNode);
+    });
   });
 
   describe('autoComplete', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #5683 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

The focus property does not work correctly when the TextField component has a multiline property. Because it still gets inputRef even though it is a textarea. In this PR, I added logic to fix this situation.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
