### PR TITLE
Add yarn cache to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn --frozen-lockfile


### PR DESCRIPTION
### WHY are these changes introduced?

Hopefully make the release action run a bit faster