### PR TITLE
Update `styles-tokenize-font` migration to ignore `@font-face` at-rules

### DIFF
--- a/.changeset/famous-years-destroy.md
+++ b/.changeset/famous-years-destroy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Updated `styles-tokenize-font` to ignore `@font-face` at-rules

--- a/polaris-migrator/src/migrations/styles-tokenize-font/styles-tokenize-font.ts
+++ b/polaris-migrator/src/migrations/styles-tokenize-font/styles-tokenize-font.ts
@@ -1,5 +1,5 @@
 import type {FileInfo, API, Options} from 'jscodeshift';
-import postcss, {Plugin} from 'postcss';
+import postcss, {Plugin, AtRule} from 'postcss';
 import valueParser from 'postcss-value-parser';
 import {toPx} from '@shopify/polaris-tokens';
 
@@ -40,6 +40,14 @@ const plugin = (options: PluginOptions = {}): Plugin => {
     Declaration(decl) {
       // @ts-expect-error - Skip if processed so we don't process it again
       if (decl[processed]) return;
+
+      if (
+        decl.parent &&
+        decl.parent.type === 'atrule' &&
+        (decl.parent as AtRule).name === 'font-face'
+      ) {
+        return;
+      }
 
       const handlers = {
         'font-size': handleFontSize,

--- a/polaris-migrator/src/migrations/styles-tokenize-font/tests/styles-tokenize-font.input.scss
+++ b/polaris-migrator/src/migrations/styles-tokenize-font/tests/styles-tokenize-font.input.scss
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: 'Custom Font';
+  font-weight: 400;
+}
+
 .font-size {
   // LENGTHS
   font-size: 12px;

--- a/polaris-migrator/src/migrations/styles-tokenize-font/tests/styles-tokenize-font.output.scss
+++ b/polaris-migrator/src/migrations/styles-tokenize-font/tests/styles-tokenize-font.output.scss
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: 'Custom Font';
+  font-weight: 400;
+}
+
 .font-size {
   // LENGTHS
   font-size: var(--p-font-size-75);


### PR DESCRIPTION
Part of #7991