### PR TITLE
Load example styles from a non-404 unpkg url

### DIFF
--- a/.changeset/grumpy-plants-cross.md
+++ b/.changeset/grumpy-plants-cross.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Load example styles without relying on the @latest npm tag to avoid errors when that tag goes away.

--- a/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
+++ b/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
@@ -4,7 +4,7 @@ import {ComponentType} from 'react';
 import styles from './PolarisExampleWrapper.module.scss';
 
 const stylesheetHref =
-  'https://unpkg.com/@shopify/polaris@latest/build/esm/styles.css';
+  'https://unpkg.com/@shopify/polaris/build/esm/styles.css';
 
 export const withPolarisExample = (Component: ComponentType) => {
   const PolarisHOC = (props: any) => {


### PR DESCRIPTION
### WHY are these changes introduced?

Examples are not working due to the unpkg @latest tag not loading.

### WHAT is this pull request doing?

Remove the @latest from unpkg url, letting it automatically calculate the `v10.0.0` (currently) version.


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
