### PR TITLE
[EmptyState] Remove old design language flex-direction

### DIFF
--- a/.changeset/silly-swans-sparkle.md
+++ b/.changeset/silly-swans-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `EmptyState` `illustration` rendering below content and actions when rendered outside of a content container

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -139,9 +139,9 @@ export function EmptyState({
       paddingBlockStart="5"
       paddingBlockEnd="16"
     >
-      <AlphaStack align="center" gap="0" reverseOrder={withinContentContainer}>
-        {detailsMarkup}
+      <AlphaStack align="center" gap="0">
         {imageMarkup}
+        {detailsMarkup}
       </AlphaStack>
     </Box>
   );


### PR DESCRIPTION
### WHY are these changes introduced?

The `flex-direction: column-reverse;` declaration in `EmptyState` is a relic of the old (purple) design language, where page level empty states were very large illustrations with content and actions kind of positioned over them, and above them on small screens. This column direction change is no longer necessary, because in the [new (current) design language](https://github.com/Shopify/polaris-ux-archive/issues/310) we always want the illustration above the content and actions and illustration sizes are 60px instead of being full page.

|Old design lang| New/current design lang|
|---|---|
|<img width="452" alt="Screenshot 2023-02-07 at 1 51 32 PM" src="https://user-images.githubusercontent.com/18447883/217338582-4429895d-4c58-4b83-9ae6-f06e27af5fbe.png">|<img width="655" alt="Screenshot 2023-02-07 at 1 38 03 PM" src="https://user-images.githubusercontent.com/18447883/217335627-6b7b85e4-6fbc-4860-a63b-cf58528708c8.png">|

Because the `flex-direction` was set on both the [default](https://github.com/Shopify/polaris/blob/b619de6aa7b13e4395cf5f705ef32c3e991bfb20/polaris-react/src/components/EmptyState/EmptyState.scss#L42) and [within content context](https://github.com/Shopify/polaris/blob/b619de6aa7b13e4395cf5f705ef32c3e991bfb20/polaris-react/src/components/EmptyState/EmptyState.scss#L87) variants, it wasn't clear that it wasn't meant to still be there. So when the `EmptyState` was rebuilt with the new Layout components, the old markup was kept with the illustration and content in reverse order, but [only within content context](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/EmptyState/EmptyState.tsx#L142) is getting reversed to the correct order.

### WHAT is this pull request doing?

This PR removes the relics of the old design language by:
- Moving `EmptyState` `illustration` markup above the content
- Removing the `reverseOrder` prop from the `AlphaStack` that wraps the markup

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
