### PR TITLE
[FormLayout.Item] do not render if children is undefined

### DIFF
--- a/.changeset/red-radios-drive.md
+++ b/.changeset/red-radios-drive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Don't render if children is null / undefined

--- a/polaris-react/src/components/FormLayout/components/Item/Item.tsx
+++ b/polaris-react/src/components/FormLayout/components/Item/Item.tsx
@@ -6,6 +6,6 @@ export interface ItemProps {
   children?: React.ReactNode;
 }
 
-export function Item(props: ItemProps) {
-  return <div className={styles.Item}>{props.children}</div>;
+export function Item({children}: ItemProps) {
+  return children ? <div className={styles.Item}>{children}</div> : null;
 }

--- a/polaris-react/src/components/FormLayout/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/FormLayout/components/Item/tests/Item.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
+import styles from '../../../FormLayout.scss';
 import {TextField} from '../../../../TextField';
 import {Item} from '../Item';
 
@@ -18,7 +19,9 @@ describe('<Item />', () => {
 
   it('does not render when children is undefined', () => {
     const item = mountWithApp(<Item />);
-    expect(item).not.toContainReactComponent(TextField);
+    expect(item).not.toContainReactComponent('div', {
+      className: styles.Item,
+    });
   });
 });
 

--- a/polaris-react/src/components/FormLayout/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/FormLayout/components/Item/tests/Item.test.tsx
@@ -15,6 +15,11 @@ describe('<Item />', () => {
       label: 'test',
     });
   });
+
+  it('does not render when children is undefined', () => {
+    const item = mountWithApp(<Item />);
+    expect(item).not.toContainReactComponent(TextField);
+  });
 });
 
 function noop() {}


### PR DESCRIPTION
Fixes: https://github.com/Shopify/polaris/issues/6956

Alternatively we could try the css approach i.e. `&:empty {padding: 0}`. I think this is safe enough though