### PR TITLE
[a11y][Page] Secondary actions should have an ability to receive focus

### DIFF
--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -1,3 +1,4 @@
+import type {RefObject} from 'react';
 import type React from 'react';
 
 /* eslint-disable @shopify/strict-component-boundaries */
@@ -223,9 +224,10 @@ export interface ComplexAction
 export interface MenuActionDescriptor extends ComplexAction, TooltipAction {
   /** Zero-indexed numerical position. Overrides the action's order in the menu */
   index?: number;
+  /** Ref to activator */
+  activatorRef?: RefObject<HTMLDivElement | HTMLButtonElement>;
 }
 
-/** Plannig to add new propery activatorRef here */
 export interface MenuGroupDescriptor extends BadgeAction {
   /** Menu group title */
   title: string;

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -225,7 +225,7 @@ export interface MenuActionDescriptor extends ComplexAction, TooltipAction {
   /** Zero-indexed numerical position. Overrides the action's order in the menu */
   index?: number;
   /** Ref to activator */
-  activatorRef?: RefObject<HTMLDivElement | HTMLButtonElement>;
+  ref?: RefObject<HTMLElement | null>;
 }
 
 export interface MenuGroupDescriptor extends BadgeAction {

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -224,7 +224,7 @@ export interface ComplexAction
 export interface MenuActionDescriptor extends ComplexAction, TooltipAction {
   /** Zero-indexed numerical position. Overrides the action's order in the menu */
   index?: number;
-  /** Ref to activator */
+  /** Reference to access DOM node */
   ref?: RefObject<HTMLElement | null>;
 }
 

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -225,6 +225,7 @@ export interface MenuActionDescriptor extends ComplexAction, TooltipAction {
   index?: number;
 }
 
+/** Plannig to add new propery activatorRef here */
 export interface MenuGroupDescriptor extends BadgeAction {
   /** Menu group title */
   title: string;


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris/issues/8105 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
