### PR TITLE
Update pattern thumbnail copy

### DIFF
--- a/polaris.shopify.com/content/patterns/app-settings-layout.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout.md
@@ -1,6 +1,6 @@
 ---
 title: App settings layout
-description: Makes it easy for merchants to scan and find setting groups.
+description: Scan and find groups of settings in apps
 url: /patterns/app-settings-layout
 previewImg: /images/patterns/pattern-thumbnail-app-settings.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8217

--- a/polaris.shopify.com/content/patterns/app-settings-layout.ts
+++ b/polaris.shopify.com/content/patterns/app-settings-layout.ts
@@ -2,8 +2,7 @@ import type {SingleVariantPattern} from '../../src/types';
 
 const pattern: SingleVariantPattern = {
   title: 'App settings layout',
-  description:
-    'Lets merchants easily scan many groups of settings and find the ones they want to change.',
+  description: 'Lets merchants scan and find groups of settings in apps.',
   howItHelps: `![App settings page with two columns](/images/patterns/app-settings-cover-image.png)
 
   1. In the left column, glanceable labels and descriptions are listed to make it easier for merchants to scan the page and quickly find what they are looking for.

--- a/polaris.shopify.com/content/patterns/date-picking.md
+++ b/polaris.shopify.com/content/patterns/date-picking.md
@@ -1,6 +1,6 @@
 ---
 title: Date picking
-description: Makes it easy for merchants to select and input dates and date ranges.
+description: Select a date or a date range
 url: /patterns/date-picking
 previewImg: /images/patterns/pattern-thumbnail-date-picking.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/7853

--- a/polaris.shopify.com/content/patterns/date-picking.ts
+++ b/polaris.shopify.com/content/patterns/date-picking.ts
@@ -4,8 +4,7 @@ const pattern: MultiVariantPattern = {
   relatedResources: `* Programming timezones can be finicky. Get great tips in the article [UTC is for everyone right](https://zachholman.com/talk/utc-is-enough-for-everyone-right)?
 * Learn about date formatting in the [Grammar and mechanics](/content/grammar-and-mechanics#date) guidelines.
 * See how to craft effective button labels in the [Actionable language](/content/actionable-language) guidelines.`,
-  description:
-    'Lets merchants select a date or date range to help them filter information or objects and schedule events or actions.',
+  description: 'Lets merchants select a date or a date range',
   variants: [
     {
       title: 'Single date',

--- a/polaris.shopify.com/content/patterns/resource-details-layout.md
+++ b/polaris.shopify.com/content/patterns/resource-details-layout.md
@@ -1,6 +1,6 @@
 ---
 title: Resource details layout
-description: Makes it easy for merchants to create, view and edit resources.
+description: Create, view, and edit resource objects
 url: /patterns/resource-details-layout
 previewImg: /images/patterns/pattern-thumbnail-resource-details.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8216

--- a/polaris.shopify.com/content/patterns/resource-details-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-details-layout.ts
@@ -2,8 +2,7 @@ import type {SingleVariantPattern} from '../../src/types';
 
 const pattern: SingleVariantPattern = {
   title: 'Resource details layout',
-  description:
-    'Lets merchants effectively create, view, and edit any resource object.',
+  description: 'Lets merchants create, view, and edit resource objects.',
   howItHelps: `![Product details page](/images/patterns/resource-detail-cover-image.png)
 
 1. The page header provides easy access to actions and navigation. It spans the full width of the page to show merchants that these actions represent the page as a whole.

--- a/polaris.shopify.com/content/patterns/resource-index-layout.md
+++ b/polaris.shopify.com/content/patterns/resource-index-layout.md
@@ -1,6 +1,6 @@
 ---
 title: Resource index layout
-description: Makes it easy for merchants to view and manage resources.
+description: Organize and take action on resource objects
 url: /patterns/resource-index-layout
 previewImg: /images/patterns/pattern-thumbnail-resource-index.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8215

--- a/polaris.shopify.com/content/patterns/resource-index-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-index-layout.ts
@@ -41,7 +41,7 @@ const pattern: SingleVariantPattern = {
       },
       {
         label: 'Card',
-        url: '/components/layout-and-structure/card',
+        url: '/components/layout-and-structure/alpha-card',
       },
     ],
     context: `

--- a/polaris.shopify.com/content/patterns/resource-index-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-index-layout.ts
@@ -2,8 +2,7 @@ import type {SingleVariantPattern} from '../../src/types';
 
 const pattern: SingleVariantPattern = {
   title: 'Resource index layout',
-  description:
-    'Lets merchants effectively view, manage, and take action on resource objects.',
+  description: 'Lets merchants organize and take action on resource objects.',
   howItHelps: `![Products index page](/images/patterns/resource-index-cover-image.png)
 
 1. The resource index layout is based on a single column to create a clear top-to-bottom hierarchy of tasks and to provide horizontal space for resource data.


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8003 

### WHAT is this pull request doing?

Updated copy for pattern thumbnails + pattern page descriptions. I made the executive decision to omit "Lets merchants" at the beginning of the image thumbnails in the interest of being succinct + DRY (and it looked better, see pics).

In the interest of DRY, since they're the same text (except with an added "Lets merchants" on the actual page subtitle), it would be cool to refactor the code to do something like (spaghetti code) `description: Lets merchants {patternThumbText}`. That way, we only have to set / change the text in one place in the future. I'd do it in this PR but I wasn't quite sure how without help.

##Pics


Before:
<img width="723" alt="pattern page with outdated copy" src="https://user-images.githubusercontent.com/13204374/221045460-9064e41e-2ff4-4634-9446-75ce7b3f60a9.png">

Middle:
<img width="1920" alt="pattern page with repetitive copy" src="https://user-images.githubusercontent.com/13204374/221045304-923c38b1-19f4-49f8-9418-fb50399081a5.png">

After:
<img width="913" alt="pattern page with short copy" src="https://user-images.githubusercontent.com/13204374/221045289-c1f4ace4-9589-4baf-b5ab-9eefbdc4631c.png">

Individual pages:
<img width="503" alt="Resource details page" src="https://user-images.githubusercontent.com/13204374/221046118-f0bbcb91-0471-4ab7-8ae3-cd37269d2e02.png">
<img width="469" alt="Date picking page" src="https://user-images.githubusercontent.com/13204374/221046120-6e86808e-8245-45e4-82bb-4903a39c4c3c.png">
<img width="508" alt="App settings page" src="https://user-images.githubusercontent.com/13204374/221046122-1ba946ff-2a7a-4be3-8ccf-db98b57780bc.png">

