### PR TITLE
[Page] Fix subtitle not displaying if it's the only prop set

### DIFF
--- a/.changeset/curvy-cats-burn.md
+++ b/.changeset/curvy-cats-burn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Page component: display subtitle even when it's the only header prop set

--- a/polaris-react/src/components/Page/Page.tsx
+++ b/polaris-react/src/components/Page/Page.tsx
@@ -33,6 +33,7 @@ export function Page({
 
   const hasHeaderContent =
     (rest.title != null && rest.title !== '') ||
+    (rest.subtitle != null && rest.subtitle !== '') ||
     rest.primaryAction != null ||
     (rest.secondaryActions != null &&
       ((isInterface(rest.secondaryActions) &&

--- a/polaris-react/src/components/Page/tests/Page.test.tsx
+++ b/polaris-react/src/components/Page/tests/Page.test.tsx
@@ -58,7 +58,7 @@ describe('<Page />', () => {
   describe('subtitle', () => {
     it('gets passed into the <Header />', () => {
       const subtitle = 'Subtitle';
-      const page = mountWithApp(<Page {...mockProps} subtitle={subtitle} />);
+      const page = mountWithApp(<Page subtitle={subtitle} />);
       expect(page).toContainReactComponent(Header, {
         subtitle,
       });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

If a <Page> component only has subtitle has a property, the `hasHeaderContent` check will return false and no header will be rendered.

This is especially valuable for Shopify Apps, where we will use the page component to wrap our page, but will not make use of the `title` props of the page, and instead leverage app-bridge's [`TitleBar`](https://shopify.dev/apps/tools/app-bridge/actions/titlebar)

### WHAT is this pull request doing?

- Add a check for the existence of `subtitle` for defining `hasHeaderContent` in `Page.tsx`
- Amend the unit test to reflect that the subtitle should render, even if it's the only prop

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
