### PR TITLE
Remove deprecation warning from annotated section

### DIFF
--- a/.changeset/rude-donuts-return.md
+++ b/.changeset/rude-donuts-return.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Removed deprecation from Layout.AnnotatedSection

--- a/polaris-react/src/components/Layout/Layout.stories.tsx
+++ b/polaris-react/src/components/Layout/Layout.stories.tsx
@@ -70,7 +70,7 @@ export function TwoColumnsWithEqualWidth() {
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
                   {
-                    id: 341,
+                    id: '341',
                     url: 'produdcts/341',
                     name: 'Black & orange scarf',
                     sku: '9234194023',
@@ -83,7 +83,7 @@ export function TwoColumnsWithEqualWidth() {
                     ),
                   },
                   {
-                    id: 256,
+                    id: '256',
                     url: 'produdcts/256',
                     name: 'Tucan scarf',
                     sku: '9234194010',
@@ -128,7 +128,7 @@ export function TwoColumnsWithEqualWidth() {
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
                   {
-                    id: 342,
+                    id: '342',
                     url: 'produdcts/342',
                     name: 'Black & orange scarf',
                     sku: '9234194023',
@@ -141,7 +141,7 @@ export function TwoColumnsWithEqualWidth() {
                     ),
                   },
                   {
-                    id: 257,
+                    id: '257',
                     url: 'produdcts/257',
                     name: 'Tucan scarf',
                     sku: '9234194010',
@@ -195,7 +195,7 @@ export function ThreeColumnsWithEqualWidth() {
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
                   {
-                    id: 343,
+                    id: '343',
                     url: 'produdcts/343',
                     name: 'Black & orange scarf',
                     sku: '9234194023',
@@ -208,7 +208,7 @@ export function ThreeColumnsWithEqualWidth() {
                     ),
                   },
                   {
-                    id: 258,
+                    id: '258',
                     url: 'produdcts/258',
                     name: 'Tucan scarf',
                     sku: '9234194010',
@@ -253,7 +253,7 @@ export function ThreeColumnsWithEqualWidth() {
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
                   {
-                    id: 344,
+                    id: '344',
                     url: 'produdcts/344',
                     name: 'Black & orange scarf',
                     sku: '9234194023',
@@ -266,7 +266,7 @@ export function ThreeColumnsWithEqualWidth() {
                     ),
                   },
                   {
-                    id: 259,
+                    id: '259',
                     url: 'produdcts/259',
                     name: 'Tucan scarf',
                     sku: '9234194010',
@@ -311,7 +311,7 @@ export function ThreeColumnsWithEqualWidth() {
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
                   {
-                    id: 345,
+                    id: '345',
                     url: 'produdcts/345',
                     name: 'Black & orange scarf',
                     sku: '9234194023',
@@ -324,7 +324,7 @@ export function ThreeColumnsWithEqualWidth() {
                     ),
                   },
                   {
-                    id: 260,
+                    id: '260',
                     url: 'produdcts/260',
                     name: 'Tucan scarf',
                     sku: '9234194010',
@@ -389,45 +389,6 @@ export function Annotated() {
             </FormLayout>
           </Card>
         </Layout.AnnotatedSection>
-      </Layout>
-    </Page>
-  );
-}
-
-export function AnnotatedWithSections() {
-  return (
-    <Page fullWidth>
-      <Layout>
-        <Layout.Section oneThird>
-          <div style={{marginTop: 'var(--p-space-5)'}}>
-            <TextContainer>
-              <Heading id="storeDetails">Store details</Heading>
-              <p>
-                <TextStyle variation="subdued">
-                  Shopify and your customers will use this information to
-                  contact you.
-                </TextStyle>
-              </p>
-            </TextContainer>
-          </div>
-        </Layout.Section>
-        <Layout.Section>
-          <Card sectioned>
-            <FormLayout>
-              <TextField
-                label="Store name"
-                onChange={() => {}}
-                autoComplete="off"
-              />
-              <TextField
-                type="email"
-                label="Account email"
-                onChange={() => {}}
-                autoComplete="email"
-              />
-            </FormLayout>
-          </Card>
-        </Layout.Section>
       </Layout>
     </Page>
   );

--- a/polaris-react/src/components/Layout/Layout.tsx
+++ b/polaris-react/src/components/Layout/Layout.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-// eslint-disable-next-line import/no-deprecated
 import {AnnotatedSection, Section} from './components';
 import styles from './Layout.scss';
 
@@ -12,13 +11,12 @@ export interface LayoutProps {
 }
 
 export const Layout: React.FunctionComponent<LayoutProps> & {
-  // eslint-disable-next-line import/no-deprecated
   AnnotatedSection: typeof AnnotatedSection;
   Section: typeof Section;
 } = function Layout({sectioned, children}: LayoutProps) {
   const content = sectioned ? <Section>{children}</Section> : children;
   return <div className={styles.Layout}>{content}</div>;
 };
-// eslint-disable-next-line import/no-deprecated
+
 Layout.AnnotatedSection = AnnotatedSection;
 Layout.Section = Section;

--- a/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -10,10 +10,13 @@ export interface AnnotatedSectionProps {
   description?: React.ReactNode;
   id?: string;
 }
-/** @deprecated Annotated sections can be composed. See examples for styling */
-export function AnnotatedSection(props: AnnotatedSectionProps) {
-  const {children, title, description, id} = props;
 
+export function AnnotatedSection({
+  children,
+  title,
+  description,
+  id,
+}: AnnotatedSectionProps) {
   const descriptionMarkup =
     typeof description === 'string' ? <p>{description}</p> : description;
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

I think we'll need to keep this around for a little longer. We can re-deprecate when we have better layout tools in place and when there's a larger refactor (renaming? removing?) of the Layout component

Addresses: https://github.com/Shopify/polaris/pull/6483#issuecomment-1181078214

cc @mbaumbach 