### PR TITLE
[Text] Update headingXs variant to use semibold instead of bold

### DIFF
--- a/.changeset/swift-hounds-sniff.md
+++ b/.changeset/swift-hounds-sniff.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated `Text` component to use `semibold` for `headingXs` variant

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -26,7 +26,7 @@ type FontWeight = 'regular' | 'medium' | 'semibold' | 'bold';
 type Color = 'success' | 'critical' | 'warning' | 'subdued';
 
 const VariantFontWeightMapping: {[V in Variant]: FontWeight} = {
-  headingXs: 'bold',
+  headingXs: 'semibold',
   headingSm: 'semibold',
   headingMd: 'semibold',
   headingLg: 'semibold',


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #7169.
Updates the `headingXs` variant to use `semibold` instead of `bold`.

### WHAT is this pull request doing?

Updates the variant font mapping to use `semibold` for the `headingXs` variant.
    <details>
      <summary>Text headingXs variant before</summary>
      <img src="https://user-images.githubusercontent.com/26749317/190215333-2ecc0470-65ff-4753-ba44-866c7223e7ea.png" alt="Text headingXs variant before">
    </details>
    <details>
      <summary>Text headingXs variant after</summary>
      <img src="https://user-images.githubusercontent.com/26749317/190215326-cdd4a150-a18b-4b0c-a11c-05086354dff9.png" alt="Text headingXs variant after">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Text} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Text as="h6" variant="headingXs">
        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ac
        convallis nulla, mollis sagittis est. Phasellus condimentum diam magna,
        et viverra sapien fringilla sed.
      </Text>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
