### PR TITLE
[Navigation] Add a tooltip to display the label for truncated nav items only

### DIFF
--- a/.changeset/kind-candles-report.md
+++ b/.changeset/kind-candles-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Add a tooltip to display the label for truncated navigation items

--- a/polaris-react/src/components/Navigation/Navigation.stories.tsx
+++ b/polaris-react/src/components/Navigation/Navigation.stories.tsx
@@ -488,10 +488,30 @@ export function WithTruncationForVariousStates() {
             },
             {
               url: '/path/to/place',
+              label: 'Not truncated',
+              icon: OrdersMinor,
+              selected: false,
+            },
+            {
+              url: '/path/to/place',
               label: 'Lengthy label with secondary action',
               icon: OrdersMinor,
               selected: false,
               truncateText: true,
+              secondaryAction: {
+                url: '/admin/orders/add',
+                accessibilityLabel: 'Add an order',
+                icon: CirclePlusOutlineMinor,
+                tooltip: {
+                  content: 'Add a lengthy order',
+                },
+              },
+            },
+            {
+              url: '/path/to/place',
+              label: 'Lengthy non-truncated label with secondary action',
+              icon: OrdersMinor,
+              selected: false,
               secondaryAction: {
                 url: '/admin/orders/add',
                 accessibilityLabel: 'Add an order',
@@ -540,7 +560,6 @@ export function WithTruncationForVariousStates() {
                   url: '/admin/products/inventory',
                   disabled: false,
                   label: 'Inventoy',
-                  new: true,
                 },
               ],
             },

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -5,6 +5,8 @@ import React, {
   MouseEvent,
   ReactNode,
   useCallback,
+  useRef,
+  useLayoutEffect,
 } from 'react';
 
 import {classNames} from '../../../../utilities/css';
@@ -24,6 +26,7 @@ import {Tooltip, TooltipProps} from '../../../Tooltip';
 import {Secondary} from './components';
 
 export const MAX_SECONDARY_ACTIONS = 2;
+const TOOLTIP_HOVER_DELAY = 1000;
 
 interface ItemURLDetails {
   url?: string;
@@ -110,12 +113,21 @@ export function Item({
   const secondaryNavigationId = useUniqueId('SecondaryNavigation');
   const {location, onNavigationDismiss} = useContext(NavigationContext);
   const [keyFocused, setKeyFocused] = useState(false);
+  const navTextRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
 
   useEffect(() => {
     if (!isNavigationCollapsed && expanded) {
       onToggleExpandedState?.();
     }
   }, [expanded, isNavigationCollapsed, onToggleExpandedState]);
+
+  useLayoutEffect(() => {
+    const navTextNode = navTextRef.current;
+    if (truncateText && navTextNode) {
+      setIsTruncated(navTextNode.scrollHeight > navTextNode.clientHeight);
+    }
+  }, [truncateText]);
 
   const handleKeyUp = useCallback(
     (event: React.KeyboardEvent) => {
@@ -171,12 +183,13 @@ export function Item({
       <div className={styles.Badge}>{badgeMarkup}</div>
     );
 
-  const labelMarkup = (
+  const itemLabelMarkup = (
     <span
       className={classNames(
         styles.Text,
         truncateText && styles['Text-truncated'],
       )}
+      ref={navTextRef}
     >
       {label}
       {indicatorMarkup}
@@ -204,7 +217,7 @@ export function Item({
           onBlur={handleBlur}
         >
           {iconMarkup}
-          {labelMarkup}
+          {itemLabelMarkup}
           {wrappedBadgeMarkup}
         </button>
       </li>
@@ -247,7 +260,7 @@ export function Item({
   const itemContentMarkup = (
     <>
       {iconMarkup}
-      {labelMarkup}
+      {itemLabelMarkup}
       {secondaryActionMarkup ? null : wrappedBadgeMarkup}
     </>
   );
@@ -290,27 +303,6 @@ export function Item({
     showExpanded && styles.subNavigationActive,
     childIsActive && styles['Item-child-active'],
     keyFocused && styles.keyFocused,
-  );
-
-  const itemLinkMarkup = (
-    <UnstyledLink
-      url={url}
-      className={itemClassName}
-      external={external}
-      tabIndex={tabIndex}
-      aria-disabled={disabled}
-      aria-label={accessibilityLabel}
-      onClick={getClickHandler(onClick)}
-      onKeyUp={handleKeyUp}
-      onBlur={handleBlur}
-      {...normalizeAriaAttributes(
-        secondaryNavigationId,
-        subNavigationItems.length > 0,
-        showExpanded,
-      )}
-    >
-      {itemContentMarkup}
-    </UnstyledLink>
   );
 
   let secondaryNavigationMarkup: ReactNode = null;
@@ -362,6 +354,41 @@ export function Item({
     Boolean(actions && actions.length) && styles['ListItem-hasAction'],
   );
 
+  const itemLinkMarkup = () => {
+    const linkMarkup = (
+      <UnstyledLink
+        url={url}
+        className={itemClassName}
+        external={external}
+        tabIndex={tabIndex}
+        aria-disabled={disabled}
+        aria-label={accessibilityLabel}
+        onClick={getClickHandler(onClick)}
+        onKeyUp={handleKeyUp}
+        onBlur={handleBlur}
+        {...normalizeAriaAttributes(
+          secondaryNavigationId,
+          subNavigationItems.length > 0,
+          showExpanded,
+        )}
+      >
+        {itemContentMarkup}
+      </UnstyledLink>
+    );
+
+    return isTruncated ? (
+      <Tooltip
+        hoverDelay={TOOLTIP_HOVER_DELAY}
+        content={label}
+        preferredPosition="above"
+      >
+        {linkMarkup}
+      </Tooltip>
+    ) : (
+      linkMarkup
+    );
+  };
+
   return (
     <li className={className}>
       <div className={styles.ItemWrapper}>
@@ -377,12 +404,12 @@ export function Item({
           secondaryActionMarkup &&
           wrappedBadgeMarkup ? (
             <span className={styles.ItemWithFloatingActions}>
-              {itemLinkMarkup}
+              {itemLinkMarkup()}
               {secondaryActionMarkup}
             </span>
           ) : (
             <>
-              {itemLinkMarkup}
+              {itemLinkMarkup()}
               {secondaryActionMarkup}
             </>
           )}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->
### WHY are these changes introduced?
>**Warning**
>This ticket is blocked by https://github.com/Shopify/core-workflows/issues/609 for the tooltip deplay

Fixes https://github.com/Shopify/core-workflows/issues/632

We are moving some hacks from web into the Polaris navigation components, this is part of that effort as outlined in the ticket above. We introduced truncation of navigation items, this change will allow the complete labels to be visible when hovering. 

<img width="400" src="https://user-images.githubusercontent.com/1307190/208170669-c541c323-50b3-4dc5-91c2-5cb058a4272e.gif" />


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

We are introducing a check on the navigation item content to see if it has in fact been truncated. If the content has been truncated then when it is hovered a tooltip is rendering displaying the labels full text. (Most likely for app/channel titles)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

 <details>
      <summary>Truncated navigation items now have a tooltip that appears, it does not appear for non-truncated</summary>
      <img src="https://user-images.githubusercontent.com/33904740/206476676-e97c1f6b-7b23-458a-a16f-793e40f23e36.gif" alt="When hovering over truncated navigation items a tooltip appears, when hover non-truncated items no tooltip is displayed">
    </details>

🎩  Polaris Storybook Spinstance -> [https://polaris.truncated-text-tooltip-finishing.raman-lally.us.spin.dev/?path=/story/all-components-navigation--with-truncation-for-various-states](https://polaris.truncated-text-tooltip-finishing.raman-lally.us.spin.dev/?path=/story/all-components-navigation--with-truncation-for-various-states)

### How to 🎩
🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
