### PR TITLE
Add constraints to `stylelint-polaris/coverage` disable comments

### DIFF
--- a/.changeset/tidy-cougars-talk.md
+++ b/.changeset/tidy-cougars-talk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': patch
+---
+
+Add constraints to `stylelint-polaris/coverage` disable comments

--- a/stylelint-polaris/plugins/coverage/index.js
+++ b/stylelint-polaris/plugins/coverage/index.js
@@ -118,7 +118,8 @@ function isDisabledCoverageRule(disabledCoverageLines, disabledRange) {
 }
 
 /**
- * Check if the disabled range includes both stylelint-disable and stylelint-enable comments
+ * Checks if the `disabledRange` is an unclosed `stylelint-disable` comment
+ * e.g. The `stylelint-disable` comment is NOT followed by `stylelint-enable`
  * @param {import('stylelint').DisabledRange} disabledRange
  */
 function isUnclosedDisabledRange(disabledRange) {

--- a/stylelint-polaris/plugins/coverage/index.js
+++ b/stylelint-polaris/plugins/coverage/index.js
@@ -82,7 +82,7 @@ module.exports = stylelint.createPlugin(
           .trim();
 
         stylelint.utils.report({
-          message: `Expected /* ${stylelintDisableText} -- polaris: Context comment for disable */`,
+          message: `Expected /* ${stylelintDisableText} -- polaris: Reason for disabling */`,
           ruleName,
           result,
           node: disabledRange.comment,

--- a/stylelint-polaris/plugins/coverage/index.js
+++ b/stylelint-polaris/plugins/coverage/index.js
@@ -77,8 +77,12 @@ module.exports = stylelint.createPlugin(
           continue;
         }
 
+        const stylelintDisableText = disabledRange.comment.text
+          .split('--')[0]
+          .trim();
+
         stylelint.utils.report({
-          message: `Missing "polaris:" prefix in disable comment description`,
+          message: `Expected /* ${stylelintDisableText} -- polaris: Context comment for disable */`,
           ruleName,
           result,
           node: disabledRange.comment,
@@ -119,7 +123,7 @@ function isDisabledCoverageRule(disabledCoverageLines, disabledRange) {
  */
 function isUnclosedDisabledRange(disabledRange) {
   if (
-    disabledRange.comment.text === 'stylelint-disable' &&
+    !disabledRange.comment.text.startsWith('stylelint-disable-next-line') &&
     !isNumber(disabledRange.end)
   ) {
     return true;

--- a/stylelint-polaris/plugins/coverage/index.test.js
+++ b/stylelint-polaris/plugins/coverage/index.test.js
@@ -16,6 +16,31 @@ testRule({
       code: '@media (min-width: 320px) {}',
       description: 'Uses allowed at-rule',
     },
+    {
+      code: `
+      	/* stylelint-disable -- polaris: context */
+        @keyframes foo {}
+        /* stylelint-enable */
+      `,
+      description:
+        'Uses disallowed at-rule with disable/enable comment and context',
+    },
+    {
+      code: `
+      	/* stylelint-disable -- polaris: context */
+        @keyframes foo {}
+      `,
+      description:
+        'Uses disallowed at-rule with disable comment and context and without enable comment',
+    },
+    {
+      code: `
+      	/* stylelint-disable-next-line -- polaris: context */
+        @keyframes foo {}
+      `,
+      description:
+        'Uses disallowed at-rule with disable next line comment and context',
+    },
   ],
 
   reject: [
@@ -24,6 +49,35 @@ testRule({
       description: 'Uses disallowed at-rule',
       message:
         'Unexpected at-rule "keyframes" (stylelint-polaris/coverage/motion)',
+    },
+    {
+      code: `
+      	/* stylelint-disable */
+        @keyframes foo {}
+        /* stylelint-enable */
+      `,
+      description:
+        'Uses disallowed at-rule with disable/enable comment and without context',
+      message: 'Missing "polaris:" prefix in disable comment description',
+    },
+    {
+      code: `
+      	/* stylelint-disable */
+
+        @keyframes fooz {}
+      `,
+      description:
+        'Uses disallowed at-rule with disable comment and without context and enable comment',
+      message: 'Missing "polaris:" prefix in disable comment description',
+    },
+    {
+      code: `
+      	/* stylelint-disable-next-line */
+        @keyframes foo {}
+      `,
+      description:
+        'Uses disallowed at-rule with disable next line comment and without context',
+      message: 'Missing "polaris:" prefix in disable comment description',
     },
   ],
 });

--- a/stylelint-polaris/plugins/coverage/index.test.js
+++ b/stylelint-polaris/plugins/coverage/index.test.js
@@ -58,7 +58,8 @@ testRule({
       `,
       description:
         'Uses disallowed at-rule with disable/enable comment and without context',
-      message: 'Missing "polaris:" prefix in disable comment description',
+      message:
+        'Expected /* stylelint-disable -- polaris: Reason for disabling */',
     },
     {
       code: `
@@ -68,7 +69,8 @@ testRule({
       `,
       description:
         'Uses disallowed at-rule with disable comment and without context and enable comment',
-      message: 'Missing "polaris:" prefix in disable comment description',
+      message:
+        'Expected /* stylelint-disable -- polaris: Reason for disabling */',
     },
     {
       code: `
@@ -77,7 +79,8 @@ testRule({
       `,
       description:
         'Uses disallowed at-rule with disable next line comment and without context',
-      message: 'Missing "polaris:" prefix in disable comment description',
+      message:
+        'Expected /* stylelint-disable-next-line -- polaris: Reason for disabling */',
     },
   ],
 });


### PR DESCRIPTION
Part of #7531 

### WHAT is this pull request doing?

This PR introduces the ability to capture `stylelint-disable` comments applied to our coverage rules and validate authors have provided context why they are opting out of the system.

Linting `stylelint-disable` comments, targeting coverage rules, was accomplished by extending the [stylelint-polaris/coverage](https://github.com/Shopify/polaris/pull/7551) plugin to post process failures against Stylelint disabled ranges and ensuring comment descriptions are both present and prefixed with `polaris:`. By leveraging `stylelint-polaris/coverage` for linting comments, we have the ability to further extend the behavior to enhance our coverage insights (for example: requiring categories in description prefixes `polaris-colors:`, ability to disable failing coverage `polaris-skip:`, etc.)

#### Examples

```scss
.my-class {
  /* stylelint-disable -- polaris: These properties override default styles in <external library> */
  color: #000 !important;
  background: #fff !important;
  /* stylelint-enable */
}

/* stylelint-disable-next-line -- polaris: This animation provides a unique merchant experience */
@keyframes amaze {}
```

If a `stylelint-disable` comment targeting a coverage rule is NOT prefixed with `polaris:` an error is reported:

<img width="975" alt="image" src="https://user-images.githubusercontent.com/32409546/199805457-8307b4f8-5f7b-4acb-be45-fd5ed0bdf566.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
