### PR TITLE
[Modal] Trigger pressed animation on backdrop click

### DIFF
--- a/.changeset/strong-poems-double.md
+++ b/.changeset/strong-poems-double.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Clicking on the modal backdrop triggers the pressed state of the modal's close button

--- a/polaris-react/src/components/Backdrop/Backdrop.tsx
+++ b/polaris-react/src/components/Backdrop/Backdrop.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Dispatch, SetStateAction} from 'react';
 
 import {classNames} from '../../utilities/css';
 import {ScrollLock} from '../ScrollLock';
@@ -10,16 +10,31 @@ export interface BackdropProps {
   transparent?: boolean;
   onClick?(): void;
   onTouchStart?(): void;
+  setClosing?: Dispatch<SetStateAction<boolean>>;
 }
 
 export function Backdrop(props: BackdropProps) {
-  const {onClick, onTouchStart, belowNavigation, transparent} = props;
+  const {onClick, onTouchStart, belowNavigation, transparent, setClosing} =
+    props;
 
   const className = classNames(
     styles.Backdrop,
     belowNavigation && styles.belowNavigation,
     transparent && styles.transparent,
   );
+
+  const handleMouseDown = () => {
+    if (setClosing) {
+      setClosing(true);
+    }
+  };
+
+  const handleMouseUp = () => {
+    if (setClosing && onClick) {
+      setClosing(false);
+      onClick();
+    }
+  };
 
   return (
     <>
@@ -28,6 +43,8 @@ export function Backdrop(props: BackdropProps) {
         className={className}
         onClick={onClick}
         onTouchStart={onTouchStart}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
       />
     </>
   );

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useRef, useEffect} from 'react';
+import React, {useState, useCallback, useRef} from 'react';
 import {TransitionGroup} from 'react-transition-group';
 
 import {focusFirstFocusableNode} from '../../utilities/focus';
@@ -137,17 +137,6 @@ export const Modal: React.FunctionComponent<ModalProps> & {
     [onIFrameLoad],
   );
 
-  useEffect(() => {
-    if (closing) {
-      onClose();
-      setClosing(false);
-    }
-  }, [closing, onClose]);
-
-  const handleOnClose = () => {
-    setClosing(true);
-  };
-
   if (open) {
     const footerMarkup =
       !footer && !primaryAction && !secondaryActions ? null : (
@@ -207,6 +196,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
         small={small}
         limitHeight={limitHeight}
         fullScreen={fullScreen}
+        setClosing={setClosing}
       >
         <Header
           titleHidden={titleHidden}
@@ -221,7 +211,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       </Dialog>
     );
 
-    backdrop = <Backdrop onClick={handleOnClose} />;
+    backdrop = <Backdrop setClosing={setClosing} onClick={onClose} />;
   }
 
   const animated = !instant;

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useRef} from 'react';
+import React, {useState, useCallback, useRef, useEffect} from 'react';
 import {TransitionGroup} from 'react-transition-group';
 
 import {focusFirstFocusableNode} from '../../utilities/focus';
@@ -90,6 +90,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   fullScreen,
 }: ModalProps) {
   const [iframeHeight, setIframeHeight] = useState(IFRAME_LOADING_HEIGHT);
+  const [closing, setClosing] = useState(false);
 
   const headerId = useUniqueId('modal-header');
   const activatorRef = useRef<HTMLDivElement>(null);
@@ -135,6 +136,17 @@ export const Modal: React.FunctionComponent<ModalProps> & {
     },
     [onIFrameLoad],
   );
+
+  useEffect(() => {
+    if (closing) {
+      onClose();
+      setClosing(false);
+    }
+  }, [closing, onClose]);
+
+  const handleOnClose = () => {
+    setClosing(true);
+  };
 
   if (open) {
     const footerMarkup =
@@ -196,7 +208,12 @@ export const Modal: React.FunctionComponent<ModalProps> & {
         limitHeight={limitHeight}
         fullScreen={fullScreen}
       >
-        <Header titleHidden={titleHidden} id={headerId} onClose={onClose}>
+        <Header
+          titleHidden={titleHidden}
+          id={headerId}
+          closing={closing}
+          onClose={onClose}
+        >
           {title}
         </Header>
         <div className={styles.BodyWrapper}>{bodyMarkup}</div>
@@ -204,7 +221,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       </Dialog>
     );
 
-    backdrop = <Backdrop onClick={onClose} />;
+    backdrop = <Backdrop onClick={handleOnClose} />;
   }
 
   const animated = !instant;

--- a/polaris-react/src/components/Modal/components/CloseButton/CloseButton.scss
+++ b/polaris-react/src/components/Modal/components/CloseButton/CloseButton.scss
@@ -13,7 +13,8 @@
     @include recolor-icon(var(--p-icon-hovered));
   }
 
-  &:active {
+  &:active,
+  &.pressed {
     background: var(--p-surface-pressed);
   }
 

--- a/polaris-react/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/polaris-react/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -8,11 +8,16 @@ import {Icon} from '../../../Icon';
 import styles from './CloseButton.scss';
 
 export interface CloseButtonProps {
+  pressed?: boolean;
   titleHidden?: boolean;
   onClick(): void;
 }
 
-export function CloseButton({titleHidden = false, onClick}: CloseButtonProps) {
+export function CloseButton({
+  pressed,
+  titleHidden = false,
+  onClick,
+}: CloseButtonProps) {
   const i18n = useI18n();
 
   return (
@@ -21,6 +26,7 @@ export function CloseButton({titleHidden = false, onClick}: CloseButtonProps) {
       className={classNames(
         styles.CloseButton,
         titleHidden && styles.titleHidden,
+        pressed && styles.pressed,
       )}
       aria-label={i18n.translate('Polaris.Common.close')}
     >

--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useEffect} from 'react';
+import React, {useRef, useEffect, SetStateAction, Dispatch} from 'react';
 import {Transition, CSSTransition} from 'react-transition-group';
 import {motion} from '@shopify/polaris-tokens';
 
@@ -22,6 +22,7 @@ export interface DialogProps {
   onExited?(): void;
   in?: boolean;
   fullScreen?: boolean;
+  setClosing?: Dispatch<SetStateAction<boolean>>;
 }
 
 export function Dialog({
@@ -35,6 +36,7 @@ export function Dialog({
   small,
   limitHeight,
   fullScreen,
+  setClosing,
   ...props
 }: DialogProps) {
   const containerNode = useRef<HTMLDivElement>(null);
@@ -52,6 +54,19 @@ export function Dialog({
       !containerNode.current.contains(document.activeElement) &&
       focusFirstFocusableNode(containerNode.current);
   }, []);
+
+  const handleKeyDown = () => {
+    if (setClosing) {
+      setClosing(true);
+    }
+  };
+
+  const handleKeyUp = () => {
+    if (setClosing) {
+      setClosing(false);
+    }
+    onClose();
+  };
 
   return (
     <TransitionChild
@@ -78,7 +93,12 @@ export function Dialog({
             className={styles.Dialog}
           >
             <div className={classes}>
-              <KeypressListener keyCode={Key.Escape} handler={onClose} />
+              <KeypressListener
+                keyCode={Key.Escape}
+                keyEvent="keydown"
+                handler={handleKeyDown}
+              />
+              <KeypressListener keyCode={Key.Escape} handler={handleKeyUp} />
               {children}
             </div>
           </div>

--- a/polaris-react/src/components/Modal/components/Header/Header.tsx
+++ b/polaris-react/src/components/Modal/components/Header/Header.tsx
@@ -8,11 +8,18 @@ import styles from './Header.scss';
 export interface HeaderProps {
   id: string;
   titleHidden: boolean;
+  closing: boolean;
   children?: React.ReactNode;
   onClose(): void;
 }
 
-export function Header({id, titleHidden, children, onClose}: HeaderProps) {
+export function Header({
+  id,
+  titleHidden,
+  closing,
+  children,
+  onClose,
+}: HeaderProps) {
   return (
     <div
       className={titleHidden || !children ? styles.titleHidden : styles.Header}
@@ -22,7 +29,11 @@ export function Header({id, titleHidden, children, onClose}: HeaderProps) {
           {children}
         </Text>
       </div>
-      <CloseButton titleHidden={titleHidden} onClick={onClose} />
+      <CloseButton
+        pressed={closing}
+        titleHidden={titleHidden}
+        onClick={onClose}
+      />
     </div>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify/issues/361647.

Clicking on the backdrop triggers the pressed state of the close button to (as stated in the issue) reenforce the user's action and an extra layer of feedback.

### WHAT is this pull request doing?

Before:


After:



### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
