### PR TITLE
Rename `AlphaCard` shadow prop

### DIFF
--- a/.changeset/selfish-poets-lick.md
+++ b/.changeset/selfish-poets-lick.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Renamed `AlphaCard` `shadow` prop

--- a/polaris-react/src/components/AlphaCard/AlphaCard.stories.tsx
+++ b/polaris-react/src/components/AlphaCard/AlphaCard.stories.tsx
@@ -60,7 +60,7 @@ export function BorderRadiusRoundedAbove() {
 
 export function Flat() {
   return (
-    <AlphaCard elevation="transparent">
+    <AlphaCard shadow="transparent">
       <AlphaStack spacing="5">
         <Text as="h3" variant="headingMd">
           Online store dashboard

--- a/polaris-react/src/components/AlphaCard/AlphaCard.tsx
+++ b/polaris-react/src/components/AlphaCard/AlphaCard.tsx
@@ -10,10 +10,7 @@ import React from 'react';
 import {useBreakpoints} from '../../utilities/breakpoints';
 import {Box} from '../Box';
 
-type CardElevationTokensScale = Extract<
-  DepthShadowAlias,
-  'card' | 'transparent'
->;
+type CardShadowTokensScale = Extract<DepthShadowAlias, 'card' | 'transparent'>;
 
 type CardBackgroundColorTokenScale = Extract<
   ColorsTokenName,
@@ -25,7 +22,7 @@ export interface AlphaCardProps {
   children?: React.ReactNode;
   background?: CardBackgroundColorTokenScale;
   hasBorderRadius?: boolean;
-  elevation?: CardElevationTokensScale;
+  shadow?: CardShadowTokensScale;
   padding?: SpacingSpaceScale;
   roundedAbove?: BreakpointsAlias;
 }
@@ -34,7 +31,7 @@ export const AlphaCard = ({
   children,
   background = 'surface',
   hasBorderRadius: hasBorderRadiusProp = true,
-  elevation = 'card',
+  shadow = 'card',
   padding = '5',
   roundedAbove,
 }: AlphaCardProps) => {
@@ -51,7 +48,7 @@ export const AlphaCard = ({
     <Box
       background={background}
       padding={padding}
-      shadow={elevation}
+      shadow={shadow}
       {...(hasBorderRadius && {borderRadius: defaultBorderRadius})}
     >
       {children}

--- a/polaris.shopify.com/pages/examples/alpha-card-flat.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-card-flat.tsx
@@ -4,7 +4,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function AlphaCardExample() {
   return (
-    <AlphaCard elevation="transparent">
+    <AlphaCard shadow="transparent">
       <AlphaStack spacing="5">
         <Text as="h3" variant="headingMd">
           Online store dashboard


### PR DESCRIPTION
### WHY are these changes introduced?

Rename shadow prop for consistency with `Box` component