### PR TITLE
Fix storybook link for perf profiler

### DIFF
--- a/polaris-react/scripts/profiler.js
+++ b/polaris-react/scripts/profiler.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 
 const iframePath =
-  'http://localhost:6006/iframe.html?id=playground--kitchen-sink&viewMode=story&globals=profiler:false';
+  'http://localhost:6006/iframe.html?args=&id=playground--kitchen-sink&viewMode=story&globals=profiler:false';
 
 (async () => {
   const browser = await puppeteer.launch();


### PR DESCRIPTION
Performance profiler has been failing since last week. Looks like maybe a storybook update changed the kitchen sink url