### PR TITLE
Update `stylelint-polaris` to define a single entry point

### DIFF
--- a/.changeset/shaggy-squids-attack.md
+++ b/.changeset/shaggy-squids-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': patch
+---
+
+Update `package.json` to define a single entry point

--- a/polaris-migrator/src/migrations/styles-insert-stylelint-disable/tests/test-config.js
+++ b/polaris-migrator/src/migrations/styles-insert-stylelint-disable/tests/test-config.js
@@ -1,7 +1,14 @@
+const path = require('path');
+
 module.exports = {
   customSyntax: 'postcss-scss',
   reportDescriptionlessDisables: true,
-  plugins: ['@shopify/stylelint-polaris/plugins/at-rule-disallowed-list'],
+  plugins: [
+    path.join(
+      __dirname,
+      '../../../../../stylelint-polaris/plugins/at-rule-disallowed-list',
+    ),
+  ],
   rules: {
     'unit-disallowed-list': ['rem'],
     'selector-pseudo-class-no-unknown': true,

--- a/stylelint-polaris/package.json
+++ b/stylelint-polaris/package.json
@@ -24,8 +24,8 @@
     "polaris",
     "stylelint"
   ],
-  "main": "index.js",
-  "types": "dist/index.d.ts",
+  "main": "./index.js",
+  "exports": "./index.js",
   "scripts": {
     "lint": "TIMING=1 eslint --cache .",
     "test": "jest",


### PR DESCRIPTION
We've removed (the experimental) support for manually accessing `stylelint-polaris/plugins/*` directly in v5 and this update enforces that with the `package.json` `exports` field: https://nodejs.org/api/packages.html#exports