### PR TITLE
[Thumbnail] Add alt text to test case

### DIFF
--- a/polaris-react/src/components/Thumbnail/tests/Thumbnail.test.tsx
+++ b/polaris-react/src/components/Thumbnail/tests/Thumbnail.test.tsx
@@ -12,8 +12,8 @@ describe('<Thumbnail />', () => {
     });
 
     it('creates an image tag when a string is provided', () => {
-      const thumbnail = mountWithApp(<Thumbnail alt="" source="abc.jpg" />);
-      expect(thumbnail).toContainReactComponent('img');
+      const thumbnail = mountWithApp(<Thumbnail alt="some alt text" source="abc.jpg" />);
+      expect(thumbnail).toContainReactComponent('img', {alt: 'some alt text'});
     });
   });
 

--- a/polaris-react/src/components/Thumbnail/tests/Thumbnail.test.tsx
+++ b/polaris-react/src/components/Thumbnail/tests/Thumbnail.test.tsx
@@ -12,7 +12,9 @@ describe('<Thumbnail />', () => {
     });
 
     it('creates an image tag when a string is provided', () => {
-      const thumbnail = mountWithApp(<Thumbnail alt="some alt text" source="abc.jpg" />);
+      const thumbnail = mountWithApp(
+        <Thumbnail alt="some alt text" source="abc.jpg" />
+      );
       expect(thumbnail).toContainReactComponent('img', {alt: 'some alt text'});
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

As I was creating a component using Thumbnail, I referenced its tests and noticed that the test case doesn't verify that content passed via the `alt` prop shows up on the final `<img>`. This tiny PR adds that verification to the existing test.

### WHAT is this pull request doing?

Very little!

### 🎩 checklist

Let me know if any of the below are relevant; I believe that if CI passes, this shouldn't require even require updating any docs.

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
