### PR TITLE
Run gen-assets on build

### DIFF
--- a/.changeset/three-donuts-taste.md
+++ b/.changeset/three-donuts-taste.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Run gen-assets on build of website

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -3,7 +3,7 @@
   "version": "0.14.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "yarn gen-assets && next build",
     "dev": "open http://localhost:3000 && next dev",
     "start": "next start",
     "lint": "run-p lint:*",


### PR DESCRIPTION
- [x] Uses turborepo monorepo build order to gurantee that icons/tokens/polairs-react is built before generating assets
- [x] Unblocks the odd double build behaviour in [site-container-builder to just go back to one build](https://github.com/Shopify/polaris-site-container-builder/blob/048858a84b3c5668a8d52102bf88c843554a4b18/.shopify-build/polaris-site-container-builder-production-builder.yml#L11-L18)

The downside is that building the monorepo will be a little bit slower.