### PR TITLE
Add `id` prop to `Text` and `Box`

### DIFF
--- a/.changeset/cyan-months-think.md
+++ b/.changeset/cyan-months-think.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added `id` prop to `Text` and `Box`

--- a/polaris-react/src/components/Box/Box.tsx
+++ b/polaris-react/src/components/Box/Box.tsx
@@ -89,6 +89,8 @@ export interface BoxProps {
   children: ReactNode;
   /** Color of children */
   color?: ColorTokenScale;
+  /** HTML id attribute */
+  id?: string;
   /** Spacing outside of container */
   maxWidth?: string;
   /** Spacing around children */
@@ -122,6 +124,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       borderRadiusTopRight,
       children,
       color,
+      id,
       maxWidth,
       padding,
       paddingBottom,
@@ -218,6 +221,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       as,
       {
         className,
+        id,
         ref,
         style: sanitizeCustomProperties(style),
       },

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -121,3 +121,9 @@
   font-size: var(--p-font-size-200);
   line-height: var(--p-font-line-height-2);
 }
+
+.break {
+  word-wrap: break-word;
+  word-break: break-word;
+  overflow-wrap: break-word;
+}

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -121,9 +121,3 @@
   font-size: var(--p-font-size-200);
   line-height: var(--p-font-line-height-2);
 }
-
-.break {
-  word-wrap: break-word;
-  word-break: break-word;
-  overflow-wrap: break-word;
-}

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -44,8 +44,6 @@ export interface TextProps {
   alignment?: Alignment;
   /** The element type */
   as: Element;
-  /** Prevent text from overflowing */
-  breakWord?: boolean;
   /** Text to display */
   children: ReactNode;
   /** Adjust color of text */
@@ -65,7 +63,6 @@ export interface TextProps {
 export const Text = ({
   alignment,
   as,
-  breakWord,
   children,
   color,
   fontWeight,
@@ -82,7 +79,6 @@ export const Text = ({
     fontWeight ? styles[fontWeight] : styles[VariantFontWeightMapping[variant]],
     (alignment || truncate) && styles.block,
     alignment && styles[alignment],
-    breakWord && styles.break,
     color && styles[color],
     truncate && styles.truncate,
     visuallyHidden && styles.visuallyHidden,

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -44,12 +44,16 @@ export interface TextProps {
   alignment?: Alignment;
   /** The element type */
   as: Element;
+  /** Prevent text from overflowing */
+  breakWord?: boolean;
   /** Text to display */
   children: ReactNode;
   /** Adjust color of text */
   color?: Color;
   /** Adjust weight of text */
   fontWeight?: FontWeight;
+  /** HTML id attribute */
+  id?: string;
   /** Truncate text overflow with ellipsis */
   truncate?: boolean;
   /** Typographic style of text */
@@ -61,9 +65,11 @@ export interface TextProps {
 export const Text = ({
   alignment,
   as,
+  breakWord,
   children,
   color,
   fontWeight,
+  id,
   truncate = false,
   variant,
   visuallyHidden = false,
@@ -76,10 +82,15 @@ export const Text = ({
     fontWeight ? styles[fontWeight] : styles[VariantFontWeightMapping[variant]],
     (alignment || truncate) && styles.block,
     alignment && styles[alignment],
+    breakWord && styles.break,
     color && styles[color],
     truncate && styles.truncate,
     visuallyHidden && styles.visuallyHidden,
   );
 
-  return <Component className={className}>{children}</Component>;
+  return (
+    <Component className={className} {...(id ? id : null)}>
+      {children}
+    </Component>
+  );
 };


### PR DESCRIPTION
### WHY are these changes introduced?

Add `id` prop to both `Text` and `Box`