### PR TITLE
Add v11 breadcrumb migration docs

### DIFF
--- a/.changeset/tasty-carrots-sip.md
+++ b/.changeset/tasty-carrots-sip.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Adds documentation for the Page breadcrumbs migration

--- a/polaris.shopify.com/content/tools/polaris-migrator.md
+++ b/polaris.shopify.com/content/tools/polaris-migrator.md
@@ -29,7 +29,7 @@ npx @shopify/polaris-migrator <migration> <path>
 
 #### `v11-react-breadcrumbs-migrate-from-array`
 
-Replace legacy Page component breadcrumbs props that used to take arrays with a single object.
+Replace legacy Page component `breadcrumbs` props with the new `backAction` prop which accepts a [`LinkAction` object](https://github.com/Shopify/polaris/blob/main/polaris-react/src/types.ts#L113-L122).
 
 ```diff
 - <Page breadcrumbs={[{url: '/testing', content: 'Home'}]}>

--- a/polaris.shopify.com/content/tools/polaris-migrator.md
+++ b/polaris.shopify.com/content/tools/polaris-migrator.md
@@ -25,6 +25,21 @@ npx @shopify/polaris-migrator <migration> <path>
 
 ## Migrations
 
+### v11
+
+#### `v11-react-breadcrumbs-migrate-from-array`
+
+Replace legacy Page component breadcrumbs props that used to take arrays with a single object.
+
+```diff
+- <Page breadcrumbs={[{url: '/testing', content: 'Home'}]}>
++ <Page backAction={{url: '/testing', content: 'Home'}}>
+```
+
+```sh
+npx @shopify/polaris-migrator v11-react-breadcrumbs-migrate-from-array <path>
+```
+
 ### v10
 
 #### `v10-react-replace-text-components`


### PR DESCRIPTION
### WHY are these changes introduced?

After we add the new migrator we should publish these docs.

Related: #8071 #8465 
