### PR TITLE
Bump actions, pmap genPng, fix nodejs version, fix issues with node 14.17

### DIFF
--- a/.changeset/swift-shoes-beam.md
+++ b/.changeset/swift-shoes-beam.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Bump GitHub action versions and add p-map for gen-og-images CI failure

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Node with v16.13.0
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.13.0
 

--- a/.github/workflows/ci-a11y-vrt.yml
+++ b/.github/workflows/ci-a11y-vrt.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node with v16.13.0
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.13.0
           cache: yarn
 
       - name: Restore cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             **/.turbo
@@ -59,18 +59,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Chromatic git history to track changes
 
       - name: Setup Node with v16.13.0
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.13.0
           cache: yarn
 
       - name: Restore cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             **/.turbo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,32 +9,32 @@ on:
 
 jobs:
   build:
-    name: 'Validate with Node v${{ matrix.node_version }}'
+    name: 'Validate with Node v${{ matrix.node-version }}'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: ['14.17.0', '16.13.0']
+        node-version: ['14.17.0', '16.13.0']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Setup Node with v${{ matrix.node_version }}
+      - name: Setup Node with v${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node_version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.node-version }}
           cache: yarn
 
       - name: Restore cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             **/.eslintcache
             **/.turbo
             node_modules/.cache/turbo
             polaris.shopify.com/.next/cache
-          key: ${{ runner.os }}-node${{ matrix.node_version }}-test-v1-${{ github.sha }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-node${{ matrix.node_version }}-test-v1-
+            ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/non-committable.yml
+++ b/.github/workflows/non-committable.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:

--- a/.github/workflows/publish-polaris-for-vscode.yml
+++ b/.github/workflows/publish-polaris-for-vscode.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         name: Use Node.js 16.x
         with:
           node-version: 16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: 'yarn'

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -12,8 +12,8 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -39,7 +39,7 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: context.issue.number,
               })
-              
+
               // Pull request from fork
               if (context.payload.repository.full_name !== pullRequest.data.head.repo.full_name) {
                 const errorMessage = '`/snapit` is not supported on pull requests from forked repositories.'
@@ -58,7 +58,7 @@ jobs:
             }
 
       - name: Checkout default branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # issue_comment requires us to checkout the branch
       # https://github.com/actions/checkout/issues/331#issuecomment-1120113003
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 

--- a/documentation/Nodejs support.md
+++ b/documentation/Nodejs support.md
@@ -23,7 +23,7 @@ The `package.json` engines. This should match the `.github/workflows/ci.yml` and
 The GitHub actions `.github/workflows/ci.yml` file. This should match the `package.json` and list all supported versions.
 
 ```yml
-node_version: ['14.17.0', '16.13.0']
+node-version: ['14.17.0', '16.13.0']
 ```
 
 The `dev.yml` file which creates a local development environment. This should match the `.nvmrc` file.

--- a/polaris-migrator/plopfile.mjs
+++ b/polaris-migrator/plopfile.mjs
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as url from 'node:url';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import {plopDir} from 'plop-dir';
 

--- a/polaris-migrator/plopfile.mjs
+++ b/polaris-migrator/plopfile.mjs
@@ -1,5 +1,5 @@
-import * as fs from 'node:fs';
-import * as url from 'node:url';
+import * as fs from 'fs';
+import * as url from 'url';
 import * as path from 'path';
 
 import {plopDir} from 'plop-dir';

--- a/polaris-migrator/rollup.config.mjs
+++ b/polaris-migrator/rollup.config.mjs
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as url from 'node:url';
 
 import {babel} from '@rollup/plugin-babel';

--- a/polaris-migrator/rollup.config.mjs
+++ b/polaris-migrator/rollup.config.mjs
@@ -1,6 +1,6 @@
-import * as fs from 'node:fs';
+import * as fs from 'fs';
 import * as path from 'path';
-import * as url from 'node:url';
+import * as url from 'url';
 
 import {babel} from '@rollup/plugin-babel';
 import {nodeResolve} from '@rollup/plugin-node-resolve';

--- a/polaris-migrator/src/migrate.ts
+++ b/polaris-migrator/src/migrate.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import fs from 'fs';
 import path from 'path';
 
 // @ts-expect-error TS can't resolve the type of this import

--- a/polaris-migrator/src/migrate.ts
+++ b/polaris-migrator/src/migrate.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import path from 'node:path';
+import path from 'path';
 
 // @ts-expect-error TS can't resolve the type of this import
 import * as jscodeshift from 'jscodeshift/src/Runner';

--- a/polaris-migrator/src/migrations/replace-border-declarations/replace-border-declarations.ts
+++ b/polaris-migrator/src/migrations/replace-border-declarations/replace-border-declarations.ts
@@ -98,7 +98,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             node.value = `var(${borderWidthLengthMap[valueInPx]})`;
 
-            targets.at(-1)!.replaced = true;
+            targets.pop()!.replaced = true;
 
             return;
           }
@@ -125,7 +125,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
             }
 
             if (isSassFunction(namespacedBorder, node)) {
@@ -151,7 +151,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
             }
 
             if (isSassFunction(namespacedBorderWidth, node)) {
@@ -177,7 +177,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
             }
 
             return StopWalkingFunctionNodes;
@@ -206,7 +206,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             node.value = `var(${borderRadiusLengthMap[valueInPx]})`;
 
-            targets.at(-1)!.replaced = true;
+            targets.pop()!.replaced = true;
 
             return;
           }
@@ -233,7 +233,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
             }
 
             if (isSassFunction(namespacedBorderRadius, node)) {
@@ -259,7 +259,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
             }
 
             return StopWalkingFunctionNodes;

--- a/polaris-migrator/src/migrations/replace-border-declarations/replace-border-declarations.ts
+++ b/polaris-migrator/src/migrations/replace-border-declarations/replace-border-declarations.ts
@@ -98,7 +98,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             node.value = `var(${borderWidthLengthMap[valueInPx]})`;
 
-            targets.pop()!.replaced = true;
+            targets[targets.length - 1]!.replaced = true;
 
             return;
           }
@@ -125,7 +125,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
             }
 
             if (isSassFunction(namespacedBorder, node)) {
@@ -151,7 +151,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
             }
 
             if (isSassFunction(namespacedBorderWidth, node)) {
@@ -177,7 +177,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
             }
 
             return StopWalkingFunctionNodes;
@@ -206,7 +206,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             node.value = `var(${borderRadiusLengthMap[valueInPx]})`;
 
-            targets.pop()!.replaced = true;
+            targets[targets.length - 1]!.replaced = true;
 
             return;
           }
@@ -233,7 +233,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
             }
 
             if (isSassFunction(namespacedBorderRadius, node)) {
@@ -259,7 +259,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
                 },
               ];
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
             }
 
             return StopWalkingFunctionNodes;

--- a/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts
+++ b/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts
@@ -87,7 +87,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             if (!isKeyOf(spaceMap, valueInPx)) return;
 
-            targets.pop()!.replaced = true;
+            targets[targets.length - 1]!.replaced = true;
 
             node.value = `var(${spaceMap[valueInPx]})`;
             return;
@@ -105,7 +105,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               if (!isKeyOf(spaceMap, valueInPx)) return;
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
 
               node.value = 'var';
               node.nodes = [

--- a/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts
+++ b/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts
@@ -87,7 +87,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             if (!isKeyOf(spaceMap, valueInPx)) return;
 
-            targets.at(-1)!.replaced = true;
+            targets.pop()!.replaced = true;
 
             node.value = `var(${spaceMap[valueInPx]})`;
             return;
@@ -105,7 +105,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               if (!isKeyOf(spaceMap, valueInPx)) return;
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
 
               node.value = 'var';
               node.nodes = [

--- a/polaris-migrator/src/migrations/replace-typography-declarations/replace-typography-declarations.ts
+++ b/polaris-migrator/src/migrations/replace-typography-declarations/replace-typography-declarations.ts
@@ -106,7 +106,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               const fontFamilyCustomProperty = fontFamilyMap[family];
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
 
               node.value = 'var';
               node.nodes = [
@@ -146,7 +146,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             if (!isKeyOf(fontSizeMap, fontSizeInPx)) return;
 
-            targets.at(-1)!.replaced = true;
+            targets.pop()!.replaced = true;
 
             node.value = `var(${fontSizeMap[fontSizeInPx]})`;
             return;
@@ -173,7 +173,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               const fontSizeVariant = fontSizeStyle[variantArg];
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
 
               if (fontSizeVariant.startsWith('--')) {
                 node.value = 'var';
@@ -203,7 +203,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               if (!isKeyOf(fontSizeMap, fontSizeInPx)) return;
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
 
               node.value = 'var';
               node.nodes = [
@@ -239,7 +239,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             if (!isKeyOf(fontWeightMap, fontWeight)) return;
 
-            targets.at(-1)!.replaced = true;
+            targets.pop()!.replaced = true;
 
             node.value = `var(${fontWeightMap[fontWeight]})`;
           }
@@ -262,7 +262,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             if (!isKeyOf(fontLineHeightMap, lineHeighInPx)) return;
 
-            targets.at(-1)!.replaced = true;
+            targets.pop()!.replaced = true;
 
             node.value = `var(${fontLineHeightMap[lineHeighInPx]})`;
 
@@ -290,7 +290,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               const lineHeightVariant = lineHeightStyle[variantArg];
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
 
               if (lineHeightVariant.startsWith('--')) {
                 node.value = 'var';
@@ -320,7 +320,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               if (!isKeyOf(fontLineHeightMap, lineHeightInPx)) return;
 
-              targets.at(-1)!.replaced = true;
+              targets.pop()!.replaced = true;
 
               node.value = 'var';
               node.nodes = [

--- a/polaris-migrator/src/migrations/replace-typography-declarations/replace-typography-declarations.ts
+++ b/polaris-migrator/src/migrations/replace-typography-declarations/replace-typography-declarations.ts
@@ -106,7 +106,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               const fontFamilyCustomProperty = fontFamilyMap[family];
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
 
               node.value = 'var';
               node.nodes = [
@@ -146,7 +146,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             if (!isKeyOf(fontSizeMap, fontSizeInPx)) return;
 
-            targets.pop()!.replaced = true;
+            targets[targets.length - 1]!.replaced = true;
 
             node.value = `var(${fontSizeMap[fontSizeInPx]})`;
             return;
@@ -173,7 +173,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               const fontSizeVariant = fontSizeStyle[variantArg];
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
 
               if (fontSizeVariant.startsWith('--')) {
                 node.value = 'var';
@@ -203,7 +203,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               if (!isKeyOf(fontSizeMap, fontSizeInPx)) return;
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
 
               node.value = 'var';
               node.nodes = [
@@ -239,7 +239,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             if (!isKeyOf(fontWeightMap, fontWeight)) return;
 
-            targets.pop()!.replaced = true;
+            targets[targets.length - 1]!.replaced = true;
 
             node.value = `var(${fontWeightMap[fontWeight]})`;
           }
@@ -262,7 +262,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
             if (!isKeyOf(fontLineHeightMap, lineHeighInPx)) return;
 
-            targets.pop()!.replaced = true;
+            targets[targets.length - 1]!.replaced = true;
 
             node.value = `var(${fontLineHeightMap[lineHeighInPx]})`;
 
@@ -290,7 +290,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               const lineHeightVariant = lineHeightStyle[variantArg];
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
 
               if (lineHeightVariant.startsWith('--')) {
                 node.value = 'var';
@@ -320,7 +320,7 @@ const plugin = (options: PluginOptions = {}): Plugin => {
 
               if (!isKeyOf(fontLineHeightMap, lineHeightInPx)) return;
 
-              targets.pop()!.replaced = true;
+              targets[targets.length - 1]!.replaced = true;
 
               node.value = 'var';
               node.nodes = [

--- a/polaris-migrator/src/utilities/testUtils.ts
+++ b/polaris-migrator/src/utilities/testUtils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/no-export, jest/valid-title, @typescript-eslint/no-var-requires */
 import fs from 'node:fs';
-import path from 'node:path';
+import path from 'path';
 
 import prettier from 'prettier';
 

--- a/polaris-migrator/src/utilities/testUtils.ts
+++ b/polaris-migrator/src/utilities/testUtils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-export, jest/valid-title, @typescript-eslint/no-var-requires */
-import fs from 'node:fs';
+import fs from 'fs';
 import path from 'path';
 
 import prettier from 'prettier';

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -59,6 +59,7 @@
     "js-yaml": "^4.1.0",
     "lodash.set": "^4.3.2",
     "playroom": "^0.28.0",
+    "p-map": "^5.5.0",
     "marked": "^4.0.16",
     "puppeteer": "^16.0.0",
     "style-loader": "^3.3.1",

--- a/polaris.shopify.com/playroom.config.js
+++ b/polaris.shopify.com/playroom.config.js
@@ -3,7 +3,7 @@
 // So we need to build into that public asset folder. Hence no dev mode and HMR
 // Workaround: restart the next dev server after each change to the playroom config and associated files.
 
-const path = require('node:path');
+const path = require('path');
 const {breakpoints, toPx} = require('@shopify/polaris-tokens');
 const {playroom} = require('./constants');
 

--- a/polaris.shopify.com/scripts/gen-og-images.mjs
+++ b/polaris.shopify.com/scripts/gen-og-images.mjs
@@ -169,7 +169,7 @@ const genOgImages = async () => {
 
   const getPNG = async (url) => {
     try {
-      const slug = url === '' ? 'home' : url.split('/').at(-1);
+      const slug = url === '' ? 'home' : url.split('/').pop();
       const imgPath =
         url.split('/').length > 1 ? url.split('/').slice(0, -1).join('/') : url;
       const html = await generateHTML(url, slug);

--- a/polaris.shopify.com/scripts/gen-og-images.mjs
+++ b/polaris.shopify.com/scripts/gen-og-images.mjs
@@ -182,8 +182,6 @@ const genOgImages = async () => {
       }
       await writeFile(`${imgDir}${imgPath}/${slug}.png`, image);
       await page.close();
-
-      console.log(`✅ Successfuly generated png for ${url}`);
     } catch (error) {
       console.error(`❌ Failed to generate png for ${url}`);
       throw new Error(error);

--- a/polaris.shopify.com/scripts/gen-og-images.mjs
+++ b/polaris.shopify.com/scripts/gen-og-images.mjs
@@ -167,9 +167,9 @@ const getPNG = async (url, browser) => {
     }
     await writeFile(`${imgDir}${imgPath}/${slug}.png`, image);
 
-    console.log(`✅ Generated png for ${slug}`);
+    console.log(`✅ Successfuly generated png for ${url}`);
   } catch (error) {
-    console.error(`❌ Failed to generate ${url}`);
+    console.error(`❌ Failed to generate png for ${url}`);
     throw new Error(error);
   }
 };

--- a/polaris.shopify.com/scripts/gen-og-images.mjs
+++ b/polaris.shopify.com/scripts/gen-og-images.mjs
@@ -154,6 +154,7 @@ const generateHTML = async (url, slug) => {
 
 const getPNG = async (url, browser) => {
   const slug = url === '' ? 'home' : url.split('/').at(-1);
+  console.log(`Creating png for ${slug}`);
   const imgPath =
     url.split('/').length > 1 ? url.split('/').slice(0, -1).join('/') : url;
   const html = await generateHTML(url, slug);
@@ -168,24 +169,29 @@ const getPNG = async (url, browser) => {
 };
 
 const genOgImages = async () => {
-  if (existsSync(imgDir)) await rm(imgDir, {recursive: true});
-  await mkdir(imgDir, {recursive: true});
+  try {
+    if (existsSync(imgDir)) await rm(imgDir, {recursive: true});
+    await mkdir(imgDir, {recursive: true});
 
-  const sitemap = await readFile(sitemapPath, 'utf-8');
-  const urls = sitemap
-    .match(/loc>[^<]+/gi)
-    .map((match) => match.replace('loc>https://polaris.shopify.com', ''));
+    const sitemap = await readFile(sitemapPath, 'utf-8');
+    const urls = sitemap
+      .match(/loc>[^<]+/gi)
+      .map((match) => match.replace('loc>https://polaris.shopify.com', ''));
 
-  const browser = await puppeteer.launch({
-    defaultViewport: {width: 1200, height: 630},
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
-  });
+    const browser = await puppeteer.launch({
+      defaultViewport: {width: 1200, height: 630},
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
 
-  const generateImages = urls.map((url) => getPNG(url, browser));
-  await Promise.all(generateImages);
+    const generateImages = urls.map((url) => getPNG(url, browser));
+    await Promise.all(generateImages);
 
-  await browser.close();
-  console.log(`✅ Created ${urls.length} og-images from sitemap`);
+    await browser.close();
+    console.log(`✅ Created ${urls.length} og-images from sitemap`);
+  } catch (error) {
+    console.error('❌ Failed to generate OG images');
+    throw new Error(error);
+  }
 };
 
 export default genOgImages;

--- a/polaris.shopify.com/src/utils/markdown.mjs
+++ b/polaris.shopify.com/src/utils/markdown.mjs
@@ -26,14 +26,14 @@ export const parseMarkdown = (inputMarkdown) => {
   // Add some custom HTML to <!-- dodont --> tags
   const dodontRegex = /<!-- (dodont) -->(.*?)<!-- end -->/gis;
   if (markdown.match(dodontRegex)) {
-    markdown = markdown.replaceAll(dodontRegex, (match) => {
+    markdown = markdown.replace(dodontRegex, (match) => {
       const matchWithoutComments = match
         .replace(/^<!-- dodont -->/, '')
         .replace(/<!-- end -->$/, '');
 
       let i = 0;
 
-      const matchWithColumns = matchWithoutComments.replaceAll(
+      const matchWithColumns = matchWithoutComments.replace(
         /#### ([^\n]+)/g,
         (match, captured) => {
           if (i === 1) {

--- a/polaris.shopify.com/src/utils/various.ts
+++ b/polaris.shopify.com/src/utils/various.ts
@@ -33,7 +33,7 @@ export const slugify = (str: string): string => {
 
 export const stripMarkdownLinks = (markdown: string): string => {
   const linkRegex = /\[([a-z ]+)\]([^\)]+)\)/gi;
-  return markdown.replaceAll(linkRegex, (_, linkText) => {
+  return markdown.replace(linkRegex, (_, linkText) => {
     return linkText;
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5658,6 +5658,14 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+aggregate-error@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-4.0.1.tgz#25091fe1573b9e0be892aeda15c7c66a545f758e"
+  integrity sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==
+  dependencies:
+    clean-stack "^4.0.0"
+    indent-string "^5.0.0"
+
 ahocorasick@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ahocorasick/-/ahocorasick-1.0.2.tgz#9eee93aef9d02bfb476d9b648d9b7a40ef2fd500"
@@ -7668,6 +7676,13 @@ clean-stack@^3.0.1:
   dependencies:
     escape-string-regexp "4.0.0"
 
+clean-stack@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-4.2.0.tgz#c464e4cde4ac789f4e0735c5d75beb49d7b30b31"
+  integrity sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==
+  dependencies:
+    escape-string-regexp "5.0.0"
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -9586,6 +9601,11 @@ escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escape-string-regexp@5.0.0, escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -9595,11 +9615,6 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
-
-escape-string-regexp@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
-  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 escodegen@^2.0.0:
   version "2.0.0"
@@ -16877,6 +16892,13 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-map@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-5.5.0.tgz#054ca8ca778dfa4cf3f8db6638ccb5b937266715"
+  integrity sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==
+  dependencies:
+    aggregate-error "^4.0.0"
 
 p-retry@^4.5.0:
   version "4.6.2"


### PR DESCRIPTION
- [x] Bump GitHub actions to the latest versions
- [x] Replace `node_version` with `node-version` this caused CI to incorrectly use the wrong node version
- [x] Fix issues to support NodeJS v14.7
  - [x] Swap .replaceAll with .replace, this should be fine as they already used regex to search for multiple matches
  - [x] Swap `at(-1)` with `[length -1]` or `.pop()`
- [x] Add `p-map` library to make sure we don't crash GitHub actions by taking 150 screenshots at the same time
- [x] Add `await page.close()` to close browser tabs after they have taken a screenshot