### PR TITLE
[Page] Use state callback in measure actions

### DIFF
--- a/.changeset/grumpy-zoos-sleep.md
+++ b/.changeset/grumpy-zoos-sleep.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Use state callback in page actions

--- a/polaris-react/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/polaris-react/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -80,14 +80,19 @@ export function Actions({actions = [], groups = [], onActionRollup}: Props) {
         actionsAndGroups.length - 1,
       );
     }
-    const showable = actionsAndGroups.slice(0, measuredActions.showable.length);
-    const rolledUp = actionsAndGroups.slice(
-      measuredActions.showable.length,
-      actionsAndGroups.length,
-    );
 
-    setMeasuredActions({showable, rolledUp});
-  }, [actions, groups, measuredActions.showable.length]);
+    setMeasuredActions((currentMeasuredActions) => {
+      const showable = actionsAndGroups.slice(
+        0,
+        currentMeasuredActions.showable.length,
+      );
+      const rolledUp = actionsAndGroups.slice(
+        currentMeasuredActions.showable.length,
+        actionsAndGroups.length,
+      );
+      return {showable, rolledUp};
+    });
+  }, [actions, groups]);
 
   const measureActions = useCallback(() => {
     if (


### PR DESCRIPTION
Partial fix for https://github.com/Shopify/polaris/issues/7330

[Spin link](https://admin.web.web-1mvc.kyle-durand.us.spin.dev/store/)

Part two might be a css based fix. The heavy re-rendering in the admin introduced with the React 18 work is causing a ton of layout thrashing in this component. The root cause will definitely need to be fixed but we'll do what we can on our end in the meantime 