### PR TITLE
[polaris.shopify.com] Fix component grid radius

### DIFF
--- a/.changeset/polite-files-warn.md
+++ b/.changeset/polite-files-warn.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed border radius of component images in the overview page.

--- a/polaris.shopify.com/src/components/Grid/Grid.module.scss
+++ b/polaris.shopify.com/src/components/Grid/Grid.module.scss
@@ -37,6 +37,10 @@
   overflow: hidden;
   margin-bottom: 1rem;
   border-radius: var(--border-radius-600);
+
+  img {
+    display: block;
+  }
 }
 
 .DeepLinks {


### PR DESCRIPTION
Before:

<img width="579" alt="image" src="https://user-images.githubusercontent.com/875708/207899582-b41b89f9-4272-4904-88d0-4480f29a8568.png">

After:

<img width="577" alt="image" src="https://user-images.githubusercontent.com/875708/207899656-dbafa74e-2394-421c-abb6-82310e0bfe17.png">
