### PR TITLE
Fix lb abbreviation

### DIFF
--- a/.changeset/sixty-dancers-exercise.md
+++ b/.changeset/sixty-dancers-exercise.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Fixed abbrevation for pounds from lbs to lb.

--- a/polaris.shopify.com/content/content/grammar-and-mechanics.md
+++ b/polaris.shopify.com/content/content/grammar-and-mechanics.md
@@ -536,7 +536,7 @@ Use an en dash without a space on either side for number ranges:
 - 5–10 products
 - October 15–31
 - 2005–2015
-- 25–100 lbs
+- 25–100 lb
 - \$0.00–\$49.99
 - 2:00 pm–3:00 pm
 
@@ -545,7 +545,7 @@ Use an en dash without a space on either side for number ranges:
 - 5 – 10 products
 - October 15 – 31
 - 2005 – 2015
-- 25 – 100lbs
+- 25 – 100 lb
 - \$0.00 – \$49.99
 - 2:00 pm – 3:00 pm
 


### PR DESCRIPTION
### WHY are these changes introduced?

Current examples contain incorrect abbreviation for pounds (should be `lb` not `lbs`).

### WHAT is this pull request doing?

Replaces instances of `lbs` with `lb`