### PR TITLE
[Banner] Fix content size

### DIFF
--- a/.changeset/blue-queens-walk.md
+++ b/.changeset/blue-queens-walk.md
@@ -2,4 +2,5 @@
 '@shopify/polaris': patch
 ---
 
-Fixed `Bleed` width
+- Fixed `Bleed` width behavior
+- Fixed `Banner` content width

--- a/.changeset/blue-queens-walk.md
+++ b/.changeset/blue-queens-walk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Bleed` width

--- a/polaris-react/src/components/Banner/Banner.scss
+++ b/polaris-react/src/components/Banner/Banner.scss
@@ -158,6 +158,11 @@
   // stylelint-enable selector-max-class, selector-max-specificity
 }
 
+.ContentWrapper {
+  margin-top: calc(-1 * var(--p-space-05));
+  flex: 1 1 auto;
+}
+
 .withinContentContainer {
   padding: var(--p-space-4);
 

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -1,12 +1,15 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
+  AlphaStack,
   Banner,
   Button,
   Card,
+  Inline,
   Link,
   List,
   Modal,
+  Text,
   TextContainer,
 } from '@shopify/polaris';
 
@@ -184,5 +187,23 @@ export function InACard() {
         <p>View a summary of your online store’s performance.</p>
       </TextContainer>
     </Card>
+  );
+}
+
+export function WithEndJustifiedContent() {
+  return (
+    <Banner status="critical">
+      <AlphaStack gap="1" fullWidth>
+        <Inline align="space-between">
+          <Text variant="headingMd" fontWeight="semibold" as="h3">
+            Deployment failed in 5min
+          </Text>
+          <Link external url="https://example.com">
+            Logs
+          </Link>
+        </Inline>
+        <p>This order was archived on March 7, 2017 at 3:12pm EDT.</p>
+      </AlphaStack>
+    </Banner>
   );
 }

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -26,8 +26,6 @@ import {Icon, IconProps} from '../Icon';
 import {WithinContentContext} from '../../utilities/within-content-context';
 import {Text} from '../Text';
 import {Box} from '../Box';
-import {Bleed} from '../Bleed';
-import {Inline} from '../Inline';
 
 import styles from './Banner.scss';
 

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -27,6 +27,7 @@ import {WithinContentContext} from '../../utilities/within-content-context';
 import {Text} from '../Text';
 import {Box} from '../Box';
 import {Bleed} from '../Bleed';
+import {Inline} from '../Inline';
 
 import styles from './Banner.scss';
 
@@ -174,10 +175,10 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
           <Icon source={iconName} color={iconColor} />
         </Box>
 
-        <Bleed marginInline="0" marginBlockStart="05">
+        <div className={styles.ContentWrapper}>
           {headingMarkup}
           {contentMarkup}
-        </Bleed>
+        </div>
       </div>
     </BannerContext.Provider>
   );

--- a/polaris-react/src/components/Bleed/Bleed.scss
+++ b/polaris-react/src/components/Bleed/Bleed.scss
@@ -1,7 +1,6 @@
 @import '../../styles/common';
 
 .Bleed {
-  width: 100%;
   // stylelint-disable -- Polaris component custom properties
   --pc-bleed-margin-block-start-xs: initial;
   --pc-bleed-margin-block-start-sm: var(--pc-bleed-margin-block-start-xs);

--- a/polaris-react/src/components/Bleed/Bleed.scss
+++ b/polaris-react/src/components/Bleed/Bleed.scss
@@ -1,7 +1,7 @@
 @import '../../styles/common';
 
 .Bleed {
-  min-width: 100%;
+  width: 100%;
   // stylelint-disable -- Polaris component custom properties
   --pc-bleed-margin-block-start-xs: initial;
   --pc-bleed-margin-block-start-sm: var(--pc-bleed-margin-block-start-xs);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes some unexpected behaviour with the `Bleed` component content width
Fixes layout of content section of `Banner`

### WHAT is this pull request doing?

Content inside `Banner` shouldn't extend past the intended content area