### PR TITLE
Temporarily disable `border-radius-base` Stylelint error

### DIFF
--- a/.changeset/heavy-beds-report.md
+++ b/.changeset/heavy-beds-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': patch
+---
+
+Temporarily disabled `border-radius-base` error

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -278,7 +278,7 @@ const stylelintPolarisCoverageOptions = {
         /\$border-width-data/,
         /\$borders-data/,
         // Legacy custom properties
-        /--p-border-radius-base/,
+        // /--p-border-radius-base/,
         /--p-border-radius-wide/,
         /--p-border-radius-full/,
         /--p-control-border-width/,


### PR DESCRIPTION
## Context

We used to have a token called `--p-border-radius-base` that [was deprecated](https://github.com/Shopify/polaris/blob/main/documentation/guides/migrating-from-v8-to-v9.md#css-custom-properties) during the v8 to v9 release.  However, when removing the border-radius function (e.g. `border-radius(base)`) we added back a token with the same name (`--p-border-radius-base`). Thus, we are temporarily disabling the lint error until we decide how to [move forward with the border radius tokens](https://github.com/Shopify/polaris/issues/4826).