### PR TITLE
Bump size limit threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     {
       "name": "polaris-react-cjs",
       "path": "polaris-react/build/cjs/index.js",
-      "limit": "216 kB"
+      "limit": "220 kB"
     },
     {
       "name": "polaris-react-esm",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The `SkeletonPage` rebuild [PR](https://github.com/Shopify/polaris/pull/7797) currently in progress is exceeding the size limit. This PR increases the size limit threshold from `216 kB` to `220 kB` to allow the size limit check to pass

<!--
  Context about the problem that’s being addressed.
-->

