### PR TITLE
Update renameProps to avoid migrating nested component props

### DIFF
--- a/.changeset/light-clocks-applaud.md
+++ b/.changeset/light-clocks-applaud.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Update `renameProps` to avoid migrating nested component props

--- a/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.input.tsx
+++ b/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.input.tsx
@@ -6,11 +6,18 @@ interface MyComponentProps {
   children?: React.ReactNode;
 }
 
+const Child = (props: {prop: string}) => <>{props.prop}</>;
+
 function MyComponent(props: MyComponentProps) {
   const value = props.newProp || props.prop;
   return <div data-prop={value}>{props.children}</div>;
 }
 
 export function App() {
-  return <MyComponent prop="value">Hello</MyComponent>;
+  return (
+    <MyComponent prop="value">
+      Hello
+      <Child prop="value" />
+    </MyComponent>
+  );
 }

--- a/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.output.tsx
+++ b/polaris-migrator/src/migrations/rename-component-prop/tests/rename-component-prop.output.tsx
@@ -6,11 +6,18 @@ interface MyComponentProps {
   children?: React.ReactNode;
 }
 
+const Child = (props: {prop: string}) => <>{props.prop}</>;
+
 function MyComponent(props: MyComponentProps) {
   const value = props.newProp || props.prop;
   return <div data-prop={value}>{props.children}</div>;
 }
 
 export function App() {
-  return <MyComponent newProp="value">Hello</MyComponent>;
+  return (
+    <MyComponent newProp="value">
+      Hello
+      <Child prop="value" />
+    </MyComponent>
+  );
 }

--- a/polaris-migrator/src/utilities/jsx.ts
+++ b/polaris-migrator/src/utilities/jsx.ts
@@ -108,8 +108,8 @@ export function renameProps(
   props: {[from: string]: string},
 ) {
   const fromProps = Object.keys(props);
-  const isFromProp = (name: unknown): name is keyof typeof props =>
-    fromProps.includes(name as string);
+  const isFromProp = (prop: unknown): prop is keyof typeof props =>
+    fromProps.includes(prop as string);
 
   source.findJSXElements(componentName)?.forEach((path) => {
     path.node.openingElement.attributes?.forEach((node) => {

--- a/polaris-migrator/src/utilities/jsx.ts
+++ b/polaris-migrator/src/utilities/jsx.ts
@@ -102,19 +102,22 @@ export function replaceJSXElement(
 }
 
 export function renameProps(
-  j: core.JSCodeshift,
+  _j: core.JSCodeshift,
   source: Collection<any>,
   componentName: string,
   props: {[from: string]: string},
 ) {
-  return source
-    .findJSXElements(componentName)
-    .find(j.JSXOpeningElement)
-    .find(j.JSXAttribute)
-    .forEach(({node}) => {
-      const propName = node.name.name.toString();
-      if (Object.keys(props).includes(propName)) {
-        node.name.name = props[propName];
+  const fromProps = Object.keys(props);
+  const isFromProp = (name: unknown): name is keyof typeof props =>
+    fromProps.includes(name as string);
+
+  source.findJSXElements(componentName)?.forEach((path) => {
+    path.node.openingElement.attributes?.forEach((node) => {
+      if (node.type === 'JSXAttribute' && isFromProp(node.name.name)) {
+        node.name.name = props[node.name.name];
       }
     });
+  });
+
+  return source;
 }


### PR DESCRIPTION
This PR updates `renameProps` to avoid migrating nested components with the same `--from` prop name e.g.

<img width="501" alt="Screen Shot 2022-09-24 at 8 40 55 AM" src="https://user-images.githubusercontent.com/32409546/192110345-3a1cf851-d5f4-4a60-ab00-1ecb9f62d5e9.png">
