### PR TITLE
[polaris.shopify.com] Add content for uppercase typography

### DIFF
--- a/.changeset/big-carrots-rescue.md
+++ b/.changeset/big-carrots-rescue.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Updated Patterns/Typography copy to include suggestions for uppercase typography styles

--- a/polaris.shopify.com/content/design/typography.md
+++ b/polaris.shopify.com/content/design/typography.md
@@ -125,7 +125,7 @@ Small heading styles, `headingXs` - `headingMd`, and body styles will remain the
 
 ### Uppercase styles
 
-The design language no longer supports uppercase typography. We recommend using the [Text component](/components/text) to apply visual hierarchy. Work with your team to determine with type style works best for your use case.
+The design language no longer supports uppercase typography. We recommend using the [Text component](/components/text) to apply visual hierarchy. Work with your team to determine a type style that works best for your use case.
 
 ---
 

--- a/polaris.shopify.com/content/design/typography.md
+++ b/polaris.shopify.com/content/design/typography.md
@@ -123,6 +123,10 @@ Small heading styles, `headingXs` - `headingMd`, and body styles will remain the
 
 ![An image showing how heading styles change based on breakpoint](/images/foundations/design/typography/type-responsive-styles@2x.png)
 
+### Uppercase styles
+
+The design language no longer supports uppercase typography. We recommend using the [Text component](/components/text) to apply visual hierarchy. Work with your team to determine with type style works best for your use case.
+
 ---
 
 ## Font stack


### PR DESCRIPTION
### WHY are these changes introduced?

Added a section to Design/Typography in the style guide to call out that the design system no longer supports uppercase typography styles.

### WHAT is this pull request doing?

<img width="1353" alt="01-30-evh8p-8m14u" src="https://user-images.githubusercontent.com/26749317/216118646-fafc6bda-4044-4e94-a25e-6157ac361485.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
