### PR TITLE
[Checkbox] Repair broken indeterminate + disabled state

### DIFF
--- a/.changeset/nine-turkeys-explode.md
+++ b/.changeset/nine-turkeys-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Repair styling for Checkbox when indeterminate and disabled

--- a/polaris-react/src/components/Checkbox/Checkbox.scss
+++ b/polaris-react/src/components/Checkbox/Checkbox.scss
@@ -42,7 +42,8 @@
     }
   }
 
-  &:disabled:checked {
+  &:disabled:checked,
+  &:disabled.Input-indeterminate {
     + .Backdrop {
       background: var(--p-border-disabled);
 

--- a/polaris-react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/polaris-react/src/components/Checkbox/Checkbox.stories.tsx
@@ -6,14 +6,71 @@ export default {
   component: Checkbox,
 } as ComponentMeta<typeof Checkbox>;
 
+type CheckboxState = boolean | 'indeterminate';
+
 export function Default() {
-  const [checked, setChecked] = useState(false);
+  const [checked, setChecked] = useState<CheckboxState>(false);
   const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
 
   return (
     <Checkbox
       label="Basic checkbox"
       checked={checked}
+      onChange={handleChange}
+    />
+  );
+}
+
+export function Indeterminate() {
+  const [checked, setChecked] = useState<CheckboxState>('indeterminate');
+  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+
+  return (
+    <Checkbox
+      label="Basic checkbox"
+      checked={checked}
+      onChange={handleChange}
+    />
+  );
+}
+
+export function DisabledUnchecked() {
+  const [checked, setChecked] = useState<CheckboxState>(false);
+  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+
+  return (
+    <Checkbox
+      label="Basic checkbox"
+      checked={checked}
+      disabled
+      onChange={handleChange}
+    />
+  );
+}
+
+export function DisabledChecked() {
+  const [checked, setChecked] = useState<CheckboxState>(true);
+  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+
+  return (
+    <Checkbox
+      label="Basic checkbox"
+      checked={checked}
+      disabled
+      onChange={handleChange}
+    />
+  );
+}
+
+export function DisabledIndeterminate() {
+  const [checked, setChecked] = useState<CheckboxState>('indeterminate');
+  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+
+  return (
+    <Checkbox
+      label="Basic checkbox"
+      checked={checked}
+      disabled
       onChange={handleChange}
     />
   );


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes - https://github.com/Shopify/polaris/issues/8213

### WHAT is this pull request doing?

Making it so that `indeterminate` and `disabled` `Checkbox` components have the correct background color so the disabled icon is able to be seen by the user.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)
 
See storybook for this PR for stories that I've added that show how this will be displayed.

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  const [checked, setChecked] = useState<CheckboxState>('indeterminate');
  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);

  return (
    <Checkbox
      label="Basic checkbox"
      checked={checked}
      disabled
      onChange={handleChange}
    />
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
