### PR TITLE
Bump size limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     {
       "name": "polaris-react-cjs",
       "path": "polaris-react/build/cjs/index.js",
-      "limit": "208 kB"
+      "limit": "209 kB"
     },
     {
       "name": "polaris-react-esm",


### PR DESCRIPTION
### WHY are these changes introduced?
Bumps size-limit for `polaris-react-cjs` from `208kb` to `209kb` to resolve failing CI checks.