### PR TITLE
Cap content column to 776px below Desktop breakpoint

### DIFF
--- a/polaris.shopify.com/src/components/Page/Page.module.scss
+++ b/polaris.shopify.com/src/components/Page/Page.module.scss
@@ -24,10 +24,16 @@
   --toc-width: 16rem;
   display: flex;
   gap: 2.5rem;
+  /* If the TOC is not visible, ensure the Post column is centered */
+  justify-content: center;
 }
 
 .Post {
   flex: 1;
+  @media screen and (max-width: $breakpointDesktop) {
+    /* Ensure the page width doesn't become too wide when TOC is hidden */
+    max-width: 776px;
+  }
 }
 
 .Footer {


### PR DESCRIPTION
As per discussion in https://github.com/Shopify/polaris/issues/8248#issuecomment-1432149956

![center-column](https://user-images.githubusercontent.com/612020/219267931-86181ec7-8ca5-4d92-9ddb-065406b7a6fe.gif)
