### PR TITLE
[stylelint-polaris] Fix custom property allowed list plugin

### DIFF
--- a/.changeset/bright-snails-clean.md
+++ b/.changeset/bright-snails-clean.md
@@ -1,0 +1,7 @@
+---
+'@shopify/stylelint-polaris': patch
+---
+
+- Updated the `polaris/custom-property-allowed-list` plugin tests for unified config
+- Updated `polaris/custom-property-allowed-list` to report problems with tailored messages for each of the two configuration options
+- Fixed metadata URLs for `polaris/*` plugins

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -358,9 +358,6 @@ const stylelintPolarisCoverageOptions = {
         },
       },
     },
-    {
-      message: 'Please use a Polaris token or component',
-    },
   ],
   'media-queries': [
     {

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -341,24 +341,22 @@ const stylelintPolarisCoverageOptions = {
       message: 'Please use a Polaris z-index token',
     },
   ],
-  conventions: [
-    {
-      'polaris/custom-property-allowed-list': {
-        // Allows definition of custom properties not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
-        allowedProperties: [/--(?!(p|pc|polaris-version)-).+/],
-        // Allows use of custom properties prefixed with `--p-` that are valid Polaris tokens
-        allowedValues: {
-          '/.+/': [
-            // Note: Order is important
-            // This pattern allows use of `--p-*` custom properties that are valid Polaris tokens
-            ...getCustomPropertyNames(tokens),
-            // This pattern flags unknown `--p-*` custom properties or usage of deprecated `--pc-*` custom properties private to polaris-react
-            /--(?!(p|pc)-).+/,
-          ],
-        },
+  conventions: {
+    'polaris/custom-property-allowed-list': {
+      // Allows definition of custom properties not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
+      allowedProperties: [/--(?!(p|pc|polaris-version)-).+/],
+      // Allows use of custom properties prefixed with `--p-` that are valid Polaris tokens
+      allowedValues: {
+        '/.+/': [
+          // Note: Order is important
+          // This pattern allows use of `--p-*` custom properties that are valid Polaris tokens
+          ...getCustomPropertyNames(tokens),
+          // This pattern flags unknown `--p-*` custom properties or usage of deprecated `--pc-*` custom properties private to polaris-react
+          /--(?!(p|pc)-).+/,
+        ],
       },
     },
-  ],
+  },
   'media-queries': [
     {
       'polaris/media-query-allowed-list': {

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -352,7 +352,7 @@ const stylelintPolarisCoverageOptions = {
             // Note: Order is important
             // This pattern allows use of `--p-*` custom properties that are valid Polaris tokens
             ...getCustomPropertyNames(tokens),
-            // This pattern flags unknown `--p-*` custom properties or usage of `--pc-*` custom properties private to polaris-react
+            // This pattern flags unknown `--p-*` custom properties or usage of deprecated `--pc-*` custom properties private to polaris-react
             /--(?!(p|pc)-).+/,
           ],
         },

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -344,16 +344,15 @@ const stylelintPolarisCoverageOptions = {
   conventions: [
     {
       'polaris/custom-property-allowed-list': {
-        // Allow any custom property not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
+        // Allows definition of custom properties not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
         allowedProperties: [/--(?!(p|pc|polaris-version)-).+/],
+        // Allows use of custom properties prefixed with `--p-` that are valid Polaris tokens
         allowedValues: {
           '/.+/': [
-            // Note: Order is important.
-            // The first pattern validates `--p-*`
-            // custom properties are valid Polaris tokens
+            // Note: Order is important
+            // This pattern allows use of `--p-*` custom properties that are valid Polaris tokens
             ...getCustomPropertyNames(tokens),
-            // and the second pattern flags unknown `--p-*` custom properties
-            // or usages of our "private" `--pc-*` custom properties
+            // This pattern flags unknown `--p-*` custom properties or usage of `--pc-*` custom properties private to polaris-react
             /--(?!(p|pc)-).+/,
           ],
         },

--- a/stylelint-polaris/plugins/coverage/index.js
+++ b/stylelint-polaris/plugins/coverage/index.js
@@ -139,7 +139,10 @@ function getMeta(category, stylelintRuleName) {
     'https://polaris.shopify.com/tools/stylelint-polaris/rules';
 
   return {
-    url: `${baseMetaUrl}/${category}-${stylelintRuleName.replace('/', '-')}`,
+    url: `${baseMetaUrl}/${category}-${stylelintRuleName.replace(
+      'polaris/',
+      '',
+    )}`,
   };
 }
 

--- a/stylelint-polaris/plugins/coverage/index.test.js
+++ b/stylelint-polaris/plugins/coverage/index.test.js
@@ -59,7 +59,7 @@ testRule({
       code: '.class {color: var(--p-legacy-var);}',
       description: 'Uses disallowed legacy variable (custom rule)',
       message:
-        'Unexpected disallowed value "--p-legacy-var" - https://polaris.shopify.com/tools/stylelint-polaris/rules/legacy-polaris-global-disallowed-list',
+        'Unexpected disallowed value "--p-legacy-var" - https://polaris.shopify.com/tools/stylelint-polaris/rules/legacy-global-disallowed-list',
     },
   ],
 });

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.js
@@ -17,16 +17,16 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
    */
   rejected: (prop, value, prefix, isInvalidProp, invalidValues) => {
     if (isInvalidProp) {
-      return `Unexpected prefix "${prefix}" for defined custom property "${prop}" - Properties with prefixes "--p-" or "--pc-" cannot be defined outside of Polaris."`;
+      return `Unexpected prefix "${prefix}" for defined custom property "${prop}" - Properties with prefixes "--p-" or "--pc-" cannot be defined outside of Polaris"`;
     }
 
     if (invalidValues) {
       const plural = invalidValues.length > 1;
-      return `Unexpected value ${value} for property "${prop}" - Token${
+      return `Unexpected value "${value}" for property "${prop}" - Token${
         plural ? 's' : ''
-      } ${invalidValues.join(', ')} ${
+      } ${invalidValues.map((token) => `"${token}"`).join(', ')} ${
         plural ? 'are' : 'is'
-      } either private or do not exist.`;
+      } either private or ${plural ? 'do' : 'does'} not exist`;
     }
   },
 });

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.js
@@ -68,22 +68,24 @@ const {rule} = stylelint.createPlugin(
         const prop = decl.prop;
         const value = decl.value;
 
-        const isInvalidProp = isInvalidCustomProperty(allowedProperties, prop);
+        const isInvalidProperty = isInvalidCustomProperty(
+          allowedProperties,
+          prop,
+        );
+
         const invalidValues = getInvalidCustomPropertyValues(
           allowedValues,
           prop,
           value,
         );
 
-        console.log(isInvalidProp, prop, invalidValues);
-
-        if (isInvalidProp || invalidValues) {
+        if (isInvalidProperty || invalidValues) {
           stylelint.utils.report({
             message: messages.rejected(
               prop,
               value,
-              isInvalidProp ? getCustomPropertyPrefix(prop) : undefined,
-              isInvalidProp,
+              isInvalidProperty ? getCustomPropertyPrefix(prop) : undefined,
+              isInvalidProperty,
               invalidValues,
             ),
             node: decl,

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.js
@@ -82,12 +82,27 @@ const {rule} = stylelint.createPlugin(
           value,
         );
 
-        if (isInvalidProperty || invalidValues) {
+        if (isInvalidProperty) {
           stylelint.utils.report({
             message: messages.rejected(
               prop,
               value,
-              isInvalidProperty ? getCustomPropertyPrefix(prop) : undefined,
+              getCustomPropertyPrefix(prop),
+              isInvalidProperty,
+              invalidValues,
+            ),
+            node: decl,
+            result,
+            ruleName,
+          });
+        }
+
+        if (invalidValues) {
+          stylelint.utils.report({
+            message: messages.rejected(
+              prop,
+              value,
+              undefined,
               isInvalidProperty,
               invalidValues,
             ),

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.js
@@ -16,14 +16,17 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
    * @type {stylelint.RuleMessageFunc}
    */
   rejected: (prop, value, prefix, isInvalidProp, invalidValues) => {
-    if (isInvalidProp && !invalidValues) {
-      return `Unexpected prefix "${prefix}" for defined custom property "${prop}. Prefixes "--p-" or "--pc-" cannot be used outside of Polaris."`;
+    if (isInvalidProp) {
+      return `Unexpected prefix "${prefix}" for defined custom property "${prop}" - Properties with prefixes "--p-" or "--pc-" cannot be defined outside of Polaris."`;
     }
 
     if (invalidValues) {
-      return `Unexpected value${
-        invalidValues.length > 1 ? 's' : ''
-      } "${invalidValues.join(', ')}" for property "${prop}"`;
+      const plural = invalidValues.length > 1;
+      return `Unexpected value ${value} for property "${prop}" - Token${
+        plural ? 's' : ''
+      } ${invalidValues.join(', ')} ${
+        plural ? 'are' : 'is'
+      } either private or do not exist.`;
     }
   },
 });

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
@@ -14,30 +14,15 @@ const polarisCustomPropertyNames = getCustomPropertyNames(tokens);
   - Tokens with this prefix should be contributed to and/or replaced with polaris-tokens
 */
 
-const externalUserDefinedCustomPropertyNames = /--(?!pc?-).+/;
-const externalConfig = [
+const allowedCustomPropertyNames = /--(?!(p|pc|polaris-version)-).+/;
+const invalidOrDeprecatedPrivateCustomPropertyNames = /--(p|pc)-.+/;
+const config = [
   {
-    allowedProperties: [externalUserDefinedCustomPropertyNames],
+    allowedProperties: [allowedCustomPropertyNames],
     allowedValues: {
       '/.+/': [
         ...polarisCustomPropertyNames,
-        externalUserDefinedCustomPropertyNames,
-      ],
-    },
-  },
-];
-
-const internalPolarisComponentCustomProperties = /--pc-.+/;
-const internalConfig = [
-  {
-    allowedProperties: [
-      '--polaris-version-number',
-      internalPolarisComponentCustomProperties,
-    ],
-    allowedValues: {
-      '/.+/': [
-        internalPolarisComponentCustomProperties,
-        ...polarisCustomPropertyNames,
+        invalidOrDeprecatedPrivateCustomPropertyNames,
       ],
     },
   },
@@ -46,24 +31,20 @@ const internalConfig = [
 testRule({
   ruleName,
   plugins: [__dirname],
-  config: externalConfig,
+  config,
   accept: [
     {
       code: '.a { border: 1px red; }',
-      description: 'Uses no custom properties',
+      description: 'Use of no custom properties is allowed',
     },
     {
       code: '.a { --test: red; }',
       description:
-        "Defining custom-properties that don't start with --p- or --pc-",
+        "Defining custom-properties that don't start with --p- or --pc- is allowed",
     },
     {
       code: '.a { color: var(--p-text); }',
-      description: 'Using custom-properties from polaris-tokens',
-    },
-    {
-      code: '.a { --test: red; color: var(--test); }',
-      description: 'Using other custom-properties',
+      description: 'Using custom-properties from polaris-tokens is allowed',
     },
   ],
 
@@ -72,7 +53,7 @@ testRule({
       code: '.a { --p-test: red; }',
       description:
         'Defining custom-properties that start with --p- is disallowed',
-      message: messages.rejected('--p-test', 'red', true, undefined),
+      message: messages.rejected('--p-test', 'red', '--p-', true, undefined),
       line: 1,
       column: 6,
       endLine: 1,
@@ -82,7 +63,7 @@ testRule({
       code: '.a { --pc-test: red; }',
       description:
         'Defining custom-properties that start with --pc- is disallowed',
-      message: messages.rejected('--pc-test', 'red', true, undefined),
+      message: messages.rejected('--pc-test', 'red', '--pc-', true, undefined),
       line: 1,
       column: 6,
       endLine: 1,
@@ -95,8 +76,9 @@ testRule({
       message: messages.rejected(
         'color',
         'var(--p-unknown)',
+        undefined,
         false,
-        '--p-unknown',
+        ['--p-unknown'],
       ),
       line: 1,
       column: 6,
@@ -106,62 +88,13 @@ testRule({
     {
       code: '.a { color: var(--pc-test); }',
       description: 'Using --pc- prefixed tokens is disallowed',
-      message: messages.rejected('color', 'var(--pc-test)', false, '--pc-test'),
+      message: messages.rejected('color', 'var(--pc-test)', undefined, false, [
+        '--pc-test',
+      ]),
       line: 1,
       column: 6,
       endLine: 1,
       endColumn: 28,
-    },
-  ],
-});
-
-testRule({
-  ruleName,
-  plugins: [__dirname],
-  config: internalConfig,
-  accept: [
-    {
-      code: '.a { --pc-test: red; }',
-      description: 'Defining custom-properties that start with --pc-',
-    },
-    {
-      code: '.a { color: var(--p-text); }',
-      description: 'Using custom-properties from polaris-tokens',
-    },
-    {
-      code: '.a { color: var(--pc-my-value); }',
-      description: 'Using custom-properties that start with --pc-',
-    },
-  ],
-  reject: [
-    {
-      code: '.a { --p-test: red; }',
-      description:
-        'Defining custom-properties that start with --p- is disallowed',
-      message: messages.rejected('--p-test', 'red', true, undefined),
-      line: 1,
-      column: 6,
-      endLine: 1,
-      endColumn: 20,
-    },
-    {
-      code: '.a { --test: red; }',
-      description:
-        "Defining custom-properties that don't start with --p- or --pc- is disallowed",
-      message: messages.rejected('--test', 'red', true, undefined),
-      line: 1,
-      column: 6,
-      endLine: 1,
-      endColumn: 18,
-    },
-    {
-      code: '.a { color: var(--test); }',
-      description: 'Using other custom-properties',
-      message: messages.rejected('color', 'var(--test)', false, '--test'),
-      line: 1,
-      column: 6,
-      endLine: 1,
-      endColumn: 25,
     },
   ],
 });

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
@@ -5,13 +5,13 @@ const {messages, ruleName} = require('.');
 const polarisCustomPropertyNames = getCustomPropertyNames(tokens);
 
 /*
- -p-* Tokens are to be defined in polaris-tokens.
+ --p-* Tokens are to be defined in polaris-tokens.
    - Defining custom properties with this prefix anywhere else is disallowed
    - Usage of them is allowed
- -pc-* Tokens are reserved for usage by components in polaris-react
+ --pc-* Tokens are reserved for usage by components in polaris-react
   - Defining custom properties with this prefix is disallowed
-  - Any new usage of them is disallowed in polaris-react
-  - Tokens with this prefix should be contributed to and/or replaced with polaris-tokens
+  - Usage and definition of them is deprecated in polaris-react
+  - Existing tokens with this prefix should be contributed to and/or replaced with polaris-tokens
 */
 
 const allowedCustomPropertyNames = /--(?!(p|pc|polaris-version)-).+/;

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
@@ -4,14 +4,16 @@ const {messages, ruleName} = require('.');
 
 const polarisCustomPropertyNames = getCustomPropertyNames(tokens);
 
-// For external usage:
-// -p-* Tokens are reserved for usage by polaris-tokens.
-//   - Defining custom properties with this prefix is disallowed
-//   - Usage of them is allowed
-// -pc-* Tokens are reserved for usage by components in polaris-react
-//  - Defining custom properties with this prefix is disallowed
-//  - Usage of them is disallowed
-// Any other tokens can be freely defined and used
+/*
+ -p-* Tokens are to be defined in polaris-tokens.
+   - Defining custom properties with this prefix anywhere else is disallowed
+   - Usage of them is allowed
+ -pc-* Tokens are reserved for usage by components in polaris-react
+  - Defining custom properties with this prefix is disallowed
+  - Any new usage of them is disallowed in polaris-react
+  - Tokens with this prefix should be contributed to and/or replaced with polaris-tokens
+*/
+
 const externalUserDefinedCustomPropertyNames = /--(?!pc?-).+/;
 const externalConfig = [
   {
@@ -25,14 +27,6 @@ const externalConfig = [
   },
 ];
 
-// For internal usage:
-// -p-* Tokens are reserved for usage by polaris-tokens.
-//   - Defining custom properties with this prefix is disallowed
-//   - Usage of them is allowed
-// -pc-* Tokens are reserved for usage by components in polaris-react
-//  - Defining custom properties with this prefix is allowed
-//  - Usage of them is allowed
-// Any other tokens should not be defined or used
 const internalPolarisComponentCustomProperties = /--pc-.+/;
 const internalConfig = [
   {

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
@@ -15,7 +15,7 @@ const polarisCustomPropertyNames = getCustomPropertyNames(tokens);
 */
 
 const allowedCustomPropertyNames = /--(?!(p|pc|polaris-version)-).+/;
-const invalidOrDeprecatedPrivateCustomPropertyNames = /--(p|pc)-.+/;
+const invalidOrDeprecatedPrivateCustomPropertyNames = /--(?!(p|pc)-).+/;
 const config = [
   {
     allowedProperties: [allowedCustomPropertyNames],


### PR DESCRIPTION
### WHY are these changes introduced?

The `polaris/custom-property-allowed-list` plugin is currently reporting a single problem for what should be two different problems that can potentially exist in the same decl (`--p-test: var(--p-unknown);`):
- one problem for definition of custom property name with disallowed prefix
  - `--p-test: var(--p-space-1);`
- one problem for definition of custom property value with invalid Polaris token or private Polaris component token
  - `color: var(--p-unknown);`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR:
- Removes remnants of internal vs external configs
- Reports problems with specific error messages for each of the two rule configuration options
- Clarifies the intentions and configuration of the rule
- Fixes the metadata URLs of custom rules

### 🎩 checklist

- [x] Tested in VS Code (https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] Tested in terminal
