### PR TITLE
Include modulo operator for Sass spacing migration

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -19,7 +19,9 @@ module.exports = {
     {
       files: ['polaris-migrator/**/tests/*.{css,scss}'],
       rules: {
-        'declaration-property-value-disallowed-list': 'off',
+        'comment-empty-line-before': undefined,
+        'declaration-property-value-disallowed-list': undefined,
+        'function-disallowed-list': undefined,
       },
     },
   ],

--- a/polaris-migrator/src/constants.ts
+++ b/polaris-migrator/src/constants.ts
@@ -1,0 +1,2 @@
+export const POLARIS_MIGRATOR_COMMENT =
+  "polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually.";

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.output.scss
@@ -7,5 +7,6 @@
 .ButtonContainer {
   right: var(--p-space-4);
   top: var(--p-space-5);
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
   bottom: spacing() + spacing();
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

There was a [missing operator](https://sass-lang.com/documentation/operators/numeric) check in the Sass spacing migration.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR:

1. Checks for  the `%` operator as well as other operators
2. Inserts a comment to help perform manual conversion checks

Example comment output:

```scss
.ButtonContainer {
  right: var(--p-space-4);
  top: var(--p-space-5);
  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
  bottom: spacing() + spacing();
}

```