### PR TITLE
Add `fullWidth` prop for `AlphaStack`

### DIFF
--- a/.changeset/stale-penguins-love.md
+++ b/.changeset/stale-penguins-love.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': patch
+---
+
+Added `fullWidth` prop to `AlphaStack` and updated styleguide docs

--- a/polaris-react/src/components/AlphaStack/AlphaStack.scss
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.scss
@@ -8,3 +8,9 @@
     max-width: 100%;
   }
 }
+
+.fullWidth {
+  > * {
+    width: 100%;
+  }
+}

--- a/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
@@ -49,3 +49,14 @@ export function AlignEnd() {
     </AlphaStack>
   );
 }
+
+export function FullWidthChildren() {
+  return (
+    <AlphaStack fullWidth>
+      <Badge>Paid</Badge>
+      <Badge>Processing</Badge>
+      <Badge>Fulfilled</Badge>
+      <Badge>Completed</Badge>
+    </AlphaStack>
+  );
+}

--- a/polaris-react/src/components/AlphaStack/AlphaStack.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.tsx
@@ -16,18 +16,24 @@ type Align = 'start' | 'end' | 'center';
 export interface AlphaStackProps {
   /** Elements to display inside stack */
   children?: React.ReactNode;
-  /** Adjust spacing between elements */
-  spacing?: Spacing;
   /** Adjust vertical alignment of elements */
   align?: Align;
+  /** Toogle elements to be full width */
+  fullWidth?: boolean;
+  /** Adjust spacing between elements */
+  spacing?: Spacing;
 }
 
 export const AlphaStack = ({
   children,
-  spacing = '4',
   align = 'start',
+  fullWidth,
+  spacing = '4',
 }: AlphaStackProps) => {
-  const className = classNames(styles.AlphaStack);
+  const className = classNames(
+    styles.AlphaStack,
+    fullWidth && styles.fullWidth,
+  );
 
   const style = {
     '--pc-stack-align': align ? `${align}` : '',

--- a/polaris-react/src/components/AlphaStack/AlphaStack.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.tsx
@@ -12,7 +12,7 @@ export interface AlphaStackProps {
   children?: React.ReactNode;
   /** Adjust vertical alignment of elements */
   align?: Align;
-  /** Toogle elements to be full width */
+  /** Toggle elements to be full width */
   fullWidth?: boolean;
   /** Adjust spacing between elements */
   spacing?: SpacingSpaceScale;

--- a/polaris.shopify.com/content/components/alpha-stack/index.md
+++ b/polaris.shopify.com/content/components/alpha-stack/index.md
@@ -18,4 +18,8 @@ examples:
     title: Vertical spacing
     description: >-
       Vertical spacing for children can be set with the spacing property. Spacing options are provided using our spacing tokens.
+  - fileName: alpha-stack-with-full-width-children.tsx
+    title: Full width children
+    description: >-
+      Set children to full width
 ---

--- a/polaris.shopify.com/pages/examples/alpha-stack-with-full-width-children.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-stack-with-full-width-children.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {AlphaStack, Badge, Text} from '@shopify/polaris';
+
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function AlphaStackWithFullWidthChildrenExample() {
+  return (
+    <div style={{width: '500px'}}>
+      <AlphaStack fullWidth>
+        <Text variant="heading4xl" as="h2">
+          AlphaStack
+        </Text>
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </AlphaStack>
+    </div>
+  );
+}
+
+export default withPolarisExample(AlphaStackWithFullWidthChildrenExample);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #7208 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds a prop to `AlphaStack` that forces children to be full width.

<img width="916" alt="Screen Shot 2022-09-29 at 2 49 11 PM" src="https://user-images.githubusercontent.com/3474483/193148385-5268d4dc-9192-41fd-8656-f5da98aa3825.png">