### PR TITLE
Early exit if target function isn't present (`scss-replace-duration` and `scss-replace-easing`)

### DIFF
--- a/.changeset/twenty-pumpkins-fry.md
+++ b/.changeset/twenty-pumpkins-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Early exit if target function isn't present for the scss-replace-duration and scss-replace-easing migrations

--- a/polaris-migrator/src/migrations/scss-replace-duration/scss-replace-duration.ts
+++ b/polaris-migrator/src/migrations/scss-replace-duration/scss-replace-duration.ts
@@ -7,6 +7,7 @@ import {
   createSassMigrator,
   setNodeValue,
   StopWalkingFunctionNodes,
+  hasSassFunction,
 } from '../../utilities/sass';
 import {isKeyOf} from '../../utilities/type-guards';
 
@@ -29,6 +30,8 @@ export default createSassMigrator(
     return (root) => {
       methods.walkDecls(root, (decl) => {
         const parsedValue = valueParser(decl.value);
+
+        if (!hasSassFunction(namespacedDuration, parsedValue)) return;
 
         parsedValue.walk((node) => {
           if (isNumericOperator(node)) {

--- a/polaris-migrator/src/migrations/scss-replace-easing/scss-replace-easing.ts
+++ b/polaris-migrator/src/migrations/scss-replace-easing/scss-replace-easing.ts
@@ -7,6 +7,7 @@ import {
   createSassMigrator,
   setNodeValue,
   StopWalkingFunctionNodes,
+  hasSassFunction,
 } from '../../utilities/sass';
 import {isKeyOf} from '../../utilities/type-guards';
 
@@ -28,6 +29,8 @@ export default createSassMigrator(
     return (root) => {
       methods.walkDecls(root, (decl) => {
         const parsedValue = valueParser(decl.value);
+
+        if (!hasSassFunction(namespacedEasing, parsedValue)) return;
 
         parsedValue.walk((node) => {
           if (isNumericOperator(node)) {


### PR DESCRIPTION
The current migrations would inject a migration comment when encountering any numeric operator in a style declaration. 

This change adds an early exit if the target Sass function ins't present in the declaration.