### PR TITLE
[ProgressBar] Add ariaLabelledBy prop to enhance accessibility

### DIFF
--- a/.changeset/wild-pigs-matter.md
+++ b/.changeset/wild-pigs-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add `ariaLabelledBy` prop to `ProgressBar` component to allow ids of description elements for accessibility

--- a/polaris-react/src/components/ProgressBar/ProgressBar.tsx
+++ b/polaris-react/src/components/ProgressBar/ProgressBar.tsx
@@ -31,6 +31,10 @@ export interface ProgressBarProps {
    * @default 'true'
    */
   animated?: boolean;
+  /**
+   * Id (ids) of element (elements) that describes progressbar
+   */
+  ariaLabelledBy?: string;
 }
 
 export function ProgressBar({
@@ -38,6 +42,7 @@ export function ProgressBar({
   size = 'medium',
   color = 'highlight',
   animated: hasAppearAnimation = true,
+  ariaLabelledBy,
 }: ProgressBarProps) {
   const i18n = useI18n();
 
@@ -63,7 +68,12 @@ export function ProgressBar({
   /* eslint-disable @shopify/jsx-no-hardcoded-content */
   return (
     <div className={className}>
-      <progress className={styles.Progress} value={parsedProgress} max="100" />
+      <progress
+        aria-labelledby={ariaLabelledBy}
+        className={styles.Progress}
+        value={parsedProgress}
+        max="100"
+      />
       <CSSTransition
         in
         appear

--- a/polaris-react/src/components/ProgressBar/tests/ProgressBar.test.tsx
+++ b/polaris-react/src/components/ProgressBar/tests/ProgressBar.test.tsx
@@ -26,6 +26,18 @@ describe('<ProgressBar />', () => {
     expect(progress).toContainReactComponent('progress', {value: 0});
   });
 
+  it('sets the aria-labelledby attribute for progress', () => {
+    const progressBarLabelId = 'label-id';
+
+    const progress = mountWithApp(
+      <ProgressBar ariaLabelledBy={progressBarLabelId} />,
+    );
+
+    expect(progress).toContainReactComponent('progress', {
+      'aria-labelledby': progressBarLabelId,
+    });
+  });
+
   describe('animated prop', () => {
     it('sets the progress bar CSSTransition to have a non-zero timeout value by default', () => {
       const progress = mountWithApp(<ProgressBar progress={20} />);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/72817

While using `ProgressBar` component, we've noticed that we could not label a progress bar which harm the accessibility.

### WHAT is this pull request doing?

We had several options how to improve accessibility which are listed in [the issue](https://github.com/Shopify/web/issues/72817). 

The option of adding `ariaLabelledBy` prop was chosen. It has the following benefits:
- `aria-labelledby` attribute can accept several space-separated `id`s which means we can have more than one element to describe a progress bar
- `aria-labelledby` attribute can even point to a hidden element
- analysing the usage of `ProgressBar` in `web` repo shows that we have different ways how the description for `ProgressBar` was provided. `p`, `span` tags and hidden elements are used. For the future refactoring to make it accessible for screen readers, it would be enough to add `id` attributed to them and pass it to `ProgressBar` component via `ariaLabelledBy` prop. No other changes are needed

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
