### PR TITLE
Add events for Link and Button

### DIFF
--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -20,7 +20,9 @@ export interface LinkProps {
   /** Removes text decoration underline to the link*/
   removeUnderline?: boolean;
   /** Callback when a link is clicked */
-  onClick?(): void;
+  onClick?(
+    event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>,
+  ): void;
   /** Descriptive text to be read to screenreaders */
   accessibilityLabel?: string;
   /** Indicates whether or not the link is the primary navigation link when rendered inside of an `IndexTable.Row` */

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -72,11 +72,11 @@ export interface BaseButton {
   /** Indicates the current checked state of the button when acting as a toggle or switch */
   ariaChecked?: 'false' | 'true';
   /** Callback when clicked */
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
   /** Callback when button becomes focussed */
-  onFocus?(): void;
+  onFocus?(event: React.FocusEvent<HTMLButtonElement>): void;
   /** Callback when focus leaves button */
-  onBlur?(): void;
+  onBlur?(event: React.FocusEvent<HTMLButtonElement>): void;
   /** Callback when a keypress event is registered on the button */
   onKeyPress?(event: React.KeyboardEvent<HTMLButtonElement>): void;
   /** Callback when a keyup event is registered on the button */
@@ -84,11 +84,11 @@ export interface BaseButton {
   /** Callback when a keydown event is registered on the button */
   onKeyDown?(event: React.KeyboardEvent<HTMLButtonElement>): void;
   /** Callback when mouse enter */
-  onMouseEnter?(): void;
+  onMouseEnter?(event: React.MouseEvent<HTMLButtonElement>): void;
   /** Callback when element is touched */
-  onTouchStart?(): void;
+  onTouchStart?(event: React.TouchEvent<HTMLButtonElement>): void;
   /** Callback when pointerdown event is being triggered */
-  onPointerDown?(): void;
+  onPointerDown?(event: React.PointerEvent<HTMLButtonElement>): void;
 }
 
 export interface Action {


### PR DESCRIPTION
### WHY are these changes introduced?

Right now, you'll get a TypeScript error, if you try to use the `event` in a callback from a onClick function.

### WHAT is this pull request doing?

Added correct TypeScript definitions.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
