### PR TITLE
Add legacy Sass API migrations

### DIFF
--- a/.changeset/old-badgers-melt.md
+++ b/.changeset/old-badgers-melt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Add legacy Sass API migrations


### PR DESCRIPTION
### WHY are these changes introduced?

- [ ] **TODO:** Add legacy Sass API migrations

Use this PR for adding more legacy Sass API migrations. See the `replace-sass-spacing` migration for and example and template.

This PR can be used to release and test new snapshot releases. Adjust the changeset entry to include newly created Sass migrations.