### PR TITLE
Add stylelint metadata within shim

### DIFF
--- a/.changeset/unlucky-roses-try.md
+++ b/.changeset/unlucky-roses-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Internally setup stylelint metadata for SASS migrations in preparation for switching to stylelint as our migration runner.


### PR DESCRIPTION
This PR belongs to a series of proposed changes:

- ㅤ ~#7499~
- 👉 **This PR**: #7541
- ㅤ #7532
- ㅤ #7543

_NOTE: This PR is best [viewed with whitespace changes hidden](https://github.com/Shopify/polaris/pull/7541/files?w=1)_

---

Stylelint rules require some metadata (name, `fixable` mainly). This PR ensures that data is set, and also takes a best-guess at a URL for linking to rules directly from in-IDE prompts.