### PR TITLE
Output operator lines as comments to preserve working Sass

### DIFF
--- a/.changeset/slow-walls-talk.md
+++ b/.changeset/slow-walls-talk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Update Sass spacing migrator to apply operator migrations as comments

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.input.scss
@@ -3,6 +3,7 @@
   padding: spacing(loose) spacing(extra-loose);
   border-radius: var(--p-border-radius-2, border-radius());
   box-shadow: var(--p-shadow-card, shadow());
+  margin: spacing(tight) 0 0 (-1 * spacing());
 }
 
 .ButtonContainer {

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-spacing.output.scss
@@ -3,12 +3,16 @@
   padding: var(--p-space-5) var(--p-space-8);
   border-radius: var(--p-border-radius-2, border-radius());
   box-shadow: var(--p-shadow-card, shadow());
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* margin: var(--p-space-2) 0 0 (-1 * var(--p-space-4)); */
+  margin: spacing(tight) 0 0 (-1 * spacing());
 }
 
 .ButtonContainer {
   right: var(--p-space-4);
   top: var(--p-space-5);
   /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
-  bottom: var(--p-space-4) + var(--p-space-4);
+  /* bottom: var(--p-space-4) + var(--p-space-4); */
+  bottom: spacing() + spacing();
   left: var(--p-space-2);
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes cases where spacing function is nested within parentheses (ex: `margin: (-1 * spacing()) 0 0`)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Mark operators if present in the parsed declaration value. Then, add the migrated value as a comment if the declaration contains an operator.