### PR TITLE
[ActionList/Modal.Header] Fix spacing regressions

### DIFF
--- a/.changeset/twenty-socks-count.md
+++ b/.changeset/twenty-socks-count.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed visual spacing regressions on `ActionList` and `Modal.Header`

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -7,15 +7,19 @@
   padding: 0;
 }
 
-.Section-withoutTitle:not(:first-child) {
+.Section:not(:first-child) {
   border-top: var(--p-border-divider);
+
+  // stylelint-disable-next-line selector-max-class, selector-max-combinators, selector-max-specificity
+  > .Section-withoutTitle .Actions {
+    padding-top: var(--p-space-2);
+  }
 }
 
 .Actions {
   outline: none;
   list-style: none;
   margin: 0;
-  border-bottom: var(--p-border-divider);
   padding: var(--p-space-2);
 }
 
@@ -24,7 +28,7 @@
   // stylelint-disable-next-line selector-max-class, selector-max-combinators, selector-max-specificity
   > .Section-withoutTitle .Actions {
     border-top: none;
-    border-bottom: none;
+    padding-top: var(--p-space-2);
   }
 }
 
@@ -32,13 +36,6 @@
   // stylelint-disable-next-line selector-max-class, selector-max-combinators
   .Actions {
     padding-top: 0;
-  }
-}
-
-.ActionList .Section:last-child {
-  // stylelint-disable-next-line selector-max-class, selector-max-combinators, selector-max-specificity
-  .Actions {
-    border-bottom: none;
   }
 }
 

--- a/polaris-react/src/components/ActionList/ActionList.stories.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.stories.tsx
@@ -178,6 +178,47 @@ export function WithSections() {
   );
 }
 
+export function WithSectionsNoTitles() {
+  const [active, setActive] = useState(true);
+
+  const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+  const activator = (
+    <Button onClick={toggleActive} disclosure>
+      More actions
+    </Button>
+  );
+
+  return (
+    <div style={{height: '250px'}}>
+      <Popover
+        active={active}
+        activator={activator}
+        autofocusTarget="first-node"
+        onClose={toggleActive}
+      >
+        <ActionList
+          actionRole="menuitem"
+          sections={[
+            {
+              items: [
+                {content: 'Import file', icon: ImportMinor},
+                {content: 'Export file', icon: ExportMinor},
+              ],
+            },
+            {
+              items: [
+                {content: 'Edit', icon: EditMinor},
+                {content: 'Delete', icon: DeleteMinor},
+              ],
+            },
+          ]}
+        />
+      </Popover>
+    </div>
+  );
+}
+
 export function WithDestructiveItem() {
   const [active, setActive] = useState(true);
 

--- a/polaris-react/src/components/Modal/components/Header/Header.scss
+++ b/polaris-react/src/components/Modal/components/Header/Header.scss
@@ -24,5 +24,5 @@
 .Title {
   @include text-breakword;
   flex: 1;
-  margin-top: var(--p-space-1);
+  align-self: center;
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

v10.11.0 introduced a visual spacing regression for a specific edge case of `ActionList` where there are section but no titles. We didn't have a storybook example for that so I've added in an example in a **temporary commit** as this is not a pattern we necessarily encourage. It also introduced a visual spacing regression for `Modal.Header` on the xs-sm breakpoints that resulted in the header not being centered.

### WHAT is this pull request doing?

* Refactors styling for ActionList
* Refactors vertical spacing of Modal.Header
    <details>
      <summary>ActionList — Section no title before</summary>
      <img src="https://user-images.githubusercontent.com/26749317/201711657-9ab79577-2d6c-48a9-ad8e-0ad83b9311ba.png" alt="ActionList — Section no title before">
    </details>
        <details>
      <summary>ActionList — Section no title after</summary>
      <img src="https://user-images.githubusercontent.com/26749317/201719792-3df23996-7f6f-4e7e-84c5-6e1f3ad91c95.png" alt="ActionList — Section no title after">
    </details>
    <details>
      <summary>Modal.Header — xs breakpoint before</summary>
      <img src="https://user-images.githubusercontent.com/26749317/201711661-3242963a-08db-493a-a20f-2de759a13d69.png" alt="Modal.Header — xs breakpoint before">
    </details>
        <details>
      <summary>Modal.Header — xs breakpoint after</summary>
      <img src="https://user-images.githubusercontent.com/26749317/201711660-450ac6fd-23ea-4daa-ae77-018f0495f9c5.png" alt="Modal.Header — xs breakpoint after">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

[Storybook URL](https://5d559397bae39100201eedc1-lnhdfnrwrt.chromatic.com/?path=/story/all-components-actionlist--with-sections-no-titles)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
