### PR TITLE
[Icon] Add data attribute with icon name to Icon component

### DIFF
--- a/.changeset/large-suns-buy.md
+++ b/.changeset/large-suns-buy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add data attribute with icon name to Icon component

--- a/polaris-react/src/components/Icon/Icon.tsx
+++ b/polaris-react/src/components/Icon/Icon.tsx
@@ -76,12 +76,16 @@ export function Icon({source, color, backdrop, accessibilityLabel}: IconProps) {
   );
 
   const SourceComponent = source;
+  const iconName = (source as React.FunctionComponent)?.name
+    ?.replace('Svg', '')
+    .replace(/\d+$/, '');
   const contentMarkup = {
     function: (
       <SourceComponent
         className={styles.Svg}
         focusable="false"
         aria-hidden="true"
+        data-icon-name={iconName}
       />
     ),
     placeholder: <div className={styles.Placeholder} />,


### PR DESCRIPTION
### WHY are these changes introduced?

For my [hackdays project](https://github.com/Shopify/web/pull/83572), I needed the name of an icon somewhere on its element so that I could link to the specific icon in the DevUI tool. This could also be useful for developers and designers using normal developer tools so that they can see what icon is being used at a glance without having to scroll through searching our icon library

### WHAT is this pull request doing?
I added a new data attribute `data-icon-name` to the icon's svg element 

Before
<img width="429" alt="Screenshot 2023-02-10 at 1 21 29 PM" src="https://user-images.githubusercontent.com/20652326/218168069-ddf59842-32b1-42ea-8bc5-6e852a734005.png">

After
<img width="430" alt="Screenshot 2023-02-10 at 1 21 06 PM" src="https://user-images.githubusercontent.com/20652326/218168091-61c06abd-34e9-4385-8c24-bde3d8083cab.png">


### How to 🎩
I used the snapshot to add this to [Shopify/web](https://github.com/Shopify/web/pull/83680) and CI passed!
<img width="1078" alt="Screenshot 2023-02-10 at 2 21 48 PM" src="https://user-images.githubusercontent.com/20652326/218179574-0225a861-653f-45d9-bb5e-4a2874b8f452.png">

