### PR TITLE
[UnstyledButton] Add disabled attribute to UnstyledButton

### DIFF
--- a/.changeset/forty-cars-shake.md
+++ b/.changeset/forty-cars-shake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Adds the `disabled` attribute to disabled `UnstyledButton` components to prevent them from being inadvertently selected by `button:not(:disabled)` CSS selectors.

--- a/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
@@ -81,6 +81,7 @@ export function UnstyledButton({
       <button
         {...interactiveProps}
         aria-disabled={disabled}
+        disabled={disabled}
         type={submit ? 'submit' : 'button'}
         aria-busy={loading ? true : undefined}
         aria-controls={ariaControls}

--- a/polaris-react/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/polaris-react/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -213,6 +213,7 @@ describe('<Button />', () => {
       const button = mountWithApp(<UnstyledButton disabled />);
       expect(button).toContainReactComponent('button', {
         'aria-disabled': true,
+        disabled: true,
       });
     });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #7728 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Adds the `disabled` attribute to the `<button>` element that is rendered by `UnstyledButton` to prevent it from being selected by `button:not(:disabled)` CSS selectors.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Button, Modal, Page, Stack, TextField} from '../src';

export function Playground() {
  const [isModalOpen, setIsModalOpen] = useState(false);

  function handleClose() {
    setIsModalOpen(false);
  }

  function noop() {}

  return (
    <Page title="Playground">
      <Button onClick={() => setIsModalOpen(true)}>Open modal</Button>
      <Button disabled>Disabled button</Button>

      <Modal
        open={isModalOpen}
        onClose={handleClose}
        title="Example modal"
        primaryAction={{
          content: 'Primary action',
          onAction: handleClose,
          disabled: true,
        }}
      >
        <Modal.Section>
          <Stack vertical>
            <p>Some content</p>
            <TextField
              onChange={noop}
              autoComplete=""
              label="Text field 1"
              value=""
            />
            <TextField
              onChange={noop}
              autoComplete=""
              label="Text field 2"
              value=""
            />
          </Stack>
        </Modal.Section>
      </Modal>
    </Page>
  );
}
```

</details>

1. Copy the above code into `Playground.tsx` and run `yarn dev`
2. Confirm that the button labeled "Disabled button" has the `disabled` attribute
3. Confirm that this fixes #7728:
    1. Click "Open modal"
    2. Use the Tab key to cycle through focusable elements within the modal
    3. Confirm that focus wraps around to the beginning of the modal despite the primary action button being disabled

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
