### PR TITLE
Add migration for sass z-index fn

### DIFF
--- a/.changeset/hot-trains-laugh.md
+++ b/.changeset/hot-trains-laugh.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Add sass z-index migration

--- a/polaris-migrator/README.md
+++ b/polaris-migrator/README.md
@@ -168,6 +168,58 @@ Replace lengths (`px`, `rem`) and legacy Sass functions (`rem()`,`border()`, `bo
 npx @shopify/polaris-migrator replace-border-declarations <path>
 ```
 
+### `replace-sass-z-index`
+
+Replace the legacy Sass `z-index()` function with the supported CSS custom property token equivalent (ex: `var(--p-z-1)`).
+
+Any invocations of `z-index()` that correspond to a z-index design-token i.e. `--p-z-1` will be replaced with a css variable declaration.
+This includes invocations to the `$fixed-element-stacking-order` sass map i.e. `z-index(modal, $fixed-element-stacking-order)`.
+
+```diff
+- .decl-1 {
+-   z-index: z-index(content);
+- }
+- .decl-2 {
+-   z-index: z-index(modal, $fixed-element-stacking-order)
+- }
++ decl-1 {
++   z-index: var(--p-z-1);
++ }
++ .decl-2 {
++   z-index: var(--p-z-11)
++ }
+```
+
+Invocations of `z-index` within an arithmetic expression will be appended with a comment for review and manual migration.
+Generally in these instances you'll want to wrap the suggested code change in a `calc` however this may defer on a case by case basis in your codebase.
+
+```diff
+.decl-3 {
++  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
++  /* z-index: var(--p-z-1) + 1 */
+  z-index: z-index(content) + 1
+}
+```
+
+Invocations of `z-index` with a custom sass map property, will also be appended with a comment for review and manual migration.
+
+```diff
+.decl-3 {
++  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
++  /* z-index: map.get($custom-sass-map, modal) */
+  z-index: z-index(modal, $custom-sass-map)
+}
+```
+
+In these cases you may also want to run `npx sass-migrator module <path> --migrate-deps --load-path <load-path>` to ensure that
+`map.get` is in scope\*\*.
+
+Be aware that this may also create additional code changes in your codebase, we recommend running this only if there are large number of instances of migrations from `z-index` to `map.get`. Otherwise it may be easier to add `use 'sass:map'` to the top of your `.scss` file manually.
+
+```sh
+npx @shopify/polaris-migrator replace-sass-spacing <path>
+```
+
 ## Creating a migration
 
 ### Setup

--- a/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
@@ -1,0 +1,119 @@
+import type {API, FileInfo, Options} from 'jscodeshift';
+import postcss, {Plugin} from 'postcss';
+import valueParser, {FunctionNode, Node} from 'postcss-value-parser';
+
+import {POLARIS_MIGRATOR_COMMENT} from '../../constants';
+
+interface PluginOptions extends Options {
+  namespace?: string;
+}
+
+const processed = Symbol('processed');
+
+function isNumericOperator(node: Node): boolean {
+  return (
+    node.value === '+' ||
+    node.value === '-' ||
+    node.value === '*' ||
+    node.value === '/' ||
+    node.value === '%'
+  );
+}
+
+const zIndexMap = {
+  content: '--p-z-1',
+  overlay: '--p-z-2',
+};
+
+const isValidElement = (
+  element: unknown,
+): element is keyof typeof zIndexMap => {
+  return Object.keys(zIndexMap).includes(element as string);
+};
+
+const hasMoreThanOneArgument = (node: FunctionNode) => {
+  if (!node.nodes || !Array.isArray(node.nodes)) return false;
+  return node.nodes && node.nodes.length > 1;
+};
+
+const plugin = (options: PluginOptions = {}): Plugin => {
+  const namespace = options?.namespace || '';
+  // This migration could be run over sass with
+  // proper legacy-polaris namespacing
+  // or some other pre-processed / post-processed css
+  // in which case we'll still want to transform a non-namespaced z-index fn.
+  const functionName = namespace ? `${namespace}.z-index` : 'z-index';
+  const isZIndexFn = (node: Node): node is FunctionNode => {
+    return node.type === 'function' && node.value === functionName;
+  };
+  return {
+    postcssPlugin: 'replace-sass-z-index',
+    Declaration(decl) {
+      // @ts-expect-error - Skip if processed so we don't process it again
+      if (decl[processed]) return;
+
+      const parsed = valueParser(decl.value);
+
+      let containsZIndexFn = false;
+      let containsCalculation = false;
+      let containsSecondArgument = false;
+
+      parsed.walk((node) => {
+        if (isZIndexFn(node)) containsZIndexFn = true;
+        if (isNumericOperator(node)) containsCalculation = true;
+
+        if (!isZIndexFn(node)) return;
+
+        if (hasMoreThanOneArgument(node)) {
+          // If there's more than one argument to the zIndex fn
+          // We assume they're passing in a custom map
+          // In this case its unlikely this will resolve to a polaris token value
+          // transform legacy zIndex usage to map-get and move on.
+          containsSecondArgument = true;
+          node.value = 'map-get';
+        } else {
+          const element = node.nodes[0].value ?? '';
+          if (!isValidElement(element)) return;
+          const zIndexCustomProperty = zIndexMap[element];
+
+          node.value = 'var';
+          node.nodes = [
+            {
+              type: 'word',
+              value: zIndexCustomProperty,
+              sourceIndex: node.nodes[0]?.sourceIndex ?? 0,
+              sourceEndIndex: zIndexCustomProperty.length,
+            },
+            // Do we need this??
+            // Initial thought is no, we don't want to replicate additional arguments.
+            // ...node.nodes.slice(1),
+          ];
+        }
+      });
+
+      if (containsZIndexFn && (containsCalculation || containsSecondArgument)) {
+        // Insert comment if the declaration value contains calculations
+        // or if the invocation of zIndex has more than one argument
+        decl.before(postcss.comment({text: POLARIS_MIGRATOR_COMMENT}));
+        decl.before(
+          postcss.comment({text: `${decl.prop}: ${parsed.toString()};`}),
+        );
+      } else {
+        decl.value = parsed.toString();
+      }
+
+      // @ts-expect-error - Mark the declaration as processed
+      decl[processed] = true;
+    },
+  };
+};
+
+export default function replaceSassZIndex(
+  fileInfo: FileInfo,
+  _: API,
+  options: Options,
+) {
+  return postcss(plugin(options)).process(fileInfo.source, {
+    syntax: require('postcss-scss'),
+  }).css;
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
@@ -84,12 +84,12 @@ const plugin = (options: PluginOptions = {}): Plugin => {
               },
             ];
           } else {
+            // map.get arguments are in the reverse order to z-index arguments.
+            // map.get expects the map object first, and the key second.
             containsUnknownSecondArgument = true;
-            node.value = 'map-get';
+            node.value = 'map.get';
             node.nodes.reverse();
           }
-          // map-get arguments are in the reverse order to z-index arguments.
-          // map-get expects the map object first, and the key second.
         } else {
           const element = node.nodes[0]?.value ?? '';
           if (!isValidElement<typeof zIndexMap>(element, zIndexMap)) return;

--- a/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
@@ -2,6 +2,7 @@ import type {API, FileInfo, Options} from 'jscodeshift';
 import postcss, {Plugin} from 'postcss';
 import valueParser, {FunctionNode, Node} from 'postcss-value-parser';
 
+import {isNumericOperator} from '../../utilities/sass';
 import {POLARIS_MIGRATOR_COMMENT} from '../../constants';
 
 interface PluginOptions extends Options {
@@ -9,16 +10,6 @@ interface PluginOptions extends Options {
 }
 
 const processed = Symbol('processed');
-
-function isNumericOperator(node: Node): boolean {
-  return (
-    node.value === '+' ||
-    node.value === '-' ||
-    node.value === '*' ||
-    node.value === '/' ||
-    node.value === '%'
-  );
-}
 
 const zIndexMap = {
   content: '--p-z-1',

--- a/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
@@ -84,9 +84,6 @@ const plugin = (options: PluginOptions = {}): Plugin => {
               sourceIndex: node.nodes[0]?.sourceIndex ?? 0,
               sourceEndIndex: zIndexCustomProperty.length,
             },
-            // Do we need this??
-            // Initial thought is no, we don't want to replicate additional arguments.
-            // ...node.nodes.slice(1),
           ];
         }
       });

--- a/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
@@ -31,10 +31,7 @@ const isValidElement = (
   return Object.keys(zIndexMap).includes(element as string);
 };
 
-const hasMoreThanOneArgument = (node: FunctionNode) => {
-  if (!node.nodes || !Array.isArray(node.nodes)) return false;
-  return node.nodes && node.nodes.length > 1;
-};
+const hasMoreThanOneArgument = (node: FunctionNode) => node.nodes.length > 1;
 
 const plugin = (options: PluginOptions = {}): Plugin => {
   const namespace = options?.namespace || '';

--- a/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
@@ -51,6 +51,9 @@ const plugin = (options: PluginOptions = {}): Plugin => {
           // transform legacy zIndex usage to map-get and move on.
           containsSecondArgument = true;
           node.value = 'map-get';
+          // map-get arguments are in the reverse order to z-index arguments.
+          // map-get expects the map object first, and the key second.
+          node.nodes.reverse();
         } else {
           const element = node.nodes[0]?.value ?? '';
           if (!isValidElement(element)) return;

--- a/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/replace-sass-z-index.ts
@@ -72,7 +72,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
           containsSecondArgument = true;
           node.value = 'map-get';
         } else {
-          const element = node.nodes[0].value ?? '';
+          const element = node.nodes[0]?.value ?? '';
           if (!isValidElement(element)) return;
           const zIndexCustomProperty = zIndexMap[element];
 

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.input.scss
@@ -1,0 +1,36 @@
+$someElement: (
+  someKey: 1000;,
+);
+
+.scenario-1 {
+  z-index: z-index(content) + 1;
+  background-color: var(--p-background);
+}
+
+.scenario-2 {
+  z-index: z-index(overlay) + 1;
+  background-color: var(--p-background);
+}
+
+.scenario-3 {
+  z-index: z-index(content);
+  background-color: var(--p-background);
+}
+
+.scenario-4 {
+  z-index: z-index(overlay);
+  background-color: var(--p-background);
+}
+
+.scenario-5 {
+  z-index: z-index(someKey, $someElement);
+  background-color: var(--p-background);
+}
+
+.scenario-6 {
+  z-index: calc(z-index(overlay) + z-index(content));
+}
+
+.scenario-7 {
+  z-index: calc(#{z-index(dev-ui, $fixed-element-stacking-order)} + 1);
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.input.scss
@@ -34,3 +34,7 @@ $someElement: (
 .scenario-7 {
   z-index: calc(#{z-index(dev-ui, $fixed-element-stacking-order)} + 1);
 }
+
+.scenario-8 {
+  z-index: z-index(modal, $fixed-element-stacking-order);
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
@@ -42,3 +42,7 @@ $someElement: (
 .scenario-7 {
   z-index: calc(#{z-index(dev-ui, $fixed-element-stacking-order)} + 1);
 }
+
+.scenario-8 {
+  z-index: var(--p-z-11);
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
@@ -28,7 +28,7 @@ $someElement: (
 
 .scenario-5 {
   /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
-  /* z-index: map-get($someElement, someKey); */
+  /* z-index: map.get($someElement, someKey); */
   z-index: z-index(someKey, $someElement);
   background-color: var(--p-background);
 }

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
@@ -28,7 +28,7 @@ $someElement: (
 
 .scenario-5 {
   /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
-  /* z-index: map-get(someKey, $someElement); */
+  /* z-index: map-get($someElement, someKey); */
   z-index: z-index(someKey, $someElement);
   background-color: var(--p-background);
 }

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
@@ -3,14 +3,14 @@ $someElement: (
 );
 
 .scenario-1 {
-  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
   /* z-index: var(--p-z-1) + 1; */
   z-index: z-index(content) + 1;
   background-color: var(--p-background);
 }
 
 .scenario-2 {
-  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
   /* z-index: var(--p-z-2) + 1; */
   z-index: z-index(overlay) + 1;
   background-color: var(--p-background);
@@ -27,14 +27,14 @@ $someElement: (
 }
 
 .scenario-5 {
-  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
   /* z-index: map-get($someElement, someKey); */
   z-index: z-index(someKey, $someElement);
   background-color: var(--p-background);
 }
 
 .scenario-6 {
-  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
   /* z-index: calc(var(--p-z-2) + var(--p-z-1)); */
   z-index: calc(z-index(overlay) + z-index(content));
 }

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.output.scss
@@ -1,0 +1,44 @@
+$someElement: (
+  someKey: 1000;,
+);
+
+.scenario-1 {
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* z-index: var(--p-z-1) + 1; */
+  z-index: z-index(content) + 1;
+  background-color: var(--p-background);
+}
+
+.scenario-2 {
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* z-index: var(--p-z-2) + 1; */
+  z-index: z-index(overlay) + 1;
+  background-color: var(--p-background);
+}
+
+.scenario-3 {
+  z-index: var(--p-z-1);
+  background-color: var(--p-background);
+}
+
+.scenario-4 {
+  z-index: var(--p-z-2);
+  background-color: var(--p-background);
+}
+
+.scenario-5 {
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* z-index: map-get(someKey, $someElement); */
+  z-index: z-index(someKey, $someElement);
+  background-color: var(--p-background);
+}
+
+.scenario-6 {
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* z-index: calc(var(--p-z-2) + var(--p-z-1)); */
+  z-index: calc(z-index(overlay) + z-index(content));
+}
+
+.scenario-7 {
+  z-index: calc(#{z-index(dev-ui, $fixed-element-stacking-order)} + 1);
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.test.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.test.ts
@@ -1,7 +1,7 @@
 import {check} from '../../../utilities/testUtils';
 
 const migration = 'replace-sass-z-index';
-const fixtures = ['with-namespace'];
+const fixtures = ['replace-sass-z-index', 'with-namespace'];
 
 for (const fixture of fixtures) {
   check(__dirname, {

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.test.ts
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/replace-sass-z-index.test.ts
@@ -1,0 +1,17 @@
+import {check} from '../../../utilities/testUtils';
+
+const migration = 'replace-sass-z-index';
+const fixtures = ['with-namespace'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: 'scss',
+    options: {
+      namespace: fixture.includes('with-namespace')
+        ? 'legacy-polaris-v8'
+        : undefined,
+    },
+  });
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.input.scss
@@ -1,0 +1,41 @@
+@use 'global-styles/legacy-polaris-v8';
+$someElement: (
+  someKey: 1000;,
+);
+
+.scenario-1 {
+  z-index: legacy-polaris-v8.z-index(content) + 1;
+  background-color: var(--p-background);
+}
+
+.scenario-2 {
+  z-index: legacy-polaris-v8.z-index(overlay) + 1;
+  background-color: var(--p-background);
+}
+
+.scenario-3 {
+  z-index: legacy-polaris-v8.z-index(content);
+  background-color: var(--p-background);
+}
+
+.scenario-4 {
+  z-index: legacy-polaris-v8.z-index(overlay);
+  background-color: var(--p-background);
+}
+
+.scenario-5 {
+  z-index: legacy-polaris-v8.z-index(someKey, $someElement);
+  background-color: var(--p-background);
+}
+
+.scenario-6 {
+  z-index: calc(
+    legacy-polaris-v8.z-index(overlay) + legacy-polaris-v8.z-index(content)
+  );
+}
+
+.scenario-7 {
+  z-index: calc(
+    #{legacy-polaris-v8.z-index(dev-ui, $fixed-element-stacking-order)} + 1
+  );
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.input.scss
@@ -39,3 +39,10 @@ $someElement: (
     #{legacy-polaris-v8.z-index(dev-ui, $fixed-element-stacking-order)} + 1
   );
 }
+
+.scenario-8 {
+  z-index: legacy-polaris-v8.z-index(
+    modal,
+    legacy-polaris-v8.$fixed-element-stacking-order
+  );
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
@@ -29,7 +29,7 @@ $someElement: (
 
 .scenario-5 {
   /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
-  /* z-index: map-get(someKey, $someElement); */
+  /* z-index: map-get($someElement, someKey); */
   z-index: legacy-polaris-v8.z-index(someKey, $someElement);
   background-color: var(--p-background);
 }

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
@@ -4,14 +4,14 @@ $someElement: (
 );
 
 .scenario-1 {
-  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
   /* z-index: var(--p-z-1) + 1; */
   z-index: legacy-polaris-v8.z-index(content) + 1;
   background-color: var(--p-background);
 }
 
 .scenario-2 {
-  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
   /* z-index: var(--p-z-2) + 1; */
   z-index: legacy-polaris-v8.z-index(overlay) + 1;
   background-color: var(--p-background);
@@ -28,14 +28,14 @@ $someElement: (
 }
 
 .scenario-5 {
-  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
   /* z-index: map-get($someElement, someKey); */
   z-index: legacy-polaris-v8.z-index(someKey, $someElement);
   background-color: var(--p-background);
 }
 
 .scenario-6 {
-  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
   /* z-index: calc(
     var(--p-z-2) + var(--p-z-1)
   ); */

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
@@ -1,0 +1,51 @@
+@use 'global-styles/legacy-polaris-v8';
+$someElement: (
+  someKey: 1000;,
+);
+
+.scenario-1 {
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* z-index: var(--p-z-1) + 1; */
+  z-index: legacy-polaris-v8.z-index(content) + 1;
+  background-color: var(--p-background);
+}
+
+.scenario-2 {
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* z-index: var(--p-z-2) + 1; */
+  z-index: legacy-polaris-v8.z-index(overlay) + 1;
+  background-color: var(--p-background);
+}
+
+.scenario-3 {
+  z-index: var(--p-z-1);
+  background-color: var(--p-background);
+}
+
+.scenario-4 {
+  z-index: var(--p-z-2);
+  background-color: var(--p-background);
+}
+
+.scenario-5 {
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* z-index: map-get(someKey, $someElement); */
+  z-index: legacy-polaris-v8.z-index(someKey, $someElement);
+  background-color: var(--p-background);
+}
+
+.scenario-6 {
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* z-index: calc(
+    var(--p-z-2) + var(--p-z-1)
+  ); */
+  z-index: calc(
+    legacy-polaris-v8.z-index(overlay) + legacy-polaris-v8.z-index(content)
+  );
+}
+
+.scenario-7 {
+  z-index: calc(
+    #{legacy-polaris-v8.z-index(dev-ui, $fixed-element-stacking-order)} + 1
+  );
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
@@ -49,3 +49,7 @@ $someElement: (
     #{legacy-polaris-v8.z-index(dev-ui, $fixed-element-stacking-order)} + 1
   );
 }
+
+.scenario-8 {
+  z-index: var(--p-z-11);
+}

--- a/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-z-index/tests/with-namespace.output.scss
@@ -29,7 +29,7 @@ $someElement: (
 
 .scenario-5 {
   /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
-  /* z-index: map-get($someElement, someKey); */
+  /* z-index: map.get($someElement, someKey); */
   z-index: legacy-polaris-v8.z-index(someKey, $someElement);
   background-color: var(--p-background);
 }


### PR DESCRIPTION
WHY are these changes introduced?
Part of #7211 

WHAT is this pull request doing?
Adding a replace-sass-z-index migration script.

Running npx @shopify/polaris-migrator replace-sass-z-index "**/*.scss" will target z-index function usage and do the following: 

* If more than one argument exists we assume the code is invoking z-index to map-get on a custom sass map. In this case, we add a comment with a migration warning and code snippet replacing the `legacy-polaris-v8.z-index` usage with `map-get`
* If there's a calculation in the same declaration but the `legacy-polaris-v8.z-index` invocation is valid and corresponds to a polaris token, we add a comment with a migration warning and a code snippet replacing that invocation with a css variable invocation pointing at the corresponding polaris-token. 
* If its just a valid `legacy-polaris-v8.z-index` invocation that corresponds to an existing polaris token, we replace it with a css-variable invocation pointing at the corresponding polaris-token. 
* Otherwise we ignore the declaration. 

Things our codemod doesn't presently understand but should: 
* interpolations. `calc(#{legacy-polaris-v8.z-index} + 1)` for example is completely ignored by our code. As post-css interprets this as an invocation of a function called `#{legacy-polaris-v8.z-index`. It doesn't seem to understand interpolations at the moment. We can probably use something like style-lint's [hasInterpolation](https://github.dev/stylelint/stylelint/blob/eee9deb35190f46c5f964769d521fef5d7d1d7a8/lib/utils/__tests__/hasInterpolation.test.js#L5) to work around this, (ty @aaronccasanova), but not something we should worry about for first pass imo. 