### PR TITLE
Only preversion packages before official release

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "type-check": "tsc --build",
     "changeset": "changeset",
     "gen-assets": "turbo run gen-assets --filter=polaris.shopify.com",
-    "preversion-packages": "turbo run preversion",
+    "preversion-packages": "node scripts/preversion.js",
     "version-packages": "yarn preversion-packages && changeset version",
     "release": "turbo run build --filter='!polaris.shopify.com' && changeset publish",
     "preversion": "echo \"Error: use @changsets/cli to version packages\" && exit 1"
@@ -47,6 +47,7 @@
     "@babel/node": "^7.14.9",
     "@changesets/changelog-github": "^0.4.4",
     "@changesets/cli": "^2.23.0",
+    "@changesets/get-release-plan": "^3.0.14",
     "@next/eslint-plugin-next": "^12.1.4",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^21.1.0",

--- a/polaris-react/scripts/readme-update-version.js
+++ b/polaris-react/scripts/readme-update-version.js
@@ -6,7 +6,7 @@ const {writeFileSync, readFileSync} = require('fs');
 
 const getReleasePlan = require('@changesets/get-release-plan').default;
 
-const {name: pkgName} = require('../package.json');
+const {name: pkgName, version} = require('../package.json');
 const {semverRegExp} = require('../scripts/utilities');
 
 const root = resolve(__dirname, '..');
@@ -14,7 +14,9 @@ const readmePath = resolve(root, 'README.md');
 
 const run = async () => {
   const {releases} = await getReleasePlan(resolve(process.cwd(), '../'));
-  const {newVersion} = releases.find((release) => release.name === pkgName);
+  const {newVersion} = releases.find((release) => release.name === pkgName) || {
+    newVersion: version,
+  };
 
   console.log(`🆕 Updating version in README.md...`);
 

--- a/scripts/preversion.js
+++ b/scripts/preversion.js
@@ -1,0 +1,24 @@
+const {execSync} = require('child_process');
+
+const getReleasePlan = require('@changesets/get-release-plan').default;
+
+const run = async () => {
+  const {releases} = await getReleasePlan(process.cwd());
+  const packages = releases.map((release) => release.name);
+
+  const execOpts = {stdio: 'inherit'};
+  execSync(
+    `yarn turbo run preversion ${packages
+      .map((pkg) => `--filter=${pkg}`)
+      .join(' ')}`,
+    execOpts,
+  );
+};
+
+try {
+  run();
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,6 +1306,18 @@
     "@manypkg/get-packages" "^1.1.3"
     semver "^5.4.1"
 
+"@changesets/assemble-release-plan@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.1.tgz#b66df8d4a5615d4d904b75f7b60faeb64eb1d506"
+  integrity sha512-d6ckasOWlKF9Mzs82jhl6TKSCgVvfLoUK1ERySrTg2TQJdrVUteZue6uEIYUTA7SgMu67UOSwol6R9yj1nTdjw==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    "@changesets/errors" "^0.1.4"
+    "@changesets/get-dependents-graph" "^1.3.3"
+    "@changesets/types" "^5.1.0"
+    "@manypkg/get-packages" "^1.1.3"
+    semver "^5.4.1"
+
 "@changesets/changelog-git@^0.1.11":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@changesets/changelog-git/-/changelog-git-0.1.11.tgz#80eb45d3562aba2164f25ccc31ac97b9dcd1ded3"
@@ -1431,6 +1443,19 @@
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@changesets/assemble-release-plan" "^5.2.0"
+    "@changesets/config" "^2.1.1"
+    "@changesets/pre" "^1.0.12"
+    "@changesets/read" "^0.5.7"
+    "@changesets/types" "^5.1.0"
+    "@manypkg/get-packages" "^1.1.3"
+
+"@changesets/get-release-plan@^3.0.14":
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/@changesets/get-release-plan/-/get-release-plan-3.0.14.tgz#b4423028a90c63feec12e22c48078f106f8d01f4"
+  integrity sha512-xzSfeyIOvUnbqMuQXVKTYUizreWQfICwoQpvEHoePVbERLocc1tPo5lzR7dmVCFcaA/DcnbP6mxyioeq+JuzSg==
+  dependencies:
+    "@babel/runtime" "^7.10.4"
+    "@changesets/assemble-release-plan" "^5.2.1"
     "@changesets/config" "^2.1.1"
     "@changesets/pre" "^1.0.12"
     "@changesets/read" "^0.5.7"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Running preversion on the `polaris-react` package when performing `/snapit` was causing an error when there wasn't a new version of `polaris-react` to be released.

See this [GitHub Action error](https://github.com/Shopify/polaris/actions/runs/3078706202/jobs/4974432156#step:11:57).

### WHAT is this pull request doing?

This PR filters the preversion pacakges to only those being released. This avoids running into the issue where the `polaris-react` preversion script was [failing on snapit](https://github.com/Shopify/polaris/actions/runs/3078706202/jobs/4974432156#step:11:57).
