### PR TITLE
Added an example of Hex code TextField to ColorPicker story

### DIFF
--- a/.changeset/happy-boxes-change.md
+++ b/.changeset/happy-boxes-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added an example of Hex code TextField to ColorPicker

--- a/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -66,13 +66,13 @@ export function WithHexTextField() {
       display: 'grid',
       gap: 'var(--p-space-2)',
       gridTemplateColumns: 'auto 1fr',
-      width: 'fit-content',
+      maxWidth: 'fit-content',
     },
     Picker: {
       gridColumn: '1 / 3',
     },
     Tile: {
-      minHeight: '100%',
+      minHeight: 'calc(100% - 0.125rem)',
       aspectRatio: '1 / 1',
       borderRadius: 'var(--p-border-radius-1)',
       border: 'var(--p-border-divider)',

--- a/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,8 +1,7 @@
-import React, {useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   ColorPicker,
-  Stack,
   TextField,
   hsbToHex,
   rgbToHsb,
@@ -48,45 +47,60 @@ export function WithTransparentValueFullWidth() {
 export function WithHexTextField() {
   const [color, setColor] = useState({
     hue: 300,
-    brightness: 1,
     saturation: 0.7,
+    brightness: 1,
   });
+
   const [hex, setHex] = useState(hsbToHex(color));
 
-  const handleBlur = React.useCallback(() => {
+  const handleBlur = useCallback(() => {
     setColor(rgbToHsb(hexToRgb(hex)));
   }, [hex]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setHex(hsbToHex(color));
   }, [color]);
 
+  const styles = {
+    Wrapper: {
+      display: 'grid',
+      gap: 'var(--p-space-2)',
+      gridTemplateColumns: 'auto 1fr',
+      width: 'fit-content',
+    },
+    Picker: {
+      gridColumn: '1 / 3',
+    },
+    Tile: {
+      minHeight: '100%',
+      aspectRatio: '1 / 1',
+      borderRadius: 'var(--p-border-radius-1)',
+      border: 'var(--p-border-divider)',
+      backgroundColor: hsbToHex(color),
+    },
+    TextField: {
+      maxWidth: 'fit-content',
+    },
+  };
+
   return (
-    <>
-      <ColorPicker onChange={setColor} color={color} />
-      <div style={{paddingTop: 8}}>
-        <Stack>
-          <div
-            style={{
-              width: 32,
-              height: 32,
-              borderRadius: 3,
-              border: '1px solid rgba(0, 0, 0, 0.2)',
-              backgroundColor: hsbToHex(color),
-            }}
-          />
-          <div style={{width: 143}}>
-            <TextField
-              label=""
-              prefix="#"
-              value={hex.replace('#', '')}
-              onChange={setHex}
-              onBlur={handleBlur}
-              autoComplete="off"
-            />
-          </div>
-        </Stack>
+    <div style={styles.Wrapper}>
+      <div style={styles.Picker}>
+        <ColorPicker onChange={setColor} color={color} />
       </div>
-    </>
+
+      <div style={styles.Tile} />
+
+      <div style={styles.TextField}>
+        <TextField
+          label=""
+          prefix="#"
+          value={hex.replace('#', '')}
+          onChange={setHex}
+          onBlur={handleBlur}
+          autoComplete="off"
+        />
+      </div>
+    </div>
   );
 }

--- a/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,6 +1,13 @@
 import React, {useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {ColorPicker} from '@shopify/polaris';
+import {
+  ColorPicker,
+  Stack,
+  TextField,
+  hsbToHex,
+  rgbToHsb,
+  hexToRgb,
+} from '@shopify/polaris';
 
 export default {
   component: ColorPicker,
@@ -36,4 +43,50 @@ export function WithTransparentValueFullWidth() {
   });
 
   return <ColorPicker fullWidth onChange={setColor} color={color} allowAlpha />;
+}
+
+export function WithHexTextField() {
+  const [color, setColor] = useState({
+    hue: 300,
+    brightness: 1,
+    saturation: 0.7,
+  });
+  const [hex, setHex] = useState(hsbToHex(color));
+
+  const handleBlur = React.useCallback(() => {
+    setColor(rgbToHsb(hexToRgb(hex)));
+  }, [hex]);
+
+  React.useEffect(() => {
+    setHex(hsbToHex(color));
+  }, [color]);
+
+  return (
+    <>
+      <ColorPicker onChange={setColor} color={color} />
+      <div style={{paddingTop: 8}}>
+        <Stack>
+          <div
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 3,
+              border: '1px solid rgba(0, 0, 0, 0.2)',
+              backgroundColor: hsbToHex(color),
+            }}
+          />
+          <div style={{width: 143}}>
+            <TextField
+              label=""
+              prefix="#"
+              value={hex.replace('#', '')}
+              onChange={setHex}
+              onBlur={handleBlur}
+              autoComplete="off"
+            />
+          </div>
+        </Stack>
+      </div>
+    </>
+  );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #6656

### WHAT is this pull request doing?

![image](https://user-images.githubusercontent.com/6844391/190245922-5893d174-c050-4f68-a014-99004d769445.png)

Added an example of Hex code TextField to ColorPicker story

1. Navigate to [`/?path=/story/all-components-colorpicker--with-hex-text-field`](https://5d559397bae39100201eedc1-misfpaqyvm.chromatic.com/?path=/story/all-components-colorpicker--with-hex-text-field)
2. Use your mouse to change the color
3. Validate if the hex color code is getting updated
4. Change the value in the TextField to a valid hex color
5. Move the focus out of the TextField (blur)
6. Validate if the ColorPickerSelectable in getting updated accordingly

PS: The example does not cover hex color with alpha

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
