### PR TITLE
Tokens: Add missing alpha values in RGBA colors

### DIFF
--- a/.changeset/lovely-needles-mix.md
+++ b/.changeset/lovely-needles-mix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': patch
+---
+
+Add missing alpha values in RGBA colors

--- a/polaris-tokens/src/token-groups/color.dark.ts
+++ b/polaris-tokens/src/token-groups/color.dark.ts
@@ -333,10 +333,10 @@ export const colors = {
     value: 'rgba(88, 173, 142, 1)',
   },
   'icon-attention': {
-    value: 'rgba(138, 97, 22)',
+    value: 'rgba(138, 97, 22, 1)',
   },
   'surface-attention': {
-    value: 'rgba(255, 234, 138)',
+    value: 'rgba(255, 234, 138, 1)',
   },
   'decorative-one-icon': {
     value: 'rgba(255, 186, 67, 1)',

--- a/polaris-tokens/src/token-groups/color.light.ts
+++ b/polaris-tokens/src/token-groups/color.light.ts
@@ -569,10 +569,10 @@ export const colors = {
       'For use as a text color in inert success elements. Not for use as a text color on banners and badges.',
   },
   'icon-attention': {
-    value: 'rgba(138, 97, 22)',
+    value: 'rgba(138, 97, 22, 1)',
   },
   'surface-attention': {
-    value: 'rgba(255, 234, 138)',
+    value: 'rgba(255, 234, 138, 1)',
   },
   'decorative-one-icon': {
     value: 'rgba(126, 87, 0, 1)',


### PR DESCRIPTION
This PR adds in some missing `alpha` values to a couple of our polaris token colors. All tokens are currently using the `rbga` color format, and there are a couple that didn't define an `alpha` value. In a browser, a value of `1` will be assumed, so it's not entirely necessary. However, in other implementations like React Native, the alpha value is required or the color will be ignored:

![image](https://user-images.githubusercontent.com/1692476/185141041-4f6ed982-de86-4c37-bab3-543d5c3b9335.png)

### How to 🎩

This is a very simple update that should have no noticeable impact where these color values are used.