### PR TITLE
Update Polaris tokens to use the TypeScript satisfies operator

### DIFF
--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -5,5 +5,4 @@ export type {
   Tokens,
   MetadataProperties,
   MetadataGroup,
-  Metadata,
 } from './types';

--- a/polaris-tokens/src/metadata.ts
+++ b/polaris-tokens/src/metadata.ts
@@ -1,4 +1,4 @@
-import type {Exact, Metadata} from './types';
+import type {MetadataBase} from './types';
 import {tokensToRems} from './utilities';
 import {breakpoints} from './token-groups/breakpoints';
 import {depth} from './token-groups/depth';
@@ -10,7 +10,7 @@ import {shape} from './token-groups/shape';
 import {spacing} from './token-groups/spacing';
 import {zIndex} from './token-groups/zIndex';
 
-export const metadata = createMetadata({
+export const metadata = {
   breakpoints: tokensToRems(breakpoints),
   colors,
   depth,
@@ -20,12 +20,6 @@ export const metadata = createMetadata({
   shape: tokensToRems(shape),
   spacing: tokensToRems(spacing),
   zIndex,
-});
+} satisfies MetadataBase;
 
-/**
- * Identity function that simply returns the provided tokens with metadata, but additionally
- * validates the input matches the `Metadata` type exactly and infers all members.
- */
-export function createMetadata<T extends Exact<Metadata, T>>(metadata: T) {
-  return metadata;
-}
+export type Metadata = typeof metadata;

--- a/polaris-tokens/src/token-groups/breakpoints.ts
+++ b/polaris-tokens/src/token-groups/breakpoints.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const breakpoints = {
   'breakpoints-xs': {
     value: '0px',
@@ -24,4 +26,13 @@ export const breakpoints = {
     description:
       'Commonly used for sizing containers (e.g. max-width). See below for media query usage.',
   },
-};
+} satisfies MetadataGroup;
+
+export type BreakpointsTokenGroup = typeof breakpoints;
+export type BreakpointsTokenName = keyof BreakpointsTokenGroup;
+
+// e.g. "xs" | "sm" | "md" | "lg" | "xl"
+export type BreakpointsTokenAlias = Extract<
+  BreakpointsTokenName,
+  `breakpoints-${string}`
+> extends `breakpoints-${infer Alias}` ? Alias : never;

--- a/polaris-tokens/src/token-groups/colors.ts
+++ b/polaris-tokens/src/token-groups/colors.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const colors = {
   background: {
     value: 'rgba(246, 246, 247, 1)',
@@ -644,4 +646,7 @@ export const colors = {
     description:
       'For use as a decorative text color that is applied on a decorative surface.',
   },
-};
+} satisfies MetadataGroup;
+
+export type ColorsTokenGroup = typeof colors;
+export type ColorsTokenName = keyof ColorsTokenGroup;

--- a/polaris-tokens/src/token-groups/depth.ts
+++ b/polaris-tokens/src/token-groups/depth.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const depth = {
   'shadow-transparent': {
     value: '0 0 0 0 transparent',
@@ -38,4 +40,7 @@ export const depth = {
   'shadows-inset-button-pressed': {
     value: 'inset 0 1px 0 rgba(0, 0, 0, 0.15)',
   },
-};
+} satisfies MetadataGroup;
+
+export type DepthTokenGroup = typeof depth;
+export type DepthTokenName = keyof DepthTokenGroup;

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const font = {
   'font-family-sans': {
     value:
@@ -64,4 +66,26 @@ export const font = {
   'font-line-height-7': {
     value: '48px',
   },
-};
+} satisfies MetadataGroup;
+
+export type FontTokenGroup = typeof font;
+export type FontTokenName = keyof FontTokenGroup;
+
+// e.g. "400" | "500" | "600" | "700" | "100" | ...
+export type FontSizeScale = Extract<
+  FontTokenName,
+  `font-size-${number}`
+> extends `font-size-${infer Scale}` ? Scale : never;
+
+// e.g. "1" | "2" | "3" | "4" | "5" | "6" | "7"
+export type FontLineHeightScale = Extract<
+  FontTokenName,
+  `font-line-height-${number}`
+> extends `font-line-height-${infer Scale}` ? Scale : never;
+
+
+// e.g. "bold" | "regular" | "medium" | "semibold"
+export type FontWeightAlias = Extract<
+  FontTokenName,
+  `font-weight-${string}`
+> extends `font-weight-${infer Alias}` ? Alias : never;

--- a/polaris-tokens/src/token-groups/legacy.ts
+++ b/polaris-tokens/src/token-groups/legacy.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const legacy = {
   'override-loading-z-index': {
     value: '514',
@@ -58,4 +60,7 @@ export const legacy = {
   'frame-offset': {
     value: '0px',
   },
-};
+} satisfies MetadataGroup;
+
+export type LegacyTokenGroup = typeof legacy;
+export type LegacyTokenName = keyof LegacyTokenGroup;

--- a/polaris-tokens/src/token-groups/motion.ts
+++ b/polaris-tokens/src/token-groups/motion.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const motion = {
   'duration-0': {
     value: '0ms',
@@ -64,4 +66,20 @@ export const motion = {
   'keyframes-spin': {
     value: '{ to { transform: rotate(1turn) } }',
   },
-};
+} satisfies MetadataGroup;
+
+export type MotionTokenGroup = typeof motion;
+export type MotionTokenName = keyof MotionTokenGroup;
+
+// e.g. "0" | "50" | "100" | "150" | ...
+export type MotionDurationScale = Extract<
+  MotionTokenName,
+  `duration-${number}`
+> extends `duration-${infer Scale}` ? Scale : never;
+
+// e.g. "bounce" | "fade-in" | "pulse" | "spin" 
+export type MotionKeyframesAlias = Extract<
+  MotionTokenName,
+  `keyframes-${string}`
+> extends `keyframes-${infer Alias}` ? Alias : never;
+

--- a/polaris-tokens/src/token-groups/shape.ts
+++ b/polaris-tokens/src/token-groups/shape.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const shape = {
   'border-radius-05': {
     value: '2px',
@@ -59,4 +61,29 @@ export const shape = {
   'border-divider-on-dark': {
     value: 'var(--p-border-width-1) solid var(--p-divider-dark)',
   },
-};
+} satisfies MetadataGroup;
+
+export type ShapeTokenGroup = typeof shape;
+export type ShapeTokenName = keyof ShapeTokenGroup;
+
+type ShapeBorderRadiusTokenName = Extract<
+  ShapeTokenName,
+  `border-radius-${string}`
+>;
+
+// e.g. "05" | "1" | "2" | "3" | "4" | "5" | "6"
+export type ShapeBorderRadiusScale = Extract<
+  ShapeBorderRadiusTokenName,
+  `border-radius-${number}`
+> extends `border-radius-${infer Scale}` ? Scale : never;
+
+// e.g. "base" | "large" | "half"
+export type ShapeBorderRadiusAlias = Exclude<
+  ShapeBorderRadiusTokenName,
+  `border-radius-${number}`
+> extends `border-radius-${infer Alias}` ? Alias : never;
+
+// e.g. "05" | "1" | "2" | ... | "base" | "large" | "half"
+export type ShapeBorderRadius = ShapeBorderRadiusScale | ShapeBorderRadiusAlias;
+
+

--- a/polaris-tokens/src/token-groups/spacing.ts
+++ b/polaris-tokens/src/token-groups/spacing.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const spacing = {
   'space-0': {
     value: '0',
@@ -50,4 +52,13 @@ export const spacing = {
   'space-32': {
     value: '128px',
   },
-};
+} satisfies MetadataGroup;
+
+export type SpacingTokenGroup = typeof spacing;
+export type SpacingTokenName = keyof SpacingTokenGroup;
+
+// e.g. "0" | "025" | "05" | "1" | "2" | "3" | ...
+export type SpacingSpaceScale = Extract<
+  SpacingTokenName,
+  `space-${number}`
+> extends `space-${infer Scale}` ? Scale : never;

--- a/polaris-tokens/src/token-groups/zIndex.ts
+++ b/polaris-tokens/src/token-groups/zIndex.ts
@@ -1,3 +1,5 @@
+import type {MetadataGroup} from '../types'
+
 export const zIndex = {
   'z-1': {
     value: '100',
@@ -35,4 +37,13 @@ export const zIndex = {
   'z-12': {
     value: '520',
   },
-};
+} satisfies MetadataGroup;
+
+export type ZIndexTokenGroup = typeof zIndex;
+export type ZIndexTokenName = keyof ZIndexTokenGroup;
+
+// e.g. "1" | "2" | "3" | "4" | "5" | "6" | ...
+export type ZIndexZScale = Extract<
+  ZIndexTokenName,
+  `z-${number}`
+> extends `z-${infer Scale}` ? Scale : never;

--- a/polaris-tokens/src/types.ts
+++ b/polaris-tokens/src/types.ts
@@ -1,3 +1,5 @@
+import type {Metadata} from './metadata';
+
 export type Entry<T> = [keyof T, T[keyof T]];
 export type Entries<T> = Entry<T>[];
 
@@ -10,28 +12,20 @@ export interface MetadataGroup {
   [token: string]: MetadataProperties;
 }
 
-export interface Metadata {
-  breakpoints: MetadataGroup;
-  colors: MetadataGroup;
-  depth: MetadataGroup;
-  font: MetadataGroup;
-  legacy: MetadataGroup;
-  motion: MetadataGroup;
-  shape: MetadataGroup;
-  spacing: MetadataGroup;
-  zIndex: MetadataGroup;
+export interface MetadataBase {
+  [tokenGroup: string]: MetadataGroup;
 }
 
 export interface TokenGroup {
   [token: string]: string;
 }
 
-export type Tokens = {
-  [Property in keyof MetadataGroup]: TokenGroup;
-};
-
 export type ExtractValues<T extends MetadataGroup> = {
   [K in keyof T]: T[K]['value'];
+};
+
+export type Tokens = {
+  [TokenGroup in keyof Metadata]: ExtractValues<Metadata[TokenGroup]>;
 };
 
 // The following utility types are copied directly from `type-fest`:

--- a/polaris-tokens/src/utilities.ts
+++ b/polaris-tokens/src/utilities.ts
@@ -83,7 +83,7 @@ export function rem(value: string) {
   );
 }
 
-export function tokensToRems<T extends Exact<MetadataGroup, T>>(tokenGroup: T) {
+export function tokensToRems<T extends MetadataGroup>(tokenGroup: T) {
   return Object.fromEntries(
     Object.entries(tokenGroup).map(([token, properties]) => [
       token,


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR updates Polaris tokens to leverage the `satisfies` operator introduced in TypeScript v4.9

TODO:
- [ ] Create snapshot release
- [ ] Tophat in the Admin
- [ ] Extract Token and TokenGroup utility types to a separate PR

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
