### PR TITLE
Replace quoted function argument values (ex: `spacing('tight')`)

### DIFF
--- a/.changeset/funny-rockets-smash.md
+++ b/.changeset/funny-rockets-smash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Update Sass spacing migration to properly map spacing functions where quoted string arguments are passed (ex: `spacing('tight')`)

--- a/.changeset/swift-fans-allow.md
+++ b/.changeset/swift-fans-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Update the Sass spacing migration to perform spacing replacement even when there is an operator.

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.input.scss
@@ -9,4 +9,5 @@
   right: spacing();
   top: spacing(loose);
   bottom: spacing() + spacing();
+  left: spacing('tight');
 }

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.output.scss
@@ -10,4 +10,5 @@
   top: var(--p-space-5);
   /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
   bottom: var(--p-space-4) + var(--p-space-4);
+  left: var(--p-space-2);
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes issue where `spacing('tight')` was being replaced by a CSS custom property within single quotes `var('--p-space-2')`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR fixes the CSS custom property value being contained within single quotes and also optimizes some of the typing inferences (less type casting).