### PR TITLE
[Stylelint Polaris] Move unit functions from spacing to legacy category

### DIFF
--- a/.changeset/slow-toys-scream.md
+++ b/.changeset/slow-toys-scream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': patch
+---
+
+Fix incorrect unit function categorization

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -218,13 +218,9 @@ const stylelintPolarisCoverageOptions = {
   ],
   spacing: [
     {
-      'function-disallowed-list': [
-        'control-vertical-padding',
-        'em',
-        'px',
-        'rem',
-        'spacing',
-      ].map(matchNameRegExp),
+      'function-disallowed-list': ['control-vertical-padding', 'spacing'].map(
+        matchNameRegExp,
+      ),
       'declaration-property-unit-disallowed-list': [
         {
           '/^padding/': ['px', 'rem', 'em'],
@@ -448,9 +444,13 @@ const stylelintPolarisCoverageOptions = {
         ].map(matchNameRegExp),
       },
       // Legacy functions
-      'function-disallowed-list': ['available-names', 'map-extend'].map(
-        matchNameRegExp,
-      ),
+      'function-disallowed-list': [
+        'available-names',
+        'map-extend',
+        'em',
+        'px',
+        'rem',
+      ].map(matchNameRegExp),
       'polaris/global-disallowed-list': [
         // Legacy variables
         / \* \$/,


### PR DESCRIPTION
### WHY are these changes introduced?
functions like `rem()` are being reported as spacing when they really could be used on any property, most commonly `width`. Moved to the Legacy category since thats where we put other overarching legacy functions
