### PR TITLE
Replace border-radius large with border-radius-2

### DIFF
--- a/polaris-react/src/components/Box/Box.tsx
+++ b/polaris-react/src/components/Box/Box.tsx
@@ -58,8 +58,7 @@ export type BorderRadiusTokenScale =
   | '4'
   | '5'
   | '6'
-  | 'full'
-  | 'large';
+  | 'full';
 
 export type BackgroundColors =
   | ColorsBackdropTokenAlias

--- a/polaris-react/src/components/Box/tests/Box.test.tsx
+++ b/polaris-react/src/components/Box/tests/Box.test.tsx
@@ -42,7 +42,10 @@ type BorderTokenAlias = Exclude<
 >;
 
 type BorderRadiusTokenScale = Extract<
-  Exclude<BorderShapeTokenScale, 'radius-half' | 'radius-base'>,
+  Exclude<
+    BorderShapeTokenScale,
+    'radius-half' | 'radius-base' | 'radius-large'
+  >,
   `radius-${string}`
 > extends `radius-${infer Scale}`
   ? Scale

--- a/polaris-react/src/components/DropZone/DropZone.scss
+++ b/polaris-react/src/components/DropZone/DropZone.scss
@@ -25,7 +25,7 @@ $dropzone-stacking-order: (
 }
 
 @mixin set-border-radius {
-  border-radius: var(--p-border-radius-large);
+  border-radius: var(--p-border-radius-2);
 }
 
 .DropZone {

--- a/polaris-react/src/components/Modal/components/CloseButton/CloseButton.scss
+++ b/polaris-react/src/components/Modal/components/CloseButton/CloseButton.scss
@@ -8,7 +8,7 @@
   margin-left: var(--p-space-5);
   margin-right: calc(-1 * var(--p-space-2));
   padding: var(--p-space-2);
-  border-radius: var(--p-border-radius-large);
+  border-radius: var(--p-border-radius-2);
 
   &:hover {
     background: var(--p-surface-hovered);


### PR DESCRIPTION
### WHY are these changes introduced?

Remove a legacy alias token that is not a part of our border radius scale.

### WHAT is this pull request doing?

- [x] Replace usage of `border-radius-large` with `border-radius-2`
- [x] Removes `border-radius-large` as an option from `Box`