### PR TITLE
Add pluralization to i18n

### DIFF
--- a/polaris-react/locales/cs.json
+++ b/polaris-react/locales/cs.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "Počet znaků: {count}",
-      "characterCountWithMaxLength": "Použité znaky: {count} z {limit}"
+      "characterCountWithMaxLength": "Použité znaky: {characterCount} z {limit}"
     },
     "TopBar": {
       "toggleMenuLabel": "Přepnout nabídku",

--- a/polaris-react/locales/da.json
+++ b/polaris-react/locales/da.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} tegn",
-      "characterCountWithMaxLength": "{count} af {limit} benyttede tegn"
+      "characterCountWithMaxLength": "{characterCount} af {limit} benyttede tegn"
     },
     "TopBar": {
       "toggleMenuLabel": "Åbn/luk menuen",

--- a/polaris-react/locales/de.json
+++ b/polaris-react/locales/de.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} Zeichen",
-      "characterCountWithMaxLength": "{count} von {limit} Zeichen verwendet"
+      "characterCountWithMaxLength": "{characterCount} von {limit} Zeichen verwendet"
     },
     "TopBar": {
       "toggleMenuLabel": "Menü ein/aus",

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -242,8 +242,14 @@
       "ariaLabel": "Remove {children}"
     },
     "TextField": {
-      "characterCount": "{count} characters",
-      "characterCountWithMaxLength": "{count} of {limit} characters used"
+      "characterCount": {
+        "one": "{count} character",
+        "other": "{count} characters"
+      },
+      "characterCountWithMaxLength": {
+        "one": "{characterCount} of {limit} character used",
+        "other": "{characterCount} of {limit} characters used"
+      }
     },
     "TooltipOverlay": {
       "accessibilityLabel": "Tooltip: {label}"

--- a/polaris-react/locales/es.json
+++ b/polaris-react/locales/es.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} caracteres",
-      "characterCountWithMaxLength": "{count} de {limit} caracteres utilizados"
+      "characterCountWithMaxLength": "{characterCount} de {limit} caracteres utilizados"
     },
     "TopBar": {
       "toggleMenuLabel": "Abrir/cerrar menú",

--- a/polaris-react/locales/fi.json
+++ b/polaris-react/locales/fi.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} merkkiä",
-      "characterCountWithMaxLength": "{count}/{limit} merkkiä käytetty"
+      "characterCountWithMaxLength": "{characterCount}/{limit} merkkiä käytetty"
     },
     "TopBar": {
       "toggleMenuLabel": "Valikon vaihto",

--- a/polaris-react/locales/fr.json
+++ b/polaris-react/locales/fr.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} caractères",
-      "characterCountWithMaxLength": "{count} sur {limit} caractères utilisés"
+      "characterCountWithMaxLength": "{characterCount} sur {limit} caractères utilisés"
     },
     "TopBar": {
       "toggleMenuLabel": "Activer le menu",

--- a/polaris-react/locales/it.json
+++ b/polaris-react/locales/it.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} caratteri",
-      "characterCountWithMaxLength": "{count} caratteri utilizzati su {limit}"
+      "characterCountWithMaxLength": "{characterCount} caratteri utilizzati su {limit}"
     },
     "TopBar": {
       "toggleMenuLabel": "Apri/chiudi menu",

--- a/polaris-react/locales/ja.json
+++ b/polaris-react/locales/ja.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count}文字",
-      "characterCountWithMaxLength": "{limit}中{count}の文字を使用"
+      "characterCountWithMaxLength": "{limit}中{characterCount}の文字を使用"
     },
     "TopBar": {
       "toggleMenuLabel": "メニューを切り替える",

--- a/polaris-react/locales/ko.json
+++ b/polaris-react/locales/ko.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count}자",
-      "characterCountWithMaxLength": "{count}/{limit}자 입력함"
+      "characterCountWithMaxLength": "{characterCount}/{limit}자 입력함"
     },
     "TopBar": {
       "toggleMenuLabel": "토글 메뉴",

--- a/polaris-react/locales/nb.json
+++ b/polaris-react/locales/nb.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} tegn",
-      "characterCountWithMaxLength": "{count} av {limit} tegn brukt"
+      "characterCountWithMaxLength": "{characterCount} av {limit} tegn brukt"
     },
     "TopBar": {
       "toggleMenuLabel": "Aktiver/deaktiver meny",

--- a/polaris-react/locales/nl.json
+++ b/polaris-react/locales/nl.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} tekens",
-      "characterCountWithMaxLength": "{count} van {limit} tekens gebruikt"
+      "characterCountWithMaxLength": "{characterCount} van {limit} tekens gebruikt"
     },
     "TopBar": {
       "toggleMenuLabel": "Schakelen tussen menu's",

--- a/polaris-react/locales/pl.json
+++ b/polaris-react/locales/pl.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} znaki(-ów)",
-      "characterCountWithMaxLength": "Użyto {count} z {limit} znaków"
+      "characterCountWithMaxLength": "Użyto {characterCount} z {limit} znaków"
     },
     "TopBar": {
       "toggleMenuLabel": "Przełącz menu",

--- a/polaris-react/locales/pt-BR.json
+++ b/polaris-react/locales/pt-BR.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} caracteres",
-      "characterCountWithMaxLength": "{count} de {limit} caracteres usados"
+      "characterCountWithMaxLength": "{characterCount} de {limit} caracteres usados"
     },
     "TopBar": {
       "toggleMenuLabel": "Alternar menu",

--- a/polaris-react/locales/pt-PT.json
+++ b/polaris-react/locales/pt-PT.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} caracteres",
-      "characterCountWithMaxLength": "{count} de {limit} caracteres utilizados"
+      "characterCountWithMaxLength": "{characterCount} de {limit} caracteres utilizados"
     },
     "TopBar": {
       "toggleMenuLabel": "Alternar menu",

--- a/polaris-react/locales/sv.json
+++ b/polaris-react/locales/sv.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} tecken",
-      "characterCountWithMaxLength": "{count} av {limit} tecken har använts"
+      "characterCountWithMaxLength": "{characterCount} av {limit} tecken har använts"
     },
     "TopBar": {
       "toggleMenuLabel": "Växla menyn",

--- a/polaris-react/locales/th.json
+++ b/polaris-react/locales/th.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} อักขระ",
-      "characterCountWithMaxLength": "ใช้อักขระไปแล้ว {count} จาก {limit}"
+      "characterCountWithMaxLength": "ใช้อักขระไปแล้ว {characterCount} จาก {limit}"
     },
     "TopBar": {
       "toggleMenuLabel": "เมนูเปิด/ปิด",

--- a/polaris-react/locales/tr.json
+++ b/polaris-react/locales/tr.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} karakter",
-      "characterCountWithMaxLength": "{count}/{limit} karakter kullanıldı"
+      "characterCountWithMaxLength": "{characterCount}/{limit} karakter kullanıldı"
     },
     "TopBar": {
       "toggleMenuLabel": "Menüyü aç/kapat",

--- a/polaris-react/locales/vi.json
+++ b/polaris-react/locales/vi.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} ký tự",
-      "characterCountWithMaxLength": "Đã sử dụng {count}/{limit} ký tự"
+      "characterCountWithMaxLength": "Đã sử dụng {characterCount}/{limit} ký tự"
     },
     "TopBar": {
       "toggleMenuLabel": "Bật/tắt menu",

--- a/polaris-react/locales/zh-CN.json
+++ b/polaris-react/locales/zh-CN.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} 个字符",
-      "characterCountWithMaxLength": "已使用 {count}/{limit} 个字符"
+      "characterCountWithMaxLength": "已使用 {characterCount}/{limit} 个字符"
     },
     "TopBar": {
       "toggleMenuLabel": "切换菜单",

--- a/polaris-react/locales/zh-TW.json
+++ b/polaris-react/locales/zh-TW.json
@@ -208,7 +208,7 @@
     },
     "TextField": {
       "characterCount": "{count} 個字元",
-      "characterCountWithMaxLength": "已使用 {count} 個字元，上限為 {limit} 個字元"
+      "characterCountWithMaxLength": "已使用 {characterCount} 個字元，上限為 {limit} 個字元"
     },
     "TopBar": {
       "toggleMenuLabel": "切換選單",

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -297,7 +297,8 @@ export function TextField({
     const characterCount = normalizedValue.length;
     const characterCountLabel = maxLength
       ? i18n.translate('Polaris.TextField.characterCountWithMaxLength', {
-          count: characterCount,
+          characterCount,
+          count: maxLength,
           limit: maxLength,
         })
       : i18n.translate('Polaris.TextField.characterCount', {

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -641,17 +641,18 @@ describe('<TextField />', () => {
         />,
       );
 
-      expect(
-        textField.find('div', {
-          id: 'MyField-CharacterCounter',
-        }),
-      ).toContainReactText('4');
+      const div = textField.find('div', {
+        id: 'MyField-CharacterCounter',
+      });
+
+      expect(div).toContainReactText('4');
+      expect(div!.props).toHaveProperty('aria-label', '4 characters');
     });
 
     it('displays remaining characters as fraction in input field with maxLength', () => {
       const textField = mountWithApp(
         <TextField
-          value="test"
+          value="T"
           maxLength={10}
           showCharacterCount
           label="TextField"
@@ -661,11 +662,15 @@ describe('<TextField />', () => {
         />,
       );
 
-      expect(
-        textField.find('div', {
-          id: 'MyField-CharacterCounter',
-        }),
-      ).toContainReactText('4/10');
+      const div = textField.find('div', {
+        id: 'MyField-CharacterCounter',
+      });
+
+      expect(div).toContainReactText('1/10');
+      expect(div!.props).toHaveProperty(
+        'aria-label',
+        '1 of 10 characters used',
+      );
     });
 
     it('announces updated character count only when input field is in focus', () => {

--- a/polaris-react/src/utilities/i18n/I18n.ts
+++ b/polaris-react/src/utilities/i18n/I18n.ts
@@ -8,12 +8,17 @@ interface TranslationDictionary {
 }
 
 export class I18n {
+  private locale?: string;
   private translation: TranslationDictionary = {};
 
   /**
    * @param translation A locale object or array of locale objects that overrides default translations. If specifying an array then your desired language dictionary should come first, followed by your fallback language dictionaries
    */
-  constructor(translation: TranslationDictionary | TranslationDictionary[]) {
+  constructor(
+    translation: TranslationDictionary | TranslationDictionary[],
+    locale?: string,
+  ) {
+    this.locale = locale;
     // slice the array to make a shallow copy of it, so we don't accidentally
     // modify the original translation array
     this.translation = Array.isArray(translation)

--- a/polaris-react/src/utilities/i18n/tests/I18n.test.ts
+++ b/polaris-react/src/utilities/i18n/tests/I18n.test.ts
@@ -30,6 +30,51 @@ describe('I18n.translate', () => {
     expect(translations[0].two).toBe('deux');
   });
 
+  it('defaults to using English pluralization rules (for backwards compatibility)', () => {
+    const i18n = new I18n({
+      plurals: {one: '{count} (one)', other: '{count} (other)'},
+    });
+    expect(i18n.translate('plurals', {count: 0})).toBe('0 (other)');
+    expect(i18n.translate('plurals', {count: 1})).toBe('1 (one)');
+    expect(i18n.translate('plurals', {count: 2})).toBe('2 (other)');
+  });
+
+  it('falls back to using `other` plural key if the proper one is missing', () => {
+    const i18n = new I18n({plurals: {other: '{count} (other)'}}, 'en');
+    expect(i18n.translate('plurals', {count: 0})).toBe('0 (other)');
+    expect(i18n.translate('plurals', {count: 1})).toBe('1 (other)');
+    expect(i18n.translate('plurals', {count: 2})).toBe('2 (other)');
+  });
+
+  it('works when count is used but it is not a pluralization context', () => {
+    const i18n = new I18n({foo: 'bar {count}'}, 'en');
+    expect(i18n.translate('foo', {count: 0})).toBe('bar 0');
+  });
+
+  it('uses the pluralization rules for zh-Hant-TW locale', () => {
+    const i18n = new I18n({plurals: {other: '{count} (other)'}}, 'zh-Hant-TW');
+    expect(i18n.translate('plurals', {count: 0})).toBe('0 (other)');
+    expect(i18n.translate('plurals', {count: 1})).toBe('1 (other)');
+    expect(i18n.translate('plurals', {count: 2})).toBe('2 (other)');
+  });
+
+  it('uses the pluralization rules for fr locale', () => {
+    const i18n = new I18n(
+      {
+        plurals: {
+          many: '{count} (many)',
+          one: '{count} (one)',
+          other: '{count} (other)',
+        },
+      },
+      'fr',
+    );
+    expect(i18n.translate('plurals', {count: 0})).toBe('0 (one)');
+    expect(i18n.translate('plurals', {count: 1})).toBe('1 (one)');
+    expect(i18n.translate('plurals', {count: 2})).toBe('2 (other)');
+    expect(i18n.translate('plurals', {count: 1000000})).toBe('1000000 (many)');
+  });
+
   it('uses replacements', () => {
     const i18n = new I18n({key: 'foo {string} {number}'});
     expect(i18n.translate('key', {string: 'bar', number: 3})).toBe('foo bar 3');


### PR DESCRIPTION
### WIP status

The mechanism for providing `locale` needs to be rethought, as the `translations` parameter can take multiple objects as "fallback" translations, or even use `react-i18n`'s `useI18n` hook:

https://polaris.shopify.com/components/app-provider#using-translations

-----

### WHY are these changes introduced?

The current `i18n.translate` implementation doesn't understand pluralization.

This means that any string that depends on the count of a noun is incorrect in all languages other than English.

Fixing this across all of Polaris will be a large effort, but making `i18n.translate` able to do the lookup is foundational to all that work. 

### WHAT is this pull request doing?

This PR adds the ability for `i18n.translate` to make use of a special `count` replacement to decide which plural version of a translation string to use.

This follows the format used by [`ruby-i18n`](https://github.com/ruby-i18n/i18n), [`react-i18n`](https://www.npmjs.com/package/@shopify/react-i18n) and Shopify's [theme](https://shopify.dev/themes/architecture/locales/storefront-locale-files)/[app extension](https://shopify.dev/apps/checkout/localize-ui-extensions) locale files.

English (`en`) translation files will contain all the `one` and `other` plural variations needed for pluralization in English. Other translation files will contain fewer or greater numbers of plural forms, according to the [plural rules of the language](https://unicode-org.github.io/cldr-staging/charts/42/supplemental/language_plural_rules.html).

`en.json`

```json
{
  "cars": {
    "one": "I have {count} car",
    "other": "I have {count} cars",
  }
}
```

When it comes to using the translations, `i18n.translate` will use the value of the `count` replacement to determine which subkey to use:

```typescript
const label = i18n.translate("cars", { count: 1 });
```

This is done by asking the [`Intl.PluralRules` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) for the subkey, then pulling that subkey out of the translation object.

### Changes made

Since `i18n` doesn't currently know the locale that it was initialized with, I added that as an optional parameter. It's only optional for backwards compatibility. Every caller should be expected to provide it alongside the translations. 

The `locale` is needed so we can access the correct pluralization rules. For backwards compatibility, if `locale` is not provided, it will default to using `en` pluralizations.

I then implemented pluralization lookups in the same manner as `ruby-i18n` and `react-i18n`.

Finally, to demonstrate its usage, I fixed the pluralization usage in `TextField`. There are many other places in Polaris that also need pluralization fixes (especially [`ResourceList`](https://github.com/Shopify/polaris/issues/4031) and `IndexProvider`), but this was the simplest / most self-contained. The others will be fixed in future PRs.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
