### PR TITLE
Add `.cache` dir to Turbo's cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,8 @@
       "dependsOn": []
     },
     "lint": {
-      "outputs": [".eslintcache"]
+      "outputs": [".eslintcache"],
+      "dependsOn": ["^gen-assets"]
     },
     "dev": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "baseBranch": "origin/main",
   "pipeline": {
     "build": {
-      "outputs": ["dist/**", ".next/**", "build/**"],
+      "outputs": ["dist/**", ".next/**", "build/**", ".cache/**"],
       "dependsOn": ["^build"]
     },
     "test": {
@@ -11,8 +11,7 @@
       "dependsOn": []
     },
     "lint": {
-      "outputs": [".eslintcache"],
-      "dependsOn": ["^gen-assets"]
+      "outputs": [".eslintcache"]
     },
     "dev": {
       "cache": false


### PR DESCRIPTION
An attempt at fixing the recent build errors surrounding:

> Cannot find module '../../.cache/site.json' or its corresponding type declarations.

Not sure if this is the right strategy 🤷‍♀️ Tests for this solution have passed 3 times, but it could be a fluke.