### PR TITLE
[DataTable] Update `DataTable` summary row implementation to support `columnContentTypes`

### DIFF
--- a/.changeset/brave-ways-carry.md
+++ b/.changeset/brave-ways-carry.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fixes bug where `DataTable` summary row would not properly inherit type defined in `columnContentTypes` prop
+Fixed a bug where `DataTable` summary row would not properly inherit type defined in `columnContentTypes` prop

--- a/.changeset/brave-ways-carry.md
+++ b/.changeset/brave-ways-carry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixes bug where `DataTable` summary row would not properly inherit type defined in `columnContentTypes` prop

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -854,6 +854,8 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     const id = `totals-cell-${index}`;
     const {truncate = false, verticalAlign} = this.props;
 
+    const {columnContentTypes} = this.props;
+
     let content;
     let contentType;
 
@@ -862,7 +864,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     }
 
     if (total !== '' && index > 0) {
-      contentType = 'numeric';
+      contentType = columnContentTypes[index];
       content = total;
     }
 

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -852,9 +852,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
   }) => {
     const fixedFirstColumns = this.fixedFirstColumns();
     const id = `totals-cell-${index}`;
-    const {truncate = false, verticalAlign} = this.props;
-
-    const {columnContentTypes} = this.props;
+    const {truncate = false, verticalAlign, columnContentTypes} = this.props;
 
     let content;
     let contentType;


### PR DESCRIPTION
Currently the summary row in `DataTable` does not properly inherit `columnContentTypes` given in the prop. Usually this results in no problems as 99% of the time summary rows display numerical values.

As per given logic numerical values are left aligned and string values are right aligned. In `shopify/web` we have a case where a string field has a summary row where alignment is now incorrect.

While it is debatable whether this should be the case in the Admin, it probably makes more sense for summary rows to inherit the `columnContentType` for each column, so we allow for consumers to decide how they want to use these.

### WHY are these changes introduced?

https://github.com/Shopify/core-issues/issues/47369

### WHAT is this pull request doing?

<details>
      <summary>Before/After Screenshots</summary>

<img width="1079" alt="Misaligned summary row due to hard-coded 'number' type in all summary rows" src="https://user-images.githubusercontent.com/4960217/201166515-86c4e6b9-8053-4563-9373-a55d557df83a.png">

<img width="1017" alt="Summary row correctly inheriting 'text' type from columnContentType definition" src="https://user-images.githubusercontent.com/4960217/201166523-64c099ec-6bda-4ecc-a310-a1ab985724e0.png">

</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card, DataTable} from '../src';

export function Playground() {
  const rows = [
    ['Emerald Silk Gown', '$875.00', 124689, 'Nov 8, 2022', '$122,500.00'],
    ['Mauve Cashmere Scarf', '$230.00', 124533, 'Nov 8, 2022', '$19,090.00'],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      '$445.00',
      124518,
      'Nov 8, 2022',
      '$14,240.00',
    ],
  ];

  return (
    <Page title="Sales by product">
      <Card>
        <DataTable
          columnContentTypes={['text', 'numeric', 'numeric', 'text', 'numeric']}
          headings={[
            'Product',
            'Price',
            'SKU Number',
            'Last updated date',
            'Net sales',
          ]}
          rows={rows}
          totals={['', '', '', 'Nov 8, 2022', '$155,830.00']}
        />
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
