### PR TITLE
Add approval guidance to releasing documentation

### DIFF
--- a/documentation/Releasing.md
+++ b/documentation/Releasing.md
@@ -12,7 +12,7 @@ To perform a release:
 - Comment `/snapit` in the **"Version Packages"** PR to cut a snapshot release
 - Create a draft pull request in `Shopify/web` for the upgrade using the snapshot
   - Tag all contributors to the release on the `Shopify/web` pull request and also create a group message tagging all contributors to nudge them for reviews, as well as to verify the changes within `Shopify/web` work as expected.
-- Once CI passes, merge the **"Version Packages"** PR
+- Once CI passes, and you've received an approval from [@Shopify/polaris-team](https://github.com/orgs/Shopify/teams/polaris-team), merge the **"Version Packages"** PR
 - Once the release is available in npm, update the draft PR to the new version and request review from the folks whose changes are part of the release as listed in the release notes
 
 ## Snapshot Release


### PR DESCRIPTION
### WHY are these changes introduced?

My team was following the release guide today and didn't realize we should receive an explicit approval for merging in the "Version Packages". This makes the instructions a bit more clear for anyone who doesn't release Polaris very often (or for their first time!)

### WHAT is this pull request doing?

Updating the docs

### How to 🎩

Read it, check for content and typos, etc.

### 🎩 checklist

- 🚫 Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- 🚫 Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- 🚫 Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- 🚫 Updated the component's `README.md` with documentation changes
- 🚫 [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
