### PR TITLE
Update Papercheck icon changeset info from major to minor

### DIFF
--- a/.changeset/ninety-lobsters-sell.md
+++ b/.changeset/ninety-lobsters-sell.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris-icons': major
+'@shopify/polaris-icons': minor
 ---
 
 Added major and minor icon for Papercheck


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes #8094

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This updates the changeset info associated with PR #8094 to be a minor change rather than a major. This only adds an icon which would be considered a breaking change.