### PR TITLE
Fixed width column for content pages

### DIFF
--- a/polaris.shopify.com/pages/[...slug].tsx
+++ b/polaris.shopify.com/pages/[...slug].tsx
@@ -39,7 +39,7 @@ const CatchAllTemplate: NextPage<Props> = ({
     : undefined;
 
   return (
-    <Page title={title} editPageLinkPath={editPageLinkPath}>
+    <Page title={title} editPageLinkPath={editPageLinkPath} isContentPage>
       <PageMeta title={title} description={description} noIndex={noIndex} />
       <Longform>
         {description ? <Markdown>{description}</Markdown> : null}

--- a/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
+++ b/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
@@ -62,7 +62,7 @@ const Components = ({
     ) : null;
 
   return (
-    <Page title={title} editPageLinkPath={editPageLinkPath}>
+    <Page title={title} editPageLinkPath={editPageLinkPath} isContentPage>
       <PageMeta title={title} description={description} />
 
       <Longform>

--- a/polaris.shopify.com/pages/tools/stylelint-polaris/rules/[rule].tsx
+++ b/polaris.shopify.com/pages/tools/stylelint-polaris/rules/[rule].tsx
@@ -56,7 +56,7 @@ const StylelintRulePage: NextPage<Props> = ({
   editPageLinkPath,
 }: Props) => {
   return (
-    <Page title={title} editPageLinkPath={editPageLinkPath}>
+    <Page title={title} editPageLinkPath={editPageLinkPath} isContentPage>
       <PageMeta title={title} description={description} />
       <Longform>
         {description ? <Markdown>{description}</Markdown> : null}

--- a/polaris.shopify.com/pages/tools/stylelint-polaris/rules/index.tsx
+++ b/polaris.shopify.com/pages/tools/stylelint-polaris/rules/index.tsx
@@ -20,7 +20,7 @@ const FoundationsCategory = ({title, description, content}: RulesProps) => {
   return (
     <>
       <PageMeta description={description} />
-      <Page>
+      <Page isContentPage>
         <Longform>
           <h1>{title}</h1>
           <p>{description}</p>

--- a/polaris.shopify.com/pages/whats-new.tsx
+++ b/polaris.shopify.com/pages/whats-new.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 const WhatsNew: NextPage<Props> = ({title, description, posts}: Props) => {
   return (
-    <Page title={title} showTOC={false}>
+    <Page title={title}>
       <PageMeta title={title} description={description} />
       <WhatsNewListing posts={posts} />
     </Page>

--- a/polaris.shopify.com/src/components/ComponentsPage/ComponentsPage.tsx
+++ b/polaris.shopify.com/src/components/ComponentsPage/ComponentsPage.tsx
@@ -27,7 +27,7 @@ export default function ComponentsPage() {
         description="Components are reusable building blocks made of interface elements and styles, packaged through code. Piece them together, improve them, and create new ones to solve merchant problems."
       />
 
-      <Page title="Components" showTOC={false}>
+      <Page title="Components">
         {componentCategories.map((category) => {
           return (
             <div key={category} className={styles.Category}>

--- a/polaris.shopify.com/src/components/FoundationsPage/FoundationsPage.tsx
+++ b/polaris.shopify.com/src/components/FoundationsPage/FoundationsPage.tsx
@@ -35,7 +35,7 @@ function FoundationsPage({
     <div className={styles.FoundationsPage}>
       <PageMeta description={description} />
 
-      <Page showTOC={false}>
+      <Page>
         <Longform>
           <h1>{title}</h1>
 

--- a/polaris.shopify.com/src/components/HomePage/HomePage.tsx
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.tsx
@@ -12,7 +12,7 @@ function HomePage({}: Props) {
   const useMotion = useMedia('(prefers-reduced-motion: no-preference)');
 
   return (
-    <Page showTOC={false}>
+    <Page>
       <div className={styles.HomePage}>
         <PageMeta description="A starter kit for reimagining commerce." />
 

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -109,7 +109,7 @@ function IconsPage() {
   )}`;
 
   return (
-    <Page title="Icons" showTOC={false}>
+    <Page title="Icons">
       <PageMeta title={pageTitle} />
 
       <div className={className(!useModal && styles.PageLayout)}>

--- a/polaris.shopify.com/src/components/Page/Page.module.scss
+++ b/polaris.shopify.com/src/components/Page/Page.module.scss
@@ -30,6 +30,9 @@
 
 .Post {
   flex: 1;
+}
+
+.PostContent {
   @media screen and (max-width: $breakpointDesktop) {
     /* Ensure the page width doesn't become too wide when TOC is hidden */
     max-width: 776px;

--- a/polaris.shopify.com/src/components/Page/Page.tsx
+++ b/polaris.shopify.com/src/components/Page/Page.tsx
@@ -2,6 +2,7 @@ import {useTOC} from '../../utils/hooks';
 import {className} from '../../utils/various';
 import Longform from '../Longform';
 import Container from '../Container';
+import {Box} from '../Box';
 
 import styles from './Page.module.scss';
 import TOC from '../TOC';
@@ -11,12 +12,21 @@ import Link from 'next/link';
 
 interface Props {
   title?: string;
-  showTOC?: boolean;
   editPageLinkPath?: string;
+  /* Content pages have a TOC, and a centered max-width column. To forcibly show
+   * or hide the TOC, use showTOC */
+  isContentPage?: boolean;
+  showTOC?: boolean;
   children: React.ReactNode;
 }
 
-function Layout({title, showTOC = true, editPageLinkPath, children}: Props) {
+function Layout({
+  title,
+  isContentPage = false,
+  showTOC = isContentPage,
+  editPageLinkPath,
+  children,
+}: Props) {
   const [tocItems] = useTOC(children);
   const {asPath} = useRouter();
 
@@ -30,7 +40,11 @@ function Layout({title, showTOC = true, editPageLinkPath, children}: Props) {
 
   return (
     <Container className={className(styles.Page, showTOC && styles.showTOC)}>
-      <article className={styles.Post} id="main">
+      <Box
+        as="article"
+        className={[styles.Post, isContentPage && styles.PostContent]}
+        id="main"
+      >
         <Breadcrumbs />
         {title && (
           <Longform>
@@ -46,7 +60,7 @@ function Layout({title, showTOC = true, editPageLinkPath, children}: Props) {
             <Link href={feedbackUrl}>Leave feedback</Link>
           </p>
         </footer>
-      </article>
+      </Box>
       {showTOC && (
         <div className={styles.TOCWrapper}>
           <TOC items={tocItems} />

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -178,7 +178,7 @@ export default function PatternPage({pattern, ...props}: Props) {
   return (
     <>
       <PageMeta title={props.title} description={pattern.description} />
-      <Page showTOC={true}>
+      <Page isContentPage>
         <Stack gap="8">
           <Stack gap="4">
             <Heading as="h1">

--- a/polaris.shopify.com/src/components/PatternsPage/index.tsx
+++ b/polaris.shopify.com/src/components/PatternsPage/index.tsx
@@ -18,7 +18,7 @@ export const PatternsPage = () => (
   <>
     <PageMeta title="Patterns" description={description} />
 
-    <Page showTOC={false}>
+    <Page>
       <div className={styles.Stack} data-gap="8">
         <div>
           <Longform>

--- a/polaris.shopify.com/src/components/TokensPage/TokensPage.tsx
+++ b/polaris.shopify.com/src/components/TokensPage/TokensPage.tsx
@@ -95,7 +95,7 @@ function TokensPage({tokenGroup}: Props) {
     .join('\n');
 
   return (
-    <Page showTOC={false}>
+    <Page>
       <div className={styles.TokensPage}>
         <div className={styles.Banner}>
           <h1>Tokens</h1>


### PR DESCRIPTION
Refs #8248 

#8399 Applied a fixed width column to _all_ pages in the docs which was incorrect: We should have only targeted content pages. This PR fixes it.

| Before | Fixed |
|--------|--------|
|![component-before](https://user-images.githubusercontent.com/612020/219984901-167bb17b-fe4a-4331-b52a-9f77c8cbc439.png)  | ![component-after](https://user-images.githubusercontent.com/612020/219984926-45d7c58f-831f-4ab4-a987-61cd4d0fe158.png) |
| ![content-before](https://user-images.githubusercontent.com/612020/219984941-c613e215-bc8b-4a1f-a127-594f171f2efd.png) | ![content-after](https://user-images.githubusercontent.com/612020/219984955-fc3745e0-77df-4935-a2ce-4b903347487f.png) |
| ![patterns-index-before](https://user-images.githubusercontent.com/612020/219984978-18c6962d-831e-42f5-89c6-2fdbaf7790ae.png) | ![patterns-index-after](https://user-images.githubusercontent.com/612020/219984984-5d8e49b5-3e68-417c-85cd-aa1c7d55574c.png) |
| ![rule-before](https://user-images.githubusercontent.com/612020/219984993-b57f598b-db9a-4133-90fd-a1349567663f.png) | ![rule-after](https://user-images.githubusercontent.com/612020/219985006-fafdd131-25cf-4227-a48e-f70d867a5b2b.png) |
|  ![rule-index-before](https://user-images.githubusercontent.com/612020/219985023-447de4c2-581d-46ad-b822-7607b5e4ca9a.png) |  ![rule-index-after](https://user-images.githubusercontent.com/612020/219985032-4588758b-7783-4268-a144-53bfb7590897.png) | 
| ![home-before](https://user-images.githubusercontent.com/612020/219985115-05d16d97-74c0-44e1-8155-07e4abc14f02.png) | ![home-after](https://user-images.githubusercontent.com/612020/219985125-bf1616fb-3d54-493d-bdbf-5302925becfc.png) |