### PR TITLE
Deprecate breadcrumbs and allow singular backAction prop on Page and Breadcrumbs

### DIFF
--- a/.changeset/metal-cows-poke.md
+++ b/.changeset/metal-cows-poke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Adds new breadcrumb prop and deprecates breadcrumbs in favor of the new singular prop.

--- a/.changeset/metal-cows-poke.md
+++ b/.changeset/metal-cows-poke.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Adds new backAction prop and deprecates breadcrumbs in favor of the new singular prop.
+Deprecated the `Page` `breadcrumbs` prop in favor of the new `backAction` prop.

--- a/.changeset/metal-cows-poke.md
+++ b/.changeset/metal-cows-poke.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Adds new breadcrumb prop and deprecates breadcrumbs in favor of the new singular prop.
+Adds new backAction prop and deprecates breadcrumbs in favor of the new singular prop.

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -10,14 +10,21 @@ import {Text} from '../Text';
 import styles from './Breadcrumbs.scss';
 
 export interface BreadcrumbsProps {
-  /** Collection of breadcrumbs */
-  breadcrumbs: (CallbackAction | LinkAction) | (CallbackAction | LinkAction)[];
+  /** @deprecated Collection of breadcrumbs */
+  breadcrumbs?: (CallbackAction | LinkAction) | (CallbackAction | LinkAction)[];
+  /** Breadcrumb link */
+  breadcrumb?: CallbackAction | LinkAction;
 }
 
-export function Breadcrumbs({breadcrumbs}: BreadcrumbsProps) {
-  const breadcrumb = Array.isArray(breadcrumbs)
-    ? breadcrumbs[breadcrumbs.length - 1]
-    : breadcrumbs;
+export function Breadcrumbs({
+  breadcrumbs,
+  breadcrumb: breadcrumbProp,
+}: BreadcrumbsProps) {
+  const breadcrumb =
+    breadcrumbProp ??
+    (Array.isArray(breadcrumbs)
+      ? breadcrumbs[breadcrumbs.length - 1]
+      : breadcrumbs);
   if (breadcrumb == null) {
     return null;
   }

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -12,16 +12,13 @@ import styles from './Breadcrumbs.scss';
 export interface BreadcrumbsProps {
   /** @deprecated Collection of breadcrumbs */
   breadcrumbs?: (CallbackAction | LinkAction) | (CallbackAction | LinkAction)[];
-  /** Breadcrumb link */
-  breadcrumb?: CallbackAction | LinkAction;
+  /** Back action link */
+  backAction?: CallbackAction | LinkAction;
 }
 
-export function Breadcrumbs({
-  breadcrumbs,
-  breadcrumb: breadcrumbProp,
-}: BreadcrumbsProps) {
+export function Breadcrumbs({breadcrumbs, backAction}: BreadcrumbsProps) {
   const breadcrumb =
-    breadcrumbProp ??
+    backAction ??
     (Array.isArray(breadcrumbs)
       ? breadcrumbs[breadcrumbs.length - 1]
       : breadcrumbs);

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -23,6 +23,12 @@ export function Breadcrumbs({breadcrumbs, backAction}: BreadcrumbsProps) {
       ? breadcrumbs[breadcrumbs.length - 1]
       : breadcrumbs);
   if (breadcrumb == null) {
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Please provide a value to backAction, it will become required in the next major release.',
+      );
+    }
     return null;
   }
 

--- a/polaris-react/src/components/Page/Page.tsx
+++ b/polaris-react/src/components/Page/Page.tsx
@@ -43,7 +43,8 @@ export function Page({
     (rest.breadcrumbs != null &&
       Array.isArray(rest.breadcrumbs) &&
       rest.breadcrumbs.length > 0) ||
-    rest.breadcrumbs != null;
+    rest.breadcrumbs != null ||
+    rest.backAction != null;
 
   const contentClassName = classNames(
     !hasHeaderContent && styles.Content,

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -51,8 +51,8 @@ export interface HeaderProps extends TitleProps {
   pagination?: PaginationProps;
   /** @deprecated Collection of breadcrumbs */
   breadcrumbs?: BreadcrumbsProps['breadcrumbs'];
-  /** A breadcrumb link */
-  breadcrumb?: BreadcrumbsProps['breadcrumb'];
+  /** A back action link */
+  backAction?: BreadcrumbsProps['backAction'];
   /** Collection of secondary page-level actions */
   secondaryActions?: MenuActionDescriptor[] | React.ReactNode;
   /** Collection of page-level groups of secondary actions */
@@ -79,7 +79,7 @@ export function Header({
   pagination,
   additionalNavigation,
   breadcrumbs,
-  breadcrumb,
+  backAction,
   secondaryActions = [],
   actionGroups = [],
   compactTitle = false,
@@ -93,9 +93,11 @@ export function Header({
     console.warn(
       'Deprecation: The `additionalNavigation` on Page is deprecated and will be removed in the next major version.',
     );
+  }
+  if (breadcrumbs && process.env.NODE_ENV === 'development') {
     // eslint-disable-next-line no-console
     console.warn(
-      'Deprecation: The `breadcrumbs` prop on Page is deprecated and will be removed in the next major version. Please replace with the singular `breadcrumb`.',
+      'Deprecation: The `breadcrumbs` prop on Page is deprecated and will be removed in the next major version. Please replace with a single `backAction`.',
     );
   }
 
@@ -107,11 +109,11 @@ export function Header({
     !actionGroups.length;
 
   const breadcrumbMarkup = () => {
-    if (breadcrumb) {
+    if (backAction) {
       return (
         <div className={styles.BreadcrumbWrapper}>
           <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
-            <Breadcrumbs breadcrumb={breadcrumb} />
+            <Breadcrumbs backAction={backAction} />
           </Box>
         </div>
       );

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -121,15 +121,13 @@ export function Header({
     (Array.isArray(breadcrumbs) && breadcrumbs.length > 0) ||
     (!Array.isArray(breadcrumbs) && breadcrumbs)
   ) {
-    return (
+    breadcrumbMarkup = (
       <div className={styles.BreadcrumbWrapper}>
         <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
           <Breadcrumbs breadcrumbs={breadcrumbs} />
         </Box>
       </div>
     );
-  } else {
-    return null;
   }
 
   const paginationMarkup =

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -108,32 +108,29 @@ export function Header({
       isReactElement(secondaryActions)) &&
     !actionGroups.length;
 
-  const breadcrumbMarkup = () => {
-    if (backAction) {
-      return (
-        <div className={styles.BreadcrumbWrapper}>
-          <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
-            <Breadcrumbs backAction={backAction} />
-          </Box>
-        </div>
-      );
-    }
-
-    if (
-      (Array.isArray(breadcrumbs) && breadcrumbs.length > 0) ||
-      (!Array.isArray(breadcrumbs) && breadcrumbs)
-    ) {
-      return (
-        <div className={styles.BreadcrumbWrapper}>
-          <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
-            <Breadcrumbs breadcrumbs={breadcrumbs} />
-          </Box>
-        </div>
-      );
-    }
-
+  let breadcrumbMarkup = null;
+  if (backAction) {
+    breadcrumbMarkup = (
+      <div className={styles.BreadcrumbWrapper}>
+        <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
+          <Breadcrumbs backAction={backAction} />
+        </Box>
+      </div>
+    );
+  } else if (
+    (Array.isArray(breadcrumbs) && breadcrumbs.length > 0) ||
+    (!Array.isArray(breadcrumbs) && breadcrumbs)
+  ) {
+    return (
+      <div className={styles.BreadcrumbWrapper}>
+        <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
+          <Breadcrumbs breadcrumbs={breadcrumbs} />
+        </Box>
+      </div>
+    );
+  } else {
     return null;
-  };
+  }
 
   const paginationMarkup =
     pagination && !isNavigationCollapsed ? (
@@ -352,7 +349,7 @@ function determineLayout({
   actionMenuMarkup: MaybeJSX;
   additionalMetadataMarkup: MaybeJSX;
   additionalNavigationMarkup: MaybeJSX;
-  breadcrumbMarkup: () => MaybeJSX;
+  breadcrumbMarkup: MaybeJSX;
   isNavigationCollapsed: boolean;
   pageTitleMarkup: JSX.Element;
   paginationMarkup: MaybeJSX;

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -49,8 +49,10 @@ export interface HeaderProps extends TitleProps {
   primaryAction?: PrimaryAction | React.ReactNode;
   /** Page-level pagination */
   pagination?: PaginationProps;
-  /** Collection of breadcrumbs */
+  /** @deprecated Collection of breadcrumbs */
   breadcrumbs?: BreadcrumbsProps['breadcrumbs'];
+  /** A breadcrumb link */
+  breadcrumb?: BreadcrumbsProps['breadcrumb'];
   /** Collection of secondary page-level actions */
   secondaryActions?: MenuActionDescriptor[] | React.ReactNode;
   /** Collection of page-level groups of secondary actions */
@@ -77,6 +79,7 @@ export function Header({
   pagination,
   additionalNavigation,
   breadcrumbs,
+  breadcrumb,
   secondaryActions = [],
   actionGroups = [],
   compactTitle = false,
@@ -90,6 +93,10 @@ export function Header({
     console.warn(
       'Deprecation: The `additionalNavigation` on Page is deprecated and will be removed in the next major version.',
     );
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: The `breadcrumbs` prop on Page is deprecated and will be removed in the next major version. Please replace with the singular `breadcrumb`.',
+    );
   }
 
   const isSingleRow =
@@ -99,15 +106,32 @@ export function Header({
       isReactElement(secondaryActions)) &&
     !actionGroups.length;
 
-  const breadcrumbMarkup =
-    (Array.isArray(breadcrumbs) && breadcrumbs.length > 0) ||
-    (!Array.isArray(breadcrumbs) && breadcrumbs) ? (
-      <div className={styles.BreadcrumbWrapper}>
-        <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
-          <Breadcrumbs breadcrumbs={breadcrumbs} />
-        </Box>
-      </div>
-    ) : null;
+  const breadcrumbMarkup = () => {
+    if (breadcrumb) {
+      return (
+        <div className={styles.BreadcrumbWrapper}>
+          <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
+            <Breadcrumbs breadcrumb={breadcrumb} />
+          </Box>
+        </div>
+      );
+    }
+
+    if (
+      (Array.isArray(breadcrumbs) && breadcrumbs.length > 0) ||
+      (!Array.isArray(breadcrumbs) && breadcrumbs)
+    ) {
+      return (
+        <div className={styles.BreadcrumbWrapper}>
+          <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
+            <Breadcrumbs breadcrumbs={breadcrumbs} />
+          </Box>
+        </div>
+      );
+    }
+
+    return null;
+  };
 
   const paginationMarkup =
     pagination && !isNavigationCollapsed ? (
@@ -326,7 +350,7 @@ function determineLayout({
   actionMenuMarkup: MaybeJSX;
   additionalMetadataMarkup: MaybeJSX;
   additionalNavigationMarkup: MaybeJSX;
-  breadcrumbMarkup: MaybeJSX;
+  breadcrumbMarkup: () => MaybeJSX;
   isNavigationCollapsed: boolean;
   pageTitleMarkup: JSX.Element;
   paginationMarkup: MaybeJSX;

--- a/polaris-react/src/components/Page/tests/Page.test.tsx
+++ b/polaris-react/src/components/Page/tests/Page.test.tsx
@@ -269,6 +269,29 @@ describe('<Page />', () => {
     });
   });
 
+  describe('backAction', () => {
+    const backAction = {
+      content: 'Products',
+      onAction: noop,
+    };
+
+    it('renders a <Header /> when defined', () => {
+      const page = mountWithApp(
+        <Page {...mockProps} backAction={backAction} />,
+      );
+      expect(page).toContainReactComponent(Header);
+    });
+
+    it('gets passed into the <Header />', () => {
+      const page = mountWithApp(
+        <Page {...mockProps} backAction={backAction} />,
+      );
+      expect(page).toContainReactComponent(Header, {
+        backAction,
+      });
+    });
+  });
+
   describe('divider', () => {
     it('renders border when divider is true and header props exist', () => {
       const wrapper = mountWithApp(<Page {...mockProps} divider />);


### PR DESCRIPTION
### WHY are these changes introduced?

As a followup to https://github.com/Shopify/polaris/pull/8016 in preparation for v11 where breadcrumb becomes singular (https://github.com/Shopify/polaris/pull/7990).

I should have originally done this and deprecated breadcrumbs but at the time we had a different upgrade path in mind. After collaborating with a number of folks we determined deprecating breadcrumbs officially and moving to a singular breadcrumb in a `backAction` prop for v11 was the best path.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
