### PR TITLE
[polaris.shopify.com] Clean up links for alpha layout pages

### DIFF
--- a/.changeset/strong-candles-visit.md
+++ b/.changeset/strong-candles-visit.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Removed link to deleted `Tile` component and cleaned up links

--- a/.changeset/strong-candles-visit.md
+++ b/.changeset/strong-candles-visit.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-Removed link to deleted `Tile` component and cleaned up links
+Removed link to deleted `Tiles` component and cleaned up links

--- a/polaris.shopify.com/content/components/alpha-stack.md
+++ b/polaris.shopify.com/content/components/alpha-stack.md
@@ -28,4 +28,4 @@ examples:
 
 ## Related components
 
-- To display elements horizontally, [use the Inline component](https://polaris.shopify.com/components/inline).
+- To display elements horizontally, [use the Inline component](https://polaris.shopify.com/components/inline)

--- a/polaris.shopify.com/content/components/box.md
+++ b/polaris.shopify.com/content/components/box.md
@@ -36,4 +36,4 @@ examples:
 
 ## Related components
 
-- For more specific use cases, [use the Card](https://polaris.shopify.com/components/card) component.
+- For more specific use cases, [use the Card component](https://polaris.shopify.com/components/card)

--- a/polaris.shopify.com/content/components/inline.md
+++ b/polaris.shopify.com/content/components/inline.md
@@ -32,5 +32,4 @@ examples:
 
 ## Related components
 
-- To create the large-scale structure of pages, [use the Columns component](https://polaris.shopify.com/components/columns)
 - To display elements vertically, [use the AlphaStack component](https://polaris.shopify.com/components/alphastack)

--- a/polaris.shopify.com/content/components/inline.md
+++ b/polaris.shopify.com/content/components/inline.md
@@ -32,5 +32,5 @@ examples:
 
 ## Related components
 
-- To create the large-scale structure of pages, [use the Columns](https://polaris.shopify.com/components/columns) and [Tile component](https://polaris.shopify.com/components/tile)
-- To display elements vertically, [use AlphaStack](https://polaris.shopify.com/components/alphastack)
+- To create the large-scale structure of pages, [use the Columns component](https://polaris.shopify.com/components/columns)
+- To display elements vertically, [use the AlphaStack component](https://polaris.shopify.com/components/alphastack)


### PR DESCRIPTION
### WHY are these changes introduced?

Removed link to deleted `Tiles` page and updated punctuation on related components section for consistency.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
