### PR TITLE
Fix the `changeset version` from `major` to `minor`

### DIFF
--- a/.changeset/green-guests-divide.md
+++ b/.changeset/green-guests-divide.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris': major
+'@shopify/polaris': minor
 ---
 
 - Improved the `useIndexResourceState` hook by exposing a new function called `removeSelectedResources`


### PR DESCRIPTION
### WHY are these changes introduced?

The `changeset` from this PR https://github.com/Shopify/polaris/pull/7064 classified the change as `major` when it should have been `minor`. This PR is to fix that.