### PR TITLE
Add workflow to dispatch the update-performance workflow

### DIFF
--- a/.github/workflows/update-performance-dispatch.yml
+++ b/.github/workflows/update-performance-dispatch.yml
@@ -1,0 +1,23 @@
+name: Update performance dispatch
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'polaris-react/**'
+
+jobs:
+  update-performance-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: "shopify",
+              repo: "polaris-coverage-shopifycloud-com",
+              workflow_id: "update-performance.yml",
+              ref: "main"
+            });


### PR DESCRIPTION
This will trigger the [update-performance](https://github.com/Shopify/polaris-coverage-shopifycloud-com/blob/ea7da299dcf52a9caafe92cf777d718681ee9019/.github/workflows/update-performance.yml) workflow to update the performance data in the Polaris coverage website.

Companion PR https://github.com/Shopify/polaris-coverage-shopifycloud-com/pull/122 which should ship first.

Not sure if there is a way to test this workflow before merging it.