### PR TITLE
[Tooltip] Add support for a hover delay before tooltip is displayed

### DIFF
--- a/.changeset/slimy-months-agree.md
+++ b/.changeset/slimy-months-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added support for hover delay before displaying tooltip

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -44,3 +44,37 @@ export function VisibleOnlyWithChildInteraction() {
     </div>
   );
 }
+
+export function WithHoverDelay() {
+  return (
+    <div style={{padding: '75px 0'}}>
+      <div style={{margin: '10px 0'}}>
+        <Tooltip content="This should appear right away.">
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            No delay
+          </Text>
+        </Tooltip>
+      </div>
+      <div style={{margin: '10px 0'}}>
+        <Tooltip hoverDelay={1000} content="This should appear after 1 second.">
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            1 second hover delay
+          </Text>
+        </Tooltip>
+      </div>
+      <div style={{margin: '10px 0'}}>
+        <Tooltip content="This should appear right away.">
+          <Button>No delay</Button>
+        </Tooltip>
+      </div>
+      <div style={{margin: '10px 0'}}>
+        <Tooltip
+          hoverDelay={2000}
+          content="This should appear after 2 seconds."
+        >
+          <Button>2 seconds hover delay</Button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -238,6 +238,52 @@ describe('<Tooltip />', () => {
       accessibilityLabel,
     });
   });
+
+  describe('with hoverDelay', () => {
+    it('renders on mouseOver after specified hoverDelay', () => {
+      jest.useFakeTimers();
+
+      const tooltip = mountWithApp(
+        <Tooltip hoverDelay={2000} content="Inner content">
+          <Link>link content</Link>
+        </Tooltip>,
+      );
+      findWrapperComponent(tooltip)!.trigger('onMouseOver');
+
+      expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
+
+      tooltip.act(() => jest.advanceTimersByTime(1999));
+
+      expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
+
+      tooltip.act(() => jest.advanceTimersByTime(1));
+
+      expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div');
+
+      jest.useRealTimers();
+    });
+
+    it('does not render on mouseOver if mouseLeave occurs before hoverDelay ellapses', () => {
+      jest.useFakeTimers();
+
+      const tooltip = mountWithApp(
+        <Tooltip hoverDelay={2000} content="Inner content">
+          <Link>link content</Link>
+        </Tooltip>,
+      );
+      findWrapperComponent(tooltip)!.trigger('onMouseOver');
+
+      tooltip.act(() => jest.advanceTimersByTime(500));
+
+      findWrapperComponent(tooltip)!.trigger('onMouseLeave');
+
+      tooltip.act(() => jest.advanceTimersByTime(2000));
+
+      expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
+
+      jest.useRealTimers();
+    });
+  });
 });
 
 function findWrapperComponent(tooltip: any) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves: Shopify/core-workflows/issues/609

Items in the side-nav bar may have a tooltip if the label is truncated. As user may be mousing down the navigation it would not be user friendly if the tooltip pops up while moving down the nav.

![tooltip-hover-delay](https://user-images.githubusercontent.com/1307190/207434028-be95386d-0fed-4aa5-aae5-aad9c8d99a2a.gif)


### WHAT is this pull request doing?

A `hoverDelay` prop is added to the `ToolTip` component which allow consumers to specify the required delay in milliseconds. By default there is no delay.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

An example can be seen in [storybook](https://polaris.ttd.jita-yi.us.spin.dev/?path=/story/all-components-tooltip--with-hover-delay).


🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
