### PR TITLE
Remove duplicates error messages

### DIFF
--- a/.changeset/hot-guests-sing.md
+++ b/.changeset/hot-guests-sing.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Removed duplicate image on error messages page.

--- a/polaris.shopify.com/content/patterns/error-messages.md
+++ b/polaris.shopify.com/content/patterns/error-messages.md
@@ -482,10 +482,7 @@ Don’t use when:
 - Try to add a next step, whether in a button or link
 - Use when there is more than one call to action
 
-![Warning banner at the top of a card below the card title](/images/foundations/patterns/error-messages/section-level-warning@2x.png)
-![Small warning banner in a section within a card](/images/foundations/patterns/error-messages/section-level-warning@2x.png)
-
----
+## ![Warning banner at the top of a card below the card title](/images/foundations/patterns/error-messages/section-level-warning@2x.png)
 
 ## Exception lists
 


### PR DESCRIPTION
### WHY are these changes introduced?

Duplicate image exists on error messages page.

<img width="831" alt="image (1)" src="https://user-images.githubusercontent.com/77791660/196733573-3e2da44d-c022-4fec-97bb-9ecfecf04aad.png">

### WHAT is this pull request doing?

Removes duplicate image.

<img width="1500" alt="Screen Shot 2022-10-19 at 10 19 20 AM" src="https://user-images.githubusercontent.com/77791660/196733786-1c980bd2-b083-464f-989a-990b601cfd26.png">
