### PR TITLE
[Text] Add responsive styling to heading2xl-heading4xl variants

### DIFF
--- a/.changeset/eighty-pumas-repair.md
+++ b/.changeset/eighty-pumas-repair.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added responsive styling to `Text` for `heading2xl`, `heading3xl`, and `heading4xl` variants

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -93,18 +93,33 @@
 }
 
 .heading2xl {
-  font-size: var(--p-font-size-500);
-  line-height: var(--p-font-line-height-5);
+  font-size: var(--p-font-size-300);
+  line-height: var(--p-font-line-height-3);
+
+  @media #{$p-breakpoints-md-up} {
+    font-size: var(--p-font-size-500);
+    line-height: var(--p-font-line-height-5);
+  }
 }
 
 .heading3xl {
-  font-size: var(--p-font-size-600);
-  line-height: var(--p-font-line-height-6);
+  font-size: var(--p-font-size-400);
+  line-height: var(--p-font-line-height-4);
+
+  @media #{$p-breakpoints-md-up} {
+    font-size: var(--p-font-size-600);
+    line-height: var(--p-font-line-height-6);
+  }
 }
 
 .heading4xl {
-  font-size: var(--p-font-size-700);
-  line-height: var(--p-font-line-height-7);
+  font-size: var(--p-font-size-600);
+  line-height: var(--p-font-line-height-6);
+
+  @media #{$p-breakpoints-md-up} {
+    font-size: var(--p-font-size-700);
+    line-height: var(--p-font-line-height-7);
+  }
 }
 
 .bodySm {


### PR DESCRIPTION
### WHY are these changes introduced?

[Storybook url](https://5d559397bae39100201eedc1-yvdsjjnrsr.chromatic.com/?path=/story/all-components-text--variants).

This was originally reviewed and approved in the `typography-beta-release` [PR](https://github.com/Shopify/polaris/pull/7068) but needs to ship first to unblock migrations. 

### WHAT is this pull request doing?

Adds responsive styling to `heading2xl` to `heading4xl` variants to support the functionality that `DisplayText` originally supported.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Storybook url.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
