### PR TITLE
Move `Text` component from beta to stable

### DIFF
--- a/.changeset/nasty-suns-hang.md
+++ b/.changeset/nasty-suns-hang.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Removed beta status from `Text`

--- a/polaris.shopify.com/content/components/text.md
+++ b/polaris.shopify.com/content/components/text.md
@@ -19,9 +19,6 @@ keywords:
   - semibold
   - bold
   - list
-status:
-  value: Beta
-  message: This component is in development. There could be breaking changes made to it in a non-major release of Polaris. Please use with caution.
 examples:
   - fileName: text-heading.tsx
     title: Heading


### PR DESCRIPTION
### WHY are these changes introduced?

Now that the admin has been migrated to use Text, we can mark `Text` as stable in v11.

### WHAT is this pull request doing?

Removes beta status and message banner from `Text` component page.
<details>
      <summary>Update Text component page</summary>
      <img src="https://user-images.githubusercontent.com/26749317/215123915-0ed9fef9-d4f7-413a-a31e-73d4e80fec28.png" alt="Update Text component page">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
