### PR TITLE
[Toast] Updates to fit a more compact layout

### DIFF
--- a/.changeset/perfect-games-cough.md
+++ b/.changeset/perfect-games-cough.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Update the Toast component to a more compact layout

--- a/polaris-react/src/components/Frame/components/Toast/Toast.scss
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.scss
@@ -5,14 +5,15 @@ $Backdrop-opacity: 0.88;
 .Toast {
   display: inline-flex;
   max-width: 500px;
-  padding: var(--p-space-2) var(--p-space-4);
-  border-radius: var(--p-border-radius-2);
+  padding: var(--p-space-2) var(--p-space-3);
+  border-radius: var(--p-border-radius-1);
   background: var(--p-surface-dark);
-  color: var(--p-text-on-dark);
+  color: var(--p-text-on-interactive);
   margin-bottom: var(--p-space-5);
+  box-shadow: var(--p-shadow-popover);
 
-  @media #{$p-breakpoints-md-up} {
-    padding: var(--p-space-4);
+  @media #{$p-breakpoints-sm-up} {
+    padding: var(--p-space-3);
   }
 
   @media (forced-colors: active) {
@@ -21,8 +22,8 @@ $Backdrop-opacity: 0.88;
 }
 
 .Action {
-  margin-left: var(--p-space-8);
-  margin-right: var(--p-space-4);
+  margin-left: var(--p-space-2);
+  color: var(--p-text-on-interactive);
 }
 
 .error {
@@ -30,8 +31,13 @@ $Backdrop-opacity: 0.88;
   color: var(--p-text-on-critical);
 
   .CloseButton {
-    fill: var(--p-icon-on-critical);
+    color: var(--p-icon-on-critical);
   }
+}
+
+.LeadingIcon {
+  @include recolor-icon(currentColor);
+  margin-right: var(--p-space-2);
 }
 
 .CloseButton {
@@ -39,23 +45,21 @@ $Backdrop-opacity: 0.88;
   align-self: center;
   flex-direction: column;
   justify-content: flex-start;
-  margin-right: calc(-1 * var(--p-space-4));
-  padding: 0 var(--p-space-4);
+  padding: 0;
   border: none;
   appearance: none;
   background: transparent;
-  color: currentColor;
+  color: var(--p-icon-subdued);
   @include recolor-icon(currentColor);
   cursor: pointer;
-
-  @media #{$p-breakpoints-md-up} {
-    align-self: flex-start;
-    margin: calc(-1 * var(--p-space-2)) calc(-1 * var(--p-space-4))
-      calc(-1 * var(--p-space-2)) 0;
-    padding: var(--p-space-2) var(--p-space-4) 0;
-  }
+  margin-left: var(--p-space-2);
 
   &:focus {
     outline: none;
+  }
+
+  &:focus,
+  &:hover {
+    color: var(--p-text-on-interactive);
   }
 }

--- a/polaris-react/src/components/Frame/components/Toast/Toast.tsx
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {MobileCancelMajor} from '@shopify/polaris-icons';
+import {CancelSmallMinor, AlertMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
 import {Key} from '../../../../types';
@@ -50,15 +50,21 @@ export function Toast({
 
   const dismissMarkup = (
     <button type="button" className={styles.CloseButton} onClick={onDismiss}>
-      <Icon source={MobileCancelMajor} />
+      <Icon source={CancelSmallMinor} />
     </button>
   );
 
   const actionMarkup = action ? (
     <div className={styles.Action}>
-      <Button plain monochrome onClick={action.onAction}>
+      <Button plain monochrome size="slim" onClick={action.onAction}>
         {action.content}
       </Button>
+    </div>
+  ) : null;
+
+  const leadingIconMarkup = error ? (
+    <div className={styles.LeadingIcon}>
+      <Icon source={AlertMinor} color="base" />
     </div>
   ) : null;
 
@@ -67,6 +73,7 @@ export function Toast({
   return (
     <div className={className}>
       <KeypressListener keyCode={Key.Escape} handler={onDismiss} />
+      {leadingIconMarkup}
       <Inline blockAlign="center">
         <Text as="span" variant="bodyMd" fontWeight="medium">
           {content}


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves: https://github.com/Shopify/polaris/issues/7766

Updates the toast to fit a more compact layout. 

Figma: https://www.figma.com/file/wgbt21f1PZm5lrUecbB5oY/%F0%9F%8D%9E-Toast-component-rework?t=t1DGV6KQXGXBfkaQ-0


### WHAT is this pull request doing?

Redesign screenshots:

<details>
<summary>Default</summary>

Before:
<img width="194" alt="default Toast component before changes" src="https://user-images.githubusercontent.com/11233957/203293475-8ee315bd-94f9-4413-b9da-ada89f74b9fa.png">

After:
<img width="252" alt="default Toast component after changes" src="https://user-images.githubusercontent.com/11233957/203294027-2e37d8a5-146e-468c-bc2e-e13015397545.png">

</details>

<details>
<summary>With Action</summary>

Before:
<img width="304" alt="Toast with action before changes" src="https://user-images.githubusercontent.com/11233957/203293640-f0a2a97a-ef7c-4771-a5ec-f58439452c94.png">

After:
<img width="221" alt="Toast with action after changes" src="https://user-images.githubusercontent.com/11233957/203294132-9e40966a-b991-4008-b767-f829ebea89f7.png">
</details>

<details>
<summary>Error</summary>

Before:
<img width="364" alt="Toast with error before changes" src="https://user-images.githubusercontent.com/11233957/203293759-7a2207ec-5160-477b-8ee6-b03593cc0dd2.png">

After:
<img width="243" alt="Toast with error after changes" src="https://user-images.githubusercontent.com/11233957/203294225-025cd97a-af39-4b7b-a02e-ba4f92c153fe.png">
</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

#### Test in spin

Spin instance: https://admin.web.nf-tost-web.nikita-filatov.eu.spin.dev/store/shop1/products?selectedView=all

<details>
<summary>Default toast</summary>

Create a new product here: [link](https://admin.web.nf-tost-web.nikita-filatov.eu.spin.dev/store/shop1/products/new)

**Expected result**
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/11233957/203316338-b8a97d25-ef8a-4666-8b54-37fdd07ce748.png">
</details>

<details>
<summary>Toast with error</summary>

1. Create a new product here: [link](https://admin.web.nf-tost-web.nikita-filatov.eu.spin.dev/store/shop1/products/new)

2. Before clicking on the Save button disable the wifi:
![image](https://user-images.githubusercontent.com/11233957/203317060-85781e21-69d1-4f78-8902-823dfb1b8edd.png)

**Expected result:**
<img width="976" alt="image" src="https://user-images.githubusercontent.com/11233957/203317249-ce3b54ab-7123-4ec9-ac9c-ad69fdf11658.png">
</details>

#### Test on local machine

1. Open http://localhost:6006/?path=/story/all-components-toast--default
5. Check
2.1 Default toast
2.2. Toast with action
2.3 Toast with error

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
