### PR TITLE
Revert "[Modal][Footer] Fix children not taking full available width"

### DIFF
--- a/.changeset/twenty-camels-push.md
+++ b/.changeset/twenty-camels-push.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Reverted Modal footer layout bug fix shipped in [#8253](https://github.com/Shopify/polaris/pull/8253)

--- a/polaris-react/src/components/Modal/components/Footer/Footer.tsx
+++ b/polaris-react/src/components/Modal/components/Footer/Footer.tsx
@@ -25,20 +25,11 @@ export function Footer({
     (secondaryActions && buttonsFrom(secondaryActions)) || null;
   const actions =
     primaryActionButton || secondaryActionButtons ? (
-      <Inline align="end" gap="2">
+      <Inline gap="2">
         {secondaryActionButtons}
         {primaryActionButton}
       </Inline>
     ) : null;
-
-  const childMarkup = children ? (
-    <Inline blockAlign="center" align="space-between">
-      <Box width="100%">{children}</Box>
-      {actions}
-    </Inline>
-  ) : (
-    actions
-  );
 
   return (
     <Inline blockAlign="center">
@@ -48,7 +39,10 @@ export function Footer({
         padding="4"
         width="100%"
       >
-        {childMarkup}
+        <Inline blockAlign="center" align="space-between">
+          <Box>{children}</Box>
+          {actions}
+        </Inline>
       </Box>
     </Inline>
   );


### PR DESCRIPTION
## Why are these changes shipping?
The bug fix is causing upstream `Modal` footer layouts to break that have already hacked a bug fix for this issue. There needs to be a thorough tophat of the 10 `PagedModals` setting `renderFooter` as well as the 62 `Modals` setting `footer` before we can confidently ship this fix.

## What is this PR doing?
Reverting Shopify/polaris#8253