### PR TITLE
Fix TextStyle migration to use `fontWeight="semibold"` instead of `fontWeight="bold"`

### DIFF
--- a/.changeset/tiny-ravens-sing.md
+++ b/.changeset/tiny-ravens-sing.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris-migrator': patch
+'polaris.shopify.com': patch
+---
+
+Fixed mapping for `TextStyle` `variation="strong"` to use `Text` `fontWeight="semibold"` instead of `fontWeight="bold"`

--- a/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-text-style.ts
+++ b/polaris-migrator/src/migrations/react-replace-text-components/steps/replace-text-style.ts
@@ -22,7 +22,7 @@ import type {MigrationOptions} from '../react-replace-text-components';
 import {POLARIS_MIGRATOR_COMMENT} from '../../../constants';
 
 const variationMap = {
-  strong: {fontWeight: 'bold'},
+  strong: {fontWeight: 'semibold'},
   subdued: {color: 'subdued'},
   positive: {color: 'success'},
   negative: {color: 'critical'},

--- a/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.output.tsx
+++ b/polaris-migrator/src/migrations/react-replace-text-components/tests/react-replace-text-components.output.tsx
@@ -44,7 +44,7 @@ export function App() {
       <Text variant="bodySm" as="p">
         Caption
       </Text>
-      <Text variant="bodyMd" fontWeight="bold" as="span">
+      <Text variant="bodyMd" fontWeight="semibold" as="span">
         Strong
       </Text>
       <Text variant="bodyMd" color="success" as="span">

--- a/polaris-migrator/src/migrations/react-replace-text-components/tests/with-relative.output.tsx
+++ b/polaris-migrator/src/migrations/react-replace-text-components/tests/with-relative.output.tsx
@@ -34,7 +34,7 @@ export function App() {
       <Text variant="bodySm" as="p">
         Caption
       </Text>
-      <Text variant="bodyMd" fontWeight="bold" as="span">
+      <Text variant="bodyMd" fontWeight="semibold" as="span">
         Strong
       </Text>
       <Text variant="bodyMd" color="success" as="span">

--- a/polaris.shopify.com/content/components/text-style.md
+++ b/polaris.shopify.com/content/components/text-style.md
@@ -37,7 +37,7 @@ status:
 
 ```diff
 - <TextStyle variation="strong">No supplier listed</TextStyle>
-+ <Text variant="bodyMd" as="span" fontWeight="bold">No supplier listed</Text>
++ <Text variant="bodyMd" as="span" fontWeight="semibold">No supplier listed</Text>
 ```
 
 ### Positive


### PR DESCRIPTION
### WHY are these changes introduced?

After running `react-replace-text-components` in our core product, we've noticed that the fontWeight mapping is incorrect and should be using `semibold` instead of `bold`. 

### WHAT is this pull request doing?

Updates the font weight mapping on the style guide and in the migration.