### PR TITLE
Adjust down breakpoint offset to be 0.04

### DIFF
--- a/.changeset/slimy-pillows-explain.md
+++ b/.changeset/slimy-pillows-explain.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'@shopify/polaris-tokens': patch
+---
+
+Increase `$p-breakpoint-*-{down,only}` breakpoint max-width values by 0.01px so that they are representable in fewer digits of precision when expressed as `em`s. This ensures they are representable without rounding when using `node-sass`'s default precision. E.g. `$p-breakpoints-md-down`changes from `max-width: 47.996875em` to `max-width: 47.9975em`.

--- a/polaris-tokens/src/utilities.ts
+++ b/polaris-tokens/src/utilities.ts
@@ -210,11 +210,12 @@ function getUpMediaCondition(breakpoint: string) {
 }
 
 /**
- * Down media condition breakpoints are being subtracted by 0.05px to prevent
+ * Down media condition breakpoints are being subtracted by 0.04px to prevent
  * them from overwriting up media queries. We experimented with multiple offsets
- * and felt that 0.05px would be the safest across different pixel densities.
+ * and felt that 0.04px would be the safest across different pixel densities,
+ * while being representable in ems with 4 decimal places of precision.
  */
 function getDownMediaCondition(breakpoint: string) {
-  const offsetBreakpoint = parseFloat(toPx(breakpoint) ?? '') - 0.05;
+  const offsetBreakpoint = parseFloat(toPx(breakpoint) ?? '') - 0.04;
   return `(max-width: ${toEm(`${offsetBreakpoint}px`)})`;
 }

--- a/polaris-tokens/tests/utilities.test.js
+++ b/polaris-tokens/tests/utilities.test.js
@@ -162,16 +162,16 @@ describe('getMediaConditions', () => {
       breakpoint1: {
         // Up: sizeInPx / 16
         up: '(min-width: 1em)',
-        // Down: (sizeInPx - 0.05) / 16
-        down: '(max-width: 0.996875em)',
-        // Only: (nextBreakpointSizeInPx - 0.05) / 16
-        only: '(min-width: 1em) and (max-width: 1.996875em)',
+        // Down: (sizeInPx - 0.04) / 16
+        down: '(max-width: 0.9975em)',
+        // Only: (nextBreakpointSizeInPx - 0.04) / 16
+        only: '(min-width: 1em) and (max-width: 1.9975em)',
       },
       breakpoint2: {
         // Up: sizeInPx / 16
         up: '(min-width: 2em)',
-        // Down: (sizeInPx - 0.05) / 16
-        down: '(max-width: 1.996875em)',
+        // Down: (sizeInPx - 0.04) / 16
+        down: '(max-width: 1.9975em)',
         // Only: Same as the up condition as there is no next breakpoint
         only: '(min-width: 2em)',
       },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #7237

### WHAT is this pull request doing?

This ensures that `$p-breakpoint-*-{down,only}` breakpoint max-width values in ems are representable in 4 decimal places. This avoids rounding issues when using node-sass's default rounding precision of 5 decimal places, as prior to this change our media queries required a precision of 6 decimal places (e.g. `$p-breakpoints-md-down: '(max-width: 47.996875em)';` is now `$p-breakpoints-md-down: '(max-width: 47.9975em)';`

