### PR TITLE
[Layout foundations] Clean up storybook example names

### DIFF
--- a/.changeset/calm-jobs-divide.md
+++ b/.changeset/calm-jobs-divide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Renamed storybook example names for consistency

--- a/polaris-react/src/components/AlphaCard/AlphaCard.stories.tsx
+++ b/polaris-react/src/components/AlphaCard/AlphaCard.stories.tsx
@@ -19,7 +19,7 @@ export function Default() {
   );
 }
 
-export function BackgroundSubdued() {
+export function WithBackgroundSubdued() {
   return (
     <AlphaCard background="surface-subdued">
       <AlphaStack gap="5">
@@ -32,7 +32,7 @@ export function BackgroundSubdued() {
   );
 }
 
-export function BorderRadiusRoundedAbove() {
+export function WithBorderRadiusRoundedAbove() {
   return (
     <AlphaCard roundedAbove="sm">
       <AlphaStack gap="5">

--- a/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
@@ -17,7 +17,7 @@ export function Default() {
   );
 }
 
-export function Gap() {
+export function WithGap() {
   return (
     <AlphaStack gap="8">
       <Badge>Paid</Badge>
@@ -28,7 +28,18 @@ export function Gap() {
   );
 }
 
-export function AlignCenter() {
+export function WithResponsiveGap() {
+  return (
+    <AlphaStack gap={{xs: '4', md: '10'}}>
+      <Badge>Paid</Badge>
+      <Badge>Processing</Badge>
+      <Badge>Fulfilled</Badge>
+      <Badge>Completed</Badge>
+    </AlphaStack>
+  );
+}
+
+export function WithAlignCenter() {
   return (
     <AlphaStack align="center">
       <Badge>Paid</Badge>
@@ -39,7 +50,7 @@ export function AlignCenter() {
   );
 }
 
-export function AlignEnd() {
+export function WithAlignEnd() {
   return (
     <AlphaStack align="end">
       <Badge>Paid</Badge>
@@ -50,20 +61,9 @@ export function AlignEnd() {
   );
 }
 
-export function FullWidthChildren() {
+export function WithFullWidthChildren() {
   return (
     <AlphaStack fullWidth>
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
-    </AlphaStack>
-  );
-}
-
-export function ResponsiveGap() {
-  return (
-    <AlphaStack gap={{xs: '4', md: '10'}}>
       <Badge>Paid</Badge>
       <Badge>Processing</Badge>
       <Badge>Fulfilled</Badge>

--- a/polaris-react/src/components/Box/Box.stories.tsx
+++ b/polaris-react/src/components/Box/Box.stories.tsx
@@ -15,7 +15,7 @@ export function Default() {
   );
 }
 
-export function BoxWithDarkBorder() {
+export function WithDarkBorder() {
   return (
     <Box background="surface" padding="4" border="dark">
       <Icon source={PaintBrushMajor} color="base" />
@@ -23,7 +23,7 @@ export function BoxWithDarkBorder() {
   );
 }
 
-export function BoxWithBorderRadius() {
+export function WithBorderRadius() {
   return (
     <Box background="surface" padding="4" borderRadius="2">
       <Icon source={PaintBrushMajor} color="highlight" />
@@ -31,7 +31,7 @@ export function BoxWithBorderRadius() {
   );
 }
 
-export function BoxWithResponsivePadding() {
+export function WithResponsivePadding() {
   return (
     <AlphaStack>
       <Box background="surface" padding={{xs: '2', sm: '8'}} border="dark">

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -27,7 +27,7 @@ export function Default() {
   );
 }
 
-export function AlignStart() {
+export function WithAlignStart() {
   return (
     <Inline align="start" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -38,7 +38,7 @@ export function AlignStart() {
   );
 }
 
-export function AlignCenter() {
+export function WithAlignCenter() {
   return (
     <Inline align="center" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -49,7 +49,7 @@ export function AlignCenter() {
   );
 }
 
-export function AlignEnd() {
+export function WithAlignEnd() {
   return (
     <Inline align="end" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -60,7 +60,7 @@ export function AlignEnd() {
   );
 }
 
-export function AlignSpaceAround() {
+export function WithAlignSpaceAround() {
   return (
     <Inline align="space-around" gap="1">
       <Badge>One</Badge>
@@ -70,7 +70,7 @@ export function AlignSpaceAround() {
   );
 }
 
-export function AlignSpaceBetween() {
+export function WithAlignSpaceBetween() {
   return (
     <Inline align="space-between" gap="1">
       <Badge>One</Badge>
@@ -80,7 +80,7 @@ export function AlignSpaceBetween() {
   );
 }
 
-export function AlignSpaceEvenly() {
+export function WithAlignSpaceEvenly() {
   return (
     <Inline align="space-evenly" gap="1">
       <Badge>One</Badge>
@@ -90,7 +90,7 @@ export function AlignSpaceEvenly() {
   );
 }
 
-export function BlockAlignCenter() {
+export function WithBlockAlignCenter() {
   return (
     <Inline blockAlign="center" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -101,7 +101,7 @@ export function BlockAlignCenter() {
   );
 }
 
-export function BlockAlignStart() {
+export function WithBlockAlignStart() {
   return (
     <Inline blockAlign="start" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -112,7 +112,7 @@ export function BlockAlignStart() {
   );
 }
 
-export function BlockAlignEnd() {
+export function WithBlockAlignEnd() {
   return (
     <Inline blockAlign="end" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -123,7 +123,7 @@ export function BlockAlignEnd() {
   );
 }
 
-export function BlockAlignBaseline() {
+export function WithBlockAlignBaseline() {
   return (
     <Inline blockAlign="baseline" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -134,7 +134,7 @@ export function BlockAlignBaseline() {
   );
 }
 
-export function BlockAlignStrech() {
+export function WithBlockAlignStrech() {
   return (
     <Inline blockAlign="stretch" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -145,7 +145,7 @@ export function BlockAlignStrech() {
   );
 }
 
-export function AlignCenterBlockAlignCenter() {
+export function WithAlignCenterBlockAlignCenter() {
   return (
     <Inline align="center" blockAlign="center" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
@@ -156,7 +156,7 @@ export function AlignCenterBlockAlignCenter() {
   );
 }
 
-export function NonWrapping() {
+export function WithNonWrapping() {
   return (
     <Inline wrap={false} gap="1">
       <Badge>Paid</Badge>
@@ -167,7 +167,7 @@ export function NonWrapping() {
   );
 }
 
-export function Gap() {
+export function WithGap() {
   return (
     <AlphaStack>
       <Inline gap="8">
@@ -187,7 +187,7 @@ export function Gap() {
   );
 }
 
-export function GapResponsive() {
+export function WithResponsiveGap() {
   return (
     <AlphaStack>
       <Inline gap={{xs: '2', md: '4'}}>

--- a/polaris-react/src/components/Tiles/Tiles.stories.tsx
+++ b/polaris-react/src/components/Tiles/Tiles.stories.tsx
@@ -32,7 +32,7 @@ export function Default() {
   );
 }
 
-export function LargeGap() {
+export function WithLargeGap() {
   return (
     <Tiles columns={{xs: 2}} gap={{xs: '10'}}>
       {children}
@@ -40,7 +40,7 @@ export function LargeGap() {
   );
 }
 
-export function ManyColumns() {
+export function WithManyColumns() {
   const children = Array.from(Array(10)).map((ele, index) => (
     <div key={index} style={styles}>
       <Text as="h2" variant="headingMd">


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #7762.

### WHAT is this pull request doing?

Renames storybook examples for layout primitives to include `With` in the name.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
