### PR TITLE
Add keywords to Naming page

### DIFF
--- a/.changeset/moody-bottles-develop.md
+++ b/.changeset/moody-bottles-develop.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Added keywords to Naming page.

--- a/polaris.shopify.com/content/content/naming.md
+++ b/polaris.shopify.com/content/content/naming.md
@@ -19,6 +19,8 @@ keywords:
   - trademarks
   - branded names
   - capitalized names
+  - abbreviation
+  - acronym
 ---
 
 ## Thoughtful naming


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/7660

### WHAT is this pull request doing?

Adds `abbreviation` and `acronym` as keywords for the Naming page. 