### PR TITLE
[TextArea] Fixes issue #5125

### DIFF
--- a/polaris-react/src/components/TextField/components/Resizer/Resizer.tsx
+++ b/polaris-react/src/components/TextField/components/Resizer/Resizer.tsx
@@ -88,6 +88,7 @@ const ENTITIES_TO_REPLACE = {
   '>': '&gt;',
   '\n': '<br>',
   '\r': '',
+  ',': ',',
 };
 
 const REPLACE_REGEX = new RegExp(

--- a/polaris-react/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
+++ b/polaris-react/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
@@ -80,6 +80,15 @@ describe('<Resizer />', () => {
         '&lt;div&gt;&amp;<br>Contents&lt;/div&gt;<br></div>';
       expect(resizer)!.toContainReactHtml(expectedEncodedContents);
     });
+
+    it('recognizes commas', () => {
+      const contents = `Contents, contents`;
+      const resizer = mountWithApp(
+        <Resizer {...mockProps} contents={contents} />,
+      );
+      const expectedEncodedContents = 'Contents, contents';
+      expect(resizer)!.toContainReactHtml(expectedEncodedContents);
+    });
   });
 
   describe('minimumLines', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5125 - Multiline TextField height bug when commas are typed

I'm not 100% sure why it's doing this, but the RegEx / replace() is choking on commas and substituting them with `undefined`. The dummy field created to determine textarea height then is calculating height on multiple `undefined` instead of multiple commas, artificially inflating the calculated height.

### WHAT is this pull request doing?

Adds commas to the regex in Resizer

