### PR TITLE
[Page] Update title type to support ReactNode

### DIFF
--- a/.changeset/cuddly-hotels-enjoy.md
+++ b/.changeset/cuddly-hotels-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Update the type of the Page title prop to ReactNode

--- a/.changeset/cuddly-hotels-enjoy.md
+++ b/.changeset/cuddly-hotels-enjoy.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Update the type of the Page title prop to ReactNode
+Added support for setting a `ReactNode` on the `Page` `title` prop

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -153,7 +153,9 @@ export function Header({
         rollup={isNavigationCollapsed}
         rollupActionsLabel={
           title
-            ? i18n.translate('Polaris.Page.Header.rollupActionsLabel', {title})
+            ? i18n.translate('Polaris.Page.Header.rollupActionsLabel', {
+                title: title as string,
+              })
             : undefined
         }
         onActionRollup={onActionRollup}
@@ -177,8 +179,14 @@ export function Header({
     actionMenuMarkup && styles.hasActionMenu,
     isNavigationCollapsed && styles.mobileView,
     !breadcrumbs.length && styles.noBreadcrumbs,
-    title && title.length < LONG_TITLE && styles.mediumTitle,
-    title && title.length > LONG_TITLE && styles.longTitle,
+    title &&
+      typeof title === 'string' &&
+      title.length < LONG_TITLE &&
+      styles.mediumTitle,
+    title &&
+      typeof title === 'string' &&
+      title.length > LONG_TITLE &&
+      styles.longTitle,
   );
 
   const {slot1, slot2, slot3, slot4, slot5, slot6} = determineLayout({
@@ -299,7 +307,7 @@ function determineLayout({
   pageTitleMarkup: JSX.Element;
   paginationMarkup: MaybeJSX;
   primaryActionMarkup: MaybeJSX;
-  title?: string;
+  title?: React.ReactNode;
 }) {
   //    Header Layout
   // |----------------------------------------------------|
@@ -322,6 +330,7 @@ function determineLayout({
         isNavigationCollapsed &&
         breadcrumbMarkup == null &&
         title != null &&
+        typeof title === 'string' &&
         title.length <= REALLY_SHORT_TITLE,
     },
     mobileDefault: {
@@ -349,6 +358,7 @@ function determineLayout({
         paginationMarkup == null &&
         actionMenuMarkup == null &&
         title != null &&
+        typeof title === 'string' &&
         title.length <= SHORT_TITLE,
     },
     desktopDefault: {

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
@@ -6,7 +6,7 @@ import styles from './Title.scss';
 
 export interface TitleProps {
   /** Page title, in large type */
-  title?: string;
+  title?: React.ReactNode;
   /** Page subtitle, in regular type*/
   subtitle?: string;
   /** Important and non-interactive status information shown immediately after the title. */


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/74318

As part of the Unifying Index Filtering and Search project, for indexes that support multiple locations, the location filter is moved into the `title` of the `Page`, as [seen in the spec](https://www.figma.com/file/bZb9bEHNCEMiYjzO0fhK4J/Index-filters-and-search?node-id=366%3A138390). This means that the Page component needs to update the allowed type of the `title` prop, from `string` to `React.ReactNode`.

### WHAT is this pull request doing?

Updates the type of the `title` prop for a Page/Header/Title component to be a ReactNode. 


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
