### PR TITLE
[stylelint-polaris][v5] Final rule categorization

### DIFF
--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -27,7 +27,7 @@ const stylelintPolarisCoverageOptions = {
     ],
     'stylelint-polaris/at-rule-disallowed-list': {
       include: [
-        // mixins
+        // Legacy mixins
         /([\w-]+\.)?color-icon($|\()/,
         /([\w-]+\.)?recolor-icon($|\()/,
         /([\w-]+\.)?control-backdrop($|\()/,
@@ -35,6 +35,7 @@ const stylelintPolarisCoverageOptions = {
       ],
     },
     'stylelint-polaris/global-disallowed-list': [
+      // Legacy mixin map-get data
       /\$polaris-colors/,
       /\$color-filter-palette-data/,
       /\$color-palette-data/,
@@ -50,10 +51,18 @@ const stylelintPolarisCoverageOptions = {
       /([\w-]+\.)?duration/,
       /([\w-]+\.)?easing/,
     ],
+    'declaration-property-unit-disallowed-list': [
+      {
+        '/^animation/': ['ms', 's'],
+        '/^transition/': ['ms', 's'],
+      },
+      {severity: 'warning'},
+    ],
     'stylelint-polaris/at-rule-disallowed-list': {
       include: [/([\w-]+\.)?skeleton-shimmer($|\()/],
     },
     'stylelint-polaris/global-disallowed-list': [
+      // Legacy mixin map-get data
       /\$duration-data/,
       /\$polaris-duration-map/,
       /\$skeleton-shimmer-duration/,
@@ -64,10 +73,17 @@ const stylelintPolarisCoverageOptions = {
       /--p-duration-1-5-0/,
     ],
   },
-  typography: {
+  font: {
     'declaration-property-value-disallowed-list': {
       'font-weight': [/(\$.*|[0-9]+)/],
     },
+    'declaration-property-unit-disallowed-list': [
+      {
+        '/^font/': ['px', 'rem', 'em'],
+        'line-height': ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
     'function-disallowed-list': [
       /([\w-]+\.)?font-family/,
       /([\w-]+\.)?font-size/,
@@ -94,6 +110,7 @@ const stylelintPolarisCoverageOptions = {
       ],
     },
     'stylelint-polaris/global-disallowed-list': [
+      // Legacy mixin map-get data
       /\$typography-condensed/,
       /\$typography-condensed/,
       /\$base-font-size/,
@@ -110,19 +127,25 @@ const stylelintPolarisCoverageOptions = {
     'declaration-property-value-disallowed-list': [
       {
         display: ['grid', 'flex'],
+        position: ['sticky'],
         top: [/(?!var\(--p-).+$/],
         bottom: [/(?!var\(--p-).+$/],
         left: [/(?!var\(--p-).+$/],
         right: [/(?!var\(--p-).+$/],
         width: [/(?!var\(--p-).+$/],
         height: [/(?!var\(--p-).+$/],
-        'z-index': [/(?!var\(--p-).+$/],
       },
       {severity: 'warning'},
     ],
+    'declaration-property-unit-disallowed-list': [
+      {
+        '/^width/': ['px', 'rem', 'em'],
+        '/^height/': ['px', 'rem', 'em'],
+      },
+      {severity: 'error'},
+    ],
     'property-disallowed-list': [
       [
-        'position',
         'grid',
         'flex',
         'flex-grow',
@@ -141,7 +164,6 @@ const stylelintPolarisCoverageOptions = {
         'grid-template-rows',
         'grid-template-columns',
         'grid-area',
-        'display',
       ],
       {severity: 'warning'},
     ],
@@ -161,11 +183,13 @@ const stylelintPolarisCoverageOptions = {
         /([\w-]+\.)?hidden-when-printing($|\()/,
         /([\w-]+\.)?print-hidden($|\()/,
         /([\w-]+\.)?layout-flex-fix($|\()/,
+        /([\w-]+\.)?safe-area-for($|\()/,
         /([\w-]+\.)?skeleton-page-header-layout($|\()/,
         /([\w-]+\.)?skeleton-page-secondary-actions-layout($|\()/,
       ],
     },
     'stylelint-polaris/global-disallowed-list': [
+      // Legacy mixin map-get data
       /\$layout-width-data/,
       /\$navigation-width/,
       /\$small-thumbnail-size/,
@@ -176,6 +200,7 @@ const stylelintPolarisCoverageOptions = {
       /--p-range-slider-thumb-size-base/,
       /--p-range-slider-thumb-size-active/,
       /--p-override-visible/,
+      /--p-override-loading-z-index/,
       /--p-icon-size/,
       /--p-choice-size/,
     ],
@@ -188,7 +213,16 @@ const stylelintPolarisCoverageOptions = {
       /([\w-]+\.)?rem/,
       /([\w-]+\.)?spacing/,
     ],
+    'declaration-property-unit-disallowed-list': [
+      {
+        '/^padding/': ['px', 'rem', 'em'],
+        '/^margin/': ['px', 'rem', 'em'],
+        '/^gap/': ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
     'stylelint-polaris/global-disallowed-list': [
+      // Legacy mixin map-get data
       /\$polaris-spacing/,
       /\$spacing-data/,
       /\$actions-vertical-spacing/,
@@ -199,6 +233,16 @@ const stylelintPolarisCoverageOptions = {
     ],
   },
   shape: {
+    'declaration-property-unit-disallowed-list': [
+      {
+        'border-width': ['px', 'rem', 'em'],
+        border: ['px', 'rem', 'em'],
+        'border-radius': ['px', 'rem', 'em'],
+        'outline-offset': ['px', 'rem', 'em'],
+        outline: ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
     'stylelint-polaris/at-rule-disallowed-list': {
       include: [
         /([\w-]+\.)?border-radius/,
@@ -212,6 +256,7 @@ const stylelintPolarisCoverageOptions = {
       ],
     },
     'stylelint-polaris/global-disallowed-list': [
+      // Legacy mixin map-get data
       /\$border-radius-data/,
       /\$border-width-data/,
       /\$borders-data/,
@@ -232,7 +277,15 @@ const stylelintPolarisCoverageOptions = {
   },
   depth: {
     'function-disallowed-list': [/([\w-]+\.)?shadow/],
+    'declaration-property-unit-disallowed-list': [
+      {
+        'box-shadow': ['px', 'rem', 'em'],
+      },
+      {severity: 'warning'},
+    ],
+    'property-disallowed-list': [['text-shadow'], {severity: 'warning'}],
     'stylelint-polaris/global-disallowed-list': [
+      // Legacy mixin map-get data
       /\$shadows-data/,
       /\$fixed-element-stacking-order/,
       /\$global-elements/,
@@ -244,15 +297,25 @@ const stylelintPolarisCoverageOptions = {
       /--p-popover-shadow/,
       /--p-modal-shadow/,
       /--p-top-bar-shadow/,
+    ],
+  },
+  'z-index': {
+    'declaration-property-value-allowed-list': [
+      {
+        'z-index': [/--p-z-\b([1-9]|1[0-2])\b/],
+      },
+      {severity: 'warning'},
+    ],
+    'function-disallowed-list': [/([\w-]+\.)?z-index/],
+    'stylelint-polaris/global-disallowed-list': [
+      // Legacy mixin map-get data
+      /\$fixed-element-stacking-order/,
+      /\$global-elements/,
+      // Legacy custom properties
       /--p-override-loading-z-index/,
     ],
   },
   conventions: {
-    'unit-disallowed-list': [
-      // TODO: Should 's' and 'ms' move to `motion`?
-      ['px', 'rem', 'em', 's', 'ms'],
-      {severity: 'warning'},
-    ],
     'stylelint-polaris/custom-properties-allowed-list': {
       // Allow any custom property not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
       allowedProperties: [/--(?!(p|pc|polaris-version)-).+/],
@@ -268,16 +331,9 @@ const stylelintPolarisCoverageOptions = {
         ],
       },
     },
-    'stylelint-polaris/global-disallowed-list': [
-      / \* \$/,
-      // Legacy custom properties
-      /--p-override-none/,
-      /--p-override-one/,
-      /--p-override-zero/,
-      /--p-non-null-content/,
-    ],
   },
-  mediaQueries: {
+  breakpoints: {
+    // Legacy functions
     'function-disallowed-list': [
       /([\w-]+\.)?breakpoint/,
       /([\w-]+\.)?layout-width/,
@@ -292,6 +348,7 @@ const stylelintPolarisCoverageOptions = {
         /^\$p-breakpoints-(xs|sm|md|lg|xl)-(up|down|only)$/,
       ],
     },
+    // Legacy mixins
     'stylelint-polaris/at-rule-disallowed-list': {
       include: [
         /([\w-]+\.)?after-topbar-sheet($|\()/,
@@ -326,7 +383,8 @@ const stylelintPolarisCoverageOptions = {
       ],
     },
   },
-  legacySass: {
+  legacy: {
+    // Legacy mixins
     'stylelint-polaris/at-rule-disallowed-list': {
       include: [
         /([\w-]+\.)?base-button-disabled($|\()/,
@@ -335,6 +393,8 @@ const stylelintPolarisCoverageOptions = {
         /([\w-]+\.)?button-full-width($|\()/,
         /([\w-]+\.)?button-outline-disabled($|\()/,
         /([\w-]+\.)?button-outline($|\()/,
+        /([\w-]+\.)?control-backdrop($|\()/,
+        /([\w-]+\.)?list-selected-indicator($|\()/,
         /([\w-]+\.)?plain-button-backdrop($|\()/,
         /([\w-]+\.)?unstyled-button($|\()/,
         /([\w-]+\.)?skeleton-content($|\()/,
@@ -343,15 +403,23 @@ const stylelintPolarisCoverageOptions = {
         /([\w-]+\.)?unstyled-list($|\()/,
         /([\w-]+\.)?range-thumb-selectors($|\()/,
         /([\w-]+\.)?range-track-selectors($|\()/,
+        /([\w-]+\.)?state($|\()/,
         /([\w-]+\.)?visually-hidden($|\()/,
       ],
     },
+    // Legacy functions
     'function-disallowed-list': [
       /([\w-]+\.)?available-names/,
       /([\w-]+\.)?map-extend/,
-      /([\w-]+\.)?control-backdrop($|\()/,
-      /([\w-]+\.)?list-selected-indicator($|\()/,
-      /([\w-]+\.)?state($|\()/,
+    ],
+    'stylelint-polaris/global-disallowed-list': [
+      // Legacy variables
+      / \* \$/,
+      // Legacy custom properties
+      /--p-override-none/,
+      /--p-override-one/,
+      /--p-override-zero/,
+      /--p-non-null-content/,
     ],
   },
 };


### PR DESCRIPTION
### WHY are these changes being introduced?
To unblock the release of v5 and enabling the linter in `@shopify/polaris` after running the disable comments codemod.

### WHAT is this pull request doing?

This PR fixes:
 - Miscategorization of a few legacy at-rules grouped into `function-disallowed-list` instead of `stylelint-polaris/at-rule-disallowed-list`
- Categories not mapping to token groups:
  - ~Changed typography to font~
  - Added z-index category
  - Changed mediaQueries to breakpoints
  - Changed legacySass to legacy (as it encompasses legacy Sass API stuff and legacy CSS custom properties)