### PR TITLE
Add flag for draft pages

### DIFF
--- a/polaris.shopify.com/content/patterns/resource-index-layout.md
+++ b/polaris.shopify.com/content/patterns/resource-index-layout.md
@@ -6,4 +6,7 @@ previewImg: /images/patterns/pattern-thumbnail-resource-index.png
 order: 10
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8215
 contentFile: 'resource-index-layout.ts'
+hideFromNav: true
+draft: true
+noIndex: true
 ---

--- a/polaris.shopify.com/pages/patterns/[...slug].tsx
+++ b/polaris.shopify.com/pages/patterns/[...slug].tsx
@@ -5,6 +5,7 @@ import globby from 'globby';
 import matter from 'gray-matter';
 
 import PatternPage from '../../src/components/PatternPage';
+import ComingSoon from '../../src/components/ComingSoon';
 import {Pattern, PatternFrontMatter} from '../../src/types';
 
 interface Props extends PatternFrontMatter {
@@ -61,6 +62,7 @@ export const getStaticProps: GetStaticProps<Props, {slug: string[]}> = async ({
   return {
     props: {
       ...data,
+      draft: data.draft || false,
       pattern,
     },
   };
@@ -80,6 +82,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
 };
 
 const PatternsPage: NextPage<Props> = (props: Props) => {
+  if (props.draft && process.env.NODE_ENV === 'production')
+    return <ComingSoon />;
   return <PatternPage {...props} />;
 };
 

--- a/polaris.shopify.com/src/components/ComingSoon/index.tsx
+++ b/polaris.shopify.com/src/components/ComingSoon/index.tsx
@@ -1,0 +1,5 @@
+import Page from '../Page';
+
+export default function ComingSoon() {
+  return <Page>Coming Soon</Page>;
+}

--- a/polaris.shopify.com/src/types.ts
+++ b/polaris.shopify.com/src/types.ts
@@ -57,6 +57,7 @@ export interface FrontMatter {
 export interface PatternFrontMatter extends FrontMatter {
   previewImg?: string;
   order?: number;
+  draft: boolean;
   githubDiscussionsLink?: string;
   contentFile: string;
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #8311

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR has the following changes: 
* Resource index layout page is hidden from nav 
* Resource index layout page has a 'noindex' tag in the `head` to [omit it from search engine indexing](https://en.wikipedia.org/wiki/Noindex)
* `draft` flag implemented for patterns, that renders a `Coming Soon` component instead of the pattern contents when enabled (and in production) 
* `draft` flag added to Resource index layout page. 


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
