### PR TITLE
[Modal][Footer] Fix children not taking full available width

### DIFF
--- a/.changeset/twelve-moose-pretend.md
+++ b/.changeset/twelve-moose-pretend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Modal` without actions not stretching `footer` to full width

--- a/polaris-react/src/components/Modal/components/Footer/Footer.tsx
+++ b/polaris-react/src/components/Modal/components/Footer/Footer.tsx
@@ -25,11 +25,20 @@ export function Footer({
     (secondaryActions && buttonsFrom(secondaryActions)) || null;
   const actions =
     primaryActionButton || secondaryActionButtons ? (
-      <Inline gap="2">
+      <Inline align="end" gap="2">
         {secondaryActionButtons}
         {primaryActionButton}
       </Inline>
     ) : null;
+
+  const childMarkup = children ? (
+    <Inline blockAlign="center" align="space-between">
+      <Box width="100%">{children}</Box>
+      {actions}
+    </Inline>
+  ) : (
+    actions
+  );
 
   return (
     <Inline blockAlign="center">
@@ -39,10 +48,7 @@ export function Footer({
         padding="4"
         width="100%"
       >
-        <Inline blockAlign="center" align="space-between">
-          <Box>{children}</Box>
-          {actions}
-        </Inline>
+        {childMarkup}
       </Box>
     </Inline>
   );


### PR DESCRIPTION
### WHY are these changes introduced?

Modals without actions currently render a Footer that doesn't stretch the full width of the container. 
### WHAT is this pull request doing?

This PR gives the inner most Box a width of 100% so its children can span the entire footer. It also ensures actions are always end-aligned, and prevents rendering an empty box when no `footer` is set on `Modal`.

|Before|After|
|---|---|
|<img width="660" alt="Screenshot 2023-02-02 at 4 17 30 PM" src="https://user-images.githubusercontent.com/18447883/216451760-4adedd36-339a-47a8-9c3f-3dc29040633c.png">|<img width="657" alt="Screenshot 2023-02-02 at 4 17 01 PM" src="https://user-images.githubusercontent.com/18447883/216451778-e6013b52-e025-468b-adad-9b8188ab8a3f.png">|

## Note 

For some reason, even after rebasing, the Chromatic snapshots won't update. Each example Modal's footer is unchanged and their actions laid out as expected when comparing the:
- Storybook examples running this branch locally
- [Storybook publish from this branch (`fix-modal-footer-content-width`)](https://5d559397bae39100201eedc1-vkfralxvvi.chromatic.com/?path=/story/all-components-modal--with-long-content-no-scroll)
- [UI Test Canvas of each example snapshot](https://shopify.chromatic.com/component?appId=5d559397bae39100201eedc1&csfId=all-components-modal&specName=Default&buildNumber=15311&k=63dc4db6de7c3753ce9cd39d-1200-interactive-true&h=19&b=-3) 
- [Storybook publish from `main` branch](https://storybook.polaris.shopify.com/?path=/story/all-components-modal--default).
- [Spinstance](https://admin.web.tophat-modal-footer.chloe-rice.us.spin.dev/store/shop1/collections/8) using the latest snapshot release of this branch

I've denied the updated snapshots so they remain correct on merging.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {
  Box,
  Page,
  AlphaStack,
  Inline,
  Link,
  Text,
  Button,
  Modal,
  TextContainer,
} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ModalExample />
    </Page>
  );
}

function ModalExample() {
  return (
    <Modal
      open
      activator={<div />}
      title="Reach more shoppers with Instagram product tags"
      footer={
        <div
          style={{
            height: 'var(--p-space-8)',
            display: 'flex',
            textAlign: 'center',
            justifyContent: 'center',
            alignItems: 'center',
          }}
        >
          <Text variant="headingMd" fontWeight="semibold">
            Find more local-delivery apps in the <Link>Shopify App Store</Link>
          </Text>
        </div>
      }
    >
      <Modal.Section>
        <TextContainer>
          <p>
            Use Instagram posts to share your products with millions of people.
            Let shoppers buy from your store without leaving Instagram.
          </p>
        </TextContainer>
      </Modal.Section>
    </Modal>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
