### PR TITLE
Port codesandbox init code to React 18

### DIFF
--- a/.changeset/tame-rockets-learn.md
+++ b/.changeset/tame-rockets-learn.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Ported codesandbox init code to React 18

--- a/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx
+++ b/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx
@@ -20,15 +20,18 @@ const getAppCode = (code: string) => {
 
 const indexCode = `
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import App from "./App";
 import { AppProvider } from "@shopify/polaris";
-import en from '@shopify/polaris/locales/en.json';
+import en from "@shopify/polaris/locales/en.json";
 import "@shopify/polaris/build/esm/styles.css";
-
-const app = <AppProvider i18n={en}><App /></AppProvider>;
-
-ReactDOM.render(app, document.getElementById("root"));
+const container = document.getElementById("root");
+const root = createRoot(container);
+root.render(
+  <AppProvider i18n={en}>
+    <App />
+  </AppProvider>
+);
 `;
 
 interface Props {


### PR DESCRIPTION
Codesandbox uses React 18 now so we're seeing errors when clicking the `Edit in codesandbox` button:
![image](https://screenshot.click/05-55-0vjbb-ipgko.png)

https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis