### PR TITLE
3/x Enforce NodeJS versions with engines in package.json

### DIFF
--- a/polaris-cli/package.json
+++ b/polaris-cli/package.json
@@ -31,7 +31,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": ">=14.13.1"
+    "node": "^16.16.0 || ^18.13.0"
   },
   "os": [
     "darwin",

--- a/polaris-for-vscode/package.json
+++ b/polaris-for-vscode/package.json
@@ -20,7 +20,7 @@
     "shopify"
   ],
   "engines": {
-    "vscode": "^1.64.0"
+    "node": "^16.16.0 || ^18.13.0"
   },
   "categories": [
     "Other"

--- a/polaris-icons/package.json
+++ b/polaris-icons/package.json
@@ -13,6 +13,9 @@
       ]
     }
   },
+  "engines": {
+    "node": "^16.16.0 || ^18.13.0"
+  },
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/polaris-migrator/package.json
+++ b/polaris-migrator/package.json
@@ -6,6 +6,9 @@
   "author": "Shopify <dev@shopify.com>",
   "homepage": "https://polaris.shopify.com",
   "repository": "https://github.com/Shopify/polaris",
+  "engines": {
+    "node": "^16.16.0 || ^18.13.0"
+  },
   "bugs": {
     "url": "https://github.com/Shopify/polaris/issues"
   },

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -10,6 +10,9 @@
   "bugs": {
     "url": "https://github.com/Shopify/polaris/issues"
   },
+  "engines": {
+    "node": "^16.16.0 || ^18.13.0"
+  },
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/polaris-tokens/package.json
+++ b/polaris-tokens/package.json
@@ -5,6 +5,9 @@
   "main": "dist/cjs/build/index.js",
   "module": "dist/esm/build/index.mjs",
   "types": "dist/types/build/index.d.ts",
+  "engines": {
+    "node": "^16.16.0 || ^18.13.0"
+  },
   "exports": {
     ".": {
       "types": "./dist/types/build/index.d.ts",

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -2,6 +2,9 @@
   "name": "polaris.shopify.com",
   "version": "0.30.1",
   "private": true,
+  "engines": {
+    "node": "^16.16.0 || ^18.13.0"
+  },
   "scripts": {
     "build": "yarn gen-assets && playroom build && next build && cp -r public ./.next/standalone/polaris.shopify.com/ && mkdirp ./.next/standalone/polaris.shopify.com/.next && cp -r .next/static ./.next/standalone/polaris.shopify.com/.next/",
     "start": "cd ./.next/standalone/polaris.shopify.com && node ./server.js",

--- a/stylelint-polaris/package.json
+++ b/stylelint-polaris/package.json
@@ -13,6 +13,9 @@
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"
   },
+  "engines": {
+    "node": "^16.16.0 || ^18.13.0"
+  },
   "files": [
     "index.js",
     "configs/",


### PR DESCRIPTION
### WHY are these changes introduced?

We currently set `engines` on the root `package.json`. The problem with this is that consumers of the library do not get this information and they can use the libraries without any warning of what version of NodeJS it supports.

This change adds the engines field to each package to ensure our consumers are using supported versions of NodeJS.

### WHAT is this pull request doing?

Adding the engines field to package.json files
