### PR TITLE
Fix deprecated sheet message

### DIFF
--- a/polaris-react/src/components/Sheet/Sheet.tsx
+++ b/polaris-react/src/components/Sheet/Sheet.tsx
@@ -45,7 +45,7 @@ export interface SheetProps {
   activator?: React.RefObject<HTMLElement> | React.ReactElement;
 }
 
-/** @deprecated Use <Modal /> instead or avoid modal patterns all together. */
+/** @deprecated Use Modal instead or avoid modal patterns all together. */
 export function Sheet({
   children,
   open,


### PR DESCRIPTION
For whatever reason vs doesn't like JSX and ignores it. So instead of seeing `use <Modal /> instead...` consumers just see `use instead`

![image](https://user-images.githubusercontent.com/6844391/212368258-c028239c-d72b-401c-810d-09cb91f6d4ed.png)
