### PR TITLE
[IndexTable] Update bulk selection copy

### DIFF
--- a/.changeset/shy-snakes-shop.md
+++ b/.changeset/shy-snakes-shop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Update copy in the IndexTable around bulk selection

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -161,7 +161,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Item",
       "defaultItemPlural": "Items",
-      "allItemsSelected": "All {itemsLength}+ {resourceNamePlural} are selected.",
+      "allItemsSelected": "All {resourceNamePlural} selected.",
       "selected": "{selectedItemsCount} selected",
       "a11yCheckboxDeselectAllSingle": "Deselect {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Select {resourceNameSingular}",
@@ -176,7 +176,7 @@
       "selectAllLabel": "Select all {resourceNamePlural}",
       "selected": "{selectedItemsCount} selected",
       "undo": "Undo",
-      "selectAllItems": "Select all {itemsLength}+ {resourceNamePlural}",
+      "selectAllItems": "Select all {resourceNamePlural} in this store",
       "selectItem": "Select {resourceName}",
       "selectButtonText": "Select",
       "sortAccessibilityLabel": "sort {direction} by"

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -940,7 +940,6 @@ function IndexTableBase({
     const customActionText =
       paginatedSelectAllActionText ??
       i18n.translate('Polaris.IndexTable.selectAllItems', {
-        itemsLength: itemCount,
         resourceNamePlural: resourceName.plural.toLocaleLowerCase(),
       });
 

--- a/polaris-react/src/utilities/index-provider/hooks.ts
+++ b/polaris-react/src/utilities/index-provider/hooks.ts
@@ -92,7 +92,6 @@ export function useBulkSelectionData({
 
     if (selectedItemsCount === SELECT_ALL_ITEMS) {
       return i18n.translate('Polaris.IndexProvider.allItemsSelected', {
-        itemsLength: itemCount,
         resourceNamePlural: resourceName.plural.toLocaleLowerCase(),
       });
     }

--- a/polaris-react/src/utilities/index-provider/tests/hooks.test.tsx
+++ b/polaris-react/src/utilities/index-provider/tests/hooks.test.tsx
@@ -189,7 +189,7 @@ describe('useBulkSelectionData', () => {
       singular: 'order',
       plural: 'orders',
     };
-    const paginatedSelectAllText = `All ${itemCount}+ ${resourceName.plural} are selected.`;
+    const paginatedSelectAllText = `All ${resourceName.plural} selected.`;
     const mockComponent = mountWithApp(
       <MockComponent
         selectedItemsCount="All"


### PR DESCRIPTION


### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/75434



### WHAT is this pull request doing?

This PR updates the copy in the bulk actions bar when a merchant is selecting more items than is visible. We are removing the `50+` and replacing it with more clear language to select all Xs in the store.

<img width="1924" alt="Screenshot 2022-11-15 at 11 36 06" src="https://user-images.githubusercontent.com/2562596/201910414-e682fc28-ef7f-4ac3-997b-56cca6cb267c.png">
<img width="1924" alt="Screenshot 2022-11-15 at 11 36 05" src="https://user-images.githubusercontent.com/2562596/201910425-7cbd101d-56e4-4406-8e5a-e7554f0f2edd.png">


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
