### PR TITLE
8248/fix toc layout

### DIFF
--- a/polaris.shopify.com/src/components/Container/Container.module.scss
+++ b/polaris.shopify.com/src/components/Container/Container.module.scss
@@ -5,7 +5,7 @@
   margin-left: auto;
   margin-right: auto;
   max-width: $pageMaxWidth;
-  padding: 0 4rem;
+  padding: 0 1.5rem;
 
   @media screen and (max-width: $breakpointTablet) {
     padding: 0 1.25rem;

--- a/polaris.shopify.com/src/components/Page/Page.module.scss
+++ b/polaris.shopify.com/src/components/Page/Page.module.scss
@@ -23,7 +23,7 @@
 .Page {
   --toc-width: 16rem;
   display: flex;
-  gap: 5rem;
+  gap: 2.5rem;
 }
 
 .Post {


### PR DESCRIPTION
This PR adjusts the page padding site wide to ensure that the minimum breakpoint at which the TOC appears allows embedded examples to show the default desktop breakpoint. Previously this would show a tablet breakpoint instead.
* Updated Page styles to reduce gap from `5rem` to `2.5rem` 
* Update Container styles to reduce horizontal padding from `4rem` to `1.5rem` 


