### PR TITLE
[TextField] Add an icon button and action.

### DIFF
--- a/.changeset/great-waves-worry.md
+++ b/.changeset/great-waves-worry.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Added optional `iconButton` and `onIconButtonClick` props to `TextField`

--- a/polaris-react/src/components/TextField/TextField.scss
+++ b/polaris-react/src/components/TextField/TextField.scss
@@ -245,7 +245,7 @@ $spinner-icon-size: 12px;
   padding-bottom: var(--p-space-2);
 }
 
-.ClearButton {
+.IconButton {
   @include focus-ring;
   @include unstyled-button;
   z-index: var(--pc-text-field-contents);

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -11,7 +11,7 @@ import {
   Tag,
   TextField,
 } from '@shopify/polaris';
-import {DeleteMinor} from '@shopify/polaris-icons';
+import {DeleteMinor, ViewMinor, HideMinor} from '@shopify/polaris-icons';
 
 export default {
   component: TextField,
@@ -432,6 +432,35 @@ export function WithClearButton() {
   );
 }
 
+export function WithIconButton() {
+  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
+  const [showing, setShowing] = useState(false);
+
+  const handleTextFieldChange = useCallback(
+    (value) => setTextFieldValue(value),
+    [],
+  );
+
+  const handleIconButtonClick = useCallback(
+    () => setShowing(!showing),
+    [showing],
+  );
+
+  return (
+    <TextField
+      label="Store name"
+      value={showing ? textFieldValue : '••••••'}
+      onChange={handleTextFieldChange}
+      iconButton={{
+        icon: showing ? HideMinor : ViewMinor,
+        accessibilityLabel: 'PIN',
+      }}
+      onIconButtonClick={handleIconButtonClick}
+      autoComplete="off"
+    />
+  );
+}
+
 export function WithMonospacedFont() {
   const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
 
@@ -446,6 +475,7 @@ export function WithMonospacedFont() {
       value={textFieldValue}
       onChange={handleTextFieldChange}
       monospaced
+      autoComplete="off"
     />
   );
 }
@@ -464,6 +494,7 @@ export function WithValueSelectedOnFocus() {
       value={textFieldValue}
       onChange={handleTextFieldChange}
       selectTextOnFocus
+      autoComplete="off"
     />
   );
 }
@@ -572,6 +603,7 @@ export function WithInlineSuggestion() {
         value={value}
         onChange={handleChange}
         suggestion={suggestion}
+        autoComplete="off"
       />
     </div>
   );

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -90,6 +90,11 @@ interface NonMutuallyExclusiveProps {
   disabled?: boolean;
   /** Show a clear text button in the input */
   clearButton?: boolean;
+  /** Show an icon button within the input */
+  iconButton?: {
+    icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+    accessibilityLabel: string;
+  } | null;
   /** Indicates whether or not the entire value should be selected on focus. */
   selectTextOnFocus?: boolean;
   /** An inline autocomplete suggestion containing the input value. The characters that complete the input value are selected for ease of deletion on input change or keypress of Backspace/Delete. The selected substring is visually highlighted with subdued styling. */
@@ -156,6 +161,8 @@ interface NonMutuallyExclusiveProps {
   monospaced?: boolean;
   /** Callback fired when clear button is clicked */
   onClearButtonClick?(id: string): void;
+  /** Callback fired when icon button is clicked */
+  onIconButtonClick?(id: string): void;
   /** Callback fired when value is changed */
   onChange?(value: string, id: string): void;
   /** Callback fired when input is focused */
@@ -189,6 +196,7 @@ export function TextField({
   labelHidden,
   disabled,
   clearButton,
+  iconButton,
   readOnly,
   autoFocus,
   focused,
@@ -222,6 +230,7 @@ export function TextField({
   selectTextOnFocus,
   suggestion,
   onClearButtonClick,
+  onIconButtonClick,
   onChange,
   onFocus,
   onBlur,
@@ -333,7 +342,7 @@ export function TextField({
     clearButton && clearButtonVisible ? (
       <button
         type="button"
-        className={styles.ClearButton}
+        className={styles.IconButton}
         onClick={handleClearButtonPress}
         disabled={disabled}
       >
@@ -343,6 +352,20 @@ export function TextField({
         <Icon source={CircleCancelMinor} color="base" />
       </button>
     ) : null;
+
+  const iconButtonMarkup = iconButton ? (
+    <button
+      type="button"
+      className={styles.IconButton}
+      onClick={handleIconButtonPress}
+      disabled={disabled}
+    >
+      <Text variant="bodySm" as="span" visuallyHidden>
+        {iconButton.accessibilityLabel}
+      </Text>
+      <Icon source={iconButton.icon} color="base" />
+    </button>
+  ) : null;
 
   const handleNumberChange = useCallback(
     (steps: number) => {
@@ -567,6 +590,7 @@ export function TextField({
           {suffixMarkup}
           {characterCountMarkup}
           {clearButtonMarkup}
+          {iconButtonMarkup}
           {spinnerMarkup}
           {backdropMarkup}
           {resizer}
@@ -624,6 +648,10 @@ export function TextField({
 
   function handleClearButtonPress() {
     onClearButtonClick && onClearButtonClick(id);
+  }
+
+  function handleIconButtonPress() {
+    onIconButtonClick && onIconButtonClick(id);
   }
 
   function handleKeyPress(event: React.KeyboardEvent) {

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
+import {ViewMinor} from '@shopify/polaris-icons';
 
 import {Connected} from '../../Connected';
 import {InlineError} from '../../InlineError';
@@ -115,7 +116,9 @@ describe('<TextField />', () => {
         </div>,
       );
 
-      textField.find(Spinner)!.domNode?.dispatchEvent(event);
+      textField.act(() => {
+        textField.find(Spinner)!.domNode?.dispatchEvent(event);
+      });
       expect(onClick).toHaveBeenCalled();
     });
 
@@ -1379,7 +1382,7 @@ describe('<TextField />', () => {
         />,
       );
       expect(textField).toContainReactComponent('button', {
-        className: 'ClearButton',
+        className: 'IconButton',
       });
     });
 
@@ -1396,7 +1399,7 @@ describe('<TextField />', () => {
       );
 
       expect(textField).not.toContainReactComponent('button', {
-        className: 'ClearButton',
+        className: 'IconButton',
       });
     });
 
@@ -1415,7 +1418,7 @@ describe('<TextField />', () => {
         />,
       );
 
-      textField.find('button', {className: 'ClearButton'})!.trigger('onClick');
+      textField.find('button', {className: 'IconButton'})!.trigger('onClick');
 
       expect(spy).toHaveBeenCalledWith('MyTextField');
     });
@@ -1433,7 +1436,7 @@ describe('<TextField />', () => {
       );
 
       expect(textField).not.toContainReactComponent('button', {
-        className: 'ClearButton',
+        className: 'IconButton',
       });
     });
 
@@ -1449,6 +1452,62 @@ describe('<TextField />', () => {
       );
       expect(textField).toContainReactComponent('div', {
         className: 'Backdrop Backdrop-connectedLeft Backdrop-connectedRight',
+      });
+    });
+  });
+
+  describe('iconButton', () => {
+    it('renders an icon button when true', () => {
+      const textField = mountWithApp(
+        <TextField
+          id="MyTextField"
+          label="TextField"
+          onChange={noop}
+          type="text"
+          value="test value"
+          autoComplete="off"
+          iconButton={{icon: ViewMinor, accessibilityLabel: 'iconButton'}}
+        />,
+      );
+      expect(textField).toContainReactComponent('button', {
+        className: 'IconButton',
+      });
+    });
+
+    it('calls onIconButtonClicked() with an id when the icon button is clicked', () => {
+      const spy = jest.fn();
+      const textField = mountWithApp(
+        <TextField
+          id="MyTextField"
+          label="TextField"
+          type="search"
+          onChange={noop}
+          onIconButtonClick={spy}
+          value="test value"
+          autoComplete="off"
+          iconButton={{icon: ViewMinor, accessibilityLabel: 'iconButton'}}
+        />,
+      );
+
+      textField.find('button', {className: 'IconButton'})!.trigger('onClick');
+
+      expect(spy).toHaveBeenCalledWith('MyTextField');
+    });
+
+    it('does not render an icon button by default', () => {
+      const textField = mountWithApp(
+        <TextField
+          id="MyTextField"
+          label="TextField"
+          onChange={noop}
+          type="text"
+          value="test value"
+          autoComplete="off"
+        />,
+      );
+
+      expect(textField).not.toContainReactComponent('button', {
+        className: 'IconButton',
       });
     });
   });

--- a/polaris.shopify.com/content/components/text-field.md
+++ b/polaris.shopify.com/content/components/text-field.md
@@ -93,6 +93,9 @@ examples:
   - fileName: text-field-with-clear-button.tsx
     title: With clear button
     description: Use to allow merchants to clear the content from a text field.
+  - fileName: text-field-with-icon-button.tsx
+    title: With icon button
+    description: Use to allow merchants to add an icon button inside a text field.
   - fileName: text-field-with-monospaced-font.tsx
     title: With monospaced font
     description: Use to apply a monospaced font to the TextField

--- a/polaris.shopify.com/pages/examples/text-field-with-icon-button.tsx
+++ b/polaris.shopify.com/pages/examples/text-field-with-icon-button.tsx
@@ -1,0 +1,35 @@
+import {TextField} from '@shopify/polaris';
+import {HideMinor, ViewMinor} from '@shopify/polaris-icons';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TextFieldWithIconButtonExample() {
+  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
+  const [showing, setShowing] = useState(false);
+
+  const handleTextFieldChange = useCallback(
+    (value) => setTextFieldValue(value),
+    [],
+  );
+
+  const handleIconButtonClick = useCallback(
+    () => setShowing(!showing),
+    [showing],
+  );
+
+  return (
+    <TextField
+      label="Store name"
+      value={showing ? textFieldValue : '••••••'}
+      onChange={handleTextFieldChange}
+      iconButton={{
+        icon: showing ? HideMinor : ViewMinor,
+        accessibilityLabel: 'PIN',
+      }}
+      onIconButtonClick={handleIconButtonClick}
+      autoComplete="off"
+    />
+  );
+}
+
+export default withPolarisExample(TextFieldWithIconButtonExample);

--- a/polaris.shopify.com/src/data/props.json
+++ b/polaris.shopify.com/src/data/props.json
@@ -9291,6 +9291,14 @@
         {
           "filePath": "polaris-react/src/components/TextField/TextField.tsx",
           "syntaxKind": "PropertySignature",
+          "name": "iconButton",
+          "value": "{icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>; accessibilityLabel: string;} | null",
+          "description": "Show an icon button within the input",
+          "isOptional": true
+        },
+        {
+          "filePath": "polaris-react/src/components/TextField/TextField.tsx",
+          "syntaxKind": "PropertySignature",
           "name": "selectTextOnFocus",
           "value": "boolean",
           "description": "Indicates whether or not the entire value should be selected on focus.",
@@ -9549,6 +9557,14 @@
           "name": "onClearButtonClick",
           "value": "(id: string) => void",
           "description": "Callback fired when clear button is clicked",
+          "isOptional": true
+        },
+        {
+          "filePath": "polaris-react/src/components/TextField/TextField.tsx",
+          "syntaxKind": "MethodSignature",
+          "name": "onIconButtonClick",
+          "value": "(id: string) => void",
+          "description": "Callback fired when icon button is clicked",
           "isOptional": true
         },
         {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Part of shopify/retail-upmarket#619

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Add an optional icon button and action inside the text field.
The icon is a generalized version of the already-implemented clear button.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {HideMinor, ViewMinor} from '@shopify/polaris-icons';

import {TextField, Page} from '../src';

export function Playground() {
  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
  const [showing, setShowing] = useState(false);

  const handleTextFieldChange = useCallback(
    (value: string) => setTextFieldValue(value),
    [],
  );

  const handleIconButtonClick = useCallback(
    () => setShowing(!showing),
    [showing],
  );

  return (
    <Page title="Playground">
      <TextField
        label="Store name"
        value={showing ? textFieldValue : '••••••'}
        onChange={handleTextFieldChange}
        iconButton={{
          icon: showing ? HideMinor : ViewMinor,
          accessibilityLabel: 'PIN',
        }}
        onIconButtonClick={handleIconButtonClick}
        autoComplete="off"
      />{' '}
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
