### PR TITLE
[stylelint-polaris] Disallow component overrides using `selector-disallowed-list`

### DIFF
--- a/.changeset/thin-tools-sort.md
+++ b/.changeset/thin-tools-sort.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': minor
+---
+
+Configured `selector-disallowed-list` to disallow Polaris component class name overrides

--- a/.changeset/thin-tools-sort.md
+++ b/.changeset/thin-tools-sort.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/stylelint-polaris': minor
+'@shopify/stylelint-polaris': major
 ---
 
 Configured `selector-disallowed-list` to disallow Polaris component class name overrides

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -371,7 +371,7 @@ const stylelintPolarisCoverageOptions = {
     },
   ],
   conventions: {
-    'selector-disallowed-list': [/class[*^]='Polaris-[a-z_-]+'/gi],
+    'selector-disallowed-list': [/class[*^~]?='Polaris-[a-z_-]+'/gi],
     'polaris/custom-property-allowed-list': {
       // Allows definition of custom properties not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
       allowedProperties: [/--(?!(p|pc|polaris-version)-).+/],

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -371,7 +371,13 @@ const stylelintPolarisCoverageOptions = {
     },
   ],
   conventions: {
-    'selector-disallowed-list': [/class[*^~]?='Polaris-[a-z_-]+'/gi],
+    'selector-disallowed-list': [
+      [/class[*^]='Polaris-[a-z_-]+'/gi],
+      {
+        message:
+          'Overriding Polaris styles is disallowed. Please consider contributing instead',
+      },
+    ],
     'polaris/custom-property-allowed-list': {
       // Allows definition of custom properties not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
       allowedProperties: [/--(?!(p|pc|polaris-version)-).+/],

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -372,7 +372,7 @@ const stylelintPolarisCoverageOptions = {
   ],
   conventions: {
     'selector-disallowed-list': [
-      [/class[*^]='Polaris-[a-z_-]+'/gi],
+      [/class[*^~]?='Polaris-[a-z_-]+'/gi],
       {
         message:
           'Overriding Polaris styles is disallowed. Please consider contributing instead',

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -371,6 +371,7 @@ const stylelintPolarisCoverageOptions = {
     },
   ],
   conventions: {
+    'selector-disallowed-list': [/class[*^]='Polaris-[a-z_-]+'/gi],
     'polaris/custom-property-allowed-list': {
       // Allows definition of custom properties not prefixed with `--p-`, `--pc-`, or `--polaris-version-`
       allowedProperties: [/--(?!(p|pc|polaris-version)-).+/],


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/7850

### WHAT is this pull request doing?

This PR configures the `selector-disallowed-list` rule in `@shopify/stylelint-polaris` to disallow Polaris React component style overrides via classname. This will make the tracking of overrides much more performant than manually finding and counting them as we do currently.

<img width="844" alt="Screenshot 2023-02-22 at 5 37 31 PM" src="https://user-images.githubusercontent.com/18447883/220776076-f558a3cd-8a31-4c2b-95a3-b51fa9f813b9.png">

### 🎩 checklist

- [x] Tested in polaris-react SCSS files
- [ ] Added rule documentation 
- [ ] Tested in Polaris Coverage (wip)
