### PR TITLE
Add processed marker to the Sass migrations template

### DIFF
--- a/polaris-migrator/templates/sass-migration/{{kebabCase migrationName}}/{{kebabCase migrationName}}.ts.hbs
+++ b/polaris-migrator/templates/sass-migration/{{kebabCase migrationName}}/{{kebabCase migrationName}}.ts.hbs
@@ -2,9 +2,14 @@ import type {FileInfo} from 'jscodeshift';
 import postcss, {Plugin} from 'postcss';
 import valueParser from 'postcss-value-parser';
 
+const processed = Symbol('processed');
+
 const plugin = (): Plugin => ({
   postcssPlugin: '{{kebabCase migrationName}}',
   Declaration(decl) {
+    // @ts-expect-error - Skip if processed so we don't process it again
+    if (decl[processed]) return;
+
     // const prop = decl.prop;
     const parsedValue = valueParser(decl.value);
 
@@ -15,6 +20,9 @@ const plugin = (): Plugin => ({
     });
 
     decl.value = parsedValue.toString();
+
+    // @ts-expect-error - Mark the declaration as processed
+    decl[processed] = true;
   },
 });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Most Sass migrations may need to have a processed marker in order to prevent the Declaration from being reprocessed when edited.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This adds that marker to the Sass template.