### PR TITLE
Add the (missing) case for migrating DisplayText to Text when size is not specified

### DIFF
--- a/.changeset/twelve-turkeys-exist.md
+++ b/.changeset/twelve-turkeys-exist.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Add the (missing) case for migrating DisplayText to Text when size is not specified

--- a/polaris-migrator/package.json
+++ b/polaris-migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-migrator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Codemod transformations to help upgrade your Polaris codebase",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",

--- a/polaris-migrator/package.json
+++ b/polaris-migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-migrator",
-  "version": "0.8.1",
+  "version": "0.8.0",
   "description": "Codemod transformations to help upgrade your Polaris codebase",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",

--- a/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-display-text.ts
+++ b/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-display-text.ts
@@ -21,6 +21,8 @@ const displayTextSizeMap = {
   extraLarge: 'heading4xl',
 };
 
+const defaultDisplayTextSize = 'medium';
+
 /**
  * Replace <DisplayText> with the <Text> component
  */
@@ -51,6 +53,11 @@ export function replaceDisplayText<NodeType = ASTNode>(
 
   source.findJSXElements(localElementName).forEach((element) => {
     replaceJSXElement(j, element, 'Text');
+
+    if (!hasJSXAttribute(j, element, 'size')) {
+      insertJSXAttribute(j, element, 'size', defaultDisplayTextSize);
+    }
+
     replaceJSXAttributes(j, element, 'size', 'variant', displayTextSizeMap);
 
     if (hasJSXAttribute(j, element, 'element')) {

--- a/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.input.tsx
+++ b/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.input.tsx
@@ -19,6 +19,7 @@ export function App() {
       <DisplayText size="extraLarge">Display text</DisplayText>
       <DisplayText size="large">Display text</DisplayText>
       <DisplayText size="medium">Display text</DisplayText>
+      <DisplayText>Display text</DisplayText>
       <DisplayText size="small">Display text</DisplayText>
       <Heading element="h1">Heading</Heading>
       <Heading>Heading</Heading>

--- a/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.output.tsx
+++ b/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.output.tsx
@@ -18,6 +18,9 @@ export function App() {
       <Text variant="headingXl" as="p">
         Display text
       </Text>
+      <Text variant="headingXl" as="p">
+        Display text
+      </Text>
       <Text variant="headingLg" as="p">
         Display text
       </Text>


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, `npx @shopify/polaris-migrator react-replace-text-components` transforms `<DisplayText>` into `<Text as="p">`. On build, this results in a type error:

```
Type error: Property 'variant' is missing in type '{ children: string; as: "p"; }' but required in type 'TextProps'.
```

The error is sane; the issue is that the migrator doesn't have a default case for DisplayText elements that omit the (optional) `size` attribute.

### WHAT is this pull request doing?

Adding a default case for DisplayText components that don't have a size. With this change, `<DisplayText>` becomes `<Text variant="headingXl" as="p">`, which does successfully build.