### PR TITLE
Add whats new section for typography page

### DIFF
--- a/.changeset/nine-donkeys-scream.md
+++ b/.changeset/nine-donkeys-scream.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Add whats new section for typography page

--- a/polaris.shopify.com/content/whats-new/version-10-typography/index.md
+++ b/polaris.shopify.com/content/whats-new/version-10-typography/index.md
@@ -1,5 +1,5 @@
 ---
-title: Polaris typography updates
+title: Version 10 Typography
 description: Learn about what changes are coming to Polaris typography.
 keywords:
   - typography

--- a/polaris.shopify.com/pages/whats-new/[slug].tsx
+++ b/polaris.shopify.com/pages/whats-new/[slug].tsx
@@ -1,0 +1,72 @@
+import type {GetStaticPaths, GetStaticProps, NextPage} from 'next';
+import fs from 'fs';
+import path from 'path';
+import globby from 'globby';
+
+import Layout from '../../src/components/Layout';
+import Longform from '../../src/components/Longform';
+import Markdown from '../../src/components/Markdown';
+import PageMeta from '../../src/components/PageMeta';
+import {parseMarkdown} from '../../src/utils/markdown.mjs';
+import {MarkdownFile} from '../../src/types';
+
+interface Props {
+  readme: MarkdownFile['readme'];
+  title: string;
+  description?: string;
+}
+
+const whatsnewDir = path.join(process.cwd(), 'content/whats-new');
+
+const WhatsNew: NextPage<Props> = ({readme, title, description}: Props) => {
+  return (
+    <Layout title={title}>
+      <PageMeta title={title} description={description} />
+
+      <Longform>
+        {description ? <Markdown text={description} /> : null}
+        <Markdown text={readme} />
+      </Longform>
+    </Layout>
+  );
+};
+
+export const getStaticProps: GetStaticProps<Props, {slug: string}> = async ({
+  params,
+}) => {
+  const mdFilePath = path.resolve(
+    process.cwd(),
+    `${whatsnewDir}/${params?.slug || ''}/index.md`,
+  );
+
+  if (fs.existsSync(mdFilePath)) {
+    const markdown = fs.readFileSync(mdFilePath, 'utf-8');
+    const {readme, frontMatter}: MarkdownFile = parseMarkdown(markdown);
+    const {title, description} = frontMatter;
+    const props: Props = {
+      title,
+      description: description || null,
+      readme,
+    };
+
+    return {props};
+  } else {
+    return {notFound: true};
+  }
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const globPath = path.resolve(process.cwd(), 'content/whats-new/*/*.md');
+  const paths = globby.sync(globPath).map((fileName: string) => {
+    return fileName
+      .replace(`${process.cwd()}/content`, '')
+      .replace('/index.md', '');
+  });
+
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export default WhatsNew;


### PR DESCRIPTION
No top level navigation but can be viewed and shared at /whats-new/version-10-typography

![localhost_3000_whats-new_version-10-typography (1)](https://user-images.githubusercontent.com/19199063/188071748-680eca37-1907-4f87-83a3-74c17f0a9282.png)
