### PR TITLE
Update deploy-polaris.shopify.com.yml to use default token

### DIFF
--- a/.github/workflows/deploy-polaris.shopify.com.yml
+++ b/.github/workflows/deploy-polaris.shopify.com.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Trigger deploy polaris.shopify.com
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: "shopify",


### PR DESCRIPTION
https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/

> https://github.com/Shopify/polaris/pull/7011 was some token dancing stuff because workflow-dispatch events that used the default GITHUB_TOKEN wouldn’t trigger jobs. https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/ just got announced so i think that has the potential to still work if you use the default GITHUB_TOKEN rather than a bespoke one. (cc [@alex.page](https://shopify.slack.com/team/W018WAZ0DMX) when you’re back from holiday in like 3 weeks)