### PR TITLE
[Typography foundations] Temporarily remove console warnings for deprecated type components

### DIFF
--- a/.changeset/friendly-geese-clean.md
+++ b/.changeset/friendly-geese-clean.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Temporarily removed console warnings for deprecated typography components

--- a/polaris-react/src/components/Caption/Caption.tsx
+++ b/polaris-react/src/components/Caption/Caption.tsx
@@ -15,13 +15,5 @@ export interface CaptionProps {
  * https://polaris.shopify.com/components/text
  */
 export function Caption({children}: CaptionProps) {
-  // TODO: Re-add console warnings after migrations are complete
-  // if (process.env.NODE_ENV === 'development') {
-  //   // eslint-disable-next-line no-console
-  //   console.warn(
-  //     'Deprecation: The `Caption` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-  //   );
-  // }
-
   return <p className={styles.Caption}>{children}</p>;
 }

--- a/polaris-react/src/components/Caption/Caption.tsx
+++ b/polaris-react/src/components/Caption/Caption.tsx
@@ -15,12 +15,13 @@ export interface CaptionProps {
  * https://polaris.shopify.com/components/text
  */
 export function Caption({children}: CaptionProps) {
-  if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The `Caption` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-    );
-  }
+  // TODO: Re-add console warnings after migrations are complete
+  // if (process.env.NODE_ENV === 'development') {
+  //   // eslint-disable-next-line no-console
+  //   console.warn(
+  //     'Deprecation: The `Caption` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
+  //   );
+  // }
 
   return <p className={styles.Caption}>{children}</p>;
 }

--- a/polaris-react/src/components/DisplayText/DisplayText.tsx
+++ b/polaris-react/src/components/DisplayText/DisplayText.tsx
@@ -39,12 +39,13 @@ export function DisplayText({
     size && styles[variationName('size', size)],
   );
 
-  if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The `DisplayText` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-    );
-  }
+  // TODO: Re-add console warnings after migrations are complete
+  // if (process.env.NODE_ENV === 'development') {
+  //   // eslint-disable-next-line no-console
+  //   console.warn(
+  //     'Deprecation: The `DisplayText` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
+  //   );
+  // }
 
   return <Element className={className}>{children}</Element>;
 }

--- a/polaris-react/src/components/DisplayText/DisplayText.tsx
+++ b/polaris-react/src/components/DisplayText/DisplayText.tsx
@@ -39,13 +39,5 @@ export function DisplayText({
     size && styles[variationName('size', size)],
   );
 
-  // TODO: Re-add console warnings after migrations are complete
-  // if (process.env.NODE_ENV === 'development') {
-  //   // eslint-disable-next-line no-console
-  //   console.warn(
-  //     'Deprecation: The `DisplayText` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-  //   );
-  // }
-
   return <Element className={className}>{children}</Element>;
 }

--- a/polaris-react/src/components/Heading/Heading.tsx
+++ b/polaris-react/src/components/Heading/Heading.tsx
@@ -24,12 +24,13 @@ export interface HeadingProps {
  * https://polaris.shopify.com/components/text
  */
 export function Heading({element: Element = 'h2', children, id}: HeadingProps) {
-  if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The `Heading` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-    );
-  }
+  // TODO: Re-add console warnings after migrations are complete
+  // if (process.env.NODE_ENV === 'development') {
+  //   // eslint-disable-next-line no-console
+  //   console.warn(
+  //     'Deprecation: The `Heading` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
+  //   );
+  // }
 
   return (
     <Element className={styles.Heading} id={id}>

--- a/polaris-react/src/components/Heading/Heading.tsx
+++ b/polaris-react/src/components/Heading/Heading.tsx
@@ -24,14 +24,6 @@ export interface HeadingProps {
  * https://polaris.shopify.com/components/text
  */
 export function Heading({element: Element = 'h2', children, id}: HeadingProps) {
-  // TODO: Re-add console warnings after migrations are complete
-  // if (process.env.NODE_ENV === 'development') {
-  //   // eslint-disable-next-line no-console
-  //   console.warn(
-  //     'Deprecation: The `Heading` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-  //   );
-  // }
-
   return (
     <Element className={styles.Heading} id={id}>
       {children}

--- a/polaris-react/src/components/Subheading/Subheading.tsx
+++ b/polaris-react/src/components/Subheading/Subheading.tsx
@@ -26,14 +26,6 @@ export function Subheading({
 }: SubheadingProps) {
   const ariaLabel = typeof children === 'string' ? children : undefined;
 
-  // TODO: Re-add console warnings after migrations are complete
-  // if (process.env.NODE_ENV === 'development') {
-  //   // eslint-disable-next-line no-console
-  //   console.warn(
-  //     'Deprecation: The `Subheading` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-  //   );
-  // }
-
   return (
     <Element aria-label={ariaLabel} className={styles.Subheading}>
       {children}

--- a/polaris-react/src/components/Subheading/Subheading.tsx
+++ b/polaris-react/src/components/Subheading/Subheading.tsx
@@ -26,12 +26,13 @@ export function Subheading({
 }: SubheadingProps) {
   const ariaLabel = typeof children === 'string' ? children : undefined;
 
-  if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The `Subheading` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-    );
-  }
+  // TODO: Re-add console warnings after migrations are complete
+  // if (process.env.NODE_ENV === 'development') {
+  //   // eslint-disable-next-line no-console
+  //   console.warn(
+  //     'Deprecation: The `Subheading` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
+  //   );
+  // }
 
   return (
     <Element aria-label={ariaLabel} className={styles.Subheading}>

--- a/polaris-react/src/components/TextStyle/TextStyle.tsx
+++ b/polaris-react/src/components/TextStyle/TextStyle.tsx
@@ -41,14 +41,6 @@ export function TextStyle({variation, children}: TextStyleProps) {
     variation === VariationValue.Code && styles.code,
   );
 
-  // TODO: Re-add console warnings after migrations are complete
-  // if (process.env.NODE_ENV === 'development') {
-  //   // eslint-disable-next-line no-console
-  //   console.warn(
-  //     'Deprecation: The `TextStyle` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-  //   );
-  // }
-
   const Element = variationElement(variation);
 
   return <Element className={className}>{children}</Element>;

--- a/polaris-react/src/components/TextStyle/TextStyle.tsx
+++ b/polaris-react/src/components/TextStyle/TextStyle.tsx
@@ -41,12 +41,13 @@ export function TextStyle({variation, children}: TextStyleProps) {
     variation === VariationValue.Code && styles.code,
   );
 
-  if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The `TextStyle` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-    );
-  }
+  // TODO: Re-add console warnings after migrations are complete
+  // if (process.env.NODE_ENV === 'development') {
+  //   // eslint-disable-next-line no-console
+  //   console.warn(
+  //     'Deprecation: The `TextStyle` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
+  //   );
+  // }
 
   const Element = variationElement(variation);
 

--- a/polaris-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/polaris-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -15,13 +15,5 @@ export interface VisuallyHiddenProps {
  * https://polaris.shopify.com/components/text
  */
 export function VisuallyHidden({children}: VisuallyHiddenProps) {
-  // TODO: Re-add console warnings after migrations are complete
-  // if (process.env.NODE_ENV === 'development') {
-  //   // eslint-disable-next-line no-console
-  //   console.warn(
-  //     'Deprecation: The  VisuallyHidden` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-  //   );
-  // }
-
   return <span className={styles.VisuallyHidden}>{children}</span>;
 }

--- a/polaris-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/polaris-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -15,12 +15,13 @@ export interface VisuallyHiddenProps {
  * https://polaris.shopify.com/components/text
  */
 export function VisuallyHidden({children}: VisuallyHiddenProps) {
-  if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The  VisuallyHidden` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
-    );
-  }
+  // TODO: Re-add console warnings after migrations are complete
+  // if (process.env.NODE_ENV === 'development') {
+  //   // eslint-disable-next-line no-console
+  //   console.warn(
+  //     'Deprecation: The  VisuallyHidden` component has been deprecated. Use the `Text` component instead. See the Polaris component guide on how to use `Text`. https://polaris.shopify.com/components/text',
+  //   );
+  // }
 
   return <span className={styles.VisuallyHidden}>{children}</span>;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To mitigate the number of console warnings for the deprecated typography components, we are going to temporarily disable them in development environments until migrations in core product are complete.

### WHAT is this pull request doing?

- Disables console warnings for `DisplayText`, `Heading`, `Subheading`, `Caption`, `TextStyle`, and `VisuallyHidden`

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
