### PR TITLE
Adding file minor icon to Polaris for metafields.

### DIFF
--- a/.changeset/curly-dancers-buy.md
+++ b/.changeset/curly-dancers-buy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': major
+---
+
+added file minor icon

--- a/polaris-icons/icons/FileMinor.svg
+++ b/polaris-icons/icons/FileMinor.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 20 20"  xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M5 2a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V6a1 1 0 0 0-.293-.707l-3-3A1 1 0 0 0 12 2H5Zm1 14V4h5v2a1 1 0 0 0 1 1h2v9H6Z" fill="#5C5F62"/></svg>

--- a/polaris-icons/icons/FileMinor.yml
+++ b/polaris-icons/icons/FileMinor.yml
@@ -1,0 +1,13 @@
+name: File
+set: minor
+description: Used to denote a file such as images, video, pdfs, etc.
+keywords:
+  - file
+  - images
+  - video
+authors:
+  - Leina Leung
+date_added: 2023-01-17
+date_modified: 2023-01-17
+version: 1
+exclusive_use:


### PR DESCRIPTION
### WHY are these changes introduced?

Related to [#8049](https://github.com/Shopify/polaris/pull/8049) I forgot one additional icon that we thought was already in Polaris so adding a File icon minor. 

Need this icon to address/fix [#495](https://github.com/Shopify/metafield-issues/issues/495)