### PR TITLE
More robust stylelint shim to support reporting

### DIFF
--- a/.changeset/seven-zoos-sin.md
+++ b/.changeset/seven-zoos-sin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Expose the .report() method to SASS migrations for easier aggregation of discovered issues during a migration run.

--- a/polaris-migrator/README.md
+++ b/polaris-migrator/README.md
@@ -278,38 +278,50 @@ migrations
 
 #### The SASS migration function
 
-Each migrator has a default export adhering to the [PostCSS Plugin API](https://github.com/postcss/postcss/blob/main/docs/writing-a-plugin.md) with one main difference: events are only executed once.
+Each migrator has a default export adhering to the [Stylelint Rule API](https://github.com/postcss/postcss/blob/main/docs/writing-a-plugin.md). A PostCSS AST is passed as the `root` and can be mutated inline, or emit warning/error reports.
 
 Continuing the example, here is what the migration may look like if our goal is to replace the Sass function `hello()` with `world()`.
 
 ```ts
 // polaris-migrator/src/migrations/replace-sass-function/replace-sass-function.ts
+import {
+  isSassFunction,
+  StopWalkingFunctionNodes,
+  createSassMigrator,
+} from '../../utilities/sass';
+import type {PolarisMigrator} from '../../utilities/sass';
 
-import type {FileInfo} from 'jscodeshift';
-import postcss, {Plugin} from 'postcss';
-import valueParser from 'postcss-value-parser';
+const replaceHelloWorld: PolarisMigrator = (_, {methods}, context) => {
+  return (root) => {
+    root.walkDecls((decl) => {
+      const parsedValue = valueParser(decl.value);
+      parsedValue.walk((node) => {
+        if (isSassFunction('hello', node)) {
+          if (context.fix) {
+            node.value = 'world';
+          } else {
+            methods.report({
+              node: decl,
+              severity: 'error',
+              message:
+                'Method hello() is no longer supported. Please migrate to world().',
+            });
+          }
 
-const plugin = (): Plugin => ({
-  postcssPlugin: 'replace-sass-function',
-  Declaration(decl) {
-    // const prop = decl.prop;
-    const parsedValue = valueParser(decl.value);
+          return StopWalkingFunctionNodes;
+        }
+      });
 
-    parsedValue.walk((node) => {
-      if (!(node.type === 'function' && node.value === 'hello')) return;
+      if (context.fix) {
+        decl.value = parsedValue.toString();
+      }
 
-      node.value = 'world';
+      methods.flushReports();
     });
+  };
+};
 
-    decl.value = parsedValue.toString();
-  },
-});
-
-export default function replaceSassFunction(fileInfo: FileInfo) {
-  return postcss(plugin()).process(fileInfo.source, {
-    syntax: require('postcss-scss'),
-  }).css;
-}
+export default createSassMigrator('replace-hello-world', replaceHelloWorld);
 ```
 
 A more complete example can be seen in [`replace-spacing-lengths.ts`](https://github.com/Shopify/polaris/blob/main/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts).

--- a/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts
+++ b/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts
@@ -1,8 +1,6 @@
 import valueParser from 'postcss-value-parser';
 
-import {POLARIS_MIGRATOR_COMMENT} from '../../constants';
 import {
-  createInlineComment,
   getFunctionArgs,
   isNumericOperator,
   isSassFunction,
@@ -16,44 +14,42 @@ import {isKeyOf} from '../../utilities/type-guards';
 
 export default createSassMigrator(
   'replace-sass-space',
-  (_, options, context) => {
+  (_, {methods, options}, context) => {
     const namespacedRem = namespace('rem', options);
 
     return (root) => {
       root.walkDecls((decl) => {
         if (!spaceProps.has(decl.prop)) return;
 
-        /**
-         * A collection of transformable values to migrate (e.g. decl lengths, functions, etc.)
-         *
-         * Note: This is evaluated at the end of each visitor execution to determine whether
-         * or not to replace the declaration or insert a comment.
-         */
-        const targets: {replaced: boolean}[] = [];
-        let hasNumericOperator = false;
         const parsedValue = valueParser(decl.value);
 
         handleSpaceProps();
 
-        if (targets.some(({replaced}) => !replaced || hasNumericOperator)) {
-          decl.before(
-            createInlineComment(POLARIS_MIGRATOR_COMMENT, {prose: true}),
-          );
-          decl.before(
-            createInlineComment(`${decl.prop}: ${parsedValue.toString()};`),
-          );
-        } else if (context.fix) {
-          decl.value = parsedValue.toString();
+        const newValue = parsedValue.toString();
+
+        if (context.fix && newValue !== decl.value) {
+          if (methods.getReportsForNode(decl)) {
+            // The "partial fix" case: When there's a new value AND a report.
+            methods.report({
+              node: decl,
+              severity: 'suggestion',
+              message: `${decl.prop}: ${parsedValue.toString()}`,
+            });
+          } else {
+            decl.value = parsedValue.toString();
+          }
         }
 
-        //
-        // Handlers
-        //
+        methods.flushReports();
 
         function handleSpaceProps() {
           parsedValue.walk((node) => {
             if (isNumericOperator(node)) {
-              hasNumericOperator = true;
+              methods.report({
+                node: decl,
+                severity: 'warning',
+                message: 'Numeric operator detected.',
+              });
               return;
             }
 
@@ -64,41 +60,72 @@ export default createSassMigrator(
 
               if (!isTransformableLength(dimension)) return;
 
-              targets.push({replaced: false});
-
               const valueInPx = toTransformablePx(node.value);
 
-              if (!isKeyOf(spaceMap, valueInPx)) return;
+              if (!isKeyOf(spaceMap, valueInPx)) {
+                methods.report({
+                  node: decl,
+                  severity: 'error',
+                  message: `Non-tokenizable value '${node.value}'`,
+                });
+                return;
+              }
 
-              targets[targets.length - 1]!.replaced = true;
+              if (context.fix) {
+                node.value = `var(${spaceMap[valueInPx]})`;
+                return;
+              }
 
-              node.value = `var(${spaceMap[valueInPx]})`;
+              methods.report({
+                node: decl,
+                severity: 'error',
+                message: `Prefer var(${spaceMap[valueInPx]}) Polaris token.`,
+              });
               return;
             }
 
             if (node.type === 'function') {
               if (isSassFunction(namespacedRem, node)) {
-                targets.push({replaced: false});
-
                 const args = getFunctionArgs(node);
 
-                if (args.length !== 1) return;
+                if (args.length !== 1) {
+                  methods.report({
+                    node: decl,
+                    severity: 'error',
+                    message: `Expected 1 argument, got ${args.length}`,
+                  });
+                  return;
+                }
 
                 const valueInPx = toTransformablePx(args[0]);
 
-                if (!isKeyOf(spaceMap, valueInPx)) return;
+                if (!isKeyOf(spaceMap, valueInPx)) {
+                  methods.report({
+                    node: decl,
+                    severity: 'error',
+                    message: `Non-tokenizable value '${args[0].trim()}'`,
+                  });
+                  return;
+                }
 
-                targets[targets.length - 1]!.replaced = true;
+                if (context.fix) {
+                  node.value = 'var';
+                  node.nodes = [
+                    {
+                      type: 'word',
+                      value: spaceMap[valueInPx],
+                      sourceIndex: node.nodes[0]?.sourceIndex ?? 0,
+                      sourceEndIndex: spaceMap[valueInPx].length,
+                    },
+                  ];
+                  return;
+                }
 
-                node.value = 'var';
-                node.nodes = [
-                  {
-                    type: 'word',
-                    value: spaceMap[valueInPx],
-                    sourceIndex: node.nodes[0]?.sourceIndex ?? 0,
-                    sourceEndIndex: spaceMap[valueInPx].length,
-                  },
-                ];
+                methods.report({
+                  node: decl,
+                  severity: 'error',
+                  message: `Prefer var(${spaceMap[valueInPx]}) Polaris token.`,
+                });
               }
 
               return StopWalkingFunctionNodes;

--- a/polaris-migrator/src/migrations/replace-spacing-lengths/tests/replace-spacing-lengths.output.scss
+++ b/polaris-migrator/src/migrations/replace-spacing-lengths/tests/replace-spacing-lengths.output.scss
@@ -15,6 +15,8 @@
   padding: 0;
   padding: 1;
   padding: 2;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   padding: #{16px + 16px};
   padding: layout-width(nav);
   padding: 10em;
@@ -23,55 +25,65 @@
   padding: var(--p-space-4, 16px);
   // Comment
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10px;
+  // error: Non-tokenizable value '10px'
   padding: 10px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10rem;
+  // error: Non-tokenizable value '10rem'
   padding: 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10px 10px;
+  // error: Non-tokenizable value '10px'
   padding: 10px 10px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10px'
   // padding: var(--p-space-4) 10px;
   padding: 16px 10px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10rem 10rem;
+  // error: Non-tokenizable value '10rem'
   padding: 10rem 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10rem'
   // padding: var(--p-space-4) 10rem;
   padding: 1rem 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10px 10rem;
+  // error: Non-tokenizable value '10px'
+  // error: Non-tokenizable value '10rem'
   padding: 10px 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10rem'
   // padding: var(--p-space-4) 10rem;
   padding: 16px 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10px'
   // padding: 10px var(--p-space-4);
   padding: 10px 1rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '-16px'
   // padding: var(--p-space-4) -16px;
   padding: 16px -16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: var(--p-space-4) + var(--p-space-4);
   padding: 16px + 16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: var(--p-space-4) + var(--p-space-4) var(--p-space-4);
   padding: 16px + 16px 16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: $var + var(--p-space-4);
   padding: $var + 16px;
   padding: calc(16px + 16px);
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: var(--p-space-4) + #{16px + 16px};
   padding: 16px + #{16px + 16px};
   // Skip negative lengths. Need to discuss replacement strategy e.g.
   // calc(-1 * var(--p-space-*)) vs var(--p-space--*)
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: -16px;
+  // error: Non-tokenizable value '-16px'
   padding: -16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: -10px;
+  // error: Non-tokenizable value '-10px'
   padding: -10px;
 
   // REM FUNCTION
@@ -86,21 +98,26 @@
   padding: calc(10rem + var(--p-choice-size, #{rem(10px)}));
   // Comment
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: rem(10px);
+  // error: Non-tokenizable value '10px'
   padding: rem(10px);
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: rem(10px) rem(10px);
+  // error: Non-tokenizable value '10px'
   padding: rem(10px) rem(10px);
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10px'
   // padding: var(--p-space-4) rem(10px);
   padding: rem(16px) rem(10px);
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '-16px'
   // padding: var(--p-space-4) -16px;
   padding: rem(16px) -16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: var(--p-space-4) + var(--p-space-4);
   padding: rem(16px) + 16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '$var \* 16px'
+  // warning: Numeric operator detected.
   // padding: rem($var * var(--p-space-4));
   padding: rem($var * 16px);
 }

--- a/polaris-migrator/src/migrations/replace-spacing-lengths/tests/with-namespace.output.scss
+++ b/polaris-migrator/src/migrations/replace-spacing-lengths/tests/with-namespace.output.scss
@@ -17,6 +17,8 @@
   padding: 0;
   padding: 1;
   padding: 2;
+  // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   padding: #{16px + 16px};
   padding: layout-width(nav);
   padding: 10em;
@@ -25,55 +27,65 @@
   padding: var(--p-space-4, 16px);
   // Comment
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10px;
+  // error: Non-tokenizable value '10px'
   padding: 10px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10rem;
+  // error: Non-tokenizable value '10rem'
   padding: 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10px 10px;
+  // error: Non-tokenizable value '10px'
   padding: 10px 10px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10px'
   // padding: var(--p-space-4) 10px;
   padding: 16px 10px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10rem 10rem;
+  // error: Non-tokenizable value '10rem'
   padding: 10rem 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10rem'
   // padding: var(--p-space-4) 10rem;
   padding: 1rem 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: 10px 10rem;
+  // error: Non-tokenizable value '10px'
+  // error: Non-tokenizable value '10rem'
   padding: 10px 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10rem'
   // padding: var(--p-space-4) 10rem;
   padding: 16px 10rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10px'
   // padding: 10px var(--p-space-4);
   padding: 10px 1rem;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '-16px'
   // padding: var(--p-space-4) -16px;
   padding: 16px -16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: var(--p-space-4) + var(--p-space-4);
   padding: 16px + 16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: var(--p-space-4) + var(--p-space-4) var(--p-space-4);
   padding: 16px + 16px 16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: $var + var(--p-space-4);
   padding: $var + 16px;
   padding: calc(16px + 16px);
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: var(--p-space-4) + #{16px + 16px};
   padding: 16px + #{16px + 16px};
   // Skip negative lengths. Need to discuss replacement strategy e.g.
   // calc(-1 * var(--p-space-*)) vs var(--p-space--*)
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: -16px;
+  // error: Non-tokenizable value '-16px'
   padding: -16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: -10px;
+  // error: Non-tokenizable value '-10px'
   padding: -10px;
 
   // REM FUNCTION
@@ -88,21 +100,26 @@
   padding: calc(10rem + var(--p-choice-size, #{legacy-polaris-v8.rem(10px)}));
   // Comment
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: legacy-polaris-v8.rem(10px);
+  // error: Non-tokenizable value '10px'
   padding: legacy-polaris-v8.rem(10px);
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
-  // padding: legacy-polaris-v8.rem(10px) legacy-polaris-v8.rem(10px);
+  // error: Non-tokenizable value '10px'
   padding: legacy-polaris-v8.rem(10px) legacy-polaris-v8.rem(10px);
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '10px'
   // padding: var(--p-space-4) legacy-polaris-v8.rem(10px);
   padding: legacy-polaris-v8.rem(16px) legacy-polaris-v8.rem(10px);
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '-16px'
   // padding: var(--p-space-4) -16px;
   padding: legacy-polaris-v8.rem(16px) -16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // warning: Numeric operator detected.
   // padding: var(--p-space-4) + var(--p-space-4);
   padding: legacy-polaris-v8.rem(16px) + 16px;
   // polaris-migrator: Unable to migrate the following expression. Please upgrade manually.
+  // error: Non-tokenizable value '$var \* 16px'
+  // warning: Numeric operator detected.
   // padding: legacy-polaris-v8.rem($var * var(--p-space-4));
   padding: legacy-polaris-v8.rem($var * 16px);
 }

--- a/polaris-migrator/templates/sass-migration/{{kebabCase migrationName}}/{{kebabCase migrationName}}.ts.hbs
+++ b/polaris-migrator/templates/sass-migration/{{kebabCase migrationName}}/{{kebabCase migrationName}}.ts.hbs
@@ -5,16 +5,39 @@ import {
   StopWalkingFunctionNodes,
   createSassMigrator,
 } from '../../utilities/sass';
+import type {PolarisMigrator} from '../../utilities/sass';
 
-// options can be passed in from cli / config.
-export default createSassMigrator('{{kebabCase migrationName}}', (_, options, context) => {
+const {{camelCase migrationName}}: PolarisMigrator = (
+  _,
+  // options will be passed in from cli / config.
+  {methods /* , options */},
+  // Use context.fix to change behaviour based on if the user has passed the
+  // `--fix` flag (always true for `polaris-migrator` CLI).
+  context,
+) => {
   return (root) => {
     root.walkDecls((decl) => {
+      // Using the parsedValue allows easy detection of individual functions and
+      // properties. Particularly useful when dealing with shorthand
+      // declarations such as `border`, `padding`, etc.
       const parsedValue = valueParser(decl.value);
-
       parsedValue.walk((node) => {
         if (isSassFunction('hello', node)) {
-          node.value = 'world';
+          if (context.fix) {
+            // When fixing, we mutate the node directly.
+            node.value = 'world';
+          } else {
+            // When not fixing, emit a report which will be aggregated and shown
+            // to the user once all migrations are run.
+            methods.report({
+              node: decl,
+              severity: 'error',
+              message:
+                'Method hello() is no longer supported. Please migrate to world().',
+            });
+          }
+
+          // We do not want to recursively walk the function's arguments.
           return StopWalkingFunctionNodes;
         }
       });
@@ -22,6 +45,14 @@ export default createSassMigrator('{{kebabCase migrationName}}', (_, options, co
       if (context.fix) {
         decl.value = parsedValue.toString();
       }
+
+      // Ensure all generated reports are flushed to the appropriate output
+      methods.flushReports();
     });
   };
-});
+};
+
+export default createSassMigrator(
+  '{{kebabCase migrationName}}',
+  {{camelCase migrationName}}
+);


### PR DESCRIPTION
This PR belongs to a series of proposed changes:

- ㅤ ~#7499~
- ㅤ ~#7541~
- 👉 **This PR**: #7532
- ㅤ #7543

_NOTE: This PR is best [viewed with whitespace changes hidden](https://github.com/Shopify/polaris/pull/7532/files?w=1)_

---

This enhances the `createSassMigrator` function to support the idea of ["Reporting"](https://stylelint.io/developer-guide/plugins/#stylelintutilsreport).

In our current case, the only reporting we're doing is inserting comments into the code, but with this API matching that of `stylelint`, it should work as an in-editor lint error reporting system also 🎉 

You'll notice from the output that reports are now inserted as comments, giving an improved DX for people running the cli migrator.