### PR TITLE
[Page] - Add spacing between title and metadata

### DIFF
--- a/.changeset/shiny-pans-deny.md
+++ b/.changeset/shiny-pans-deny.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Add spacing between title and metadata for Page component

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.scss
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.scss
@@ -28,6 +28,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  row-gap: var(--p-space-2);
 
   .Title {
     display: inline;


### PR DESCRIPTION
### WHY are these changes introduced?
On smaller screens, or if the title is long and causes the metadata to wrap, there should be some spacing between the items. 

### WHAT is this pull request doing?

**Before**
<img width="358" alt="Screen Shot 2022-11-01 at 1 20 54 PM" src="https://user-images.githubusercontent.com/1152185/199297903-d01797a2-87d2-4c57-9a68-c1eb4d0608ae.png">

**After**
<img width="476" alt="Screen Shot 2022-11-01 at 1 19 14 PM" src="https://user-images.githubusercontent.com/1152185/199297929-f0d3a97e-c492-453b-a13f-2eaa50b46731.png">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Open the Page component in the playground and shrink the size of the viewport until the title wraps.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
