### PR TITLE
[polaris.shopify.com] Replace typography with Text component

### DIFF
--- a/.changeset/blue-tools-fetch.md
+++ b/.changeset/blue-tools-fetch.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Replaced usage of typography components (`DisplayText`, `Heading`, `Subheading`, `Caption`, `VisuallyHidden`, `TextStyle`) with the new `Text` component

--- a/polaris.shopify.com/pages/examples/app-provider-default.tsx
+++ b/polaris.shopify.com/pages/examples/app-provider-default.tsx
@@ -53,11 +53,9 @@ function AppProviderExample() {
 
               return (
                 <ResourceList.Item id={id} url={url} media={media}>
-                  <h3>
-                    <Text variant="bodyMd" fontWeight="bold" as="span">
-                      {name}
-                    </Text>
-                  </h3>
+                  <Text variant="bodyMd" fontWeight="bold" as="h3">
+                    {name}
+                  </Text>
                   <div>{location}</div>
                 </ResourceList.Item>
               );

--- a/polaris.shopify.com/pages/examples/app-provider-default.tsx
+++ b/polaris.shopify.com/pages/examples/app-provider-default.tsx
@@ -4,7 +4,7 @@ import {
   Card,
   ResourceList,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -54,7 +54,9 @@ function AppProviderExample() {
               return (
                 <ResourceList.Item id={id} url={url} media={media}>
                   <h3>
-                    <TextStyle variation="strong">{name}</TextStyle>
+                    <Text variant="bodyMd" fontWeight="bold" as="span">
+                      {name}
+                    </Text>
                   </h3>
                   <div>{location}</div>
                 </ResourceList.Item>

--- a/polaris.shopify.com/pages/examples/app-provider-with-i18n.tsx
+++ b/polaris.shopify.com/pages/examples/app-provider-with-i18n.tsx
@@ -4,7 +4,7 @@ import {
   Card,
   ResourceList,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -54,7 +54,9 @@ function AppProviderI18NExample() {
               return (
                 <ResourceList.Item id={id} url={url} media={media}>
                   <h3>
-                    <TextStyle variation="strong">{name}</TextStyle>
+                    <Text variant="bodyMd" fontWeight="bold" as="span">
+                      {name}
+                    </Text>
                   </h3>
                   <div>{location}</div>
                 </ResourceList.Item>

--- a/polaris.shopify.com/pages/examples/app-provider-with-i18n.tsx
+++ b/polaris.shopify.com/pages/examples/app-provider-with-i18n.tsx
@@ -53,11 +53,9 @@ function AppProviderI18NExample() {
 
               return (
                 <ResourceList.Item id={id} url={url} media={media}>
-                  <h3>
-                    <Text variant="bodyMd" fontWeight="bold" as="span">
-                      {name}
-                    </Text>
-                  </h3>
+                  <Text variant="bodyMd" fontWeight="bold" as="h3">
+                    {name}
+                  </Text>
                   <div>{location}</div>
                 </ResourceList.Item>
               );

--- a/polaris.shopify.com/pages/examples/card-with-custom-react-node-title.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-custom-react-node-title.tsx
@@ -1,4 +1,4 @@
-import {Card, Stack, Icon, Subheading, List} from '@shopify/polaris';
+import {Card, Stack, Icon, List, Text} from '@shopify/polaris';
 import {ProductsMajor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -10,7 +10,9 @@ function CardExample() {
         title={
           <Stack>
             <Icon source={ProductsMajor} />
-            <Subheading>New Products</Subheading>
+            <Text variant="headingXs" as="h3">
+              New Products
+            </Text>
           </Stack>
         }
       >

--- a/polaris.shopify.com/pages/examples/combobox-with-multi-select-and-vertical-content.tsx
+++ b/polaris.shopify.com/pages/examples/combobox-with-multi-select-and-vertical-content.tsx
@@ -1,10 +1,10 @@
 import {
-  TextStyle,
   Stack,
   Tag,
   Listbox,
   EmptySearchResult,
   Combobox,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback, useMemo} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -68,7 +68,9 @@ function MultiselectTagComboboxExample() {
       return (
         <p>
           {start}
-          <TextStyle variation="strong">{highlight}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {highlight}
+          </Text>
           {end}
         </p>
       );

--- a/polaris.shopify.com/pages/examples/drop-zone-accepts-only-svg-files.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-accepts-only-svg-files.tsx
@@ -1,11 +1,4 @@
-import {
-  Stack,
-  Thumbnail,
-  Caption,
-  Banner,
-  List,
-  DropZone,
-} from '@shopify/polaris';
+import {Stack, Thumbnail, Banner, List, DropZone, Text} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -32,7 +25,10 @@ function DropZoneAcceptingSVGFilesExample() {
             source={window.URL.createObjectURL(file)}
           />
           <div>
-            {file.name} <Caption>{file.size} bytes</Caption>
+            {file.name}{' '}
+            <Text variant="bodySm" as="p">
+              {file.size} bytes
+            </Text>
           </div>
         </Stack>
       ))}

--- a/polaris.shopify.com/pages/examples/drop-zone-default.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-default.tsx
@@ -1,4 +1,4 @@
-import {DropZone, Stack, Thumbnail, Caption} from '@shopify/polaris';
+import {DropZone, Stack, Thumbnail, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -30,7 +30,10 @@ function DropZoneExample() {
               }
             />
             <div>
-              {file.name} <Caption>{file.size} bytes</Caption>
+              {file.name}{' '}
+              <Text variant="bodySm" as="p">
+                {file.size} bytes
+              </Text>
             </div>
           </Stack>
         ))}

--- a/polaris.shopify.com/pages/examples/drop-zone-nested.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-nested.tsx
@@ -1,4 +1,4 @@
-import {DropZone, Stack, Thumbnail, Caption, Card} from '@shopify/polaris';
+import {DropZone, Stack, Thumbnail, Card, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -29,7 +29,10 @@ function NestedDropZoneExample() {
             }
           />
           <div>
-            {file.name} <Caption>{file.size} bytes</Caption>
+            {file.name}{' '}
+            <Text variant="bodySm" as="p">
+              {file.size} bytes
+            </Text>
           </div>
         </Stack>
       ))}

--- a/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-dialog-trigger.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-dialog-trigger.tsx
@@ -1,4 +1,4 @@
-import {Stack, Thumbnail, Caption, Card, DropZone} from '@shopify/polaris';
+import {Stack, Thumbnail, Card, DropZone, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -33,7 +33,10 @@ function DropZoneWithCustomFileDialogExample() {
             }
           />
           <div>
-            {file.name} <Caption>{file.size} bytes</Caption>
+            {file.name}{' '}
+            <Text variant="bodySm" as="p">
+              {file.size} bytes
+            </Text>
           </div>
         </Stack>
       ))}

--- a/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-upload-text.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-upload-text.tsx
@@ -1,4 +1,4 @@
-import {DropZone, Stack, Thumbnail, Caption} from '@shopify/polaris';
+import {DropZone, Stack, Thumbnail, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -32,7 +32,10 @@ function DropZoneExample() {
             }
           />
           <div>
-            {file.name} <Caption>{file.size} bytes</Caption>
+            {file.name}{' '}
+            <Text variant="bodySm" as="p">
+              {file.size} bytes
+            </Text>
           </div>
         </Stack>
       ))}

--- a/polaris.shopify.com/pages/examples/drop-zone-with-drop-on-page.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-drop-on-page.tsx
@@ -1,4 +1,4 @@
-import {Stack, Thumbnail, Caption, DropZone, Page} from '@shopify/polaris';
+import {Stack, Thumbnail, DropZone, Page, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -28,7 +28,10 @@ function DropZoneWithDropOnPageExample() {
             }
           />
           <div>
-            {file.name} <Caption>{file.size} bytes</Caption>
+            {file.name}{' '}
+            <Text variant="bodySm" as="p">
+              {file.size} bytes
+            </Text>
           </div>
         </Stack>
       ))}

--- a/polaris.shopify.com/pages/examples/drop-zone-with-image-file-upload.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-image-file-upload.tsx
@@ -1,11 +1,4 @@
-import {
-  DropZone,
-  Stack,
-  Thumbnail,
-  Caption,
-  Banner,
-  List,
-} from '@shopify/polaris';
+import {DropZone, Stack, Thumbnail, Banner, List, Text} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -33,7 +26,10 @@ function DropZoneWithImageFileUpload() {
             source={window.URL.createObjectURL(file)}
           />
           <div>
-            {file.name} <Caption>{file.size} bytes</Caption>
+            {file.name}{' '}
+            <Text variant="bodySm" as="p">
+              {file.size} bytes
+            </Text>
           </div>
         </Stack>
       ))}

--- a/polaris.shopify.com/pages/examples/drop-zone-with-single-file-upload.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-single-file-upload.tsx
@@ -1,4 +1,4 @@
-import {DropZone, Stack, Thumbnail, Caption} from '@shopify/polaris';
+import {DropZone, Stack, Thumbnail, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -27,7 +27,10 @@ function DropZoneExample() {
         }
       />
       <div>
-        {file.name} <Caption>{file.size} bytes</Caption>
+        {file.name}{' '}
+        <Text variant="bodySm" as="p">
+          {file.size} bytes
+        </Text>
       </div>
     </Stack>
   );

--- a/polaris.shopify.com/pages/examples/filters-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-disabled.tsx
@@ -5,7 +5,7 @@ import {
   Filters,
   Button,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -107,9 +107,9 @@ function DisableAllFiltersExample() {
                 media={media}
                 accessibilityLabel={`View details for ${name}`}
               >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
+                <Text as="h3" variant="bodyMd" fontWeight="bold">
+                  {name}
+                </Text>
                 <div>{location}</div>
               </ResourceList.Item>
             );

--- a/polaris.shopify.com/pages/examples/filters-some-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-some-disabled.tsx
@@ -5,7 +5,7 @@ import {
   Filters,
   Button,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -126,9 +126,9 @@ function DisableSomeFiltersExample() {
                 media={media}
                 accessibilityLabel={`View details for ${name}`}
               >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
+                <Text as="h3" variant="bodyMd" fontWeight="bold">
+                  {name}
+                </Text>
                 <div>{location}</div>
               </ResourceList.Item>
             );

--- a/polaris.shopify.com/pages/examples/filters-with-a-resource-list.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-a-resource-list.tsx
@@ -6,7 +6,7 @@ import {
   ResourceList,
   Filters,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -172,9 +172,9 @@ function ResourceListFiltersExample() {
                 media={media}
                 accessibilityLabel={`View details for ${name}`}
               >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
+                <Text as="h3" variant="bodyMd" fontWeight="bold">
+                  {name}
+                </Text>
                 <div>{location}</div>
               </ResourceList.Item>
             );

--- a/polaris.shopify.com/pages/examples/filters-with-children-content.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-children-content.tsx
@@ -5,7 +5,7 @@ import {
   Filters,
   Button,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -103,9 +103,9 @@ function FiltersExample() {
                 media={media}
                 accessibilityLabel={`View details for ${name}`}
               >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
+                <Text as="h3" variant="bodyMd" fontWeight="bold">
+                  {name}
+                </Text>
                 <div>{location}</div>
               </ResourceList.Item>
             );

--- a/polaris.shopify.com/pages/examples/filters-with-help-text.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-help-text.tsx
@@ -6,7 +6,7 @@ import {
   ResourceList,
   Filters,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -174,9 +174,9 @@ function ResourceListFiltersExample() {
                 media={media}
                 accessibilityLabel={`View details for ${name}`}
               >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
+                <Text as="h3" variant="bodyMd" fontWeight="bold">
+                  {name}
+                </Text>
                 <div>{location}</div>
               </ResourceList.Item>
             );

--- a/polaris.shopify.com/pages/examples/filters-with-query-field-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-query-field-disabled.tsx
@@ -6,7 +6,7 @@ import {
   ResourceList,
   Filters,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -173,9 +173,9 @@ function ResourceListFiltersExample() {
                 media={media}
                 accessibilityLabel={`View details for ${name}`}
               >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
+                <Text as="h3" variant="bodyMd" fontWeight="bold">
+                  {name}
+                </Text>
                 <div>{location}</div>
               </ResourceList.Item>
             );

--- a/polaris.shopify.com/pages/examples/filters-with-query-field-hidden.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-query-field-hidden.tsx
@@ -6,7 +6,7 @@ import {
   ResourceList,
   Filters,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -173,9 +173,9 @@ function ResourceListFiltersExample() {
                 media={media}
                 accessibilityLabel={`View details for ${name}`}
               >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
+                <Text as="h3" variant="bodyMd" fontWeight="bold">
+                  {name}
+                </Text>
                 <div>{location}</div>
               </ResourceList.Item>
             );

--- a/polaris.shopify.com/pages/examples/filters-without-clear-button.tsx
+++ b/polaris.shopify.com/pages/examples/filters-without-clear-button.tsx
@@ -5,7 +5,7 @@ import {
   Filters,
   Button,
   Avatar,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -108,9 +108,9 @@ function Playground() {
                 media={media}
                 accessibilityLabel={`View details for ${name}`}
               >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
+                <Text as="h3" variant="bodyMd" fontWeight="bold">
+                  {name}
+                </Text>
                 <div>{location}</div>
               </ResourceList.Item>
             );

--- a/polaris.shopify.com/pages/examples/fullscreen-bar-no-children.tsx
+++ b/polaris.shopify.com/pages/examples/fullscreen-bar-no-children.tsx
@@ -1,4 +1,4 @@
-import {FullscreenBar, Button, DisplayText} from '@shopify/polaris';
+import {FullscreenBar, Button, Text} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -18,7 +18,9 @@ function FullscreenBarExample() {
         {!isFullscreen && (
           <Button onClick={() => setFullscreen(true)}>Go Fullscreen</Button>
         )}
-        <DisplayText size="small">Page content</DisplayText>
+        <Text variant="headingLg" as="p">
+          Page content
+        </Text>
       </div>
     </div>
   );

--- a/polaris.shopify.com/pages/examples/fullscreen-bar-with-children.tsx
+++ b/polaris.shopify.com/pages/examples/fullscreen-bar-with-children.tsx
@@ -2,8 +2,8 @@ import {
   Badge,
   ButtonGroup,
   FullscreenBar,
-  DisplayText,
   Button,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -29,7 +29,9 @@ function FullscreenBarExample() {
       >
         <Badge status="info">Draft</Badge>
         <div style={{marginLeft: '1rem', flexGrow: 1}}>
-          <DisplayText size="small">Page title</DisplayText>
+          <Text variant="headingLg" as="p">
+            Page title
+          </Text>
         </div>
         <ButtonGroup>
           <Button onClick={() => {}}>Secondary Action</Button>
@@ -48,7 +50,9 @@ function FullscreenBarExample() {
         {!isFullscreen && (
           <Button onClick={() => setFullscreen(true)}>Go Fullscreen</Button>
         )}
-        <DisplayText size="small">Page content</DisplayText>
+        <Text variant="headingLg" as="p">
+          Page content
+        </Text>
       </div>
     </div>
   );

--- a/polaris.shopify.com/pages/examples/index-table-default.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-default.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -43,7 +38,9 @@ function SimpleIndexTableExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-flush.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-flush.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -43,7 +38,9 @@ function SimpleFlushIndexTableExample() {
         position={index}
       >
         <IndexTable.Cell flush>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell flush>{location}</IndexTable.Cell>
         <IndexTable.Cell flush>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-small-screen-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-small-screen-with-all-of-its-elements.tsx
@@ -115,11 +115,9 @@ function SmallScreenIndexTableWithAllElementsExample() {
         position={index}
       >
         <div style={{padding: '.75rem 1rem'}}>
-          <p>
-            <Text variant="bodyMd" fontWeight="bold" as="span">
-              {name}
-            </Text>
-          </p>
+          <Text variant="bodyMd" fontWeight="bold" as="p">
+            {name}
+          </Text>
           <p>{location}</p>
           <p>{orders}</p>
           <p>{amountSpent}</p>

--- a/polaris.shopify.com/pages/examples/index-table-small-screen-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-small-screen-with-all-of-its-elements.tsx
@@ -1,11 +1,11 @@
 import {
   TextField,
   IndexTable,
-  TextStyle,
   Card,
   Filters,
   Select,
   useIndexResourceState,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -116,7 +116,9 @@ function SmallScreenIndexTableWithAllElementsExample() {
       >
         <div style={{padding: '.75rem 1rem'}}>
           <p>
-            <TextStyle variation="strong">{name}</TextStyle>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {name}
+            </Text>
           </p>
           <p>{location}</p>
           <p>{orders}</p>

--- a/polaris.shopify.com/pages/examples/index-table-small-screen.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-small-screen.tsx
@@ -38,11 +38,9 @@ function SimpleSmallScreenIndexTableExample() {
         position={index}
       >
         <div style={{padding: '12px 16px'}}>
-          <p>
-            <Text variant="bodyMd" fontWeight="bold" as="span">
-              {name}
-            </Text>
-          </p>
+          <Text variant="bodyMd" fontWeight="bold" as="p">
+            {name}
+          </Text>
           <p>{location}</p>
           <p>{orders}</p>
           <p>{amountSpent}</p>

--- a/polaris.shopify.com/pages/examples/index-table-small-screen.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-small-screen.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -44,7 +39,9 @@ function SimpleSmallScreenIndexTableExample() {
       >
         <div style={{padding: '12px 16px'}}>
           <p>
-            <TextStyle variation="strong">{name}</TextStyle>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {name}
+            </Text>
           </p>
           <p>{location}</p>
           <p>{orders}</p>

--- a/polaris.shopify.com/pages/examples/index-table-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-all-of-its-elements.tsx
@@ -1,11 +1,11 @@
 import {
   TextField,
   IndexTable,
-  TextStyle,
   Card,
   Filters,
   Select,
   useIndexResourceState,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -115,7 +115,9 @@ function IndexTableWithAllElementsExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-bulk-actions-and-selection-across-pages.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-bulk-actions-and-selection-across-pages.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -64,7 +59,9 @@ function IndexTableWithBulkActionsAndSelectionAcrossPagesExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-bulk-actions.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -64,7 +59,9 @@ function IndexTableWithBulkActionsExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-clickable-button-column.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-clickable-button-column.tsx
@@ -1,9 +1,9 @@
 import {
   IndexTable,
-  TextStyle,
   Card,
   Button,
   useIndexResourceState,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -49,7 +49,9 @@ function ClickThroughButtonIndexTableExample() {
             url={url}
             onClick={() => console.log(`Clicked ${name}`)}
           >
-            <TextStyle variation="strong">{name}</TextStyle>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {name}
+            </Text>
           </Button>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-empty-state.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-empty-state.tsx
@@ -1,9 +1,9 @@
 import {
   EmptySearchResult,
   IndexTable,
-  TextStyle,
   Card,
   useIndexResourceState,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -35,7 +35,9 @@ function IndexTableWithCustomEmptyStateExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-filtering.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-filtering.tsx
@@ -1,11 +1,11 @@
 import {
   TextField,
   IndexTable,
-  TextStyle,
   Card,
   Filters,
   Select,
   useIndexResourceState,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -94,7 +94,9 @@ function IndexTableWithFilteringExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-loading-state.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-loading-state.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -43,7 +38,9 @@ function IndexTableWithLoadingExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-multiple-promoted-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-multiple-promoted-bulk-actions.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -90,7 +85,9 @@ function IndexTableWithMultiplePromotedBulkActionsExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-row-navigation-link.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-row-navigation-link.tsx
@@ -1,9 +1,9 @@
 import {
   IndexTable,
-  TextStyle,
   Card,
   Link,
   useIndexResourceState,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -49,7 +49,9 @@ function ClickThroughLinkIndexTableExample() {
             url={url}
             onClick={() => console.log(`Clicked ${name}`)}
           >
-            <TextStyle variation="strong">{name}</TextStyle>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {name}
+            </Text>
           </Link>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-row-status.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-row-status.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -46,7 +41,9 @@ function IndexTableWithRowStatusExample() {
         status={status}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-with-sticky-last-column.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-sticky-last-column.tsx
@@ -1,9 +1,4 @@
-import {
-  IndexTable,
-  TextStyle,
-  Card,
-  useIndexResourceState,
-} from '@shopify/polaris';
+import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -43,7 +38,9 @@ function StickyLastCellIndexTableExample() {
         position={index}
       >
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/index-table-without-checkboxes.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-without-checkboxes.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, TextStyle, Card} from '@shopify/polaris';
+import {IndexTable, Card, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -30,7 +30,9 @@ function IndexTableWithoutCheckboxesExample() {
     ({id, name, location, orders, amountSpent}, index) => (
       <IndexTable.Row id={id} key={id} position={index}>
         <IndexTable.Cell>
-          <TextStyle variation="strong">{name}</TextStyle>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
         </IndexTable.Cell>
         <IndexTable.Cell>{location}</IndexTable.Cell>
         <IndexTable.Cell>{orders}</IndexTable.Cell>

--- a/polaris.shopify.com/pages/examples/layout-annotated-with-sections.tsx
+++ b/polaris.shopify.com/pages/examples/layout-annotated-with-sections.tsx
@@ -5,8 +5,7 @@ import {
   FormLayout,
   TextField,
   TextContainer,
-  TextStyle,
-  Heading,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -18,12 +17,14 @@ function LayoutExample() {
         <Layout.Section oneThird>
           <div style={{marginTop: 'var(--p-space-5)'}}>
             <TextContainer>
-              <Heading id="storeDetails">Store details</Heading>
+              <Text id="storeDetails" variant="headingMd" as="h2">
+                Store details
+              </Text>
               <p>
-                <TextStyle variation="subdued">
+                <Text variant="bodyMd" color="subdued" as="span">
                   Shopify and your customers will use this information to
                   contact you.
-                </TextStyle>
+                </Text>
               </p>
             </TextContainer>
           </div>

--- a/polaris.shopify.com/pages/examples/layout-annotated-with-sections.tsx
+++ b/polaris.shopify.com/pages/examples/layout-annotated-with-sections.tsx
@@ -20,12 +20,10 @@ function LayoutExample() {
               <Text id="storeDetails" variant="headingMd" as="h2">
                 Store details
               </Text>
-              <p>
-                <Text variant="bodyMd" color="subdued" as="span">
-                  Shopify and your customers will use this information to
-                  contact you.
-                </Text>
-              </p>
+              <Text variant="bodyMd" color="subdued" as="p">
+                Shopify and your customers will use this information to contact
+                you.
+              </Text>
             </TextContainer>
           </div>
         </Layout.Section>

--- a/polaris.shopify.com/pages/examples/layout-three-columns-with-equal-width.tsx
+++ b/polaris.shopify.com/pages/examples/layout-three-columns-with-equal-width.tsx
@@ -2,9 +2,9 @@ import {
   Page,
   Layout,
   Card,
-  TextStyle,
   ResourceList,
   Thumbnail,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -16,7 +16,9 @@ function LayoutExample() {
         <Layout.Section oneThird>
           <Card title="Florida" actions={[{content: 'Manage'}]}>
             <Card.Section>
-              <TextStyle variation="subdued">455 units available</TextStyle>
+              <Text variant="bodyMd" color="subdued" as="span">
+                455 units available
+              </Text>
             </Card.Section>
             <Card.Section title="Items">
               <ResourceList
@@ -60,7 +62,9 @@ function LayoutExample() {
                       accessibilityLabel={`View details for ${name}`}
                     >
                       <h3>
-                        <TextStyle variation="strong">{name}</TextStyle>
+                        <Text variant="bodyMd" fontWeight="bold" as="span">
+                          {name}
+                        </Text>
                       </h3>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>
@@ -74,7 +78,9 @@ function LayoutExample() {
         <Layout.Section oneThird>
           <Card title="Nevada" actions={[{content: 'Manage'}]}>
             <Card.Section>
-              <TextStyle variation="subdued">301 units available</TextStyle>
+              <Text variant="bodyMd" color="subdued" as="span">
+                301 units available
+              </Text>
             </Card.Section>
             <Card.Section title="Items">
               <ResourceList
@@ -118,7 +124,9 @@ function LayoutExample() {
                       accessibilityLabel={`View details for ${name}`}
                     >
                       <h3>
-                        <TextStyle variation="strong">{name}</TextStyle>
+                        <Text variant="bodyMd" fontWeight="bold" as="span">
+                          {name}
+                        </Text>
                       </h3>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>
@@ -132,7 +140,9 @@ function LayoutExample() {
         <Layout.Section oneThird>
           <Card title="Minneapolis" actions={[{content: 'Manage'}]}>
             <Card.Section>
-              <TextStyle variation="subdued">1931 units available</TextStyle>
+              <Text variant="bodyMd" color="subdued" as="span">
+                1931 units available
+              </Text>
             </Card.Section>
             <Card.Section title="Items">
               <ResourceList
@@ -176,7 +186,9 @@ function LayoutExample() {
                       accessibilityLabel={`View details for ${name}`}
                     >
                       <h3>
-                        <TextStyle variation="strong">{name}</TextStyle>
+                        <Text variant="bodyMd" fontWeight="bold" as="span">
+                          {name}
+                        </Text>
                       </h3>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>

--- a/polaris.shopify.com/pages/examples/layout-three-columns-with-equal-width.tsx
+++ b/polaris.shopify.com/pages/examples/layout-three-columns-with-equal-width.tsx
@@ -61,11 +61,9 @@ function LayoutExample() {
                       media={media}
                       accessibilityLabel={`View details for ${name}`}
                     >
-                      <h3>
-                        <Text variant="bodyMd" fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
+                      <Text variant="bodyMd" fontWeight="bold" as="h3">
+                        {name}
+                      </Text>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>
                     </ResourceList.Item>
@@ -123,11 +121,9 @@ function LayoutExample() {
                       media={media}
                       accessibilityLabel={`View details for ${name}`}
                     >
-                      <h3>
-                        <Text variant="bodyMd" fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
+                      <Text variant="bodyMd" fontWeight="bold" as="h3">
+                        {name}
+                      </Text>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>
                     </ResourceList.Item>
@@ -185,11 +181,9 @@ function LayoutExample() {
                       media={media}
                       accessibilityLabel={`View details for ${name}`}
                     >
-                      <h3>
-                        <Text variant="bodyMd" fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
+                      <Text variant="bodyMd" fontWeight="bold" as="h3">
+                        {name}
+                      </Text>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>
                     </ResourceList.Item>

--- a/polaris.shopify.com/pages/examples/layout-two-columns-with-equal-width.tsx
+++ b/polaris.shopify.com/pages/examples/layout-two-columns-with-equal-width.tsx
@@ -2,9 +2,9 @@ import {
   Page,
   Layout,
   Card,
-  TextStyle,
   ResourceList,
   Thumbnail,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -16,7 +16,9 @@ function LayoutExample() {
         <Layout.Section oneHalf>
           <Card title="Florida" actions={[{content: 'Manage'}]}>
             <Card.Section>
-              <TextStyle variation="subdued">455 units available</TextStyle>
+              <Text variant="bodyMd" color="subdued" as="span">
+                455 units available
+              </Text>
             </Card.Section>
             <Card.Section title="Items">
               <ResourceList
@@ -60,7 +62,9 @@ function LayoutExample() {
                       accessibilityLabel={`View details for ${name}`}
                     >
                       <h3>
-                        <TextStyle variation="strong">{name}</TextStyle>
+                        <Text variant="bodyMd" fontWeight="bold" as="span">
+                          {name}
+                        </Text>
                       </h3>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>
@@ -74,7 +78,9 @@ function LayoutExample() {
         <Layout.Section oneHalf>
           <Card title="Nevada" actions={[{content: 'Manage'}]}>
             <Card.Section>
-              <TextStyle variation="subdued">301 units available</TextStyle>
+              <Text variant="bodyMd" color="subdued" as="span">
+                301 units available
+              </Text>
             </Card.Section>
             <Card.Section title="Items">
               <ResourceList
@@ -118,7 +124,9 @@ function LayoutExample() {
                       accessibilityLabel={`View details for ${name}`}
                     >
                       <h3>
-                        <TextStyle variation="strong">{name}</TextStyle>
+                        <Text variant="bodyMd" fontWeight="bold" as="span">
+                          {name}
+                        </Text>
                       </h3>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>

--- a/polaris.shopify.com/pages/examples/layout-two-columns-with-equal-width.tsx
+++ b/polaris.shopify.com/pages/examples/layout-two-columns-with-equal-width.tsx
@@ -61,11 +61,9 @@ function LayoutExample() {
                       media={media}
                       accessibilityLabel={`View details for ${name}`}
                     >
-                      <h3>
-                        <Text variant="bodyMd" fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
+                      <Text variant="bodyMd" fontWeight="bold" as="h3">
+                        {name}
+                      </Text>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>
                     </ResourceList.Item>
@@ -123,11 +121,9 @@ function LayoutExample() {
                       media={media}
                       accessibilityLabel={`View details for ${name}`}
                     >
-                      <h3>
-                        <Text variant="bodyMd" fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
+                      <Text variant="bodyMd" fontWeight="bold" as="h3">
+                        {name}
+                      </Text>
                       <div>SKU: {sku}</div>
                       <div>{quantity} available</div>
                     </ResourceList.Item>

--- a/polaris.shopify.com/pages/examples/navigation-with-aria-labelledby.tsx
+++ b/polaris.shopify.com/pages/examples/navigation-with-aria-labelledby.tsx
@@ -1,4 +1,4 @@
-import {Frame, Navigation, VisuallyHidden} from '@shopify/polaris';
+import {Frame, Navigation, Text} from '@shopify/polaris';
 import {HomeMinor, OrdersMinor, ProductsMinor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -7,9 +7,9 @@ function NavigationExample() {
   return (
     <Frame>
       <Navigation location="/" ariaLabelledBy="label-id">
-        <VisuallyHidden>
+        <Text variant="bodySm" as="span" visuallyHidden>
           <p id="label-id">Hidden label</p>
-        </VisuallyHidden>
+        </Text>
         <Navigation.Section
           items={[
             {

--- a/polaris.shopify.com/pages/examples/popover-with-searchable-listbox.tsx
+++ b/polaris.shopify.com/pages/examples/popover-with-searchable-listbox.tsx
@@ -4,12 +4,11 @@ import {
   TextField,
   Icon,
   Link,
-  Heading,
   Popover,
   AutoSelection,
   Scrollable,
   EmptySearchResult,
-  DisplayText,
+  Text,
 } from '@shopify/polaris';
 import {SearchMinor} from '@shopify/polaris-icons';
 
@@ -185,9 +184,9 @@ function PopoverWithSearchableListboxExample() {
       }}
     >
       <Link monochrome removeUnderline onClick={handleOpenPicker}>
-        <DisplayText element="h1">
+        <Text as="h1" variant="headingXl">
           {segments[selectedSegmentIndex].label}
-        </DisplayText>
+        </Text>
       </Link>
     </div>
   );

--- a/polaris.shopify.com/pages/examples/resource-item-default.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-default.tsx
@@ -1,4 +1,4 @@
-import {Card, ResourceList, ResourceItem, TextStyle} from '@shopify/polaris';
+import {Card, ResourceList, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -30,9 +30,9 @@ function ResourceItemExample() {
               accessibilityLabel={`View details for ${title}`}
               name={title}
             >
-              <h3>
-                <TextStyle variation="strong">{title}</TextStyle>
-              </h3>
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {title}
+              </Text>
               {authorMarkup}
             </ResourceItem>
           );

--- a/polaris.shopify.com/pages/examples/resource-item-with-media.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-media.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  ResourceItem,
-  Avatar,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -41,9 +35,9 @@ function ResourceItemExample() {
               accessibilityLabel={`View details for ${name}`}
               name={name}
             >
-              <h3>
-                <TextStyle variation="strong">{name}</TextStyle>
-              </h3>
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {name}
+              </Text>
               <div>{location}</div>
             </ResourceItem>
           );

--- a/polaris.shopify.com/pages/examples/resource-item-with-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-shortcut-actions.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  ResourceItem,
-  Avatar,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -46,9 +40,9 @@ function ResourceItemExample() {
               accessibilityLabel={`View details for ${name}`}
               name={name}
             >
-              <h3>
-                <TextStyle variation="strong">{name}</TextStyle>
-              </h3>
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {name}
+              </Text>
               <div>{location}</div>
             </ResourceItem>
           );

--- a/polaris.shopify.com/pages/examples/resource-item-with-vertical-alignment.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-vertical-alignment.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  ResourceItem,
-  Avatar,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -42,9 +36,9 @@ function ResourceItemExample() {
               accessibilityLabel={`View details for ${name}`}
               name={name}
             >
-              <h3>
-                <TextStyle variation="strong">{name}</TextStyle>
-              </h3>
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {name}
+              </Text>
               <div>{location}</div>
               <div>{lastOrder}</div>
             </ResourceItem>

--- a/polaris.shopify.com/pages/examples/resource-list-default.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-default.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -38,9 +32,9 @@ function ResourceListExample() {
               media={media}
               accessibilityLabel={`View details for ${name}`}
             >
-              <h3>
-                <TextStyle variation="strong">{name}</TextStyle>
-              </h3>
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {name}
+              </Text>
               <div>{location}</div>
             </ResourceItem>
           );

--- a/polaris.shopify.com/pages/examples/resource-list-with-a-custom-empty-search-result-state.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-a-custom-empty-search-result-state.tsx
@@ -6,7 +6,7 @@ import {
   ResourceList,
   Avatar,
   ResourceItem,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -96,9 +96,9 @@ function ResourceListWithFilteringExample() {
 
     return (
       <ResourceItem id={id} url={url} media={media}>
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-all-of-its-elements.tsx
@@ -6,7 +6,7 @@ import {
   ResourceList,
   Avatar,
   ResourceItem,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -157,9 +157,9 @@ function ResourceListExample() {
         shortcutActions={shortcutActions}
         persistActions
       >
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-alternate-tool.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-alternate-tool.tsx
@@ -4,7 +4,7 @@ import {
   Button,
   Avatar,
   ResourceItem,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -52,9 +52,9 @@ function ResourceListWithAlternateToolExample() {
         media={media}
         accessibilityLabel={`View details for ${name}`}
       >
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-bulk-actions.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -78,9 +72,9 @@ function ResourceListWithBulkActionsExample() {
         media={media}
         accessibilityLabel={`View details for ${name}`}
       >
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-filtering.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-filtering.tsx
@@ -6,7 +6,7 @@ import {
   ResourceList,
   Avatar,
   ResourceItem,
-  TextStyle,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -105,9 +105,9 @@ function ResourceListWithFilteringExample() {
 
     return (
       <ResourceItem id={id} url={url} media={media}>
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-item-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-item-shortcut-actions.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -50,9 +44,9 @@ function ResourceListExample() {
               accessibilityLabel={`View details for ${name}`}
               shortcutActions={shortcutActions}
             >
-              <h3>
-                <TextStyle variation="strong">{name}</TextStyle>
-              </h3>
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {name}
+              </Text>
               <div>{location}</div>
             </ResourceItem>
           );

--- a/polaris.shopify.com/pages/examples/resource-list-with-loading-state.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-loading-state.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -79,9 +73,9 @@ function ResourceListWithLoadingExample() {
         media={media}
         accessibilityLabel={`View details for ${name}`}
       >
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-multiselect.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-multiselect.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -104,9 +98,9 @@ function ResourceListExample() {
         sortOrder={index}
         accessibilityLabel={`View details for ${name}`}
       >
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-persistent-item-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-persistent-item-shortcut-actions.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -51,9 +45,9 @@ function ResourceListExample() {
               shortcutActions={shortcutActions}
               persistActions
             >
-              <h3>
-                <TextStyle variation="strong">{name}</TextStyle>
-              </h3>
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {name}
+              </Text>
               <div>{location}</div>
             </ResourceItem>
           );

--- a/polaris.shopify.com/pages/examples/resource-list-with-selection-and-no-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-selection-and-no-bulk-actions.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -55,9 +49,9 @@ function ResourceListWithSelectionExample() {
         media={media}
         accessibilityLabel={`View details for ${name}`}
       >
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-sorting.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-sorting.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -61,9 +55,9 @@ function ResourceListWithSortingExample() {
         media={media}
         accessibilityLabel={`View details for ${name}`}
       >
-        <h3>
-          <TextStyle variation="strong">{name}</TextStyle>
-        </h3>
+        <Text variant="bodyMd" fontWeight="bold" as="h3">
+          {name}
+        </Text>
         <div>{location}</div>
       </ResourceItem>
     );

--- a/polaris.shopify.com/pages/examples/resource-list-with-total-count.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-total-count.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  ResourceList,
-  Avatar,
-  ResourceItem,
-  TextStyle,
-} from '@shopify/polaris';
+import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -38,9 +32,9 @@ function ResourceListWithTotalItemsCount() {
               media={media}
               accessibilityLabel={`View details for ${name}`}
             >
-              <h3>
-                <TextStyle variation="strong">{name}</TextStyle>
-              </h3>
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {name}
+              </Text>
               <div>{location}</div>
             </ResourceItem>
           );

--- a/polaris.shopify.com/pages/examples/select-with-separate-validation-error.tsx
+++ b/polaris.shopify.com/pages/examples/select-with-separate-validation-error.tsx
@@ -5,8 +5,8 @@ import {
   Select,
   InlineError,
   Card,
-  TextStyle,
   Link,
+  Text,
 } from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -61,12 +61,12 @@ function SeparateValidationErrorExample() {
 
     return (
       <span>
-        <TextStyle variation="negative">
+        <Text variant="bodyMd" color="critical" as="span">
           <p>
             {`${weightError}${unitError} is required when weight based shipping rates are enabled. `}
             <Link>Manage shipping</Link>
           </p>
-        </TextStyle>
+        </Text>
       </span>
     );
   }

--- a/polaris.shopify.com/pages/examples/setting-toggle-default.tsx
+++ b/polaris.shopify.com/pages/examples/setting-toggle-default.tsx
@@ -1,4 +1,4 @@
-import {SettingToggle, TextStyle} from '@shopify/polaris';
+import {SettingToggle, Text} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -18,7 +18,11 @@ function SettingToggleExample() {
       }}
       enabled={active}
     >
-      This setting is <TextStyle variation="strong">{textStatus}</TextStyle>.
+      This setting is{' '}
+      <Text variant="bodyMd" fontWeight="bold" as="span">
+        {textStatus}
+      </Text>
+      .
     </SettingToggle>
   );
 }

--- a/polaris.shopify.com/pages/examples/sheet-default.tsx
+++ b/polaris.shopify.com/pages/examples/sheet-default.tsx
@@ -4,9 +4,9 @@ import {
   Page,
   Card,
   Sheet,
-  Heading,
   Scrollable,
   ChoiceList,
+  Text,
 } from '@shopify/polaris';
 import {MobileCancelMajor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
@@ -106,7 +106,9 @@ function SheetExample() {
               width: '100%',
             }}
           >
-            <Heading>Manage sales channels</Heading>
+            <Text variant="headingMd" as="h2">
+              Manage sales channels
+            </Text>
             <Button
               accessibilityLabel="Cancel"
               icon={MobileCancelMajor}

--- a/polaris.shopify.com/pages/examples/sheet-with-searchable-listbox.tsx
+++ b/polaris.shopify.com/pages/examples/sheet-with-searchable-listbox.tsx
@@ -5,15 +5,13 @@ import {
   Listbox,
   Page,
   Sheet,
-  Heading,
   Scrollable,
-  TextStyle,
-  Subheading,
   AutoSelection,
   Icon,
   Button,
   EmptySearchResult,
   TextContainer,
+  Text,
 } from '@shopify/polaris';
 import {MobileCancelMajor, SearchMinor} from '@shopify/polaris-icons';
 
@@ -319,9 +317,9 @@ function SheetWithSearchableListboxExample() {
                 marginBottom: 'var(--p-space-2)',
               }}
             >
-              <TextStyle variation="subdued">
-                <Subheading>Action</Subheading>
-              </TextStyle>
+              <Text variant="headingXs" as="h3" color="subdued">
+                Action
+              </Text>
               <Button
                 accessibilityLabel="Cancel"
                 icon={MobileCancelMajor}
@@ -330,10 +328,12 @@ function SheetWithSearchableListboxExample() {
               />
             </div>
             <TextContainer>
-              <Heading>Look up customer segmentation membership</Heading>
-              <TextStyle variation="subdued">
+              <Text variant="headingMd" as="h2">
+                Look up customer segmentation membership
+              </Text>
+              <Text variant="bodyMd" color="subdued" as="span">
                 Look up whether a customer is included in a segment.
-              </TextStyle>
+              </Text>
             </TextContainer>
           </div>
           <div

--- a/polaris.shopify.com/pages/examples/stack-fill-available-space-proportionally.tsx
+++ b/polaris.shopify.com/pages/examples/stack-fill-available-space-proportionally.tsx
@@ -1,11 +1,13 @@
-import {Stack, Heading, Badge} from '@shopify/polaris';
+import {Stack, Badge, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function StackExample() {
   return (
     <Stack distribution="fill">
-      <Heading>Order #1136</Heading>
+      <Text variant="headingMd" as="h2">
+        Order #1136
+      </Text>
       <Badge>Paid</Badge>
       <Badge>Fulfilled</Badge>
     </Stack>

--- a/polaris.shopify.com/pages/examples/stack-vertical-centering.tsx
+++ b/polaris.shopify.com/pages/examples/stack-vertical-centering.tsx
@@ -1,17 +1,17 @@
-import {Stack, Heading, Badge} from '@shopify/polaris';
+import {Stack, Badge, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function StackExample() {
   return (
     <Stack alignment="center">
-      <Heading>
+      <Text variant="headingMd" as="h2">
         Order
         <br />
         #1136
         <br />
         was paid
-      </Heading>
+      </Text>
       <Badge>Paid</Badge>
       <Badge>Fulfilled</Badge>
     </Stack>

--- a/polaris.shopify.com/pages/examples/stack-where-a-single-item-fills-the-remaining-space.tsx
+++ b/polaris.shopify.com/pages/examples/stack-where-a-single-item-fills-the-remaining-space.tsx
@@ -1,4 +1,4 @@
-import {Stack, Heading, Badge} from '@shopify/polaris';
+import {Stack, Badge, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -6,7 +6,9 @@ function StackExample() {
   return (
     <Stack>
       <Stack.Item fill>
-        <Heading>Order #1136</Heading>
+        <Text variant="headingMd" as="h2">
+          Order #1136
+        </Text>
       </Stack.Item>
       <Stack.Item>
         <Badge>Paid</Badge>

--- a/polaris.shopify.com/pages/examples/stack-where-items-fill-space-evenly.tsx
+++ b/polaris.shopify.com/pages/examples/stack-where-items-fill-space-evenly.tsx
@@ -1,11 +1,13 @@
-import {Stack, Heading, Badge} from '@shopify/polaris';
+import {Stack, Badge, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function StackExample() {
   return (
     <Stack distribution="fillEvenly">
-      <Heading>Order #1136</Heading>
+      <Text variant="headingMd" as="h2">
+        Order #1136
+      </Text>
       <Badge>Paid</Badge>
       <Badge>Fulfilled</Badge>
     </Stack>

--- a/polaris.shopify.com/pages/examples/text-container-default.tsx
+++ b/polaris.shopify.com/pages/examples/text-container-default.tsx
@@ -1,11 +1,13 @@
-import {TextContainer, Heading} from '@shopify/polaris';
+import {TextContainer, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextContainerExample() {
   return (
     <TextContainer>
-      <Heading>Install the Shopify POS App</Heading>
+      <Text variant="headingMd" as="h2">
+        Install the Shopify POS App
+      </Text>
       <p>
         Shopify POS is the easiest way to sell your products in person.
         Available for iPad, iPhone, and Android.

--- a/polaris.shopify.com/pages/examples/text-container-tight.tsx
+++ b/polaris.shopify.com/pages/examples/text-container-tight.tsx
@@ -1,11 +1,13 @@
-import {TextContainer, Heading} from '@shopify/polaris';
+import {TextContainer, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextContainerExample() {
   return (
     <TextContainer spacing="tight">
-      <Heading>Install the Shopify POS App</Heading>
+      <Text variant="headingMd" as="h2">
+        Install the Shopify POS App
+      </Text>
       <p>
         Shopify POS is the easiest way to sell your products in person.
         Available for iPad, iPhone, and Android.

--- a/polaris.shopify.com/pages/examples/tooltip-default.tsx
+++ b/polaris.shopify.com/pages/examples/tooltip-default.tsx
@@ -1,4 +1,4 @@
-import {Tooltip, TextStyle} from '@shopify/polaris';
+import {Tooltip, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -6,7 +6,9 @@ function TooltipExample() {
   return (
     <div style={{padding: '75px 0'}}>
       <Tooltip active content="This order has shipping labels.">
-        <TextStyle variation="strong">Order #1001</TextStyle>
+        <Text variant="bodyMd" fontWeight="bold" as="span">
+          Order #1001
+        </Text>
       </Tooltip>
     </div>
   );

--- a/polaris.shopify.com/pages/examples/top-bar-default.tsx
+++ b/polaris.shopify.com/pages/examples/top-bar-default.tsx
@@ -1,10 +1,4 @@
-import {
-  TopBar,
-  ActionList,
-  Icon,
-  VisuallyHidden,
-  Frame,
-} from '@shopify/polaris';
+import {TopBar, ActionList, Icon, Frame, Text} from '@shopify/polaris';
 import {ArrowLeftMinor, QuestionMarkMajor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -85,7 +79,9 @@ function TopBarExample() {
       activatorContent={
         <span>
           <Icon source={QuestionMarkMajor} />
-          <VisuallyHidden>Secondary menu</VisuallyHidden>
+          <Text variant="bodySm" as="span" visuallyHidden>
+            Secondary menu
+          </Text>
         </span>
       }
       open={isSecondaryMenuOpen}


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #6588.

### WHAT is this pull request doing?

Replaces usage of legacy typography components in the style guide to use the new `<Text />` component with the polaris migrator:
```sh
polaris-migrator replace-text-component "./polaris.shopify.com/pages/**/*.tsx"
```

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
