### PR TITLE
Edit icons documentation

### DIFF
--- a/.changeset/good-trains-teach.md
+++ b/.changeset/good-trains-teach.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+replace mention of polaris-icons site with icons library

--- a/.changeset/good-trains-teach.md
+++ b/.changeset/good-trains-teach.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-replace mention of polaris-icons site with icons library
+Replace mention of polaris-icons site with icons library

--- a/polaris.shopify.com/content/foundations/design/icons/index.md
+++ b/polaris.shopify.com/content/foundations/design/icons/index.md
@@ -65,7 +65,7 @@ The purpose of an icon is to clarify the content by providing a visual cue and i
 
 ### Keep internationalization in mind
 
-Whenever possible, use a universally recognized icon. However, there will be times where only a locally understood icon will work to communicate a concept. When deciding what symbol should be used, check that it will be understood at a glance by people from different cultures and&nbsp;backgrounds.
+Whenever possible, use a universally recognized icon. However, there will be times where only a locally understood icon will work to communicate a concept. When deciding what symbol should be used, check that it will be understood at a glance by people from different cultures and backgrounds.
 
 ---
 
@@ -80,9 +80,7 @@ Icons are commonly used:
 - Inline with text to add clarity
 - To direct attention to something the merchant can take action on
 
-To browse a list of all available icons, visit the [polaris-icons](https://polaris-icons.shopify.com/) site.
-
----
+To browse all available icons, visit the [Icons library](https://polaris.shopify.com/icons).
 
 ## System icons
 


### PR DESCRIPTION
### WHY are these changes introduced?

Icons documentation still references "polaris-icons site," even though that site has now been integrated into polaris.shopify.com. 
<img width="545" alt="Screen Shot 2022-09-07 at 10 34 55 AM" src="https://user-images.githubusercontent.com/77791660/188920108-27653d5f-cf4a-44b9-83a3-61f0455f62be.png">

### WHAT is this pull request doing?
Replace old reference to "polaris-icons site" with "Icons library."
<img width="464" alt="Screen Shot 2022-09-07 at 10 34 16 AM" src="https://user-images.githubusercontent.com/77791660/188919932-abeae88b-8e60-491d-89b8-3a501b6abb84.png">
