### PR TITLE
[stylelint-polaris] Categorize disallowed units

### DIFF
--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -265,6 +265,16 @@ const stylelintPolarisCoverageOptions = {
   },
   depth: {
     'function-disallowed-list': [/([\w-]+\.)?shadow/],
+    'declaration-property-unit-disallowed-list': [
+      {
+        'box-shadow': ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
+    'property-disallowed-list': [
+      ['text-shadow', 'drop-shadow'],
+      {severity: 'warning'},
+    ],
     'stylelint-polaris/global-disallowed-list': [
       /\$shadows-data/,
       /\$fixed-element-stacking-order/,

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -139,7 +139,7 @@ const stylelintPolarisCoverageOptions = {
         '/^width/': ['px', 'rem', 'em'],
         '/^height/': ['px', 'rem', 'em'],
       },
-      {severity: 'warning'},
+      {severity: 'error'},
     ],
     'property-disallowed-list': [
       [

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -52,8 +52,8 @@ const stylelintPolarisCoverageOptions = {
     ],
     'declaration-property-unit-disallowed-list': [
       {
-        '/^animation/': ['px', 'rem', 'em'],
-        '/^transition/': ['px', 'rem', 'em'],
+        '/^animation/': ['ms', 's'],
+        '/^transition/': ['ms', 's'],
       },
       {severity: 'warning'},
     ],

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -134,6 +134,13 @@ const stylelintPolarisCoverageOptions = {
       },
       {severity: 'warning'},
     ],
+    'declaration-property-unit-disallowed-list': [
+      {
+        '/^width/': ['px', 'rem', 'em'],
+        '/^height/': ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
     'property-disallowed-list': [
       [
         'position',

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -278,10 +278,7 @@ const stylelintPolarisCoverageOptions = {
       },
       {severity: 'warning'},
     ],
-    'property-disallowed-list': [
-      ['text-shadow', 'drop-shadow'],
-      {severity: 'warning'},
-    ],
+    'property-disallowed-list': [['text-shadow'], {severity: 'warning'}],
     'stylelint-polaris/global-disallowed-list': [
       /\$shadows-data/,
       /\$fixed-element-stacking-order/,

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -50,6 +50,13 @@ const stylelintPolarisCoverageOptions = {
       /([\w-]+\.)?duration/,
       /([\w-]+\.)?easing/,
     ],
+    'declaration-property-unit-disallowed-list': [
+      {
+        '/^animation/': ['px', 'rem', 'em'],
+        '/^transition/': ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
     'stylelint-polaris/at-rule-disallowed-list': {
       include: [/([\w-]+\.)?skeleton-shimmer($|\()/],
     },
@@ -68,6 +75,13 @@ const stylelintPolarisCoverageOptions = {
     'declaration-property-value-disallowed-list': {
       'font-weight': [/(\$.*|[0-9]+)/],
     },
+    'declaration-property-unit-disallowed-list': [
+      {
+        '/^font/': ['px', 'rem', 'em'],
+        'line-height': ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
     'function-disallowed-list': [
       /([\w-]+\.)?font-family/,
       /([\w-]+\.)?font-size/,
@@ -176,6 +190,7 @@ const stylelintPolarisCoverageOptions = {
       /--p-range-slider-thumb-size-base/,
       /--p-range-slider-thumb-size-active/,
       /--p-override-visible/,
+      /--p-override-loading-z-index/,
       /--p-icon-size/,
       /--p-choice-size/,
     ],
@@ -188,6 +203,14 @@ const stylelintPolarisCoverageOptions = {
       /([\w-]+\.)?rem/,
       /([\w-]+\.)?spacing/,
     ],
+    'declaration-property-unit-disallowed-list': [
+      {
+        '/^padding/': ['px', 'rem', 'em'],
+        '/^margin/': ['px', 'rem', 'em'],
+        '/^gap/': ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
     'stylelint-polaris/global-disallowed-list': [
       /\$polaris-spacing/,
       /\$spacing-data/,
@@ -199,6 +222,16 @@ const stylelintPolarisCoverageOptions = {
     ],
   },
   shape: {
+    'declaration-property-unit-disallowed-list': [
+      {
+        'border-width': ['px', 'rem', 'em'],
+        border: ['px', 'rem', 'em'],
+        'border-radius': ['px', 'rem', 'em'],
+        'outline-offset': ['px', 'rem', 'em'],
+        outline: ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
     'stylelint-polaris/at-rule-disallowed-list': {
       include: [
         /([\w-]+\.)?border-radius/,
@@ -244,15 +277,9 @@ const stylelintPolarisCoverageOptions = {
       /--p-popover-shadow/,
       /--p-modal-shadow/,
       /--p-top-bar-shadow/,
-      /--p-override-loading-z-index/,
     ],
   },
   conventions: {
-    'unit-disallowed-list': [
-      // TODO: Should 's' and 'ms' move to `motion`?
-      ['px', 'rem', 'em', 's', 'ms'],
-      {severity: 'warning'},
-    ],
     'stylelint-polaris/custom-properties-allowed-list': {
       // Allow any custom property not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
       allowedProperties: [/--(?!(p|pc|polaris-version)-).+/],


### PR DESCRIPTION
### WHY are these changes introduced?

The current categorization of disallowed units is under "conventions" and rejects via the `unit-disallowed-list` rule. I propose we reject the disallowed units by category using `declaration-property-unit-disallowed-list` to target specific properties, as `px` `rem` units are valid for `width` and `height` and shouldn't cause stylelint warnings.

### WHAT is this pull request doing?

Instead of getting a generic stylelint warning for any use of `px`, `rem`, `em`, `ms`, `s`

```
Unexpected unit "px" (unit-disallowed-list)  stylelint-polaris/coverage/conventions
```

We can output a tailored message like 

```
(declaration-property-unit-disallowed-list)  stylelint-polaris/coverage/typography
Unexpected "px" value for property "font-size". Use a typography design token instead.
```

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
