### PR TITLE
[Stack] Use `gap` over `margin` for internal spacing

### DIFF
--- a/.changeset/eleven-actors-perform.md
+++ b/.changeset/eleven-actors-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Use CSS property `gap` over `margin` for spacing within a `Stack` component

--- a/polaris-react/src/components/Stack/Stack.scss
+++ b/polaris-react/src/components/Stack/Stack.scss
@@ -3,12 +3,9 @@
   display: flex;
   flex-wrap: wrap;
   align-items: stretch;
-  margin-top: calc(-1 * var(--pc-stack-spacing));
-  margin-left: calc(-1 * var(--pc-stack-spacing));
+  gap: var(--pc-stack-spacing);
 
   > .Item {
-    margin-top: var(--pc-stack-spacing);
-    margin-left: var(--pc-stack-spacing);
     max-width: 100%;
   }
 }
@@ -92,11 +89,6 @@
 
 .vertical {
   flex-direction: column;
-  margin-left: var(--p-space-0);
-
-  > .Item {
-    margin-left: var(--p-space-0);
-  }
 }
 
 .Item {


### PR DESCRIPTION
### WHY are these changes introduced?

I've noticed sometimes when using a `Stack` component, certain situations arise when the negative left/top margin present in the `Stack` component can have unfortunate layout consequences. By updating the component to use the `gap` CSS property instead, we can remove these negative margins and ensure we create a consistent experience, no matter the context that the component is used.

### WHAT is this pull request doing?

Removes the `margin` declarations in the `Stack.scss` file and replaces them with the leaner `gap` property.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
