### PR TITLE
Warn when encountering spread operator and ignore type imports

### DIFF
--- a/.changeset/fifty-cooks-reply.md
+++ b/.changeset/fifty-cooks-reply.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Ignore replacing type imports and warn when encountering unknown props for Text component migration

--- a/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-display-text.ts
+++ b/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-display-text.ts
@@ -2,9 +2,11 @@ import type {ASTNode, Collection, JSCodeshift} from 'jscodeshift';
 
 import {
   hasJSXAttribute,
+  hasJSXSpreadAttribute,
   replaceJSXElement,
   replaceJSXAttributes,
   insertJSXAttribute,
+  insertJSXComment,
 } from '../../../utilities/jsx';
 import {
   getImportSpecifierName,
@@ -13,6 +15,7 @@ import {
   updateImports,
 } from '../../../utilities/imports';
 import type {MigrationOptions} from '../react-replace-text-components';
+import {POLARIS_MIGRATOR_COMMENT} from '../../../constants';
 
 const displayTextSizeMap = {
   small: 'headingLg',
@@ -52,6 +55,10 @@ export function replaceDisplayText<NodeType = ASTNode>(
   });
 
   source.findJSXElements(localElementName).forEach((element) => {
+    if (hasJSXSpreadAttribute(j, element)) {
+      insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
+    }
+
     replaceJSXElement(j, element, 'Text');
 
     if (!hasJSXAttribute(j, element, 'size')) {

--- a/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-other.ts
+++ b/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-other.ts
@@ -5,6 +5,8 @@ import {
   replaceJSXElement,
   replaceJSXAttributes,
   insertJSXAttribute,
+  hasJSXSpreadAttribute,
+  insertJSXComment,
 } from '../../../utilities/jsx';
 import {
   hasImportSpecifier,
@@ -13,6 +15,7 @@ import {
   updateImports,
 } from '../../../utilities/imports';
 import type {MigrationOptions} from '../react-replace-text-components';
+import {POLARIS_MIGRATOR_COMMENT} from '../../../constants';
 
 const components = {
   Heading: {
@@ -65,6 +68,10 @@ export function replaceOther<NodeType = ASTNode>(
     });
 
     source.findJSXElements(localElementName).forEach((element) => {
+      if (hasJSXSpreadAttribute(j, element)) {
+        insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
+      }
+
       replaceJSXElement(j, element, 'Text');
       insertJSXAttribute(j, element, 'variant', variant);
 

--- a/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-text-style.ts
+++ b/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-text-style.ts
@@ -7,6 +7,8 @@ import {
   replaceJSXAttributes,
   insertJSXAttribute,
   removeJSXAttributes,
+  hasJSXSpreadAttribute,
+  insertJSXComment,
 } from '../../../utilities/jsx';
 import {
   insertImportSpecifier,
@@ -17,6 +19,7 @@ import {
   updateImports,
 } from '../../../utilities/imports';
 import type {MigrationOptions} from '../react-replace-text-components';
+import {POLARIS_MIGRATOR_COMMENT} from '../../../constants';
 
 const variationMap = {
   strong: {fontWeight: 'bold'},
@@ -56,6 +59,10 @@ export function replaceTextStyle<NodeType = ASTNode>(
   });
 
   source.findJSXElements(localElementName).forEach((element) => {
+    if (hasJSXSpreadAttribute(j, element)) {
+      insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
+    }
+
     replaceJSXElement(j, element, 'Text');
     insertJSXAttribute(j, element, 'variant', 'bodyMd');
     getJSXAttributes(j, element, 'variation')

--- a/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.input.tsx
+++ b/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.input.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type {TextStyleProps} from '@shopify/polaris';
 import {
   DisplayText,
   Heading,
@@ -12,6 +13,10 @@ const noop = (..._: any) => {};
 
 export function App() {
   const textStyle = TextStyle;
+  const textStyleProps: TextStyleProps = {
+    variation: 'positive',
+  };
+
   noop(textStyle);
 
   return (
@@ -31,6 +36,7 @@ export function App() {
       <TextStyle variation="negative">Negative</TextStyle>
       <TextStyle variation="warning">Warning</TextStyle>
       <TextStyle variation="code">Code</TextStyle>
+      <TextStyle {...textStyleProps}>Positive</TextStyle>
       <VisuallyHidden>Hidden text</VisuallyHidden>
     </>
   );

--- a/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.output.tsx
+++ b/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.output.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
+import type {TextStyleProps} from '@shopify/polaris';
 import {Text, InlineCode} from '@shopify/polaris';
 
 const noop = (..._: any) => {};
 
 export function App() {
   const textStyle = Text;
+  const textStyleProps: TextStyleProps = {
+    variation: 'positive',
+  };
+
   noop(textStyle);
 
   return (
@@ -53,6 +58,10 @@ export function App() {
       </Text>
       <Text variant="bodyMd" as="span">
         <InlineCode>Code</InlineCode>
+      </Text>
+      {/* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */}
+      <Text {...textStyleProps} variant="bodyMd" as="span">
+        Positive
       </Text>
       <Text variant="bodySm" as="span" visuallyHidden>
         Hidden text

--- a/polaris-migrator/src/utilities/imports.ts
+++ b/polaris-migrator/src/utilities/imports.ts
@@ -8,6 +8,7 @@ export function hasImportDeclaration(
   return Boolean(
     source
       .find(j.ImportDeclaration)
+      .filter((path) => path.node.importKind !== 'type')
       .filter((path) => path.node.source.value === sourcePath).length,
   );
 }
@@ -19,6 +20,7 @@ export function getImportDeclaration(
 ) {
   return source
     .find(j.ImportDeclaration)
+    .filter((path) => path.node.importKind !== 'type')
     .filter((path) => path.node.source.value === sourcePath);
 }
 

--- a/polaris-migrator/src/utilities/jsx.ts
+++ b/polaris-migrator/src/utilities/jsx.ts
@@ -24,6 +24,15 @@ export function hasJSXAttribute(
   return getJSXAttributes(j, element, attributeName).length > 0;
 }
 
+export function hasJSXSpreadAttribute(
+  j: core.JSCodeshift,
+  element: ASTPath<any>,
+) {
+  return (
+    j(element).find(j.JSXOpeningElement).find(j.JSXSpreadAttribute).length > 0
+  );
+}
+
 export function removeJSXAttributes(
   j: core.JSCodeshift,
   element: ASTPath<any>,
@@ -120,4 +129,27 @@ export function renameProps(
   });
 
   return source;
+}
+
+export function insertJSXComment(
+  j: core.JSCodeshift,
+  element: ASTPath<any>,
+  comment: string,
+  position: 'before' | 'after' = 'before',
+) {
+  const commentContent = j.jsxEmptyExpression();
+  commentContent.comments = [j.commentBlock(` ${comment} `, false, true)];
+
+  const jsxComment = j.jsxExpressionContainer(commentContent);
+  const lineBreak = j.jsxText('\n');
+
+  if (position === 'before') {
+    element.insertBefore(jsxComment);
+    element.insertBefore(lineBreak);
+  }
+
+  if (position === 'after') {
+    element.insertAfter(lineBreak);
+    element.insertAfter(jsxComment);
+  }
 }


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes ##7665
Fixes ##7666

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Ignores modifying `import type` for the Text component migration
- Inserts a migration warning when encountering unknown props on a target component to migrate
 