### PR TITLE
[Typography foundations] Add `headingXs` variant

### DIFF
--- a/polaris-react/src/components/Text/README.md
+++ b/polaris-react/src/components/Text/README.md
@@ -31,6 +31,16 @@ Typography helps establish hierarchy and communicate important content by creati
 
 ## Examples
 
+### Heading extra small
+
+Use to create a extra small heading text.
+
+```jsx
+<Text variant="headingXs" as="h6">
+  Online store dashboard
+</Text>
+```
+
 ### Heading small
 
 Use to create a small heading text.

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -67,24 +67,29 @@
   font-weight: var(--p-font-weight-bold);
 }
 
-.headingSm {
+.headingXs {
   font-size: var(--p-font-size-75);
   line-height: var(--p-font-line-height-1);
 }
 
-.headingMd {
+.headingSm {
   font-size: var(--p-font-size-100);
   line-height: var(--p-font-line-height-2);
 }
 
-.headingLg {
+.headingMd {
   font-size: var(--p-font-size-200);
   line-height: var(--p-font-line-height-3);
 }
 
-.headingXl {
+.headingLg {
   font-size: var(--p-font-size-300);
   line-height: var(--p-font-line-height-3);
+}
+
+.headingXl {
+  font-size: var(--p-font-size-400);
+  line-height: var(--p-font-line-height-4);
 }
 
 .heading2xl {

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -7,6 +7,7 @@ import styles from './Text.scss';
 type Element = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
 
 type Variant =
+  | 'headingXs'
   | 'headingSm'
   | 'headingMd'
   | 'headingLg'
@@ -25,7 +26,8 @@ type FontWeight = 'regular' | 'medium' | 'semibold' | 'bold';
 type Color = 'success' | 'critical' | 'warning' | 'subdued';
 
 const VariantFontWeightMapping: {[V in Variant]: FontWeight} = {
-  headingSm: 'bold',
+  headingXs: 'bold',
+  headingSm: 'semibold',
   headingMd: 'semibold',
   headingLg: 'semibold',
   headingXl: 'semibold',

--- a/polaris.shopify.com/content/components/text/index.md
+++ b/polaris.shopify.com/content/components/text/index.md
@@ -55,21 +55,21 @@ These are suggested replacements for existing text style components, but ultimat
 
 ```diff
 - <DisplayText size="small">Sales this year</DisplayText>
-+ <Text variant="headingXl" as="p">Sales this year</Text>
++ <Text variant="headingLg" as="p">Sales this year</Text>
 ```
 
 #### Medium
 
 ```diff
 - <DisplayText size="medium">Sales this year</DisplayText>
-+ <Text variant="heading2xl" as="p">Sales this year</Text>
++ <Text variant="headingXl" as="p">Sales this year</Text>
 ```
 
 #### Large
 
 ```diff
 - <DisplayText size="large">Sales this year</DisplayText>
-+ <Text variant="heading3xl" as="p">Sales this year</Text>
++ <Text variant="heading2xl" as="p">Sales this year</Text>
 ```
 
 #### Extra large
@@ -83,14 +83,14 @@ These are suggested replacements for existing text style components, but ultimat
 
 ```diff
 - <Heading>Online store dashboard</Heading>
-+ <Text variant="headingLg" as="h2">Online store dashboard</Text>
++ <Text variant="headingMd" as="h2">Online store dashboard</Text>
 ```
 
 ### Subheading
 
 ```diff
 - <Subheading>Accounts</Subheading>
-+ <Text variant="headingSm" as="h3">Accounts</Text>
++ <Text variant="headingXs" as="h3">Accounts</Text>
 ```
 
 ### Caption

--- a/polaris.shopify.com/pages/examples/text-heading.tsx
+++ b/polaris.shopify.com/pages/examples/text-heading.tsx
@@ -26,6 +26,9 @@ function TextExample() {
       <Text variant="headingSm" as="h6">
         Online store dashboard
       </Text>
+      <Text variant="headingXs" as="h6">
+        Online store dashboard
+      </Text>
     </Stack>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #6967.

### WHAT is this pull request doing?

Moves tshirt sizes for `Text` variants down and add `headingXs` variant.
Also updates the mapping for existing typography components to the new Text component for the style guide. 
    <details>
      <summary>Text heading variants before</summary>
      <img src="https://user-images.githubusercontent.com/26749317/185474837-f3bed90c-deab-45c1-8bd6-5b57baffe948.png" alt="Text heading variants before">
    </details>
    <details>
      <summary>Text heading variants after</summary>
      <img src="https://user-images.githubusercontent.com/26749317/185474834-8ad67fad-9156-4856-959b-2ab914be7ba4.png" alt="Text heading variants after">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Text} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Text as="h1" variant="heading4xl">
        Heading 4xl variant
      </Text>
      <Text as="h2" variant="heading3xl">
        Heading 3xl variant
      </Text>
      <Text as="h3" variant="heading2xl">
        Heading 2xl variant
      </Text>
      <Text as="h4" variant="headingXl">
        Heading xl variant
      </Text>
      <Text as="h5" variant="headingLg">
        Heading lg variant
      </Text>
      <Text as="h6" variant="headingMd">
        Heading md variant
      </Text>
      <Text as="h6" variant="headingSm">
        Heading sm variant
      </Text>
      <Text as="h6" variant="headingXs">
        Heading xs variant
      </Text>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
