### PR TITLE
Remove migration for `0` and `0px` length values

### DIFF
--- a/.changeset/dull-roses-deliver.md
+++ b/.changeset/dull-roses-deliver.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Remove `0` and `0px` length values from `replace-sass-lengths` migration

--- a/polaris-migrator/src/migrations/replace-sass-lengths/replace-sass-lengths.ts
+++ b/polaris-migrator/src/migrations/replace-sass-lengths/replace-sass-lengths.ts
@@ -39,8 +39,6 @@ const isTargetProp = (propName: unknown): propName is TargetProp =>
 
 // Mapping of spacing tokens and their corresponding px values
 const spacingTokensMap = {
-  '0': '--p-space-0',
-  '0px': '--p-space-0',
   '1px': '--p-space-025',
   '2px': '--p-space-05',
   '4px': '--p-space-1',

--- a/polaris-migrator/src/migrations/replace-sass-lengths/tests/replace-sass-lengths.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-lengths/tests/replace-sass-lengths.output.scss
@@ -4,7 +4,7 @@
   color: lightsteelblue;
 
   // Unitless
-  padding: var(--p-space-0);
+  padding: 0;
   padding: 1;
   padding: 2;
 
@@ -31,8 +31,8 @@
   padding: 10px 10rem;
   padding: var(--p-space-4) 10rem;
   padding: 10px var(--p-space-4);
-  padding: var(--p-space-0) var(--p-space-4);
-  padding: var(--p-space-4) var(--p-space-0);
+  padding: 0 var(--p-space-4);
+  padding: var(--p-space-4) 0;
 
   // Double shorthand mixed edge cases
   padding: var(--p-space-4) 4in;

--- a/polaris-migrator/src/migrations/replace-sass-lengths/tests/with-namespace.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-lengths/tests/with-namespace.output.scss
@@ -5,7 +5,7 @@
   color: lightsteelblue;
 
   // Unitless
-  padding: var(--p-space-0);
+  padding: 0;
   padding: 1;
   padding: 2;
 
@@ -32,8 +32,8 @@
   padding: 10px 10rem;
   padding: var(--p-space-4) 10rem;
   padding: 10px var(--p-space-4);
-  padding: var(--p-space-0) var(--p-space-4);
-  padding: var(--p-space-4) var(--p-space-0);
+  padding: 0 var(--p-space-4);
+  padding: var(--p-space-4) 0;
 
   // Double shorthand mixed edge cases
   padding: var(--p-space-4) 4in;


### PR DESCRIPTION
Part of: #7212

Removing these migrations to [unblock migrating other length values](https://github.com/Shopify/web/pull/74434#issuecomment-1263844980). This PR removes `0` and `0px` length migrations for margin and padding properties. We will need to have further discussion on whether to have 0s in Polaris' token scales.
