### PR TITLE
Fix IndexTable rendering issue in Safari

### DIFF
--- a/.changeset/young-cooks-tie.md
+++ b/.changeset/young-cooks-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix `IndexTable` Safari rendering issue

--- a/polaris-react/src/components/Checkbox/Checkbox.scss
+++ b/polaris-react/src/components/Checkbox/Checkbox.scss
@@ -65,6 +65,7 @@
   transform-origin: 50% 50%;
   pointer-events: none;
 
+  will-change: transform;
   transform: translate(-50%, -50%) scale(0.25);
   opacity: 0;
   transition: opacity var(--p-duration-100) var(--p-ease),


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR introduces the `will-change` property to the `Checkbox` component to mitigate slow rendering performance of hundreds of checkboxes on a page (e.g. in the `IndexTable`) in Safari. We recognize this is a short term patch and should follow up with a more robust/long term solution.

As pointed out in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change):

> `will-change` is intended to be used as a last resort, in order to try to deal with existing performance problems

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
