### PR TITLE
Add Polaris migrator utility to `getFunctionArgs`

### DIFF
--- a/.changeset/five-eyes-kiss.md
+++ b/.changeset/five-eyes-kiss.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Add `getFunctionArgs` utility

--- a/polaris-migrator/src/utilities/sass.ts
+++ b/polaris-migrator/src/utilities/sass.ts
@@ -89,6 +89,28 @@ export function hasSassFunction(
   return containsSassFunction;
 }
 
+export function getFunctionArgs(node: FunctionNode): string[] {
+  const args: string[] = [];
+
+  let arg = '';
+
+  node.nodes.forEach((node) => {
+    if (node.type === 'div' && node.value === ',') {
+      args.push(arg);
+      arg = '';
+      return;
+    }
+
+    arg += valueParser.stringify(node);
+  });
+
+  if (arg) {
+    args.push(arg);
+  }
+
+  return args;
+}
+
 /**
  * All transformable dimension units. These values are used to determine
  * if a decl.value can be converted to pixels and mapped to a Polaris custom property.

--- a/polaris-migrator/src/utilities/tests/sass.test.ts
+++ b/polaris-migrator/src/utilities/tests/sass.test.ts
@@ -1,0 +1,76 @@
+import valueParser from 'postcss-value-parser';
+
+import {getFunctionArgs} from '../sass';
+
+describe('getFunctionArgs', () => {
+  it('zero args', () => {
+    const node = getFunctionNode('rem()');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual([]);
+  });
+
+  it('one arg', () => {
+    const node = getFunctionNode('rem(1px)');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px']);
+  });
+
+  it('one arg (trailing comma)', () => {
+    const node = getFunctionNode('rem(1px,)');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px']);
+  });
+
+  it('two args', () => {
+    const node = getFunctionNode('rem(1px, 2px)');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px', '2px']);
+  });
+
+  it('three args', () => {
+    const node = getFunctionNode('rem(1px, 2px, 3px)');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px', '2px', '3px']);
+  });
+
+  it('nested functions', () => {
+    const node = getFunctionNode('rem(1px, func(2px), func(func(3px)))');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px', 'func(2px)', 'func(func(3px))']);
+  });
+
+  it('interpolated args', () => {
+    const node = getFunctionNode('rem(1px, #{2 + $var}, $var)');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px', '#{2 + $var}', '$var']);
+  });
+
+  it('trimmed', () => {
+    const node = getFunctionNode('rem( 1px , \n func( 2px) , \t #{ $var })');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px', 'func( 2px)', '#{ $var }']);
+  });
+
+  it('nested comments', () => {
+    const node = getFunctionNode('rem(1px, /* comment */ 2px)');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px', '/* comment */ 2px']);
+  });
+
+  it('separates args by comma dividers', () => {
+    const node = getFunctionNode('rem(1px, 2/3, 4:5)');
+    const args = getFunctionArgs(node);
+    expect(args).toStrictEqual(['1px', '2/3', '4:5']);
+  });
+});
+
+/** Test utility to quickly access the first `valueParser.FunctionNode` */
+function getFunctionNode(value: string): valueParser.FunctionNode {
+  const parsedValue = valueParser(value);
+
+  if (parsedValue.nodes[0]?.type !== 'function') {
+    throw new Error(`Expected ${value} to be a function`);
+  }
+
+  return parsedValue.nodes[0];
+}


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR introduces a `getFunctionArgs` utility to the Polaris migrator. For examples of how this can be leveraged, see the [replace-typography-declarations](https://github.com/Shopify/polaris/blob/fdc6e123de7cc17574ee295ad9b84f6d40cdbfe2/polaris-migrator/src/migrations/replace-typography-declarations/replace-typography-declarations.ts#L93-L99) migration which uses `getFunctionArgs` to identify if a function was provided the expected number of args and uses the args to access replacement values.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
