### PR TITLE
[Frame] Added new property to reduce width

### DIFF
--- a/.changeset/real-beans-buy.md
+++ b/.changeset/real-beans-buy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Introduces shrink prop to Frame component to reduce frame width

--- a/polaris-react/src/components/Frame/Frame.scss
+++ b/polaris-react/src/components/Frame/Frame.scss
@@ -12,7 +12,7 @@
   }
 
   @media #{$p-breakpoints-md-up} {
-    width: calc(100% - var(--pc-frame-offset));
+    width: calc(100% - var(--pc-frame-offset) - var(--pc-frame-shrink));
     margin-left: var(--pc-frame-offset);
   }
 }
@@ -139,7 +139,7 @@
 
   @media #{$p-breakpoints-md-up} {
     left: var(--pc-frame-offset);
-    width: calc(100% - var(--pc-frame-offset));
+    width: calc(100% - var(--pc-frame-offset) - var(--pc-frame-shrink));
   }
 }
 
@@ -152,7 +152,7 @@
 
   @media #{$p-breakpoints-md-up} {
     left: var(--pc-frame-offset);
-    width: calc(100% - var(--pc-frame-offset));
+    width: calc(100% - var(--pc-frame-offset) - var(--pc-frame-shrink));
   }
 }
 
@@ -208,7 +208,7 @@
         calc(#{$layout-width-nav-base} + var(--pc-frame-offset)),
         left
       );
-      width: calc(100% - #{$layout-width-nav-base} - var(--pc-frame-offset));
+      width: calc(100% - #{$layout-width-nav-base} - var(--pc-frame-offset) - var(--pc-frame-shrink));
     }
   }
 }

--- a/polaris-react/src/components/Frame/Frame.tsx
+++ b/polaris-react/src/components/Frame/Frame.tsx
@@ -34,6 +34,8 @@ export interface FrameProps {
   logo?: Logo;
   /** A horizontal offset that pushes the frame to the right, leaving empty space on the left */
   offset?: string;
+  /** Reduces the frame width */
+  shrink?: string;
   /** The content to display inside the frame. */
   children?: React.ReactNode;
   /** Accepts a top bar component that will be rendered at the top-most portion of an application frame */
@@ -90,6 +92,7 @@ class FrameInner extends PureComponent<CombinedProps, State> {
     }
     this.setGlobalRibbonRootProperty();
     this.setOffset();
+    this.setShrink();
   }
 
   componentDidUpdate(prevProps: FrameProps) {
@@ -97,6 +100,7 @@ class FrameInner extends PureComponent<CombinedProps, State> {
       this.setGlobalRibbonHeight();
     }
     this.setOffset();
+    this.setShrink();
   }
 
   render() {
@@ -313,6 +317,11 @@ class FrameInner extends PureComponent<CombinedProps, State> {
       '--pc-frame-global-ribbon-height',
       `${globalRibbonHeight}px`,
     );
+  };
+
+  private setShrink = () => {
+    const {shrink = '0px'} = this.props;
+    setRootProperty('--pc-frame-shrink', shrink);
   };
 
   private showToast = (toast: ToastPropsWithID) => {

--- a/polaris-react/src/components/Frame/components/ToastManager/ToastManager.scss
+++ b/polaris-react/src/components/Frame/components/ToastManager/ToastManager.scss
@@ -11,6 +11,7 @@
 .ToastManager {
   position: fixed;
   z-index: var(--p-z-12);
+  width: calc(100% - var(--pc-frame-shrink));
   right: 0;
   left: 0;
   text-align: center;

--- a/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
+++ b/polaris-react/src/components/Modal/components/Dialog/Dialog.scss
@@ -12,6 +12,7 @@ $breakpoints-height-limit-up: '(min-height: #{breakpoint($height-limit + $vertic
 .Container {
   position: fixed;
   z-index: var(--p-z-11);
+  width: calc(100% - var(--pc-frame-shrink));
   top: 0;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

Closes https://github.com/Shopify/growth-activation/issues/3743

https://user-images.githubusercontent.com/5440293/195697305-cf6861d4-785d-437e-8f1c-a88464081489.mov


### WHY are these changes introduced?

- New prop that allows us to shrink the width of the Frame component
- This allows the Persistent Setup Guide (sidebar) to more easily integrate into the app without doing hacky style overrides
- Prevents us from needing to override Polaris style classes to support the component. See below:

https://github.com/Shopify/web/blob/main/app/components/SetupGuide/components/Sidebar/components/Console/Console.scss#L35

![Screen Shot 2022-10-13 at 3 55 05 PM](https://user-images.githubusercontent.com/5440293/195696644-722b380f-cfc7-499a-9d9a-4719630a0769.png)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Added `shrink` prop to the `Frame` component which sets a root property `--pc-frame-shrink` to be used in CSS files
- The `--pc-frame-shrink` will ensure that other components used by the Frame will be properly aligned (ex: Topbar, GlobalRibbon, ContextualSaveBar, Dialogs)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

- Go to [spin machine here]
- Verify that the Frame has been reduced in size and that there is whitespace on the side
- Verify that following components are properly aligned with the new frame size:
- TopBar
- GlobalRibbon
- ContextualSaveBar
- Dialog
- ToastManager

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
