### PR TITLE
Revert "Revert "[Layout foundations] Migrate `Card` to `LegacyCard`" (#8350)"

### DIFF
--- a/.changeset/nervous-poets-happen.md
+++ b/.changeset/nervous-poets-happen.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Migrated usage of `Card` to `LegacyCard`

--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -41,7 +41,7 @@ Otherwise include the CSS in your HTML. We suggest copying the styles file into 
 
 ```js
 import enTranslations from '@shopify/polaris/locales/en.json';
-import {AppProvider, Page, Card, Button} from '@shopify/polaris';
+import {AppProvider, Page, LegacyCard, Button} from '@shopify/polaris';
 ```
 
 3.  Tell React to render the element in the DOM:
@@ -50,9 +50,9 @@ import {AppProvider, Page, Card, Button} from '@shopify/polaris';
 ReactDOM.render(
   <AppProvider i18n={enTranslations}>
     <Page title="Example app">
-      <Card sectioned>
+      <LegacyCard sectioned>
         <Button onClick={() => alert('Button clicked!')}>Example button</Button>
-      </Card>
+      </LegacyCard>
     </Page>
   </AppProvider>,
   document.querySelector('#app'),

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -19,13 +19,13 @@ import {
 import {
   ActionList,
   Badge,
-  Card,
   ContextualSaveBar,
   DropZone,
   DropZoneProps,
   FormLayout,
   Frame,
   Layout,
+  LegacyCard,
   Loading,
   Modal,
   Navigation,
@@ -595,7 +595,7 @@ export function DetailsPage() {
       <Layout>
         {skipToContentTarget}
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Title"
@@ -614,17 +614,17 @@ export function DetailsPage() {
                 multiline
               />
             </FormLayout>
-          </Card>
-          <Card title="Media" sectioned>
+          </LegacyCard>
+          <LegacyCard title="Media" sectioned>
             <DropZone onDrop={handleDropZoneDrop}>
               {uploadedFiles}
               {fileUpload}
             </DropZone>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card title="Organization">
-            <Card.Section>
+          <LegacyCard title="Organization">
+            <LegacyCard.Section>
               <Select
                 label="Product type"
                 options={options}
@@ -638,10 +638,10 @@ export function DetailsPage() {
                 onChange={setSelected}
                 value={selected}
               />
-            </Card.Section>
-            <Card.Section title="Collections" />
-            <Card.Section title="Tags" />
-          </Card>
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Collections" />
+            <LegacyCard.Section title="Tags" />
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>
@@ -652,12 +652,12 @@ export function DetailsPage() {
     <SkeletonPage>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText lines={9} />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>

--- a/polaris-react/src/components/AppProvider/AppProvider.stories.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.stories.tsx
@@ -3,7 +3,7 @@ import type {ComponentMeta} from '@storybook/react';
 import {
   AppProvider,
   Avatar,
-  Card,
+  LegacyCard,
   ContextualSaveBar,
   Layout,
   Page,
@@ -39,7 +39,7 @@ export function Default() {
       }}
     >
       <Page>
-        <Card>
+        <LegacyCard>
           <ResourceList
             showHeader
             items={[
@@ -72,7 +72,7 @@ export function Default() {
               );
             }}
           />
-        </Card>
+        </LegacyCard>
       </Page>
     </AppProvider>
   );
@@ -99,7 +99,7 @@ export function WithI18n() {
       }}
     >
       <Page>
-        <Card>
+        <LegacyCard>
           <ResourceList
             showHeader
             items={[
@@ -132,7 +132,7 @@ export function WithI18n() {
               );
             }}
           />
-        </Card>
+        </LegacyCard>
       </Page>
     </AppProvider>
   );

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -4,7 +4,7 @@ import {
   AlphaStack,
   Banner,
   Button,
-  Card,
+  LegacyCard,
   Inline,
   Link,
   List,
@@ -175,7 +175,7 @@ export function WithFocus() {
 
 export function InACard() {
   return (
-    <Card title="Online store dashboard" sectioned>
+    <LegacyCard title="Online store dashboard" sectioned>
       <TextContainer>
         <Banner onDismiss={() => {}}>
           <p>
@@ -186,7 +186,7 @@ export function InACard() {
 
         <p>View a summary of your online store’s performance.</p>
       </TextContainer>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris-react/src/components/CalloutCard/CalloutCard.tsx
+++ b/polaris-react/src/components/CalloutCard/CalloutCard.tsx
@@ -3,7 +3,7 @@ import {CancelSmallMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../utilities/css';
 import type {Action} from '../../types';
-import {Card} from '../Card';
+import {LegacyCard} from '../LegacyCard';
 import {TextContainer} from '../TextContainer';
 import {ButtonGroup} from '../ButtonGroup';
 import {Button, buttonFrom} from '../Button';
@@ -71,10 +71,10 @@ export function CalloutCard({
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <div className={containerClassName}>
         {dismissButton}
-        <Card.Section>
+        <LegacyCard.Section>
           <div className={styles.CalloutCard}>
             <div className={styles.Content}>
               <div className={styles.Title}>
@@ -88,8 +88,8 @@ export function CalloutCard({
 
             <Image alt="" className={imageClassName} source={illustration} />
           </div>
-        </Card.Section>
+        </LegacyCard.Section>
       </div>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/Collapsible/Collapsible.stories.tsx
+++ b/polaris-react/src/components/Collapsible/Collapsible.stories.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Button,
-  Card,
+  LegacyCard,
   Collapsible,
   Link,
   Stack,
@@ -20,7 +20,7 @@ export function Default() {
 
   return (
     <div style={{height: '200px'}}>
-      <Card sectioned>
+      <LegacyCard sectioned>
         <Stack vertical>
           <Button
             onClick={handleToggle}
@@ -48,7 +48,7 @@ export function Default() {
             </TextContainer>
           </Collapsible>
         </Stack>
-      </Card>
+      </LegacyCard>
     </div>
   );
 }

--- a/polaris-react/src/components/DataTable/DataTable.stories.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Card, DataTable, Link, Page} from '@shopify/polaris';
+import {LegacyCard, DataTable, Link, Page} from '@shopify/polaris';
 
 export default {
   component: DataTable,
@@ -37,7 +37,7 @@ export function Default() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -56,7 +56,7 @@ export function Default() {
           rows={rows}
           totals={['', '', '', 255, '$155,830.00']}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -84,7 +84,7 @@ export function Sortable() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -107,7 +107,7 @@ export function Sortable() {
           initialSortColumnIndex={4}
           onSort={handleSort}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -127,7 +127,7 @@ export function WithFooter() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -147,7 +147,7 @@ export function WithFooter() {
           totals={['', '', '', 255, '$155,830.00']}
           footerContent={`Showing ${rows.length} of ${rows.length} results`}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -167,7 +167,7 @@ export function WithCustomTotalsHeading() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           showTotalsInFooter
           columnContentTypes={[
@@ -191,7 +191,7 @@ export function WithCustomTotalsHeading() {
             plural: 'Total net sales',
           }}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -211,7 +211,7 @@ export function WithTotalsInFooter() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -231,7 +231,7 @@ export function WithTotalsInFooter() {
           totals={['', '', '', 255, '$155,830.00']}
           showTotalsInFooter
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -281,7 +281,7 @@ export function WithRowHeadingLinks() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -294,7 +294,7 @@ export function WithRowHeadingLinks() {
           rows={rows}
           totals={['', '', '', 255, '$155,830.00']}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -352,7 +352,7 @@ export function WithAllOfItsElements() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -379,7 +379,7 @@ export function WithAllOfItsElements() {
           fixedFirstColumns={1}
           truncate
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -397,7 +397,7 @@ export function WithColumnSpanning() {
       '$1.00',
     ],
     // eslint-disable-next-line react/jsx-key
-    [<Card>Hello</Card>],
+    [<LegacyCard>Hello</LegacyCard>],
     [
       'Sep 19, 2010, 1:02 pm NDT',
       '#1234',
@@ -412,7 +412,7 @@ export function WithColumnSpanning() {
 
   return (
     <Page title="Payouts">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -438,7 +438,7 @@ export function WithColumnSpanning() {
           rows={rows}
           verticalAlign="middle"
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -493,7 +493,7 @@ export function WithFixedColumns() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -526,7 +526,7 @@ export function WithFixedColumns() {
           showTotalsInFooter
           footerContent={`Showing ${rows.length} of ${rows.length} results`}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -576,7 +576,7 @@ export function WithIncreasedDensityAndZebraStriping() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -600,7 +600,7 @@ export function WithIncreasedDensityAndZebraStriping() {
           hasZebraStripingOnData
           increasedTableDensity
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -845,7 +845,7 @@ export function WithStickyHeaderEnabled() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -870,7 +870,7 @@ export function WithStickyHeaderEnabled() {
           increasedTableDensity
           stickyHeader
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris-react/src/components/DropZone/DropZone.stories.tsx
+++ b/polaris-react/src/components/DropZone/DropZone.stories.tsx
@@ -3,7 +3,7 @@ import type {ComponentMeta} from '@storybook/react';
 import {
   Banner,
   Text,
-  Card,
+  LegacyCard,
   DropZone,
   List,
   Page,
@@ -337,12 +337,12 @@ export function Nested() {
 
   return (
     <DropZone outline={false} onDrop={handleDrop}>
-      <Card sectioned>
+      <LegacyCard sectioned>
         <DropZone onClick={handleDropZoneClick}>
           {uploadedFiles}
           {fileUpload}
         </DropZone>
-      </Card>
+      </LegacyCard>
     </DropZone>
   );
 }
@@ -457,7 +457,7 @@ export function WithCustomFileDialogTrigger() {
   );
 
   return (
-    <Card
+    <LegacyCard
       sectioned
       title="Product Images"
       actions={[
@@ -474,6 +474,6 @@ export function WithCustomFileDialogTrigger() {
       >
         {uploadedFiles}
       </DropZone>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/EmptyState/EmptyState.stories.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Card, EmptyState, Link} from '@shopify/polaris';
+import {LegacyCard, EmptyState, Link} from '@shopify/polaris';
 
 export default {
   component: EmptyState,
@@ -8,7 +8,7 @@ export default {
 
 export function Default() {
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <EmptyState
         heading="Manage your inventory transfers"
         action={{content: 'Add transfer'}}
@@ -20,13 +20,13 @@ export function Default() {
       >
         <p>Track and receive your incoming inventory from suppliers.</p>
       </EmptyState>
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithSubduedFooterContext() {
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <EmptyState
         heading="Manage your inventory transfers"
         action={{content: 'Add transfer'}}
@@ -48,13 +48,13 @@ export function WithSubduedFooterContext() {
       >
         <p>Track and receive your incoming inventory from suppliers.</p>
       </EmptyState>
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithFullWidthLayout() {
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <EmptyState
         heading="Upload a file to get started"
         action={{content: 'Upload files'}}
@@ -67,7 +67,7 @@ export function WithFullWidthLayout() {
           full width.
         </p>
       </EmptyState>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris-react/src/components/Filters/Filters.stories.tsx
+++ b/polaris-react/src/components/Filters/Filters.stories.tsx
@@ -3,7 +3,7 @@ import type {ComponentMeta} from '@storybook/react';
 import {
   Avatar,
   Button,
-  Card,
+  LegacyCard,
   ChoiceList,
   DataTable,
   Filters,
@@ -149,7 +149,7 @@ export function WithAResourceList() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -195,7 +195,7 @@ export function WithAResourceList() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 
@@ -340,8 +340,8 @@ export function WithADataTable() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
-        <Card.Section>
+      <LegacyCard>
+        <LegacyCard.Section>
           <Filters
             queryValue={queryValue}
             filters={filters}
@@ -350,7 +350,7 @@ export function WithADataTable() {
             onQueryClear={handleQueryValueRemove}
             onClearAll={handleFiltersClearAll}
           />
-        </Card.Section>
+        </LegacyCard.Section>
         <DataTable
           columnContentTypes={[
             'text',
@@ -379,7 +379,7 @@ export function WithADataTable() {
           ]}
           totals={['', '', '', 255, '$155,830.00']}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 
@@ -454,7 +454,7 @@ export function WithChildrenContent() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -506,7 +506,7 @@ export function WithChildrenContent() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 
@@ -577,7 +577,7 @@ export function Disabled() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -633,7 +633,7 @@ export function Disabled() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 
@@ -724,7 +724,7 @@ export function SomeDisabled() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -779,7 +779,7 @@ export function SomeDisabled() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 
@@ -852,7 +852,7 @@ export function WithoutClearButton() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -907,7 +907,7 @@ export function WithoutClearButton() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 
@@ -1052,7 +1052,7 @@ export function WithHelpText() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -1100,7 +1100,7 @@ export function WithHelpText() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 
@@ -1249,7 +1249,7 @@ export function WithQueryFieldHidden() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -1296,7 +1296,7 @@ export function WithQueryFieldHidden() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 
@@ -1445,7 +1445,7 @@ export function WithQueryFieldDisabled() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -1492,7 +1492,7 @@ export function WithQueryFieldDisabled() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris-react/src/components/Frame/Frame.stories.tsx
+++ b/polaris-react/src/components/Frame/Frame.stories.tsx
@@ -3,7 +3,7 @@ import type {ComponentMeta} from '@storybook/react';
 import {
   ActionList,
   AppProvider,
-  Card,
+  LegacyCard,
   ContextualSaveBar,
   FormLayout,
   Frame,
@@ -238,7 +238,7 @@ export function InAnApplication() {
           title="Account details"
           description="Jaded Pixel will use this as your account information."
         >
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Full name"
@@ -254,7 +254,7 @@ export function InAnApplication() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.AnnotatedSection>
       </Layout>
     </Page>
@@ -264,12 +264,12 @@ export function InAnApplication() {
     <SkeletonPage>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText lines={9} />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>
@@ -577,7 +577,7 @@ export function WithAnOffset() {
           title="Account details"
           description="Jaded Pixel will use this as your account information."
         >
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Full name"
@@ -593,7 +593,7 @@ export function WithAnOffset() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.AnnotatedSection>
       </Layout>
     </Page>
@@ -603,12 +603,12 @@ export function WithAnOffset() {
     <SkeletonPage>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText lines={9} />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>

--- a/polaris-react/src/components/Grid/Grid.stories.tsx
+++ b/polaris-react/src/components/Grid/Grid.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Card, Grid, Page} from '@shopify/polaris';
+import {LegacyCard, Grid, Page} from '@shopify/polaris';
 
 export default {
   component: Grid,
@@ -11,14 +11,14 @@ export function TwoColumn() {
     <Page fullWidth>
       <Grid>
         <Grid.Cell columnSpan={{xs: 6, sm: 3, md: 3, lg: 6, xl: 6}}>
-          <Card title="Sales" sectioned>
+          <LegacyCard title="Sales" sectioned>
             <p>View a summary of your online store’s sales.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
         <Grid.Cell columnSpan={{xs: 6, sm: 3, md: 3, lg: 6, xl: 6}}>
-          <Card title="Orders" sectioned>
+          <LegacyCard title="Orders" sectioned>
             <p>View a summary of your online store’s orders.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
       </Grid>
     </Page>
@@ -30,14 +30,14 @@ export function TwoThirdsAndOneThirdColumn() {
     <Page fullWidth>
       <Grid columns={{sm: 3}}>
         <Grid.Cell columnSpan={{xs: 6, sm: 4, md: 4, lg: 8, xl: 8}}>
-          <Card title="Sales" sectioned>
+          <LegacyCard title="Sales" sectioned>
             <p>View a summary of your online store’s sales.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
         <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <Card title="Orders" sectioned>
+          <LegacyCard title="Orders" sectioned>
             <p>View a summary of your online store’s orders.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
       </Grid>
     </Page>
@@ -49,19 +49,19 @@ export function ThreeOneThirdColumn() {
     <Page fullWidth>
       <Grid>
         <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <Card title="Sales" sectioned>
+          <LegacyCard title="Sales" sectioned>
             <p>View a summary of your online store’s sales.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
         <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <Card title="Orders" sectioned>
+          <LegacyCard title="Orders" sectioned>
             <p>View a summary of your online store’s orders.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
         <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <Card title="Orders" sectioned>
+          <LegacyCard title="Orders" sectioned>
             <p>View a summary of your online store’s orders.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
       </Grid>
     </Page>
@@ -71,7 +71,7 @@ export function ThreeOneThirdColumn() {
 export function CustomLayout() {
   return (
     <Page fullWidth>
-      <Card sectioned>
+      <LegacyCard sectioned>
         <Grid
           columns={{xs: 1, sm: 4, md: 4, lg: 6, xl: 6}}
           areas={{
@@ -110,7 +110,7 @@ export function CustomLayout() {
             />
           </Grid.Cell>
         </Grid>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Button,
-  Card,
+  LegacyCard,
   EmptySearchResult,
   Filters,
   IndexTable,
@@ -66,7 +66,7 @@ export function Default() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -83,7 +83,7 @@ export function Default() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -135,7 +135,7 @@ export function Flush() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -152,7 +152,7 @@ export function Flush() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -207,7 +207,7 @@ export function SmallScreen() {
 
   return (
     <div style={{width: '430px'}}>
-      <Card>
+      <LegacyCard>
         <IndexTable
           resourceName={resourceName}
           itemCount={customers.length}
@@ -225,7 +225,7 @@ export function SmallScreen() {
         >
           {rowMarkup}
         </IndexTable>
-      </Card>
+      </LegacyCard>
     </div>
   );
 }
@@ -281,7 +281,7 @@ export function SmallScreenLoading() {
 
   return (
     <div style={{width: '430px'}}>
-      <Card>
+      <LegacyCard>
         <IndexTable
           resourceName={resourceName}
           itemCount={customers.length}
@@ -300,7 +300,7 @@ export function SmallScreenLoading() {
         >
           {rowMarkup}
         </IndexTable>
-      </Card>
+      </LegacyCard>
     </div>
   );
 }
@@ -344,7 +344,7 @@ export function WithEmptyState() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -362,7 +362,7 @@ export function WithEmptyState() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -435,7 +435,7 @@ export function WithBulkActions() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -454,7 +454,7 @@ export function WithBulkActions() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -553,7 +553,7 @@ export function WithMultiplePromotedBulkActions() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -572,7 +572,7 @@ export function WithMultiplePromotedBulkActions() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -649,7 +649,7 @@ export function WithBulkActionsAndSelectionAcrossPages() {
     <div
       style={{padding: 'var(--p-space-4) var(--p-space-4) var(--p-space-10)'}}
     >
-      <Card>
+      <LegacyCard>
         <IndexTable
           resourceName={resourceName}
           itemCount={customers.length}
@@ -669,7 +669,7 @@ export function WithBulkActionsAndSelectionAcrossPages() {
         >
           {rowMarkup}
         </IndexTable>
-      </Card>
+      </LegacyCard>
     </div>
   );
 }
@@ -722,7 +722,7 @@ export function WithLoadingState() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -740,7 +740,7 @@ export function WithLoadingState() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -840,7 +840,7 @@ export function WithFiltering() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <div style={{padding: '16px', display: 'flex'}}>
         <div style={{flex: 1}}>
           <Filters
@@ -878,7 +878,7 @@ export function WithFiltering() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 
   function disambiguateLabel(key, value) {
@@ -950,7 +950,7 @@ export function WithRowStatus() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -967,7 +967,7 @@ export function WithRowStatus() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -1044,7 +1044,7 @@ export function WithStickyLastColumn() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -1066,7 +1066,7 @@ export function WithStickyLastColumn() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -1124,7 +1124,7 @@ export function WithRowNavigationLink() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -1141,7 +1141,7 @@ export function WithRowNavigationLink() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -1199,7 +1199,7 @@ export function WithClickableButtonColumn() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -1216,7 +1216,7 @@ export function WithClickableButtonColumn() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -1260,7 +1260,7 @@ export function WithoutCheckboxes() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -1274,7 +1274,7 @@ export function WithoutCheckboxes() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -1395,7 +1395,7 @@ export function WithAllOfItsElements() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <div style={{padding: '16px', display: 'flex'}}>
         <div style={{flex: 1}}>
           <Filters
@@ -1437,7 +1437,7 @@ export function WithAllOfItsElements() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 
   function disambiguateLabel(key, value) {
@@ -1595,7 +1595,7 @@ export function WithSortableHeadings() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={rows.length}
@@ -1622,7 +1622,7 @@ export function WithSortableHeadings() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -1763,7 +1763,7 @@ export function WithSortableCustomHeadings() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={rows.length}
@@ -1799,7 +1799,7 @@ export function WithSortableCustomHeadings() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -1851,7 +1851,7 @@ export function WithCustomTooltips() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -1876,7 +1876,7 @@ export function WithCustomTooltips() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -2000,7 +2000,7 @@ export function SmallScreenWithAllOfItsElements() {
 
   return (
     <div style={{width: '430px'}}>
-      <Card>
+      <LegacyCard>
         <div style={{padding: '16px', display: 'flex'}}>
           <div style={{flex: 1}}>
             <Filters
@@ -2042,7 +2042,7 @@ export function SmallScreenWithAllOfItsElements() {
         >
           {rowMarkup}
         </IndexTable>
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris-react/src/components/Layout/Layout.stories.tsx
+++ b/polaris-react/src/components/Layout/Layout.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Banner,
-  Card,
+  LegacyCard,
   FormLayout,
   Text,
   Layout,
@@ -22,9 +22,9 @@ export function OneColumn() {
     <Page fullWidth>
       <Layout>
         <Layout.Section>
-          <Card title="Online store dashboard" sectioned>
+          <LegacyCard title="Online store dashboard" sectioned>
             <p>View a summary of your online store’s performance.</p>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>
@@ -36,19 +36,19 @@ export function TwoColumnsWithPrimaryAndSecondaryWidths() {
     <Page fullWidth>
       <Layout>
         <Layout.Section>
-          <Card title="Order details" sectioned>
+          <LegacyCard title="Order details" sectioned>
             <p>
               Use to follow a normal section with a secondary section to create
               a 2/3 + 1/3 layout on detail pages (such as individual product or
               order pages). Can also be used on any page that needs to structure
               a lot of content. This layout stacks the columns on small screens.
             </p>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card title="Tags" sectioned>
+          <LegacyCard title="Tags" sectioned>
             <p>Add tags to your order.</p>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>
@@ -60,13 +60,13 @@ export function TwoColumnsWithEqualWidth() {
     <Page fullWidth>
       <Layout>
         <Layout.Section oneHalf>
-          <Card title="Florida" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Florida" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 455 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -118,17 +118,17 @@ export function TwoColumnsWithEqualWidth() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section oneHalf>
-          <Card title="Nevada" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Nevada" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 301 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -180,8 +180,8 @@ export function TwoColumnsWithEqualWidth() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>
@@ -193,13 +193,13 @@ export function ThreeColumnsWithEqualWidth() {
     <Page fullWidth>
       <Layout>
         <Layout.Section oneThird>
-          <Card title="Florida" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Florida" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 455 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -251,17 +251,17 @@ export function ThreeColumnsWithEqualWidth() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section oneThird>
-          <Card title="Nevada" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Nevada" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 301 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -313,17 +313,17 @@ export function ThreeColumnsWithEqualWidth() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section oneThird>
-          <Card title="Minneapolis" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Minneapolis" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 1931 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -375,8 +375,8 @@ export function ThreeColumnsWithEqualWidth() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>
@@ -392,7 +392,7 @@ export function Annotated() {
           title="Store details"
           description="Shopify and your customers will use this information to contact you."
         >
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Store name"
@@ -406,7 +406,7 @@ export function Annotated() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.AnnotatedSection>
       </Layout>
     </Page>
@@ -427,7 +427,7 @@ export function AnnotatedWithBannerAtTheTop() {
           title="Store details"
           description="Shopify and your customers will use this information to contact you."
         >
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Store name"
@@ -441,7 +441,7 @@ export function AnnotatedWithBannerAtTheTop() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.AnnotatedSection>
       </Layout>
     </Page>

--- a/polaris-react/src/components/LegacyCard/components/Subsection/tests/Subsection.test.tsx
+++ b/polaris-react/src/components/LegacyCard/components/Subsection/tests/Subsection.test.tsx
@@ -3,7 +3,7 @@ import {mountWithApp} from 'tests/utilities';
 
 import {Subsection} from '../Subsection';
 
-describe('<Card.Subsection />', () => {
+describe('<LegacyCard.Subsection />', () => {
   it('can have any valid react element for children', () => {
     const childrenMarkup = <p>Some content</p>;
 

--- a/polaris-react/src/components/Listbox/Listbox.stories.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.stories.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
-  Card,
+  LegacyCard,
   EmptySearchResult,
   Scrollable,
   TextField,
@@ -314,7 +314,7 @@ export function WithSearch() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <div
         style={{
           alignItems: 'stretch',
@@ -344,6 +344,6 @@ export function WithSearch() {
           {listboxMarkup}
         </Scrollable>
       </div>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/MediaCard/MediaCard.tsx
+++ b/polaris-react/src/components/MediaCard/MediaCard.tsx
@@ -5,7 +5,7 @@ import {useToggle} from '../../utilities/use-toggle';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import type {ActionListItemDescriptor, ComplexAction} from '../../types';
-import {Card} from '../Card';
+import {LegacyCard} from '../LegacyCard';
 import {Button, buttonFrom} from '../Button';
 import {Text} from '../Text';
 import {Popover} from '../Popover';
@@ -137,20 +137,20 @@ export function MediaCard({
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <div className={mediaCardClassName}>
         <div className={mediaContainerClassName}>{children}</div>
         <div className={infoContainerClassName}>
-          <Card.Section>
+          <LegacyCard.Section>
             {popoverActionsMarkup}
             <Stack vertical spacing="tight">
               {headerMarkup}
               <p className={styles.Description}>{description}</p>
               {actionMarkup}
             </Stack>
-          </Card.Section>
+          </LegacyCard.Section>
         </div>
       </div>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/OptionList/OptionList.stories.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Button, Card, OptionList, Popover} from '@shopify/polaris';
+import {Button, LegacyCard, OptionList, Popover} from '@shopify/polaris';
 
 export default {
   component: OptionList,
@@ -10,7 +10,7 @@ export function Default() {
   const [selected, setSelected] = useState([]);
 
   return (
-    <Card>
+    <LegacyCard>
       <OptionList
         title="Inventory Location"
         onChange={setSelected}
@@ -23,7 +23,7 @@ export function Default() {
         ]}
         selected={selected}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -31,7 +31,7 @@ export function Multiple() {
   const [selected, setSelected] = useState([]);
 
   return (
-    <Card>
+    <LegacyCard>
       <OptionList
         title="Manage sales channels availability"
         onChange={setSelected}
@@ -45,7 +45,7 @@ export function Multiple() {
         selected={selected}
         allowMultiple
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -53,7 +53,7 @@ export function WithSections() {
   const [selected, setSelected] = useState([]);
 
   return (
-    <Card>
+    <LegacyCard>
       <OptionList
         onChange={setSelected}
         sections={[
@@ -85,7 +85,7 @@ export function WithSections() {
         selected={selected}
         allowMultiple
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Badge, Button, Card, Page, PageActions, Stack} from '@shopify/polaris';
+import {
+  Badge,
+  Button,
+  LegacyCard,
+  Page,
+  PageActions,
+  Stack,
+} from '@shopify/polaris';
 import {PlusMinor, ArrowDownMinor, ExternalMinor} from '@shopify/polaris-icons';
 
 export default {
@@ -45,9 +52,9 @@ export function Default() {
         hasNext: true,
       }}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -69,9 +76,9 @@ export function WithCustomPrimaryAction() {
         </Button>
       }
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -91,14 +98,14 @@ export function WithoutPrimaryActionInHeader() {
         hasNext: true,
       }}
     >
-      <Card sectioned title="Fulfill order">
+      <LegacyCard sectioned title="Fulfill order">
         <Stack alignment="center">
           <Stack.Item fill>
             <p>Buy postage and ship remaining 2 items</p>
           </Stack.Item>
           <Button primary>Continue</Button>
         </Stack>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -149,9 +156,9 @@ export function WithToolTipAction() {
         },
       ]}
     >
-      <Card title="Product X" sectioned>
+      <LegacyCard title="Product X" sectioned>
         <p>Product X information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -164,9 +171,9 @@ export function WithSubtitle() {
       subtitle="Statement period: May 3, 2019 to June 2, 2019"
       secondaryActions={[{content: 'Download', icon: ArrowDownMinor}]}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -185,9 +192,9 @@ export function WithExternalLink() {
         },
       ]}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -199,9 +206,9 @@ export function WithoutPagination() {
       title="General"
       primaryAction={{content: 'Save'}}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -217,9 +224,9 @@ export function FullWidth() {
         hasNext: true,
       }}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -232,9 +239,9 @@ export function NarrowWidth() {
       title="Add payment method"
       primaryAction={{content: 'Save', disabled: true}}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
       <PageActions
         primaryAction={{content: 'Save', disabled: true}}
         secondaryActions={[{content: 'Delete'}]}
@@ -272,9 +279,9 @@ export function WithActionGroups() {
         },
       ]}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -295,9 +302,9 @@ export function WithContentAfterTitle() {
         hasNext: true,
       }}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }
@@ -309,9 +316,9 @@ export function WithDivider() {
       title="General"
       divider
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris-react/src/components/Page/tests/Page.test.tsx
+++ b/polaris-react/src/components/Page/tests/Page.test.tsx
@@ -4,7 +4,7 @@ import {mountWithApp} from 'tests/utilities';
 
 import type {ActionMenuProps} from '../../ActionMenu';
 import {Badge} from '../../Badge';
-import {Card} from '../../Card';
+import {LegacyCard} from '../../LegacyCard';
 import {Page, PageProps} from '../Page';
 import {Header} from '../components';
 
@@ -33,9 +33,9 @@ describe('<Page />', () => {
 
   describe('children', () => {
     it('renders its children', () => {
-      const card = <Card />;
+      const card = <LegacyCard />;
       const page = mountWithApp(<Page {...mockProps}>{card}</Page>);
-      expect(page).toContainReactComponent(Card);
+      expect(page).toContainReactComponent(LegacyCard);
     });
   });
 

--- a/polaris-react/src/components/Popover/Popover.stories.tsx
+++ b/polaris-react/src/components/Popover/Popover.stories.tsx
@@ -4,7 +4,7 @@ import {
   ActionList,
   Avatar,
   Button,
-  Card,
+  LegacyCard,
   FormLayout,
   Popover,
   ResourceList,
@@ -215,7 +215,7 @@ export function WithLazyLoadedList() {
   }));
 
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <div style={{height: '280px'}}>
         <Popover
           sectioned
@@ -229,7 +229,7 @@ export function WithLazyLoadedList() {
           </Popover.Pane>
         </Popover>
       </div>
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem({name, initials}) {

--- a/polaris-react/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/polaris-react/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Card, RangeSlider, Stack, TextField} from '@shopify/polaris';
+import {LegacyCard, RangeSlider, Stack, TextField} from '@shopify/polaris';
 
 export default {
   component: RangeSlider,
@@ -15,14 +15,14 @@ export function Default() {
   );
 
   return (
-    <Card sectioned title="Background color">
+    <LegacyCard sectioned title="Background color">
       <RangeSlider
         label="Opacity percentage"
         value={rangeValue}
         onChange={handleRangeSliderChange}
         output
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -35,7 +35,7 @@ export function WithMinAndMax() {
   );
 
   return (
-    <Card sectioned title="Navigation branding">
+    <LegacyCard sectioned title="Navigation branding">
       <RangeSlider
         output
         label="Logo offset"
@@ -44,7 +44,7 @@ export function WithMinAndMax() {
         value={rangeValue}
         onChange={handleRangeSliderChange}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -57,7 +57,7 @@ export function WithSteps() {
   );
 
   return (
-    <Card sectioned title="Navigation branding">
+    <LegacyCard sectioned title="Navigation branding">
       <RangeSlider
         output
         label="Logo offset"
@@ -67,7 +67,7 @@ export function WithSteps() {
         value={rangeValue}
         onChange={handleRangeSliderChange}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -85,7 +85,7 @@ export function WithPrefixAndSuffix() {
   };
 
   return (
-    <Card sectioned title="Text color">
+    <LegacyCard sectioned title="Text color">
       <RangeSlider
         output
         label="Hue color mix"
@@ -96,7 +96,7 @@ export function WithPrefixAndSuffix() {
         prefix={<p>Hue</p>}
         suffix={<p style={suffixStyles}>{rangeValue}</p>}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -169,7 +169,7 @@ export function WithDualThumb() {
       : intermediateTextFieldValue[1];
 
   return (
-    <Card sectioned title="Minimum requirements">
+    <LegacyCard sectioned title="Minimum requirements">
       <div onKeyDown={handleEnterKeyPress}>
         <RangeSlider
           output
@@ -208,6 +208,6 @@ export function WithDualThumb() {
           />
         </Stack>
       </div>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/ResourceItem/ResourceItem.stories.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.stories.tsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Avatar,
-  Card,
+  LegacyCard,
   ResourceItem,
   ResourceList,
   ResourceListProps,
@@ -19,7 +19,7 @@ export function Default() {
   >([]);
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'blog post', plural: 'blog posts'}}
         items={[
@@ -53,13 +53,13 @@ export function Default() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithMedia() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -100,13 +100,13 @@ export function WithMedia() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithShortcutActions() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -151,13 +151,13 @@ export function WithShortcutActions() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithPersistedShortcutActions() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -204,13 +204,13 @@ export function WithPersistedShortcutActions() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithVerticalAlignment() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -253,6 +253,6 @@ export function WithVerticalAlignment() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/ResourceList/ResourceList.stories.tsx
+++ b/polaris-react/src/components/ResourceList/ResourceList.stories.tsx
@@ -3,7 +3,7 @@ import type {ComponentMeta} from '@storybook/react';
 import {
   Avatar,
   Button,
-  Card,
+  LegacyCard,
   EmptyState,
   Filters,
   Layout,
@@ -20,7 +20,7 @@ export default {
 
 export function Default() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -58,7 +58,7 @@ export function Default() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -94,7 +94,7 @@ export function WithEmptyState() {
     <Page title="Files">
       <Layout>
         <Layout.Section>
-          <Card>
+          <LegacyCard>
             <ResourceList
               emptyState={emptyStateMarkup}
               items={items}
@@ -102,7 +102,7 @@ export function WithEmptyState() {
               filterControl={filterControl}
               resourceName={{singular: 'file', plural: 'files'}}
             />
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>
@@ -133,7 +133,7 @@ export function WithSelectionAndNoBulkActions() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -142,7 +142,7 @@ export function WithSelectionAndNoBulkActions() {
         onSelectionChange={setSelectedItems}
         selectable
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {
@@ -213,7 +213,7 @@ export function WithBulkActions() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -223,7 +223,7 @@ export function WithBulkActions() {
         promotedBulkActions={promotedBulkActions}
         bulkActions={bulkActions}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {
@@ -290,7 +290,7 @@ export function WithBulkActionsAndManyItems() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -300,7 +300,7 @@ export function WithBulkActionsAndManyItems() {
         promotedBulkActions={promotedBulkActions}
         bulkActions={bulkActions}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {
@@ -371,7 +371,7 @@ export function WithLoadingState() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -382,7 +382,7 @@ export function WithLoadingState() {
         bulkActions={bulkActions}
         loading
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {
@@ -409,7 +409,7 @@ export function WithLoadingState() {
 
 export function WithTotalCount() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -449,13 +449,13 @@ export function WithTotalCount() {
         showHeader
         totalItemsCount={50}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithHeaderContent() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         headerContent="Customer details shown below"
         items={[
@@ -494,7 +494,7 @@ export function WithHeaderContent() {
         }}
         showHeader
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -522,7 +522,7 @@ export function WithSorting() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -537,7 +537,7 @@ export function WithSorting() {
           console.log(`Sort option changed to ${selected}.`);
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {
@@ -584,14 +584,14 @@ export function WithAlternateTool() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         items={items}
         renderItem={renderItem}
         resourceName={resourceName}
         alternateTool={<Button>Email customers</Button>}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {
@@ -694,14 +694,14 @@ export function WithFiltering() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
         renderItem={renderItem}
         filterControl={filterControl}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {
@@ -806,7 +806,7 @@ export function WithACustomEmptySearchResultState() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -814,7 +814,7 @@ export function WithACustomEmptySearchResultState() {
         filterControl={filterControl}
         emptySearchState={<div>This is a custom empty state</div>}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {
@@ -853,7 +853,7 @@ export function WithACustomEmptySearchResultState() {
 
 export function WithItemShortcutActions() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -903,13 +903,13 @@ export function WithItemShortcutActions() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithPersistentItemShortcutActions() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -960,7 +960,7 @@ export function WithPersistentItemShortcutActions() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -1034,7 +1034,7 @@ export function WithMultiselect() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -1045,7 +1045,7 @@ export function WithMultiselect() {
         bulkActions={bulkActions}
         resolveItemId={resolveItemIds}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item, _, index) {
@@ -1183,7 +1183,7 @@ export function WithAllOfItsElements() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -1203,7 +1203,7 @@ export function WithAllOfItsElements() {
         }}
         filterControl={filterControl}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris-react/src/components/Scrollable/Scrollable.stories.tsx
+++ b/polaris-react/src/components/Scrollable/Scrollable.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Card, Scrollable} from '@shopify/polaris';
+import {LegacyCard, Scrollable} from '@shopify/polaris';
 
 export default {
   component: Scrollable,
@@ -8,7 +8,7 @@ export default {
 
 export function Default() {
   return (
-    <Card title="Terms of service" sectioned>
+    <LegacyCard title="Terms of service" sectioned>
       <Scrollable shadow style={{height: '200px'}} focusable>
         <p>
           By signing up for the Shopify service (“Service”) or any of the
@@ -56,7 +56,7 @@ export function Default() {
           from time to time for any updates or changes that may impact you.
         </p>
       </Scrollable>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -156,7 +156,7 @@ export function WithHorizonalScrollPrevention() {
 
 export function ScrollToChildComponent() {
   return (
-    <Card title="Terms of service" sectioned>
+    <LegacyCard title="Terms of service" sectioned>
       <Scrollable shadow style={{height: '200px'}}>
         <ol>
           <li>Account Terms</li>
@@ -443,13 +443,13 @@ export function ScrollToChildComponent() {
           credit card information is always encrypted.
         </p>
       </Scrollable>
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithScrollHint() {
   return (
-    <Card title="Terms of service" sectioned>
+    <LegacyCard title="Terms of service" sectioned>
       <Scrollable hint shadow style={{height: '200px'}} focusable>
         <p>
           By signing up for the Shopify service (“Service”) or any of the
@@ -497,13 +497,13 @@ export function WithScrollHint() {
           from time to time for any updates or changes that may impact you.
         </p>
       </Scrollable>
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function OnScrolledToBottom() {
   return (
-    <Card title="Terms of service" sectioned>
+    <LegacyCard title="Terms of service" sectioned>
       <Scrollable
         focusable
         style={{height: '200px'}}
@@ -555,6 +555,6 @@ export function OnScrolledToBottom() {
           from time to time for any updates or changes that may impact you.
         </p>
       </Scrollable>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/Select/Select.stories.tsx
+++ b/polaris-react/src/components/Select/Select.stories.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
-  Card,
+  LegacyCard,
   FormLayout,
   Icon,
   InlineError,
@@ -157,7 +157,7 @@ export function WithSeparateValidationError() {
     </Stack>
   );
 
-  return <Card sectioned>{formGroupMarkup}</Card>;
+  return <LegacyCard sectioned>{formGroupMarkup}</LegacyCard>;
 
   function generateErrorMessage() {
     const weightError =

--- a/polaris-react/src/components/SettingToggle/SettingToggle.tsx
+++ b/polaris-react/src/components/SettingToggle/SettingToggle.tsx
@@ -3,7 +3,7 @@ import React, {useMemo} from 'react';
 import type {ComplexAction} from '../../types';
 import {SettingAction} from '../SettingAction';
 import {buttonFrom} from '../Button';
-import {Card} from '../Card';
+import {LegacyCard} from '../LegacyCard';
 import {globalIdGeneratorFactory} from '../../utilities/unique-id';
 
 export interface SettingToggleProps {
@@ -30,10 +30,10 @@ export function SettingToggle({enabled, action, children}: SettingToggleProps) {
     : null;
 
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <SettingAction action={actionMarkup}>
         <label htmlFor={id}>{children}</label>
       </SettingAction>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/Sheet/Sheet.stories.tsx
+++ b/polaris-react/src/components/Sheet/Sheet.stories.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Button,
-  Card,
+  LegacyCard,
   ChoiceList,
   Text,
   List,
@@ -87,14 +87,14 @@ export function Default() {
 
   return (
     <Page narrowWidth>
-      <Card
+      <LegacyCard
         sectioned
         subdued
         title="Product availability"
         actions={salesChannelAction}
       >
         {salesChannelsCardMarkup}
-      </Card>
+      </LegacyCard>
       <Sheet
         open={sheetActive}
         onClose={toggleSheetActive}

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.stories.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
-  Card,
+  LegacyCard,
   Layout,
   SkeletonBodyText,
   SkeletonDisplayText,
@@ -18,45 +18,45 @@ export function WithDynamicContent() {
     <SkeletonPage primaryAction>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <SkeletonBodyText />
-          </Card>
-          <Card sectioned>
+          </LegacyCard>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText />
             </TextContainer>
-          </Card>
-          <Card sectioned>
+          </LegacyCard>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card>
-            <Card.Section>
+          <LegacyCard>
+            <LegacyCard.Section>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
                 <SkeletonBodyText lines={2} />
               </TextContainer>
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={1} />
-            </Card.Section>
-          </Card>
-          <Card subdued>
-            <Card.Section>
+            </LegacyCard.Section>
+          </LegacyCard>
+          <LegacyCard subdued>
+            <LegacyCard.Section>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
                 <SkeletonBodyText lines={2} />
               </TextContainer>
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>
@@ -68,33 +68,33 @@ export function WithStaticContent() {
     <SkeletonPage title="Products" primaryAction>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <SkeletonBodyText />
-          </Card>
-          <Card sectioned title="Images">
+          </LegacyCard>
+          <LegacyCard sectioned title="Images">
             <SkeletonBodyText />
-          </Card>
-          <Card sectioned title="Variants">
+          </LegacyCard>
+          <LegacyCard sectioned title="Variants">
             <SkeletonBodyText />
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card title="Sales channels">
-            <Card.Section>
+          <LegacyCard title="Sales channels">
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={1} />
-            </Card.Section>
-          </Card>
-          <Card title="Organization" subdued>
-            <Card.Section>
+            </LegacyCard.Section>
+          </LegacyCard>
+          <LegacyCard title="Organization" subdued>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>
@@ -106,45 +106,45 @@ export function WithNarrowWidth() {
     <SkeletonPage primaryAction narrowWidth>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <SkeletonBodyText />
-          </Card>
-          <Card sectioned>
+          </LegacyCard>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText />
             </TextContainer>
-          </Card>
-          <Card sectioned>
+          </LegacyCard>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card>
-            <Card.Section>
+          <LegacyCard>
+            <LegacyCard.Section>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
                 <SkeletonBodyText lines={2} />
               </TextContainer>
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={1} />
-            </Card.Section>
-          </Card>
-          <Card subdued>
-            <Card.Section>
+            </LegacyCard.Section>
+          </LegacyCard>
+          <LegacyCard subdued>
+            <LegacyCard.Section>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
                 <SkeletonBodyText lines={2} />
               </TextContainer>
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>
@@ -156,45 +156,45 @@ export function WithFullWidth() {
     <SkeletonPage primaryAction fullWidth>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <SkeletonBodyText />
-          </Card>
-          <Card sectioned>
+          </LegacyCard>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText />
             </TextContainer>
-          </Card>
-          <Card sectioned>
+          </LegacyCard>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card>
-            <Card.Section>
+          <LegacyCard>
+            <LegacyCard.Section>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
                 <SkeletonBodyText lines={2} />
               </TextContainer>
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={1} />
-            </Card.Section>
-          </Card>
-          <Card subdued>
-            <Card.Section>
+            </LegacyCard.Section>
+          </LegacyCard>
+          <LegacyCard subdued>
+            <LegacyCard.Section>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
                 <SkeletonBodyText lines={2} />
               </TextContainer>
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>

--- a/polaris-react/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/polaris-react/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
-import {Card} from '../../Card';
+import {LegacyCard} from '../../LegacyCard';
 import {Layout} from '../../Layout';
 import {SkeletonBodyText} from '../../SkeletonBodyText';
 import {SkeletonPage} from '../SkeletonPage';
@@ -13,12 +13,12 @@ describe('<SkeletonPage />', () => {
       return (
         <Layout>
           <Layout.Section>
-            <Card sectioned>
+            <LegacyCard sectioned>
               <SkeletonBodyText />
-            </Card>
-            <Card sectioned title="Variants">
+            </LegacyCard>
+            <LegacyCard sectioned title="Variants">
               <SkeletonBodyText />
-            </Card>
+            </LegacyCard>
           </Layout.Section>
         </Layout>
       );

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.stories.tsx
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Card, SkeletonTabs} from '@shopify/polaris';
+import {LegacyCard, SkeletonTabs} from '@shopify/polaris';
 
 export default {
   component: SkeletonTabs,
@@ -8,16 +8,16 @@ export default {
 
 export function Default() {
   return (
-    <Card>
+    <LegacyCard>
       <SkeletonTabs />
-    </Card>
+    </LegacyCard>
   );
 }
 
 export function WithACustomCount() {
   return (
-    <Card>
+    <LegacyCard>
       <SkeletonTabs count={4} />
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/Spinner/Spinner.stories.tsx
+++ b/polaris-react/src/components/Spinner/Spinner.stories.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Button,
-  Card,
+  LegacyCard,
   Form,
   FormLayout,
   Spinner,
@@ -81,12 +81,12 @@ export function WithFocusManagement() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs tabs={tabs.current} selected={selected} onSelect={handleTabChange}>
-        <Card.Section title={tabs.current[selected].content}>
+        <LegacyCard.Section title={tabs.current[selected].content}>
           {sectionMarkup}
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/Tabs/Tabs.stories.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Badge, Card, Tabs} from '@shopify/polaris';
+import {Badge, LegacyCard, Tabs} from '@shopify/polaris';
 
 export default {
   component: Tabs,
@@ -39,13 +39,13 @@ export function Default() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
-        <Card.Section title={tabs[selected].content}>
+        <LegacyCard.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -72,13 +72,13 @@ export function Fitted() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
-        <Card.Section title={tabs[selected].content}>
+        <LegacyCard.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -113,13 +113,13 @@ export function WithBadgeContent() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
-        <Card.Section title={tabs[selected].content}>
+        <LegacyCard.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }
 
@@ -156,17 +156,17 @@ export function WithCustomDisclosure() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs
         tabs={tabs}
         selected={selected}
         onSelect={handleTabChange}
         disclosureText="More views"
       >
-        <Card.Section title={tabs[selected].content}>
+        <LegacyCard.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Button,
-  Card,
+  LegacyCard,
   ChoiceList,
   FormLayout,
   InlineError,
@@ -383,9 +383,9 @@ export function WithSeparateValidationError() {
   );
 
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <FormLayout>{formGroupMarkup}</FormLayout>
-    </Card>
+    </LegacyCard>
   );
 
   function isValueInvalid(content) {

--- a/polaris-react/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/polaris-react/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
-  Card,
+  LegacyCard,
   FormLayout,
   Heading,
   TextField,
@@ -14,7 +14,7 @@ export default {
 
 export function Default() {
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <VisuallyHidden>
         <Heading>Title and description</Heading>
       </VisuallyHidden>
@@ -32,7 +32,7 @@ export function Default() {
           autoComplete="off"
         />
       </FormLayout>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/app-provider-default.tsx
+++ b/polaris.shopify.com/pages/examples/app-provider-default.tsx
@@ -1,7 +1,7 @@
 import {
   AppProvider,
   Page,
-  Card,
+  LegacyCard,
   ResourceList,
   Avatar,
   Text,
@@ -30,7 +30,7 @@ function AppProviderExample() {
       }}
     >
       <Page>
-        <Card>
+        <LegacyCard>
           <ResourceList
             showHeader
             items={[
@@ -61,7 +61,7 @@ function AppProviderExample() {
               );
             }}
           />
-        </Card>
+        </LegacyCard>
       </Page>
     </AppProvider>
   );

--- a/polaris.shopify.com/pages/examples/app-provider-with-i18n.tsx
+++ b/polaris.shopify.com/pages/examples/app-provider-with-i18n.tsx
@@ -1,7 +1,7 @@
 import {
   AppProvider,
   Page,
-  Card,
+  LegacyCard,
   ResourceList,
   Avatar,
   Text,
@@ -30,7 +30,7 @@ function AppProviderI18NExample() {
       }}
     >
       <Page>
-        <Card>
+        <LegacyCard>
           <ResourceList
             showHeader
             items={[
@@ -61,7 +61,7 @@ function AppProviderI18NExample() {
               );
             }}
           />
-        </Card>
+        </LegacyCard>
       </Page>
     </AppProvider>
   );

--- a/polaris.shopify.com/pages/examples/banner-in-a-card.tsx
+++ b/polaris.shopify.com/pages/examples/banner-in-a-card.tsx
@@ -1,10 +1,10 @@
-import {Card, TextContainer, Banner, Link} from '@shopify/polaris';
+import {LegacyCard, TextContainer, Banner, Link} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BannerExample() {
   return (
-    <Card title="Online store dashboard" sectioned>
+    <LegacyCard title="Online store dashboard" sectioned>
       <TextContainer>
         <Banner onDismiss={() => {}}>
           <p>
@@ -15,7 +15,7 @@ function BannerExample() {
 
         <p>View a summary of your online store’s performance.</p>
       </TextContainer>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/card-with-a-subdued-section.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-a-subdued-section.tsx
@@ -11,7 +11,6 @@ function CardExample() {
           <List.Item>Ezequiel Manno</List.Item>
         </List>
       </Card.Section>
-
       <Card.Section subdued title="Deactivated staff accounts">
         <List>
           <List.Item>Felix Crafford</List.Item>

--- a/polaris.shopify.com/pages/examples/card-with-multiple-sections.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-multiple-sections.tsx
@@ -8,7 +8,6 @@ function CardExample() {
       <Card.Section>
         <p>View a summary of your online store’s performance.</p>
       </Card.Section>
-
       <Card.Section>
         <p>
           View a summary of your online store’s performance, including sales,

--- a/polaris.shopify.com/pages/examples/card-with-multiple-titled-sections.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-multiple-titled-sections.tsx
@@ -8,7 +8,6 @@ function CardExample() {
       <Card.Section title="Reports">
         <p>View a summary of your online store’s performance.</p>
       </Card.Section>
-
       <Card.Section title="Summary">
         <p>
           View a summary of your online store’s performance, including sales,

--- a/polaris.shopify.com/pages/examples/collapsible-default.tsx
+++ b/polaris.shopify.com/pages/examples/collapsible-default.tsx
@@ -1,5 +1,5 @@
 import {
-  Card,
+  LegacyCard,
   Stack,
   Button,
   Collapsible,
@@ -16,7 +16,7 @@ function CollapsibleExample() {
 
   return (
     <div style={{height: '200px'}}>
-      <Card sectioned>
+      <LegacyCard sectioned>
         <Stack vertical>
           <Button
             onClick={handleToggle}
@@ -41,7 +41,7 @@ function CollapsibleExample() {
             </TextContainer>
           </Collapsible>
         </Stack>
-      </Card>
+      </LegacyCard>
     </div>
   );
 }

--- a/polaris.shopify.com/pages/examples/data-table-default.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-default.tsx
@@ -1,4 +1,4 @@
-import {Page, Card, DataTable} from '@shopify/polaris';
+import {Page, LegacyCard, DataTable} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -17,7 +17,7 @@ function DataTableExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -36,7 +36,7 @@ function DataTableExample() {
           rows={rows}
           totals={['', '', '', 255, '$155,830.00']}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/data-table-sortable.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-sortable.tsx
@@ -1,4 +1,4 @@
-import {Page, Card, DataTable} from '@shopify/polaris';
+import {Page, LegacyCard, DataTable} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -25,7 +25,7 @@ function SortableDataTableExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -48,7 +48,7 @@ function SortableDataTableExample() {
           initialSortColumnIndex={4}
           onSort={handleSort}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 

--- a/polaris.shopify.com/pages/examples/data-table-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-all-of-its-elements.tsx
@@ -1,4 +1,4 @@
-import {Link, Page, Card, DataTable} from '@shopify/polaris';
+import {Link, Page, LegacyCard, DataTable} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -55,7 +55,7 @@ function FullDataTableExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -79,7 +79,7 @@ function FullDataTableExample() {
           onSort={handleSort}
           footerContent={`Showing ${rows.length} of ${rows.length} results`}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 

--- a/polaris.shopify.com/pages/examples/data-table-with-custom-totals-heading.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-custom-totals-heading.tsx
@@ -1,4 +1,4 @@
-import {Page, Card, DataTable} from '@shopify/polaris';
+import {Page, LegacyCard, DataTable} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -17,7 +17,7 @@ function DataTableExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           showTotalsInFooter
           columnContentTypes={[
@@ -41,7 +41,7 @@ function DataTableExample() {
             plural: 'Total net sales',
           }}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/data-table-with-fixed-first-columns.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-fixed-first-columns.tsx
@@ -1,4 +1,4 @@
-import {Link, Page, Card, DataTable, useBreakpoints} from '@shopify/polaris';
+import {Link, Page, LegacyCard, DataTable, useBreakpoints} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -281,7 +281,7 @@ function DataTableWithFixedFirstColumnsExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -330,7 +330,7 @@ function DataTableWithFixedFirstColumnsExample() {
           stickyHeader
           fixedFirstColumns={fixedFirstColumns}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/data-table-with-footer.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-footer.tsx
@@ -1,4 +1,4 @@
-import {Page, Card, DataTable} from '@shopify/polaris';
+import {Page, LegacyCard, DataTable} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -17,7 +17,7 @@ function DataTableFooterExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -37,7 +37,7 @@ function DataTableFooterExample() {
           totals={['', '', '', 255, '$155,830.00']}
           footerContent={`Showing ${rows.length} of ${rows.length} results`}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/data-table-with-increased-density-and-zebra-striping.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-increased-density-and-zebra-striping.tsx
@@ -1,4 +1,4 @@
-import {Link, Page, Card, DataTable} from '@shopify/polaris';
+import {Link, Page, LegacyCard, DataTable} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -55,7 +55,7 @@ function FullDataTableExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -81,7 +81,7 @@ function FullDataTableExample() {
           hasZebraStripingOnData
           increasedTableDensity
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 

--- a/polaris.shopify.com/pages/examples/data-table-with-row-heading-links.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-row-heading-links.tsx
@@ -1,4 +1,4 @@
-import {Link, Page, Card, DataTable} from '@shopify/polaris';
+import {Link, Page, LegacyCard, DataTable} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -47,7 +47,7 @@ function DataTableLinkExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -60,7 +60,7 @@ function DataTableLinkExample() {
           rows={rows}
           totals={['', '', '', 255, '$155,830.00']}
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/data-table-with-sticky-header-enabled.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-sticky-header-enabled.tsx
@@ -1,4 +1,4 @@
-import {Link, Page, Card, DataTable} from '@shopify/polaris';
+import {Link, Page, LegacyCard, DataTable} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -250,7 +250,7 @@ function FullDataTableExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -277,7 +277,7 @@ function FullDataTableExample() {
           increasedTableDensity
           stickyHeader
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 

--- a/polaris.shopify.com/pages/examples/data-table-with-totals-in-footer.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-totals-in-footer.tsx
@@ -1,4 +1,4 @@
-import {Page, Card, DataTable} from '@shopify/polaris';
+import {Page, LegacyCard, DataTable} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -17,7 +17,7 @@ function DataTableExample() {
 
   return (
     <Page title="Sales by product">
-      <Card>
+      <LegacyCard>
         <DataTable
           columnContentTypes={[
             'text',
@@ -37,7 +37,7 @@ function DataTableExample() {
           totals={['', '', '', 255, '$155,830.00']}
           showTotalsInFooter
         />
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/drop-zone-nested.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-nested.tsx
@@ -1,4 +1,4 @@
-import {DropZone, Stack, Thumbnail, Card, Text} from '@shopify/polaris';
+import {DropZone, Stack, Thumbnail, LegacyCard, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -41,12 +41,12 @@ function NestedDropZoneExample() {
 
   return (
     <DropZone outline={false} onDrop={handleDrop}>
-      <Card sectioned>
+      <LegacyCard sectioned>
         <DropZone onClick={handleDropZoneClick}>
           {uploadedFiles}
           {fileUpload}
         </DropZone>
-      </Card>
+      </LegacyCard>
     </DropZone>
   );
 }

--- a/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-dialog-trigger.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-dialog-trigger.tsx
@@ -1,4 +1,4 @@
-import {Stack, Thumbnail, Card, DropZone, Text} from '@shopify/polaris';
+import {Stack, Thumbnail, LegacyCard, DropZone, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -44,7 +44,7 @@ function DropZoneWithCustomFileDialogExample() {
   );
 
   return (
-    <Card
+    <LegacyCard
       sectioned
       title="Product Images"
       actions={[
@@ -52,8 +52,7 @@ function DropZoneWithCustomFileDialogExample() {
           content: 'Upload Image',
           onAction: toggleOpenFileDialog,
         },
-      ]}
-    >
+      ]}>
       <DropZone
         openFileDialog={openFileDialog}
         onDrop={handleDropZoneDrop}
@@ -61,7 +60,7 @@ function DropZoneWithCustomFileDialogExample() {
       >
         {uploadedFiles}
       </DropZone>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/empty-state-default.tsx
+++ b/polaris.shopify.com/pages/examples/empty-state-default.tsx
@@ -1,10 +1,10 @@
-import {Card, EmptyState} from '@shopify/polaris';
+import {LegacyCard, EmptyState} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function EmptyStateExample() {
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <EmptyState
         heading="Manage your inventory transfers"
         action={{content: 'Add transfer'}}
@@ -16,7 +16,7 @@ function EmptyStateExample() {
       >
         <p>Track and receive your incoming inventory from suppliers.</p>
       </EmptyState>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/empty-state-with-full-width-layout.tsx
+++ b/polaris.shopify.com/pages/examples/empty-state-with-full-width-layout.tsx
@@ -1,10 +1,10 @@
-import {Card, EmptyState} from '@shopify/polaris';
+import {LegacyCard, EmptyState} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function EmptyStateExample() {
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <EmptyState
         heading="Upload a file to get started"
         action={{content: 'Upload files'}}
@@ -17,7 +17,7 @@ function EmptyStateExample() {
           full width.
         </p>
       </EmptyState>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/empty-state-with-subdued-footer-context.tsx
+++ b/polaris.shopify.com/pages/examples/empty-state-with-subdued-footer-context.tsx
@@ -1,10 +1,10 @@
-import {Card, EmptyState, Link} from '@shopify/polaris';
+import {LegacyCard, EmptyState, Link} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function EmptyStateExample() {
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <EmptyState
         heading="Manage your inventory transfers"
         action={{content: 'Add transfer'}}
@@ -26,7 +26,7 @@ function EmptyStateExample() {
       >
         <p>Track and receive your incoming inventory from suppliers.</p>
       </EmptyState>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/filters-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-disabled.tsx
@@ -1,6 +1,6 @@
 import {
   TextField,
-  Card,
+  LegacyCard,
   ResourceList,
   Filters,
   Button,
@@ -59,7 +59,7 @@ function DisableAllFiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -115,7 +115,7 @@ function DisableAllFiltersExample() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/filters-some-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-some-disabled.tsx
@@ -1,6 +1,6 @@
 import {
   TextField,
-  Card,
+  LegacyCard,
   ResourceList,
   Filters,
   Button,
@@ -79,7 +79,7 @@ function DisableSomeFiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -134,7 +134,7 @@ function DisableSomeFiltersExample() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/filters-with-a-data-table.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-a-data-table.tsx
@@ -1,7 +1,7 @@
 import {
   ChoiceList,
   TextField,
-  Card,
+  LegacyCard,
   Filters,
   DataTable,
 } from '@shopify/polaris';
@@ -127,8 +127,8 @@ function DataTableFiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
-        <Card.Section>
+      <LegacyCard>
+        <LegacyCard.Section>
           <Filters
             queryValue={queryValue}
             filters={filters}
@@ -137,7 +137,7 @@ function DataTableFiltersExample() {
             onQueryClear={handleQueryValueRemove}
             onClearAll={handleFiltersClearAll}
           />
-        </Card.Section>
+        </LegacyCard.Section>
         <DataTable
           columnContentTypes={[
             'text',
@@ -166,7 +166,7 @@ function DataTableFiltersExample() {
           ]}
           totals={['', '', '', 255, '$155,830.00']}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/filters-with-a-resource-list.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-a-resource-list.tsx
@@ -2,7 +2,7 @@ import {
   ChoiceList,
   TextField,
   RangeSlider,
-  Card,
+  LegacyCard,
   ResourceList,
   Filters,
   Avatar,
@@ -134,7 +134,7 @@ function ResourceListFiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -180,7 +180,7 @@ function ResourceListFiltersExample() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/filters-with-children-content.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-children-content.tsx
@@ -1,6 +1,6 @@
 import {
   TextField,
-  Card,
+  LegacyCard,
   ResourceList,
   Filters,
   Button,
@@ -59,7 +59,7 @@ function FiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -111,7 +111,7 @@ function FiltersExample() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/filters-with-help-text.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-help-text.tsx
@@ -2,7 +2,7 @@ import {
   ChoiceList,
   TextField,
   RangeSlider,
-  Card,
+  LegacyCard,
   ResourceList,
   Filters,
   Avatar,
@@ -134,7 +134,7 @@ function ResourceListFiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -182,7 +182,7 @@ function ResourceListFiltersExample() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/filters-with-query-field-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-query-field-disabled.tsx
@@ -2,7 +2,7 @@ import {
   ChoiceList,
   TextField,
   RangeSlider,
-  Card,
+  LegacyCard,
   ResourceList,
   Filters,
   Avatar,
@@ -134,7 +134,7 @@ function ResourceListFiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -181,7 +181,7 @@ function ResourceListFiltersExample() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/filters-with-query-field-hidden.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-query-field-hidden.tsx
@@ -2,7 +2,7 @@ import {
   ChoiceList,
   TextField,
   RangeSlider,
-  Card,
+  LegacyCard,
   ResourceList,
   Filters,
   Avatar,
@@ -134,7 +134,7 @@ function ResourceListFiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -181,7 +181,7 @@ function ResourceListFiltersExample() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/filters-without-clear-button.tsx
+++ b/polaris.shopify.com/pages/examples/filters-without-clear-button.tsx
@@ -1,6 +1,6 @@
 import {
   TextField,
-  Card,
+  LegacyCard,
   ResourceList,
   Filters,
   Button,
@@ -61,7 +61,7 @@ function Playground() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card>
+      <LegacyCard>
         <ResourceList
           resourceName={{singular: 'customer', plural: 'customers'}}
           filterControl={
@@ -116,7 +116,7 @@ function Playground() {
             );
           }}
         />
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/frame-in-an-application.tsx
+++ b/polaris.shopify.com/pages/examples/frame-in-an-application.tsx
@@ -1,7 +1,7 @@
 import {
   ActionList,
   AppProvider,
-  Card,
+  LegacyCard,
   ContextualSaveBar,
   FormLayout,
   Frame,
@@ -222,7 +222,7 @@ function FrameExample() {
           title="Account details"
           description="Jaded Pixel will use this as your account information."
         >
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Full name"
@@ -238,7 +238,7 @@ function FrameExample() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.AnnotatedSection>
       </Layout>
     </Page>
@@ -248,12 +248,12 @@ function FrameExample() {
     <SkeletonPage>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText lines={9} />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>

--- a/polaris.shopify.com/pages/examples/frame-with-an-offset.tsx
+++ b/polaris.shopify.com/pages/examples/frame-with-an-offset.tsx
@@ -1,7 +1,7 @@
 import {
   ActionList,
   AppProvider,
-  Card,
+  LegacyCard,
   ContextualSaveBar,
   FormLayout,
   Frame,
@@ -222,7 +222,7 @@ function FrameExample() {
           title="Account details"
           description="Jaded Pixel will use this as your account information."
         >
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Full name"
@@ -238,7 +238,7 @@ function FrameExample() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.AnnotatedSection>
       </Layout>
     </Page>
@@ -248,12 +248,12 @@ function FrameExample() {
     <SkeletonPage>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText lines={9} />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>

--- a/polaris.shopify.com/pages/examples/grid-custom-layout.tsx
+++ b/polaris.shopify.com/pages/examples/grid-custom-layout.tsx
@@ -1,11 +1,11 @@
-import {Page, Grid, Card} from '@shopify/polaris';
+import {Page, Grid, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function GridExample() {
   return (
     <Page fullWidth>
-      <Card sectioned>
+      <LegacyCard sectioned>
         <Grid
           columns={{xs: 1, sm: 4, md: 4, lg: 6, xl: 6}}
           areas={{
@@ -44,7 +44,7 @@ function GridExample() {
             />
           </Grid.Cell>
         </Grid>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/grid-three-one-third-column.tsx
+++ b/polaris.shopify.com/pages/examples/grid-three-one-third-column.tsx
@@ -1,4 +1,4 @@
-import {Page, Grid, Card} from '@shopify/polaris';
+import {Page, Grid, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -7,14 +7,14 @@ function GridExample() {
     <Page fullWidth>
       <Grid columns={{sm: 3}}>
         <Grid.Cell columnSpan={{xs: 6, sm: 4, md: 4, lg: 8, xl: 8}}>
-          <Card title="Sales" sectioned>
+          <LegacyCard title="Sales" sectioned>
             <p>View a summary of your online store’s sales.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
         <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <Card title="Orders" sectioned>
+          <LegacyCard title="Orders" sectioned>
             <p>View a summary of your online store’s orders.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
       </Grid>
     </Page>

--- a/polaris.shopify.com/pages/examples/grid-two-column.tsx
+++ b/polaris.shopify.com/pages/examples/grid-two-column.tsx
@@ -1,4 +1,4 @@
-import {Page, Grid, Card} from '@shopify/polaris';
+import {Page, Grid, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -7,14 +7,14 @@ function GridExample() {
     <Page fullWidth>
       <Grid>
         <Grid.Cell columnSpan={{xs: 6, sm: 3, md: 3, lg: 6, xl: 6}}>
-          <Card title="Sales" sectioned>
+          <LegacyCard title="Sales" sectioned>
             <p>View a summary of your online store’s sales.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
         <Grid.Cell columnSpan={{xs: 6, sm: 3, md: 3, lg: 6, xl: 6}}>
-          <Card title="Orders" sectioned>
+          <LegacyCard title="Orders" sectioned>
             <p>View a summary of your online store’s orders.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
       </Grid>
     </Page>

--- a/polaris.shopify.com/pages/examples/grid-two-thirds-and-one-third-column.tsx
+++ b/polaris.shopify.com/pages/examples/grid-two-thirds-and-one-third-column.tsx
@@ -1,4 +1,4 @@
-import {Page, Grid, Card} from '@shopify/polaris';
+import {Page, Grid, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -7,14 +7,14 @@ function GridExample() {
     <Page fullWidth>
       <Grid columns={{sm: 3}}>
         <Grid.Cell columnSpan={{xs: 6, sm: 4, md: 4, lg: 8, xl: 8}}>
-          <Card title="Sales" sectioned>
+          <LegacyCard title="Sales" sectioned>
             <p>View a summary of your online store’s sales.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
         <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <Card title="Orders" sectioned>
+          <LegacyCard title="Orders" sectioned>
             <p>View a summary of your online store’s orders.</p>
-          </Card>
+          </LegacyCard>
         </Grid.Cell>
       </Grid>
     </Page>

--- a/polaris.shopify.com/pages/examples/index-table-default.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-default.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -50,7 +50,7 @@ function SimpleIndexTableExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -67,7 +67,7 @@ function SimpleIndexTableExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-flush.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-flush.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -50,7 +50,7 @@ function SimpleFlushIndexTableExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -67,7 +67,7 @@ function SimpleFlushIndexTableExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-small-screen-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-small-screen-with-all-of-its-elements.tsx
@@ -1,7 +1,7 @@
 import {
   TextField,
   IndexTable,
-  Card,
+  LegacyCard,
   Filters,
   Select,
   useIndexResourceState,
@@ -128,7 +128,7 @@ function SmallScreenIndexTableWithAllElementsExample() {
 
   return (
     <div style={{width: '430px'}}>
-      <Card>
+      <LegacyCard>
         <div style={{padding: '16px', display: 'flex'}}>
           <div style={{flex: 1}}>
             <Filters
@@ -170,7 +170,7 @@ function SmallScreenIndexTableWithAllElementsExample() {
         >
           {rowMarkup}
         </IndexTable>
-      </Card>
+      </LegacyCard>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/index-table-small-screen.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-small-screen.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -51,7 +51,7 @@ function SimpleSmallScreenIndexTableExample() {
 
   return (
     <div style={{width: '430px'}}>
-      <Card>
+      <LegacyCard>
         <IndexTable
           resourceName={resourceName}
           itemCount={customers.length}
@@ -69,7 +69,7 @@ function SimpleSmallScreenIndexTableExample() {
         >
           {rowMarkup}
         </IndexTable>
-      </Card>
+      </LegacyCard>
     </div>
   );
 }

--- a/polaris.shopify.com/pages/examples/index-table-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-all-of-its-elements.tsx
@@ -1,7 +1,7 @@
 import {
   TextField,
   IndexTable,
-  Card,
+  LegacyCard,
   Filters,
   Select,
   useIndexResourceState,
@@ -127,7 +127,7 @@ function IndexTableWithAllElementsExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <div style={{padding: '16px', display: 'flex'}}>
         <div style={{flex: 1}}>
           <Filters
@@ -169,7 +169,7 @@ function IndexTableWithAllElementsExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 
   function disambiguateLabel(key, value) {

--- a/polaris.shopify.com/pages/examples/index-table-with-bulk-actions-and-selection-across-pages.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-bulk-actions-and-selection-across-pages.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -71,7 +71,7 @@ function IndexTableWithBulkActionsAndSelectionAcrossPagesExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -91,7 +91,7 @@ function IndexTableWithBulkActionsAndSelectionAcrossPagesExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-with-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-bulk-actions.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -71,7 +71,7 @@ function IndexTableWithBulkActionsExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -90,7 +90,7 @@ function IndexTableWithBulkActionsExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-with-clickable-button-column.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-clickable-button-column.tsx
@@ -1,6 +1,6 @@
 import {
   IndexTable,
-  Card,
+  LegacyCard,
   Button,
   useIndexResourceState,
   Text,
@@ -62,7 +62,7 @@ function ClickThroughButtonIndexTableExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -79,7 +79,7 @@ function ClickThroughButtonIndexTableExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-with-empty-state.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-empty-state.tsx
@@ -1,7 +1,7 @@
 import {
   EmptySearchResult,
   IndexTable,
-  Card,
+  LegacyCard,
   useIndexResourceState,
   Text,
 } from '@shopify/polaris';
@@ -47,7 +47,7 @@ function IndexTableWithCustomEmptyStateExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -65,7 +65,7 @@ function IndexTableWithCustomEmptyStateExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-with-filtering.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-filtering.tsx
@@ -1,7 +1,7 @@
 import {
   TextField,
   IndexTable,
-  Card,
+  LegacyCard,
   Filters,
   Select,
   useIndexResourceState,
@@ -106,7 +106,7 @@ function IndexTableWithFilteringExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <div style={{padding: '16px', display: 'flex'}}>
         <div style={{flex: 1}}>
           <Filters
@@ -144,7 +144,7 @@ function IndexTableWithFilteringExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 
   function disambiguateLabel(key, value) {

--- a/polaris.shopify.com/pages/examples/index-table-with-loading-state.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-loading-state.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -50,7 +50,7 @@ function IndexTableWithLoadingExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -68,7 +68,7 @@ function IndexTableWithLoadingExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-with-multiple-promoted-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-multiple-promoted-bulk-actions.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -97,7 +97,7 @@ function IndexTableWithMultiplePromotedBulkActionsExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -116,7 +116,7 @@ function IndexTableWithMultiplePromotedBulkActionsExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-with-row-navigation-link.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-row-navigation-link.tsx
@@ -1,6 +1,6 @@
 import {
   IndexTable,
-  Card,
+  LegacyCard,
   Link,
   useIndexResourceState,
   Text,
@@ -62,7 +62,7 @@ function ClickThroughLinkIndexTableExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -79,7 +79,7 @@ function ClickThroughLinkIndexTableExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-with-row-status.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-row-status.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -53,7 +53,7 @@ function IndexTableWithRowStatusExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -70,7 +70,7 @@ function IndexTableWithRowStatusExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-with-sticky-last-column.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-sticky-last-column.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, useIndexResourceState, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, useIndexResourceState, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -50,7 +50,7 @@ function StickyLastCellIndexTableExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -68,7 +68,7 @@ function StickyLastCellIndexTableExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/index-table-without-checkboxes.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-without-checkboxes.tsx
@@ -1,4 +1,4 @@
-import {IndexTable, Card, Text} from '@shopify/polaris';
+import {IndexTable, LegacyCard, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -42,7 +42,7 @@ function IndexTableWithoutCheckboxesExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <IndexTable
         resourceName={resourceName}
         itemCount={customers.length}
@@ -56,7 +56,7 @@ function IndexTableWithoutCheckboxesExample() {
       >
         {rowMarkup}
       </IndexTable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/layout-annotated-with-banner-at-the-top.tsx
+++ b/polaris.shopify.com/pages/examples/layout-annotated-with-banner-at-the-top.tsx
@@ -2,7 +2,7 @@ import {
   Page,
   Layout,
   Banner,
-  Card,
+  LegacyCard,
   FormLayout,
   TextField,
 } from '@shopify/polaris';
@@ -23,7 +23,7 @@ function LayoutExample() {
           title="Store details"
           description="Shopify and your customers will use this information to contact you."
         >
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Store name"
@@ -37,7 +37,7 @@ function LayoutExample() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.AnnotatedSection>
       </Layout>
     </Page>

--- a/polaris.shopify.com/pages/examples/layout-annotated-with-sections.tsx
+++ b/polaris.shopify.com/pages/examples/layout-annotated-with-sections.tsx
@@ -1,7 +1,7 @@
 import {
   Page,
   Layout,
-  Card,
+  LegacyCard,
   FormLayout,
   TextField,
   TextContainer,
@@ -28,7 +28,7 @@ function LayoutExample() {
           </div>
         </Layout.Section>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Store name"
@@ -42,7 +42,7 @@ function LayoutExample() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>

--- a/polaris.shopify.com/pages/examples/layout-annotated.tsx
+++ b/polaris.shopify.com/pages/examples/layout-annotated.tsx
@@ -1,4 +1,4 @@
-import {Page, Layout, Card, FormLayout, TextField} from '@shopify/polaris';
+import {Page, Layout, LegacyCard, FormLayout, TextField} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -11,7 +11,7 @@ function LayoutExample() {
           title="Store details"
           description="Shopify and your customers will use this information to contact you."
         >
-          <Card sectioned>
+          <LegacyCard sectioned>
             <FormLayout>
               <TextField
                 label="Store name"
@@ -25,7 +25,7 @@ function LayoutExample() {
                 autoComplete="email"
               />
             </FormLayout>
-          </Card>
+          </LegacyCard>
         </Layout.AnnotatedSection>
       </Layout>
     </Page>

--- a/polaris.shopify.com/pages/examples/layout-one-column.tsx
+++ b/polaris.shopify.com/pages/examples/layout-one-column.tsx
@@ -1,4 +1,4 @@
-import {Page, Layout, Card} from '@shopify/polaris';
+import {Page, Layout, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -7,9 +7,9 @@ function LayoutExample() {
     <Page fullWidth>
       <Layout>
         <Layout.Section>
-          <Card title="Online store dashboard" sectioned>
+          <LegacyCard title="Online store dashboard" sectioned>
             <p>View a summary of your online store’s performance.</p>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>

--- a/polaris.shopify.com/pages/examples/layout-three-columns-with-equal-width.tsx
+++ b/polaris.shopify.com/pages/examples/layout-three-columns-with-equal-width.tsx
@@ -1,7 +1,7 @@
 import {
   Page,
   Layout,
-  Card,
+  LegacyCard,
   ResourceList,
   Thumbnail,
   Text,
@@ -14,13 +14,13 @@ function LayoutExample() {
     <Page fullWidth>
       <Layout>
         <Layout.Section oneThird>
-          <Card title="Florida" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Florida" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 455 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -70,17 +70,17 @@ function LayoutExample() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section oneThird>
-          <Card title="Nevada" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Nevada" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 301 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -130,17 +130,17 @@ function LayoutExample() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section oneThird>
-          <Card title="Minneapolis" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Minneapolis" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 1931 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -190,8 +190,8 @@ function LayoutExample() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>

--- a/polaris.shopify.com/pages/examples/layout-two-columns-with-equal-width.tsx
+++ b/polaris.shopify.com/pages/examples/layout-two-columns-with-equal-width.tsx
@@ -1,7 +1,7 @@
 import {
   Page,
   Layout,
-  Card,
+  LegacyCard,
   ResourceList,
   Thumbnail,
   Text,
@@ -14,13 +14,13 @@ function LayoutExample() {
     <Page fullWidth>
       <Layout>
         <Layout.Section oneHalf>
-          <Card title="Florida" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Florida" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 455 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -70,17 +70,17 @@ function LayoutExample() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section oneHalf>
-          <Card title="Nevada" actions={[{content: 'Manage'}]}>
-            <Card.Section>
+          <LegacyCard title="Nevada" actions={[{content: 'Manage'}]}>
+            <LegacyCard.Section>
               <Text variant="bodyMd" color="subdued" as="span">
                 301 units available
               </Text>
-            </Card.Section>
-            <Card.Section title="Items">
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Items">
               <ResourceList
                 resourceName={{singular: 'product', plural: 'products'}}
                 items={[
@@ -130,8 +130,8 @@ function LayoutExample() {
                   );
                 }}
               />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>

--- a/polaris.shopify.com/pages/examples/layout-two-columns-with-primary-and-secondary-widths.tsx
+++ b/polaris.shopify.com/pages/examples/layout-two-columns-with-primary-and-secondary-widths.tsx
@@ -1,4 +1,4 @@
-import {Page, Layout, Card} from '@shopify/polaris';
+import {Page, Layout, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -7,19 +7,19 @@ function LayoutExample() {
     <Page fullWidth>
       <Layout>
         <Layout.Section>
-          <Card title="Order details" sectioned>
+          <LegacyCard title="Order details" sectioned>
             <p>
               Use to follow a normal section with a secondary section to create
               a 2/3 + 1/3 layout on detail pages (such as individual product or
               order pages). Can also be used on any page that needs to structure
               a lot of content. This layout stacks the columns on small screens.
             </p>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card title="Tags" sectioned>
+          <LegacyCard title="Tags" sectioned>
             <p>Add tags to your order.</p>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>

--- a/polaris.shopify.com/pages/examples/listbox-with-search.tsx
+++ b/polaris.shopify.com/pages/examples/listbox-with-search.tsx
@@ -3,7 +3,7 @@ import {
   Stack,
   Icon,
   Page,
-  Card,
+  LegacyCard,
   Layout,
   Button,
   Popover,
@@ -247,7 +247,7 @@ function ListboxWithSearchExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <div
         style={{
           alignItems: 'stretch',
@@ -278,7 +278,7 @@ function ListboxWithSearchExample() {
           {listboxMarkup}
         </Scrollable>
       </div>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/option-list-default.tsx
+++ b/polaris.shopify.com/pages/examples/option-list-default.tsx
@@ -1,4 +1,4 @@
-import {Card, OptionList} from '@shopify/polaris';
+import {LegacyCard, OptionList} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -6,7 +6,7 @@ function OptionListExample() {
   const [selected, setSelected] = useState([]);
 
   return (
-    <Card>
+    <LegacyCard>
       <OptionList
         title="Inventory Location"
         onChange={setSelected}
@@ -19,7 +19,7 @@ function OptionListExample() {
         ]}
         selected={selected}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/option-list-multiple.tsx
+++ b/polaris.shopify.com/pages/examples/option-list-multiple.tsx
@@ -1,4 +1,4 @@
-import {Card, OptionList} from '@shopify/polaris';
+import {LegacyCard, OptionList} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -6,7 +6,7 @@ function MultipleOptionListExample() {
   const [selected, setSelected] = useState([]);
 
   return (
-    <Card>
+    <LegacyCard>
       <OptionList
         title="Manage sales channels availability"
         onChange={setSelected}
@@ -20,7 +20,7 @@ function MultipleOptionListExample() {
         selected={selected}
         allowMultiple
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/option-list-with-sections.tsx
+++ b/polaris.shopify.com/pages/examples/option-list-with-sections.tsx
@@ -1,4 +1,4 @@
-import {Card, OptionList} from '@shopify/polaris';
+import {LegacyCard, OptionList} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -6,7 +6,7 @@ function OptionListWithSectionsExample() {
   const [selected, setSelected] = useState([]);
 
   return (
-    <Card>
+    <LegacyCard>
       <OptionList
         onChange={setSelected}
         sections={[
@@ -28,7 +28,7 @@ function OptionListWithSectionsExample() {
         selected={selected}
         allowMultiple
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/page-default.tsx
+++ b/polaris.shopify.com/pages/examples/page-default.tsx
@@ -1,4 +1,4 @@
-import {Page, Badge, Card} from '@shopify/polaris';
+import {Page, Badge, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -40,9 +40,9 @@ function PageExample() {
         hasNext: true,
       }}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-full-width.tsx
+++ b/polaris.shopify.com/pages/examples/page-full-width.tsx
@@ -1,4 +1,4 @@
-import {Page, Card} from '@shopify/polaris';
+import {Page, LegacyCard} from '@shopify/polaris';
 import {PlusMinor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -14,9 +14,9 @@ function PageExample() {
         hasNext: true,
       }}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-narrow-width.tsx
+++ b/polaris.shopify.com/pages/examples/page-narrow-width.tsx
@@ -1,4 +1,4 @@
-import {Page, Card, PageActions} from '@shopify/polaris';
+import {Page, LegacyCard, PageActions} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -10,9 +10,9 @@ function PageExample() {
       title="Add payment method"
       primaryAction={{content: 'Save', disabled: true}}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
       <PageActions
         primaryAction={{content: 'Save', disabled: true}}
         secondaryActions={[{content: 'Delete'}]}

--- a/polaris.shopify.com/pages/examples/page-with-action-groups.tsx
+++ b/polaris.shopify.com/pages/examples/page-with-action-groups.tsx
@@ -1,4 +1,4 @@
-import {Page, Card} from '@shopify/polaris';
+import {Page, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -31,9 +31,9 @@ function PageExample() {
         },
       ]}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-with-content-after-title.tsx
+++ b/polaris.shopify.com/pages/examples/page-with-content-after-title.tsx
@@ -1,4 +1,4 @@
-import {Page, Badge, Card} from '@shopify/polaris';
+import {Page, Badge, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -18,9 +18,9 @@ function PageExample() {
         hasNext: true,
       }}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-with-custom-primary-action.tsx
+++ b/polaris.shopify.com/pages/examples/page-with-custom-primary-action.tsx
@@ -1,4 +1,4 @@
-import {Page, Button, Card} from '@shopify/polaris';
+import {Page, Button, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -19,9 +19,9 @@ function PageExample() {
         </Button>
       }
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-with-divider.tsx
+++ b/polaris.shopify.com/pages/examples/page-with-divider.tsx
@@ -1,4 +1,4 @@
-import {Page, Card} from '@shopify/polaris';
+import {Page, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -9,9 +9,9 @@ function PageExample() {
       title="General"
       divider
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-with-external-link.tsx
+++ b/polaris.shopify.com/pages/examples/page-with-external-link.tsx
@@ -1,4 +1,4 @@
-import {Page, Card} from '@shopify/polaris';
+import {Page, LegacyCard} from '@shopify/polaris';
 import {ExternalMinor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -17,9 +17,9 @@ function PageExample() {
         },
       ]}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-with-subtitle.tsx
+++ b/polaris.shopify.com/pages/examples/page-with-subtitle.tsx
@@ -1,4 +1,4 @@
-import {Page, Card} from '@shopify/polaris';
+import {Page, LegacyCard} from '@shopify/polaris';
 import {ArrowDownMinor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -11,9 +11,9 @@ function PageExample() {
       subtitle="Statement period: May 3, 2019 to June 2, 2019"
       secondaryActions={[{content: 'Download', icon: ArrowDownMinor}]}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-without-pagination.tsx
+++ b/polaris.shopify.com/pages/examples/page-without-pagination.tsx
@@ -1,4 +1,4 @@
-import {Page, Card} from '@shopify/polaris';
+import {Page, LegacyCard} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -9,9 +9,9 @@ function PageExample() {
       title="General"
       primaryAction={{content: 'Save'}}
     >
-      <Card title="Credit card" sectioned>
+      <LegacyCard title="Credit card" sectioned>
         <p>Credit card information</p>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/page-without-primary-action-in-header.tsx
+++ b/polaris.shopify.com/pages/examples/page-without-primary-action-in-header.tsx
@@ -1,4 +1,4 @@
-import {Page, Card, Stack, Button} from '@shopify/polaris';
+import {Page, LegacyCard, Stack, Button} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -17,14 +17,14 @@ function PageExample() {
         hasNext: true,
       }}
     >
-      <Card sectioned title="Fulfill order">
+      <LegacyCard sectioned title="Fulfill order">
         <Stack alignment="center">
           <Stack.Item fill>
             <p>Buy postage and ship remaining 2 items</p>
           </Stack.Item>
           <Button primary>Continue</Button>
         </Stack>
-      </Card>
+      </LegacyCard>
     </Page>
   );
 }

--- a/polaris.shopify.com/pages/examples/popover-with-lazy-loaded-list.tsx
+++ b/polaris.shopify.com/pages/examples/popover-with-lazy-loaded-list.tsx
@@ -1,4 +1,4 @@
-import {Button, Card, Popover, ResourceList, Avatar} from '@shopify/polaris';
+import {Button, LegacyCard, Popover, ResourceList, Avatar} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -55,7 +55,7 @@ function PopoverLazyLoadExample() {
   }));
 
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <div style={{height: '280px'}}>
         <Popover
           sectioned
@@ -69,7 +69,7 @@ function PopoverLazyLoadExample() {
           </Popover.Pane>
         </Popover>
       </div>
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem({name, initials}) {

--- a/polaris.shopify.com/pages/examples/range-slider-default.tsx
+++ b/polaris.shopify.com/pages/examples/range-slider-default.tsx
@@ -1,4 +1,4 @@
-import {Card, RangeSlider} from '@shopify/polaris';
+import {LegacyCard, RangeSlider} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -11,14 +11,14 @@ function RangeSliderExample() {
   );
 
   return (
-    <Card sectioned title="Background color">
+    <LegacyCard sectioned title="Background color">
       <RangeSlider
         label="Opacity percentage"
         value={rangeValue}
         onChange={handleRangeSliderChange}
         output
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/range-slider-with-dual-thumb.tsx
+++ b/polaris.shopify.com/pages/examples/range-slider-with-dual-thumb.tsx
@@ -1,4 +1,4 @@
-import {Card, RangeSlider, Stack, TextField} from '@shopify/polaris';
+import {LegacyCard, RangeSlider, Stack, TextField} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -71,7 +71,7 @@ function DualThumbRangeSliderExample() {
       : intermediateTextFieldValue[1];
 
   return (
-    <Card sectioned title="Minimum requirements">
+    <LegacyCard sectioned title="Minimum requirements">
       <div onKeyDown={handleEnterKeyPress}>
         <RangeSlider
           output
@@ -110,7 +110,7 @@ function DualThumbRangeSliderExample() {
           />
         </Stack>
       </div>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/range-slider-with-min-and-max.tsx
+++ b/polaris.shopify.com/pages/examples/range-slider-with-min-and-max.tsx
@@ -1,4 +1,4 @@
-import {Card, RangeSlider} from '@shopify/polaris';
+import {LegacyCard, RangeSlider} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -11,7 +11,7 @@ function RangeSliderWithPreciseRangeControlExample() {
   );
 
   return (
-    <Card sectioned title="Navigation branding">
+    <LegacyCard sectioned title="Navigation branding">
       <RangeSlider
         output
         label="Logo offset"
@@ -20,7 +20,7 @@ function RangeSliderWithPreciseRangeControlExample() {
         value={rangeValue}
         onChange={handleRangeSliderChange}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/range-slider-with-prefix-and-suffix.tsx
+++ b/polaris.shopify.com/pages/examples/range-slider-with-prefix-and-suffix.tsx
@@ -1,4 +1,4 @@
-import {Card, RangeSlider} from '@shopify/polaris';
+import {LegacyCard, RangeSlider} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -16,7 +16,7 @@ function RangeSliderWithPrefixAndSuffixExample() {
   };
 
   return (
-    <Card sectioned title="Text color">
+    <LegacyCard sectioned title="Text color">
       <RangeSlider
         output
         label="Hue color mix"
@@ -27,7 +27,7 @@ function RangeSliderWithPrefixAndSuffixExample() {
         prefix={<p>Hue</p>}
         suffix={<p style={suffixStyles}>{rangeValue}</p>}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/range-slider-with-steps.tsx
+++ b/polaris.shopify.com/pages/examples/range-slider-with-steps.tsx
@@ -1,4 +1,4 @@
-import {Card, RangeSlider} from '@shopify/polaris';
+import {LegacyCard, RangeSlider} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -11,7 +11,7 @@ function RangeSliderWithPreciseRangeControlExample() {
   );
 
   return (
-    <Card sectioned title="Navigation branding">
+    <LegacyCard sectioned title="Navigation branding">
       <RangeSlider
         output
         label="Logo offset"
@@ -21,7 +21,7 @@ function RangeSliderWithPreciseRangeControlExample() {
         value={rangeValue}
         onChange={handleRangeSliderChange}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/resource-item-default.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-default.tsx
@@ -1,4 +1,4 @@
-import {Card, ResourceList, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -6,7 +6,7 @@ function ResourceItemExample() {
   const [selectedItems, setSelectedItems] = useState([]);
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'blog post', plural: 'blog posts'}}
         items={[
@@ -38,7 +38,7 @@ function ResourceItemExample() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/resource-item-with-media.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-media.tsx
@@ -1,10 +1,10 @@
-import {Card, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceItemExample() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -43,7 +43,7 @@ function ResourceItemExample() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/resource-item-with-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-shortcut-actions.tsx
@@ -1,10 +1,10 @@
-import {Card, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceItemExample() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -48,7 +48,7 @@ function ResourceItemExample() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/resource-item-with-vertical-alignment.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-vertical-alignment.tsx
@@ -1,10 +1,10 @@
-import {Card, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, ResourceItem, Avatar, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceItemExample() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -45,7 +45,7 @@ function ResourceItemExample() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/resource-list-default.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-default.tsx
@@ -1,10 +1,10 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListExample() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -40,7 +40,7 @@ function ResourceListExample() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/resource-list-with-a-custom-empty-search-result-state.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-a-custom-empty-search-result-state.tsx
@@ -2,7 +2,7 @@ import {
   TextField,
   Filters,
   Button,
-  Card,
+  LegacyCard,
   ResourceList,
   Avatar,
   ResourceItem,
@@ -79,7 +79,7 @@ function ResourceListWithFilteringExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -87,7 +87,7 @@ function ResourceListWithFilteringExample() {
         filterControl={filterControl}
         emptySearchState={<div>This is a custom empty state</div>}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-all-of-its-elements.tsx
@@ -2,7 +2,7 @@ import {
   TextField,
   Filters,
   Button,
-  Card,
+  LegacyCard,
   ResourceList,
   Avatar,
   ResourceItem,
@@ -119,7 +119,7 @@ function ResourceListExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -139,7 +139,7 @@ function ResourceListExample() {
         }}
         filterControl={filterControl}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-alternate-tool.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-alternate-tool.tsx
@@ -1,5 +1,5 @@
 import {
-  Card,
+  LegacyCard,
   ResourceList,
   Button,
   Avatar,
@@ -31,14 +31,14 @@ function ResourceListWithAlternateToolExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         items={items}
         renderItem={renderItem}
         resourceName={resourceName}
         alternateTool={<Button>Email customers</Button>}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-bulk-actions.tsx
@@ -1,4 +1,4 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -48,7 +48,7 @@ function ResourceListWithBulkActionsExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -58,7 +58,7 @@ function ResourceListWithBulkActionsExample() {
         promotedBulkActions={promotedBulkActions}
         bulkActions={bulkActions}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-empty-state.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-empty-state.tsx
@@ -3,7 +3,7 @@ import {
   EmptyState,
   Page,
   Layout,
-  Card,
+  LegacyCard,
   ResourceList,
 } from '@shopify/polaris';
 import React from 'react';
@@ -41,7 +41,7 @@ function ResourceListWithEmptyStateExample() {
     <Page title="Files">
       <Layout>
         <Layout.Section>
-          <Card>
+          <LegacyCard>
             <ResourceList
               emptyState={emptyStateMarkup}
               items={items}
@@ -49,7 +49,7 @@ function ResourceListWithEmptyStateExample() {
               filterControl={filterControl}
               resourceName={{singular: 'file', plural: 'files'}}
             />
-          </Card>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </Page>

--- a/polaris.shopify.com/pages/examples/resource-list-with-filtering.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-filtering.tsx
@@ -2,7 +2,7 @@ import {
   TextField,
   Filters,
   Button,
-  Card,
+  LegacyCard,
   ResourceList,
   Avatar,
   ResourceItem,
@@ -89,14 +89,14 @@ function ResourceListWithFilteringExample() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
         renderItem={renderItem}
         filterControl={filterControl}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-item-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-item-shortcut-actions.tsx
@@ -1,10 +1,10 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListExample() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -52,7 +52,7 @@ function ResourceListExample() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/resource-list-with-loading-state.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-loading-state.tsx
@@ -1,4 +1,4 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -48,7 +48,7 @@ function ResourceListWithLoadingExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -59,7 +59,7 @@ function ResourceListWithLoadingExample() {
         bulkActions={bulkActions}
         loading
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-multiselect.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-multiselect.tsx
@@ -1,4 +1,4 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -72,7 +72,7 @@ function ResourceListExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -83,7 +83,7 @@ function ResourceListExample() {
         bulkActions={bulkActions}
         resolveItemId={resolveItemIds}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item, _, index) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-persistent-item-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-persistent-item-shortcut-actions.tsx
@@ -1,10 +1,10 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListExample() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -53,7 +53,7 @@ function ResourceListExample() {
           );
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/resource-list-with-selection-and-no-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-selection-and-no-bulk-actions.tsx
@@ -1,4 +1,4 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -26,7 +26,7 @@ function ResourceListWithSelectionExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -35,7 +35,7 @@ function ResourceListWithSelectionExample() {
         onSelectionChange={setSelectedItems}
         selectable
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-sorting.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-sorting.tsx
@@ -1,4 +1,4 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -26,7 +26,7 @@ function ResourceListWithSortingExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={resourceName}
         items={items}
@@ -41,7 +41,7 @@ function ResourceListWithSortingExample() {
           console.log(`Sort option changed to ${selected}.`);
         }}
       />
-    </Card>
+    </LegacyCard>
   );
 
   function renderItem(item) {

--- a/polaris.shopify.com/pages/examples/resource-list-with-total-count.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-total-count.tsx
@@ -1,10 +1,10 @@
-import {Card, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
+import {LegacyCard, ResourceList, Avatar, ResourceItem, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListWithTotalItemsCount() {
   return (
-    <Card>
+    <LegacyCard>
       <ResourceList
         resourceName={{singular: 'customer', plural: 'customers'}}
         items={[
@@ -42,7 +42,7 @@ function ResourceListWithTotalItemsCount() {
         showHeader
         totalItemsCount={50}
       />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/scrollable-default.tsx
+++ b/polaris.shopify.com/pages/examples/scrollable-default.tsx
@@ -1,10 +1,10 @@
-import {Card, Scrollable} from '@shopify/polaris';
+import {LegacyCard, Scrollable} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ScrollableExample() {
   return (
-    <Card title="Terms of service" sectioned>
+    <LegacyCard title="Terms of service" sectioned>
       <Scrollable shadow style={{height: '100px'}} focusable>
         <p>
           By signing up for the Shopify service (“Service”) or any of the
@@ -22,7 +22,7 @@ function ScrollableExample() {
           from time to time for any updates or changes that may impact you.
         </p>
       </Scrollable>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/scrollable-to-child-component.tsx
+++ b/polaris.shopify.com/pages/examples/scrollable-to-child-component.tsx
@@ -1,10 +1,10 @@
-import {Card, Scrollable} from '@shopify/polaris';
+import {LegacyCard, Scrollable} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ScrollableExample() {
   return (
-    <Card title="Terms of service" sectioned>
+    <LegacyCard title="Terms of service" sectioned>
       <Scrollable shadow style={{height: '100px'}}>
         <ol>
           <li>Account Terms</li>
@@ -291,7 +291,7 @@ function ScrollableExample() {
           credit card information is always encrypted.
         </p>
       </Scrollable>
-    </Card>
+    </LegacyCard>
   );
 }
 export default withPolarisExample(ScrollableExample);

--- a/polaris.shopify.com/pages/examples/select-with-separate-validation-error.tsx
+++ b/polaris.shopify.com/pages/examples/select-with-separate-validation-error.tsx
@@ -4,7 +4,7 @@ import {
   TextField,
   Select,
   InlineError,
-  Card,
+  LegacyCard,
   Link,
   Text,
 } from '@shopify/polaris';
@@ -47,7 +47,7 @@ function SeparateValidationErrorExample() {
     </Stack>
   );
 
-  return <Card sectioned>{formGroupMarkup}</Card>;
+  return <LegacyCard sectioned>{formGroupMarkup}</LegacyCard>;
 
   function generateErrorMessage() {
     const weightError =

--- a/polaris.shopify.com/pages/examples/sheet-default.tsx
+++ b/polaris.shopify.com/pages/examples/sheet-default.tsx
@@ -2,7 +2,7 @@ import {
   List,
   Button,
   Page,
-  Card,
+  LegacyCard,
   Sheet,
   Scrollable,
   ChoiceList,
@@ -76,14 +76,13 @@ function SheetExample() {
 
   return (
     <Page narrowWidth>
-      <Card
+      <LegacyCard
         sectioned
         subdued
         title="Product availability"
-        actions={salesChannelAction}
-      >
+        actions={salesChannelAction}>
         {salesChannelsCardMarkup}
-      </Card>
+      </LegacyCard>
       <Sheet
         open={sheetActive}
         onClose={toggleSheetActive}

--- a/polaris.shopify.com/pages/examples/skeleton-page-with-dynamic-content.tsx
+++ b/polaris.shopify.com/pages/examples/skeleton-page-with-dynamic-content.tsx
@@ -1,7 +1,7 @@
 import {
   SkeletonPage,
   Layout,
-  Card,
+  LegacyCard,
   SkeletonBodyText,
   TextContainer,
   SkeletonDisplayText,
@@ -14,45 +14,45 @@ function SkeletonExample() {
     <SkeletonPage primaryAction>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <SkeletonBodyText />
-          </Card>
-          <Card sectioned>
+          </LegacyCard>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText />
             </TextContainer>
-          </Card>
-          <Card sectioned>
+          </LegacyCard>
+          <LegacyCard sectioned>
             <TextContainer>
               <SkeletonDisplayText size="small" />
               <SkeletonBodyText />
             </TextContainer>
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card>
-            <Card.Section>
+          <LegacyCard>
+            <LegacyCard.Section>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
                 <SkeletonBodyText lines={2} />
               </TextContainer>
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={1} />
-            </Card.Section>
-          </Card>
-          <Card subdued>
-            <Card.Section>
+            </LegacyCard.Section>
+          </LegacyCard>
+          <LegacyCard subdued>
+            <LegacyCard.Section>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
                 <SkeletonBodyText lines={2} />
               </TextContainer>
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>

--- a/polaris.shopify.com/pages/examples/skeleton-page-with-static-content.tsx
+++ b/polaris.shopify.com/pages/examples/skeleton-page-with-static-content.tsx
@@ -1,4 +1,4 @@
-import {SkeletonPage, Layout, Card, SkeletonBodyText} from '@shopify/polaris';
+import {SkeletonPage, Layout, LegacyCard, SkeletonBodyText} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -7,33 +7,33 @@ function SkeletonExample() {
     <SkeletonPage title="Products" primaryAction>
       <Layout>
         <Layout.Section>
-          <Card sectioned>
+          <LegacyCard sectioned>
             <SkeletonBodyText />
-          </Card>
-          <Card sectioned title="Images">
+          </LegacyCard>
+          <LegacyCard sectioned title="Images">
             <SkeletonBodyText />
-          </Card>
-          <Card sectioned title="Variants">
+          </LegacyCard>
+          <LegacyCard sectioned title="Variants">
             <SkeletonBodyText />
-          </Card>
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
-          <Card title="Sales channels">
-            <Card.Section>
+          <LegacyCard title="Sales channels">
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={1} />
-            </Card.Section>
-          </Card>
-          <Card title="Organization" subdued>
-            <Card.Section>
+            </LegacyCard.Section>
+          </LegacyCard>
+          <LegacyCard title="Organization" subdued>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-            <Card.Section>
+            </LegacyCard.Section>
+            <LegacyCard.Section>
               <SkeletonBodyText lines={2} />
-            </Card.Section>
-          </Card>
+            </LegacyCard.Section>
+          </LegacyCard>
         </Layout.Section>
       </Layout>
     </SkeletonPage>

--- a/polaris.shopify.com/pages/examples/skeleton-tabs-default.tsx
+++ b/polaris.shopify.com/pages/examples/skeleton-tabs-default.tsx
@@ -1,12 +1,12 @@
-import {Card, SkeletonTabs} from '@shopify/polaris';
+import {LegacyCard, SkeletonTabs} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function SkeletonExample() {
   return (
-    <Card>
+    <LegacyCard>
       <SkeletonTabs />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/skeleton-tabs-with-a-custom-count.tsx
+++ b/polaris.shopify.com/pages/examples/skeleton-tabs-with-a-custom-count.tsx
@@ -1,12 +1,12 @@
-import {Card, SkeletonTabs} from '@shopify/polaris';
+import {LegacyCard, SkeletonTabs} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function SkeletonExample() {
   return (
-    <Card>
+    <LegacyCard>
       <SkeletonTabs count={4} />
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/spinner-with-focus-management.tsx
+++ b/polaris.shopify.com/pages/examples/spinner-with-focus-management.tsx
@@ -4,7 +4,7 @@ import {
   FormLayout,
   TextField,
   Button,
-  Card,
+  LegacyCard,
   Tabs,
 } from '@shopify/polaris';
 import {useState, useEffect, useCallback, useRef} from 'react';
@@ -69,13 +69,13 @@ function SpinnerWithFocusManagement() {
   );
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs tabs={tabs.current} selected={selected} onSelect={handleTabChange}>
-        <Card.Section title={tabs.current[selected].content}>
+        <LegacyCard.Section title={tabs.current[selected].content}>
           {sectionMarkup}
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/tabs-default.tsx
+++ b/polaris.shopify.com/pages/examples/tabs-default.tsx
@@ -1,4 +1,4 @@
-import {Card, Tabs} from '@shopify/polaris';
+import {LegacyCard, Tabs} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -35,13 +35,13 @@ function TabsExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
-        <Card.Section title={tabs[selected].content}>
+        <LegacyCard.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/tabs-fitted.tsx
+++ b/polaris.shopify.com/pages/examples/tabs-fitted.tsx
@@ -1,4 +1,4 @@
-import {Card, Tabs} from '@shopify/polaris';
+import {LegacyCard, Tabs} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -25,13 +25,13 @@ function FittedTabsExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
-        <Card.Section title={tabs[selected].content}>
+        <LegacyCard.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/tabs-with-badge-content.tsx
+++ b/polaris.shopify.com/pages/examples/tabs-with-badge-content.tsx
@@ -1,4 +1,4 @@
-import {Badge, Card, Tabs} from '@shopify/polaris';
+import {Badge, LegacyCard, Tabs} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -33,13 +33,13 @@ function TabsWithBadgeExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
-        <Card.Section title={tabs[selected].content}>
+        <LegacyCard.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/tabs-with-custom-disclosure.tsx
+++ b/polaris.shopify.com/pages/examples/tabs-with-custom-disclosure.tsx
@@ -1,4 +1,4 @@
-import {Card, Tabs} from '@shopify/polaris';
+import {LegacyCard, Tabs} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -35,18 +35,18 @@ function TabsWithCustomDisclosureExample() {
   ];
 
   return (
-    <Card>
+    <LegacyCard>
       <Tabs
         tabs={tabs}
         selected={selected}
         onSelect={handleTabChange}
         disclosureText="More views"
       >
-        <Card.Section title={tabs[selected].content}>
+        <LegacyCard.Section title={tabs[selected].content}>
           <p>Tab {selected} selected</p>
-        </Card.Section>
+        </LegacyCard.Section>
       </Tabs>
-    </Card>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/text-field-with-separate-validation-error.tsx
+++ b/polaris.shopify.com/pages/examples/text-field-with-separate-validation-error.tsx
@@ -5,7 +5,7 @@ import {
   TextField,
   InlineError,
   Button,
-  Card,
+  LegacyCard,
 } from '@shopify/polaris';
 import {DeleteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
@@ -77,9 +77,9 @@ function SeparateValidationErrorExample() {
   );
 
   return (
-    <Card sectioned>
+    <LegacyCard sectioned>
       <FormLayout>{formGroupMarkup}</FormLayout>
-    </Card>
+    </LegacyCard>
   );
 
   function isValueInvalid(content) {


### PR DESCRIPTION
This reverts commit eccf6fade11777955007d3518fd20b4d6fc3dd66.
Adds back migrations to replace usage of `Card` with `LegacyCard`.
More context in the original PR [here](https://github.com/Shopify/polaris/pull/8289).
Part of https://github.com/Shopify/polaris/issues/8182.