### PR TITLE
Clean up markdown metadata in html elements

### DIFF
--- a/polaris.shopify.com/src/components/PatternPage/Blocks.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/Blocks.tsx
@@ -38,8 +38,12 @@ export const HowItHelps = ({children}: {children: string}) => (
             <Image fill src={src} alt={alt ?? ''} />
           </div>
         ) : null,
-      ol: (props) => <Stack as="ol" gap="2" {...props} />,
-      li: (props) => <li {...props} />,
+      ol: ({children}) => (
+        <Stack as="ol" gap="2">
+          {children}
+        </Stack>
+      ),
+      li: ({children}) => <li>{children}</li>,
       dl: (props) => (
         <Box as="dl" className={styles.DefinitionList}>
           {props.children}
@@ -48,7 +52,7 @@ export const HowItHelps = ({children}: {children: string}) => (
       dt: (props) => <dt>{props.children}</dt>,
       dd: (props) => <dd>{props.children}</dd>,
       // @ts-expect-error react-markdown doesn't know about the extra data
-      customtable: ({children, ...props}) => {
+      customtable: ({children}) => {
         return <div className={styles.CustomTable}>{children}</div>;
       },
       strong: ({children}) => (
@@ -72,8 +76,12 @@ export const UsefulToKnow = ({children}: {children: string}) => (
             <Image fill src={src} alt={alt ?? ''} />
           </div>
         ) : null,
-      ol: (props) => <Stack as="ol" gap="2" {...props} />,
-      li: (props) => <li {...props} />,
+      ol: ({children}) => (
+        <Stack as="ol" gap="2">
+          {children}
+        </Stack>
+      ),
+      li: ({children}) => <li>{children}</li>,
       // We're using table as a handy shortcut for rendering a CSS grid
       // But that grid is actually rendered as an unordered list of items!
       // Should probably just be MDX at this point...

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -132,8 +132,10 @@ function PatternPageContent({
       {description ? (
         <Markdown
           components={{
-            p: (props) => (
-              <Box as="p" className={styles.VariantDescription} {...props} />
+            p: ({children}) => (
+              <Box as="p" className={styles.VariantDescription}>
+                {children}
+              </Box>
             ),
           }}
         >


### PR DESCRIPTION
### WHY are these changes introduced?

At the moment we don't have any relevant `props` that need to be passed through to our custom markdown `components`. The Markdown component also passes down its metadata to the components we specify, so we shouldn't spread until we: 

1. Have identified a need for doing so 
2. Have a mechanism for ensuring no weird metadata can make its way to the underlying HTML elements. 

### WHAT is this pull request doing?
Removes prop spreading from all custom components passed into the `Markdown` component as part of the `PatternPage` implementation.


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
