### PR TITLE
Add 'New' status badge to Patterns nav item

### DIFF
--- a/.changeset/pretty-news-happen.md
+++ b/.changeset/pretty-news-happen.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Add 'New' status badge to Patterns nav item

--- a/polaris.shopify.com/content/patterns/index.md
+++ b/polaris.shopify.com/content/patterns/index.md
@@ -4,6 +4,9 @@ description: Design patterns help ensure consistent behavior across the Shopify 
 icon: BehaviorMajor
 order: 6
 newSection: true
+status:
+  value: New
+  message: ''
 ---
 
 ![Design system building blocks, with pattern block highlighted.](/images/foundations/patterns/patterns@2x.png)

--- a/polaris.shopify.com/src/components/StatusBadge/StatusBadge.module.scss
+++ b/polaris.shopify.com/src/components/StatusBadge/StatusBadge.module.scss
@@ -16,7 +16,8 @@
   }
 
   &[data-value='beta'],
-  &[data-value='information'] {
+  &[data-value='information'],
+  &[data-value='new'] {
     background: var(--surface-information);
   }
 }

--- a/polaris.shopify.com/src/types.ts
+++ b/polaris.shopify.com/src/types.ts
@@ -151,6 +151,7 @@ export enum Breakpoints {
 }
 
 export enum StatusName {
+  New = 'New',
   Deprecated = 'Deprecated',
   Alpha = 'Alpha',
   Beta = 'Beta',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8172

We just launched the new Patterns section, and want to draw attention to it.

<img width="333" alt="Screenshot 2023-02-24 at 11 47 50 am" src="https://user-images.githubusercontent.com/612020/221064621-ac9ad756-46b8-4b00-b355-1adaf6bc274a.png">


### WHAT is this pull request doing?

Status badge type `New` has been added, then applied to the patterns page.