### PR TITLE
Documentation, fix broken link in releasing documentation to adding a changeset content

### DIFF
--- a/documentation/Releasing.md
+++ b/documentation/Releasing.md
@@ -22,7 +22,7 @@ To perform a release:
 1. Add a comment in your feature branch PR with the slash command "/snapit"
 2. This will trigger the `snapit.yml` workflow to create a new snapshot release
 
-> Note: Your feature branch PR should have **at least one** changeset. The snapshot release will only release packages with a pending changeset. More info on [adding a changeset](https://github.com/Shopify/polaris/blob/.github/CONTRIBUTING.md#adding-a-changeset).
+> Note: Your feature branch PR should have **at least one** changeset. The snapshot release will only release packages with a pending changeset. More info on [adding a changeset](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#adding-a-changeset).
 
 ### [polaris-for-figma](/polaris-for-figma)
 


### PR DESCRIPTION
### WHY are these changes introduced?

[Release documentation](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md) has a broken link to "adding a changeset"

### WHAT is this pull request doing?

Adds the missing branch name within the linked URL