### PR TITLE
Fix typo on pattern pages

### DIFF
--- a/polaris.shopify.com/content/patterns/resource-details-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-details-layout.ts
@@ -32,7 +32,7 @@ const pattern: SingleVariantPattern = {
   |Arrange content in order of importance.|![](/images/patterns/resource-detail-usage-5.png)|`,
   relatedResources: `* The [Resource index layout](/patterns/resource-index-layout) pattern is a complement to the resource detail layout pattern.
 * Learn about the meaning of “resources” on the [Resource list](/components/resource-list) component page
-* Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) the app design guidelines.
+* Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) in the app design guidelines.
 * Check out the Polaris [Spacing](/design/space) guidelines to understand Polaris grid and spacing scale.`,
   example: {
     relatedComponents: [

--- a/polaris.shopify.com/content/patterns/resource-index-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-index-layout.ts
@@ -28,7 +28,7 @@ const pattern: SingleVariantPattern = {
   relatedResources: `* The [Resource detail layout](/patterns/resource-details-layout) pattern is a complement to the resource index layout pattern.
 * Use the [Empty state component](/components/empty-state) when the resource index is empty.
 * Learn about the meaning of “resources” on the [Resource list](/components/resource-list) component page
-* Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) the app design guidelines.
+* Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) in the app design guidelines.
 * Check out the Polaris [Spacing](/design/space) guidelines to understand Polaris grid and spacing scale.`,
   example: {
     relatedComponents: [


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8249, minor typo in resource-index-layout and resource-details-layout pattern pages. 

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
