### PR TITLE
Update banners on patterns index and legacy-banner

### DIFF
--- a/polaris.shopify.com/content/patterns-legacy/index.md
+++ b/polaris.shopify.com/content/patterns-legacy/index.md
@@ -2,8 +2,8 @@
 title: Patterns (legacy)
 description: Design patterns help ensure consistent behavior across the Shopify admin.
 status:
-  value: Deprecated
-  message: These patterns are deprecated, please use with caution.
+  value: Legacy
+  message: Guidance in legacy patterns is still accurate and useful.
 noIndex: true
 hideFromNav: true
 ---

--- a/polaris.shopify.com/src/components/FoundationsPage/FoundationsPage.tsx
+++ b/polaris.shopify.com/src/components/FoundationsPage/FoundationsPage.tsx
@@ -45,7 +45,7 @@ function FoundationsPage({
           <p>{description}</p>
         </Longform>
         <Stack gap="8">
-          {typedStatus && <StatusBanner status={typedStatus} />}
+          {typedStatus ? <StatusBanner status={typedStatus} /> : null}
 
           <Grid>
             {items

--- a/polaris.shopify.com/src/components/FoundationsPage/FoundationsPage.tsx
+++ b/polaris.shopify.com/src/components/FoundationsPage/FoundationsPage.tsx
@@ -45,7 +45,7 @@ function FoundationsPage({
           <p>{description}</p>
         </Longform>
         <Stack gap="8">
-          {typedStatus ? <StatusBanner status={typedStatus} /> : null}
+          {typedStatus && <StatusBanner status={typedStatus} />}
 
           <Grid>
             {items

--- a/polaris.shopify.com/src/components/PatternsPage/index.tsx
+++ b/polaris.shopify.com/src/components/PatternsPage/index.tsx
@@ -24,9 +24,8 @@ export const PatternsPage = () => (
             <p>{description}</p>
           </Longform>
           <UpdateBanner
-            message={`We are making changes to the patterns section. Expect changes to
-              happen here and [join the discussion](https://github.com/Shopify/polaris/discussions/categories/pattern-documentation)
-              to make it better. [See old patterns here](/patterns-legacy).`}
+            message={`Our pattern documentation is evolving. [Join the discussions](https://github.com/Shopify/polaris/discussions/categories/pattern-documentation) to make it better. The [legacy patterns documentation](/patterns-legacy) can still be used.
+              to make it better.`}
             className={styles.UpdateBanner}
           />
         </div>

--- a/polaris.shopify.com/src/components/PatternsPage/index.tsx
+++ b/polaris.shopify.com/src/components/PatternsPage/index.tsx
@@ -24,8 +24,7 @@ export const PatternsPage = () => (
             <p>{description}</p>
           </Longform>
           <UpdateBanner
-            message={`Our pattern documentation is evolving. [Join the discussions](https://github.com/Shopify/polaris/discussions/categories/pattern-documentation) to make it better. The [legacy patterns documentation](/patterns-legacy) can still be used.
-              to make it better.`}
+            message={`Our pattern documentation is evolving. [Join our discussions](https://github.com/Shopify/polaris/discussions/categories/pattern-documentation) to make it better. The [legacy patterns documentation](/patterns-legacy) can still be used.`}
             className={styles.UpdateBanner}
           />
         </div>

--- a/polaris.shopify.com/src/components/StatusBanner/StatusBanner.module.scss
+++ b/polaris.shopify.com/src/components/StatusBanner/StatusBanner.module.scss
@@ -19,6 +19,11 @@
     background: var(--surface-information);
   }
 
+  &[data-value='legacy'],
+  &[data-value='information'] {
+    background: var(--surface-information);
+  }
+
   h2 {
     margin-top: 0;
     @include heading-3;

--- a/polaris.shopify.com/src/types.ts
+++ b/polaris.shopify.com/src/types.ts
@@ -155,6 +155,7 @@ export enum StatusName {
   Alpha = 'Alpha',
   Beta = 'Beta',
   Information = 'Information',
+  Legacy = 'Legacy',
   Warning = 'Warning',
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Partially fixes #8220. Still an open question on updated banner styling for pattern index tbd.
I also noticed a visual bug where there's missing spacing between the header and the body but that was already there and I couldn't figure out how to fix it in this PR. 😓

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Updating copy and adding an informative banner to pattern / pattern-legacy index pages.

<img width="723" alt="Pattern index" src="https://user-images.githubusercontent.com/13204374/221033205-9b8e56f8-4675-4072-b513-60f3636b9bf4.png">
<img width="712" alt="Legacy pattern index" src="https://user-images.githubusercontent.com/13204374/221033222-eda61540-e931-433f-a29b-d6c7df72454c.png">
