### PR TITLE
Add `breakWord` prop to `Text`

### DIFF
--- a/.changeset/pink-forks-thank.md
+++ b/.changeset/pink-forks-thank.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris': patch
+'@shopify/polaris': minor
 ---
 
 Added `breakWord` prop to `Text`

--- a/.changeset/pink-forks-thank.md
+++ b/.changeset/pink-forks-thank.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added `breakWord` prop to `Text`

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -121,3 +121,7 @@
   font-size: var(--p-font-size-200);
   line-height: var(--p-font-line-height-2);
 }
+
+.break {
+  overflow-wrap: break-word;
+}

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -44,6 +44,8 @@ export interface TextProps {
   alignment?: Alignment;
   /** The element type */
   as: Element;
+  /** Prevent text from overflowing */
+  breakWord?: boolean;
   /** Text to display */
   children: ReactNode;
   /** Adjust color of text */
@@ -61,6 +63,7 @@ export interface TextProps {
 export const Text = ({
   alignment,
   as,
+  breakWord,
   children,
   color,
   fontWeight,
@@ -76,6 +79,7 @@ export const Text = ({
     fontWeight ? styles[fontWeight] : styles[VariantFontWeightMapping[variant]],
     (alignment || truncate) && styles.block,
     alignment && styles[alignment],
+    breakWord && styles.break,
     color && styles[color],
     truncate && styles.truncate,
     visuallyHidden && styles.visuallyHidden,


### PR DESCRIPTION
### WHAT is this pull request doing?

Add `breakWord` prop to `Text` to support functionality offered by the [`text-breakword` mixin](https://github.com/Shopify/polaris/blob/main/polaris-react/src/styles/shared/_typography.scss#L143)