### PR TITLE
[Navigation] Fixed item secondaryActions alignment in mobile when floating actions are enabled

### DIFF
--- a/.changeset/loud-cycles-check.md
+++ b/.changeset/loud-cycles-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed Navigation item secondaryActions alignment in mobile when floating actions are enabled

--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -298,6 +298,9 @@ $disabled-fade: 0.6;
 .ItemWithFloatingActions {
   // stylelint-disable-next-line -- required for absolute positioning of actions
   position: relative;
+  // stylelint-disable-next-line -- position actions to to the right of label
+  display: flex;
+  flex-wrap: nowrap;
 
   .SecondaryActions {
     margin-right: 0;


### PR DESCRIPTION
### WHY are these changes introduced?

This fixes an alignment issues when in mobile mode with `displayActionsOnHover` is enabled. The actions should be horizontally aligned next to the item label but are wrapped to below the label instead.

Before
<img width="378" alt="before" src="https://user-images.githubusercontent.com/1307190/214080539-f3efac9e-e63c-470d-b5e4-d93ff5952d58.png">

After
<img width="389" alt="after" src="https://user-images.githubusercontent.com/1307190/214080536-18154467-e2ca-45bc-93aa-afd1fe7d3766.png">


### WHAT is this pull request doing?

Adds `display: flex` when using floating actions so ensure items are always horizontally aligned

### How to 🎩

See [polaris storybook instance](https://polaris.nav.jita-yi.us.spin.dev/?path=/story/all-components-navigation--with-multiple-secondary-actions-for-an-item)

1. Go through the navigation examples with multiple action items
2. Ensure all action icons and labels are always correctly horizontally aligned for all possible states:
- mobile/desktop widths
- displayActionsOnHover enabled/disabled
- truncateText enabled/disabled
- with badge

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
