### PR TITLE
Rotate tokens so CI runs in the release PR's

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
       - name: Free up space on GitHub image
         run: |
@@ -41,4 +43,4 @@ jobs:
           publish: yarn release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}


### PR DESCRIPTION
Copying the work in https://github.com/Shopify/quilt/pull/2426/files this updates the tokens so that CI runs when creating the release PR's.