### PR TITLE
Dark-mode fixes 

### DIFF
--- a/polaris.shopify.com/src/components/ExampleWrapper/ExampleWrapper.module.scss
+++ b/polaris.shopify.com/src/components/ExampleWrapper/ExampleWrapper.module.scss
@@ -6,6 +6,7 @@
   box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.05), 0px 1px 2px rgba(0, 0, 0, 0.15);
   .Buttons {
     display: flex;
+    color: var(--p-text-subdued);
     justify-content: flex-end;
     border-top: 1px solid rgba(0, 0, 0, 0.075);
     padding: 0.75rem 1rem;

--- a/polaris.shopify.com/src/components/ExampleWrapper/ExampleWrapper.module.scss
+++ b/polaris.shopify.com/src/components/ExampleWrapper/ExampleWrapper.module.scss
@@ -1,20 +1,22 @@
 @import '../../styles/variables.scss';
+@import '../../styles/mixins.scss';
 .ExampleFrame {
+  --example-button-text-color: inherit;
+  @include dark-mode {
+    --example-button-text-color: rgba(78, 82, 184, 1);
+  }
   background: #ffffff;
   border-radius: var(--border-radius-400);
   overflow: hidden;
   box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.05), 0px 1px 2px rgba(0, 0, 0, 0.15);
   .Buttons {
     display: flex;
-    color: var(--p-text-subdued);
+    color: var(--example-button-text-color);
     justify-content: flex-end;
     border-top: 1px solid rgba(0, 0, 0, 0.075);
     padding: 0.75rem 1rem;
     gap: 0.5rem;
     align-items: center;
-    // button,
-    // a {
-    // }
   }
   iframe {
     display: block;

--- a/polaris.shopify.com/src/components/InlinePill/InlinePill.module.scss
+++ b/polaris.shopify.com/src/components/InlinePill/InlinePill.module.scss
@@ -1,10 +1,19 @@
+@import '../../styles/mixins.scss';
 .InlinePill {
+  --inline-pill-background: #f2f7fe;
+  --inline-pill-border-color: #103262;
+  --inline-pill-color: #103262;
+  @include dark-mode {
+    --inline-pill-background: #002852;
+    --inline-pill-border-color: #b5c9fa;
+    --inline-pill-color: #b5c9fa;
+  }
   display: inline-block;
   padding: 0px 5px;
-  background: #f2f7fe;
-  border: 0.5px solid #103262;
+  background: var(--inline-pill-background);
+  border: 0.5px solid var(--inline-pill-border-color);
   border-radius: 3px;
-  color: #103262;
+  color: var(--inline-pill-color);
   vertical-align: bottom;
   font-size: var(--font-size-100);
 }

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -9,11 +9,13 @@
 .TabGroup {
   --tab-background: var(--p-surface-subdued);
   --tab-background-pressed: rgba(250, 250, 250, 1);
+  --tab-background-hover: rgba(241, 241, 241, 1);
   --tab-border: 1px solid #c9cccf;
   @include dark-mode {
     --tab-background: #18181d;
     --tab-background-pressed: var(--tab-background);
     --tab-border: 1px solid rgba(55, 55, 55, 1);
+    --tab-background-hover: rgba(41, 41, 41, 1);
   }
   border-color: var(--tab-border-color);
   isolation: isolate;
@@ -97,7 +99,7 @@
       border-bottom: 0;
     }
     &:hover {
-      background-color: rgba(241, 241, 241, 1);
+      background-color: var(--tab-background-hover);
     }
 
     &:focus,

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -256,13 +256,14 @@
   --props-table-border-color: #c9cccf;
   --props-table-heading-background: rgba(0, 0, 0, 0.02);
   --props-table-content-background: inherit;
-  border: 1px solid var(--props-table-border-color);
   @include dark-mode {
     --props-table-border-color: rgba(55, 55, 55, 1);
     --props-table-heading-background: rgba(30, 30, 35, 1);
     --props-table-content-background: rgba(22, 22, 25, 1);
   }
+  border: 1px solid var(--props-table-border-color);
   border-radius: var(--border-radius-400);
+  background: var(--props-table-content-background);
 
   h3 {
     background: var(--props-table-heading-background);
@@ -275,7 +276,7 @@
     dt {
       color: var(--text-strong);
     }
-    background: var(--props-table-content-background);
+
     border-top: 1px solid var(--props-table-border-color);
     grid-template-columns: fit-content(35%) 1fr;
     padding: 1rem;

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -8,7 +8,7 @@
 
 .TabGroup {
   --tab-background: var(--p-surface-subdued);
-  --tab-background-pressed: var(--p-surface-pressed);
+  --tab-background-pressed: rgba(250, 250, 250, 1);
   --tab-border: 1px solid #c9cccf;
   @include dark-mode {
     --tab-background: #18181d;
@@ -64,7 +64,6 @@
 }
 
 .ExamplesList {
-  --surface-pressed: rgba(250, 250, 250, 1);
   --border-subdued: rgba(201, 204, 207, 1);
 
   display: flex;

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -7,6 +7,15 @@
 }
 
 .TabGroup {
+  --tab-background: var(--p-surface-subdued);
+  --tab-background-pressed: var(--p-surface-pressed);
+  --tab-border: 1px solid #c9cccf;
+  @include dark-mode {
+    --tab-background: #18181d;
+    --tab-background-pressed: var(--tab-background);
+    --tab-border: 1px solid rgba(55, 55, 55, 1);
+  }
+  border-color: var(--tab-border-color);
   isolation: isolate;
   margin-left: -1rem;
   margin-right: -1rem;
@@ -23,13 +32,13 @@
   }
 }
 .Panel {
+  background-color: var(--tab-background);
   position: relative;
   padding: 1rem;
-  background-color: var(--p-surface-subdued);
   // Tuck it up underneath the tabs so it makes the tab buttons appear connected
   // to the panel by hiding a part of the border
   margin-top: -1px;
-  border: var(--p-border-divider);
+  border: var(--tab-border);
   border-radius: var(--border-radius-400);
 
   .TabGroup[data-selected='0'] & {
@@ -65,6 +74,7 @@
   z-index: 5;
 
   button {
+    background: var(--tab-background);
     z-index: 5;
     padding: 0.5rem 1rem;
     text-align: left;
@@ -83,8 +93,8 @@
 
     &[aria-selected='true'] {
       color: var(--text-strong);
-      background-color: var(--surface-pressed);
-      border: var(--p-border-divider);
+      background-color: var(--tab-background-pressed);
+      border: var(--tab-border);
       border-bottom: 0;
     }
     &:hover {
@@ -94,7 +104,7 @@
     &:focus,
     &:focus-visible {
       box-shadow: none;
-      border: var(--p-border-divider);
+      border: var(--tab-border);
       border-bottom: 0;
     }
   }
@@ -148,6 +158,10 @@
       counter-increment: item;
     }
     li:before {
+      --props-list-counter-background: inherit;
+      @include dark-mode {
+        --props-list-counter-background: rgba(240, 240, 240, 1);
+      }
       width: 24px;
       height: 24px;
       position: absolute;
@@ -155,10 +169,12 @@
       content: counter(item);
       font-weight: 700;
       color: rgba(153, 35, 247, 1);
+      background: var(--props-list-counter-background);
       vertical-align: bottom;
       text-align: center;
       display: block;
-      border-radius: 100%;
+      line-height: 1.5rem;
+      border-radius: var(--p-border-radius-2);
     }
   }
   @media screen and (max-width: $breakpointTablet) {
@@ -238,22 +254,28 @@
 
 .CustomTable {
   --props-table-border-color: #c9cccf;
+  --props-table-heading-background: rgba(0, 0, 0, 0.02);
+  --props-table-content-background: inherit;
   border: 1px solid var(--props-table-border-color);
   @include dark-mode {
-    --props-table-border-color: white;
+    --props-table-border-color: rgba(55, 55, 55, 1);
+    --props-table-heading-background: rgba(30, 30, 35, 1);
+    --props-table-content-background: rgba(22, 22, 25, 1);
   }
   border-radius: var(--border-radius-400);
 
   h3 {
-    background: rgba(0, 0, 0, 0.02);
+    background: var(--props-table-heading-background);
+    color: var(--text-strong);
     padding: 0.66rem 1rem;
     margin: 0;
   }
   .DefinitionList {
     display: grid;
-    @include dark-mode {
-      background: rgba(255, 255, 255, 0.05);
+    dt {
+      color: var(--text-strong);
     }
+    background: var(--props-table-content-background);
     border-top: 1px solid var(--props-table-border-color);
     grid-template-columns: fit-content(35%) 1fr;
     padding: 1rem;

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -217,7 +217,7 @@ body,
 .dark-mode {
   --text: #b0b0bc;
   --text-strong: #e7e7f1;
-  --text-subdued: #808089;
+  --text-subdued: #85858e;
   --text-link: #8bb2ff;
   --surface-information: #02382d;
   --surface-warning: #4c250f;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves #7986 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR includes the following changes: 

- ordered list counter-item background changed  `#F0F0F0` in dark mode under How it helps merchants
  - before:  <img width="768" alt="Screenshot 2023-02-03 at 4 30 52 pm" src="https://user-images.githubusercontent.com/12119389/216520240-0e67a81f-c2eb-44f9-b318-99e9f80adc8b.png">
  - after: <img width="593" alt="Screenshot 2023-02-03 at 4 31 14 pm" src="https://user-images.githubusercontent.com/12119389/216520293-c4ae6493-d062-4716-b59f-65415bc375c2.png">
- "Useful when merchants" description list styles updated: 
 -  before: <img width="789" alt="Screenshot 2023-02-03 at 4 36 17 pm" src="https://user-images.githubusercontent.com/12119389/216521017-2fda5b56-f570-49d8-aa32-f71063f50ef0.png">
 - after: <img width="586" alt="Screenshot 2023-02-03 at 4 35 53 pm" src="https://user-images.githubusercontent.com/12119389/216520951-06ec35d8-6ec9-4659-80a6-4bd9ae9db659.png">
- InlinePill styles updated: 
 - before: <img width="569" alt="Screenshot 2023-02-03 at 4 36 48 pm" src="https://user-images.githubusercontent.com/12119389/216521167-47c5b5c0-49b0-4e67-8e63-7b4d6618a230.png">
 - after: <img width="559" alt="Screenshot 2023-02-03 at 4 37 13 pm" src="https://user-images.githubusercontent.com/12119389/216521133-7fcbce3c-9e47-4043-9443-c64ff0a28c15.png">
-`text-subdued` darkmode value changed globally.
- Embedded example action links changed to `rgba(78, 82, 184, 1); ` in dark mode: 
 - before: <img width="802" alt="Screenshot 2023-02-03 at 4 43 15 pm" src="https://user-images.githubusercontent.com/12119389/216521954-fbbcb46e-8ece-4292-abc9-b453d4a4565a.png">
 - after:  <img width="589" alt="Screenshot 2023-02-03 at 4 43 04 pm" src="https://user-images.githubusercontent.com/12119389/216521929-b03111d9-359a-4f80-bb49-46d2e6406155.png">



<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
