### PR TITLE
Update `stylelint-polaris` config to address out of memory issues

### DIFF
--- a/.changeset/nervous-bats-switch.md
+++ b/.changeset/nervous-bats-switch.md
@@ -2,4 +2,4 @@
 '@shopify/stylelint-polaris': patch
 ---
 
-Use RegExp pattern to exclude invalid scope reports and address memory issues
+Use RegExp pattern to exclude reporting invalid scope disables and address memory issues

--- a/.changeset/nervous-bats-switch.md
+++ b/.changeset/nervous-bats-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': patch
+---
+
+Explore RegExp pattern for addressing out of memory issue

--- a/.changeset/nervous-bats-switch.md
+++ b/.changeset/nervous-bats-switch.md
@@ -2,4 +2,4 @@
 '@shopify/stylelint-polaris': patch
 ---
 
-Explore RegExp pattern for addressing out of memory issue
+Use RegExp pattern to exclude invalid scope reports and address memory issues

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -477,12 +477,7 @@ module.exports = {
       // Report invalid scope disables for all rules except coverage rules
       // Note: This doesn't affect the default Stylelint behavior/reporting
       // and is only need because we dynamically create these rule names
-      except: Object.entries(stylelintPolarisCoverageOptions).flatMap(
-        ([categoryName, categoryConfigRules]) =>
-          Object.keys(categoryConfigRules).map(
-            (categoryRuleName) => `polaris/${categoryName}/${categoryRuleName}`,
-          ),
-      ),
+      except: /^polaris\/.+?\/.+$/,
     },
   ],
   plugins: [


### PR DESCRIPTION
Note: The out of memory issue only occurs when using Stylelint programmatically to lint multiple repositories within the same process, such as on a coverage site. It does not occur when using Stylelint in a "regular" way, like running it from the CLI or within VS Code.

While moving from an array of string literal rule names to a regular expression pattern may result in a slight loss of accuracy, the consistent coverage rule naming conventions we have established should mitigate any potential issues.