### PR TITLE
Updating typos in metaobject and metafield icons

### DIFF
--- a/.changeset/spotty-coins-attend.md
+++ b/.changeset/spotty-coins-attend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': minor
+---
+
+Corrected some types with Metaobjects and Metafields

--- a/polaris-icons/icons/MetafieldsMajor.yml
+++ b/polaris-icons/icons/MetafieldsMajor.yml
@@ -1,4 +1,4 @@
-name: metafields
+name: Metafields
 set: major
 description: Used to represent metafields
 keywords:

--- a/polaris-icons/icons/MetafieldsMinor.yml
+++ b/polaris-icons/icons/MetafieldsMinor.yml
@@ -1,4 +1,4 @@
-name: metafields
+name: Metafields
 set: minor
 description: Used to represent metafields
 keywords:

--- a/polaris-icons/icons/MetaobjectMinor.yml
+++ b/polaris-icons/icons/MetaobjectMinor.yml
@@ -2,7 +2,7 @@ name: Metaobject
 set: minor
 description: Used to represent metaobjects
 keywords:
-  - metaobbject
+  - metaobject
   - content
 authors:
   - Sai Nihas

--- a/polaris-icons/icons/MetaobjectReferenceMinor.yml
+++ b/polaris-icons/icons/MetaobjectReferenceMinor.yml
@@ -2,7 +2,7 @@ name: Metaobject Reference
 set: minor
 description: Used to represent a metaobject referenced on other resources
 keywords:
-  - metaobbject
+  - metaobject
   - reference
 authors:
   - Sai Nihas


### PR DESCRIPTION
### WHY are these changes introduced?

Missed some typos in my original issue. @kjbrum was able to spot them in polaris.

![image (3)](https://user-images.githubusercontent.com/99364596/217069611-8ed63e9e-cc2a-4c62-a4e3-71521b2a3557.png)
![image (2)](https://user-images.githubusercontent.com/99364596/217069617-38308cad-d77b-451e-878f-70fe082a65c6.png)
![image (1)](https://user-images.githubusercontent.com/99364596/217069621-15a7029f-13b5-4c20-bd7b-97b921940ae7.png)

### WHAT is this pull request doing?
- update "metaobbject" to "metaobject"
- update "metafields" to "Metafields"