### PR TITLE
Rename SearchResults component so it doesn't use the same name as the type

### DIFF
--- a/.changeset/funny-tables-develop.md
+++ b/.changeset/funny-tables-develop.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Renamed SearchResults component in GlobalSearch.tsx

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
@@ -200,7 +200,7 @@ function GlobalSearch() {
               aria-label="Search results"
             >
               {searchResults && (
-                <SearchResults
+                <SearchResultsList
                   searchResults={searchResults}
                   currentItemId={currentItemId}
                 />
@@ -213,7 +213,7 @@ function GlobalSearch() {
   );
 }
 
-function SearchResults({
+function SearchResultsList({
   searchResults,
   currentItemId,
 }: {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

While working on [adding a page to our coverage website](https://github.com/Shopify/polaris-coverage-shopifycloud-com/pull/106), I got an error from babel/parser saying that the `SearchResults` identifier was declared more than once in the `GlobalSearch.tsx` file

And looking in the file, babel is right! Look at line 6 and line 216

### WHAT is this pull request doing?

I renamed the component from `SearchResults` to `SearchResultsList`. I'm not really good at naming things, so feel free to suggest a better one :)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
