### PR TITLE
updated disabled nav item styles to fix scrolling issue and alignment

### DIFF
--- a/.changeset/red-students-bake.md
+++ b/.changeset/red-students-bake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix an issue where navigation shows a scrollbar when rendering some nav items

--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -166,7 +166,6 @@ $disabled-fade: 0.6;
 
 .Item-disabled {
   color: var(--p-text-disabled);
-  pointer-events: none;
   opacity: $disabled-fade;
 
   .Icon {
@@ -243,6 +242,10 @@ $disabled-fade: 0.6;
     background: var(--p-background-hovered);
     color: var(--p-text);
     text-decoration: none;
+  }
+
+  &.ItemInnerDisabled {
+    pointer-events: none;
   }
 }
 

--- a/polaris-react/src/components/Navigation/Navigation.stories.tsx
+++ b/polaris-react/src/components/Navigation/Navigation.stories.tsx
@@ -53,6 +53,24 @@ export function Default() {
   );
 }
 
+export function DisabledItemsWithoutUrls() {
+  return (
+    <Frame>
+      <Navigation location="/">
+        <Navigation.Section
+          items={[
+            {icon: HomeMinor, label: 'Home', disabled: true},
+            {icon: OrdersMinor, label: 'Orders', disabled: true},
+            {icon: ProductsMinor, label: 'Products', disabled: true},
+            {icon: CustomersMinor, label: 'Customers', disabled: true},
+            {icon: MarketingMinor, label: 'Marketing', disabled: true},
+          ]}
+        />
+      </Navigation>
+    </Frame>
+  );
+}
+
 export function WithMultipleSecondaryNavigations() {
   return (
     <Frame>

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -206,20 +206,29 @@ export function Item({
 
     return (
       <li className={styles.ListItem}>
-        <button
-          type="button"
-          className={className}
-          disabled={disabled}
-          aria-disabled={disabled}
-          aria-label={accessibilityLabel}
-          onClick={getClickHandler(onClick)}
-          onKeyUp={handleKeyUp}
-          onBlur={handleBlur}
-        >
-          {iconMarkup}
-          {itemLabelMarkup}
-          {wrappedBadgeMarkup}
-        </button>
+        <div className={styles.ItemWrapper}>
+          <div
+            className={classNames(
+              styles.ItemInnerWrapper,
+              disabled && styles.ItemInnerDisabled,
+            )}
+          >
+            <button
+              type="button"
+              className={className}
+              disabled={disabled}
+              aria-disabled={disabled}
+              aria-label={accessibilityLabel}
+              onClick={getClickHandler(onClick)}
+              onKeyUp={handleKeyUp}
+              onBlur={handleBlur}
+            >
+              {iconMarkup}
+              {itemLabelMarkup}
+              {wrappedBadgeMarkup}
+            </button>
+          </div>
+        </div>
       </li>
     );
   }
@@ -398,6 +407,7 @@ export function Item({
             selected && canBeActive && styles['ItemInnerWrapper-selected'],
             displayActionsOnHover &&
               styles['ItemInnerWrapper-display-actions-on-hover'],
+            disabled && styles.ItemInnerDisabled,
           )}
         >
           {displayActionsOnHover &&


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/79951

In the admin when we are loading the page a horizontal scrollbar is appearing under navigation, it disappears once the navigation properly loads. 

### WHAT is this pull request doing?

In this PR we updated how navigation items without urls are rendered and how their disabled styles work. This fixes the issue as when we are loading in admin we render the nav with disabled navigation items to display a pseudo "loading" state. Now the disabled navigation items without urls will display with the same spacing as the normal navigation items, so we should have less of a jarring loading state transition in web. 

Before:
<img width="383" alt="Screenshot 2023-01-12 at 4 32 53 PM" src="https://user-images.githubusercontent.com/33904740/212185907-fbda9c04-8725-4313-9ec0-38da5a7ed54d.png">

After:
<img width="334" alt="Screenshot 2023-01-12 at 4 32 14 PM" src="https://user-images.githubusercontent.com/33904740/212185920-10eab3b0-0e1b-464f-99a3-9e8c148e4f48.png">


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🎩  Link -> https://polaris.nav-loading-scroll-bar-fix.raman-lally.us.spin.dev/?path=/story/all-components-navigation--disabled-items-without-urls

🎩  for Admin -> [admin.web.nav-width-scrollbar-bug.raman-lally.us.spin.dev](https://admin.web.nav-width-scrollbar-bug.raman-lally.us.spin.dev/store/shop1)

Look at the `Disabled Items without URLs` story to see what we use as the pseudo "loading" state in admin

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
