### PR TITLE
[Text] Makes 'as' optional and use a default for 'variant'

### DIFF
--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -52,7 +52,7 @@ export interface TextProps {
   /** Adjust horizontal alignment of text */
   alignment?: Alignment;
   /** The element type */
-  as: Element;
+  as?: Element;
   /** Prevent text from overflowing */
   breakWord?: boolean;
   /** Text to display */
@@ -66,7 +66,7 @@ export interface TextProps {
   /** Truncate text overflow with ellipsis */
   truncate?: boolean;
   /** Typographic style of text */
-  variant: Variant;
+  variant?: Variant;
   /** Visually hide the text */
   visuallyHidden?: boolean;
 }
@@ -80,7 +80,7 @@ export const Text = ({
   fontWeight,
   id,
   truncate = false,
-  variant,
+  variant = 'bodyMd',
   visuallyHidden = false,
 }: TextProps) => {
   const Component = as || (visuallyHidden ? 'span' : 'p');


### PR DESCRIPTION
### WHY are these changes introduced?

While removing the deprecated `TextStyle` component in favour of `Text` I found myself repeating a lot of `<Text variant... as...>` so I wondered why `Text` couldn't use some sensible defaults for the `as` and `variant` so that a simple `<Text>Hello!</Text>` makes already sense without much to write or think about.

### WHAT is this pull request doing?

I suggest `bodyMd` as the default variant because according to the migration guide this is what a `TextStyle` would render.

Also, according to the very first line of the component:

```ts
  const Component = as || (visuallyHidden ? 'span' : 'p');
```

there was already in place the logic which consider `as` as an optional parameter, which is not reflected in the typings.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
