### PR TITLE
Add generic migration script for renaming a prop

### DIFF
--- a/.changeset/witty-cycles-develop.md
+++ b/.changeset/witty-cycles-develop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Added generic migration script for renaming a component prop

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "preversion-packages": "node scripts/preversion.js",
     "version-packages": "yarn preversion-packages && changeset version",
     "release": "turbo run build --filter='!polaris.shopify.com' && changeset publish",
-    "preversion": "echo \"Error: use @changsets/cli to version packages\" && exit 1"
+    "preversion": "echo \"Error: use @changsets/cli to version packages\" && exit 1",
+    "new-migration": "yarn workspace @shopify/polaris-migrator generate"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/polaris-migrator/README.md
+++ b/polaris-migrator/README.md
@@ -17,4 +17,113 @@ npx @shopify/polaris-migrator <migration> <path>
 
 ## Documentation
 
-Visit [polaris.shopify.com/docs/advanced-features/migrations](https://polaris.shopify.com/docs/advanced-features/migrations) to view available migrations.
+> Coming soon ✨
+> ~~Visit [polaris.shopify.com/docs/advanced-features/migrations](https://polaris.shopify.com/docs/advanced-features/migrations) to view available migrations.~~
+
+## Creating a migration
+
+### Setup
+
+Run `yarn new-migration` to generate a new migration from a template.
+
+```sh
+❯ yarn new-migration
+$ yarn workspace @shopify/polaris-migrator generate
+$ plop
+? [PLOP] Please choose a generator. (Use arrow keys)
+❯ sass-migration
+  typescript-migration
+```
+
+We will use the `sass-migration` and call our migration `replace-sass-function` for this example. Provide the name of your migration:
+
+```sh
+? [PLOP] Please choose a generator. sass-migration
+? Name of the migration (e.g. replace-sass-layout) replace-sass-function
+```
+
+The generator will create the following files in the `migrations` folder:
+
+```
+migrations
+└── replace-sass-function
+    ├── replace-sass-function.ts
+    └── tests
+        ├── replace-sass-function.input.scss
+        ├── replace-sass-function.output.scss
+        └── replace-sass-function.test.ts
+```
+
+### Writing migration function
+
+A migration is simply a javascript function which serves as the entry-point for your codemod. The `replace-sass-function.ts` file defines a "migration" function. This function is named the same as the provided migration name, `replace-sass-function`, and is the default export of the file.
+
+Some example code has been provided for each template. You can make any migration code adjustments in the migration function. For Sass migrations, a [PostCSS plugin](https://github.com/postcss/postcss/blob/main/docs/writing-a-plugin.md) is used to parse and transform the source code provided by the [jscodeshift](https://github.com/facebook/jscodeshift).
+
+```ts
+// polaris-migrator/src/migrations/replace-sass-function/replace-sass-function.ts
+
+import type {FileInfo} from 'jscodeshift';
+import postcss, {Plugin} from 'postcss';
+import valueParser from 'postcss-value-parser';
+
+const plugin = (): Plugin => ({
+  postcssPlugin: 'replace-sass-function',
+  Declaration(decl) {
+    // const prop = decl.prop;
+    const parsedValue = valueParser(decl.value);
+
+    parsedValue.walk((node) => {
+      if (!(node.type === 'function' && node.value === 'hello')) return;
+
+      node.value = 'world';
+    });
+
+    decl.value = parsedValue.toString();
+  },
+});
+
+export default function replaceSassFunction(fileInfo: FileInfo) {
+  return postcss(plugin()).process(fileInfo.source, {
+    syntax: require('postcss-scss'),
+  }).css;
+}
+```
+
+This example migration will replace the Sass function `hello()` with `world()`.
+
+### Testing
+
+The template will also generate starting test files you can use to test your migration. In your migrations `tests` folder, you can see 3 files:
+
+- `replace-sass-function.test.ts` – Runs the fixtures and sets up additional migration options
+- `replace-sass-function.input.scss` – The starting source input
+- `replace-sass-function.output.scss` – The expected output after migration
+
+The main test file will load the input/output fixtures to test your migration against. You can configure additional fixtures and test migration options (see the `replace-sass-spacing.test.ts` as an example).
+
+Run tests locally from workspace root by filtering to the migrations package:
+
+```sh
+npx turbo run test --filter=polaris-migrator -- replace-sass-function
+```
+
+### Testing in another codebase
+
+Once you are confident the migration is ready, create a new pull request including your migration and a new [changeset](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#adding-a-changeset).
+
+In your PR, you can add a comment with the text `/snapit` to create a new [snapshot release](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#snapshot-release). Once created, this snapshot can be used in a separate codebase:
+
+```sh
+# example snapshot release
+npx @shopify/polaris-migrator@0.0.0-snapshot-release-20220919213536 replace-sass-function "./app/**/*.scss"
+```
+
+### Resources
+
+- [The jscodeshift API](https://github.com/facebook/jscodeshift#the-jscodeshift-api)
+- [Writing a PostCSS plugin](https://github.com/postcss/postcss/blob/main/docs/writing-a-plugin.md)
+- [CodeshiftCommunity Recipes](https://www.codeshiftcommunity.com/docs/import-manipulation)
+- Common utilities:
+  - [`jsx.ts`](https://github.com/Shopify/polaris/blob/main/polaris-migrator/src/utilities/jsx.ts)
+  - [`imports.ts`](https://github.com/Shopify/polaris/blob/main/polaris-migrator/src/utilities/imports.ts)

--- a/polaris-migrator/src/migrations/rename-component-prop/rename-component-prop.ts
+++ b/polaris-migrator/src/migrations/rename-component-prop/rename-component-prop.ts
@@ -1,0 +1,21 @@
+import type {API, FileInfo, Options} from 'jscodeshift';
+
+import {renameProps} from '../../utilities/jsx';
+
+export default function renameComponentProp(
+  file: FileInfo,
+  {jscodeshift: j}: API,
+  options: Options,
+) {
+  if (!options.componentName || !options.from || !options.to) {
+    throw new Error('Missing required options: componentName, from, to');
+  }
+
+  const source = j(file.source);
+  const componentName = options.componentName;
+  const props = {[options.from]: options.to};
+
+  renameProps(j, source, componentName, props);
+
+  return source.toSource();
+}

--- a/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.input.tsx
+++ b/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.input.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface MyComponentProps {
+  prop?: string;
+  newProp?: string;
+  children?: React.ReactNode;
+}
+
+function MyComponent(props: MyComponentProps) {
+  const value = props.newProp || props.prop;
+  return <div data-prop={value}>{props.children}</div>;
+}
+
+export function App() {
+  return <MyComponent prop="value">Hello</MyComponent>;
+}

--- a/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.output.tsx
+++ b/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.output.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface MyComponentProps {
+  prop?: string;
+  newProp?: string;
+  children?: React.ReactNode;
+}
+
+function MyComponent(props: MyComponentProps) {
+  const value = props.newProp || props.prop;
+  return <div data-prop={value}>{props.children}</div>;
+}
+
+export function App() {
+  return <MyComponent newProp="value">Hello</MyComponent>;
+}

--- a/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.test.ts
+++ b/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.test.ts
@@ -1,0 +1,16 @@
+import {check} from '../../../utilities/testUtils';
+
+const migration = 'rename-component-prop';
+const fixtures = ['rename-component-prop'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    migration,
+    options: {
+      componentName: 'MyComponent',
+      from: 'prop',
+      to: 'newProp',
+    },
+  });
+}

--- a/polaris-migrator/src/utilities/jsx.ts
+++ b/polaris-migrator/src/utilities/jsx.ts
@@ -1,4 +1,4 @@
-import core, {ASTPath} from 'jscodeshift';
+import core, {ASTPath, Collection} from 'jscodeshift';
 
 export function getJSXAttributes(
   j: core.JSCodeshift,
@@ -99,4 +99,22 @@ export function replaceJSXElement(
   );
 
   return j(element).replaceWith(newComponent);
+}
+
+export function renameProps(
+  j: core.JSCodeshift,
+  source: Collection<any>,
+  componentName: string,
+  props: {[from: string]: string},
+) {
+  return source
+    .findJSXElements(componentName)
+    .find(j.JSXOpeningElement)
+    .find(j.JSXAttribute)
+    .forEach(({node}) => {
+      const propName = node.name.name.toString();
+      if (Object.keys(props).includes(propName)) {
+        node.name.name = props[propName];
+      }
+    });
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This script can help assist with component prop renames for future component prop migrations.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds a generic migration to rename any component prop.

```diff
-<Component prop="value" />
-<Component prop />
+<Component newProp="value" />
+<Component newProp />
```

```sh
npx npx @shopify/polaris-migrator rename-component-prop <path> -- --component=MyComponent --from=prop --to=newProp
```