### PR TITLE
[IndexTable] Update loading state

### DIFF
--- a/.changeset/famous-penguins-tap.md
+++ b/.changeset/famous-penguins-tap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updates the loading state of the `IndexTable`

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -91,18 +91,13 @@ $table-loading-animation-duration: 2s;
   tbody tr {
     background: linear-gradient(
       90deg,
-      var(--p-surface) 10%,
+      var(--p-surface) 5%,
       var(--p-surface-hovered) 20%,
-      var(--p-surface) 30%
+      var(--p-surface) 35%
     );
     background-size: 200% 100%;
     animation: shimmer $table-loading-animation-duration infinite linear;
-  }
-
-  @for $stagger from 1 through 25 {
-    tbody tr:nth-child(25n + #{$stagger}) {
-      animation-delay: $stagger / 25 * $table-loading-animation-duration;
-    }
+    animation-delay: calc(0.125s * var(--pc-index-table-row-stagger-index));
   }
 }
 
@@ -110,18 +105,13 @@ $table-loading-animation-duration: 2s;
   li {
     background: linear-gradient(
       90deg,
-      var(--p-surface) 10%,
+      var(--p-surface) 5%,
       var(--p-surface-hovered) 20%,
-      var(--p-surface) 30%
+      var(--p-surface) 35%
     );
     background-size: 200% 100%;
     animation: shimmer $table-loading-animation-duration infinite linear;
-  }
-
-  @for $stagger from 1 through 10 {
-    li:nth-child(10n + #{$stagger}) {
-      animation-delay: $stagger / 10 * $table-loading-animation-duration;
-    }
+    animation-delay: calc(0.125s * var(--pc-index-table-row-stagger-index));
   }
 }
 

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -76,19 +76,48 @@ $loading-panel-height: 53px;
 
 @keyframes shimmer {
   0% {
-    background: var(--p-surface);
-  }
-  50% {
-    background: var(--p-surface-hovered);
+    background-position: 200% 0%;
   }
   100% {
-    background: var(--p-surface);
+    background-position: 0%;
   }
 }
 
 .Table-loading {
-  td {
-    animation: shimmer 1s infinite;
+  tbody tr {
+    background: linear-gradient(
+      90deg,
+      var(--p-surface) 40%,
+      var(--p-surface-hovered) 50%,
+      var(--p-surface) 60%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 2s infinite var(--p-ease-in-out);
+  }
+
+  @for $stagger from 1 through 25 {
+    tbody tr:nth-child(25n + #{$stagger}) {
+      animation-delay: $stagger / 25 * 2s;
+    }
+  }
+}
+
+.CondensedList-loading {
+  li {
+    background: linear-gradient(
+      90deg,
+      var(--p-surface) 40%,
+      var(--p-surface-hovered) 50%,
+      var(--p-surface) 60%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 2s infinite var(--p-ease-in-out);
+  }
+
+  @for $stagger from 1 through 10 {
+    li:nth-child(10n + #{$stagger}) {
+      animation-delay: $stagger / 10 * 2s;
+    }
   }
 }
 
@@ -145,49 +174,39 @@ $loading-panel-height: 53px;
   }
 
   &.statusSuccess {
-    // stylelint-disable-next-line selector-max-combinators, selector-max-class, selector-max-specificity
-    &,
-    .TableCell-first,
-    .TableCell-first + .TableCell {
+    // stylelint-disable-next-line selector-max-class
+    .TableCell {
       background-color: var(--p-surface-primary-selected);
     }
   }
 
   &.statusSubdued {
-    // stylelint-disable-next-line selector-max-combinators, selector-max-class, selector-max-specificity
-    &,
-    .TableCell-first,
-    .TableCell-first + .TableCell {
+    // stylelint-disable-next-line selector-max-class
+    .TableCell {
       background-color: var(--p-surface-subdued);
     }
   }
 
   &.TableRow-hovered {
-    // stylelint-disable-next-line selector-max-class, selector-max-combinators, selector-max-specificity
-    &,
-    .TableCell-first,
-    .TableCell-first + .TableCell {
+    // stylelint-disable-next-line selector-max-class
+    .TableCell {
       background-color: var(--p-surface-hovered);
     }
   }
 
   &.TableRow-selected {
-    // stylelint-disable-next-line selector-max-class, selector-max-combinators, selector-max-specificity
-    &,
+    // stylelint-disable-next-line selector-max-class
+    .TableCell,
     .TableHeading-first,
-    .TableHeading-second,
-    .TableCell-first,
-    .TableCell-first + .TableCell {
+    .TableHeading-second {
       background-color: var(--p-surface-selected);
     }
   }
 
   // stylelint-disable-next-line selector-max-class
   &.TableRow-hovered.TableRow-selected {
-    // stylelint-disable-next-line selector-max-class, selector-max-combinators, selector-max-specificity
-    &,
-    .TableCell-first,
-    .TableCell-first + .TableCell {
+    // stylelint-disable-next-line selector-max-class
+    .TableCell {
       background-color: var(--p-surface-selected-hovered);
     }
   }

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -84,6 +84,17 @@ $loading-panel-height: 53px;
   }
 }
 
+@keyframes shimmer-min-motion {
+  0%,
+  100% {
+    background: var(--p-surface);
+  }
+
+  50% {
+    background: var(--p-surface-hovered);
+  }
+}
+
 $table-loading-animation-duration: 2s;
 
 .Table-loading {
@@ -98,6 +109,13 @@ $table-loading-animation-duration: 2s;
     background-size: 200% 100%;
     animation: shimmer $table-loading-animation-duration infinite linear;
     animation-delay: calc(0.125s * var(--pc-index-table-row-stagger-index));
+
+    // stylelint-disable-next-line stylelint-polaris/media-queries-allowed-list
+    @media (prefers-reduced-motion) {
+      background: var(--p-surface);
+      animation-name: shimmer-min-motion;
+      animation-delay: 0s;
+    }
   }
 }
 
@@ -112,6 +130,13 @@ $table-loading-animation-duration: 2s;
     background-size: 200% 100%;
     animation: shimmer $table-loading-animation-duration infinite linear;
     animation-delay: calc(0.125s * var(--pc-index-table-row-stagger-index));
+
+    // stylelint-disable-next-line stylelint-polaris/media-queries-allowed-list
+    @media (prefers-reduced-motion) {
+      background: var(--p-surface);
+      animation-name: shimmer-min-motion;
+      animation-delay: 0s;
+    }
   }
 }
 

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -74,6 +74,24 @@ $loading-panel-height: 53px;
   border-collapse: collapse;
 }
 
+@keyframes shimmer {
+  0% {
+    background: var(--p-surface);
+  }
+  50% {
+    background: var(--p-surface-hovered);
+  }
+  100% {
+    background: var(--p-surface);
+  }
+}
+
+.Table-loading {
+  td {
+    animation: shimmer 1s infinite;
+  }
+}
+
 .Table-scrolling {
   // stylelint-disable-next-line selector-max-class, selector-max-combinators
   .TableCell-first,

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -78,6 +78,7 @@ $loading-panel-height: 53px;
   0% {
     background-position: 200% 0%;
   }
+
   100% {
     background-position: 0%;
   }
@@ -208,7 +209,7 @@ $table-loading-animation-duration: 2s;
 
   // stylelint-disable-next-line selector-max-class
   &.TableRow-hovered.TableRow-selected {
-    // stylelint-disable-next-line selector-max-class
+    // stylelint-disable-next-line selector-max-class, selector-max-specificity
     .TableCell {
       background-color: var(--p-surface-selected-hovered);
     }

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -83,24 +83,24 @@ $loading-panel-height: 53px;
   }
 }
 
-$table-loading-duration: 2s;
+$table-loading-animation-duration: 2s;
 
 .Table-loading {
+  // stylelint-disable-next-line selector-max-type, selector-max-combinators
   tbody tr {
     background: linear-gradient(
       90deg,
-      var(--p-surface) 40%,
-      var(--p-surface-hovered) 50%,
-      var(--p-surface) 60%
+      var(--p-surface) 10%,
+      var(--p-surface-hovered) 20%,
+      var(--p-surface) 30%
     );
     background-size: 200% 100%;
-    animation: shimmer $table-loading-duration infinite var(--p-ease-in-out);
+    animation: shimmer $table-loading-animation-duration infinite linear;
   }
 
   @for $stagger from 1 through 25 {
     tbody tr:nth-child(25n + #{$stagger}) {
-      animation-delay: ($stagger / 25 * $table-loading-duration) -
-        $table-loading-duration;
+      animation-delay: $stagger / 25 * $table-loading-animation-duration;
     }
   }
 }
@@ -109,18 +109,17 @@ $table-loading-duration: 2s;
   li {
     background: linear-gradient(
       90deg,
-      var(--p-surface) 40%,
-      var(--p-surface-hovered) 50%,
-      var(--p-surface) 60%
+      var(--p-surface) 10%,
+      var(--p-surface-hovered) 20%,
+      var(--p-surface) 30%
     );
     background-size: 200% 100%;
-    animation: shimmer $table-loading-duration infinite var(--p-ease-in-out);
+    animation: shimmer $table-loading-animation-duration infinite linear;
   }
 
   @for $stagger from 1 through 10 {
     li:nth-child(10n + #{$stagger}) {
-      animation-delay: ($stagger / 10 * $table-loading-duration) -
-        $table-loading-duration;
+      animation-delay: $stagger / 10 * $table-loading-animation-duration;
     }
   }
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -83,6 +83,8 @@ $loading-panel-height: 53px;
   }
 }
 
+$table-loading-duration: 2s;
+
 .Table-loading {
   tbody tr {
     background: linear-gradient(
@@ -92,12 +94,13 @@ $loading-panel-height: 53px;
       var(--p-surface) 60%
     );
     background-size: 200% 100%;
-    animation: shimmer 2s infinite var(--p-ease-in-out);
+    animation: shimmer $table-loading-duration infinite var(--p-ease-in-out);
   }
 
   @for $stagger from 1 through 25 {
     tbody tr:nth-child(25n + #{$stagger}) {
-      animation-delay: $stagger / 25 * 2s;
+      animation-delay: ($stagger / 25 * $table-loading-duration) -
+        $table-loading-duration;
     }
   }
 }
@@ -111,12 +114,13 @@ $loading-panel-height: 53px;
       var(--p-surface) 60%
     );
     background-size: 200% 100%;
-    animation: shimmer 2s infinite var(--p-ease-in-out);
+    animation: shimmer $table-loading-duration infinite var(--p-ease-in-out);
   }
 
   @for $stagger from 1 through 10 {
     li:nth-child(10n + #{$stagger}) {
-      animation-delay: $stagger / 10 * 2s;
+      animation-delay: ($stagger / 10 * $table-loading-duration) -
+        $table-loading-duration;
     }
   }
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -223,6 +223,159 @@ export function SmallScreen() {
   );
 }
 
+export function SmallScreenLoading() {
+  const customers = [
+    {
+      id: '3415',
+      url: 'customers/341',
+      name: 'Mae Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$2,400',
+    },
+    {
+      id: '2565',
+      url: 'customers/256',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+    {
+      id: '1234',
+      url: 'customers/341',
+      name: 'David Reynolds',
+      location: 'Phoenix, USA',
+      orders: 4,
+      amountSpent: '$84',
+    },
+    {
+      id: '1289',
+      url: 'customers/256',
+      name: 'Jennifer Jennings',
+      location: 'Boise, USA',
+      orders: 62,
+      amountSpent: '$542',
+    },
+    {
+      id: '9874',
+      url: 'customers/341',
+      name: 'Robert Bradley',
+      location: 'Seattle, USA',
+      orders: 21,
+      amountSpent: '$450',
+    },
+    {
+      id: '4873',
+      url: 'customers/256',
+      name: 'Brian Johnson',
+      location: 'San Diego, USA',
+      orders: 35,
+      amountSpent: '$765',
+    },
+    {
+      id: '9082',
+      url: 'customers/341',
+      name: 'Kimberley Rogers',
+      location: 'Kansas City, USA',
+      orders: 36,
+      amountSpent: '$1,230',
+    },
+    {
+      id: '3627',
+      url: 'customers/256',
+      name: 'Nina Rodriguez',
+      location: 'Mobile, USA',
+      orders: 67,
+      amountSpent: '$986',
+    },
+    {
+      id: '4328',
+      url: 'customers/341',
+      name: 'Pam Mahoney',
+      location: 'Austin, USA',
+      orders: 24,
+      amountSpent: '$2,300',
+    },
+    {
+      id: '2635',
+      url: 'customers/256',
+      name: 'Joe Talbot',
+      location: 'Tacoma, USA',
+      orders: 5,
+      amountSpent: '$86',
+    },
+    {
+      id: '0982',
+      url: 'customers/341',
+      name: 'Billy Parker',
+      location: 'Madison, USA',
+      orders: 87,
+      amountSpent: '$1,930',
+    },
+    {
+      id: '8326',
+      url: 'customers/256',
+      name: 'Ahmed Mahmood',
+      location: 'Portland, USA',
+      orders: 34,
+      amountSpent: '$243',
+    },
+  ];
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(customers);
+
+  const rowMarkup = customers.map(
+    ({id, name, location, orders, amountSpent}, index) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <div style={{padding: '12px 16px'}}>
+          <p>
+            <TextStyle variation="strong">{name}</TextStyle>
+          </p>
+          <p>{location}</p>
+          <p>{orders}</p>
+          <p>{amountSpent}</p>
+        </div>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <div style={{width: '430px'}}>
+      <Card>
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          condensed
+          loading
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {title: 'Order count'},
+            {title: 'Amount spent'},
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </Card>
+    </div>
+  );
+}
+
 export function WithEmptyState() {
   const customers = [];
   const resourceName = {
@@ -596,6 +749,86 @@ export function WithLoadingState() {
       location: 'Los Angeles, USA',
       orders: 30,
       amountSpent: '$140',
+    },
+    {
+      id: '1234',
+      url: 'customers/341',
+      name: 'David Reynolds',
+      location: 'Phoenix, USA',
+      orders: 4,
+      amountSpent: '$84',
+    },
+    {
+      id: '1289',
+      url: 'customers/256',
+      name: 'Jennifer Jennings',
+      location: 'Boise, USA',
+      orders: 62,
+      amountSpent: '$542',
+    },
+    {
+      id: '9874',
+      url: 'customers/341',
+      name: 'Robert Bradley',
+      location: 'Seattle, USA',
+      orders: 21,
+      amountSpent: '$450',
+    },
+    {
+      id: '4873',
+      url: 'customers/256',
+      name: 'Brian Johnson',
+      location: 'San Diego, USA',
+      orders: 35,
+      amountSpent: '$765',
+    },
+    {
+      id: '9082',
+      url: 'customers/341',
+      name: 'Kimberley Rogers',
+      location: 'Kansas City, USA',
+      orders: 36,
+      amountSpent: '$1,230',
+    },
+    {
+      id: '3627',
+      url: 'customers/256',
+      name: 'Nina Rodriguez',
+      location: 'Mobile, USA',
+      orders: 67,
+      amountSpent: '$986',
+    },
+    {
+      id: '4328',
+      url: 'customers/341',
+      name: 'Pam Mahoney',
+      location: 'Austin, USA',
+      orders: 24,
+      amountSpent: '$2,300',
+    },
+    {
+      id: '2635',
+      url: 'customers/256',
+      name: 'Joe Talbot',
+      location: 'Tacoma, USA',
+      orders: 5,
+      amountSpent: '$86',
+    },
+    {
+      id: '0982',
+      url: 'customers/341',
+      name: 'Billy Parker',
+      location: 'Madison, USA',
+      orders: 87,
+      amountSpent: '$1,930',
+    },
+    {
+      id: '8326',
+      url: 'customers/256',
+      name: 'Ahmed Mahmood',
+      location: 'Portland, USA',
+      orders: 34,
+      amountSpent: '$243',
     },
   ];
   const resourceName = {

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -4,8 +4,7 @@ import {
   SortAscendingMajor,
   SortDescendingMajor,
 } from '@shopify/polaris-icons';
-import {CSSTransition} from 'react-transition-group';
-import {tokens, toPx, motion} from '@shopify/polaris-tokens';
+import {tokens, toPx} from '@shopify/polaris-tokens';
 
 import {debounce} from '../../utilities/debounce';
 import {useToggle} from '../../utilities/use-toggle';
@@ -17,7 +16,6 @@ import {EmptySearchResult} from '../EmptySearchResult';
 import {EventListener} from '../EventListener';
 import {Stack} from '../Stack';
 import {Sticky} from '../Sticky';
-import {Spinner} from '../Spinner';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {Button} from '../Button';
 import {Tooltip} from '../Tooltip';
@@ -505,37 +503,6 @@ function IndexTableBase({
 
   const paginatedSelectAllAction = getPaginatedSelectAllAction();
 
-  const loadingTransitionClassNames = {
-    enter: styles['LoadingContainer-enter'],
-    enterActive: styles['LoadingContainer-enter-active'],
-    exit: styles['LoadingContainer-exit'],
-    exitActive: styles['LoadingContainer-exit-active'],
-  };
-
-  const loadingMarkup = (
-    <CSSTransition
-      in={loading}
-      classNames={loadingTransitionClassNames}
-      timeout={parseInt(motion['duration-100'], 10)}
-      appear
-      unmountOnExit
-    >
-      <div className={styles.LoadingPanel}>
-        <div className={styles.LoadingPanelRow}>
-          <Spinner size="small" />
-          <span className={styles.LoadingPanelText}>
-            {i18n.translate(
-              'Polaris.IndexTable.resourceLoadingAccessibilityLabel',
-              {
-                resourceNamePlural: resourceName.plural.toLocaleLowerCase(),
-              },
-            )}
-          </span>
-        </div>
-      </div>
-    </CSSTransition>
-  );
-
   const stickyTableClassNames = classNames(
     styles.StickyTable,
     condensed && styles['StickyTable-condensed'],
@@ -565,7 +532,6 @@ function IndexTableBase({
 
           const bulkActionsMarkup = shouldShowBulkActions ? (
             <div className={bulkActionClassNames} data-condensed={condensed}>
-              {loadingMarkup}
               <BulkActions
                 smallScreen={smallScreen}
                 label={i18n.translate('Polaris.IndexTable.selected', {
@@ -607,7 +573,6 @@ function IndexTableBase({
                 !selectable && styles.unselectable,
               )}
             >
-              {loadingMarkup}
               {sort}
               {selectable && selectButtonMarkup}
             </div>
@@ -616,7 +581,6 @@ function IndexTableBase({
               className={stickyHeaderClassNames}
               ref={stickyHeaderWrapperElement}
             >
-              {loadingMarkup}
               <div className={stickyColumnHeaderClassNames}>
                 {stickyColumnHeader}
               </div>
@@ -671,6 +635,7 @@ function IndexTableBase({
 
   const tableClassNames = classNames(
     styles.Table,
+    loading && styles['Table-loading'],
     hasMoreLeftColumns && styles['Table-scrolling'],
     selectMode && styles.disableTextSelection,
     selectMode && shouldShowBulkActions && styles.selectMode,
@@ -739,10 +704,7 @@ function IndexTableBase({
 
   return (
     <>
-      <div className={styles.IndexTable}>
-        {!shouldShowBulkActions && !condensed && loadingMarkup}
-        {tableContentMarkup}
-      </div>
+      <div className={styles.IndexTable}>{tableContentMarkup}</div>
       {scrollBarMarkup}
     </>
   );

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -668,12 +668,17 @@ function IndexTableBase({
     </>
   );
 
+  const condensedListClassNames = classNames(
+    styles.CondensedList,
+    loading && styles['CondensedList-loading'],
+  );
+
   const bodyMarkup = condensed ? (
     <>
       {sharedMarkup}
       <ul
         data-selectmode={Boolean(selectMode || isSmallScreenSelectable)}
-        className={styles.CondensedList}
+        className={condensedListClassNames}
         ref={condensedListElement}
       >
         {children}

--- a/polaris-react/src/components/IndexTable/components/Row/Row.tsx
+++ b/polaris-react/src/components/IndexTable/components/Row/Row.tsx
@@ -143,6 +143,10 @@ export const Row = memo(function Row({
 
   const checkboxMarkup = selectable ? <Checkbox /> : null;
 
+  const style = {
+    '--pc-index-table-row-stagger-index': position,
+  } as React.CSSProperties;
+
   return (
     <RowContext.Provider value={contextValue}>
       <RowHoveredContext.Provider value={hovered}>
@@ -153,6 +157,7 @@ export const Row = memo(function Row({
           onMouseLeave={setHoverOut}
           onClick={handleRowClick}
           ref={tableRowCallbackRef}
+          style={style}
         >
           {checkboxMarkup}
           {children}

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -6,7 +6,6 @@ import {getTableHeadingsBySelector} from '../utilities';
 import {EmptySearchResult} from '../../EmptySearchResult';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../../EventListener';
-import {Spinner} from '../../Spinner';
 import {Sticky} from '../../Sticky';
 import {Button} from '../../Button';
 import {Checkbox} from '../../Checkbox';

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -102,14 +102,16 @@ describe('<IndexTable>', () => {
     expect(index).toContainReactComponentTimes(Component, 2);
   });
 
-  it('renders a spinner if loading is passed', () => {
+  it('passes a class if loading is passed', () => {
     const index = mountWithApp(
       <IndexTable {...defaultProps} loading itemCount={mockTableItems.length}>
         {mockTableItems.map(mockRenderRow)}
       </IndexTable>,
     );
 
-    expect(index).toContainReactComponent(Spinner);
+    expect(index).toContainReactComponent('table', {
+      className: expect.stringContaining('Table-loading'),
+    });
   });
 
   it('toggles page selection when select all checkbox is changed', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/74392

Updates the loading state of the IndexTable to be a pulsing effect across all rows. The spinner for loading is now being handled as part of the [filtering UI](https://www.figma.com/file/W6lQdgF7ENyKKE8c60YIP1/Index-filters-and-search-(cont'd)?node-id=748%3A270656)

Here's how it looks in a spinstance: https://admin.web.table-loading.marc-thomas.eu.spin.dev/store/shop1/orders?inContextTimeframe=none&delivery_method=

### WHAT is this pull request doing?

https://user-images.githubusercontent.com/2562596/195607120-abcda113-647d-4491-9c38-ab4c7ed5a612.mov

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
