### PR TITLE
[feature] Adds `blurOnEnterKeyPress` to programmatically trigger blur events on `TextField`

### DIFF
--- a/.changeset/swift-eyes-compare.md
+++ b/.changeset/swift-eyes-compare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Adds blurOnEnterKeyPress prop to TextField component to expose pseudo "submit on enter" functionality.

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -5,11 +5,14 @@ import {
   LegacyCard,
   ChoiceList,
   FormLayout,
+  Frame,
   InlineError,
+  Page,
   Select,
   LegacyStack,
   Tag,
   TextField,
+  Toast,
 } from '@shopify/polaris';
 import {DeleteMinor} from '@shopify/polaris-icons';
 
@@ -443,6 +446,38 @@ export function WithClearButton() {
   );
 }
 
+export function WithBlurOnEnterKeyPress() {
+  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
+  const [toastActive, setToastActive] = useState(false);
+
+  const handleTextFieldChange = useCallback(
+    (value) => setTextFieldValue(value),
+    [],
+  );
+
+  const handleTextFieldBlur = useCallback(() => setToastActive(true), []);
+
+  const toastMarkup = toastActive ? (
+    <Toast content="Message sent" onDismiss={() => setToastActive(false)} />
+  ) : null;
+
+  return (
+    <Frame>
+      <Page title="Blur on enter key press example">
+        <TextField
+          label="Store name"
+          value={textFieldValue}
+          onBlur={handleTextFieldBlur}
+          onChange={handleTextFieldChange}
+          blurOnEnterKeyPress
+          autoComplete="off"
+        />
+        {toastMarkup}
+      </Page>
+    </Frame>
+  );
+}
+
 export function WithMonospacedFont() {
   const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
 
@@ -453,6 +488,7 @@ export function WithMonospacedFont() {
 
   return (
     <TextField
+      autoComplete="off"
       label="Store name"
       value={textFieldValue}
       onChange={handleTextFieldChange}
@@ -471,6 +507,7 @@ export function WithValueSelectedOnFocus() {
 
   return (
     <TextField
+      autoComplete="off"
       label="Store name"
       value={textFieldValue}
       onChange={handleTextFieldChange}
@@ -578,6 +615,7 @@ export function WithInlineSuggestion() {
   return (
     <div onKeyDown={handleKeyDown}>
       <TextField
+        autoComplete="off"
         type="text"
         label="State"
         value={value}

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -160,6 +160,8 @@ interface NonMutuallyExclusiveProps {
   requiredIndicator?: boolean;
   /** Indicates whether or not a monospaced font should be used */
   monospaced?: boolean;
+  /** Indicates whether or not to blur the input and trigger any blur callbacks when the enter key is pressed */
+  blurOnEnterKeyPress?: boolean;
   /** Callback fired when clear button is clicked */
   onClearButtonClick?(id: string): void;
   /** Callback fired when value is changed */
@@ -232,6 +234,7 @@ export function TextField({
   monospaced,
   selectTextOnFocus,
   suggestion,
+  blurOnEnterKeyPress,
   onClearButtonClick,
   onChange,
   onSpinnerChange,
@@ -657,6 +660,12 @@ export function TextField({
   function handleKeyPress(event: React.KeyboardEvent) {
     const {key, which} = event;
     const numbersSpec = /[\d.eE+-]$/;
+
+    if (which === Key.Enter && blurOnEnterKeyPress) {
+      inputRef.current?.blur();
+      return;
+    }
+
     if (type !== 'number' || which === Key.Enter || numbersSpec.test(key)) {
       return;
     }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

In some cases we want to allow users to press "enter" on their keyboard when inputs do not have a "submit" button. Consider a modal similar to the App Bridge `ResourcePicker` which has an input albeit no "enter" or "submit" button. That is because the input searches as the user types their query into the input. 

However, in the event that we only want to run a query when the user blurs their input (via `onBlur`) by clicking out of focus, tabbing out, or by pressing `Enter` on their keyboard. This PR adds the `blurOnEnterKeyPress` prop as an optional boolean that programmatically blurs the input via the `inputRef`, thus triggering unfocusing the input and triggering the `onBlur` callback (if defined).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

-->

<details>
  <summary>Video example from Storybook</summary>

  https://user-images.githubusercontent.com/4250423/199359141-bdd531d8-34b6-4384-b1e4-2e1fbaa549b5.mov

</details>


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Using storybook, open the TextField component and navigate to the `With Blur On Enter Key Press` example. Pressing `enter` while the input is focused will trigger the callback which displays a Toast.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
  - [x] Chrome latest
  - [x] FF latest
  - [x] Safari latest
  - [ ] ~Edge~ N/A (built on Chromium).
  - [x] In at least one of the above browsers, test both retina and non-retina displays
  - [x] iPhone (5/SE/X) (10+) Safari Mobile
  - [x] iPad (10+) Safari Mobile
  - [x] Android device (5.x) Chrome
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] ~Updated the component's `README.md` with documentation changes~ N/A
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
