### PR TITLE
[polaris.shopify.com] Update alpha banner message

### DIFF
--- a/.changeset/fresh-games-arrive.md
+++ b/.changeset/fresh-games-arrive.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Updated alpha status message that documentation is in development for `Bleed`, `Columns`, `Tiles`, `Inline`, `ContentBlock`, `AlphaCard`, `AlphaStack`, and `Box`

--- a/.changeset/fresh-games-arrive.md
+++ b/.changeset/fresh-games-arrive.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-Updated alpha status message that documentation is in development for `Bleed`, `Columns`, `Tiles`, `Inline`, `ContentBlock`, `AlphaCard`, `AlphaStack`, and `Box`
+Updated alpha status message that documentation is in development for `Bleed`, `Columns`, `Tiles`, `Inline`, `AlphaCard`, `AlphaStack`, and `Box`

--- a/polaris.shopify.com/content/components/alpha-card.md
+++ b/polaris.shopify.com/content/components/alpha-card.md
@@ -22,7 +22,7 @@ keywords:
   - call out
 status:
   value: Alpha
-  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
+  message: This component and its documentation is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
 examples:
   - fileName: alpha-card-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/alpha-stack.md
+++ b/polaris.shopify.com/content/components/alpha-stack.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
+  message: This component and its documentation is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
 examples:
   - fileName: alpha-stack-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/bleed.md
+++ b/polaris.shopify.com/content/components/bleed.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
+  message: This component and its documentation is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
 examples:
   - fileName: bleed-vertical.tsx
     title: Vertical

--- a/polaris.shopify.com/content/components/box.md
+++ b/polaris.shopify.com/content/components/box.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
+  message: This component and its documentation is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
 examples:
   - fileName: box-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/columns.md
+++ b/polaris.shopify.com/content/components/columns.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
+  message: This component and its documentation is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
 examples:
   - fileName: columns-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/inline.md
+++ b/polaris.shopify.com/content/components/inline.md
@@ -6,12 +6,12 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
+  message: This component and its documentation is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
 examples:
   - fileName: inline-default.tsx
     title: Default
     description: >-
-     Items are vertically centered with 16px of space around them. They’ll wrap onto multiple lines when needed.
+      Items are vertically centered with 16px of space around them. They’ll wrap onto multiple lines when needed.
   - fileName: inline-with-non-wrapping.tsx
     title: Non-wrapping
     description: >-

--- a/polaris.shopify.com/content/components/tiles.md
+++ b/polaris.shopify.com/content/components/tiles.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
+  message: This component and its documentation is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
 examples:
   - fileName: tiles-with-spacing.tsx
     title: Spacing


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #7670.

### WHAT is this pull request doing?

Updates the message in the status banner to include that documentation is also in development.
    <details>
      <summary>Updated Bleed banner</summary>
      <img src="https://user-images.githubusercontent.com/26749317/202476127-708a7d25-4fc3-441c-bb6d-385457d23b1d.png" alt="Updated Bleed banner">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
