### PR TITLE
Migrate `--p-space-0` tokens in SCSS files to `0` 

### DIFF
--- a/.changeset/calm-vans-guess.md
+++ b/.changeset/calm-vans-guess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Migrate `--p-space-0` tokens to `0` in SCSS files

--- a/.changeset/calm-vans-guess.md
+++ b/.changeset/calm-vans-guess.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Migrate `--p-space-0` tokens to `0` in SCSS files
+Migrated `--p-space-0` tokens to `0` in SCSS files

--- a/polaris-react/src/components/Card/Card.scss
+++ b/polaris-react/src/components/Card/Card.scss
@@ -42,7 +42,7 @@
   }
 
   @media print and #{$p-breakpoints-sm-up} {
-    padding: var(--p-space-2) var(--p-space-4) var(--p-space-0);
+    padding: var(--p-space-2) var(--p-space-4) 0;
   }
 }
 
@@ -78,18 +78,18 @@
 }
 
 .Section-fullWidth {
-  padding: var(--p-space-4) var(--p-space-0);
+  padding: var(--p-space-4) 0;
 
   @media #{$p-breakpoints-sm-up} {
-    padding: var(--p-space-5) var(--p-space-0);
+    padding: var(--p-space-5) 0;
   }
 }
 
 .Section-flush {
-  padding: var(--p-space-0);
+  padding: 0;
 
   @media #{$p-breakpoints-sm-up} {
-    padding: var(--p-space-0);
+    padding: 0;
   }
 }
 

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -42,7 +42,7 @@
   }
 
   @media print and #{$p-breakpoints-sm-up} {
-    padding: var(--p-space-2) var(--p-space-4) var(--p-space-0);
+    padding: var(--p-space-2) var(--p-space-4) 0;
   }
 }
 
@@ -78,18 +78,18 @@
 }
 
 .Section-fullWidth {
-  padding: var(--p-space-4) var(--p-space-0);
+  padding: var(--p-space-4) 0;
 
   @media #{$p-breakpoints-sm-up} {
-    padding: var(--p-space-5) var(--p-space-0);
+    padding: var(--p-space-5) 0;
   }
 }
 
 .Section-flush {
-  padding: var(--p-space-0);
+  padding: 0;
 
   @media #{$p-breakpoints-sm-up} {
-    padding: var(--p-space-0);
+    padding: 0;
   }
 }
 

--- a/polaris-react/src/components/LegacyStack/LegacyStack.scss
+++ b/polaris-react/src/components/LegacyStack/LegacyStack.scss
@@ -26,7 +26,7 @@
 
 .spacingNone {
   // stylelint-disable-next-line -- Polaris component custom properties
-  --pc-stack-spacing: var(--p-space-0);
+  --pc-stack-spacing: 0;
 }
 
 .spacingExtraTight {
@@ -117,10 +117,10 @@
 
 .vertical {
   flex-direction: column;
-  margin-left: var(--p-space-0);
+  margin-left: 0;
 
   > .Item {
-    margin-left: var(--p-space-0);
+    margin-left: 0;
   }
 }
 

--- a/polaris-react/src/components/Stack/Stack.scss
+++ b/polaris-react/src/components/Stack/Stack.scss
@@ -26,7 +26,7 @@
 
 .spacingNone {
   // stylelint-disable-next-line -- Polaris component custom properties
-  --pc-stack-spacing: var(--p-space-0);
+  --pc-stack-spacing: 0;
 }
 
 .spacingExtraTight {
@@ -117,10 +117,10 @@
 
 .vertical {
   flex-direction: column;
-  margin-left: var(--p-space-0);
+  margin-left: 0;
 
   > .Item {
-    margin-left: var(--p-space-0);
+    margin-left: 0;
   }
 }
 

--- a/polaris-react/src/components/TextField/TextField.scss
+++ b/polaris-react/src/components/TextField/TextField.scss
@@ -247,8 +247,8 @@ $spinner-icon-size: 12px;
   width: 100%;
 
   > .Input {
-    padding-left: var(--p-space-0);
-    padding-right: var(--p-space-0);
+    padding-left: 0;
+    padding-right: 0;
   }
 
   @media #{$p-breakpoints-sm-up} {


### PR DESCRIPTION
### WHY are these changes introduced?

While our team has decided to keep the `--p-space-0` token in our system we don't need to be using it to replace unitless zero values.

### WHAT is this pull request doing?

Runs the `styles-replace-custom-property` migration from `@shopify/polaris-migrator` to replace any instances of `--p-space-0` with `0` in `polaris-react` Sass files. e.g.

```sh
npx @shopify/polaris-migrator styles-replace-custom-property \
  --decl="/.+/" --from="--p-space-0" --to="0" '../polaris-react/src/**/*.scss'
```