### PR TITLE
[IndexTable] Add sort toggle labels and fix z-index icon issue

### DIFF
--- a/.changeset/cyan-adults-refuse.md
+++ b/.changeset/cyan-adults-refuse.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Update `IndexTable` in sortable mode to fix visual bugs and include label Tooltips

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -235,11 +235,20 @@ $loading-panel-height: 53px;
 .TableHeadingSortIcon {
   order: 1;
   opacity: 0;
+  height: var(--p-space-5);
+  width: var(--p-space-5);
   transition: var(--p-ease) var(--p-duration-150) opacity;
 }
 
 .TableHeadingSortIcon-visible {
   opacity: 1;
+}
+
+.TableHeadingSortSvg {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .ColumnHeaderCheckboxWrapper {

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -218,7 +218,7 @@ $loading-panel-height: 53px;
   padding: 0;
   border: 0;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   font-weight: var(--p-font-weight-medium);

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -217,6 +217,7 @@ $loading-panel-height: 53px;
   padding: 0;
   border: 0;
   cursor: pointer;
+  position: static;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -237,7 +238,8 @@ $loading-panel-height: 53px;
   opacity: 0;
   height: var(--p-space-5);
   width: var(--p-space-5);
-  transition: var(--p-ease) var(--p-duration-150) opacity;
+  transition: opacity var(--p-duration-200) var(--p-ease-in)
+    var(--p-duration-100);
 }
 
 .TableHeadingSortIcon-visible {
@@ -396,6 +398,12 @@ $loading-panel-height: 53px;
     .TableCell:last-child {
       background-color: var(--p-surface-selected);
     }
+  }
+}
+
+.Table-sortable {
+  .TableHeading {
+    background-color: var(--p-surface-subdued);
   }
 }
 

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -213,11 +213,11 @@ $loading-panel-height: 53px;
 }
 
 .TableHeadingSortButton {
+  position: static;
   background: none;
   padding: 0;
   border: 0;
   cursor: pointer;
-  position: static;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1351,11 +1351,23 @@ export function WithSortableHeadings() {
   const [sortIndex, setSortIndex] = useState(0);
   const [sortDirection, setSortDirection] = useState('descending');
 
+  const sortToggleLabels = {
+    0: {ascending: 'A-Z', descending: 'Z-A'},
+    1: {ascending: 'Ascending', descending: 'Descending'},
+    2: {ascending: 'Newest', descending: 'Oldest'},
+    3: {ascending: 'Ascending', descending: 'Ascending'},
+    4: {ascending: 'A-Z', descending: 'Z-A'},
+    5: {ascending: 'A-Z', descending: 'Z-A'},
+    6: {ascending: 'A-Z', descending: 'Z-A'},
+    7: {ascending: 'A-Z', descending: 'Z-A'},
+  };
+
   const initialRows = [
     {
       id: '3411',
       url: 'customers/341',
       name: 'Mae Jemison',
+      date: '2022-02-04',
       location: 'Decatur, USA',
       orders: 20,
       amountSpent: '$2,400',
@@ -1366,6 +1378,7 @@ export function WithSortableHeadings() {
     {
       id: '2561',
       url: 'customers/256',
+      date: '2022-01-19',
       name: 'Ellen Ochoa',
       location: 'Los Angeles, USA',
       orders: 30,
@@ -1377,6 +1390,7 @@ export function WithSortableHeadings() {
     {
       id: '1245',
       url: 'customers/123',
+      date: '2021-12-12',
       name: 'Anne-Marie Johnson',
       location: 'Portland, USA',
       orders: 10,
@@ -1388,6 +1402,7 @@ export function WithSortableHeadings() {
     {
       id: '8741',
       url: 'customers/543',
+      date: '2022-05-11',
       name: 'Bradley Stevens',
       location: 'Hialeah, USA',
       orders: 5,
@@ -1436,6 +1451,7 @@ export function WithSortableHeadings() {
       {
         id,
         name,
+        date,
         location,
         orders,
         amountSpent,
@@ -1454,6 +1470,7 @@ export function WithSortableHeadings() {
         <IndexTable.Cell>
           <TextStyle variation="strong">{name}</TextStyle>
         </IndexTable.Cell>
+        <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>
         <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
@@ -1475,6 +1492,7 @@ export function WithSortableHeadings() {
         onSelectionChange={handleSelectionChange}
         headings={[
           {title: 'Name'},
+          {title: 'Date'},
           {title: 'Order count'},
           {title: 'Amount spent'},
           {title: 'Location'},
@@ -1482,10 +1500,12 @@ export function WithSortableHeadings() {
           {title: 'Payment status'},
           {title: 'Notes'},
         ]}
-        sortable={[true, true, false, true, true, true, false]}
+        sortable={[true, true, false, true, true, false, false]}
         sortDirection={sortDirection}
         sortColumnIndex={sortIndex}
         onSort={handleClickSortHeading}
+        sortToggleLabels={sortToggleLabels}
+        lastColumnSticky
       >
         {rowMarkup}
       </IndexTable>

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1359,6 +1359,9 @@ export function WithSortableHeadings() {
       location: 'Decatur, USA',
       orders: 20,
       amountSpent: '$2,400',
+      fulfillmentStatus: 'Fulfilled',
+      paymentStatus: 'Paid',
+      notes: '',
     },
     {
       id: '2561',
@@ -1367,6 +1370,9 @@ export function WithSortableHeadings() {
       location: 'Los Angeles, USA',
       orders: 30,
       amountSpent: '$140',
+      fulfillmentStatus: 'Fulfilled',
+      paymentStatus: 'Not paid',
+      notes: 'This customer lives on the 3rd floor',
     },
     {
       id: '1245',
@@ -1375,6 +1381,9 @@ export function WithSortableHeadings() {
       location: 'Portland, USA',
       orders: 10,
       amountSpent: '$250',
+      fulfillmentStatus: 'Fulfilled',
+      paymentStatus: 'Not paid',
+      notes: '',
     },
     {
       id: '8741',
@@ -1383,6 +1392,9 @@ export function WithSortableHeadings() {
       location: 'Hialeah, USA',
       orders: 5,
       amountSpent: '$26',
+      fulfillmentStatus: 'Unfulfilled',
+      paymentStatus: 'Not paid',
+      notes: 'This customer has requested fragile delivery',
     },
   ];
   const [sortedRows, setSortedRows] = useState(
@@ -1420,7 +1432,19 @@ export function WithSortableHeadings() {
   }
 
   const rowMarkup = rows.map(
-    ({id, name, location, orders, amountSpent}, index) => (
+    (
+      {
+        id,
+        name,
+        location,
+        orders,
+        amountSpent,
+        fulfillmentStatus,
+        paymentStatus,
+        notes,
+      },
+      index,
+    ) => (
       <IndexTable.Row
         id={id}
         key={id}
@@ -1433,6 +1457,9 @@ export function WithSortableHeadings() {
         <IndexTable.Cell>{orders}</IndexTable.Cell>
         <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
+        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+        <IndexTable.Cell>{notes}</IndexTable.Cell>
       </IndexTable.Row>
     ),
   );
@@ -1451,8 +1478,11 @@ export function WithSortableHeadings() {
           {title: 'Order count'},
           {title: 'Amount spent'},
           {title: 'Location'},
+          {title: 'Fulfillment status'},
+          {title: 'Payment status'},
+          {title: 'Notes'},
         ]}
-        sortable={[true, false, false, true]}
+        sortable={[true, true, false, true, true, true, false]}
         sortDirection={sortDirection}
         sortColumnIndex={sortIndex}
         onSort={handleClickSortHeading}

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -15,7 +15,6 @@ import {Checkbox as PolarisCheckbox} from '../Checkbox';
 import {EmptySearchResult} from '../EmptySearchResult';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
-import {Icon} from '../Icon';
 import {Stack} from '../Stack';
 import {Sticky} from '../Sticky';
 import {Spinner} from '../Spinner';
@@ -830,22 +829,17 @@ function IndexTableBase({
       const isCurrentlySorted = index === sortColumnIndex;
       const isAscending = sortDirection === 'ascending';
       let newDirection: IndexTableSortDirection = defaultSortDirection;
-      let source =
+      let SourceComponent =
         defaultSortDirection === 'ascending'
           ? SortAscendingMajor
           : SortDescendingMajor;
       if (isCurrentlySorted) {
         newDirection = isAscending ? 'descending' : 'ascending';
-        source =
+        SourceComponent =
           sortDirection === 'ascending'
             ? SortAscendingMajor
             : SortDescendingMajor;
       }
-
-      const sortAccessibilityLabel = i18n.translate(
-        'Polaris.IndexTable.sortAccessibilityLabel',
-        {direction: newDirection},
-      );
 
       const iconMarkup = (
         <span
@@ -854,7 +848,11 @@ function IndexTableBase({
             isCurrentlySorted && styles['TableHeadingSortIcon-visible'],
           )}
         >
-          <Icon source={source} accessibilityLabel={sortAccessibilityLabel} />
+          <SourceComponent
+            focusable="false"
+            aria-hidden="true"
+            className={styles.TableHeadingSortSvg}
+          />
         </span>
       );
 

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -20,6 +20,7 @@ import {SelectionType} from '../../../utilities/index-provider';
 import {AfterInitialMount} from '../../AfterInitialMount';
 import {UnstyledButton} from '../../UnstyledButton';
 import {Icon} from '../../Icon';
+import {Tooltip} from '../../Tooltip';
 
 jest.mock('../utilities', () => ({
   ...jest.requireActual('../utilities'),
@@ -624,6 +625,10 @@ describe('<IndexTable>', () => {
       defaultSortDirection: 'descending',
       sortColumnIndex: 0,
       onSort: jest.fn(),
+      sortToggleLabels: {
+        0: {ascending: 'A-Z', descending: 'Z-A'},
+        2: {ascending: 'Newest', descending: 'Oldest'},
+      },
     };
 
     describe('sortable', () => {
@@ -675,9 +680,7 @@ describe('<IndexTable>', () => {
               ? SortAscendingMajor
               : SortDescendingMajor;
 
-          expect(index.findAll('th')[1]).toContainReactComponent(Icon, {
-            source,
-          });
+          expect(index.findAll('th')[1]).toContainReactComponent(source);
         },
       );
     });
@@ -699,9 +702,7 @@ describe('<IndexTable>', () => {
               ? SortAscendingMajor
               : SortDescendingMajor;
 
-          expect(index.findAll('th')[3]).toContainReactComponent(Icon, {
-            source,
-          });
+          expect(index.findAll('th')[3]).toContainReactComponent(source);
         },
       );
     });
@@ -720,6 +721,40 @@ describe('<IndexTable>', () => {
         });
 
         expect(onSort).toHaveBeenCalledWith(0, 'descending');
+      });
+    });
+
+    describe('sortToggleLabels', () => {
+      it('renders the toggle label value for the selected index when ascending', () => {
+        const index = mountWithApp(
+          <IndexTable
+            {...defaultSortingProps}
+            sortDirection="ascending"
+            sortColumnIndex={0}
+          >
+            {tableItems.map(mockRenderRow)}
+          </IndexTable>,
+        );
+
+        expect(index.findAll(Tooltip)[0].prop('content')).toBe(
+          defaultSortingProps!.sortToggleLabels![0].ascending,
+        );
+      });
+
+      it('renders the toggle label value for the selected index when descending', () => {
+        const index = mountWithApp(
+          <IndexTable
+            {...defaultSortingProps}
+            sortDirection="descending"
+            sortColumnIndex={2}
+          >
+            {tableItems.map(mockRenderRow)}
+          </IndexTable>,
+        );
+
+        expect(index.findAll(Tooltip)[2].prop('content')).toBe(
+          defaultSortingProps!.sortToggleLabels![2].descending,
+        );
       });
     });
   });

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -755,6 +755,21 @@ describe('<IndexTable>', () => {
           defaultSortingProps!.sortToggleLabels![2].descending,
         );
       });
+
+      it('does not render the toggle label value for the selected index if not sortable', () => {
+        const index = mountWithApp(
+          <IndexTable
+            {...defaultSortingProps}
+            sortDirection="descending"
+            sortColumnIndex={1}
+          >
+            {tableItems.map(mockRenderRow)}
+          </IndexTable>,
+        );
+        expect(index.findAll('th')[1]).toContainReactComponent(Tooltip);
+        expect(index.findAll('th')[2]).not.toContainReactComponent(Tooltip);
+        expect(index.findAll('th')[3]).toContainReactComponent(Tooltip);
+      });
     });
   });
 });

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -19,7 +19,6 @@ import {ScrollContainer} from '../components';
 import {SelectionType} from '../../../utilities/index-provider';
 import {AfterInitialMount} from '../../AfterInitialMount';
 import {UnstyledButton} from '../../UnstyledButton';
-import {Icon} from '../../Icon';
 import {Tooltip} from '../../Tooltip';
 
 jest.mock('../utilities', () => ({


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/74406
Fixes https://github.com/Shopify/web/issues/74393

This PR fixes a couple of bugs in the IndexTable when the table is sortable and adds the ability to have Tooltips showing the sort direction label.

- Fixes a visual bug where if a table is sticky and sortable, the sticky headings have a different color to the unsticky ones
- Fixes a visual bug where the sort icon would display above the sticky heading cells
- Adds functionality to display the label of the sort direction in a Tooltip when hovering over the index table heading.


https://user-images.githubusercontent.com/2562596/194280147-f553b94e-6f91-411c-9914-87bb96c35103.mov



### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
