### PR TITLE
Choicelist update

### DIFF
--- a/.changeset/shiny-files-protect.md
+++ b/.changeset/shiny-files-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Increase taptarget height and width for choice in choicelist on small screens

--- a/.changeset/sweet-rockets-hug.md
+++ b/.changeset/sweet-rockets-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Adding 100% width to choicelist items on small screens for increased accessibility

--- a/polaris-react/src/components/Choice/Choice.scss
+++ b/polaris-react/src/components/Choice/Choice.scss
@@ -1,13 +1,13 @@
 @import '../../styles/common';
 
 .Choice {
-  display: inline-flex;
+  display: flex;
   justify-content: flex-start;
   padding: var(--p-space-1) 0;
   cursor: pointer;
 
-  @media #{$p-breakpoints-sm-down} {
-    width: 100%;
+  @media #{$p-breakpoints-sm-up} {
+    display: inline-flex;
   }
 }
 

--- a/polaris-react/src/components/Choice/Choice.scss
+++ b/polaris-react/src/components/Choice/Choice.scss
@@ -5,6 +5,11 @@
   justify-content: flex-start;
   padding: var(--p-space-1) 0;
   cursor: pointer;
+
+  @media #{$p-breakpoints-sm-down} {
+    min-height: 44px;
+    width: 100%;
+  }
 }
 
 .labelHidden {

--- a/polaris-react/src/components/Choice/Choice.scss
+++ b/polaris-react/src/components/Choice/Choice.scss
@@ -7,7 +7,6 @@
   cursor: pointer;
 
   @media #{$p-breakpoints-sm-down} {
-    min-height: 44px;
     width: 100%;
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?


Contributes to [#14004](https://github.com/Shopify/online-store-web/issues/14004) in online-store-web and is related to #7226 changes.

We believe lengthening the tap target on the checkbox and radio buttons (ultimately changes made at the ChoiceList level) in mobile will provide easier accessibility on smaller screens.

### WHAT is this pull request doing?

Adds a media query that increases the width of ChoiceList items (checkbox and radio buttons) to 100% width for easier accessibility on a small screen.

  <details>
      <summary>Before/After Video</summary>

Before width 100%:

https://user-images.githubusercontent.com/69861203/191824923-0b70160b-f1dc-47bf-933c-aab163e10dec.mov

After width 100%:

https://user-images.githubusercontent.com/69861203/191824957-55149a73-5bbe-4143-837b-51ac5d8bb70d.mov


</details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Spin link: https://admin.web.choicelistfinal.rana-jurjus.us.spin.dev/store/shop1/themes/1/editor

1. Ensure you are in mobile web view (use dev tools) on a smaller screened device (iPhone SE for example)
2. Open the section list bottom sheet and select a section that has choicelist items (ex: Featured Collection, Header for checkboxes. Cannot find radio button options to tophat at this time). Ensure everything looks okay, that the cell has 100% width, and that you can click anywhere within that cell to toggle the selection.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
  - Firefox does not allow me to access the spin link unfortunately.
- [X] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [X] Updated the component's `README.md` with documentation changes (added changeset)
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
