### PR TITLE
[DataTable] Add `fixedFirstColumns` prop

### DIFF
--- a/.changeset/lazy-nails-relax.md
+++ b/.changeset/lazy-nails-relax.md
@@ -2,4 +2,5 @@
 '@shopify/polaris': minor
 ---
 
-Added `fixedFirstColumns` prop to `DataTable` so that multiple columns can be fixed
+- Added a `fixedFirstColumns` prop to `DataTable` so that multiple columns can be fixed
+- Deprecated the `DataTable` `fixedFirstColumn` prop

--- a/.changeset/lazy-nails-relax.md
+++ b/.changeset/lazy-nails-relax.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added `fixedFirstColumns` prop to `DataTable` so that multiple columns can be fixed

--- a/polaris-react/src/components/DataTable/DataTable.scss
+++ b/polaris-react/src/components/DataTable/DataTable.scss
@@ -349,7 +349,9 @@
 
   &.separate:is(table) th,
   &.separate:is(th) {
-    border-right: var(--p-border-divider);
+    &:last-of-type {
+      border-right: var(--p-border-divider);
+    }
   }
 }
 

--- a/polaris-react/src/components/DataTable/DataTable.stories.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.stories.tsx
@@ -13,6 +13,48 @@ export default {
   },
 } as ComponentMeta<typeof DataTable>;
 
+function sortRows(rows, index, direction) {
+  return [...rows].sort((rowA, rowB) => {
+    let type;
+    if (rowA[index].length > 1) {
+      if (!isNaN(parseFloat(rowA[index]))) {
+        type = 'number';
+      } else if (!isNaN(parseFloat(rowA[index].substring(1)))) {
+        type = 'currency';
+      } else type = 'string';
+    } else {
+      type = !isNaN(parseFloat(rowA[index])) ? 'number' : 'string';
+    }
+
+    let itemA;
+    let itemB;
+    if (type === 'number') {
+      itemA = parseInt(rowA[index], 10);
+    } else if (type === 'currency') {
+      itemA = parseFloat(rowA[index].substring(1));
+    } else {
+      itemA = rowA[index];
+    }
+    if (type === 'number') {
+      itemB = parseInt(rowB[index], 10);
+    } else if (type === 'currency') {
+      itemB = parseFloat(rowA[index].substring(1));
+    } else {
+      itemB = rowA[index];
+    }
+    if (type === 'string') {
+      let result;
+
+      if (itemA > itemB) result = 1;
+      else if (itemB > itemA) result = -1;
+      else result = 0;
+      return direction === 'descending' ? result * -1 : result;
+    }
+
+    return direction === 'descending' ? itemB - itemA : itemA - itemB;
+  });
+}
+
 export function Default() {
   const rows = [
     ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
@@ -53,7 +95,7 @@ export function Default() {
 }
 
 export function Sortable() {
-  const [sortedRows, setSortedRows] = useState(null);
+  const [sortedRows, setSortedRows] = useState<any[]>();
 
   const initiallySortedRows = [
     ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
@@ -69,7 +111,7 @@ export function Sortable() {
   const rows = sortedRows ? sortedRows : initiallySortedRows;
 
   const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
+    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
     [rows],
   );
 
@@ -101,15 +143,6 @@ export function Sortable() {
       </Card>
     </Page>
   );
-
-  function sortCurrency(rows, index, direction) {
-    return [...rows].sort((rowA, rowB) => {
-      const amountA = parseFloat(rowA[index].substring(1));
-      const amountB = parseFloat(rowB[index].substring(1));
-
-      return direction === 'descending' ? amountB - amountA : amountA - amountB;
-    });
-  }
 }
 
 export function WithFooter() {
@@ -300,7 +333,7 @@ export function WithRowHeadingLinks() {
 }
 
 export function WithAllOfItsElements() {
-  const [sortedRows, setSortedRows] = useState(null);
+  const [sortedRows, setSortedRows] = useState<any[]>();
 
   const initiallySortedRows = [
     [
@@ -346,7 +379,7 @@ export function WithAllOfItsElements() {
 
   const rows = sortedRows ? sortedRows : initiallySortedRows;
   const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
+    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
     [rows],
   );
 
@@ -376,26 +409,75 @@ export function WithAllOfItsElements() {
           onSort={handleSort}
           footerContent={`Showing ${rows.length} of ${rows.length} results`}
           stickyHeader
-          hasFixedNthColumn
-          nthIndex={1}
+          fixedFirstColumns={1}
           truncate
         />
       </Card>
     </Page>
   );
-
-  function sortCurrency(rows, index, direction) {
-    return [...rows].sort((rowA, rowB) => {
-      const amountA = parseFloat(rowA[index].substring(1));
-      const amountB = parseFloat(rowB[index].substring(1));
-
-      return direction === 'descending' ? amountB - amountA : amountA - amountB;
-    });
-  }
 }
 
-export function WithFixedFirstColumn() {
-  const [sortedRows, setSortedRows] = useState(null);
+export function WithColumnSpanning() {
+  const rows = [
+    [
+      'Sep 19, 2010, 1:02 pm NDT',
+      '#1234',
+      'Adjustment',
+      '$1.00',
+      '$1.00',
+      '$1.00',
+      '$1.00',
+      '$1.00',
+    ],
+    // eslint-disable-next-line react/jsx-key
+    [<Card>Hello</Card>],
+    [
+      'Sep 19, 2010, 1:02 pm NDT',
+      '#1234',
+      'Adjustment',
+      '$1.00',
+      '$1.00',
+      '$1.00',
+      '$1.00',
+      '$1.00',
+    ],
+  ];
+
+  return (
+    <Page title="Payouts">
+      <Card>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'transactionDate',
+            'reference',
+            'type',
+            'amount',
+            'fee',
+            'net',
+            'gross',
+            'number',
+          ]}
+          rows={rows}
+          verticalAlign="middle"
+        />
+      </Card>
+    </Page>
+  );
+}
+
+export function WithFixedColumns() {
+  const [sortedRows, setSortedRows] = useState<any[]>();
 
   const initiallySortedRows = [
     [
@@ -478,63 +560,30 @@ export function WithFixedFirstColumn() {
           ]}
           rows={rows}
           totals={['', '', '', '', '', '', 255, '$1399', '$155,830.00']}
-          sortable={[true, true, true, true, true, true, true, true, true]}
+          sortable={[
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            true,
+          ]}
           defaultSortDirection="descending"
           initialSortColumnIndex={4}
           onSort={handleSort}
-          hasFixedNthColumn
-          nthIndex={1}
+          fixedFirstColumns={3}
           truncate
         />
       </Card>
     </Page>
   );
-
-  function sortRows(rows, index, direction) {
-    return [...rows].sort((rowA, rowB) => {
-      let type;
-      if (rowA[index].length > 1) {
-        if (!isNaN(parseFloat(rowA[index]))) {
-          type = 'number';
-        } else if (!isNaN(parseFloat(rowA[index].substring(1)))) {
-          type = 'currency';
-        } else type = 'string';
-      } else {
-        type = !isNaN(parseFloat(rowA[index])) ? 'number' : 'string';
-      }
-
-      let itemA;
-      let itemB;
-      if (type === 'number') {
-        itemA = parseInt(rowA[index], 10);
-      } else if (type === 'currency') {
-        itemA = parseFloat(rowA[index].substring(1));
-      } else {
-        itemA = rowA[index];
-      }
-      if (type === 'number') {
-        itemB = parseInt(rowB[index], 10);
-      } else if (type === 'currency') {
-        itemB = parseFloat(rowA[index].substring(1));
-      } else {
-        itemB = rowA[index];
-      }
-      if (type === 'string') {
-        let result;
-
-        if (itemA > itemB) result = 1;
-        else if (itemB > itemA) result = -1;
-        else result = 0;
-        return direction === 'descending' ? result * -1 : result;
-      }
-
-      return direction === 'descending' ? itemB - itemA : itemA - itemB;
-    });
-  }
 }
 
 export function WithIncreasedDensityAndZebraStriping() {
-  const [sortedRows, setSortedRows] = useState(null);
+  const [sortedRows, setSortedRows] = useState<any[]>();
 
   const initiallySortedRows = [
     [
@@ -580,7 +629,7 @@ export function WithIncreasedDensityAndZebraStriping() {
 
   const rows = sortedRows ? sortedRows : initiallySortedRows;
   const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
+    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
     [rows],
   );
 
@@ -615,19 +664,10 @@ export function WithIncreasedDensityAndZebraStriping() {
       </Card>
     </Page>
   );
-
-  function sortCurrency(rows, index, direction) {
-    return [...rows].sort((rowA, rowB) => {
-      const amountA = parseFloat(rowA[index].substring(1));
-      const amountB = parseFloat(rowB[index].substring(1));
-
-      return direction === 'descending' ? amountB - amountA : amountA - amountB;
-    });
-  }
 }
 
 export function WithStickyHeaderEnabled() {
-  const [sortedRows, setSortedRows] = useState(null);
+  const [sortedRows, setSortedRows] = useState<any[]>();
 
   const initiallySortedRows = [
     [
@@ -868,7 +908,7 @@ export function WithStickyHeaderEnabled() {
 
   const rows = sortedRows ? sortedRows : initiallySortedRows;
   const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
+    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
     [rows],
   );
 
@@ -904,13 +944,4 @@ export function WithStickyHeaderEnabled() {
       </Card>
     </Page>
   );
-
-  function sortCurrency(rows, index, direction) {
-    return [...rows].sort((rowA, rowB) => {
-      const amountA = parseFloat(rowA[index].substring(1));
-      const amountB = parseFloat(rowB[index].substring(1));
-
-      return direction === 'descending' ? amountB - amountA : amountA - amountB;
-    });
-  }
 }

--- a/polaris-react/src/components/DataTable/DataTable.stories.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.stories.tsx
@@ -376,7 +376,8 @@ export function WithAllOfItsElements() {
           onSort={handleSort}
           footerContent={`Showing ${rows.length} of ${rows.length} results`}
           stickyHeader
-          hasFixedFirstColumn
+          hasFixedNthColumn
+          nthIndex={1}
           truncate
         />
       </Card>
@@ -481,7 +482,8 @@ export function WithFixedFirstColumn() {
           defaultSortDirection="descending"
           initialSortColumnIndex={4}
           onSort={handleSort}
-          hasFixedFirstColumn
+          hasFixedNthColumn
+          nthIndex={1}
           truncate
         />
       </Card>

--- a/polaris-react/src/components/DataTable/DataTable.stories.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.stories.tsx
@@ -13,45 +13,12 @@ export default {
   },
 } as ComponentMeta<typeof DataTable>;
 
-function sortRows(rows, index, direction) {
+function sortCurrency(rows, index, direction) {
   return [...rows].sort((rowA, rowB) => {
-    let type;
-    if (rowA[index].length > 1) {
-      if (!isNaN(parseFloat(rowA[index]))) {
-        type = 'number';
-      } else if (!isNaN(parseFloat(rowA[index].substring(1)))) {
-        type = 'currency';
-      } else type = 'string';
-    } else {
-      type = !isNaN(parseFloat(rowA[index])) ? 'number' : 'string';
-    }
+    const amountA = parseFloat(rowA[index].substring(1));
+    const amountB = parseFloat(rowB[index].substring(1));
 
-    let itemA;
-    let itemB;
-    if (type === 'number') {
-      itemA = parseInt(rowA[index], 10);
-    } else if (type === 'currency') {
-      itemA = parseFloat(rowA[index].substring(1));
-    } else {
-      itemA = rowA[index];
-    }
-    if (type === 'number') {
-      itemB = parseInt(rowB[index], 10);
-    } else if (type === 'currency') {
-      itemB = parseFloat(rowA[index].substring(1));
-    } else {
-      itemB = rowA[index];
-    }
-    if (type === 'string') {
-      let result;
-
-      if (itemA > itemB) result = 1;
-      else if (itemB > itemA) result = -1;
-      else result = 0;
-      return direction === 'descending' ? result * -1 : result;
-    }
-
-    return direction === 'descending' ? itemB - itemA : itemA - itemB;
+    return direction === 'descending' ? amountB - amountA : amountA - amountB;
   });
 }
 
@@ -111,7 +78,7 @@ export function Sortable() {
   const rows = sortedRows ? sortedRows : initiallySortedRows;
 
   const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
+    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
     [rows],
   );
 
@@ -379,7 +346,7 @@ export function WithAllOfItsElements() {
 
   const rows = sortedRows ? sortedRows : initiallySortedRows;
   const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
+    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
     [rows],
   );
 
@@ -477,9 +444,7 @@ export function WithColumnSpanning() {
 }
 
 export function WithFixedColumns() {
-  const [sortedRows, setSortedRows] = useState<any[]>();
-
-  const initiallySortedRows = [
+  const rows = [
     [
       'Emerald Silk Gown',
       'Formalwear',
@@ -525,12 +490,6 @@ export function WithFixedColumns() {
       '$140.00',
     ],
   ];
-  const rows = sortedRows ? sortedRows : initiallySortedRows;
-
-  const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
-    [rows],
-  );
 
   return (
     <Page title="Sales by product">
@@ -560,22 +519,12 @@ export function WithFixedColumns() {
           ]}
           rows={rows}
           totals={['', '', '', '', '', '', 255, '$1399', '$155,830.00']}
-          sortable={[
-            false,
-            false,
-            false,
-            false,
-            true,
-            false,
-            false,
-            false,
-            true,
-          ]}
-          defaultSortDirection="descending"
           initialSortColumnIndex={4}
-          onSort={handleSort}
+          stickyHeader
           fixedFirstColumns={3}
           truncate
+          showTotalsInFooter
+          footerContent={`Showing ${rows.length} of ${rows.length} results`}
         />
       </Card>
     </Page>
@@ -583,9 +532,7 @@ export function WithFixedColumns() {
 }
 
 export function WithIncreasedDensityAndZebraStriping() {
-  const [sortedRows, setSortedRows] = useState<any[]>();
-
-  const initiallySortedRows = [
+  const rows = [
     [
       <Link
         removeUnderline
@@ -627,12 +574,6 @@ export function WithIncreasedDensityAndZebraStriping() {
     ],
   ];
 
-  const rows = sortedRows ? sortedRows : initiallySortedRows;
-  const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
-    [rows],
-  );
-
   return (
     <Page title="Sales by product">
       <Card>
@@ -653,10 +594,8 @@ export function WithIncreasedDensityAndZebraStriping() {
           ]}
           rows={rows}
           totals={['', '', '', 255, '$155,830.00']}
-          sortable={[false, true, false, false, true]}
           defaultSortDirection="descending"
           initialSortColumnIndex={4}
-          onSort={handleSort}
           footerContent={`Showing ${rows.length} of ${rows.length} results`}
           hasZebraStripingOnData
           increasedTableDensity
@@ -667,9 +606,7 @@ export function WithIncreasedDensityAndZebraStriping() {
 }
 
 export function WithStickyHeaderEnabled() {
-  const [sortedRows, setSortedRows] = useState<any[]>();
-
-  const initiallySortedRows = [
+  const rows = [
     [
       <Link
         removeUnderline
@@ -906,12 +843,6 @@ export function WithStickyHeaderEnabled() {
     ],
   ];
 
-  const rows = sortedRows ? sortedRows : initiallySortedRows;
-  const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortRows(rows, index, direction)),
-    [rows],
-  );
-
   return (
     <Page title="Sales by product">
       <Card>
@@ -932,10 +863,8 @@ export function WithStickyHeaderEnabled() {
           ]}
           rows={rows}
           totals={['', '', '', 255, '$155,830.00']}
-          sortable={[false, true, false, false, true]}
           defaultSortDirection="descending"
           initialSortColumnIndex={4}
-          onSort={handleSort}
           footerContent={`Showing ${rows.length} of ${rows.length} results`}
           hasZebraStripingOnData
           increasedTableDensity

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -405,8 +405,15 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
   }
 
   private fixedFirstColumns() {
-    const {hasFixedFirstColumn, fixedFirstColumns = 0} = this.props;
-    return hasFixedFirstColumn && !fixedFirstColumns ? 1 : fixedFirstColumns;
+    const {hasFixedFirstColumn, fixedFirstColumns = 0, headings} = this.props;
+    const numberOfFixedFirstColumns =
+      hasFixedFirstColumn && !fixedFirstColumns ? 1 : fixedFirstColumns;
+
+    if (numberOfFixedFirstColumns >= headings.length) {
+      return 0;
+    }
+
+    return numberOfFixedFirstColumns;
   }
 
   private setCellRef = ({

--- a/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
+++ b/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
@@ -12,7 +12,7 @@ import {Tooltip} from '../../../Tooltip';
 export interface CellProps {
   content?: React.ReactNode;
   contentType?: string;
-  firstColumn?: boolean;
+  nthColumn?: boolean;
   truncate?: boolean;
   header?: boolean;
   total?: boolean;
@@ -29,8 +29,8 @@ export interface CellProps {
   stickyCellWidth?: number;
   hovered?: boolean;
   handleFocus?: FocusEventHandler;
-  inFixedFirstColumn?: boolean;
-  hasFixedFirstColumn?: boolean;
+  inFixedNthColumn?: boolean;
+  hasFixedNthColumn?: boolean;
   fixedCellVisible?: boolean;
   firstColumnMinWidth?: string;
 }
@@ -38,7 +38,7 @@ export interface CellProps {
 export function Cell({
   content,
   contentType,
-  firstColumn,
+  nthColumn,
   truncate,
   header,
   total,
@@ -46,7 +46,7 @@ export function Cell({
   sorted,
   sortable,
   sortDirection,
-  inFixedFirstColumn,
+  inFixedNthColumn,
   verticalAlign = 'top',
   defaultSortDirection = 'ascending',
   onSort,
@@ -56,7 +56,7 @@ export function Cell({
   stickyCellWidth,
   hovered = false,
   handleFocus = () => {},
-  hasFixedFirstColumn = false,
+  hasFixedNthColumn = false,
   fixedCellVisible = false,
   firstColumnMinWidth,
 }: CellProps) {
@@ -66,8 +66,8 @@ export function Cell({
   const className = classNames(
     styles.Cell,
     styles[`Cell-${variationName('verticalAlign', verticalAlign)}`],
-    firstColumn && styles['Cell-firstColumn'],
-    firstColumn && truncate && styles['Cell-truncated'],
+    nthColumn && styles['Cell-firstColumn'],
+    nthColumn && truncate && styles['Cell-truncated'],
     header && styles['Cell-header'],
     total && styles['Cell-total'],
     totalInFooter && styles['Cell-total-footer'],
@@ -77,8 +77,8 @@ export function Cell({
     stickyHeadingCell && styles.StickyHeaderCell,
     hovered && styles['Cell-hovered'],
     fixedCellVisible && styles.separate,
-    firstColumn &&
-      inFixedFirstColumn &&
+    nthColumn &&
+      inFixedNthColumn &&
       stickyHeadingCell &&
       styles.FixedFirstColumn,
   );
@@ -109,9 +109,9 @@ export function Cell({
 
   const focusable = !(
     stickyHeadingCell &&
-    hasFixedFirstColumn &&
-    firstColumn &&
-    !inFixedFirstColumn
+    hasFixedNthColumn &&
+    nthColumn &&
+    !inFixedNthColumn
   );
 
   const sortableHeadingContent = (
@@ -138,7 +138,7 @@ export function Cell({
       className={className}
       aria-sort={sortDirection}
       style={
-        firstColumn && firstColumnMinWidth
+        nthColumn && firstColumnMinWidth
           ? {minWidth: firstColumnMinWidth}
           : {minWidth: stickyCellWidth}
       }
@@ -155,7 +155,7 @@ export function Cell({
       className={className}
       scope="col"
       aria-sort={sortDirection}
-      style={firstColumn ? {minWidth: firstColumnMinWidth} : {}}
+      style={nthColumn ? {minWidth: firstColumnMinWidth} : {}}
     >
       {columnHeadingContent}
     </th>
@@ -174,7 +174,7 @@ export function Cell({
   );
 
   const cellMarkup =
-    header || firstColumn ? (
+    header || nthColumn ? (
       headingMarkup
     ) : (
       <td className={className} {...colSpanProp}>

--- a/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
+++ b/polaris-react/src/components/DataTable/components/Cell/Cell.tsx
@@ -33,6 +33,7 @@ export interface CellProps {
   hasFixedNthColumn?: boolean;
   fixedCellVisible?: boolean;
   firstColumnMinWidth?: string;
+  style?: React.CSSProperties;
 }
 
 export function Cell({
@@ -59,6 +60,7 @@ export function Cell({
   hasFixedNthColumn = false,
   fixedCellVisible = false,
   firstColumnMinWidth,
+  style,
 }: CellProps) {
   const i18n = useI18n();
   const numeric = contentType === 'numeric';
@@ -130,6 +132,11 @@ export function Cell({
 
   const colSpanProp = colSpan && colSpan > 1 ? {colSpan} : {};
 
+  const minWidthStyles =
+    nthColumn && firstColumnMinWidth
+      ? {minWidth: firstColumnMinWidth}
+      : {minWidth: stickyCellWidth};
+
   const stickyHeading = (
     <th
       ref={setRef}
@@ -137,11 +144,10 @@ export function Cell({
       {...colSpanProp}
       className={className}
       aria-sort={sortDirection}
-      style={
-        nthColumn && firstColumnMinWidth
-          ? {minWidth: firstColumnMinWidth}
-          : {minWidth: stickyCellWidth}
-      }
+      style={{
+        ...style,
+        ...minWidthStyles,
+      }}
       data-index-table-sticky-heading
     >
       {columnHeadingContent}

--- a/polaris-react/src/components/DataTable/components/Cell/tests/Cell.test.tsx
+++ b/polaris-react/src/components/DataTable/components/Cell/tests/Cell.test.tsx
@@ -24,9 +24,9 @@ describe('<Cell />', () => {
     });
   });
 
-  describe('firstColumn', () => {
+  describe('nthColumn', () => {
     it('renders a table heading element when true', () => {
-      const cell = mountWithTable(<Cell firstColumn />);
+      const cell = mountWithTable(<Cell nthColumn />);
 
       expect(cell).toContainReactComponent('th');
     });
@@ -44,13 +44,7 @@ describe('<Cell />', () => {
     it('sets the aria-sort attribute to the sortDirection when the table is currently sorted by that column', () => {
       const sortDirection = 'ascending';
       const cell = mountWithTable(
-        <Cell
-          header
-          firstColumn
-          sortable
-          sorted
-          sortDirection={sortDirection}
-        />,
+        <Cell header nthColumn sortable sorted sortDirection={sortDirection} />,
       );
 
       expect(cell).toContainReactComponent('th', {
@@ -63,7 +57,7 @@ describe('<Cell />', () => {
       const cell = mountWithTable(
         <Cell
           header
-          firstColumn
+          nthColumn
           sortable
           sorted={false}
           sortDirection={sortDirection}
@@ -78,13 +72,13 @@ describe('<Cell />', () => {
 
   describe('sortable', () => {
     it('renders an Icon when table is sortable by that column', () => {
-      const cell = mountWithTable(<Cell header firstColumn sortable />);
+      const cell = mountWithTable(<Cell header nthColumn sortable />);
 
       expect(cell).toContainReactComponent(Icon);
     });
 
     it('renders no Icon when table is not sortable by that column', () => {
-      const cell = mountWithTable(<Cell header firstColumn sortable={false} />);
+      const cell = mountWithTable(<Cell header nthColumn sortable={false} />);
 
       expect(cell).not.toContainReactComponent(Icon);
     });
@@ -96,7 +90,7 @@ describe('<Cell />', () => {
         const cell = mountWithTable(
           <Cell
             header
-            firstColumn
+            nthColumn
             sortable
             sortDirection="none"
             defaultSortDirection="descending"
@@ -112,7 +106,7 @@ describe('<Cell />', () => {
         const cell = mountWithTable(
           <Cell
             header
-            firstColumn
+            nthColumn
             sortable
             sortDirection="none"
             defaultSortDirection="ascending"
@@ -128,7 +122,7 @@ describe('<Cell />', () => {
     describe('when set to ascending', () => {
       it('renders an up caret Icon when table is currently sorted by that column', () => {
         const cell = mountWithTable(
-          <Cell header firstColumn sortable sorted sortDirection="ascending" />,
+          <Cell header nthColumn sortable sorted sortDirection="ascending" />,
         );
 
         expect(cell).toContainReactComponent(Icon, {
@@ -138,7 +132,7 @@ describe('<Cell />', () => {
 
       it('renders an Icon with an accessibility label indicating the next sort direction is descending', () => {
         const cell = mountWithTable(
-          <Cell header firstColumn sortable sorted sortDirection="ascending" />,
+          <Cell header nthColumn sortable sorted sortDirection="ascending" />,
         );
 
         expect(cell).toContainReactComponent(Icon, {
@@ -150,13 +144,7 @@ describe('<Cell />', () => {
     describe('when set to descending', () => {
       it('renders a down caret Icon when table is currently sorted by that column', () => {
         const cell = mountWithTable(
-          <Cell
-            header
-            firstColumn
-            sortable
-            sorted
-            sortDirection="descending"
-          />,
+          <Cell header nthColumn sortable sorted sortDirection="descending" />,
         );
 
         expect(cell).toContainReactComponent(Icon, {
@@ -166,13 +154,7 @@ describe('<Cell />', () => {
 
       it('renders an Icon with an accessibility label indicating the next sort direction is ascending', () => {
         const cell = mountWithTable(
-          <Cell
-            header
-            firstColumn
-            sortable
-            sorted
-            sortDirection="descending"
-          />,
+          <Cell header nthColumn sortable sorted sortDirection="descending" />,
         );
 
         expect(cell).toContainReactComponent(Icon, {
@@ -188,7 +170,7 @@ describe('<Cell />', () => {
         const cell = mountWithTable(
           <Cell
             header
-            firstColumn
+            nthColumn
             sortable
             sorted={false}
             sortDirection="none"
@@ -207,7 +189,7 @@ describe('<Cell />', () => {
         const cell = mountWithTable(
           <Cell
             header
-            firstColumn
+            nthColumn
             sortable
             sorted={false}
             defaultSortDirection="ascending"
@@ -225,7 +207,7 @@ describe('<Cell />', () => {
         const cell = mountWithTable(
           <Cell
             header
-            firstColumn
+            nthColumn
             sortable
             sorted={false}
             defaultSortDirection="descending"
@@ -245,7 +227,7 @@ describe('<Cell />', () => {
       const cell = mountWithTable(
         <Cell
           header
-          firstColumn
+          nthColumn
           sortable
           sorted={false}
           content="Heading 1"

--- a/polaris-react/src/components/DataTable/components/Navigation/Navigation.tsx
+++ b/polaris-react/src/components/DataTable/components/Navigation/Navigation.tsx
@@ -11,7 +11,7 @@ export interface NavigationProps {
   columnVisibilityData: ColumnVisibilityData[];
   isScrolledFarthestLeft?: boolean;
   isScrolledFarthestRight?: boolean;
-  fixedFirstColumn?: boolean;
+  fixedFirstColumns: number;
   navigateTableLeft?(): void;
   navigateTableRight?(): void;
   setRef?: (ref: HTMLDivElement | null) => void;
@@ -23,13 +23,13 @@ export function Navigation({
   isScrolledFarthestRight,
   navigateTableLeft,
   navigateTableRight,
-  fixedFirstColumn,
+  fixedFirstColumns,
   setRef = () => {},
 }: NavigationProps) {
   const i18n = useI18n();
 
   const pipMarkup = columnVisibilityData.map((column, index) => {
-    if (fixedFirstColumn && index === 0) return;
+    if (index < fixedFirstColumns) return;
     const className = classNames(
       styles.Pip,
       column.isVisible && styles['Pip-visible'],

--- a/polaris-react/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
+++ b/polaris-react/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
@@ -14,6 +14,7 @@ describe('<Navigation />', () => {
 
     const navigation = mountWithApp(
       <Navigation
+        fixedFirstColumns={0}
         columnVisibilityData={columnVisibilityData}
         isScrolledFarthestLeft
         isScrolledFarthestRight={false}
@@ -31,6 +32,7 @@ describe('<Navigation />', () => {
 
     const navigation = mountWithApp(
       <Navigation
+        fixedFirstColumns={0}
         columnVisibilityData={columnVisibilityData}
         isScrolledFarthestLeft
         isScrolledFarthestRight={false}
@@ -53,7 +55,7 @@ describe('<Navigation />', () => {
         columnVisibilityData={columnVisibilityData}
         isScrolledFarthestLeft
         isScrolledFarthestRight={false}
-        fixedFirstColumn
+        fixedFirstColumns={1}
       />,
     );
 

--- a/polaris-react/src/components/DataTable/tests/DataTable.test.tsx
+++ b/polaris-react/src/components/DataTable/tests/DataTable.test.tsx
@@ -92,11 +92,11 @@ describe('<DataTable />', () => {
         .filter((cell) => cell.prop('stickyHeadingCell') !== true);
 
       const firstColumnCells = cells.filter(
-        (cell) => cell.prop('firstColumn') === true,
+        (cell) => cell.prop('nthColumn') === true,
       );
 
       const secondColumnCells = cells.filter(
-        (cell) => cell.prop('firstColumn') !== true,
+        (cell) => cell.prop('nthColumn') !== true,
       );
 
       expect(cells).toHaveLength(4);
@@ -227,7 +227,7 @@ describe('<DataTable />', () => {
         .findAll(Cell)
         .filter(
           (cell) =>
-            cell.prop('total') === true && cell.prop('firstColumn') !== true,
+            cell.prop('total') === true && cell.prop('nthColumn') !== true,
         );
 
       totalsCells.forEach((total) => expect(total).toContainReactText(''));
@@ -300,7 +300,7 @@ describe('<DataTable />', () => {
 
       const firstColumnCells = dataTable
         .findAll(Cell)
-        .filter((cell) => cell.prop('firstColumn') === true);
+        .filter((cell) => cell.prop('nthColumn') === true);
 
       firstColumnCells.forEach((cell) =>
         expect(cell).toHaveReactProps({truncate: false}),
@@ -312,7 +312,7 @@ describe('<DataTable />', () => {
 
       const firstColumnCells = dataTable
         .findAll(Cell)
-        .filter((cell) => cell.prop('firstColumn') === true);
+        .filter((cell) => cell.prop('nthColumn') === true);
 
       firstColumnCells.forEach((cell) =>
         expect(cell).toHaveReactProps({truncate: true}),

--- a/polaris-react/src/components/DataTable/tests/DataTable.test.tsx
+++ b/polaris-react/src/components/DataTable/tests/DataTable.test.tsx
@@ -565,4 +565,77 @@ describe('<DataTable />', () => {
       expect(threeSpanCells).toHaveLength(1);
     });
   });
+
+  describe('fixedFirstColumns', () => {
+    const headings = ['Product', 'Price', 'Order Number'];
+    const rows = [
+      [
+        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+        '$875.00',
+        124518,
+        83,
+        '$122,500.00',
+      ],
+    ];
+
+    const columnContentTypes: DataTableProps['columnContentTypes'] = [
+      'text',
+      'numeric',
+      'numeric',
+    ];
+
+    const fixedFirstColumnsProps = {
+      headings,
+      rows,
+      columnContentTypes,
+    };
+
+    it('sets fixed first columns', () => {
+      const dataTable = mountWithApp(
+        <DataTable {...fixedFirstColumnsProps} fixedFirstColumns={2} />,
+      );
+
+      const table = dataTable.find('table')!.domNode;
+
+      Object.defineProperty(table, 'scrollWidth', {
+        value: 100,
+        writable: true,
+        configurable: true,
+      });
+
+      window.dispatchEvent(new Event('resize'));
+      timer.runAllTimers();
+
+      dataTable.forceUpdate();
+
+      const separateTable = dataTable.findAll('table')[0];
+      const separateTableHeadingGroup = separateTable.find('thead');
+      const separateTableHeaders = separateTableHeadingGroup?.findAll('th');
+
+      expect(separateTableHeaders).toHaveLength(2);
+    });
+
+    it('sets "fixedFirstColumns" to 0 if it exceeds or is equal to columns amount', () => {
+      const dataTable = mountWithApp(
+        <DataTable {...fixedFirstColumnsProps} fixedFirstColumns={3} />,
+      );
+
+      const table = dataTable.find('table')!.domNode;
+
+      Object.defineProperty(table, 'scrollWidth', {
+        value: 100,
+        writable: true,
+        configurable: true,
+      });
+
+      window.dispatchEvent(new Event('resize'));
+      timer.runAllTimers();
+
+      dataTable.forceUpdate();
+
+      const tables = dataTable.findAll('table');
+
+      expect(tables).toHaveLength(1);
+    });
+  });
 });

--- a/polaris-react/src/components/DataTable/tests/DataTable.test.tsx
+++ b/polaris-react/src/components/DataTable/tests/DataTable.test.tsx
@@ -87,27 +87,22 @@ describe('<DataTable />', () => {
         />,
       );
 
-      const cells = dataTable
-        .findAll(Cell)
-        .filter((cell) => cell.prop('stickyHeadingCell') !== true);
+      const cells = dataTable.findAll(Cell);
 
-      const firstColumnCells = cells.filter(
-        (cell) => cell.prop('nthColumn') === true,
-      );
-
-      const secondColumnCells = cells.filter(
-        (cell) => cell.prop('nthColumn') !== true,
-      );
-
+      // 2 for the headers and 2 for the body
       expect(cells).toHaveLength(4);
 
-      firstColumnCells.forEach((cell) =>
-        expect(cell.prop('contentType')).toBe('text'),
-      );
+      expect(
+        cells
+          .filter((cell) => cell.prop('header'))
+          .map((cell) => cell.prop('contentType')),
+      ).toStrictEqual(columnContentTypes);
 
-      secondColumnCells.forEach((cell) =>
-        expect(cell.prop('contentType')).toBe('numeric'),
-      );
+      expect(
+        cells
+          .filter((cell) => !cell.prop('header'))
+          .map((cell) => cell.prop('contentType')),
+      ).toStrictEqual(columnContentTypes);
     });
   });
 

--- a/polaris.shopify.com/content/components/data-table/index.md
+++ b/polaris.shopify.com/content/components/data-table/index.md
@@ -32,7 +32,11 @@ examples:
     description: Use as a broad example that includes most props available to data table.
   - fileName: data-table-with-fixed-first-columns.tsx
     title: With fixed first columns
-    description: Use when the table contains many columns and it would benefit the merchant to see a set number of columns when scrolling to the right.
+    description:
+      Use when the table contains many columns and it would benefit the merchant to see a set number of columns when scrolling to the right. For example, the first column in the "Sales by Product" report table is fixed because the product names are important to reference while analyzing the sales data in other columns.
+
+
+      When fixing multiple columns, ensure other data within the table is visible and not limited on smaller screens.
   - fileName: data-table-with-increased-density-and-zebra-striping.tsx
     title: With increased density and zebra striping
     description: Use as a broad example that includes most props available to data table.

--- a/polaris.shopify.com/content/components/data-table/index.md
+++ b/polaris.shopify.com/content/components/data-table/index.md
@@ -30,9 +30,9 @@ examples:
   - fileName: data-table-with-all-of-its-elements.tsx
     title: With all of its elements
     description: Use as a broad example that includes most props available to data table.
-  - fileName: data-table-with-fixed-first-column.tsx
-    title: With fixed first column
-    description: Use when the table contains many columns and it would benefit the merchant to see the first column when scrolling to the right.
+  - fileName: data-table-with-fixed-first-columns.tsx
+    title: With fixed first columns
+    description: Use when the table contains many columns and it would benefit the merchant to see a set number of columns when scrolling to the right.
   - fileName: data-table-with-increased-density-and-zebra-striping.tsx
     title: With increased density and zebra striping
     description: Use as a broad example that includes most props available to data table.

--- a/polaris.shopify.com/pages/examples/data-table-with-fixed-first-columns.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-fixed-first-columns.tsx
@@ -1,5 +1,6 @@
 import {Link, Page, Card, DataTable} from '@shopify/polaris';
 import {useState} from 'react';
+import {useMedia} from '../../src/utils/hooks';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function DataTableWithFixedFirstColumnsExample() {
@@ -276,6 +277,8 @@ function DataTableWithFixedFirstColumnsExample() {
     ],
   ];
   const [sortedRows, setSortedRows] = useState(rows);
+  const showFixedColumns = useMedia('screen and (max-width: 850px)');
+  const fixedFirstColumns = showFixedColumns ? 2 : 0;
 
   return (
     <Page title="Sales by product">
@@ -326,7 +329,7 @@ function DataTableWithFixedFirstColumnsExample() {
           }}
           footerContent={`Showing ${sortedRows.length} of ${sortedRows.length} results`}
           stickyHeader
-          fixedFirstColumns={2}
+          fixedFirstColumns={fixedFirstColumns}
         />
       </Card>
     </Page>

--- a/polaris.shopify.com/pages/examples/data-table-with-fixed-first-columns.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-fixed-first-columns.tsx
@@ -1,8 +1,8 @@
 import {Link, Page, Card, DataTable} from '@shopify/polaris';
-import {useState, useCallback} from 'react';
+import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function DataTableWithFixedFirstColumnExample() {
+function DataTableWithFixedFirstColumnsExample() {
   const rows = [
     [
       <Link
@@ -16,6 +16,8 @@ function DataTableWithFixedFirstColumnExample() {
       124689,
       140,
       '$121,500.00',
+      '$14,250.00',
+      '$12,240.00',
     ],
     [
       <Link
@@ -29,6 +31,8 @@ function DataTableWithFixedFirstColumnExample() {
       124533,
       83,
       '$19,090.00',
+      '$12,240.00',
+      '$11,270.00',
     ],
     [
       <Link
@@ -42,6 +46,8 @@ function DataTableWithFixedFirstColumnExample() {
       124518,
       32,
       '$14,240.00',
+      '$10,241.00',
+      '$10,201.00',
     ],
     [
       <Link
@@ -55,6 +61,8 @@ function DataTableWithFixedFirstColumnExample() {
       124689,
       140,
       '$121,500.00',
+      '$14,240.00',
+      '$14,200.10',
     ],
     [
       <Link
@@ -68,6 +76,8 @@ function DataTableWithFixedFirstColumnExample() {
       124533,
       83,
       '$19,090.00',
+      '$14,300.30',
+      '$17,200.00',
     ],
     [
       <Link
@@ -81,6 +91,8 @@ function DataTableWithFixedFirstColumnExample() {
       124518,
       32,
       '$14,240.00',
+      '$18,770.07',
+      '$15,545.00',
     ],
     [
       <Link
@@ -94,6 +106,8 @@ function DataTableWithFixedFirstColumnExample() {
       124689,
       140,
       '$121,500.00',
+      '$14,240.00',
+      '$14,240.00',
     ],
     [
       <Link
@@ -107,6 +121,8 @@ function DataTableWithFixedFirstColumnExample() {
       124533,
       83,
       '$19,090.00',
+      '$19,290.00',
+      '$12,997.00',
     ],
     [
       <Link
@@ -120,6 +136,8 @@ function DataTableWithFixedFirstColumnExample() {
       124518,
       32,
       '$14,240.00',
+      '$11,211.20',
+      '$11,343.50',
     ],
     [
       <Link
@@ -133,6 +151,8 @@ function DataTableWithFixedFirstColumnExample() {
       124689,
       140,
       '$121,500.00',
+      '$12,430.00',
+      '$17,420.00',
     ],
     [
       <Link
@@ -146,6 +166,8 @@ function DataTableWithFixedFirstColumnExample() {
       124533,
       83,
       '$19,090.00',
+      '$14,790.00',
+      '$12,370.00',
     ],
     [
       <Link
@@ -159,6 +181,8 @@ function DataTableWithFixedFirstColumnExample() {
       124518,
       32,
       '$14,240.00',
+      '$16,241.00',
+      '$18,211.00',
     ],
     [
       <Link
@@ -172,6 +196,8 @@ function DataTableWithFixedFirstColumnExample() {
       124689,
       140,
       '$121,500.00',
+      '$15,111.00',
+      '$11,221.00',
     ],
     [
       <Link
@@ -185,6 +211,8 @@ function DataTableWithFixedFirstColumnExample() {
       124533,
       83,
       '$19,090.00',
+      '$17,880.00',
+      '$11,280.00',
     ],
     [
       <Link
@@ -198,6 +226,8 @@ function DataTableWithFixedFirstColumnExample() {
       124518,
       32,
       '$14,240.00',
+      '$11,111.00',
+      '$17,211.00',
     ],
     [
       <Link
@@ -211,6 +241,8 @@ function DataTableWithFixedFirstColumnExample() {
       124689,
       140,
       '$121,500.00',
+      '$14,240.00',
+      '$17,840.00',
     ],
     [
       <Link
@@ -224,6 +256,8 @@ function DataTableWithFixedFirstColumnExample() {
       124533,
       83,
       '$19,090.00',
+      '$13,238.00',
+      '$14,288.00',
     ],
     [
       <Link
@@ -237,9 +271,11 @@ function DataTableWithFixedFirstColumnExample() {
       124518,
       32,
       '$14,240.00',
+      '$14,988.00',
+      '$14,902.10',
     ],
   ];
-  const [sortedRows, setSortedRows] = useState<any[]>(rows);
+  const [sortedRows, setSortedRows] = useState(rows);
 
   return (
     <Page title="Sales by product">
@@ -251,6 +287,8 @@ function DataTableWithFixedFirstColumnExample() {
             'numeric',
             'numeric',
             'numeric',
+            'numeric',
+            'numeric',
           ]}
           headings={[
             'Product',
@@ -258,10 +296,12 @@ function DataTableWithFixedFirstColumnExample() {
             'SKU Number',
             'Net quantity',
             'Net sales',
+            'Gross sales',
+            'Discounts',
           ]}
           rows={sortedRows}
-          totals={['', '', '', 255, '$155,830.00']}
-          sortable={[true, true, false, false, true]}
+          totals={['', '', '', 255, '$155,830.00', '', '']}
+          sortable={[false, true, false, false, true]}
           defaultSortDirection="descending"
           initialSortColumnIndex={4}
           onSort={(index, direction) => {
@@ -286,11 +326,11 @@ function DataTableWithFixedFirstColumnExample() {
           }}
           footerContent={`Showing ${sortedRows.length} of ${sortedRows.length} results`}
           stickyHeader
-          hasFixedFirstColumn
+          fixedFirstColumns={2}
         />
       </Card>
     </Page>
   );
 }
 
-export default withPolarisExample(DataTableWithFixedFirstColumnExample);
+export default withPolarisExample(DataTableWithFixedFirstColumnsExample);


### PR DESCRIPTION


### WHY are these changes introduced?

We are currently using the `DataTable`, but there was a requirement in our current project for the first 2 columns within the table to be fixed.  

### WHAT is this pull request doing?

This PR adds a `fixFirstColumns` prop in favour of the `hasFixedFirstColumn` prop, which now has a deprecation warning if still being used in development. In the event that `hasFixedFirstColumn` is still being used, we will default to showing 1 fixed column. Additionally, if a number defined in `fixFirstColumns` exceeds or is equal to the amount of columns within the table, no fixed columns will be rendered. 

#### Before
<img width="400" alt="data table before changes" src="https://user-images.githubusercontent.com/69977658/186171194-ee68ab88-9ab1-4b9c-a566-8773e454e162.png">

#### After

**Without sticky header**

<img width="400" alt="data table without sticky header" src="https://user-images.githubusercontent.com/69977658/186171256-2e41ddae-3e7b-4f10-9c73-8bcb09c34ba2.png">

**With sticky header**

<img width="400" alt="data table with sticky header" src="https://user-images.githubusercontent.com/69977658/186171392-7dc23de8-915d-4c5c-b778-057ca7768ef5.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Card, DataTable} from '../src';

export function Playground() {
  return (
    const rows = [
    [
      'Emerald Silk Gown',
      'Formalwear',
      "Jill's formal",
      10,
      '$875.00',
      124689,
      140,
      '$426.00',
      '$122,500.00',
    ],
    [
      'Mauve Cashmere Scarf',
      'Accessories',
      "Jack's Accessories",
      253,
      '$230.00',
      124533,
      83,
      '$620.00',
      '$19,090.00',
    ],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      'Ensembles',
      'Avocado Fashions',
      23,
      '$445.00',
      124518,
      32,
      '$353.00',
      '$14,240.00',
    ],
    [
      'Socks',
      'Essentials',
      'Avocado Fashions',
      465,
      '$4.00',
      124518,
      32,
      '$3.00',
      '$140.00',
    ],
  ];

  return (
    <Page title="Sales by product">
      <Card>
        <DataTable
          columnContentTypes={[
            'text',
            'text',
            'text',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
          ]}
          headings={[
            'Product',
            'Category',
            'Vendor',
            'Orders',
            'Price',
            'SKU Number',
            'Net quantity',
            'Shipping',
            'Net sales',
          ]}
          rows={rows}
          totals={['', '', '', '', '', '', 255, '$1399', '$155,830.00']}
          initialSortColumnIndex={4}
          stickyHeader
          fixedFirstColumns={3}
          truncate
          showTotalsInFooter
          footerContent={`Showing ${rows.length} of ${rows.length} results`}
        />
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
