### PR TITLE
Update the Release process to help reduce the review bottleneck

### DIFF
--- a/documentation/Releasing.md
+++ b/documentation/Releasing.md
@@ -10,10 +10,10 @@ We have a [GitHub action](https://github.com/changesets/action) that
 To perform a release:
 
 - Comment `/snapit` in the **"Version Packages"** PR to cut a snapshot release
-- Create a draft pull request in `Shopify/web` for the upgrade using the snapshot
-  - Tag all contributors to the release on the `Shopify/web` pull request and also create a group message tagging all contributors to nudge them for reviews, as well as to verify the changes within `Shopify/web` work as expected.
-- Once CI passes, and you've received an approval from [@Shopify/polaris-team](https://github.com/orgs/Shopify/teams/polaris-team), merge the **"Version Packages"** PR
-- Once the release is available in npm, update the draft PR to the new version and request review from the folks whose changes are part of the release as listed in the release notes
+- Create a pull request in `Shopify/web` for the upgrade using the snapshot
+- Once CI passes in the `Shopify/web` PR, and you've received an approval from [@Shopify/polaris-team](https://github.com/orgs/Shopify/teams/polaris-team), merge the **"Version Packages"** PR in `Shopify/polaris`
+- Once the release is available in npm, update the `Shopify/web` PR to the new version and request review from the folks whose changes are part of the release as listed in the release notes
+- Optional: You can create a group message tagging all contributors to nudge them for reviews, as well as to verify the changes within `Shopify/web` work as expected
 
 ## Snapshot Release
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

We have been experience a process bottleneck issue in how we release packages. This process change should help ensure we aren't shipping a broken package, yet not blocking new changes being merged into Polaris.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This moves the `Shopify/web` tophatting step from the snapshot phase to the official release update phase. This way, we aren't having to wait on reviewer approval prior to release. We can release new versions (**Version Packages** PR) as soon as we can confirm the snapshot release builds and passes CI tests in web. Then, tophatting can be performed by contributors after the official release has been performed.