### PR TITLE
[PageActions] Group actions together

### DIFF
--- a/.changeset/nasty-olives-call.md
+++ b/.changeset/nasty-olives-call.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Grouped PageActions actions at the trailing edge of the container

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -42,11 +42,9 @@ export function PageActions({
     secondaryActionsMarkup = <>{secondaryActions}</>;
   }
 
-  const distribution = secondaryActionsMarkup ? 'equalSpacing' : 'trailing';
-
   return (
     <div className={styles.PageActions}>
-      <Stack distribution={distribution} spacing="tight">
+      <Stack distribution="trailing" spacing="tight">
         {secondaryActionsMarkup}
         {primaryActionMarkup}
       </Stack>

--- a/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
+++ b/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
@@ -18,26 +18,6 @@ describe('<PageActions />', () => {
       expect(pageActions).toContainReactComponentTimes(Stack, 1);
     });
 
-    it('uses equalSpacing distribution if secondaryActions are provided', () => {
-      const mockActions = [{content: 'Delete'}];
-
-      const pageActions = mountWithApp(
-        <PageActions secondaryActions={mockActions} />,
-      );
-      const stack = pageActions.find(Stack);
-      expect(stack).toHaveReactProps({
-        distribution: 'equalSpacing',
-      });
-    });
-
-    it('uses trailing distribution if secondaryActions are not provided', () => {
-      const pageActions = mountWithApp(<PageActions />);
-      const stack = pageActions.find(Stack);
-      expect(stack).toHaveReactProps({
-        distribution: 'trailing',
-      });
-    });
-
     it('passes spacing tight to Stack', () => {
       const pageActions = mountWithApp(<PageActions />);
       const stack = pageActions.find(Stack);


### PR DESCRIPTION
### WHY are these changes introduced?

There are inconsistencies across the admin in how related actions are grouped together. We usually group actions together, right-aligned as seen in the ContextualSaveBar below.

<img width="2096" alt="Screenshot 2023-01-20 at 13 09 31" src="https://user-images.githubusercontent.com/2562596/213702476-0384360a-6255-4b78-82da-cc92e291e423.png">

The PageActions component places the secondary action justified left whilst the primary action is justified right. This PR removes that logic and always places the secondary action justified right, next to the primary action.

<img width="1331" alt="Screenshot 2023-01-20 at 13 08 42" src="https://user-images.githubusercontent.com/2562596/213702643-6b4ca1a7-4e52-4c8a-a566-bf424e09f397.png">


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
