### PR TITLE
Update `AlphaCard` border radius to a boolean

### DIFF
--- a/.changeset/fast-candles-approve.md
+++ b/.changeset/fast-candles-approve.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Updated `AlphaCard` border radius to a boolean

--- a/polaris-react/src/components/AlphaCard/AlphaCard.stories.tsx
+++ b/polaris-react/src/components/AlphaCard/AlphaCard.stories.tsx
@@ -32,9 +32,9 @@ export function BackgroundSubdued() {
   );
 }
 
-export function BorderRadius() {
+export function WithoutBorderRadius() {
   return (
-    <AlphaCard borderRadius="4">
+    <AlphaCard hasBorderRadius={false}>
       <AlphaStack spacing="5">
         <Text as="h3" variant="headingMd">
           Online store dashboard

--- a/polaris-react/src/components/AlphaCard/AlphaCard.tsx
+++ b/polaris-react/src/components/AlphaCard/AlphaCard.tsx
@@ -17,7 +17,7 @@ type CardElevationTokensScale = Extract<
 
 type CardBackgroundColorTokenScale = Extract<
   BackgroundColorTokenScale,
-  'surface' | `surface-${string}`
+  'surface' | 'surface-subdued'
 >;
 
 type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
@@ -26,28 +26,27 @@ export interface AlphaCardProps {
   /** Elements to display inside card */
   children?: React.ReactNode;
   backgroundColor?: CardBackgroundColorTokenScale;
-  borderRadius?: BorderRadiusTokenScale;
+  hasBorderRadius?: boolean;
   elevation?: CardElevationTokensScale;
   padding?: SpacingTokenScale;
   roundedAbove?: Breakpoint;
 }
 
-const defaultBorderRadius = '2';
-
 export const AlphaCard = ({
   children,
   backgroundColor = 'surface',
-  borderRadius: borderRadiusProp = defaultBorderRadius,
+  hasBorderRadius: hasBorderRadiusProp = true,
   elevation = 'card',
   padding = '5',
   roundedAbove,
 }: AlphaCardProps) => {
   const breakpoints = useBreakpoints();
+  const defaultBorderRadius = '2' as BorderRadiusTokenScale;
 
-  let borderRadius = !roundedAbove ? borderRadiusProp : null;
+  let hasBorderRadius = !roundedAbove && hasBorderRadiusProp;
 
   if (roundedAbove && breakpoints[`${roundedAbove}Up`]) {
-    borderRadius = borderRadiusProp;
+    hasBorderRadius = true;
   }
 
   return (
@@ -55,7 +54,7 @@ export const AlphaCard = ({
       background={backgroundColor}
       padding={padding}
       shadow={elevation}
-      {...(borderRadius && {borderRadius})}
+      {...(hasBorderRadius && {borderRadius: defaultBorderRadius})}
     >
       {children}
     </Box>

--- a/polaris.shopify.com/content/components/alpha-card/index.md
+++ b/polaris.shopify.com/content/components/alpha-card/index.md
@@ -29,9 +29,9 @@ examples:
   - fileName: alpha-card-subdued.tsx
     title: With subdued for secondary content
     description: Use for content that you want to deprioritize. Subdued cards don’t stand out as much as cards with white backgrounds so don’t use them for information or actions that are critical to merchants.
-  - fileName: alpha-card-border-radius.tsx
-    title: Border radius
-    description: Border radius can be adjusted when cards are nested, or added after a certain breakpoint.
+  - fileName: alpha-card-without-border-radius.tsx
+    title: Without border radius
+    description: Border radius can be toggled off, or added after a certain breakpoint.
   - fileName: alpha-card-flat.tsx
     title: Elevation
     description: Border radius can be adjusted when cards are nested, or added after a certain breakpoint.

--- a/polaris.shopify.com/content/components/alpha-card/index.md
+++ b/polaris.shopify.com/content/components/alpha-card/index.md
@@ -34,5 +34,5 @@ examples:
     description: Border radius can be toggled off, or added after a certain breakpoint.
   - fileName: alpha-card-flat.tsx
     title: Elevation
-    description: Border radius can be adjusted when cards are nested, or added after a certain breakpoint.
+    description: Elevation can be set to flat
 ---

--- a/polaris.shopify.com/pages/examples/alpha-card-without-border-radius.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-card-without-border-radius.tsx
@@ -5,7 +5,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function AlphaCardExample() {
   return (
     <AlphaStack>
-      <AlphaCard borderRadius="4">
+      <AlphaCard hasBorderRadius={false}>
         <AlphaStack spacing="5">
           <Text as="h3" variant="headingMd">
             Online store dashboard


### PR DESCRIPTION
### WHY are these changes introduced?

Based on conversation around `Card` https://github.com/Shopify/polaris/discussions/7195#discussioncomment-3737800

### WHAT is this pull request doing?

Border radius on the `AlphaCard` component is now a boolean so a card can either have no border radius or a border radius of `2` from the border radius token scale.

No change to the responsive border radius behaviour, a card can switch from no border radius to border radius of `2` at a breakpoint that's passed in as a prop.