### PR TITLE
Replace Sass spacing but leave comment if needs manual check

### DIFF
--- a/.changeset/swift-fans-allow.md
+++ b/.changeset/swift-fans-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Update the Sass spacing migration to perform spacing replacement even when there is an operator.

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.input.scss
@@ -1,4 +1,5 @@
 .Card {
+  z-index: z-index(content) + 1;
   padding: spacing(loose) spacing(extra-loose);
   border-radius: var(--p-border-radius-2, border-radius());
   box-shadow: var(--p-shadow-card, shadow());

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.output.scss
@@ -1,4 +1,5 @@
 .Card {
+  z-index: z-index(content) + 1;
   padding: var(--p-space-5) var(--p-space-8);
   border-radius: var(--p-border-radius-2, border-radius());
   box-shadow: var(--p-shadow-card, shadow());
@@ -8,5 +9,5 @@
   right: var(--p-space-4);
   top: var(--p-space-5);
   /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
-  bottom: spacing() + spacing();
+  bottom: var(--p-space-4) + var(--p-space-4);
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

It will be easier to migrate spacing if we do the spacing conversion but leave a comment to manually check the migration when there is an operator.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Performs the spacing replacement even if there is an operator.