### PR TITLE
[Migrator] Add `migrate-sass-transition` migration for transition durations & easing

### DIFF
--- a/.changeset/famous-ghosts-march.md
+++ b/.changeset/famous-ghosts-march.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Introduce `migrate-motion` migration for migrating `transition`, `transition-duration`, and `transition-delay` usages of duration values.

--- a/polaris-migrator/README.md
+++ b/polaris-migrator/README.md
@@ -235,6 +235,37 @@ Be aware that this may also create additional code changes in your codebase, we 
 npx @shopify/polaris-migrator replace-sass-spacing <path>
 ```
 
+### `replace-sass-transition`
+
+Replace timings (`ms`, `s`) and legacy Sass functions (`duration()`,`easing()`) in transition declarations (`transition`, `transition-duration`, `transition-delay`, and `transition-timing-function`) with the corresponding Polaris [motion](https://polaris.shopify.com/tokens/motion) token.
+
+```diff
+- transition-duration: 100ms;
++ transition-duration: var(--p-duration-100);
+
+- transition-duration: legacy-polaris-v8.duration('slow');
++ transition-duration: var(--p-duration-300);
+
+- transition-timing-function: linear;
++ transition-timing-function: var(--p-linear);
+
+- transition-timing-function: legacy-polaris-v8.easing('in');
++ transition-timing-function: var(--p-ease-in);
+
+- transition: opacity 100ms linear;
++ transition: opacity var(--p-duration-100) linear;
+
+- transition: opacity legacy-polaris-v8.duration('slow') linear;
++ transition: opacity var(--p-duration-300) linear;
+
+- transition: opacity 100ms linear, left 100ms linear;
++ transition: opacity var(--p-duration-100) linear, left var(--p-duration-100) linear;
+```
+
+```sh
+npx @shopify/polaris-migrator replace-sass-transition <path>
+```
+
 ## Creating Migrations
 
 Sometimes referred to as "codemods", migrations are JavaScript functions which modify some code from one form to another (eg; to move between breaking versions of `@shopify/polaris`). ASTs (Abstract Syntax Trees) are used to "walk" through the code in discreet, strongly typed steps, called "nodes". All changes made to nodes (and thus the AST) are then written out as the new/"migrated" version of the code.

--- a/polaris-migrator/src/migrations/replace-sass-transition/replace-sass-transition.ts
+++ b/polaris-migrator/src/migrations/replace-sass-transition/replace-sass-transition.ts
@@ -1,0 +1,389 @@
+import {Declaration} from 'postcss';
+import valueParser, {
+  ParsedValue,
+  Node,
+  FunctionNode,
+} from 'postcss-value-parser';
+
+import {
+  namespace,
+  isSassFunction,
+  isSassVariable,
+  hasNumericOperator,
+  isTransformableDuration,
+  isPolarisVar,
+  createSassMigrator,
+} from '../../utilities/sass';
+import {isKeyOf} from '../../utilities/type-guards';
+
+const DEFAULT_DURATION = 'base';
+const DEFAULT_FUNCTION = 'base';
+
+const durationFuncMap = {
+  none: '--p-duration-0',
+  fast: '--p-duration-100',
+  base: '--p-duration-200',
+  slow: '--p-duration-300',
+  slower: '--p-duration-400',
+  slowest: '--p-duration-500',
+};
+
+const durationConstantsMap = {
+  '0': '--p-duration-0',
+  '0s': '--p-duration-0',
+  '0ms': '--p-duration-0',
+  '50ms': '--p-duration-50',
+  '0.05s': '--p-duration-50',
+  '100ms': '--p-duration-100',
+  '0.1s': '--p-duration-100',
+  '150ms': '--p-duration-150',
+  '0.15s': '--p-duration-150',
+  '200ms': '--p-duration-200',
+  '0.2s': '--p-duration-200',
+  '250ms': '--p-duration-250',
+  '0.25s': '--p-duration-250',
+  '300ms': '--p-duration-300',
+  '0.3s': '--p-duration-300',
+  '350ms': '--p-duration-350',
+  '0.35s': '--p-duration-350',
+  '400ms': '--p-duration-400',
+  '0.4s': '--p-duration-400',
+  '450ms': '--p-duration-450',
+  '0.45s': '--p-duration-450',
+  '500ms': '--p-duration-500',
+  '0.5s': '--p-duration-500',
+  '5s': '--p-duration-5000',
+};
+
+const easingFuncMap = {
+  base: '--p-ease',
+  in: '--p-ease-in',
+  out: '--p-ease-out',
+};
+
+const easingFuncConstantsMap = {
+  linear: '--p-linear',
+  ease: '--p-ease',
+  'ease-in': '--p-ease-in',
+  'ease-out': '--p-ease-out',
+  'ease-in-out': '--p-ease-in-out',
+};
+
+const deprecatedEasingFuncs = ['anticipate', 'excite', 'overshoot'];
+
+// Per the spec for transition easing functions:
+// https://w3c.github.io/csswg-drafts/css-easing/#easing-functions
+const cssEasingBuiltinFuncs = [
+  'linear',
+  'ease',
+  'ease-in',
+  'ease-out',
+  'ease-in-out',
+  'cubic-bezier',
+  'step-start',
+  'step-end',
+  'steps',
+];
+
+function normaliseStringifiedNumber(number: string): string {
+  return Number(number).toString();
+}
+
+function setNodeValue(node: Node, value: string): void {
+  const {sourceIndex} = node;
+  const parsedValue = valueParser(value).nodes[0];
+  Object.assign(node, parsedValue);
+  // The node we're replacing might be mid-way through a higher-level value
+  // string. Eg; 'border: 1px solid', the 'solid' node is 5 characters into the
+  // higher-level value, so we need to correct the index here.
+  node.sourceIndex += sourceIndex;
+  node.sourceEndIndex += sourceIndex;
+}
+
+export default createSassMigrator(
+  'replace-sass-transition',
+  (_, {methods, options}, context) => {
+    const durationFunc = namespace('duration', options);
+
+    function migrateLegacySassEasingFunction(
+      node: FunctionNode,
+      decl: Declaration,
+    ) {
+      const easingFunc = node.nodes[0]?.value ?? DEFAULT_FUNCTION;
+
+      if (!isKeyOf(easingFuncMap, easingFunc)) {
+        const comment = deprecatedEasingFuncs.includes(easingFunc)
+          ? `The ${easingFunc} easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.`
+          : `Unexpected easing function '${easingFunc}'.`;
+
+        methods.report({
+          severity: 'warning',
+          node: decl,
+          message: comment,
+        });
+
+        return;
+      }
+
+      const easingCustomProperty = easingFuncMap[easingFunc];
+      const targetValue = `var(${easingCustomProperty})`;
+
+      if (context.fix) {
+        setNodeValue(node, targetValue);
+      } else {
+        methods.report({
+          severity: 'error',
+          node: decl,
+          message: `Replace easing function with token: ${targetValue}`,
+        });
+      }
+    }
+
+    function insertUnexpectedEasingFunctionComment(
+      node: Node,
+      decl: Declaration,
+    ) {
+      methods.report({
+        severity: 'warning',
+        node: decl,
+        message: `Unexpected easing function '${node.value}'. See https://polaris.shopify.com/tokens/motion for possible values.`,
+      });
+    }
+
+    function mutateTransitionDurationValue(
+      node: Node,
+      decl: Declaration,
+    ): void {
+      if (isPolarisVar(node)) {
+        return;
+      }
+
+      if (isSassVariable(node)) {
+        methods.report({
+          severity: 'warning',
+          node: decl,
+          message: `Cannot statically analyse SASS variable ${node.value}.`,
+        });
+        return;
+      }
+
+      if (isSassFunction(durationFunc, node)) {
+        const duration = node.nodes[0]?.value ?? DEFAULT_DURATION;
+
+        if (!isKeyOf(durationFuncMap, duration)) {
+          methods.report({
+            severity: 'warning',
+            node: decl,
+            message: `Unknown duration key '${duration}'.`,
+          });
+          return;
+        }
+
+        const durationCustomProperty = durationFuncMap[duration];
+        const targetValue = `var(${durationCustomProperty})`;
+
+        if (context.fix) {
+          setNodeValue(node, targetValue);
+        } else {
+          methods.report({
+            severity: 'error',
+            node: decl,
+            message: `Replace duration with token: ${targetValue}`,
+          });
+        }
+
+        return;
+      }
+
+      const unit = valueParser.unit(node.value);
+      if (unit) {
+        const constantDuration = `${normaliseStringifiedNumber(unit.number)}${
+          unit.unit
+        }`;
+
+        if (!isKeyOf(durationConstantsMap, constantDuration)) {
+          methods.report({
+            severity: 'warning',
+            node: decl,
+            message: `No matching duration token for '${constantDuration}'.`,
+          });
+
+          return;
+        }
+
+        const durationCustomProperty = durationConstantsMap[constantDuration];
+        const targetValue = `var(${durationCustomProperty})`;
+
+        if (context.fix) {
+          setNodeValue(node, targetValue);
+        } else {
+          methods.report({
+            severity: 'error',
+            node: decl,
+            message: `Replace duration value with token: ${targetValue}`,
+          });
+        }
+      }
+    }
+
+    function mutateTransitionFunctionValue(
+      node: Node,
+      decl: Declaration,
+    ): void {
+      if (isPolarisVar(node)) {
+        return;
+      }
+
+      if (isSassVariable(node)) {
+        methods.report({
+          severity: 'warning',
+          node: decl,
+          message: `Cannot statically analyse SASS variable ${node.value}.`,
+        });
+        return;
+      }
+
+      if (node.type === 'function') {
+        const easingFuncHandlers = {
+          [namespace('easing', options)]: migrateLegacySassEasingFunction,
+          // Per the spec, these can all be functions:
+          // https://w3c.github.io/csswg-drafts/css-easing/#easing-functions
+          linear: insertUnexpectedEasingFunctionComment,
+          'cubic-bezier': insertUnexpectedEasingFunctionComment,
+          steps: insertUnexpectedEasingFunctionComment,
+        };
+
+        if (isKeyOf(easingFuncHandlers, node.value)) {
+          easingFuncHandlers[node.value](node, decl);
+          return;
+        }
+      }
+
+      if (node.type === 'word') {
+        if (isKeyOf(easingFuncConstantsMap, node.value)) {
+          const targetValue = `var(${easingFuncConstantsMap[node.value]})`;
+
+          if (context.fix) {
+            setNodeValue(node, targetValue);
+          } else {
+            methods.report({
+              severity: 'error',
+              node: decl,
+              message: `Replace easing function with token: ${targetValue}`,
+            });
+          }
+
+          return;
+        }
+
+        if (cssEasingBuiltinFuncs.includes(node.value)) {
+          insertUnexpectedEasingFunctionComment(node, decl);
+        }
+      }
+    }
+
+    function mutateTransitionDelayValue(node: Node, decl: Declaration): void {
+      // For now, we treat delays like durations
+      return mutateTransitionDurationValue(node, decl);
+    }
+
+    function mutateTransitionShorthandValue(
+      decl: Declaration,
+      parsedValue: ParsedValue,
+    ): void {
+      const splitValues: Node[][] = [[]];
+
+      // Gathering up references of nodes into groups. Important to note that
+      // we're dealing with mutable structures here, so we are purposefully
+      // NOT making copies.
+      parsedValue.nodes.forEach((node) => {
+        if (node.type === 'div') {
+          splitValues.push([]);
+        } else {
+          splitValues[splitValues.length - 1].push(node);
+        }
+      });
+
+      splitValues.forEach((nodes) => {
+        // From the spec:
+        //
+        // Note that order is important within the items in this property: the
+        // first value that can be parsed as a time is assigned to the
+        // transition-duration, and the second value that can be parsed as a
+        // time is assigned to transition-delay.
+        // https://w3c.github.io/csswg-drafts/css-transitions-1/#transition-shorthand-property
+        //
+        // That sounds like an array to me! [0] is duration, [1] is delay.
+        const timings: Node[] = [];
+
+        nodes.forEach((node) => {
+          const unit = valueParser.unit(node.value);
+          if (
+            isTransformableDuration(unit) ||
+            isSassFunction(durationFunc, node)
+          ) {
+            timings.push(node);
+          } else {
+            // This node could be either the property to animate, or an easing
+            // function. We try mutate the easing function, but if not we assume
+            // it's the property to animate and therefore do not leave a comment.
+            mutateTransitionFunctionValue(node, decl);
+          }
+        });
+
+        if (timings[0]) {
+          mutateTransitionDurationValue(timings[0], decl);
+        }
+
+        if (timings[1]) {
+          mutateTransitionDelayValue(timings[1], decl);
+        }
+      });
+    }
+
+    return (root) => {
+      methods.walkDecls(root, (decl) => {
+        const handlers: {[key: string]: () => void} = {
+          'transition-duration': () => {
+            parsedValue.nodes.forEach((node) => {
+              mutateTransitionDurationValue(node, decl);
+            });
+          },
+          'transition-delay': () => {
+            parsedValue.nodes.forEach((node) => {
+              mutateTransitionDelayValue(node, decl);
+            });
+          },
+          'transition-timing-function': () => {
+            parsedValue.nodes.forEach((node) => {
+              mutateTransitionFunctionValue(node, decl);
+            });
+          },
+          transition: () => {
+            mutateTransitionShorthandValue(decl, parsedValue);
+          },
+        };
+
+        if (!handlers[decl.prop]) {
+          return;
+        }
+
+        const parsedValue = valueParser(decl.value);
+
+        if (hasNumericOperator(parsedValue)) {
+          methods.report({
+            node: decl,
+            severity: 'warning',
+            message: 'Numeric operator detected.',
+          });
+        }
+
+        handlers[decl.prop]();
+
+        if (context.fix) {
+          decl.value = parsedValue.toString();
+        }
+      });
+    };
+  },
+);

--- a/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-duration.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-duration.input.scss
@@ -1,0 +1,177 @@
+.duration-simple-string-arg {
+  opacity: 1;
+  transition-duration: legacy-polaris-v8.duration('none');
+  transition-duration: legacy-polaris-v8.duration('fast');
+  transition-duration: legacy-polaris-v8.duration('base');
+  transition-duration: legacy-polaris-v8.duration('slow');
+  transition-duration: legacy-polaris-v8.duration('slower');
+  transition-duration: legacy-polaris-v8.duration('slowest');
+}
+
+.duration-simple-non-string-arg {
+  opacity: 1;
+  transition-duration: legacy-polaris-v8.duration();
+  transition-duration: legacy-polaris-v8.duration(none);
+  transition-duration: legacy-polaris-v8.duration(fast);
+  transition-duration: legacy-polaris-v8.duration(base);
+  transition-duration: legacy-polaris-v8.duration(slow);
+  transition-duration: legacy-polaris-v8.duration(slower);
+  transition-duration: legacy-polaris-v8.duration(slowest);
+}
+
+.duration-simple-constant {
+  opacity: 1;
+  transition-duration: 0;
+  transition-duration: 0ms;
+  transition-duration: 0s;
+  transition-duration: 50ms;
+  transition-duration: 0.05s;
+  transition-duration: 100ms;
+  transition-duration: 0.1s;
+  transition-duration: 150ms;
+  transition-duration: 0.15s;
+  transition-duration: 200ms;
+  transition-duration: 0.2s;
+  transition-duration: 250ms;
+  transition-duration: 0.25s;
+  transition-duration: 300ms;
+  transition-duration: 0.3s;
+  transition-duration: 350ms;
+  transition-duration: 0.35s;
+  transition-duration: 400ms;
+  transition-duration: 0.4s;
+  transition-duration: 450ms;
+  transition-duration: 0.45s;
+  transition-duration: 500ms;
+  transition-duration: 0.5s;
+  transition-duration: 5s;
+}
+
+.duration-compound-string-arg {
+  opacity: 1;
+  transition: opacity legacy-polaris-v8.duration('none') linear;
+  transition: opacity legacy-polaris-v8.duration('fast') linear;
+  transition: opacity legacy-polaris-v8.duration('base') linear;
+  transition: opacity legacy-polaris-v8.duration('slow') linear;
+  transition: opacity legacy-polaris-v8.duration('slower') linear;
+  transition: opacity legacy-polaris-v8.duration('slowest') linear;
+}
+
+.duration-compound-non-string-arg {
+  opacity: 1;
+  transition: opacity legacy-polaris-v8.duration() linear;
+  transition: opacity legacy-polaris-v8.duration(none) linear;
+  transition: opacity legacy-polaris-v8.duration(fast) linear;
+  transition: opacity legacy-polaris-v8.duration(base) linear;
+  transition: opacity legacy-polaris-v8.duration(slow) linear;
+  transition: opacity legacy-polaris-v8.duration(slower) linear;
+  transition: opacity legacy-polaris-v8.duration(slowest) linear;
+}
+
+.duration-compound-constant {
+  opacity: 1;
+  transition: opacity 0 linear;
+  transition: opacity 0ms linear;
+  transition: opacity 0s linear;
+  transition: opacity 50ms linear;
+  transition: opacity 0.05s linear;
+  transition: opacity 100ms linear;
+  transition: opacity 0.1s linear;
+  transition: opacity 150ms linear;
+  transition: opacity 0.15s linear;
+  transition: opacity 200ms linear;
+  transition: opacity 0.2s linear;
+  transition: opacity 250ms linear;
+  transition: opacity 0.25s linear;
+  transition: opacity 300ms linear;
+  transition: opacity 0.3s linear;
+  transition: opacity 350ms linear;
+  transition: opacity 0.35s linear;
+  transition: opacity 400ms linear;
+  transition: opacity 0.4s linear;
+  transition: opacity 450ms linear;
+  transition: opacity 0.45s linear;
+  transition: opacity 500ms linear;
+  transition: opacity 0.5s linear;
+  transition: opacity 5s linear;
+}
+
+.duration-multiple-string-arg {
+  opacity: 1;
+  transition: opacity legacy-polaris-v8.duration('none') linear,
+    left legacy-polaris-v8.duration('none') linear;
+  transition: opacity legacy-polaris-v8.duration('fast') linear,
+    left legacy-polaris-v8.duration('fast') linear;
+  transition: opacity legacy-polaris-v8.duration('base') linear,
+    left legacy-polaris-v8.duration('base') linear;
+  transition: opacity legacy-polaris-v8.duration('slow') linear,
+    left legacy-polaris-v8.duration('slow') linear;
+  transition: opacity legacy-polaris-v8.duration('slower') linear,
+    left legacy-polaris-v8.duration('slower') linear;
+  transition: opacity legacy-polaris-v8.duration('slowest') linear,
+    left legacy-polaris-v8.duration('slowest') linear;
+}
+
+.duration-multiple-non-string-arg {
+  opacity: 1;
+  transition: opacity legacy-polaris-v8.duration() linear,
+    left legacy-polaris-v8.duration() linear;
+  transition: opacity legacy-polaris-v8.duration(none) linear,
+    left legacy-polaris-v8.duration(none) linear;
+  transition: opacity legacy-polaris-v8.duration(fast) linear,
+    left legacy-polaris-v8.duration(fast) linear;
+  transition: opacity legacy-polaris-v8.duration(base) linear,
+    left legacy-polaris-v8.duration(base) linear;
+  transition: opacity legacy-polaris-v8.duration(slow) linear,
+    left legacy-polaris-v8.duration(slow) linear;
+  transition: opacity legacy-polaris-v8.duration(slower) linear,
+    left legacy-polaris-v8.duration(slower) linear;
+  transition: opacity legacy-polaris-v8.duration(slowest) linear,
+    left legacy-polaris-v8.duration(slowest) linear;
+}
+
+.duration-multiple-constant {
+  opacity: 1;
+  transition: opacity 0 linear, left 0 linear;
+  transition: opacity 0ms linear, left 0ms linear;
+  transition: opacity 0s linear, left 0s linear;
+  transition: opacity 50ms linear, left 50ms linear;
+  transition: opacity 0.05s linear, left 0.05s linear;
+  transition: opacity 100ms linear, left 100ms linear;
+  transition: opacity 0.1s linear, left 0.1s linear;
+  transition: opacity 150ms linear, left 150ms linear;
+  transition: opacity 0.15s linear, left 0.15s linear;
+  transition: opacity 200ms linear, left 200ms linear;
+  transition: opacity 0.2s linear, left 0.2s linear;
+  transition: opacity 250ms linear, left 250ms linear;
+  transition: opacity 0.25s linear, left 0.25s linear;
+  transition: opacity 300ms linear, left 300ms linear;
+  transition: opacity 0.3s linear, left 0.3s linear;
+  transition: opacity 350ms linear, left 350ms linear;
+  transition: opacity 0.35s linear, left 0.35s linear;
+  transition: opacity 400ms linear, left 400ms linear;
+  transition: opacity 0.4s linear, left 0.4s linear;
+  transition: opacity 450ms linear, left 450ms linear;
+  transition: opacity 0.45s linear, left 0.45s linear;
+  transition: opacity 500ms linear, left 500ms linear;
+  transition: opacity 0.5s linear, left 0.5s linear;
+  transition: opacity 5s linear, left 5s linear;
+}
+
+.edges {
+  // sass calculation
+  transition: (legacy-polaris-v8.duration() - 33ms) fill linear 33ms;
+  // Duration comes after easing func
+  transition: opacity linear 0.5s;
+  // Duration + Delay
+  transition: opacity legacy-polaris-v8.duration(slower) linear
+    legacy-polaris-v8.duration(fast);
+  // Duration + Delay after easing func
+  transition: opacity linear legacy-polaris-v8.duration(slower)
+    legacy-polaris-v8.duration(fast);
+  // foobar isn't a valid duration key
+  transition-duration: legacy-polaris-v8.duration(foobar);
+  // can't process variables
+  transition-duration: $foo;
+  transition: opacity $foo 0.5s;
+}

--- a/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-duration.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-duration.output.scss
@@ -1,0 +1,212 @@
+.duration-simple-string-arg {
+  opacity: 1;
+  transition-duration: var(--p-duration-0);
+  transition-duration: var(--p-duration-100);
+  transition-duration: var(--p-duration-200);
+  transition-duration: var(--p-duration-300);
+  transition-duration: var(--p-duration-400);
+  transition-duration: var(--p-duration-500);
+}
+
+.duration-simple-non-string-arg {
+  opacity: 1;
+  transition-duration: var(--p-duration-200);
+  transition-duration: var(--p-duration-0);
+  transition-duration: var(--p-duration-100);
+  transition-duration: var(--p-duration-200);
+  transition-duration: var(--p-duration-300);
+  transition-duration: var(--p-duration-400);
+  transition-duration: var(--p-duration-500);
+}
+
+.duration-simple-constant {
+  opacity: 1;
+  transition-duration: var(--p-duration-0);
+  transition-duration: var(--p-duration-0);
+  transition-duration: var(--p-duration-0);
+  transition-duration: var(--p-duration-50);
+  transition-duration: var(--p-duration-50);
+  transition-duration: var(--p-duration-100);
+  transition-duration: var(--p-duration-100);
+  transition-duration: var(--p-duration-150);
+  transition-duration: var(--p-duration-150);
+  transition-duration: var(--p-duration-200);
+  transition-duration: var(--p-duration-200);
+  transition-duration: var(--p-duration-250);
+  transition-duration: var(--p-duration-250);
+  transition-duration: var(--p-duration-300);
+  transition-duration: var(--p-duration-300);
+  transition-duration: var(--p-duration-350);
+  transition-duration: var(--p-duration-350);
+  transition-duration: var(--p-duration-400);
+  transition-duration: var(--p-duration-400);
+  transition-duration: var(--p-duration-450);
+  transition-duration: var(--p-duration-450);
+  transition-duration: var(--p-duration-500);
+  transition-duration: var(--p-duration-500);
+  transition-duration: var(--p-duration-5000);
+}
+
+.duration-compound-string-arg {
+  opacity: 1;
+  transition: opacity var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-100) var(--p-linear);
+  transition: opacity var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-300) var(--p-linear);
+  transition: opacity var(--p-duration-400) var(--p-linear);
+  transition: opacity var(--p-duration-500) var(--p-linear);
+}
+
+.duration-compound-non-string-arg {
+  opacity: 1;
+  transition: opacity var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-100) var(--p-linear);
+  transition: opacity var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-300) var(--p-linear);
+  transition: opacity var(--p-duration-400) var(--p-linear);
+  transition: opacity var(--p-duration-500) var(--p-linear);
+}
+
+.duration-compound-constant {
+  opacity: 1;
+  transition: opacity var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-50) var(--p-linear);
+  transition: opacity var(--p-duration-50) var(--p-linear);
+  transition: opacity var(--p-duration-100) var(--p-linear);
+  transition: opacity var(--p-duration-100) var(--p-linear);
+  transition: opacity var(--p-duration-150) var(--p-linear);
+  transition: opacity var(--p-duration-150) var(--p-linear);
+  transition: opacity var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-250) var(--p-linear);
+  transition: opacity var(--p-duration-250) var(--p-linear);
+  transition: opacity var(--p-duration-300) var(--p-linear);
+  transition: opacity var(--p-duration-300) var(--p-linear);
+  transition: opacity var(--p-duration-350) var(--p-linear);
+  transition: opacity var(--p-duration-350) var(--p-linear);
+  transition: opacity var(--p-duration-400) var(--p-linear);
+  transition: opacity var(--p-duration-400) var(--p-linear);
+  transition: opacity var(--p-duration-450) var(--p-linear);
+  transition: opacity var(--p-duration-450) var(--p-linear);
+  transition: opacity var(--p-duration-500) var(--p-linear);
+  transition: opacity var(--p-duration-500) var(--p-linear);
+  transition: opacity var(--p-duration-5000) var(--p-linear);
+}
+
+.duration-multiple-string-arg {
+  opacity: 1;
+  transition: opacity var(--p-duration-0) var(--p-linear),
+    left var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-100) var(--p-linear),
+    left var(--p-duration-100) var(--p-linear);
+  transition: opacity var(--p-duration-200) var(--p-linear),
+    left var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-300) var(--p-linear),
+    left var(--p-duration-300) var(--p-linear);
+  transition: opacity var(--p-duration-400) var(--p-linear),
+    left var(--p-duration-400) var(--p-linear);
+  transition: opacity var(--p-duration-500) var(--p-linear),
+    left var(--p-duration-500) var(--p-linear);
+}
+
+.duration-multiple-non-string-arg {
+  opacity: 1;
+  transition: opacity var(--p-duration-200) var(--p-linear),
+    left var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-0) var(--p-linear),
+    left var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-100) var(--p-linear),
+    left var(--p-duration-100) var(--p-linear);
+  transition: opacity var(--p-duration-200) var(--p-linear),
+    left var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-300) var(--p-linear),
+    left var(--p-duration-300) var(--p-linear);
+  transition: opacity var(--p-duration-400) var(--p-linear),
+    left var(--p-duration-400) var(--p-linear);
+  transition: opacity var(--p-duration-500) var(--p-linear),
+    left var(--p-duration-500) var(--p-linear);
+}
+
+.duration-multiple-constant {
+  opacity: 1;
+  transition: opacity var(--p-duration-0) var(--p-linear),
+    left var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-0) var(--p-linear),
+    left var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-0) var(--p-linear),
+    left var(--p-duration-0) var(--p-linear);
+  transition: opacity var(--p-duration-50) var(--p-linear),
+    left var(--p-duration-50) var(--p-linear);
+  transition: opacity var(--p-duration-50) var(--p-linear),
+    left var(--p-duration-50) var(--p-linear);
+  transition: opacity var(--p-duration-100) var(--p-linear),
+    left var(--p-duration-100) var(--p-linear);
+  transition: opacity var(--p-duration-100) var(--p-linear),
+    left var(--p-duration-100) var(--p-linear);
+  transition: opacity var(--p-duration-150) var(--p-linear),
+    left var(--p-duration-150) var(--p-linear);
+  transition: opacity var(--p-duration-150) var(--p-linear),
+    left var(--p-duration-150) var(--p-linear);
+  transition: opacity var(--p-duration-200) var(--p-linear),
+    left var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-200) var(--p-linear),
+    left var(--p-duration-200) var(--p-linear);
+  transition: opacity var(--p-duration-250) var(--p-linear),
+    left var(--p-duration-250) var(--p-linear);
+  transition: opacity var(--p-duration-250) var(--p-linear),
+    left var(--p-duration-250) var(--p-linear);
+  transition: opacity var(--p-duration-300) var(--p-linear),
+    left var(--p-duration-300) var(--p-linear);
+  transition: opacity var(--p-duration-300) var(--p-linear),
+    left var(--p-duration-300) var(--p-linear);
+  transition: opacity var(--p-duration-350) var(--p-linear),
+    left var(--p-duration-350) var(--p-linear);
+  transition: opacity var(--p-duration-350) var(--p-linear),
+    left var(--p-duration-350) var(--p-linear);
+  transition: opacity var(--p-duration-400) var(--p-linear),
+    left var(--p-duration-400) var(--p-linear);
+  transition: opacity var(--p-duration-400) var(--p-linear),
+    left var(--p-duration-400) var(--p-linear);
+  transition: opacity var(--p-duration-450) var(--p-linear),
+    left var(--p-duration-450) var(--p-linear);
+  transition: opacity var(--p-duration-450) var(--p-linear),
+    left var(--p-duration-450) var(--p-linear);
+  transition: opacity var(--p-duration-500) var(--p-linear),
+    left var(--p-duration-500) var(--p-linear);
+  transition: opacity var(--p-duration-500) var(--p-linear),
+    left var(--p-duration-500) var(--p-linear);
+  transition: opacity var(--p-duration-5000) var(--p-linear),
+    left var(--p-duration-5000) var(--p-linear);
+}
+
+.edges {
+  // sass calculation
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
+  // warning: No matching duration token for '33ms'.
+  // transition: (legacy-polaris-v8.duration() - 33ms) fill var(--p-linear) 33ms;
+  transition: (legacy-polaris-v8.duration() - 33ms) fill linear 33ms;
+  // Duration comes after easing func
+  transition: opacity var(--p-linear) var(--p-duration-500);
+  // Duration + Delay
+  transition: opacity var(--p-duration-400) var(--p-linear)
+    var(--p-duration-100);
+  // Duration + Delay after easing func
+  transition: opacity var(--p-linear) var(--p-duration-400)
+    var(--p-duration-100);
+  // foobar isn't a valid duration key
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unknown duration key 'foobar'.
+  transition-duration: legacy-polaris-v8.duration(foobar);
+  // can't process variables
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Cannot statically analyse SASS variable $foo.
+  transition-duration: $foo;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Cannot statically analyse SASS variable $foo.
+  // transition: opacity $foo var(--p-duration-500);
+  transition: opacity $foo 0.5s;
+}

--- a/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-easing.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-easing.input.scss
@@ -1,0 +1,138 @@
+.easing-simple-string-arg {
+  opacity: 1;
+  transition-timing-function: legacy-polaris-v8.easing('anticipate');
+  transition-timing-function: legacy-polaris-v8.easing('base');
+  transition-timing-function: legacy-polaris-v8.easing('excite');
+  transition-timing-function: legacy-polaris-v8.easing('in');
+  transition-timing-function: legacy-polaris-v8.easing('out');
+  transition-timing-function: legacy-polaris-v8.easing('overshoot');
+}
+
+.easing-simple-non-string-arg {
+  opacity: 1;
+  transition-timing-function: legacy-polaris-v8.easing();
+  transition-timing-function: legacy-polaris-v8.easing(anticipate);
+  transition-timing-function: legacy-polaris-v8.easing(base);
+  transition-timing-function: legacy-polaris-v8.easing(excite);
+  transition-timing-function: legacy-polaris-v8.easing(in);
+  transition-timing-function: legacy-polaris-v8.easing(out);
+  transition-timing-function: legacy-polaris-v8.easing(overshoot);
+}
+
+.easing-simple-builtins {
+  opacity: 1;
+  transition-timing-function: linear;
+  // See: https://w3c.github.io/csswg-drafts/css-easing/#typedef-linear-easing-function
+  transition-timing-function: linear(1);
+  transition-timing-function: ease;
+  transition-timing-function: ease-in;
+  transition-timing-function: ease-out;
+  transition-timing-function: ease-in-out;
+  transition-timing-function: cubic-bezier(0, 0, 1, 1);
+  // See:https://w3c.github.io/csswg-drafts/css-easing/#typedef-step-easing-function
+  transition-timing-function: step-start;
+  transition-timing-function: step-end;
+  transition-timing-function: steps(1, jump-end);
+}
+
+.easing-shorthand-string-arg {
+  opacity: 1;
+  transition: opacity 300ms legacy-polaris-v8.easing('anticipate');
+  transition: opacity 300ms legacy-polaris-v8.easing('base');
+  transition: opacity 300ms legacy-polaris-v8.easing('excite');
+  transition: opacity 300ms legacy-polaris-v8.easing('in');
+  transition: opacity 300ms legacy-polaris-v8.easing('out');
+  transition: opacity 300ms legacy-polaris-v8.easing('overshoot');
+}
+
+.easing-shorthand-non-string-arg {
+  opacity: 1;
+  transition: opacity 300ms legacy-polaris-v8.easing();
+  transition: opacity 300ms legacy-polaris-v8.easing(anticipate);
+  transition: opacity 300ms legacy-polaris-v8.easing(base);
+  transition: opacity 300ms legacy-polaris-v8.easing(excite);
+  transition: opacity 300ms legacy-polaris-v8.easing(in);
+  transition: opacity 300ms legacy-polaris-v8.easing(out);
+  transition: opacity 300ms legacy-polaris-v8.easing(overshoot);
+}
+
+.easing-shorthand-builtins {
+  opacity: 1;
+  transition: opacity 300ms linear;
+  // See: https://w3c.github.io/csswg-drafts/css-easing/#typedef-linear-easing-function
+  transition: opacity 300ms linear(1);
+  transition: opacity 300ms ease;
+  transition: opacity 300ms ease-in;
+  transition: opacity 300ms ease-out;
+  transition: opacity 300ms ease-in-out;
+  transition: opacity 300ms cubic-bezier(0, 0, 1, 1);
+  // See:https://w3c.github.io/csswg-drafts/css-easing/#typedef-step-easing-function
+  transition: opacity 300ms step-start;
+  transition: opacity 300ms step-end;
+  transition: opacity 300ms steps(1, jump-end);
+}
+
+.easing-multiple-string-arg {
+  opacity: 1;
+  transition: opacity 300ms legacy-polaris-v8.easing('anticipate'),
+    left 300ms legacy-polaris-v8.easing('anticipate');
+  transition: opacity 300ms legacy-polaris-v8.easing('base'),
+    left 300ms legacy-polaris-v8.easing('base');
+  transition: opacity 300ms legacy-polaris-v8.easing('excite'),
+    left 300ms legacy-polaris-v8.easing('excite');
+  transition: opacity 300ms legacy-polaris-v8.easing('in'),
+    left 300ms legacy-polaris-v8.easing('in');
+  transition: opacity 300ms legacy-polaris-v8.easing('out'),
+    left 300ms legacy-polaris-v8.easing('out');
+  transition: opacity 300ms legacy-polaris-v8.easing('overshoot'),
+    left 300ms legacy-polaris-v8.easing('overshoot');
+}
+
+.easing-multiple-non-string-arg {
+  opacity: 1;
+  transition: opacity 300ms legacy-polaris-v8.easing(),
+    left 300ms legacy-polaris-v8.easing();
+  transition: opacity 300ms legacy-polaris-v8.easing(anticipate),
+    left 300ms legacy-polaris-v8.easing(anticipate);
+  transition: opacity 300ms legacy-polaris-v8.easing(base),
+    left 300ms legacy-polaris-v8.easing(base);
+  transition: opacity 300ms legacy-polaris-v8.easing(excite),
+    left 300ms legacy-polaris-v8.easing(excite);
+  transition: opacity 300ms legacy-polaris-v8.easing(in),
+    left 300ms legacy-polaris-v8.easing(in);
+  transition: opacity 300ms legacy-polaris-v8.easing(out),
+    left 300ms legacy-polaris-v8.easing(out);
+  transition: opacity 300ms legacy-polaris-v8.easing(overshoot),
+    left 300ms legacy-polaris-v8.easing(overshoot);
+}
+
+.easing-multiple-builtins {
+  opacity: 1;
+  transition: opacity 300ms linear, left 300ms linear;
+  // See: https://w3c.github.io/csswg-drafts/css-easing/#typedef-linear-easing-function
+  transition: opacity 300ms linear(1), left 300ms linear(1);
+  transition: opacity 300ms ease, left 300ms ease;
+  transition: opacity 300ms ease-in, left 300ms ease-in;
+  transition: opacity 300ms ease-out, left 300ms ease-out;
+  transition: opacity 300ms ease-in-out, left 300ms ease-in-out;
+  transition: opacity 300ms cubic-bezier(0, 0, 1, 1),
+    left 300ms cubic-bezier(0, 0, 1, 1);
+  // See:https://w3c.github.io/csswg-drafts/css-easing/#typedef-step-easing-function
+  transition: opacity 300ms step-start, left 300ms step-start;
+  transition: opacity 300ms step-end, left 300ms step-start;
+  transition: opacity 300ms steps(1, jump-end), left 300ms steps(1, jump-end);
+}
+
+$easingFunc: 'ease-in';
+
+.edges {
+  // Without an easing function
+  transition: fill 300ms;
+  // Unknown values are flagged
+  transition-timing-function: legacy-polaris-v8.easing(foobar);
+  // Can only handle hard coded values
+  transition-timing-function: legacy-polaris-v8.easing($easingFunc);
+  // can't process variables
+  transition-timing-function: $foo;
+  transition: opacity $foo 0.5s;
+}

--- a/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-easing.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-easing.output.scss
@@ -1,0 +1,241 @@
+.easing-simple-string-arg {
+  opacity: 1;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The anticipate easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: legacy-polaris-v8.easing('anticipate');
+  transition-timing-function: var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The excite easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: legacy-polaris-v8.easing('excite');
+  transition-timing-function: var(--p-ease-in);
+  transition-timing-function: var(--p-ease-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The overshoot easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: legacy-polaris-v8.easing('overshoot');
+}
+
+.easing-simple-non-string-arg {
+  opacity: 1;
+  transition-timing-function: var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The anticipate easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: legacy-polaris-v8.easing(anticipate);
+  transition-timing-function: var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The excite easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: legacy-polaris-v8.easing(excite);
+  transition-timing-function: var(--p-ease-in);
+  transition-timing-function: var(--p-ease-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The overshoot easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: legacy-polaris-v8.easing(overshoot);
+}
+
+.easing-simple-builtins {
+  opacity: 1;
+  transition-timing-function: var(--p-linear);
+  // See: https://w3c.github.io/csswg-drafts/css-easing/#typedef-linear-easing-function
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'linear'. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: linear(1);
+  transition-timing-function: var(--p-ease);
+  transition-timing-function: var(--p-ease-in);
+  transition-timing-function: var(--p-ease-out);
+  transition-timing-function: var(--p-ease-in-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'cubic-bezier'. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: cubic-bezier(0, 0, 1, 1);
+  // See:https://w3c.github.io/csswg-drafts/css-easing/#typedef-step-easing-function
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'step-start'. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: step-start;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'step-end'. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: step-end;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'steps'. See https://polaris.shopify.com/tokens/motion for possible values.
+  transition-timing-function: steps(1, jump-end);
+}
+
+.easing-shorthand-string-arg {
+  opacity: 1;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The anticipate easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing("anticipate");
+  transition: opacity 300ms legacy-polaris-v8.easing('anticipate');
+  transition: opacity var(--p-duration-300) var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The excite easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing("excite");
+  transition: opacity 300ms legacy-polaris-v8.easing('excite');
+  transition: opacity var(--p-duration-300) var(--p-ease-in);
+  transition: opacity var(--p-duration-300) var(--p-ease-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The overshoot easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing("overshoot");
+  transition: opacity 300ms legacy-polaris-v8.easing('overshoot');
+}
+
+.easing-shorthand-non-string-arg {
+  opacity: 1;
+  transition: opacity var(--p-duration-300) var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The anticipate easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing(anticipate);
+  transition: opacity 300ms legacy-polaris-v8.easing(anticipate);
+  transition: opacity var(--p-duration-300) var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The excite easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing(excite);
+  transition: opacity 300ms legacy-polaris-v8.easing(excite);
+  transition: opacity var(--p-duration-300) var(--p-ease-in);
+  transition: opacity var(--p-duration-300) var(--p-ease-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The overshoot easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing(overshoot);
+  transition: opacity 300ms legacy-polaris-v8.easing(overshoot);
+}
+
+.easing-shorthand-builtins {
+  opacity: 1;
+  transition: opacity var(--p-duration-300) var(--p-linear);
+  // See: https://w3c.github.io/csswg-drafts/css-easing/#typedef-linear-easing-function
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'linear'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) linear(1);
+  transition: opacity 300ms linear(1);
+  transition: opacity var(--p-duration-300) var(--p-ease);
+  transition: opacity var(--p-duration-300) var(--p-ease-in);
+  transition: opacity var(--p-duration-300) var(--p-ease-out);
+  transition: opacity var(--p-duration-300) var(--p-ease-in-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'cubic-bezier'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) cubic-bezier(0, 0, 1, 1);
+  transition: opacity 300ms cubic-bezier(0, 0, 1, 1);
+  // See:https://w3c.github.io/csswg-drafts/css-easing/#typedef-step-easing-function
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'step-start'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) step-start;
+  transition: opacity 300ms step-start;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'step-end'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) step-end;
+  transition: opacity 300ms step-end;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'steps'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) steps(1, jump-end);
+  transition: opacity 300ms steps(1, jump-end);
+}
+
+.easing-multiple-string-arg {
+  opacity: 1;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The anticipate easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing("anticipate"), left var(--p-duration-300) legacy-polaris-v8.easing("anticipate");
+  transition: opacity 300ms legacy-polaris-v8.easing('anticipate'),
+    left 300ms legacy-polaris-v8.easing('anticipate');
+  transition: opacity var(--p-duration-300) var(--p-ease),
+    left var(--p-duration-300) var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The excite easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing("excite"), left var(--p-duration-300) legacy-polaris-v8.easing("excite");
+  transition: opacity 300ms legacy-polaris-v8.easing('excite'),
+    left 300ms legacy-polaris-v8.easing('excite');
+  transition: opacity var(--p-duration-300) var(--p-ease-in),
+    left var(--p-duration-300) var(--p-ease-in);
+  transition: opacity var(--p-duration-300) var(--p-ease-out),
+    left var(--p-duration-300) var(--p-ease-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The overshoot easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing("overshoot"), left var(--p-duration-300) legacy-polaris-v8.easing("overshoot");
+  transition: opacity 300ms legacy-polaris-v8.easing('overshoot'),
+    left 300ms legacy-polaris-v8.easing('overshoot');
+}
+
+.easing-multiple-non-string-arg {
+  opacity: 1;
+  transition: opacity var(--p-duration-300) var(--p-ease),
+    left var(--p-duration-300) var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The anticipate easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing(anticipate), left var(--p-duration-300) legacy-polaris-v8.easing(anticipate);
+  transition: opacity 300ms legacy-polaris-v8.easing(anticipate),
+    left 300ms legacy-polaris-v8.easing(anticipate);
+  transition: opacity var(--p-duration-300) var(--p-ease),
+    left var(--p-duration-300) var(--p-ease);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The excite easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing(excite), left var(--p-duration-300) legacy-polaris-v8.easing(excite);
+  transition: opacity 300ms legacy-polaris-v8.easing(excite),
+    left 300ms legacy-polaris-v8.easing(excite);
+  transition: opacity var(--p-duration-300) var(--p-ease-in),
+    left var(--p-duration-300) var(--p-ease-in);
+  transition: opacity var(--p-duration-300) var(--p-ease-out),
+    left var(--p-duration-300) var(--p-ease-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: The overshoot easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) legacy-polaris-v8.easing(overshoot), left var(--p-duration-300) legacy-polaris-v8.easing(overshoot);
+  transition: opacity 300ms legacy-polaris-v8.easing(overshoot),
+    left 300ms legacy-polaris-v8.easing(overshoot);
+}
+
+.easing-multiple-builtins {
+  opacity: 1;
+  transition: opacity var(--p-duration-300) var(--p-linear),
+    left var(--p-duration-300) var(--p-linear);
+  // See: https://w3c.github.io/csswg-drafts/css-easing/#typedef-linear-easing-function
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'linear'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) linear(1), left var(--p-duration-300) linear(1);
+  transition: opacity 300ms linear(1), left 300ms linear(1);
+  transition: opacity var(--p-duration-300) var(--p-ease),
+    left var(--p-duration-300) var(--p-ease);
+  transition: opacity var(--p-duration-300) var(--p-ease-in),
+    left var(--p-duration-300) var(--p-ease-in);
+  transition: opacity var(--p-duration-300) var(--p-ease-out),
+    left var(--p-duration-300) var(--p-ease-out);
+  transition: opacity var(--p-duration-300) var(--p-ease-in-out),
+    left var(--p-duration-300) var(--p-ease-in-out);
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'cubic-bezier'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) cubic-bezier(0, 0, 1, 1), left var(--p-duration-300) cubic-bezier(0, 0, 1, 1);
+  transition: opacity 300ms cubic-bezier(0, 0, 1, 1),
+    left 300ms cubic-bezier(0, 0, 1, 1);
+  // See:https://w3c.github.io/csswg-drafts/css-easing/#typedef-step-easing-function
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'step-start'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) step-start, left var(--p-duration-300) step-start;
+  transition: opacity 300ms step-start, left 300ms step-start;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'step-end'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // warning: Unexpected easing function 'step-start'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) step-end, left var(--p-duration-300) step-start;
+  transition: opacity 300ms step-end, left 300ms step-start;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'steps'. See https://polaris.shopify.com/tokens/motion for possible values.
+  // transition: opacity var(--p-duration-300) steps(1, jump-end), left var(--p-duration-300) steps(1, jump-end);
+  transition: opacity 300ms steps(1, jump-end), left 300ms steps(1, jump-end);
+}
+
+$easingFunc: 'ease-in';
+
+.edges {
+  // Without an easing function
+  transition: fill var(--p-duration-300);
+  // Unknown values are flagged
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function 'foobar'.
+  transition-timing-function: legacy-polaris-v8.easing(foobar);
+  // Can only handle hard coded values
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Unexpected easing function '$easingFunc'.
+  transition-timing-function: legacy-polaris-v8.easing($easingFunc);
+  // can't process variables
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Cannot statically analyse SASS variable $foo.
+  transition-timing-function: $foo;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Cannot statically analyse SASS variable $foo.
+  // transition: opacity $foo var(--p-duration-500);
+  transition: opacity $foo 0.5s;
+}

--- a/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-transition.test.ts
+++ b/polaris-migrator/src/migrations/replace-sass-transition/tests/replace-sass-transition.test.ts
@@ -1,0 +1,15 @@
+import {check} from '../../../utilities/testUtils';
+
+const migration = 'replace-sass-transition';
+const fixtures = ['replace-sass-duration', 'replace-sass-easing'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: 'scss',
+    options: {
+      namespace: 'legacy-polaris-v8',
+    },
+  });
+}


### PR DESCRIPTION
_NOTE: This leverages the functionality in #7543 to get some sweet sweet clean code and juicy verbose output!_

### WHY are these changes introduced?

ref https://github.com/Shopify/polaris/issues/7213

This PR covers the `transition`, `transition-duration`, `transition-delay`, and `transition-timing-function` properties, their various complex uses and a couple of edge cases as seen in the wild.

### WHAT is this pull request doing?

Example migrations (taken from the test files):

#### `duration`

* `transition-duration: 100ms;`
    ↳ `transition-duration: var(--p-duration-100);`
* `transition-duration: legacy-polaris-v8.duration('slow');`
    ↳ `transition-duration: var(--p-duration-300);`
* `transition: opacity 100ms linear;`
    ↳ `transition: opacity var(--p-duration-100) linear;`
* `transition: opacity legacy-polaris-v8.duration('slow') linear;`
    ↳ `transition: opacity var(--p-duration-300) linear;`
* `transition: opacity 100ms linear, left 100ms linear;`
    ↳ `transition: opacity var(--p-duration-100) linear, left var(--p-duration-100) linear;`
* `transition: opacity legacy-polaris-v8.duration(slow) linear, left legacy-polaris-v8.duration(slow) linear;`
    ↳ `transition: opacity var(--p-duration-300) linear, left var(--p-duration-300) linear;`
* `transition: opacity legacy-polaris-v8.duration(slower) linear legacy-polaris-v8.duration(fast);`
    ↳ `transition: opacity var(--p-duration-400) linear var(--p-duration-100);`

#### `easing`


* `transition-timing-function: linear`
    ↳ `transition-timing-function: var(--p-linear)`
* `transition-timing-function: legacy-polaris-v8.easing('in')`
    ↳ `transition-timing-function: var(--p-ease-in);`
* `transition: opacity 300ms legacy-polaris-v8.easing('base');`
    ↳ `transition: opacity var(--p-duration-300) var(--p-ease);`

Will output various error messages for things it can't migrate:

* `transition-timing-function: legacy-polaris-v8.easing(anticipate);`
    ↳
    ```
    /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. The anticipate easing function is no longer available in Polaris. See https://polaris.shopify.com/tokens/motion for possible values. */
    transition-timing-function: legacy-polaris-v8.easing('anticipate');
    ```
* `transition-timing-function: cubic-bezier(0, 0, 1, 1);`
    ↳
    ```
    /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. Unexpected easing function 'cubic-bezier'. See https://polaris.shopify.com/tokens/motion for possible values. */
    transition-timing-function: cubic-bezier(0, 0, 1, 1);
    ```


---

## Notes

1. We consider `cubic-bezier()` / `linear()` / other built-in CSS easing functions as failures (inserting a comment when they're detected).
2. We consider use of variables (`$foo`) as failures (because we can't statically analyse what their value is).