### PR TITLE
[Polaris Lighthouse] Enable report descriptionless disables

### DIFF
--- a/.changeset/silver-pans-tie.md
+++ b/.changeset/silver-pans-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': major
+---
+
+report descriptionless disables

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -496,6 +496,7 @@ const stylelintPolarisCoverageOptions = {
 /** @type {import('stylelint').Config} */
 module.exports = {
   customSyntax: 'postcss-scss',
+  reportDescriptionlessDisables: true,
   reportNeedlessDisables: [
     true,
     {


### PR DESCRIPTION
### WHY are these changes introduced?

Enabling descriptionless disables in stylelint polaris so we can enforce context messages on disables and use them to track why stylelint polaris is being overridden 

<img width="679" alt="Screenshot 2023-02-22 at 10 36 39 AM" src="https://user-images.githubusercontent.com/20652326/220677644-03fc4871-b5b5-4c0b-b630-daf28f62d7fc.png">
