### PR TITLE
[Tooltip] Add optional zIndexOverride prop to Tooltip

### DIFF
--- a/.changeset/late-files-join.md
+++ b/.changeset/late-files-join.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Add optional zIndexOverride prop to the Tooltip
+Added an optional `zIndexOverride` prop to `Tooltip`

--- a/.changeset/late-files-join.md
+++ b/.changeset/late-files-join.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Add optional zIndexOverride prop to the Tooltip

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -55,6 +55,8 @@ export interface TooltipProps {
    * @default '1'
    */
   borderRadius?: BorderRadius;
+  /** Override on the default z-index of 400 */
+  zIndexOverride?: number;
   /* Callback fired when the tooltip is activated */
   onOpen?(): void;
   /* Callback fired when the tooltip is dismissed */
@@ -73,6 +75,7 @@ export function Tooltip({
   width = 'default',
   padding = 'default',
   borderRadius = '1',
+  zIndexOverride,
   onOpen,
   onClose,
 }: TooltipProps) {
@@ -132,6 +135,7 @@ export function Tooltip({
         width={width}
         padding={padding}
         borderRadius={borderRadius}
+        zIndexOverride={zIndexOverride}
       >
         {content}
       </TooltipOverlay>

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -22,6 +22,7 @@ export interface TooltipOverlayProps {
   width?: Width;
   padding?: Padding;
   borderRadius?: BorderRadius;
+  zIndexOverride?: number;
   onClose(): void;
 }
 
@@ -36,6 +37,7 @@ export function TooltipOverlay({
   width,
   padding,
   borderRadius,
+  zIndexOverride,
 }: TooltipOverlayProps) {
   const i18n = useI18n();
   const markup = active ? (
@@ -45,6 +47,7 @@ export function TooltipOverlay({
       preferredPosition={preferredPosition}
       preventInteraction={preventInteraction}
       render={renderTooltip}
+      zIndexOverride={zIndexOverride}
     />
   ) : null;
 

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/tests/TooltipOverlay.test.tsx
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/tests/TooltipOverlay.test.tsx
@@ -35,4 +35,21 @@ describe('<TooltipOverlay />', () => {
       'aria-label': accessibilityLabel,
     });
   });
+
+  it('is set to value of zIndexOverride prop if given', () => {
+    const activator = document.createElement('button');
+    const tooltipOverlay = mountWithApp(
+      <TooltipOverlay
+        {...defaultProps}
+        activator={activator}
+        zIndexOverride={100}
+      >
+        Content
+      </TooltipOverlay>,
+    );
+
+    expect(tooltipOverlay).toContainReactComponent('div', {
+      style: expect.objectContaining({zIndex: 100}),
+    });
+  });
 });

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -239,6 +239,18 @@ describe('<Tooltip />', () => {
     });
   });
 
+  it("passes 'zIndexOverride' to TooltipOverlay", () => {
+    const tooltip = mountWithApp(
+      <Tooltip active content="Inner content" zIndexOverride={100}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      zIndexOverride: 100,
+    });
+  });
+
   describe('width', () => {
     it('renders content with the default width', () => {
       const tooltip = mountWithApp(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

In situations where there are two activators that render a `Tooltip`, we'd like the ability to give visual priority to one of them. An example of this is using sortable headers on the `IndexTable`, followed by an information tooltip within that header which causes this overlap:

<img width="224" alt="Screenshot 2023-01-18 at 1 27 02 PM" src="https://user-images.githubusercontent.com/22782157/213264009-a15aca00-7157-459c-810d-54208d7b1b5f.png">

It also looks like this prop can be used in other places in the Web repo as there are multiple places which are overriding the z-index value by selecting the `'Polaris-PositionedOverlay'` class.

### WHAT is this pull request doing?

This PR mirrors the `zIndexOverride` prop implementation as seen in the `Popover` component, since both components use the shared `PositionedOverlay` component.

### How to 🎩

No tophatting is necessary.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
