### PR TITLE
Improve readability of markdown tables by wrapping on words

### DIFF
--- a/.changeset/five-hornets-tickle.md
+++ b/.changeset/five-hornets-tickle.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Improve readability of markdown tables by wrapping on words

--- a/polaris.shopify.com/src/components/Longform/Longform.module.scss
+++ b/polaris.shopify.com/src/components/Longform/Longform.module.scss
@@ -212,8 +212,9 @@
   :global {
     .table-wrapper {
       overflow: auto;
-      max-width: calc(100vw - 1.25rem);
+      max-width: calc(100vw - 2.5rem);
       width: 100%;
+      overflow-wrap: normal;
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Markdown table entries were wrapping in a gross and unreadable way due to `overflow-wrap: anywhere;` from `Frame`.

See `Before` and `After` below: 👇 

### Before: 
![word-wrap-before](https://user-images.githubusercontent.com/1747353/214395531-cc9f1c6f-036b-4679-a142-3f5a9a9768f1.png)


### After:
![word-wrap-after](https://user-images.githubusercontent.com/1747353/214395545-15371944-af70-4dfc-87c7-c75f1b3a2fe5.png)



### WHAT is this pull request doing?

These simple changes:
1. Introduce a word-wrapping `overflow-wrap: normal;` to markdown tables to improve readability by not breaking in the middle of words
2. Fix the max width of table wrappers to match the design of `1.25rem` for Page padding


### How to 🎩

🎩 link to spinstance: https://polaris.word-wrap.marlow-payne.us.spin.dev/

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] ~Updated the component's `README.md` with documentation changes~
- [x] ~[Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide~
