### PR TITLE
[TextField] Fix logic to trigger focus onClick when used with Combobox

### DIFF
--- a/.changeset/many-rice-give.md
+++ b/.changeset/many-rice-give.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed logic to trigger `TextField` focus on click when used with `Combobox`

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -462,7 +462,9 @@ export function TextField({
     suggestion && styles.suggestion,
   );
 
-  const handleOnFocus = (event: React.FocusEvent<HTMLElement>) => {
+  const handleOnFocus = (
+    event: React.FocusEvent<HTMLElement> | React.MouseEvent<HTMLInputElement>,
+  ) => {
     setFocus(true);
 
     if (selectTextOnFocus && !suggestion) {
@@ -471,7 +473,7 @@ export function TextField({
     }
 
     if (onFocus) {
-      onFocus(event);
+      onFocus(event as React.FocusEvent<HTMLInputElement>);
     }
   };
 
@@ -577,7 +579,19 @@ export function TextField({
     onChange && onChange(event.currentTarget.value, id);
   }
 
-  function handleClick({target}: React.MouseEvent) {
+  function handleClick(event: React.MouseEvent<HTMLInputElement>) {
+    const {target} = event;
+
+    // For TextFields used with Combobox, focus needs to be set again even
+    // if the TextField is already focused to trigger the logic to open the
+    // Combobox activator
+    const inputRefRole = inputRef?.current?.getAttribute('role');
+    if (target === inputRef.current && inputRefRole === 'combobox') {
+      inputRef.current?.focus();
+      handleOnFocus(event);
+      return;
+    }
+
     if (
       isPrefixOrSuffix(target) ||
       isVerticalContent(target) ||


### PR DESCRIPTION
### WHY are these changes introduced?

There was a bug for `TextField` logic on single select that prevented the popover from opening when attempting to click on an already-focused `TextField`.

### WHAT is this pull request doing?

[Storybook URL.](https://5d559397bae39100201eedc1-lsltreslqe.chromatic.com/?path=/story/all-components-combobox--with-manual-selection)

Adds logic to the click handler in `TextField` that, if the `inputRef` role is `combobox` and the target is the same as the `inputRef`, trigger the focus handler. By limiting this logic to inputs with the role `combobox`, behavior for `TextFields` not used in the context of a `Combobox` are unchanged.

Triggering the focus handler in `TextField` has a trickle down effect on triggering the focus handler in `Combobox.TextField` and, by extension, will cause the popover to become active. The second gif below also includes a demo of the multiselect to show that behavior remains as expected.
    <details>
      <summary>Single select — bug</summary>
      <img src="https://user-images.githubusercontent.com/26749317/198079916-5a5f9462-7912-4e19-9553-436a31bfcb55.gif" alt="Single select — bug">
    </details>
    <details>
      <summary>Single select — fixed</summary>
      <img src="https://user-images.githubusercontent.com/26749317/198079475-e0b99c3c-515a-4cbd-8a2e-351627dda408.gif" alt="Single select — fixed">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

[Storybook URL](https://5d559397bae39100201eedc1-lsltreslqe.chromatic.com/?path=/story/all-components-combobox--with-manual-selection).

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
