### PR TITLE
Fix async calls to `getCacheJson` script

### DIFF
--- a/.changeset/metal-squids-dream.md
+++ b/.changeset/metal-squids-dream.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed issue where `cache/site.json` wasn't generated

--- a/polaris.shopify.com/scripts/gen-assets.mjs
+++ b/polaris.shopify.com/scripts/gen-assets.mjs
@@ -3,7 +3,8 @@ import genCacheJson from './gen-cache-json.mjs';
 import genOgImages from './gen-og-images.mjs';
 
 const genAssets = async () => {
-  await Promise.all([genSiteMap(), genCacheJson()]);
+  genCacheJson();
+  await genSiteMap();
   await genOgImages();
 };
 

--- a/polaris.shopify.com/scripts/gen-cache-json.mjs
+++ b/polaris.shopify.com/scripts/gen-cache-json.mjs
@@ -88,6 +88,4 @@ const genCacheJson = () => {
   console.log('✅ Generated .cache/nav.json and .cache/site.json');
 };
 
-genCacheJson();
-
 export default genCacheJson;

--- a/polaris.shopify.com/scripts/watch-md.mjs
+++ b/polaris.shopify.com/scripts/watch-md.mjs
@@ -6,7 +6,7 @@ import genCacheJson from './gen-cache-json.mjs';
 const mdPath = path.join(process.cwd(), 'content');
 
 // Run intially
-await genCacheJson();
+genCacheJson();
 
 // Run whenever there is a change to a .md file
-chokidar.watch(mdPath).on('change', async () => await genCacheJson());
+chokidar.watch(mdPath).on('change', genCacheJson);


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #7135.

### WHAT is this pull request doing?

Node checks were failing due to `cache/site.json` not being generated. Fixes any invocation of the `genCacheJson()` function to not use any `await` or `Promise.all()`, as it is not an async function.

<img width="1115" alt="09-49-qo8ve-1tiix" src="https://user-images.githubusercontent.com/26749317/189414177-5e92ee8f-9e8a-456a-9384-a26f9bb1dd47.png">

<!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
