### PR TITLE
[Modal] Fix footer layout

### DIFF
--- a/.changeset/metal-trees-report.md
+++ b/.changeset/metal-trees-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed a layout issue with Modal footer

--- a/polaris-react/src/components/Modal/components/Footer/Footer.tsx
+++ b/polaris-react/src/components/Modal/components/Footer/Footer.tsx
@@ -4,7 +4,6 @@ import type {ComplexAction} from '../../../../types';
 import {buttonsFrom} from '../../../Button';
 import {ButtonGroup} from '../../../ButtonGroup';
 import {Box} from '../../../Box';
-import {Columns} from '../../../Columns';
 import {Inline} from '../../../Inline';
 
 export interface FooterProps {
@@ -40,12 +39,12 @@ export function Footer({
       padding="4"
       width="100%"
     >
-      <Columns columns={{xs: '1fr auto'}}>
+      <Inline align="space-between">
         <Inline blockAlign="center">{children}</Inline>
         <Inline align="end" blockAlign="center">
           {actions}
         </Inline>
-      </Columns>
+      </Inline>
     </Box>
   );
 }


### PR DESCRIPTION
Footer content should wrap with actions

Before | After
---|---
![admin web web-1qmu aveline-thelen us spin dev_store_shop1_draft_orders_new](https://user-images.githubusercontent.com/6844391/210632277-9bda84d1-d5c6-4652-b493-87612d3182b6.png) | ![admin shopify com_store_kyle-durand_draft_orders_new](https://user-images.githubusercontent.com/6844391/210632272-8cc72c07-0706-4930-86b1-0b5f57f5d45f.png)


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Modal, Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Modal
        title="Modal title"
        open
        onClose={() => {}}
        primaryAction={{content: 'Change market'}}
        secondaryActions={[{content: 'Cancel', onAction: () => {}}]}
        footer="Other footer content"
      >
        <Modal.Section>
          <p>Modal content</p>
        </Modal.Section>
      </Modal>
    </Page>
  );
}

```

</details>
