### PR TITLE
[IndexTable] Fix overflowing sticky column

### DIFF
--- a/.changeset/chilled-camels-fail.md
+++ b/.changeset/chilled-camels-fail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix long content on index table's sticky columns hiding the rest of the table

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -89,11 +89,22 @@ $loading-panel-height: 53px;
     filter: drop-shadow(1px 0 0 var(--p-divider));
   }
 
-  // stylelint-disable-next-line selector-max-class, selector-max-combinators
-  .TableCell-first + .TableCell,
-  .TableHeading-second {
-    @media #{$p-breakpoints-sm-up} {
-      filter: drop-shadow(1px 0 0 var(--p-divider));
+  &.Table-sticky {
+    // stylelint-disable-next-line selector-max-class, selector-max-combinators, selector-max-specificity
+    .TableCell-first + .TableCell,
+    .TableHeading-second {
+      @media #{$p-breakpoints-sm-up} {
+        filter: drop-shadow(1px 0 0 var(--p-divider));
+      }
+    }
+
+    // stylelint-disable-next-line selector-max-class
+    &.Table-unselectable {
+      // stylelint-disable-next-line selector-max-class, selector-max-specificity
+      .TableHeading-second,
+      .TableCell:first-child {
+        filter: drop-shadow(1px 0 0 var(--p-divider));
+      }
     }
   }
 
@@ -102,7 +113,6 @@ $loading-panel-height: 53px;
     .TableHeading-second,
     .TableCell:first-child {
       visibility: visible;
-      filter: drop-shadow(1px 0 0 var(--p-divider));
     }
   }
 }
@@ -241,22 +251,8 @@ $loading-panel-height: 53px;
   padding-right: var(--p-space-05);
 }
 
-.TableHeading-second {
-  &:not(.TableHeading-unselectable) {
-    padding-left: 0;
-
-    @media #{$p-breakpoints-sm-up} {
-      position: sticky;
-      z-index: auto;
-      left: 0;
-    }
-  }
-
-  &.TableHeading-unselectable {
-    position: sticky;
-    z-index: auto;
-    left: 0;
-  }
+.TableHeading-second:not(.TableHeading-unselectable) {
+  padding-left: 0;
 }
 
 .TableCell {
@@ -281,19 +277,41 @@ $loading-panel-height: 53px;
 .TableCell-first + .TableCell {
   left: var(--pc-checkbox-offset);
   padding-left: 0;
+}
 
-  @media #{$p-breakpoints-sm-up} {
-    position: sticky;
-    z-index: var(--pc-index-table-sticky-cell);
+.Table-sticky {
+  // stylelint-disable-next-line selector-max-combinators, selector-max-class
+  .TableCell-first + .TableCell {
+    @media #{$p-breakpoints-sm-up} {
+      position: sticky;
+      z-index: var(--pc-index-table-sticky-cell);
+    }
+  }
+
+  .TableHeading-second {
+    &:not(.TableHeading-unselectable) {
+      @media #{$p-breakpoints-sm-up} {
+        position: sticky;
+        z-index: auto;
+        left: 0;
+      }
+    }
+    // stylelint-disable-next-line selector-max-class
+    &.TableHeading-unselectable {
+      position: sticky;
+      z-index: auto;
+      left: 0;
+    }
   }
 }
 
 .Table-unselectable {
-  .TableCell:first-child {
+  // stylelint-disable-next-line selector-max-class, selector-max-specificity
+  &.Table-sticky .TableCell:first-child {
     left: 0;
     background-color: var(--p-surface);
-    position: sticky;
     z-index: var(--pc-index-table-sticky-cell);
+    position: sticky;
   }
 
   .statusSuccess {

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -302,9 +302,14 @@ function IndexTableBase({
             tableHeadings.current.length - 1
           ].getBoundingClientRect().width
         : 0;
+    // Secure some space for the remaining columns to be visible
+    const restOfContentMinWidth = 100;
     setCanFitStickyColumn(
       scrollableRect.width >
-        firstStickyColumnWidth + checkboxColumnWidth + lastStickyColumnWidth,
+        firstStickyColumnWidth +
+          checkboxColumnWidth +
+          lastStickyColumnWidth +
+          restOfContentMinWidth,
     );
   }, [lastColumnSticky, selectable]);
 

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -279,6 +279,41 @@ function IndexTableBase({
     setSmallScreen(smallScreen);
   }, [smallScreen]);
 
+  const [canFitStickyColumn, setCanFitStickyColumn] = useState(true);
+
+  const handleCanFitStickyColumn = useCallback(() => {
+    if (!scrollableContainerElement.current || !tableHeadings.current.length) {
+      return;
+    }
+    const scrollableRect =
+      scrollableContainerElement.current.getBoundingClientRect();
+    const checkboxColumnWidth = selectable
+      ? tableHeadings.current[0].getBoundingClientRect().width
+      : 0;
+    const firstStickyColumnWidth =
+      tableHeadings.current[selectable ? 1 : 0].getBoundingClientRect().width;
+    const lastColumnIsNotTheFirst = selectable
+      ? tableHeadings.current.length > 2
+      : 1;
+    // Don't consider the last column in the calculations if it's not sticky
+    const lastStickyColumnWidth =
+      lastColumnSticky && lastColumnIsNotTheFirst
+        ? tableHeadings.current[
+            tableHeadings.current.length - 1
+          ].getBoundingClientRect().width
+        : 0;
+    setCanFitStickyColumn(
+      scrollableRect.width >
+        firstStickyColumnWidth + checkboxColumnWidth + lastStickyColumnWidth,
+    );
+  }, [lastColumnSticky, selectable]);
+
+  useEffect(() => {
+    if (tableInitialized) {
+      handleCanFitStickyColumn();
+    }
+  }, [handleCanFitStickyColumn, tableInitialized]);
+
   const handleResize = useCallback(() => {
     // hide the scrollbar when resizing
     scrollBarElement.current?.style.setProperty(
@@ -290,11 +325,13 @@ function IndexTableBase({
     debounceResizeTableScrollbar();
     handleCanScrollRight();
     handleIsSmallScreen();
+    handleCanFitStickyColumn();
   }, [
     resizeTableHeadings,
     debounceResizeTableScrollbar,
     handleCanScrollRight,
     handleIsSmallScreen,
+    handleCanFitStickyColumn,
   ]);
 
   const handleScrollContainerScroll = useCallback(
@@ -608,8 +645,12 @@ function IndexTableBase({
     selectMode && styles.disableTextSelection,
     selectMode && shouldShowBulkActions && styles.selectMode,
     !selectable && styles['Table-unselectable'],
-    lastColumnSticky && styles['Table-sticky-last'],
-    lastColumnSticky && canScrollRight && styles['Table-sticky-scrolling'],
+    canFitStickyColumn && styles['Table-sticky'],
+    canFitStickyColumn && lastColumnSticky && styles['Table-sticky-last'],
+    canFitStickyColumn &&
+      lastColumnSticky &&
+      canScrollRight &&
+      styles['Table-sticky-scrolling'],
   );
 
   const emptyStateMarkup = emptyState ? (

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -166,7 +166,7 @@ describe('<IndexTable>', () => {
     );
 
     expect(index).toContainReactComponent('table', {
-      className: 'Table Table-sticky-last',
+      className: 'Table Table-sticky Table-sticky-last',
     });
   });
 
@@ -220,7 +220,7 @@ describe('<IndexTable>', () => {
       scrollContainer!.trigger('onScroll', true, false);
 
       expect(index).toContainReactComponent('table', {
-        className: 'Table Table-scrolling Table-sticky-last',
+        className: 'Table Table-scrolling Table-sticky Table-sticky-last',
       });
     });
   });
@@ -348,7 +348,7 @@ describe('<IndexTable>', () => {
       );
 
       expect(index).toContainReactComponent('table', {
-        className: 'Table Table-sticky-last',
+        className: 'Table Table-sticky Table-sticky-last',
       });
       expect(index).toContainReactComponent('th', {
         children: title,
@@ -374,7 +374,7 @@ describe('<IndexTable>', () => {
       );
 
       expect(index).toContainReactComponent('table', {
-        className: 'Table Table-sticky-last',
+        className: 'Table Table-sticky Table-sticky-last',
       });
       expect(index).toContainReactComponent(VisuallyHidden, {
         children: title,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4012 

When a table column is sticky and bigger than the container (_aka_, causes an overflow) the table width is not calculated properly and the non-sticky columns overlap the sticky one. Check this [pure html reproduction](https://codesandbox.io/s/icy-river-0srh0k?file=/index.html) for a better understanding of the root issue.

Disclaimer: This PR does not fit the _condensed_ mode of the table, which has it's own issues when overflowing

### WHAT is this pull request doing?

The bug does not happen on small screens because the only sticky column in that size is the one with checkboxes, which is small enough to not cause an issue, but when a sticky column has long texts the problem can happen on bigger screens.

To solve it I calculate dynamically the size of the sticky column(s) and apply the sticky styles only when the full width of the table can fit them without an overflow. If the table is narrower than the sticky columns, the small screen styles are applied (only the checkbox remains sticky)

If users do not want this behaviour, they can still apply a `max-width` and `white-space: wrap` to the wider cells or columns, which is the non-official solution to this bug right now (`web` is doing it, in case you want to check that the fix does not affect that setup)

  <details>
    <summary>Fixed table (gif)</summary>
    <img src="https://screenshot.click/index-table-fix-1.gif" alt="Index table with two rows, checkboxes and four more columns. The first column is wider than the table. When scrolling horizontally, only the checkbox remains sticky and the rest of the content scrolls">
  </details>


### 🎩 checklist

[Spin instance
](https://admin.web.web-kf1h.paqui-calabria.eu.spin.dev/store/shop1/)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
