### PR TITLE
[useIndexResourceState] - Improves the hook to support removing selected items from `selectedResources`

### DIFF
--- a/.changeset/green-guests-divide.md
+++ b/.changeset/green-guests-divide.md
@@ -3,4 +3,4 @@
 ---
 
 - Improved the `useIndexResourceState` hook by exposing a new function called `removeSelectedResources`
-- The purpose of the `removeSelectedResources` function is to remove one or more items from the `selectedResources` state
+- The `removeSelectedResources` function supports removing one or more items from the `selectedResources` state

--- a/.changeset/green-guests-divide.md
+++ b/.changeset/green-guests-divide.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': major
+---
+
+- Improved the `useIndexResourceState` hook by exposing a new function called `removeSelectedResources`
+- The purpose of the `removeSelectedResources` function is to remove one or more items from the `selectedResources` state

--- a/polaris-react/src/utilities/tests/use-index-resource-state.test.tsx
+++ b/polaris-react/src/utilities/tests/use-index-resource-state.test.tsx
@@ -14,6 +14,9 @@ interface TypedChildProps {
   selectedResources: ReturnType<
     typeof useIndexResourceState
   >['selectedResources'];
+  removeSelectedResources: ReturnType<
+    typeof useIndexResourceState
+  >['removeSelectedResources'];
 }
 
 describe('useIndexResourceState', () => {
@@ -28,14 +31,19 @@ describe('useIndexResourceState', () => {
     resources?: T[];
     options?: Parameters<typeof useIndexResourceState>[1];
   }) {
-    const {selectedResources, allResourcesSelected, handleSelectionChange} =
-      useIndexResourceState(resources, options);
+    const {
+      selectedResources,
+      allResourcesSelected,
+      handleSelectionChange,
+      removeSelectedResources,
+    } = useIndexResourceState(resources, options);
 
     return (
       <TypedChild
         onClick={handleSelectionChange}
         selectedResources={selectedResources}
         allResourcesSelected={allResourcesSelected}
+        removeSelectedResources={removeSelectedResources}
       />
     );
   }
@@ -47,14 +55,19 @@ describe('useIndexResourceState', () => {
     resources?: T[];
     options?: Parameters<typeof useIndexResourceState>[1];
   }) {
-    const {selectedResources, allResourcesSelected, clearSelection} =
-      useIndexResourceState(resources, options);
+    const {
+      selectedResources,
+      allResourcesSelected,
+      clearSelection,
+      removeSelectedResources,
+    } = useIndexResourceState(resources, options);
 
     return (
       <TypedChild
         onClick={clearSelection}
         selectedResources={selectedResources}
         allResourcesSelected={allResourcesSelected}
+        removeSelectedResources={removeSelectedResources}
       />
     );
   }
@@ -502,6 +515,29 @@ describe('useIndexResourceState', () => {
 
       expect(mockComponent).toContainReactComponent(TypedChild, {
         selectedResources: [],
+      });
+    });
+  });
+
+  describe('removeSelectedResources', () => {
+    it('removes the selection correctly', () => {
+      const idOne = '1';
+      const idTwo = '2';
+      const idThree = '3';
+      const resources = [{id: idOne}, {id: idTwo}, {id: idThree}];
+      const mockComponent = mountWithApp(
+        <MockClearComponent
+          resources={resources}
+          options={{selectedResources: [idOne, idTwo, idThree]}}
+        />,
+      );
+
+      mockComponent
+        .find(TypedChild)!
+        .trigger('removeSelectedResources', [idTwo]);
+
+      expect(mockComponent).toContainReactComponent(TypedChild, {
+        selectedResources: [idOne, idThree],
       });
     });
   });

--- a/polaris-react/src/utilities/use-index-resource-state.ts
+++ b/polaris-react/src/utilities/use-index-resource-state.ts
@@ -124,10 +124,28 @@ export function useIndexResourceState<T extends {[key: string]: unknown}>(
     setAllResourcesSelected(false);
   }, []);
 
+  const removeSelectedResources = useCallback(
+    (removeResources: string[]) => {
+      const selectedResourcesCopy = [...selectedResources];
+
+      const newSelectedResources = selectedResourcesCopy.filter(
+        (resource) => !removeResources.includes(resource),
+      );
+
+      setSelectedResources(newSelectedResources);
+
+      if (newSelectedResources.length === 0) {
+        setAllResourcesSelected(false);
+      }
+    },
+    [selectedResources],
+  );
+
   return {
     selectedResources,
     allResourcesSelected,
     handleSelectionChange,
     clearSelection,
+    removeSelectedResources,
   };
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

<!-- link to issue if one exists -->
Closes: https://github.com/Shopify/polaris/issues/7063

<!--
  Context about the problem that’s being addressed.
-->

P.S.: This is my first time contributing to the `Polaris` repo. I have tried to follow the contributions README, but if I have missed a step, please let me know (thank you!!).

As part of the product tax categories project, merchants have the ability to change a product category assigned to a product before clicking the in-line save button. Once saved, the product is removed from the `<IndexTable />`. However, if this product was checked off prior to removal, the count of products `selected` in the `<IndexTable />` would not update. 

This count of products is managed by the `selectedResources` state which is exposed from the `useIndexResourceState` hook. Currently, there is no way to mutate the state of `selectedResources` to manually remove specific items from the array, resulting in an inaccurate count of items selected. Refer to the demo of the issue below.

**Demo of the issue**

[Issue demo](https://user-images.githubusercontent.com/62807600/187731606-22a37cf4-0c52-4af5-a62d-7debe4c3652f.mov)

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR creates a new function called `removeSelectedResources` which is exposed by the `useIndexResourceState` hook. This new function accepts an array of items to remove as an argument. The function manipulates the `selectedResources` state by removing the items passed in as an argument. Refer to the demo of the fix below.

**Demo of the fix**

[Fix demo](https://user-images.githubusercontent.com/62807600/187732521-416189f6-4e4c-4e0f-a03d-e35295773eb1.mov)

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

To tophat the fix for this, perform the following steps:

1. Copy-page the code below into <code>playground/Playground.tsx</code> 

<details>
<summary>Playground code</summary>

```jsx
import React from 'react';

import {Button, IndexTable, Page, useIndexResourceState} from '../src';

const productsFixture = [
  {
    id: 'gid://shopify/Product/1',
    title: 'Aerodynamic Granite Shoes',
  },
  {
    id: 'gid://shopify/Product/2',
    title: 'Aerodynamic Bronze Car',
  },
  {
    id: 'gid://shopify/Product/3',
    title: 'Durable Steel Wallet',
  },
  {
    id: 'gid://shopify/Product/4',
    title: 'Ergonomic Marble Watch',
  },
  {
    id: 'gid://shopify/Product/5',
    title: 'Gorgeous Silk Plate',
  },
];

export function Playground() {
  const [products, setProducts] = React.useState(productsFixture);

  const {selectedResources, removeSelectedResources, handleSelectionChange} =
    useIndexResourceState<{[key: string]: any}>(products);

  const rowMarkup = products.map((product, index) => (
    <IndexTable.Row
      id={product.id}
      key={product.id}
      selected={selectedResources.includes(product.id)}
      position={index}
    >
      <IndexTable.Cell>{product.title}</IndexTable.Cell>
      <IndexTable.Cell>
        <div onClick={(event: any) => event.stopPropagation()}>
          <Button
            onClick={() => {
              const newProducts = products.filter(
                (prod) => prod.id !== product.id,
              );
              setProducts(newProducts);
              removeSelectedResources([product.id]);
            }}
          >
            Remove product
          </Button>
        </div>
      </IndexTable.Cell>
    </IndexTable.Row>
  ));

  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <IndexTable
        headings={[{title: 'Product'}, {title: 'Actions', hidden: true}]}
        promotedBulkActions={[{content: 'bulk action'}]}
        itemCount={products.length}
        onSelectionChange={handleSelectionChange}
        selectedItemsCount={selectedResources.length}
      >
        {rowMarkup}
      </IndexTable>
    </Page>
  );
}
```

</details>

2. Refer to the demo of the fix video above and replicate the actions performed

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
