### PR TITLE
[Polaris Lighthouse] Remove layout rules from index page

### DIFF
--- a/polaris.shopify.com/pages/tools/stylelint-polaris/rules/index.tsx
+++ b/polaris.shopify.com/pages/tools/stylelint-polaris/rules/index.tsx
@@ -88,6 +88,10 @@ function ruleListMarkdown(): string {
     }
   });
 
+  // Temporary removal of layout rules until it is re-enabled
+  // https://github.com/Shopify/polaris/issues/8188
+  delete content['Layout'];
+
   const ruleList: string[] = Object.keys(content).reduce(
     (prev: string[], key: string) => [...prev, ...content[key]],
     [],


### PR DESCRIPTION
Since we temporarily disabled layout rules from Stylelint Polaris, https://github.com/Shopify/polaris/pull/8168, temporarily removing the rules from the https://polaris.shopify.com/tools/stylelint-polaris/rules
