### PR TITLE
Update `Bleed` to be full width

### DIFF
--- a/.changeset/funny-dryers-change.md
+++ b/.changeset/funny-dryers-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated `Bleed` to take up full width of container

--- a/polaris-react/src/components/Bleed/Bleed.scss
+++ b/polaris-react/src/components/Bleed/Bleed.scss
@@ -1,6 +1,7 @@
 @import '../../styles/common';
 
 .Bleed {
+  width: 100%;
   // stylelint-disable -- Polaris component custom properties
   --pc-bleed-margin-block-start-xs: initial;
   --pc-bleed-margin-block-start-sm: var(--pc-bleed-margin-block-start-xs);

--- a/polaris-react/src/components/Bleed/Bleed.scss
+++ b/polaris-react/src/components/Bleed/Bleed.scss
@@ -1,7 +1,7 @@
 @import '../../styles/common';
 
 .Bleed {
-  width: 100%;
+  min-width: 100%;
   // stylelint-disable -- Polaris component custom properties
   --pc-bleed-margin-block-start-xs: initial;
   --pc-bleed-margin-block-start-sm: var(--pc-bleed-margin-block-start-xs);


### PR DESCRIPTION
### WHY are these changes introduced?

`Bleed` should stretch to the width of its parent element since the intent of the component is to affect spacing relative to the parent element.

### WHAT is this pull request doing?

Sets `Bleed` to take up the full width of the parent element.

Before|After
:----:|:----:
<img width="782" alt="Screenshot 2023-01-30 at 10 05 39 AM" src="https://user-images.githubusercontent.com/3474483/215558330-b76af84f-dd07-426b-928e-60ed111a6bd1.png">|<img width="783" alt="Screenshot 2023-01-30 at 10 05 15 AM" src="https://user-images.githubusercontent.com/3474483/215558360-419a3c92-f9cc-46ac-b89f-978af2011b4e.png">

Playground Example

```jsx
import React from 'react';

import {Box, AlphaStack, Banner, Inline, Link, Text} from '../src';

export function Playground() {
  return (
    <Box padding="4">
      <Banner status="critical">
        <AlphaStack gap="1" fullWidth>
          <Inline align="space-between">
            <Text variant="headingMd" fontWeight="semibold" as="h3">
              Deployment failed in 5min
            </Text>
            <Link external url="https://example.com">
              Logs
            </Link>
          </Inline>
          <p>This order was archived on March 7, 2017 at 3:12pm EDT.</p>
        </AlphaStack>
      </Banner>
    </Box>
  );
}
```