### PR TITLE
[Layout foundations] Remove `display` from `Box` root styling

### DIFF
--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -62,7 +62,7 @@
     "preversion": "node ./scripts/readme-update-version"
   },
   "dependencies": {
-    "@shopify/polaris-icons": "^5.4.0",
+    "@shopify/polaris-icons": "^6.1.0",
     "@shopify/polaris-tokens": "^6.0.0",
     "@types/react": "*",
     "@types/react-dom": "*",

--- a/polaris-react/src/components/Box/Box.scss
+++ b/polaris-react/src/components/Box/Box.scss
@@ -1,5 +1,4 @@
 .Box {
-  display: block;
   background-color: var(--pc-box-background, initial);
   box-shadow: var(--pc-box-shadow, initial);
   /* stylelint-disable declaration-block-no-redundant-longhand-properties */


### PR DESCRIPTION
### WHY are these changes introduced?

Removes `display: block` from the root `.Box` classname.
This was added during the beginning stages of prototyping and is no longer needed.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
