### PR TITLE
Update badge and banner color for alpha components

### DIFF
--- a/.changeset/forty-pumpkins-bow.md
+++ b/.changeset/forty-pumpkins-bow.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Updated status badge color and banner for Alpha components

--- a/polaris.shopify.com/src/components/StatusBadge/StatusBadge.module.scss
+++ b/polaris.shopify.com/src/components/StatusBadge/StatusBadge.module.scss
@@ -6,7 +6,10 @@
   padding: 0.05rem 0.25rem;
   color: var(--text);
 
-  &[data-value='alpha'],
+  &[data-value='alpha'] {
+    background: var(--surface-attention);
+  }
+
   &[data-value='warning'],
   &[data-value='deprecated'] {
     background: var(--surface-warning);

--- a/polaris.shopify.com/src/components/StatusBanner/StatusBanner.module.scss
+++ b/polaris.shopify.com/src/components/StatusBanner/StatusBanner.module.scss
@@ -5,7 +5,10 @@
   background: var(--surface-subdued);
   border-radius: var(--border-radius-400);
 
-  &[data-value='alpha'],
+  &[data-value='alpha'] {
+    background: var(--surface-attention);
+  }
+
   &[data-value='warning'],
   &[data-value='deprecated'] {
     background: var(--surface-warning);

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -198,10 +198,11 @@ body,
   --text-subdued: #767676;
   --text-link: #4e52b8;
   --surface: #fff;
-  --surface-subdued: #f9f9f9;
-  --surface-information: #dcf5f0;
-  --surface-warning: #ffeceb;
+  --surface-attention: #ffffe1;
   --surface-code-inline: #f1f1f1;
+  --surface-information: #dcf5f0;
+  --surface-subdued: #f9f9f9;
+  --surface-warning: #ffeceb;
   --primary: #008060;
   --border-color: #e9e9e9;
   --border: 1px solid var(--border-color);


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #8239.

Updates alpha component status banner and badge to use `surface-attention` color to differentiate from deprecated components.

### WHAT is this pull request doing?

Adds `--surface-attention` to global styles to be used for alpha components.

<img src="https://user-images.githubusercontent.com/26749317/217257582-df6c93dd-1f4d-44d6-9aa6-dcef2ff8a5f6.png" alt="Updated Alpha component banner and badge">

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
