### PR TITLE
[ColorPicker] Extend the ColorPicker component to support a textfield for a Hex color

### DIFF
--- a/.changeset/olive-lemons-whisper.md
+++ b/.changeset/olive-lemons-whisper.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Extend the ColorPicker component to support a textfield for a Hex color

--- a/polaris-react/src/components/ColorPicker/ColorPicker.scss
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.scss
@@ -166,7 +166,7 @@ $vertical-picker-border-radius: calc(var(--pc-color-picker-size) * 0.5);
   cursor: pointer;
 }
 
-.HexTexField {
+.TextField {
   padding: var(--p-space-4) 0;
   display: flex;
 }

--- a/polaris-react/src/components/ColorPicker/ColorPicker.scss
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.scss
@@ -18,6 +18,10 @@
   --pc-color-picker-dragger-shadow: inset 0 1px 2px 0
       var(--p-shadow-color-picker-dragger),
     0 1px 2px 0 var(--p-shadow-color-picker-dragger);
+  --pc-color-picker-square-preview-size: 36px;
+}
+
+.Container {
   user-select: none;
   display: flex;
 }
@@ -160,4 +164,16 @@ $vertical-picker-border-radius: calc(var(--pc-color-picker-size) * 0.5);
   height: 100%;
   width: 100%;
   cursor: pointer;
+}
+
+.HexTexField {
+  padding: var(--p-space-4) 0;
+  display: flex;
+}
+
+.SquarePreview {
+  width: var(--pc-color-picker-square-preview-size);
+  height: var(--pc-color-picker-square-preview-size);
+  border-radius: var(--p-border-radius-1);
+  border: var(--p-border-width-1) solid var(--p-border-subdued);
 }

--- a/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -37,3 +37,27 @@ export function WithTransparentValueFullWidth() {
 
   return <ColorPicker fullWidth onChange={setColor} color={color} allowAlpha />;
 }
+
+export function WithHexColorTextField() {
+  const [color, setColor] = useState({
+    hue: 300,
+    brightness: 1,
+    saturation: 0.7,
+    alpha: 0.7,
+  });
+
+  return <ColorPicker onChange={setColor} color={color} showHexTextField />;
+}
+
+export function WithHexColorTextFieldFullWidth() {
+  const [color, setColor] = useState({
+    hue: 300,
+    brightness: 1,
+    saturation: 0.7,
+    alpha: 0.7,
+  });
+
+  return (
+    <ColorPicker onChange={setColor} color={color} showHexTextField fullWidth />
+  );
+}

--- a/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -46,7 +46,7 @@ export function WithHexColorTextField() {
     alpha: 0.7,
   });
 
-  return <ColorPicker onChange={setColor} color={color} showHexTextField />;
+  return <ColorPicker onChange={setColor} color={color} showTextField />;
 }
 
 export function WithHexColorTextFieldFullWidth() {
@@ -58,6 +58,6 @@ export function WithHexColorTextFieldFullWidth() {
   });
 
   return (
-    <ColorPicker onChange={setColor} color={color} showHexTextField fullWidth />
+    <ColorPicker onChange={setColor} color={color} showTextField fullWidth />
   );
 }

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -4,7 +4,6 @@ import {debounce} from '../../utilities/debounce';
 import {clamp} from '../../utilities/clamp';
 import {classNames} from '../../utilities/css';
 import {hsbToRgb} from '../../utilities/color-transformers';
-import type {HSBColor, HSBAColor} from '../../utilities/color-types';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
 
@@ -15,6 +14,7 @@ import {
   SlidableProps,
   TextField,
 } from './components';
+import type {TextFieldProps} from './components';
 import styles from './ColorPicker.scss';
 
 interface State {
@@ -24,22 +24,9 @@ interface State {
   };
 }
 
-interface Color extends HSBColor {
-  /** Level of transparency */
-  alpha?: HSBAColor['alpha'];
-}
-
-export interface ColorPickerProps {
+export interface ColorPickerProps extends TextFieldProps {
   /** ID for the element */
   id?: string;
-  /** The currently selected color */
-  color: Color;
-  /** Allow user to select an alpha value */
-  allowAlpha?: boolean;
-  /** Allow HuePicker to take the full width */
-  fullWidth?: boolean;
-  /** Callback when color is selected */
-  onChange(color: HSBAColor): void;
   /** Displays a text field that accepts HEX colors */
   showHexTextField?: boolean;
 }

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -8,7 +8,13 @@ import type {HSBColor, HSBAColor} from '../../utilities/color-types';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
 
-import {AlphaPicker, HuePicker, Slidable, SlidableProps} from './components';
+import {
+  AlphaPicker,
+  HuePicker,
+  Slidable,
+  SlidableProps,
+  TextField,
+} from './components';
 import styles from './ColorPicker.scss';
 
 interface State {
@@ -34,6 +40,8 @@ export interface ColorPickerProps {
   fullWidth?: boolean;
   /** Callback when color is selected */
   onChange(color: HSBAColor): void;
+  /** Displays a text field that accepts HEX colors */
+  showHexTextField?: boolean;
 }
 
 const RESIZE_DEBOUNCE_TIME_MS = 200;
@@ -114,27 +122,48 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
       />
     ) : null;
 
+    const hexTextFieldMarkup = this.props.showHexTextField ? (
+      <div className={styles.HexTexField}>
+        <div
+          className={styles.SquarePreview}
+          style={{backgroundColor: colorString}}
+        />
+        <TextField
+          color={color}
+          allowAlpha={allowAlpha}
+          fullWidth={fullWidth}
+        />
+      </div>
+    ) : null;
+
     const className = classNames(
       styles.ColorPicker,
       fullWidth && styles.fullWidth,
     );
 
     return (
-      <div className={className} id={id} onMouseDown={this.handlePickerDrag}>
-        <div ref={this.setColorNode} className={styles.MainColor}>
-          <div
-            className={styles.ColorLayer}
-            style={{backgroundColor: colorString}}
-          />
-          <Slidable
-            onChange={this.handleDraggerMove}
-            draggerX={draggerX}
-            draggerY={draggerY}
-          />
+      <div className={className}>
+        <div
+          className={styles.Container}
+          id={id}
+          onMouseDown={this.handlePickerDrag}
+        >
+          <div ref={this.setColorNode} className={styles.MainColor}>
+            <div
+              className={styles.ColorLayer}
+              style={{backgroundColor: colorString}}
+            />
+            <Slidable
+              onChange={this.handleDraggerMove}
+              draggerX={draggerX}
+              draggerY={draggerY}
+            />
+          </div>
+          <HuePicker hue={hue} onChange={this.handleHueChange} />
+          {alphaSliderMarkup}
+          <EventListener event="resize" handler={this.handleResize} />
         </div>
-        <HuePicker hue={hue} onChange={this.handleHueChange} />
-        {alphaSliderMarkup}
-        <EventListener event="resize" handler={this.handleResize} />
+        {hexTextFieldMarkup}
       </div>
     );
   }

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -100,7 +100,7 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
   }
 
   render() {
-    const {id, color, allowAlpha, fullWidth} = this.props;
+    const {id, color, allowAlpha, fullWidth, onChange} = this.props;
     const {hue, saturation, brightness, alpha: providedAlpha} = color;
     const {pickerSize} = this.state;
 
@@ -113,6 +113,7 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
       0,
       pickerSize.height,
     );
+    const rgbaColor = hsbToRgb({hue, saturation, brightness, alpha});
 
     const alphaSliderMarkup = allowAlpha ? (
       <AlphaPicker
@@ -126,7 +127,9 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
       <div className={styles.HexTexField}>
         <div
           className={styles.SquarePreview}
-          style={{backgroundColor: colorString}}
+          style={{
+            backgroundColor: `rgba(${rgbaColor.red}, ${rgbaColor.green}, ${rgbaColor.blue}, ${alpha})`,
+          }}
         />
         <TextField
           color={color}

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -24,12 +24,25 @@ interface State {
   };
 }
 
-export interface ColorPickerProps extends TextFieldProps {
-  /** ID for the element */
-  id?: string;
-  /** Displays a text field that accepts HEX colors */
-  showHexTextField?: boolean;
-}
+type WithTextFieldProps =
+  | {
+      /** Allow user to select an alpha value */
+      allowAlpha?: false;
+      /** Displays a text field that accepts HEX colors */
+      showHexTextField?: never | false;
+    }
+  | {
+      /** Allow user to select an alpha value */
+      allowAlpha?: true;
+      /** Displays a text field that accepts HEX colors */
+      showHexTextField?: boolean;
+    };
+
+export type ColorPickerProps = TextFieldProps &
+  WithTextFieldProps & {
+    /** ID for the element */
+    id?: string;
+  };
 
 const RESIZE_DEBOUNCE_TIME_MS = 200;
 export class ColorPicker extends PureComponent<ColorPickerProps, State> {
@@ -87,7 +100,8 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
   }
 
   render() {
-    const {id, color, allowAlpha, fullWidth, onChange} = this.props;
+    const {id, color, allowAlpha, fullWidth, onChange, showHexTextField} =
+      this.props;
     const {hue, saturation, brightness, alpha: providedAlpha} = color;
     const {pickerSize} = this.state;
 
@@ -110,22 +124,18 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
       />
     ) : null;
 
-    const hexTextFieldMarkup = this.props.showHexTextField ? (
-      <div className={styles.HexTexField}>
-        <div
-          className={styles.SquarePreview}
-          style={{
-            backgroundColor: `rgba(${rgbaColor.red}, ${rgbaColor.green}, ${rgbaColor.blue}, ${alpha})`,
-          }}
-        />
-        <TextField
-          color={color}
-          allowAlpha={allowAlpha}
-          fullWidth={fullWidth}
-          onChange={onChange}
-        />
-      </div>
-    ) : null;
+    const hexTextFieldMarkup =
+      showHexTextField && !allowAlpha ? (
+        <div className={styles.HexTexField}>
+          <div
+            className={styles.SquarePreview}
+            style={{
+              backgroundColor: `rgba(${rgbaColor.red}, ${rgbaColor.green}, ${rgbaColor.blue}, ${alpha})`,
+            }}
+          />
+          <TextField color={color} fullWidth={fullWidth} onChange={onChange} />
+        </div>
+      ) : null;
 
     const className = classNames(
       styles.ColorPicker,

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -135,6 +135,7 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
           color={color}
           allowAlpha={allowAlpha}
           fullWidth={fullWidth}
+          onChange={onChange}
         />
       </div>
     ) : null;

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -28,14 +28,14 @@ type WithTextFieldProps =
   | {
       /** Allow user to select an alpha value */
       allowAlpha?: false;
-      /** Displays a text field that accepts HEX colors */
-      showHexTextField?: never | false;
+      /** Displays a text field that accepts color code */
+      showTextField?: never | false;
     }
   | {
       /** Allow user to select an alpha value */
       allowAlpha?: true;
-      /** Displays a text field that accepts HEX colors */
-      showHexTextField?: boolean;
+      /** Displays a text field that accepts color code */
+      showTextField?: boolean;
     };
 
 export type ColorPickerProps = TextFieldProps &
@@ -100,7 +100,7 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
   }
 
   render() {
-    const {id, color, allowAlpha, fullWidth, onChange, showHexTextField} =
+    const {id, color, allowAlpha, fullWidth, onChange, showTextField} =
       this.props;
     const {hue, saturation, brightness, alpha: providedAlpha} = color;
     const {pickerSize} = this.state;
@@ -125,7 +125,7 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
     ) : null;
 
     const hexTextFieldMarkup =
-      showHexTextField && !allowAlpha ? (
+      showTextField && !allowAlpha ? (
         <div className={styles.HexTexField}>
           <div
             className={styles.SquarePreview}

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -143,12 +143,8 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
     );
 
     return (
-      <div className={className}>
-        <div
-          className={styles.Container}
-          id={id}
-          onMouseDown={this.handlePickerDrag}
-        >
+      <div className={className} id={id}>
+        <div className={styles.Container} onMouseDown={this.handlePickerDrag}>
           <div ref={this.setColorNode} className={styles.MainColor}>
             <div
               className={styles.ColorLayer}

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -126,7 +126,7 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
 
     const hexTextFieldMarkup =
       showTextField && !allowAlpha ? (
-        <div className={styles.HexTexField}>
+        <div className={styles.TextField}>
           <div
             className={styles.SquarePreview}
             style={{

--- a/polaris-react/src/components/ColorPicker/components/TextField/TextField.scss
+++ b/polaris-react/src/components/ColorPicker/components/TextField/TextField.scss
@@ -1,0 +1,21 @@
+.ColorPickerTextFieldSize {
+  width: calc(
+    var(--pc-color-picker-size) + var(--pc-color-picker-dragger-size) +
+      var(--p-space-2) - var(--pc-color-picker-square-preview-size) -
+      (2 * var(--p-border-width-1))
+  );
+  margin-left: var(--p-space-2);
+}
+
+.withAlpha {
+  width: calc(
+    var(--pc-color-picker-size) +
+      (2 * (var(--pc-color-picker-dragger-size) + 6px + var(--p-space-2))) -
+      var(--p-space-2) - var(--pc-color-picker-square-preview-size) -
+      (2 * var(--p-border-width-1))
+  );
+}
+
+.fullWidth {
+  width: 100%;
+}

--- a/polaris-react/src/components/ColorPicker/components/TextField/TextField.scss
+++ b/polaris-react/src/components/ColorPicker/components/TextField/TextField.scss
@@ -7,15 +7,6 @@
   margin-left: var(--p-space-2);
 }
 
-.withAlpha {
-  width: calc(
-    var(--pc-color-picker-size) +
-      (2 * (var(--pc-color-picker-dragger-size) + 6px + var(--p-space-2))) -
-      var(--p-space-2) - var(--pc-color-picker-square-preview-size) -
-      (2 * var(--p-border-width-1))
-  );
-}
-
 .fullWidth {
   width: 100%;
 }

--- a/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
@@ -20,15 +20,13 @@ interface Color extends HSBColor {
 export interface TextFieldProps {
   /** The currently selected color */
   color: Color;
-  /** Allow user to select an alpha value */
-  allowAlpha?: boolean;
   /** Allow HuePicker to take the full width */
   fullWidth?: boolean;
   /** Callback when color is selected */
   onChange(color: HSBAColor): void;
 }
 
-function TextField({color, allowAlpha, fullWidth, onChange}: TextFieldProps) {
+function TextField({color, fullWidth, onChange}: TextFieldProps) {
   const [internalValue, setInternalValue] = useState<string | null>(
     hsbToHex(color),
   );
@@ -39,7 +37,6 @@ function TextField({color, allowAlpha, fullWidth, onChange}: TextFieldProps) {
 
   const className = classNames(
     styles.ColorPickerTextFieldSize,
-    allowAlpha && styles.withAlpha,
     fullWidth && styles.fullWidth,
   );
 

--- a/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useEffect, useState, useRef} from 'react';
 
 import {
   hsbToHex,
-  expandHex,
   hexToRgb,
   rgbToHsb,
 } from '../../../../utilities/color-transformers';
@@ -45,7 +44,8 @@ function TextField({color, allowAlpha, fullWidth, onChange}: TextFieldProps) {
   );
 
   const handleUpdate = useCallback(() => {
-    const validUserInput = coerceToValidUserInput(value);
+    const coercedValue = !value.startsWith('#') ? `#${value}` : value;
+    const validUserInput = isHexString(coercedValue);
 
     if (!validUserInput) {
       return;
@@ -53,11 +53,11 @@ function TextField({color, allowAlpha, fullWidth, onChange}: TextFieldProps) {
 
     setInternalValue(null);
 
-    const colorHasChanged = validUserInput !== hsbToHex(color);
+    const colorHasChanged = coercedValue !== hsbToHex(color);
 
     if (colorHasChanged) {
       ignoreChangeRef.current = true;
-      onChange({...rgbToHsb(hexToRgb(validUserInput)), alpha: 1});
+      onChange({...rgbToHsb(hexToRgb(coercedValue)), alpha: 1});
     }
   }, [value, onChange, color]);
 
@@ -80,11 +80,6 @@ function TextField({color, allowAlpha, fullWidth, onChange}: TextFieldProps) {
       />
     </div>
   );
-}
-
-function coerceToValidUserInput(value: string) {
-  const coercedValue = !value.startsWith('#') ? `#${value}` : value;
-  return isHexString(coercedValue) ? expandHex(coercedValue) : null;
 }
 
 export {TextField};

--- a/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
@@ -1,0 +1,55 @@
+import React, {useCallback} from 'react';
+
+import {hsbToHex} from '../../../../utilities/color-transformers';
+import type {HSBColor, HSBAColor} from '../../../../utilities/color-types';
+import {classNames} from '../../../../utilities/css';
+import {TextField as PolarisTextField} from '../../../TextField';
+
+import styles from './TextField.scss';
+
+interface Color extends HSBColor {
+  /** Level of transparency */
+  alpha?: HSBAColor['alpha'];
+}
+
+interface TextFieldProps {
+  /** The currently selected color (coming from parent) */
+  color: Color;
+  /** Allow user to select an alpha value (coming from parent) */
+  allowAlpha?: boolean;
+  /** Allow HuePicker to take the full width (coming from parent) */
+  fullWidth?: boolean;
+}
+
+function TextField({color, allowAlpha, fullWidth}: TextFieldProps) {
+  const hexColor = hsbToHex(color);
+
+  const handleTextChange = useCallback(() => {
+    console.log('text changed');
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    console.log('text changed');
+  }, []);
+
+  const className = classNames(
+    styles.ColorPickerTextFieldSize,
+    allowAlpha && styles.withAlpha,
+    fullWidth && styles.fullWidth,
+  );
+
+  return (
+    <div className={className}>
+      <PolarisTextField
+        label=""
+        prefix="#"
+        value={hexColor.replace('#', '').toUpperCase()}
+        onChange={handleTextChange}
+        onBlur={handleBlur}
+        autoComplete="off"
+      />
+    </div>
+  );
+}
+
+export {TextField};

--- a/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState, useRef} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {
   hsbToHex,

--- a/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
@@ -30,7 +30,6 @@ function TextField({color, fullWidth, onChange}: TextFieldProps) {
   const [internalValue, setInternalValue] = useState<string | null>(
     hsbToHex(color),
   );
-  const ignoreChangeRef = useRef(false);
   const value = internalValue ?? hsbToHex(color);
 
   const valueForDisplay = value.replace('#', '').toUpperCase();
@@ -53,7 +52,6 @@ function TextField({color, fullWidth, onChange}: TextFieldProps) {
     const colorHasChanged = coercedValue !== hsbToHex(color);
 
     if (colorHasChanged) {
-      ignoreChangeRef.current = true;
       onChange({...rgbToHsb(hexToRgb(coercedValue)), alpha: 1});
     }
   }, [value, onChange, color]);

--- a/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/ColorPicker/components/TextField/TextField.tsx
@@ -18,15 +18,14 @@ interface Color extends HSBColor {
   alpha?: HSBAColor['alpha'];
 }
 
-// TODO Move the types to here and extend it on ColorPicker
-interface TextFieldProps {
-  /** The currently selected color (coming from parent) */
+export interface TextFieldProps {
+  /** The currently selected color */
   color: Color;
-  /** Allow user to select an alpha value (coming from parent) */
+  /** Allow user to select an alpha value */
   allowAlpha?: boolean;
-  /** Allow HuePicker to take the full width (coming from parent) */
+  /** Allow HuePicker to take the full width */
   fullWidth?: boolean;
-  /** Callback when color is selected (coming from Parent) */
+  /** Callback when color is selected */
   onChange(color: HSBAColor): void;
 }
 

--- a/polaris-react/src/components/ColorPicker/components/TextField/index.ts
+++ b/polaris-react/src/components/ColorPicker/components/TextField/index.ts
@@ -1,1 +1,2 @@
 export {TextField} from './TextField';
+export type {TextFieldProps} from './TextField';

--- a/polaris-react/src/components/ColorPicker/components/TextField/index.ts
+++ b/polaris-react/src/components/ColorPicker/components/TextField/index.ts
@@ -1,0 +1,1 @@
+export {TextField} from './TextField';

--- a/polaris-react/src/components/ColorPicker/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/ColorPicker/components/TextField/tests/TextField.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {TextField as PolarisTextField} from '../../../../TextField';
+import {TextField} from '../TextField';
+import styles from '../TextField.scss';
+
+const BLUE = {
+  hsl: {
+    hue: 240,
+    brightness: 1,
+    saturation: 1,
+  },
+  hex: '0000FF',
+};
+
+const RED = {
+  hsl: {
+    hue: 0,
+    brightness: 1,
+    saturation: 1,
+  },
+  hex: 'FF0000',
+};
+
+describe('<TextField />', () => {
+  it('shows the hex color and `#` as prefix inside the input field', () => {
+    const textField = mountWithApp(
+      <TextField color={BLUE.hsl} onChange={noop} />,
+    );
+    expect(textField).toContainReactComponent(PolarisTextField, {
+      value: BLUE.hex,
+      prefix: '#',
+      placeholder: BLUE.hex,
+    });
+  });
+
+  describe('styles/classes', () => {
+    it('does not apply fullWidth styles based on props', () => {
+      const textField = mountWithApp(
+        <TextField color={BLUE.hsl} onChange={noop} />,
+      );
+      expect(textField.find('div')?.props.className).not.toMatch(
+        styles.fullWidth,
+      );
+    });
+
+    it('applies fullWidth styles based on props', () => {
+      const textField = mountWithApp(
+        <TextField color={RED.hsl} onChange={noop} fullWidth />,
+      );
+      expect(textField.find('div')?.props.className).toMatch('fullWidth');
+    });
+  });
+});
+
+function noop() {}

--- a/polaris-react/src/components/ColorPicker/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/ColorPicker/components/TextField/tests/TextField.test.tsx
@@ -40,7 +40,7 @@ describe('<TextField />', () => {
       const textField = mountWithApp(
         <TextField color={BLUE.hsl} onChange={noop} />,
       );
-      expect(textField.find('div')?.props.className).not.toMatch(
+      expect(textField.find('div')!.props.className).not.toMatch(
         styles.fullWidth,
       );
     });
@@ -49,8 +49,29 @@ describe('<TextField />', () => {
       const textField = mountWithApp(
         <TextField color={RED.hsl} onChange={noop} fullWidth />,
       );
-      expect(textField.find('div')?.props.className).toMatch('fullWidth');
+      expect(textField.find('div')!.props.className).toMatch('fullWidth');
     });
+  });
+
+  it('allows users to type a hex color', () => {
+    const onChangeSpy = jest.fn();
+    const textField = mountWithApp(
+      <TextField color={BLUE.hsl} onChange={onChangeSpy} fullWidth />,
+    );
+    expect(textField.find('input')!.props.value).toBe(BLUE.hex);
+    expect(onChangeSpy).not.toHaveBeenCalled();
+    textField.find(PolarisTextField)!.trigger('onChange', RED.hex);
+    expect(onChangeSpy).toHaveBeenCalledWith({...RED.hsl, alpha: 1});
+  });
+
+  it('does not call onChange callback if the input is not a valid hex color', () => {
+    const onChangeSpy = jest.fn();
+    const textField = mountWithApp(
+      <TextField color={BLUE.hsl} onChange={onChangeSpy} fullWidth />,
+    );
+    expect(onChangeSpy).not.toHaveBeenCalled();
+    textField.find(PolarisTextField)!.trigger('onChange', 'invalid');
+    expect(onChangeSpy).not.toHaveBeenCalledWith();
   });
 });
 

--- a/polaris-react/src/components/ColorPicker/components/index.ts
+++ b/polaris-react/src/components/ColorPicker/components/index.ts
@@ -3,3 +3,5 @@ export * from './AlphaPicker';
 export * from './HuePicker';
 
 export * from './Slidable';
+
+export * from './TextField';

--- a/polaris-react/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/polaris-react/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -89,9 +89,9 @@ describe('<ColorPicker />', () => {
   });
 
   describe('TextField', () => {
-    it('shows the TextField when `showHexTextField` is true', () => {
+    it('shows the TextField when `showTextField` is true', () => {
       const colorPicker = mountWithApp(
-        <ColorPicker color={red} onChange={jest.fn()} showHexTextField />,
+        <ColorPicker color={red} onChange={jest.fn()} showTextField />,
       );
 
       expect(colorPicker).toContainReactComponent(TextField, {color: red});
@@ -102,7 +102,7 @@ describe('<ColorPicker />', () => {
         <ColorPicker
           color={red}
           onChange={jest.fn()}
-          showHexTextField
+          showTextField
           allowAlpha
         />,
       );
@@ -114,7 +114,7 @@ describe('<ColorPicker />', () => {
       it("is called when TextField's onChange is triggered", () => {
         const spy = jest.fn();
         const colorPicker = mountWithApp(
-          <ColorPicker color={red} onChange={spy} showHexTextField />,
+          <ColorPicker color={red} onChange={spy} showTextField />,
         );
 
         colorPicker.find('input')!.trigger('onChange', {
@@ -127,7 +127,7 @@ describe('<ColorPicker />', () => {
       it("is not called TextField's onChange is triggered", () => {
         const spy = jest.fn();
         const colorPicker = mountWithApp(
-          <ColorPicker color={red} onChange={spy} showHexTextField />,
+          <ColorPicker color={red} onChange={spy} showTextField />,
         );
 
         colorPicker.find('input')!.trigger('onChange', {
@@ -161,7 +161,7 @@ describe('<ColorPicker />', () => {
 
     it('is passed down to TextField', () => {
       const colorPicker = mountWithApp(
-        <ColorPicker color={red} onChange={jest.fn()} showHexTextField />,
+        <ColorPicker color={red} onChange={jest.fn()} showTextField />,
       );
 
       expect(colorPicker).toContainReactComponent(TextField, {color: red});

--- a/polaris-react/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/polaris-react/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -3,13 +3,19 @@ import {mountWithApp} from 'tests/utilities';
 
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../../EventListener';
-import {Slidable, AlphaPicker} from '../components';
+import {Slidable, AlphaPicker, TextField} from '../components';
 import {ColorPicker} from '../ColorPicker';
 
 const red = {
   hue: 0,
   saturation: 1,
   brightness: 1,
+};
+
+const blue = {
+  hue: 240,
+  brightness: 1,
+  saturation: 1,
 };
 
 describe('<ColorPicker />', () => {
@@ -82,6 +88,57 @@ describe('<ColorPicker />', () => {
     });
   });
 
+  describe('TextField', () => {
+    it('shows the TextField when `showHexTextField` is true', () => {
+      const colorPicker = mountWithApp(
+        <ColorPicker color={red} onChange={jest.fn()} showHexTextField />,
+      );
+
+      expect(colorPicker).toContainReactComponent(TextField, {color: red});
+    });
+
+    it('does not show TextField when `allowAlpha` is true', () => {
+      const colorPicker = mountWithApp(
+        <ColorPicker
+          color={red}
+          onChange={jest.fn()}
+          showHexTextField
+          allowAlpha
+        />,
+      );
+
+      expect(colorPicker).not.toContainReactComponent(TextField);
+    });
+
+    describe('onChange', () => {
+      it("is called when TextField's onChange is triggered", () => {
+        const spy = jest.fn();
+        const colorPicker = mountWithApp(
+          <ColorPicker color={red} onChange={spy} showHexTextField />,
+        );
+
+        colorPicker.find('input')!.trigger('onChange', {
+          currentTarget: {value: '0000FF'},
+        });
+
+        expect(spy).toHaveBeenCalledWith({...blue, alpha: 1});
+      });
+
+      it("is not called TextField's onChange is triggered", () => {
+        const spy = jest.fn();
+        const colorPicker = mountWithApp(
+          <ColorPicker color={red} onChange={spy} showHexTextField />,
+        );
+
+        colorPicker.find('input')!.trigger('onChange', {
+          currentTarget: {value: 'invalid'},
+        });
+
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('id', () => {
     it('is passed down to the first child', () => {
       const id = 'MyID';
@@ -100,6 +157,14 @@ describe('<ColorPicker />', () => {
       );
 
       expect(colorPicker).toContainReactComponent(AlphaPicker, {color: red});
+    });
+
+    it('is passed down to TextField', () => {
+      const colorPicker = mountWithApp(
+        <ColorPicker color={red} onChange={jest.fn()} showHexTextField />,
+      );
+
+      expect(colorPicker).toContainReactComponent(TextField, {color: red});
     });
   });
 

--- a/polaris-react/src/utilities/color-transformers.ts
+++ b/polaris-react/src/utilities/color-transformers.ts
@@ -301,10 +301,3 @@ export function colorToHsla(color: string): HSLAColor {
       );
   }
 }
-
-export function expandHex(hex: string) {
-  if (hex.length === 4) {
-    return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
-  }
-  return hex;
-}

--- a/polaris-react/src/utilities/color-transformers.ts
+++ b/polaris-react/src/utilities/color-transformers.ts
@@ -301,3 +301,10 @@ export function colorToHsla(color: string): HSLAColor {
       );
   }
 }
+
+export function expandHex(hex: string) {
+  if (hex.length === 4) {
+    return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  return hex;
+}

--- a/polaris-react/src/utilities/color-validation.ts
+++ b/polaris-react/src/utilities/color-validation.ts
@@ -1,5 +1,7 @@
 import type {RGBColor, RGBAColor} from './color-types';
 
+const IS_HEX_STRING_REGEX = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i;
+
 // implements: https://www.w3.org/WAI/ER/WD-AERT/#color-contrast
 export function isLight({red, green, blue}: RGBColor | RGBAColor): boolean {
   const contrast = (red * 299 + green * 587 + blue * 114) / 1000;
@@ -8,4 +10,8 @@ export function isLight({red, green, blue}: RGBColor | RGBAColor): boolean {
 
 export function isDark(color: RGBColor | RGBAColor): boolean {
   return !isLight(color);
+}
+
+export function isHexString(value: string) {
+  return IS_HEX_STRING_REGEX.test(value);
 }

--- a/polaris-react/src/utilities/color-validation.ts
+++ b/polaris-react/src/utilities/color-validation.ts
@@ -1,6 +1,6 @@
 import type {RGBColor, RGBAColor} from './color-types';
 
-const IS_HEX_STRING_REGEX = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i;
+const IS_HEX_STRING_REGEX = /(^#[0-9A-F]{6}$)/i;
 
 // implements: https://www.w3.org/WAI/ER/WD-AERT/#color-contrast
 export function isLight({red, green, blue}: RGBColor | RGBAColor): boolean {

--- a/polaris.shopify.com/content/components/color-picker/index.md
+++ b/polaris.shopify.com/content/components/color-picker/index.md
@@ -25,8 +25,8 @@ examples:
     title: With transparent value full width
     description: Use when attached to a visual builder to allow the designated object to have a transparent background that allows underlying objects to show through.
   - fileName: color-picker-with-hex-color-text-field.tsx
-    title: With text field for color code
-    description: Use to allow merchants to type a color code.
+    title: With text field for color code (HEX)
+    description: Use to allow merchants to type a color code (HEX).
 ---
 
 ## Best practices

--- a/polaris.shopify.com/content/components/color-picker/index.md
+++ b/polaris.shopify.com/content/components/color-picker/index.md
@@ -24,6 +24,9 @@ examples:
   - fileName: color-picker-with-transparent-value-full-width.tsx
     title: With transparent value full width
     description: Use when attached to a visual builder to allow the designated object to have a transparent background that allows underlying objects to show through.
+  - fileName: color-picker-with-hex-color-text-field.tsx
+    title: With text field for color code
+    description: Use to allow merchants to type a color code.
 ---
 
 ## Best practices

--- a/polaris.shopify.com/pages/examples/color-picker-with-hex-color-text-field.tsx
+++ b/polaris.shopify.com/pages/examples/color-picker-with-hex-color-text-field.tsx
@@ -1,0 +1,16 @@
+import {ColorPicker} from '@shopify/polaris';
+import {useState} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function ColorPickerWithTransparentValueExample() {
+  const [color, setColor] = useState({
+    hue: 300,
+    brightness: 1,
+    saturation: 0.7,
+    alpha: 0.7,
+  });
+
+  return <ColorPicker onChange={setColor} color={color} showHexTextField />;
+}
+
+export default withPolarisExample(ColorPickerWithTransparentValueExample);

--- a/polaris.shopify.com/pages/examples/color-picker-with-hex-color-text-field.tsx
+++ b/polaris.shopify.com/pages/examples/color-picker-with-hex-color-text-field.tsx
@@ -10,7 +10,7 @@ function ColorPickerWithTransparentValueExample() {
     alpha: 0.7,
   });
 
-  return <ColorPicker onChange={setColor} color={color} showHexTextField />;
+  return <ColorPicker onChange={setColor} color={color} showTextField />;
 }
 
 export default withPolarisExample(ColorPickerWithTransparentValueExample);

--- a/polaris.shopify.com/src/data/props.json
+++ b/polaris.shopify.com/src/data/props.json
@@ -3998,9 +3998,9 @@
         "deprecated": false
       },
       {
-        "name": "showHexTextField",
+        "name": "showTextField",
         "type": "boolean",
-        "comment": "Displays a text field that accepts colors code (HEX). Only available if `allowAlpha` is false",
+        "comment": "Displays a text field that accepts colors code. Only available if `allowAlpha` is false",
         "optional": true,
         "deprecated": false
       }

--- a/polaris.shopify.com/src/data/props.json
+++ b/polaris.shopify.com/src/data/props.json
@@ -3996,6 +3996,13 @@
         "comment": "Callback when color is selected",
         "optional": false,
         "deprecated": false
+      },
+      {
+        "name": "showHexTextField",
+        "type": "boolean",
+        "comment": "Displays a text field that accepts colors code (HEX). Only available if `allowAlpha` is false",
+        "optional": true,
+        "deprecated": false
       }
     ]
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #6656

There are around 8 projects in Shopify that extends the current ColorPicker implementation to support a text field that users can type color code (mainly hex colors). This PR aims to introduce this functionality.

Here is a click through video to show case the component:

https://user-images.githubusercontent.com/3033781/187452578-ad8d4e10-4337-492b-b9ef-356f56cf5049.mp4

I've used the Playground to to simulate a few scenarios, in the order showed in the video:

1. Start showing the default use case is still the same
2. Enable/disable the `showTextField` prop highlighting that both the text field  and the color preview show up using the current color as value
3. Enabled `allowAlpha` to show that it has priority over the `showTextField` one and hides the field (**Reason**: I am not quite sure how to handle alpha in HEX color code, so I decided to leave it out for now and improve that in the future.)
4. Enabled `fullWidth` to show that the new fields adapt their width to follow the other components of ColorPicker
5. Changed the text to show that the color in the preview, `HuePicker` and `Slidable` adjusts according to what was typed (if the text is a valid HEX code)
6. Used the slider to show that the text and the square color preview update accordingly
7. Clicked in the color buttons created to show case that in case the property changes, the component behaves well and updates all sub-components accordingly

### WHAT is this pull request doing?

📦  The changes are introduced as `minor`, since it is adding a new functionality
🆕  Introduced a new property called `showTextField` that defaults to `false`. The property defines whether or not the input will be displayed.
💅  Added CSS calculation to define who big the text field should be based on `Slidable` and `HuePicker` size
💅  Added a square div to preview the selected color by the left side of the text field
🎨  Added 2 stories to show-case the textfield (normal size and full width)
🔍  Added Typescript validations to not allow `allowAlpha` and `showTextField` both together. **Reason**: Please check item 3 above.
🤖  Wrote tests to cover all functionalities (both TextField and ColorPicker)
📄  Updated `polaris.shopify.com` to list the new use-case and the new property created
🎨  The UI was based on the definition on my team (Shopify Forms) and here is the link for [Figma](https://www.figma.com/file/QA9F9pKBAsDbHy3VVqZH1n/Forms---Overlay-Form-(Build)?node-id=743%3A24459)


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {ColorPicker, Page} from '../src';

export function Playground() {
  const [fullWidth, setFullWidth] = React.useState(false);
  const [allowAlpha, setAllowAlpha] = React.useState(false);
  const [showHexTextField, setShowHexTextField] = React.useState(false);
  const [color, setColor] = React.useState({
    hue: 120,
    brightness: 1,
    saturation: 1,
  });

  return (
    <Page title="Playground">
      <div style={{marginBottom: 12}}>
        <div>
          <input
            type="checkbox"
            id="fullWidth"
            name="fullWidth"
            checked={fullWidth}
            onChange={() => setFullWidth(!fullWidth)}
          />
          <label htmlFor="fullWidth">fullWidth</label>
        </div>
        <div>
          <input
            type="checkbox"
            id="allowAlpha"
            name="allowAlpha"
            checked={allowAlpha}
            onChange={() => setAllowAlpha(!allowAlpha)}
          />
          <label htmlFor="allowAlpha">allowAlpha</label>
        </div>
        <div>
          <input
            type="checkbox"
            id="showHexTextField"
            name="showHexTextField"
            checked={showHexTextField}
            onChange={() => setShowHexTextField(!showHexTextField)}
          />
          <label htmlFor="showHexTextField">showHexTextField</label>
        </div>
      </div>
      <div style={{display: 'flex', marginBottom: 24}}>
        <button
          onClick={() =>
            setColor({
              hue: 0,
              brightness: 1,
              saturation: 1,
            })
          }
        >
          Red
        </button>
        <button
          onClick={() =>
            setColor({
              hue: 120,
              brightness: 1,
              saturation: 1,
            })
          }
        >
          Green
        </button>
        <button
          onClick={() =>
            setColor({
              hue: 240,
              brightness: 1,
              saturation: 1,
            })
          }
        >
          blue
        </button>
      </div>

      <ColorPicker
        color={color}
        onChange={(newColor) => {
          console.log('newColor', newColor);
          setColor(newColor);
        }}
        fullWidth={fullWidth}
        allowAlpha={allowAlpha}
        showHexTextField={showHexTextField}
      />
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
  - used mobile simulator on chrome
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
  - Chrome latest
  - Safari latest
  - Firefox latest
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
  - Updated storybook
  - Updated `polaris.shopify.com`
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide