### PR TITLE
Removing mouse up and mouse down from modal `Backdrop` component

### DIFF
--- a/.changeset/gentle-chefs-hear.md
+++ b/.changeset/gentle-chefs-hear.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris': major
+'@shopify/polaris': patch
 ---
 
 Replaces mouse up and down events on Backdrop with onClick to close Modal

--- a/.changeset/gentle-chefs-hear.md
+++ b/.changeset/gentle-chefs-hear.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Replaces mouse up and down events on Backdrop with onClick to close Modal
+Replaced mouse up and down events on Backdrop with onClick to close Modal

--- a/.changeset/gentle-chefs-hear.md
+++ b/.changeset/gentle-chefs-hear.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+Replaces mouse up and down events on Backdrop with onClick to close Modal

--- a/polaris-react/src/components/Backdrop/Backdrop.tsx
+++ b/polaris-react/src/components/Backdrop/Backdrop.tsx
@@ -1,4 +1,4 @@
-import React, {Dispatch, SetStateAction} from 'react';
+import React from 'react';
 
 import {classNames} from '../../utilities/css';
 import {ScrollLock} from '../ScrollLock';
@@ -10,31 +10,16 @@ export interface BackdropProps {
   transparent?: boolean;
   onClick?(): void;
   onTouchStart?(): void;
-  setClosing?: Dispatch<SetStateAction<boolean>>;
 }
 
 export function Backdrop(props: BackdropProps) {
-  const {onClick, onTouchStart, belowNavigation, transparent, setClosing} =
-    props;
+  const {onClick, onTouchStart, belowNavigation, transparent} = props;
 
   const className = classNames(
     styles.Backdrop,
     belowNavigation && styles.belowNavigation,
     transparent && styles.transparent,
   );
-
-  const handleMouseDown = () => {
-    if (setClosing) {
-      setClosing(true);
-    }
-  };
-
-  const handleMouseUp = () => {
-    if (setClosing && onClick) {
-      setClosing(false);
-      onClick();
-    }
-  };
 
   return (
     <>
@@ -43,8 +28,6 @@ export function Backdrop(props: BackdropProps) {
         className={className}
         onClick={onClick}
         onTouchStart={onTouchStart}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
       />
     </>
   );

--- a/polaris-react/src/components/Backdrop/Backdrop.tsx
+++ b/polaris-react/src/components/Backdrop/Backdrop.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Dispatch, SetStateAction} from 'react';
 
 import {classNames} from '../../utilities/css';
 import {ScrollLock} from '../ScrollLock';
@@ -10,10 +10,12 @@ export interface BackdropProps {
   transparent?: boolean;
   onClick?(): void;
   onTouchStart?(): void;
+  setClosing?: Dispatch<SetStateAction<boolean>>;
 }
 
 export function Backdrop(props: BackdropProps) {
-  const {onClick, onTouchStart, belowNavigation, transparent} = props;
+  const {onClick, onTouchStart, belowNavigation, transparent, setClosing} =
+    props;
 
   const className = classNames(
     styles.Backdrop,
@@ -21,13 +23,27 @@ export function Backdrop(props: BackdropProps) {
     transparent && styles.transparent,
   );
 
+  const handleMouseDown = () => {
+    if (setClosing) {
+      setClosing(true);
+    }
+  };
+
+  const handleClick = () => {
+    if (setClosing && onClick) {
+      setClosing(false);
+      onClick();
+    }
+  };
+
   return (
     <>
       <ScrollLock />
       <div
         className={className}
-        onClick={onClick}
+        onClick={handleClick}
         onTouchStart={onTouchStart}
+        onMouseDown={handleMouseDown}
       />
     </>
   );

--- a/polaris-react/src/components/Backdrop/tests/Backdrop.test.tsx
+++ b/polaris-react/src/components/Backdrop/tests/Backdrop.test.tsx
@@ -4,11 +4,13 @@ import {mountWithApp} from 'tests/utilities';
 import {Backdrop} from '..';
 
 describe('<Backdrop />', () => {
-  describe('onDismiss()', () => {
+  describe('onClick()', () => {
     it('is called when the backdrop is clicked', () => {
       const spy = jest.fn();
-      const backdrop = mountWithApp(<Backdrop onClick={spy} />);
-      backdrop.find('div', {onClick: spy})!.trigger('onClick');
+      const backdrop = mountWithApp(
+        <Backdrop onClick={spy} setClosing={() => {}} />,
+      );
+      backdrop.find('div')!.trigger('onClick');
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -217,7 +217,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       </Dialog>
     );
 
-    backdrop = <Backdrop onClick={onClose} />;
+    backdrop = <Backdrop setClosing={setClosing} onClick={onClose} />;
   }
 
   const animated = !instant;

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -217,7 +217,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       </Dialog>
     );
 
-    backdrop = <Backdrop setClosing={setClosing} onClick={onClose} />;
+    backdrop = <Backdrop onClick={onClose} />;
   }
 
   const animated = !instant;


### PR DESCRIPTION
[Spin instance](https://polaris.polaris-f45t.emmanuel-etti.us.spin.dev/)

### WHY are these changes introduced?
- Closes https://github.com/Shopify/polaris/issues/8144
- Modal component closes when a user selects within the modal (for example, in an input field while selecting typed input) but overshoots the modal boundaries and releases their mouse outside the modal (in the backdrop).

### WHAT is this pull request doing?
- Removes the `onMouseUp` and `onMouseDown` handles from `Backdrop` component. There is a test that covers this case of explicitly clicking the backdrop to close it and we think that is sufficient behaviour.

### Before

https://user-images.githubusercontent.com/78582921/213541746-f3304f21-737f-411b-aea1-a8cc35264e57.mov

### After

https://user-images.githubusercontent.com/78582921/214117861-d8866a19-b45d-4d08-a94f-cd467199a3b5.mov

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
