### PR TITLE
[Layout foundations] Fix broken images

### DIFF
--- a/.changeset/gentle-dodos-shake.md
+++ b/.changeset/gentle-dodos-shake.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed broken image urls for component pages

--- a/polaris.shopify.com/content/components/deprecated/caption.md
+++ b/polaris.shopify.com/content/components/deprecated/caption.md
@@ -50,7 +50,7 @@ Captions are primarily used in [data visualizations](https://polaris.shopify.com
 #### Do
 
 - Use caption for labelling data visualizations
-  ![Diagram of using captions to label graphs and other data content](/images/components/caption/do-use-caption-for-labeling-data-visualizations@2x.png)
+  ![Diagram of using captions to label graphs and other data content](/images/components/deprecated/caption/do-use-caption-for-labeling-data-visualizations@2x.png)
 - Received April 21, 2017
 
 #### Don’t

--- a/polaris.shopify.com/content/components/feedback-indicators/skeleton-display-text.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/skeleton-display-text.md
@@ -40,12 +40,12 @@ Show static display text that that never changes on a page. For example, keep pa
 #### Do
 
 Show actual display text for static content and use skeleton display text for dynamic content.
-![Image showing skeleton display text for dynamic content](/images/components/skeleton-display-text/do-show-display-text-for-static-content@2x.png)
+![Image showing skeleton display text for dynamic content](/images/components/feedback-indicators/skeleton-display-text/do-show-display-text-for-static-content@2x.png)
 
 #### Don’t
 
 Use skeleton display text for static content or placeholder content for dynamic content.
-![Image showing skeleton display text for static content and placeholder text for dynamic content](/images/components/skeleton-display-text/dont-use-skeleton-for-static-or-placeholder-content-for-dynamic@2x.png)
+![Image showing skeleton display text for static content and placeholder text for dynamic content](/images/components/feedback-indicators/skeleton-display-text/dont-use-skeleton-for-static-or-placeholder-content-for-dynamic@2x.png)
 
 <!-- end -->
 
@@ -55,7 +55,7 @@ Use skeleton display text for static content or placeholder content for dynamic 
 
 Show skeleton display text for dynamic page titles.
 
-![Image showing skeleton display text for dynamic page title](/images/components/skeleton-display-text/do-use-skeleton-for-dynamic-page-titles@2x.png)
+![Image showing skeleton display text for dynamic page title](/images/components/feedback-indicators/skeleton-display-text/do-use-skeleton-for-dynamic-page-titles@2x.png)
 
 <!-- end -->
 

--- a/polaris.shopify.com/content/components/feedback-indicators/skeleton-page.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/skeleton-page.md
@@ -38,13 +38,13 @@ Secondary actions are always represented with skeleton content. You can change t
 
 Use skeleton loading for dynamic content, and use actual content for content that doesn’t change.
 
-![Image showing skeleton loading for changing content](/images/components/skeleton-page/do-use-skeleton-for-changing-content@2x.png)
+![Image showing skeleton loading for changing content](/images/components/feedback-indicators/skeleton-page/do-use-skeleton-for-changing-content@2x.png)
 
 #### Don’t
 
 Use placeholder content that will change when the page fully loads. This will confuse merchants and create a jumpy loading experience.
 
-![Image showing placeholder content that will change](/images/components/skeleton-page/dont-use-placeholder-content-that-will-change@2x.png)
+![Image showing placeholder content that will change](/images/components/feedback-indicators/skeleton-page/dont-use-placeholder-content-that-will-change@2x.png)
 
 <!-- end -->
 

--- a/polaris.shopify.com/content/components/lists/resource-list.md
+++ b/polaris.shopify.com/content/components/lists/resource-list.md
@@ -109,7 +109,7 @@ Resource lists function as:
 
 Because a details page displays all the content and actions for an individual resource, you can think of a resource list as a summary of these details pages. In this way resource lists bridge a middle level in Shopify’s navigation hierarchy.
 
-![Schematic showing content from a details page being surfaced on a resource list](/images/components/resource-list/list-surfacing-show@2x.png)
+![Schematic showing content from a details page being surfaced on a resource list](/images/components/lists/resource-list/list-surfacing-show@2x.png)
 
 #### A resource list isn’t a data table
 

--- a/polaris.shopify.com/content/components/navigation/link.md
+++ b/polaris.shopify.com/content/components/navigation/link.md
@@ -70,13 +70,13 @@ Edge cases: External icons should not be used to indicate a new tab or window is
 
 Use as a standalone, identifying icon only
 
-![Shopify admin search search results with an example of the external link icon being used as a decorative element](/images/components/link/external-link-icon-decorative@2x.png)
+![Shopify admin search search results with an example of the external link icon being used as a decorative element](/images/components/navigation/link/external-link-icon-decorative@2x.png)
 
 #### Don’t
 
 Avoid using the icon beside link text
 
-![Shopify admin page with an example of an external link to the Shopify help center with no icon](/images/components/link/external-link-dont-example@2x.png)
+![Shopify admin page with an example of an external link to the Shopify help center with no icon](/images/components/navigation/link/external-link-dont-example@2x.png)
 
 <!-- end -->
 

--- a/polaris.shopify.com/content/components/selection-and-input/combobox.md
+++ b/polaris.shopify.com/content/components/selection-and-input/combobox.md
@@ -33,7 +33,7 @@ examples:
 
 ## Anatomy
 
-![A diagram of the Combobox component showing the smaller primitive components it is composed of.](/images/components/combobox/combobox-anatomy.png)
+![A diagram of the Combobox component showing the smaller primitive components it is composed of.](/images/components/selection-and-input/combobox/combobox-anatomy.png)
 
 A combobox is made up of the following:
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #8403.
Fixes broken images in style guide on component pages.

### WHAT is this pull request doing?

Adds component grouping in url for images.
    <details>
      <summary>Fixed Combobox page</summary>
      <img src="https://user-images.githubusercontent.com/26749317/219390647-bd8560ec-e8b0-4147-96e1-49aceef34c5e.png" alt="Fixed Combobox page">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
