### PR TITLE
Codify the Suggestion-on-partial-fix pattern

### DIFF
--- a/.changeset/odd-pans-poke.md
+++ b/.changeset/odd-pans-poke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Expose utilities for SASS Migrations to leverage the Suggestion-on-partial-fix pattern

--- a/polaris-migrator/README.md
+++ b/polaris-migrator/README.md
@@ -293,7 +293,7 @@ import type {PolarisMigrator} from '../../utilities/sass';
 
 const replaceHelloWorld: PolarisMigrator = (_, {methods}, context) => {
   return (root) => {
-    root.walkDecls((decl) => {
+    methods.walkDecls(root, (decl) => {
       const parsedValue = valueParser(decl.value);
       parsedValue.walk((node) => {
         if (isSassFunction('hello', node)) {
@@ -311,12 +311,9 @@ const replaceHelloWorld: PolarisMigrator = (_, {methods}, context) => {
           return StopWalkingFunctionNodes;
         }
       });
-
       if (context.fix) {
         decl.value = parsedValue.toString();
       }
-
-      methods.flushReports();
     });
   };
 };

--- a/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts
+++ b/polaris-migrator/src/migrations/replace-spacing-lengths/replace-spacing-lengths.ts
@@ -18,29 +18,16 @@ export default createSassMigrator(
     const namespacedRem = namespace('rem', options);
 
     return (root) => {
-      root.walkDecls((decl) => {
+      methods.walkDecls(root, (decl) => {
         if (!spaceProps.has(decl.prop)) return;
 
         const parsedValue = valueParser(decl.value);
 
         handleSpaceProps();
 
-        const newValue = parsedValue.toString();
-
-        if (context.fix && newValue !== decl.value) {
-          if (methods.getReportsForNode(decl)) {
-            // The "partial fix" case: When there's a new value AND a report.
-            methods.report({
-              node: decl,
-              severity: 'suggestion',
-              message: `${decl.prop}: ${parsedValue.toString()}`,
-            });
-          } else {
-            decl.value = parsedValue.toString();
-          }
+        if (context.fix) {
+          decl.value = parsedValue.toString();
         }
-
-        methods.flushReports();
 
         function handleSpaceProps() {
           parsedValue.walk((node) => {

--- a/polaris-migrator/templates/sass-migration/{{kebabCase migrationName}}/{{kebabCase migrationName}}.ts.hbs
+++ b/polaris-migrator/templates/sass-migration/{{kebabCase migrationName}}/{{kebabCase migrationName}}.ts.hbs
@@ -16,7 +16,7 @@ const {{camelCase migrationName}}: PolarisMigrator = (
   context,
 ) => {
   return (root) => {
-    root.walkDecls((decl) => {
+    methods.walkDecls(root, (decl) => {
       // Using the parsedValue allows easy detection of individual functions and
       // properties. Particularly useful when dealing with shorthand
       // declarations such as `border`, `padding`, etc.
@@ -45,9 +45,6 @@ const {{camelCase migrationName}}: PolarisMigrator = (
       if (context.fix) {
         decl.value = parsedValue.toString();
       }
-
-      // Ensure all generated reports are flushed to the appropriate output
-      methods.flushReports();
     });
   };
 };


### PR DESCRIPTION
This PR belongs to a series of proposed changes:

- ㅤ ~#7499~
- ㅤ ~#7541~
- ㅤ ~#7532~
- 👉 **This PR**: #7543

_NOTE: This PR is best [viewed with whitespace changes hidden](https://github.com/Shopify/polaris/pull/7543/files?w=1)_

---

Our migrations follow jscodeshift [best practice of _Don't Break Shit; Prompt Instead_](https://www.codeshiftcommunity.com/docs/guiding-principles#codemods-should-do-as-much-as-can-be-safely-done-automatically-or-prompt-for-human-intervention).

Our version of ["Prompting for human input"](https://www.codeshiftcommunity.com/docs/prompting-for-human-input) is done by inserting suggestions as comments, but leaving the actual CSS alone. We then manually review all the suggestions and manually migrate them where possible.

To achieve this, we're currently following a Check -> Change -> Report -> Undo pattern:

1. *Check*: Check if the migration is applicable to the current CSS decl (ie; don't run a spacing migration on `display: flex`)
2. *Change*: Optimistically make changes to a CSS's decl where possible
3. *Report*: When a change is needed, but can't be made (commonly: SASS math is involved), we report (ie; insert a comment in the code)
4. *Undo*: If there were reports _and_ changes, we flag it as a _Partial Fix_, and insert the changes as a comment instead of replacing the actual SASS.

This PR codifies the 4th step so individual migrations don't have to worry about the complexities of detecting the Partial Fix case, and performing the Undo step.