### PR TITLE
Fix static breakpoint mixin replacements

### DIFF
--- a/.changeset/sixty-eels-deliver.md
+++ b/.changeset/sixty-eels-deliver.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Fix static breakpoint mixin replacement values

--- a/.changeset/sixty-eels-deliver.md
+++ b/.changeset/sixty-eels-deliver.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris-migrator': patch
----
-
-Fix static breakpoint mixin replacement values

--- a/documentation/guides/migrating-from-v9-to-v10.md
+++ b/documentation/guides/migrating-from-v9-to-v10.md
@@ -77,11 +77,11 @@ The following Sass mixins have been removed. You will need to replace any instan
 
 | Before                                                 | After                              |
 | ------------------------------------------------------ | ---------------------------------- |
-| `@include page-content-when-partially-condensed()`     | `@media #{$p-breakpoints-md-down}` |
+| `@include page-content-when-partially-condensed()`     | `@media #{$p-breakpoints-lg-down}` |
 | `@include page-content-when-not-partially-condensed()` | `@media #{$p-breakpoints-md-up}`   |
 | `@include page-content-when-fully-condensed()`         | `@media #{$p-breakpoints-sm-down}` |
 | `@include page-content-when-not-fully-condensed()`     | `@media #{$p-breakpoints-sm-up}`   |
-| `@include page-content-when-layout-stacked()`          | `@media #{$p-breakpoints-md-down}` |
+| `@include page-content-when-layout-stacked()`          | `@media #{$p-breakpoints-lg-down}` |
 | `@include page-content-when-layout-not-stacked()`      | `@media #{$p-breakpoints-md-up}`   |
 | `@include page-before-resource-list-small()`           | `@media #{$p-breakpoints-sm-down}` |
 | `@include page-after-resource-list-small()`            | `@media #{$p-breakpoints-sm-up}`   |
@@ -90,7 +90,7 @@ The following Sass mixins have been removed. You will need to replace any instan
 | `@include when-typography-not-condensed()`             | `@media #{$p-breakpoints-md-up}`   |
 | `@include frame-when-nav-hidden()`                     | `@media #{$p-breakpoints-md-down}` |
 | `@include frame-when-nav-displayed()`                  | `@media #{$p-breakpoints-md-up}`   |
-| `@include frame-with-nav-when-not-max-width()`         | `@media #{$p-breakpoints-xl-down}` |
+| `@include frame-with-nav-when-not-max-width()`         | `@media #{$p-breakpoints-lg-down}` |
 | `@include after-topbar-sheet()`                        | `@media #{$p-breakpoints-sm-up}`   |
 
 ### Sass dynamic mixins

--- a/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/replace-static-breakpoint-mixins.ts
+++ b/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/replace-static-breakpoint-mixins.ts
@@ -3,11 +3,11 @@ import postcss, {Plugin} from 'postcss';
 
 /** Mapping of static breakpoint mixins from old to new */
 const staticBreakpointMixins = {
-  'page-content-when-partially-condensed': '#{$p-breakpoints-md-down}',
+  'page-content-when-partially-condensed': '#{$p-breakpoints-lg-down}',
   'page-content-when-not-partially-condensed': '#{$p-breakpoints-md-up}',
   'page-content-when-fully-condensed': '#{$p-breakpoints-sm-down}',
   'page-content-when-not-fully-condensed': '#{$p-breakpoints-sm-up}',
-  'page-content-when-layout-stacked': '#{$p-breakpoints-md-down}',
+  'page-content-when-layout-stacked': '#{$p-breakpoints-lg-down}',
   'page-content-when-layout-not-stacked': '#{$p-breakpoints-md-up}',
   'page-before-resource-list-small': '#{$p-breakpoints-sm-down}',
   'page-after-resource-list-small': '#{$p-breakpoints-sm-up}',
@@ -16,7 +16,7 @@ const staticBreakpointMixins = {
   'when-typography-not-condensed': '#{$p-breakpoints-md-up}',
   'frame-when-nav-hidden': '#{$p-breakpoints-md-down}',
   'frame-when-nav-displayed': '#{$p-breakpoints-md-up}',
-  'frame-with-nav-when-not-max-width': '#{$p-breakpoints-xl-down}',
+  'frame-with-nav-when-not-max-width': '#{$p-breakpoints-lg-down}',
   'after-topbar-sheet': '#{$p-breakpoints-sm-up}',
 };
 

--- a/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/tests/replace-static-breakpoint-mixins.output.scss
+++ b/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/tests/replace-static-breakpoint-mixins.output.scss
@@ -1,5 +1,5 @@
 .root {
-  @media #{$p-breakpoints-md-down} {
+  @media #{$p-breakpoints-lg-down} {
     padding-bottom: spacing(loose);
 
     &.Active {
@@ -23,7 +23,7 @@
     border-radius: spacing(tight);
   }
 
-  @media #{$p-breakpoints-md-down} {
+  @media #{$p-breakpoints-lg-down} {
     @include stacked-elements;
   }
 
@@ -51,7 +51,7 @@
     }
   }
 
-  @media #{$p-breakpoints-xl-down} {
+  @media #{$p-breakpoints-lg-down} {
     padding: spacing(tight) 0;
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

A few of the mixin replacement values in our migration guide were listed incorrectly. This PR updates those values as well as usages of them in our migration tool. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
| Mixin | Before | After |
| --- | --- | --- | 
| page-content-when-partially-condensed() |  #{$p-breakpoints-md-down} | #{$p-breakpoints-lg-down} |
| page-content-when-layout-stacked() | #{$p-breakpoints-md-down} | #{$p-breakpoints-lg-down} |
| frame-with-nav-when-not-max-width() | #{$p-breakpoints-xl-down} | #{$p-breakpoints-lg-down} |