### PR TITLE
[polaris.shopify.com] Remove text alignment guidance

### DIFF
--- a/polaris.shopify.com/content/foundations/design/typography/index.md
+++ b/polaris.shopify.com/content/foundations/design/typography/index.md
@@ -58,12 +58,6 @@ Line length describes the width of the content. For longer body text, the recomm
 
 ![A diagram showing the ideal line length for text](/images/foundations/design/typography/text-line-length@2x.png)
 
-### Right align tabular numbers
-
-Right align numbers when they're inside a table. This keeps the decimal in the same place and makes numerical data easier to read and compare.
-
-![An image showing right aligning numbers within a table](/images/foundations/design/typography/text-tabular-numbers@2x.png)
-
 ### Color
 
 Color can be used to add contrast and reinforce the hierarchy between text.


### PR DESCRIPTION
The text alignment guidance is more nuanced than what we provide right now. We need to spend some more time with this. For now we're going to remove the section to avoid conflicting guidance.

This PR removes "Right align tabular numbers section"