### PR TITLE
[`Badge`] Fix `new` status styling

### DIFF
--- a/.changeset/cool-mangos-shave.md
+++ b/.changeset/cool-mangos-shave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fix Badge component "new" status styling

--- a/.changeset/cool-mangos-shave.md
+++ b/.changeset/cool-mangos-shave.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Fix Badge component "new" status styling
+Fixed Badge component "new" status styling

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -43,8 +43,6 @@
 }
 
 .statusNew {
-  color: var(--p-text);
-  font-weight: var(--p-font-weight-medium);
   border: none;
 }
 

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -34,6 +34,10 @@ export function Critical() {
   return <Badge status="critical">Action required</Badge>;
 }
 
+export function New() {
+  return <Badge status="new">Fulfilled</Badge>;
+}
+
 export function Incomplete() {
   return (
     <Badge progress="incomplete" status="attention">

--- a/polaris-react/src/components/Badge/Badge.tsx
+++ b/polaris-react/src/components/Badge/Badge.tsx
@@ -11,7 +11,6 @@ import styles from './Badge.scss';
 import type {Progress, Size, Status} from './types';
 import {Pip} from './components';
 import {getDefaultAccessibilityLabel} from './utils';
-import {StatusActiveMajor} from '@shopify/polaris-icons';
 
 const DEFAULT_SIZE: Size = 'medium';
 interface NonMutuallyExclusiveProps {

--- a/polaris-react/src/components/Badge/Badge.tsx
+++ b/polaris-react/src/components/Badge/Badge.tsx
@@ -11,6 +11,7 @@ import styles from './Badge.scss';
 import type {Progress, Size, Status} from './types';
 import {Pip} from './components';
 import {getDefaultAccessibilityLabel} from './utils';
+import {StatusActiveMajor} from '@shopify/polaris-icons';
 
 const DEFAULT_SIZE: Size = 'medium';
 interface NonMutuallyExclusiveProps {
@@ -89,7 +90,11 @@ export function Badge({
         </span>
       )}
       {children && (
-        <Text as="span" variant="bodySm">
+        <Text
+          as="span"
+          variant="bodySm"
+          fontWeight={status === 'new' ? 'medium' : undefined}
+        >
           {children}
         </Text>
       )}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #8028<!-- link to issue if one exists -->

Re-adds the `new` status styling to the `Badge`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
* Adds the correct props to the `Text` component used in `badge`
* Creates a new storybook story for showing the `new` badge. This use case was missing and may have been a reason that this bug was not originally caught

Current bug (missing bolder font-weight)
<img width="102" alt="Screenshot 2023-01-11 at 11 59 33 AM" src="https://user-images.githubusercontent.com/4642404/211892353-3dbfac99-c02f-4f75-b7a1-5209b1fcc5a4.png">

Fix (with bolder font-weight)
<img width="98" alt="Screenshot 2023-01-11 at 11 58 22 AM" src="https://user-images.githubusercontent.com/4642404/211892413-75df100e-283f-4db4-9716-2576c0a01984.png">


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)
 
 Spin up the storybook instance locally and check that the `Badge` component "New" story shows the badge with a bolder font weight (font-weight: 500)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
