### PR TITLE
Remove superfluouss useCallbacks from tab code examples

### DIFF
--- a/polaris.shopify.com/pages/examples/tabs-default.tsx
+++ b/polaris.shopify.com/pages/examples/tabs-default.tsx
@@ -1,14 +1,9 @@
 import {Card, Tabs} from '@shopify/polaris';
-import {useState, useCallback} from 'react';
+import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TabsExample() {
   const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
 
   const tabs = [
     {
@@ -36,7 +31,7 @@ function TabsExample() {
 
   return (
     <Card>
-      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
+      <Tabs tabs={tabs} selected={selected} onSelect={setSelected}>
         <Card.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
         </Card.Section>

--- a/polaris.shopify.com/pages/examples/tabs-fitted.tsx
+++ b/polaris.shopify.com/pages/examples/tabs-fitted.tsx
@@ -1,14 +1,9 @@
 import {Card, Tabs} from '@shopify/polaris';
-import {useState, useCallback} from 'react';
+import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function FittedTabsExample() {
   const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
 
   const tabs = [
     {
@@ -26,7 +21,7 @@ function FittedTabsExample() {
 
   return (
     <Card>
-      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
+      <Tabs tabs={tabs} selected={selected} onSelect={setSelected} fitted>
         <Card.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
         </Card.Section>

--- a/polaris.shopify.com/pages/examples/tabs-with-badge-content.tsx
+++ b/polaris.shopify.com/pages/examples/tabs-with-badge-content.tsx
@@ -1,14 +1,9 @@
 import {Badge, Card, Tabs} from '@shopify/polaris';
-import {useState, useCallback} from 'react';
+import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TabsWithBadgeExample() {
   const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
 
   const tabs = [
     {
@@ -34,7 +29,7 @@ function TabsWithBadgeExample() {
 
   return (
     <Card>
-      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
+      <Tabs tabs={tabs} selected={selected} onSelect={setSelected} fitted>
         <Card.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
         </Card.Section>

--- a/polaris.shopify.com/pages/examples/tabs-with-custom-disclosure.tsx
+++ b/polaris.shopify.com/pages/examples/tabs-with-custom-disclosure.tsx
@@ -1,14 +1,9 @@
 import {Card, Tabs} from '@shopify/polaris';
-import {useState, useCallback} from 'react';
+import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TabsWithCustomDisclosureExample() {
   const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
 
   const tabs = [
     {
@@ -39,7 +34,7 @@ function TabsWithCustomDisclosureExample() {
       <Tabs
         tabs={tabs}
         selected={selected}
-        onSelect={handleTabChange}
+        onSelect={setSelected}
         disclosureText="More views"
       >
         <Card.Section title={tabs[selected].content}>


### PR DESCRIPTION
### WHY are these changes introduced?

I cargo-culted a `useCallback` from the examples and [got called out on it](https://github.com/Shopify/partners/pull/43725#discussion_r1033836949) 🤣 

If I can make this bungle (while usually knowing better), someone else may do the same while referencing the code samples from the docs.

### WHAT is this pull request doing?

Removes some premature optimization to simplify the code examples.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
