### PR TITLE
Allow single value for columns. Add oneThird, oneHalf, twoThirds array options

### DIFF
--- a/.changeset/wild-lizards-crash.md
+++ b/.changeset/wild-lizards-crash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Allow single value for columns. Add oneThird, oneHalf, twoThirds array options

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,53 +1,11 @@
-import {CancelSmallMinor} from '@shopify/polaris-icons';
 import React from 'react';
 
-import {
-  Page,
-  Columns,
-  Tag,
-  Box,
-  Bleed,
-  AlphaStack,
-  UnstyledButton,
-  Inline,
-  Text,
-  Icon,
-} from '../src';
+import {Page} from '../src';
 
 export function Playground() {
   return (
     <Page title="Playground">
-      <Columns columns={17}>{genChildren(23)}</Columns>
-
-      <hr />
-
-      <Columns columns={{xs: 3, sm: 4, md: 5}}>{genChildren(6)}</Columns>
-
-      <hr />
-
-      <Columns columns={{xs: ['oneThird', 'twoThirds']}}>
-        {genChildren(6)}
-      </Columns>
-
-      <hr />
-
-      <Columns columns={{xs: ['twoThirds', 'oneThird']}}>
-        {genChildren(6)}
-      </Columns>
-
-      <hr />
-
-      <Columns columns={{xs: ['oneHalf', 'oneHalf']}}>{genChildren(6)}</Columns>
+      {/* Add the code you want to test in here */}
     </Page>
   );
-}
-
-function genChildren(count: number) {
-  const background =
-    'repeating-linear-gradient(45deg, var(--p-background), var(--p-background) 5px, var(--p-decorative-four-surface) 5px, var(--p-decorative-four-surface) 10px';
-  return Array.from({length: count}).map((_, index) => (
-    <div key={index} style={{background}}>
-      {index}
-    </div>
-  ));
 }

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,27 +1,53 @@
+import {CancelSmallMinor} from '@shopify/polaris-icons';
 import React from 'react';
 
-import {Page, Columns} from '../src';
-
-const background =
-  'repeating-linear-gradient(45deg, var(--p-background), var(--p-background) 5px, var(--p-decorative-four-surface) 5px, var(--p-decorative-four-surface) 10px';
+import {
+  Page,
+  Columns,
+  Tag,
+  Box,
+  Bleed,
+  AlphaStack,
+  UnstyledButton,
+  Inline,
+  Text,
+  Icon,
+} from '../src';
 
 export function Playground() {
   return (
     <Page title="Playground">
-      <Columns
-        columns={{
-          xs: 3,
-          sm: ['oneHalf', 'oneHalf'],
-          md: ['oneThird', 'twoThirds'],
-          lg: ['oneThird', 'oneThird', 'oneThird'],
-          xl: ['oneThird', 'twoThirds'],
-        }}
-      >
-        <div style={{background}}>01</div>
-        <div style={{background}}>02</div>
-        <div style={{background}}>03</div>
-        <div style={{background}}>04</div>
+      <Columns columns={17}>{genChildren(23)}</Columns>
+
+      <hr />
+
+      <Columns columns={{xs: 3, sm: 4, md: 5}}>{genChildren(6)}</Columns>
+
+      <hr />
+
+      <Columns columns={{xs: ['oneThird', 'twoThirds']}}>
+        {genChildren(6)}
       </Columns>
+
+      <hr />
+
+      <Columns columns={{xs: ['twoThirds', 'oneThird']}}>
+        {genChildren(6)}
+      </Columns>
+
+      <hr />
+
+      <Columns columns={{xs: ['oneHalf', 'oneHalf']}}>{genChildren(6)}</Columns>
     </Page>
   );
+}
+
+function genChildren(count: number) {
+  const background =
+    'repeating-linear-gradient(45deg, var(--p-background), var(--p-background) 5px, var(--p-decorative-four-surface) 5px, var(--p-decorative-four-surface) 10px';
+  return Array.from({length: count}).map((_, index) => (
+    <div key={index} style={{background}}>
+      {index}
+    </div>
+  ));
 }

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,11 +1,27 @@
 import React from 'react';
 
-import {Page} from '../src';
+import {Page, Columns} from '../src';
+
+const background =
+  'repeating-linear-gradient(45deg, var(--p-background), var(--p-background) 5px, var(--p-decorative-four-surface) 5px, var(--p-decorative-four-surface) 10px';
 
 export function Playground() {
   return (
     <Page title="Playground">
-      {/* Add the code you want to test in here */}
+      <Columns
+        columns={{
+          xs: 3,
+          sm: ['oneHalf', 'oneHalf'],
+          md: ['oneThird', 'twoThirds'],
+          lg: ['oneThird', 'oneThird', 'oneThird'],
+          xl: ['oneThird', 'twoThirds'],
+        }}
+      >
+        <div style={{background}}>01</div>
+        <div style={{background}}>02</div>
+        <div style={{background}}>03</div>
+        <div style={{background}}>04</div>
+      </Columns>
     </Page>
   );
 }

--- a/polaris-react/src/components/Columns/Columns.scss
+++ b/polaris-react/src/components/Columns/Columns.scss
@@ -6,32 +6,32 @@
   --pc-columns-md: var(--pc-columns-sm);
   --pc-columns-lg: var(--pc-columns-md);
   --pc-columns-xl: var(--pc-columns-lg);
-  --pc-columns-space-xs: var(--p-space-4);
-  --pc-columns-space-sm: var(--pc-columns-space-xs);
-  --pc-columns-space-md: var(--pc-columns-space-sm);
-  --pc-columns-space-lg: var(--pc-columns-space-md);
-  --pc-columns-space-xl: var(--pc-columns-space-lg);
+  --pc-columns-spacing-xs: var(--p-space-4);
+  --pc-columns-spacing-sm: var(--pc-columns-spacing-xs);
+  --pc-columns-spacing-md: var(--pc-columns-spacing-sm);
+  --pc-columns-spacing-lg: var(--pc-columns-spacing-md);
+  --pc-columns-spacing-xl: var(--pc-columns-spacing-lg);
   display: grid;
-  gap: var(--pc-columns-space-xs);
+  gap: var(--pc-columns-spacing-xs);
   grid-template-columns: var(--pc-columns-xs);
 
   @media #{$p-breakpoints-sm-up} {
-    gap: var(--pc-columns-space-sm);
+    gap: var(--pc-columns-spacing-sm);
     grid-template-columns: var(--pc-columns-sm);
   }
 
   @media #{$p-breakpoints-md-up} {
-    gap: var(--pc-columns-space-md);
+    gap: var(--pc-columns-spacing-md);
     grid-template-columns: var(--pc-columns-md);
   }
 
   @media #{$p-breakpoints-lg-up} {
-    gap: var(--pc-columns-space-lg);
+    gap: var(--pc-columns-spacing-lg);
     grid-template-columns: var(--pc-columns-lg);
   }
 
   @media #{$p-breakpoints-xl-up} {
-    gap: var(--pc-columns-space-xl);
+    gap: var(--pc-columns-spacing-xl);
     grid-template-columns: var(--pc-columns-xl);
   }
 }

--- a/polaris-react/src/components/Columns/Columns.tsx
+++ b/polaris-react/src/components/Columns/Columns.tsx
@@ -8,8 +8,11 @@ import {sanitizeCustomProperties} from '../../utilities/css';
 
 import styles from './Columns.scss';
 
+type ColumnWidths = 'oneThird' | 'oneHalf' | 'twoThirds';
+type ColumnTypes = number | string | ColumnWidths[];
+
 type Columns = {
-  [Breakpoint in BreakpointsAlias]?: number | string;
+  [Breakpoint in BreakpointsAlias]?: ColumnTypes;
 };
 
 type Spacing = {
@@ -36,9 +39,7 @@ export function Columns({columns, children, spacing}: ColumnsProps) {
     '--pc-columns-md': formatColumns(columns?.md),
     '--pc-columns-lg': formatColumns(columns?.lg),
     '--pc-columns-xl': formatColumns(columns?.xl),
-    '--pc-columns-space-xs': spacing?.xs
-      ? `var(--p-space-${spacing?.xs})`
-      : undefined,
+    '--pc-columns-space-xs': `var(--p-space-${spacing?.xs || '4'})`,
     '--pc-columns-space-sm': spacing?.sm
       ? `var(--p-space-${spacing?.sm})`
       : undefined,
@@ -60,8 +61,18 @@ export function Columns({columns, children, spacing}: ColumnsProps) {
   );
 }
 
-function formatColumns(columns?: number | string) {
+function formatColumns(columns?: ColumnTypes) {
   if (!columns) return undefined;
+
+  if (Array.isArray(columns)) {
+    return columns
+      .map((column) =>
+        column === 'oneThird' || column === 'oneHalf'
+          ? 'minmax(0, 1fr)'
+          : 'minmax(0, 2fr)',
+      )
+      .join(' ');
+  }
 
   return typeof columns === 'number'
     ? `repeat(${columns}, minmax(0, 1fr))`

--- a/polaris-react/src/components/Columns/Columns.tsx
+++ b/polaris-react/src/components/Columns/Columns.tsx
@@ -11,9 +11,11 @@ import styles from './Columns.scss';
 type ColumnWidths = 'oneThird' | 'oneHalf' | 'twoThirds';
 type ColumnTypes = number | string | ColumnWidths[];
 
-type Columns = {
-  [Breakpoint in BreakpointsAlias]?: ColumnTypes;
-};
+type Columns =
+  | number
+  | {
+      [Breakpoint in BreakpointsAlias]?: ColumnTypes;
+    };
 
 type Spacing = {
   [Breakpoint in BreakpointsAlias]?: SpacingSpaceScale;
@@ -34,12 +36,18 @@ export interface ColumnsProps {
 
 export function Columns({columns, children, spacing}: ColumnsProps) {
   const style = {
-    '--pc-columns-xs': formatColumns(columns?.xs || 6),
-    '--pc-columns-sm': formatColumns(columns?.sm),
-    '--pc-columns-md': formatColumns(columns?.md),
-    '--pc-columns-lg': formatColumns(columns?.lg),
-    '--pc-columns-xl': formatColumns(columns?.xl),
-    '--pc-columns-space-xs': `var(--p-space-${spacing?.xs || '4'})`,
+    ...(typeof columns === 'number'
+      ? {'--pc-columns-xs': `repeat(${columns}, minmax(0, 1fr))`}
+      : {
+          '--pc-columns-xs': formatColumns(columns?.xs || 6),
+          '--pc-columns-sm': formatColumns(columns?.sm),
+          '--pc-columns-md': formatColumns(columns?.md),
+          '--pc-columns-lg': formatColumns(columns?.lg),
+          '--pc-columns-xl': formatColumns(columns?.xl),
+        }),
+    '--pc-columns-space-xs': spacing?.xs
+      ? `var(--p-space-${spacing?.xs})`
+      : undefined,
     '--pc-columns-space-sm': spacing?.sm
       ? `var(--p-space-${spacing?.sm})`
       : undefined,
@@ -52,7 +60,7 @@ export function Columns({columns, children, spacing}: ColumnsProps) {
     '--pc-columns-space-xl': spacing?.xl
       ? `var(--p-space-${spacing?.xl})`
       : undefined,
-  } as React.CSSProperties;
+  } as unknown as React.CSSProperties;
 
   return (
     <div className={styles.Columns} style={sanitizeCustomProperties(style)}>


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris/issues/7592

<details>
  <summary>API playground</summary>

```jsx
import React from 'react';

import {Page, Columns} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Columns columns={7} spacing={{xs: '1', sm: '2', md: '3', lg: '4'}}>
        {genChildren(23)}
      </Columns>

      <hr />

      <Columns columns={['oneThird', 'twoThirds']}>{genChildren(5)}</Columns>

      <hr />

      <Columns columns={{xs: 3, sm: 4, md: 5}}>{genChildren(6)}</Columns>

      <hr />

      <Columns columns={{xs: ['twoThirds', 'oneThird']}}>
        {genChildren(6)}
      </Columns>

      <hr />

      <Columns
        columns={{xs: ['oneHalf', 'oneHalf'], lg: ['oneThird', 'twoThirds']}}
      >
        {genChildren(6)}
      </Columns>

      <hr />

      <Columns columns={{xs: ['oneHalf', 'oneHalf']}}>{genChildren(6)}</Columns>
    </Page>
  );
}

function genChildren(count: number) {
  const background =
    'repeating-linear-gradient(45deg, var(--p-background), var(--p-background) 5px, var(--p-decorative-four-surface) 5px, var(--p-decorative-four-surface) 10px';
  return Array.from({length: count}).map((_, index) => (
    <div key={index} style={{background}}>
      {index}
    </div>
  ));
}

```
</details>