### PR TITLE
Update Polaris tokens to expose token group types

### DIFF
--- a/.changeset/little-pens-change.md
+++ b/.changeset/little-pens-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Expose token group types

--- a/.changeset/little-pens-change.md
+++ b/.changeset/little-pens-change.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-tokens': minor
 ---
 
-Expose token group types
+Exposed types for each token group including scale/alias unions for select token groups

--- a/polaris-tokens/scripts/toTokenValues.ts
+++ b/polaris-tokens/scripts/toTokenValues.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
-import {removeMetadata} from '../src';
-import type {Entry, Entries, Metadata, Tokens} from '../src/types';
+import {removeMetadata, Metadata} from '../src';
+import type {Entry, Entries, Tokens} from '../src/types';
 
 const outputDir = path.join(__dirname, '../build');
 const outputFile = path.join(outputDir, 'index.ts');

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -5,5 +5,39 @@ export type {
   Tokens,
   MetadataProperties,
   MetadataGroup,
-  Metadata,
 } from './types';
+
+export type {
+  BreakpointsTokenName,
+  BreakpointsAlias,
+} from './token-groups/breakpoints';
+
+export type {ColorsTokenName} from './token-groups/colors';
+
+export type {DepthTokenName} from './token-groups/depth';
+
+export type {
+  FontTokenName,
+  FontSizeScale,
+  FontLineHeightScale,
+  FontWeightAlias,
+} from './token-groups/font';
+
+export type {LegacyTokenName} from './token-groups/legacy';
+
+export type {
+  MotionTokenName,
+  MotionDurationScale,
+  MotionKeyframesAlias,
+} from './token-groups/motion';
+
+export type {
+  ShapeTokenName,
+  ShapeBorderRadiusScale,
+  ShapeBorderRadiusAlias,
+  ShapeBorderRadiusScaleOrAlias,
+} from './token-groups/shape';
+
+export type {SpacingTokenName, SpacingSpaceScale} from './token-groups/spacing';
+
+export type {ZIndexTokenName, ZIndexZScale} from './token-groups/zIndex';

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -8,36 +8,48 @@ export type {
 } from './types';
 
 export type {
+  BreakpointsTokenGroup,
   BreakpointsTokenName,
   BreakpointsAlias,
 } from './token-groups/breakpoints';
 
-export type {ColorsTokenName} from './token-groups/colors';
+export type {ColorsTokenGroup, ColorsTokenName} from './token-groups/colors';
 
-export type {DepthTokenName} from './token-groups/depth';
+export type {DepthTokenGroup, DepthTokenName} from './token-groups/depth';
 
 export type {
+  FontTokenGroup,
   FontTokenName,
   FontSizeScale,
   FontLineHeightScale,
   FontWeightAlias,
 } from './token-groups/font';
 
-export type {LegacyTokenName} from './token-groups/legacy';
+export type {LegacyTokenGroup, LegacyTokenName} from './token-groups/legacy';
 
 export type {
+  MotionTokenGroup,
   MotionTokenName,
   MotionDurationScale,
   MotionKeyframesAlias,
 } from './token-groups/motion';
 
 export type {
+  ShapeTokenGroup,
   ShapeTokenName,
   ShapeBorderRadiusScale,
   ShapeBorderRadiusAlias,
   ShapeBorderRadiusScaleOrAlias,
 } from './token-groups/shape';
 
-export type {SpacingTokenName, SpacingSpaceScale} from './token-groups/spacing';
+export type {
+  SpacingTokenGroup,
+  SpacingTokenName,
+  SpacingSpaceScale,
+} from './token-groups/spacing';
 
-export type {ZIndexTokenName, ZIndexZScale} from './token-groups/zIndex';
+export type {
+  ZIndexTokenGroup,
+  ZIndexTokenName,
+  ZIndexZScale,
+} from './token-groups/zIndex';

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -39,7 +39,6 @@ export type {
   ShapeTokenName,
   ShapeBorderRadiusScale,
   ShapeBorderRadiusAlias,
-  ShapeBorderRadiusScaleOrAlias,
 } from './token-groups/shape';
 
 export type {

--- a/polaris-tokens/src/metadata.ts
+++ b/polaris-tokens/src/metadata.ts
@@ -1,4 +1,4 @@
-import type {Exact, Metadata} from './types';
+import type {Exact, MetadataBase} from './types';
 import {tokensToRems} from './utilities';
 import {breakpoints} from './token-groups/breakpoints';
 import {depth} from './token-groups/depth';
@@ -22,10 +22,12 @@ export const metadata = createMetadata({
   zIndex,
 });
 
+export type Metadata = typeof metadata;
+
 /**
  * Identity function that simply returns the provided tokens with metadata, but additionally
  * validates the input matches the `Metadata` type exactly and infers all members.
  */
-export function createMetadata<T extends Exact<Metadata, T>>(metadata: T) {
+export function createMetadata<T extends Exact<MetadataBase, T>>(metadata: T) {
   return metadata;
 }

--- a/polaris-tokens/src/token-groups/breakpoints.ts
+++ b/polaris-tokens/src/token-groups/breakpoints.ts
@@ -25,3 +25,14 @@ export const breakpoints = {
       'Commonly used for sizing containers (e.g. max-width). See below for media query usage.',
   },
 };
+
+export type BreakpointsTokenGroup = typeof breakpoints;
+export type BreakpointsTokenName = keyof BreakpointsTokenGroup;
+
+// e.g. "xs" | "sm" | "md" | "lg" | "xl"
+export type BreakpointsAlias = Extract<
+  BreakpointsTokenName,
+  `breakpoints-${string}`
+> extends `breakpoints-${infer Alias}`
+  ? Alias
+  : never;

--- a/polaris-tokens/src/token-groups/breakpoints.ts
+++ b/polaris-tokens/src/token-groups/breakpoints.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const breakpoints = {
   'breakpoints-xs': {
     value: '0px',
@@ -26,7 +28,7 @@ export const breakpoints = {
   },
 };
 
-export type BreakpointsTokenGroup = typeof breakpoints;
+export type BreakpointsTokenGroup = TokenGroup<typeof breakpoints>;
 export type BreakpointsTokenName = keyof BreakpointsTokenGroup;
 
 // e.g. "xs" | "sm" | "md" | "lg" | "xl"

--- a/polaris-tokens/src/token-groups/colors.ts
+++ b/polaris-tokens/src/token-groups/colors.ts
@@ -645,3 +645,6 @@ export const colors = {
       'For use as a decorative text color that is applied on a decorative surface.',
   },
 };
+
+export type ColorsTokenGroup = typeof colors;
+export type ColorsTokenName = keyof ColorsTokenGroup;

--- a/polaris-tokens/src/token-groups/colors.ts
+++ b/polaris-tokens/src/token-groups/colors.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const colors = {
   background: {
     value: 'rgba(246, 246, 247, 1)',
@@ -646,5 +648,5 @@ export const colors = {
   },
 };
 
-export type ColorsTokenGroup = typeof colors;
+export type ColorsTokenGroup = TokenGroup<typeof colors>;
 export type ColorsTokenName = keyof ColorsTokenGroup;

--- a/polaris-tokens/src/token-groups/depth.ts
+++ b/polaris-tokens/src/token-groups/depth.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const depth = {
   'shadow-transparent': {
     value: '0 0 0 0 transparent',
@@ -40,5 +42,5 @@ export const depth = {
   },
 };
 
-export type DepthTokenGroup = typeof depth;
+export type DepthTokenGroup = TokenGroup<typeof depth>;
 export type DepthTokenName = keyof DepthTokenGroup;

--- a/polaris-tokens/src/token-groups/depth.ts
+++ b/polaris-tokens/src/token-groups/depth.ts
@@ -39,3 +39,6 @@ export const depth = {
     value: 'inset 0 1px 0 rgba(0, 0, 0, 0.15)',
   },
 };
+
+export type DepthTokenGroup = typeof depth;
+export type DepthTokenName = keyof DepthTokenGroup;

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const font = {
   'font-family-sans': {
     value:
@@ -66,7 +68,7 @@ export const font = {
   },
 };
 
-export type FontTokenGroup = typeof font;
+export type FontTokenGroup = TokenGroup<typeof font>;
 export type FontTokenName = keyof FontTokenGroup;
 
 // e.g. "400" | "500" | "600" | "700" | "100" | ...

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -65,3 +65,30 @@ export const font = {
     value: '48px',
   },
 };
+
+export type FontTokenGroup = typeof font;
+export type FontTokenName = keyof FontTokenGroup;
+
+// e.g. "400" | "500" | "600" | "700" | "100" | ...
+export type FontSizeScale = Extract<
+  FontTokenName,
+  `font-size-${number}`
+> extends `font-size-${infer Scale}`
+  ? Scale
+  : never;
+
+// e.g. "1" | "2" | "3" | "4" | "5" | "6" | "7"
+export type FontLineHeightScale = Extract<
+  FontTokenName,
+  `font-line-height-${number}`
+> extends `font-line-height-${infer Scale}`
+  ? Scale
+  : never;
+
+// e.g. "bold" | "regular" | "medium" | "semibold"
+export type FontWeightAlias = Extract<
+  FontTokenName,
+  `font-weight-${string}`
+> extends `font-weight-${infer Alias}`
+  ? Alias
+  : never;

--- a/polaris-tokens/src/token-groups/legacy.ts
+++ b/polaris-tokens/src/token-groups/legacy.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const legacy = {
   'override-loading-z-index': {
     value: '514',
@@ -60,5 +62,5 @@ export const legacy = {
   },
 };
 
-export type LegacyTokenGroup = typeof legacy;
+export type LegacyTokenGroup = TokenGroup<typeof legacy>;
 export type LegacyTokenName = keyof LegacyTokenGroup;

--- a/polaris-tokens/src/token-groups/legacy.ts
+++ b/polaris-tokens/src/token-groups/legacy.ts
@@ -59,3 +59,6 @@ export const legacy = {
     value: '0px',
   },
 };
+
+export type LegacyTokenGroup = typeof legacy;
+export type LegacyTokenName = keyof LegacyTokenGroup;

--- a/polaris-tokens/src/token-groups/motion.ts
+++ b/polaris-tokens/src/token-groups/motion.ts
@@ -65,3 +65,22 @@ export const motion = {
     value: '{ to { transform: rotate(1turn) } }',
   },
 };
+
+export type MotionTokenGroup = typeof motion;
+export type MotionTokenName = keyof MotionTokenGroup;
+
+// e.g. "0" | "50" | "100" | "150" | ...
+export type MotionDurationScale = Extract<
+  MotionTokenName,
+  `duration-${number}`
+> extends `duration-${infer Scale}`
+  ? Scale
+  : never;
+
+// e.g. "bounce" | "fade-in" | "pulse" | "spin"
+export type MotionKeyframesAlias = Extract<
+  MotionTokenName,
+  `keyframes-${string}`
+> extends `keyframes-${infer Alias}`
+  ? Alias
+  : never;

--- a/polaris-tokens/src/token-groups/motion.ts
+++ b/polaris-tokens/src/token-groups/motion.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const motion = {
   'duration-0': {
     value: '0ms',
@@ -66,7 +68,7 @@ export const motion = {
   },
 };
 
-export type MotionTokenGroup = typeof motion;
+export type MotionTokenGroup = TokenGroup<typeof motion>;
 export type MotionTokenName = keyof MotionTokenGroup;
 
 // e.g. "0" | "50" | "100" | "150" | ...

--- a/polaris-tokens/src/token-groups/shape.ts
+++ b/polaris-tokens/src/token-groups/shape.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const shape = {
   'border-radius-05': {
     value: '2px',
@@ -61,7 +63,7 @@ export const shape = {
   },
 };
 
-export type ShapeTokenGroup = typeof shape;
+export type ShapeTokenGroup = TokenGroup<typeof shape>;
 export type ShapeTokenName = keyof ShapeTokenGroup;
 
 type ShapeBorderRadiusTokenName = Extract<

--- a/polaris-tokens/src/token-groups/shape.ts
+++ b/polaris-tokens/src/token-groups/shape.ts
@@ -60,3 +60,32 @@ export const shape = {
     value: 'var(--p-border-width-1) solid var(--p-divider-dark)',
   },
 };
+
+export type ShapeTokenGroup = typeof shape;
+export type ShapeTokenName = keyof ShapeTokenGroup;
+
+type ShapeBorderRadiusTokenName = Extract<
+  ShapeTokenName,
+  `border-radius-${string}`
+>;
+
+// e.g. "05" | "1" | "2" | "3" | "4" | "5" | "6"
+export type ShapeBorderRadiusScale = Extract<
+  ShapeBorderRadiusTokenName,
+  `border-radius-${number}`
+> extends `border-radius-${infer Scale}`
+  ? Scale
+  : never;
+
+// e.g. "base" | "large" | "half"
+export type ShapeBorderRadiusAlias = Exclude<
+  ShapeBorderRadiusTokenName,
+  `border-radius-${number}`
+> extends `border-radius-${infer Alias}`
+  ? Alias
+  : never;
+
+// e.g. "05" | "1" | "2" | ... | "base" | "large" | "half"
+export type ShapeBorderRadiusScaleOrAlias =
+  | ShapeBorderRadiusScale
+  | ShapeBorderRadiusAlias;

--- a/polaris-tokens/src/token-groups/shape.ts
+++ b/polaris-tokens/src/token-groups/shape.ts
@@ -86,8 +86,3 @@ export type ShapeBorderRadiusAlias = Exclude<
 > extends `border-radius-${infer Alias}`
   ? Alias
   : never;
-
-// e.g. "05" | "1" | "2" | ... | "base" | "large" | "half"
-export type ShapeBorderRadiusScaleOrAlias =
-  | ShapeBorderRadiusScale
-  | ShapeBorderRadiusAlias;

--- a/polaris-tokens/src/token-groups/spacing.ts
+++ b/polaris-tokens/src/token-groups/spacing.ts
@@ -51,3 +51,14 @@ export const spacing = {
     value: '128px',
   },
 };
+
+export type SpacingTokenGroup = typeof spacing;
+export type SpacingTokenName = keyof SpacingTokenGroup;
+
+// e.g. "0" | "025" | "05" | "1" | "2" | "3" | ...
+export type SpacingSpaceScale = Extract<
+  SpacingTokenName,
+  `space-${number}`
+> extends `space-${infer Scale}`
+  ? Scale
+  : never;

--- a/polaris-tokens/src/token-groups/spacing.ts
+++ b/polaris-tokens/src/token-groups/spacing.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const spacing = {
   'space-0': {
     value: '0',
@@ -52,7 +54,7 @@ export const spacing = {
   },
 };
 
-export type SpacingTokenGroup = typeof spacing;
+export type SpacingTokenGroup = TokenGroup<typeof spacing>;
 export type SpacingTokenName = keyof SpacingTokenGroup;
 
 // e.g. "0" | "025" | "05" | "1" | "2" | "3" | ...

--- a/polaris-tokens/src/token-groups/zIndex.ts
+++ b/polaris-tokens/src/token-groups/zIndex.ts
@@ -36,3 +36,14 @@ export const zIndex = {
     value: '520',
   },
 };
+
+export type ZIndexTokenGroup = typeof zIndex;
+export type ZIndexTokenName = keyof ZIndexTokenGroup;
+
+// e.g. "1" | "2" | "3" | "4" | "5" | "6" | ...
+export type ZIndexZScale = Extract<
+  ZIndexTokenName,
+  `z-${number}`
+> extends `z-${infer Scale}`
+  ? Scale
+  : never;

--- a/polaris-tokens/src/token-groups/zIndex.ts
+++ b/polaris-tokens/src/token-groups/zIndex.ts
@@ -1,3 +1,5 @@
+import type {TokenGroup} from '../types';
+
 export const zIndex = {
   'z-1': {
     value: '100',
@@ -37,7 +39,7 @@ export const zIndex = {
   },
 };
 
-export type ZIndexTokenGroup = typeof zIndex;
+export type ZIndexTokenGroup = TokenGroup<typeof zIndex>;
 export type ZIndexTokenName = keyof ZIndexTokenGroup;
 
 // e.g. "1" | "2" | "3" | "4" | "5" | "6" | ...

--- a/polaris-tokens/src/types.ts
+++ b/polaris-tokens/src/types.ts
@@ -1,3 +1,5 @@
+import type {Metadata} from './metadata';
+
 export type Entry<T> = [keyof T, T[keyof T]];
 export type Entries<T> = Entry<T>[];
 
@@ -10,28 +12,20 @@ export interface MetadataGroup {
   [token: string]: MetadataProperties;
 }
 
-export interface Metadata {
-  breakpoints: MetadataGroup;
-  colors: MetadataGroup;
-  depth: MetadataGroup;
-  font: MetadataGroup;
-  legacy: MetadataGroup;
-  motion: MetadataGroup;
-  shape: MetadataGroup;
-  spacing: MetadataGroup;
-  zIndex: MetadataGroup;
+export interface MetadataBase {
+  [tokenGroup: string]: MetadataGroup;
 }
 
 export interface TokenGroup {
   [token: string]: string;
 }
 
-export type Tokens = {
-  [Property in keyof MetadataGroup]: TokenGroup;
-};
-
 export type ExtractValues<T extends MetadataGroup> = {
   [K in keyof T]: T[K]['value'];
+};
+
+export type Tokens = {
+  [TokenGroup in keyof Metadata]: ExtractValues<Metadata[TokenGroup]>;
 };
 
 // The following utility types are copied directly from `type-fest`:

--- a/polaris-tokens/src/types.ts
+++ b/polaris-tokens/src/types.ts
@@ -16,16 +16,12 @@ export interface MetadataBase {
   [tokenGroup: string]: MetadataGroup;
 }
 
-export interface TokenGroup {
-  [token: string]: string;
-}
-
-export type ExtractValues<T extends MetadataGroup> = {
+export type TokenGroup<T extends MetadataGroup = MetadataGroup> = {
   [K in keyof T]: T[K]['value'];
 };
 
 export type Tokens = {
-  [TokenGroup in keyof Metadata]: ExtractValues<Metadata[TokenGroup]>;
+  [TokenGroupName in keyof Metadata]: TokenGroup<Metadata[TokenGroupName]>;
 };
 
 // The following utility types are copied directly from `type-fest`:

--- a/polaris-tokens/src/utilities.ts
+++ b/polaris-tokens/src/utilities.ts
@@ -1,11 +1,4 @@
-import type {
-  Entry,
-  Exact,
-  ExtractValues,
-  MetadataGroup,
-  Tokens,
-  TokenGroup,
-} from './types';
+import type {Entry, Exact, MetadataGroup, Tokens, TokenGroup} from './types';
 import type {breakpoints as metaBreakpointsTokenGroup} from './token-groups/breakpoints';
 
 const BASE_FONT_SIZE = 16;
@@ -132,11 +125,11 @@ export function removeMetadata<T extends Exact<MetadataGroup, T>>(
 
       return [tokenName, value];
     }),
-  ) as ExtractValues<T>;
+  ) as TokenGroup<T>;
 }
 
 export type MetaBreakpointsTokenGroup = typeof metaBreakpointsTokenGroup;
-export type BreakpointsTokenGroup = ExtractValues<MetaBreakpointsTokenGroup>;
+export type BreakpointsTokenGroup = TokenGroup<MetaBreakpointsTokenGroup>;
 
 export type BreakpointsTokenName = keyof BreakpointsTokenGroup;
 

--- a/polaris-tokens/src/utilities.ts
+++ b/polaris-tokens/src/utilities.ts
@@ -1,5 +1,9 @@
 import type {Entry, Exact, MetadataGroup, Tokens, TokenGroup} from './types';
-import type {breakpoints as metaBreakpointsTokenGroup} from './token-groups/breakpoints';
+import type {
+  breakpoints as metaBreakpointsTokenGroup,
+  BreakpointsTokenGroup,
+  BreakpointsTokenName,
+} from './token-groups/breakpoints';
 
 const BASE_FONT_SIZE = 16;
 
@@ -129,17 +133,6 @@ export function removeMetadata<T extends Exact<MetadataGroup, T>>(
 }
 
 export type MetaBreakpointsTokenGroup = typeof metaBreakpointsTokenGroup;
-export type BreakpointsTokenGroup = TokenGroup<MetaBreakpointsTokenGroup>;
-
-export type BreakpointsTokenName = keyof BreakpointsTokenGroup;
-
-/**
- * Alias extracted from each Polaris `breakpoints` token name.
- *
- * @example 'xs' | 'sm' | 'md' | 'lg' | 'xl'
- */
-export type BreakpointsAlias =
-  BreakpointsTokenName extends `${string}-${infer Alias}` ? Alias : never;
 
 /**
  * Alias direction used for composing Polaris `breakpoints` utilities.


### PR DESCRIPTION
Closes #7164 

### WHAT is this pull request doing?

This PR kicks off a pattern for exposing detailed token group types and utilities:
- A `TokenGroup` type is exposed for each token group e.g. `type FontTokenGroup = {...}`
- A `TokenName` union type is exposed for each token group e.g.
  `type FontTokenName = 'font-size-1'  | 'font-size-2' | 'font-weight-medium' | 'font-weight-bold' | ...`
- A `Scale` and/or `Alias` union type is exposed for select sub-token group naming conventions (we can expand on these iteratively) e.g.
  - `type FontSizeScale = '1' | '2' | ...`
  - `type FontWeightAlias = 'medium' | 'bold' | ...`
  
Additionally, this PR improves the accuracy of a couple existing types:
- `Metadata` now represents the inferred `metadata` object
- `Tokens` now represents the inferred `metadata` object with `value` extracted

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
