### PR TITLE
Add redirects for moved legacy patterns

### DIFF
--- a/polaris.shopify.com/next.config.js
+++ b/polaris.shopify.com/next.config.js
@@ -104,6 +104,36 @@ const nextConfig = {
         destination: 'https://github.com/Shopify/polaris/blob/main/LICENSE.md',
         permanent: true,
       },
+      {
+        source: '/patterns/error-messages',
+        destination: '/content/error-messages',
+        permanent: true,
+      },
+      {
+        source: '/patterns/help-content',
+        destination: '/content/help-content',
+        permanent: true,
+      },
+      {
+        source: '/patterns/loading',
+        destination: '/patterns-legacy/loading',
+        permanent: true,
+      },
+      {
+        source: '/patterns/new-badge',
+        destination: '/patterns-legacy/new-badge',
+        permanent: true,
+      },
+      {
+        source: '/patterns/pickers',
+        destination: '/patterns-legacy/pickers',
+        permanent: true,
+      },
+      {
+        source: '/patterns/text-fields',
+        destination: '/patterns-legacy/text-fields',
+        permanent: true,
+      },
       ...actions,
       ...deprecated,
       ...feedbackIndicators,


### PR DESCRIPTION
Combined with https://github.com/Shopify/polaris/pull/8397, the routes are now:

||Old|New|
|--|--|--|
|**design-patterns** | `/patterns/design-patterns` | `404`|
|**page-layouts** | `/patterns/page-layouts` | `404`|
|**error-messages** | `/patterns/error-messages` | `/content/error-messages`|
|**help-content** | `/patterns/help-content` | `/content/help-content`|
|**loading** | `/patterns/loading` | `/patterns-legacy/loading`|
|**new-badge** | `/patterns/new-badge` | `/patterns-legacy/new-badge`|
|**pickers** | `/patterns/pickers` | `/patterns-legacy/pickers`|
|**text-fields** | `/patterns/text-fields` | `/patterns-legacy/text-fields`|
