### PR TITLE
[Tooltip] Add callback props onClose and onOpen

### DIFF
--- a/.changeset/twelve-flowers-listen.md
+++ b/.changeset/twelve-flowers-listen.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-add onVisibilityChange callback for Tooltip component
+Added `onVisibilityChange` callback to `Tooltip`

--- a/.changeset/twelve-flowers-listen.md
+++ b/.changeset/twelve-flowers-listen.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Added `onVisibilityChange` callback to `Tooltip`
+Added `onClose` and `onOpen` callbacks to `Tooltip`

--- a/.changeset/twelve-flowers-listen.md
+++ b/.changeset/twelve-flowers-listen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+add onVisibilityChange callback for Tooltip component

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
 
-import {Page} from '../src';
+import {Page, Tooltip, TextStyle} from '../src';
 
 export function Playground() {
+  const callMonorailEventEmitter = (tooltipActivated: boolean) => {
+    if (tooltipActivated) console.log('Calling monorail event emitter!!');
+  };
+
   return (
     <Page title="Playground">
-      {/* Add the code you want to test in here */}
+      <Tooltip
+        active
+        content="This order has shipping labels."
+        onVisibilityChange={callMonorailEventEmitter}
+      >
+        <TextStyle variation="strong">Order #1001</TextStyle>
+      </Tooltip>
     </Page>
   );
 }

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,21 +1,11 @@
 import React from 'react';
 
-import {Page, Tooltip, TextStyle} from '../src';
+import {Page} from '../src';
 
 export function Playground() {
-  const callMonorailEventEmitter = (tooltipActivated: boolean) => {
-    if (tooltipActivated) console.log('Calling monorail event emitter!!');
-  };
-
   return (
     <Page title="Playground">
-      <Tooltip
-        active
-        content="This order has shipping labels."
-        onVisibilityChange={callMonorailEventEmitter}
-      >
-        <TextStyle variation="strong">Order #1001</TextStyle>
-      </Tooltip>
+      {/* Add the code you want to test in here */}
     </Page>
   );
 }

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -28,8 +28,10 @@ export interface TooltipProps {
   activatorWrapper?: string;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
-  /* Callback fired when the tooltip is activated or dismissed */
-  onVisibilityChange?(active: boolean): void;
+  /* Callback fired when the tooltip is activated */
+  onOpen?(): void;
+  /* Callback fired when the tooltip is dismissed */
+  onClose?(): void;
 }
 
 export function Tooltip({
@@ -40,7 +42,8 @@ export function Tooltip({
   preferredPosition = 'below',
   activatorWrapper = 'span',
   accessibilityLabel,
-  onVisibilityChange,
+  onOpen,
+  onClose,
 }: TooltipProps) {
   const WrapperComponent: any = activatorWrapper;
   const {
@@ -67,16 +70,13 @@ export function Tooltip({
     accessibilityNode.setAttribute('data-polaris-tooltip-activator', 'true');
   }, [id, children]);
 
-  useEffect(() => {
-    if (onVisibilityChange) onVisibilityChange(active);
-  }, [active, onVisibilityChange]);
-
   const handleKeyUp = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key !== 'Escape') return;
+      onClose?.();
       handleBlur();
     },
-    [handleBlur],
+    [handleBlur, onClose],
   );
 
   const portal = activatorNode ? (
@@ -97,8 +97,14 @@ export function Tooltip({
 
   return (
     <WrapperComponent
-      onFocus={handleFocus}
-      onBlur={handleBlur}
+      onFocus={() => {
+        onOpen?.();
+        handleFocus();
+      }}
+      onBlur={() => {
+        onClose?.();
+        handleBlur();
+      }}
       onMouseLeave={handleMouseLeave}
       onMouseOver={handleMouseEnterFix}
       ref={setActivator}
@@ -125,11 +131,13 @@ export function Tooltip({
 
   function handleMouseEnter() {
     mouseEntered.current = true;
+    onOpen?.();
     handleFocus();
   }
 
   function handleMouseLeave() {
     mouseEntered.current = false;
+    onClose?.();
     handleBlur();
   }
 

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -4,7 +4,6 @@ import {Portal} from '../Portal';
 import {findFirstFocusableNode} from '../../utilities/focus';
 import {useUniqueId} from '../../utilities/unique-id';
 import {useToggle} from '../../utilities/use-toggle';
-import {Key} from '../../types';
 
 import {TooltipOverlay, TooltipOverlayProps} from './components';
 
@@ -29,6 +28,8 @@ export interface TooltipProps {
   activatorWrapper?: string;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
+  /* Callback fired when the tooltip is activated or dismissed */
+  onVisibilityChange?(active: boolean): void;
 }
 
 export function Tooltip({
@@ -39,6 +40,7 @@ export function Tooltip({
   preferredPosition = 'below',
   activatorWrapper = 'span',
   accessibilityLabel,
+  onVisibilityChange,
 }: TooltipProps) {
   const WrapperComponent: any = activatorWrapper;
   const {
@@ -65,9 +67,13 @@ export function Tooltip({
     accessibilityNode.setAttribute('data-polaris-tooltip-activator', 'true');
   }, [id, children]);
 
+  useEffect(() => {
+    if (onVisibilityChange) onVisibilityChange(active);
+  }, [active, onVisibilityChange]);
+
   const handleKeyUp = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.keyCode !== Key.Escape) return;
+      if (event.key !== 'Escape') return;
       handleBlur();
     },
     [handleBlur],

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -31,6 +31,7 @@ describe('<Tooltip />', () => {
         <Link>link content</Link>
       </Tooltip>,
     );
+
     expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
   });
 
@@ -99,6 +100,7 @@ describe('<Tooltip />', () => {
     findWrapperComponent(tooltip)!.trigger('onKeyUp', {
       key: 'Escape',
     });
+
     expect(tooltip).toContainReactComponent(TooltipOverlay, {
       active: false,
     });
@@ -116,11 +118,30 @@ describe('<Tooltip />', () => {
       </Tooltip>,
     );
 
-    findWrapperComponent(tooltip)!.trigger('onKeyUp', {
-      key: 'Escape',
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      active: true,
     });
 
-    tooltip.forceUpdate();
+    expect(changeSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onVisibilityChange when initially activated and then closed', () => {
+    const changeSpy = jest.fn();
+    const tooltip = mountWithApp(
+      <Tooltip
+        active
+        content="This order has shipping labels."
+        onVisibilityChange={changeSpy}
+      >
+        <div>Order #1001</div>
+      </Tooltip>,
+    );
+
+    tooltip.act(() =>
+      findWrapperComponent(tooltip)!.trigger('onKeyUp', {
+        key: 'Escape',
+      }),
+    );
 
     expect(tooltip).toContainReactComponent(TooltipOverlay, {
       active: false,
@@ -169,7 +190,7 @@ describe('<Tooltip />', () => {
     const changeSpy = jest.fn();
 
     const tooltip = mountWithApp(
-      <Tooltip content="Inner content" onVisibilityChange={changeSpy}>
+      <Tooltip active content="Inner content" onVisibilityChange={changeSpy}>
         <Link>link content</Link>
       </Tooltip>,
     );
@@ -187,7 +208,7 @@ describe('<Tooltip />', () => {
     const changeSpy = jest.fn();
 
     const tooltip = mountWithApp(
-      <Tooltip content="Inner content" onVisibilityChange={changeSpy}>
+      <Tooltip active content="Inner content" onVisibilityChange={changeSpy}>
         <Link>link content</Link>
       </Tooltip>,
     );

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -106,13 +106,13 @@ describe('<Tooltip />', () => {
     });
   });
 
-  it('calls onVisibilityChange when initially activated', () => {
-    const changeSpy = jest.fn();
+  it('does not call onOpen when initially activated', () => {
+    const openSpy = jest.fn();
     const tooltip = mountWithApp(
       <Tooltip
         active
         content="This order has shipping labels."
-        onVisibilityChange={changeSpy}
+        onOpen={openSpy}
       >
         <div>Order #1001</div>
       </Tooltip>,
@@ -122,16 +122,16 @@ describe('<Tooltip />', () => {
       active: true,
     });
 
-    expect(changeSpy).toHaveBeenCalledWith(true);
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
-  it('calls onVisibilityChange when initially activated and then closed', () => {
-    const changeSpy = jest.fn();
+  it('calls onClose when initially activated and then closed', () => {
+    const closeSpy = jest.fn();
     const tooltip = mountWithApp(
       <Tooltip
         active
         content="This order has shipping labels."
-        onVisibilityChange={changeSpy}
+        onClose={closeSpy}
       >
         <div>Order #1001</div>
       </Tooltip>,
@@ -147,14 +147,14 @@ describe('<Tooltip />', () => {
       active: false,
     });
 
-    expect(changeSpy).toHaveBeenCalledWith(false);
+    expect(closeSpy).toHaveBeenCalled();
   });
 
-  it('calls onVisibilityChange on mouseOver', () => {
-    const changeSpy = jest.fn();
+  it('calls onOpen on mouseOver', () => {
+    const openSpy = jest.fn();
 
     const tooltip = mountWithApp(
-      <Tooltip content="Inner content" onVisibilityChange={changeSpy}>
+      <Tooltip content="Inner content" onOpen={openSpy}>
         <Link>link content</Link>
       </Tooltip>,
     );
@@ -165,14 +165,14 @@ describe('<Tooltip />', () => {
       active: true,
     });
 
-    expect(changeSpy).toHaveBeenCalledWith(true);
+    expect(openSpy).toHaveBeenCalled();
   });
 
-  it('calls onVisibilityChange on focus', () => {
-    const changeSpy = jest.fn();
+  it('calls onOpen on focus', () => {
+    const openSpy = jest.fn();
 
     const tooltip = mountWithApp(
-      <Tooltip content="Inner content" onVisibilityChange={changeSpy}>
+      <Tooltip content="Inner content" onOpen={openSpy}>
         <Link>link content</Link>
       </Tooltip>,
     );
@@ -183,14 +183,14 @@ describe('<Tooltip />', () => {
       active: true,
     });
 
-    expect(changeSpy).toHaveBeenCalledWith(true);
+    expect(openSpy).toHaveBeenCalled();
   });
 
-  it('calls onVisibilityChange on blur', () => {
-    const changeSpy = jest.fn();
+  it('calls onClose on blur', () => {
+    const closeSpy = jest.fn();
 
     const tooltip = mountWithApp(
-      <Tooltip active content="Inner content" onVisibilityChange={changeSpy}>
+      <Tooltip active content="Inner content" onClose={closeSpy}>
         <Link>link content</Link>
       </Tooltip>,
     );
@@ -201,14 +201,14 @@ describe('<Tooltip />', () => {
       active: false,
     });
 
-    expect(changeSpy).toHaveBeenCalledWith(false);
+    expect(closeSpy).toHaveBeenCalled();
   });
 
-  it('calls onVisibilityChange on mouseLeave', () => {
-    const changeSpy = jest.fn();
+  it('calls onClose on mouseLeave', () => {
+    const closeSpy = jest.fn();
 
     const tooltip = mountWithApp(
-      <Tooltip active content="Inner content" onVisibilityChange={changeSpy}>
+      <Tooltip active content="Inner content" onClose={closeSpy}>
         <Link>link content</Link>
       </Tooltip>,
     );
@@ -219,7 +219,7 @@ describe('<Tooltip />', () => {
       active: false,
     });
 
-    expect(changeSpy).toHaveBeenCalledWith(false);
+    expect(closeSpy).toHaveBeenCalled();
   });
 
   it('passes accessibility label to TooltipOverlay', () => {

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -4,7 +4,6 @@ import {mountWithApp} from 'tests/utilities';
 import {Link} from '../../Link';
 import {Tooltip} from '../Tooltip';
 import {TooltipOverlay} from '../components';
-import {Key} from '../../../types';
 
 describe('<Tooltip />', () => {
   it('renders its children', () => {
@@ -98,11 +97,108 @@ describe('<Tooltip />', () => {
     );
 
     findWrapperComponent(tooltip)!.trigger('onKeyUp', {
-      keyCode: Key.Escape,
+      key: 'Escape',
     });
     expect(tooltip).toContainReactComponent(TooltipOverlay, {
       active: false,
     });
+  });
+
+  it('calls onVisibilityChange when initially activated', () => {
+    const changeSpy = jest.fn();
+    const tooltip = mountWithApp(
+      <Tooltip
+        active
+        content="This order has shipping labels."
+        onVisibilityChange={changeSpy}
+      >
+        <div>Order #1001</div>
+      </Tooltip>,
+    );
+
+    findWrapperComponent(tooltip)!.trigger('onKeyUp', {
+      key: 'Escape',
+    });
+
+    tooltip.forceUpdate();
+
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      active: false,
+    });
+
+    expect(changeSpy).toHaveBeenCalledWith(false);
+  });
+
+  it('calls onVisibilityChange on mouseOver', () => {
+    const changeSpy = jest.fn();
+
+    const tooltip = mountWithApp(
+      <Tooltip content="Inner content" onVisibilityChange={changeSpy}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    findWrapperComponent(tooltip)!.trigger('onMouseOver');
+
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      active: true,
+    });
+
+    expect(changeSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onVisibilityChange on focus', () => {
+    const changeSpy = jest.fn();
+
+    const tooltip = mountWithApp(
+      <Tooltip content="Inner content" onVisibilityChange={changeSpy}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    findWrapperComponent(tooltip)!.trigger('onFocus');
+
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      active: true,
+    });
+
+    expect(changeSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onVisibilityChange on blur', () => {
+    const changeSpy = jest.fn();
+
+    const tooltip = mountWithApp(
+      <Tooltip content="Inner content" onVisibilityChange={changeSpy}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    findWrapperComponent(tooltip)!.trigger('onBlur');
+
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      active: false,
+    });
+
+    expect(changeSpy).toHaveBeenCalledWith(false);
+  });
+
+  it('calls onVisibilityChange on mouseLeave', () => {
+    const changeSpy = jest.fn();
+
+    const tooltip = mountWithApp(
+      <Tooltip content="Inner content" onVisibilityChange={changeSpy}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    findWrapperComponent(tooltip)!.trigger('onMouseLeave');
+
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      active: false,
+    });
+
+    expect(changeSpy).toHaveBeenCalledWith(false);
   });
 
   it('passes accessibility label to TooltipOverlay', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

It would be very helpful for consumers of the Tooltip component to be able to know when the visibility of the tooltip toggles on or off. This could be for firing monorail or other logging events.

### WHAT is this pull request doing?

Adding two callback functions for when the tooltip opens and closes.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
