### PR TITLE
Add installation instructions for Polaris CLI

### DIFF
--- a/polaris.shopify.com/content/tools/polaris-cli.md
+++ b/polaris.shopify.com/content/tools/polaris-cli.md
@@ -11,6 +11,18 @@ keywords:
 
 [<img src="https://img.shields.io/npm/v/@shopify/polaris-cli.svg?labelColor=f9f9f9&color=dcf5f0" alt="npm version" style="width: 95px" />](https://www.npmjs.com/package/@shopify/polaris-cli)
 
+## Installation
+
+You can install the Polaris plugin for the Shopify CLI by running the following command:
+
+```sh
+shopify plugins install @shopify/polaris-cli
+```
+
+See the [Shopify CLI command syntax](https://shopify.dev/apps/tools/cli/commands#command-syntax) section for how to execute commands using other package managers (ex: npm, Yarn, or pnpm).
+
+## Commands
+
 ### migrate
 
 Executes the [Polaris Migrator](/tools/polaris-migrator). This makes version upgrades faster and safer by performing codemod transformations to your codebase. You can apply any of the [available Polaris migrations](/tools/polaris-migrator#migrations) using the [Shopify CLI](https://shopify.dev/apps/tools/cli/commands) `migrate` command.


### PR DESCRIPTION
### WHY are these changes introduced?

Polaris CLI isn't currently installed by default with the Shopify CLI. We need to add back the installation instructions for this CLI plugin.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Add installation instructions on the Polaris CLI page.

<img width="1488" alt="Screenshot 2023-02-22 at 1 57 49 PM" src="https://user-images.githubusercontent.com/11774595/220731423-1d9d6b73-fb1d-4e80-bc3e-77108dfa3d08.png">
