### PR TITLE
Revert "Version Packages"

### DIFF
--- a/.changeset/sharp-rules-dress.md
+++ b/.changeset/sharp-rules-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': patch
+---
+
+Converted percentage fill-opacity to float in two icons for better compatibility

--- a/polaris-cli/CHANGELOG.md
+++ b/polaris-cli/CHANGELOG.md
@@ -1,7 +1,5 @@
 # @shopify/polaris-cli
 
-## 0.1.14
-
 ## 0.1.13
 
 ### Patch Changes

--- a/polaris-cli/package.json
+++ b/polaris-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-cli",
-  "version": "0.1.14",
+  "version": "0.1.13",
   "description": "Commands for building Shopify Apps with Polaris",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",

--- a/polaris-icons/CHANGELOG.md
+++ b/polaris-icons/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 6.11.3
-
-### Patch Changes
-
-- [#8499](https://github.com/Shopify/polaris/pull/8499) [`31021ccaa`](https://github.com/Shopify/polaris/commit/31021ccaae1e9bdd70e3ce448f0498a053abb233) Thanks [@lfroms](https://github.com/lfroms)! - Converted percentage fill-opacity to float in two icons for better compatibility
-
 ## 6.11.2
 
 ### Patch Changes

--- a/polaris-icons/package.json
+++ b/polaris-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-icons",
-  "version": "6.11.3",
+  "version": "6.11.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify Inc.",
   "main": "dist/index.js",

--- a/polaris-migrator/package.json
+++ b/polaris-migrator/package.json
@@ -52,7 +52,7 @@
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "@shopify/polaris": "^10.32.1",
+    "@shopify/polaris": "^10.32.0",
     "plop": "^3.1.1",
     "plop-dir": "^0.0.5",
     "prettier": "^2.7.1",

--- a/polaris-react/CHANGELOG.md
+++ b/polaris-react/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## 10.32.1
-
-### Patch Changes
-
-- Updated dependencies [[`31021ccaa`](https://github.com/Shopify/polaris/commit/31021ccaae1e9bdd70e3ce448f0498a053abb233)]:
-  - @shopify/polaris-icons@6.11.3
-
 ## 10.32.0
 
 ### Minor Changes

--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -33,7 +33,7 @@ Otherwise include the CSS in your HTML. We suggest copying the styles file into 
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/@shopify/polaris@10.32.1/build/esm/styles.css"
+  href="https://unpkg.com/@shopify/polaris@10.32.0/build/esm/styles.css"
 />
 ```
 
@@ -70,7 +70,7 @@ If React doesn’t make sense for your application, you can use a CSS-only versi
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/@shopify/polaris@10.32.1/build/esm/styles.css"
+  href="https://unpkg.com/@shopify/polaris@10.32.0/build/esm/styles.css"
 />
 ```
 

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/polaris",
   "description": "Shopify’s admin product component library",
-  "version": "10.32.1",
+  "version": "10.32.0",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",
@@ -62,7 +62,7 @@
     "preversion": "node ./scripts/readme-update-version"
   },
   "dependencies": {
-    "@shopify/polaris-icons": "^6.11.3",
+    "@shopify/polaris-icons": "^6.11.2",
     "@shopify/polaris-tokens": "^6.6.1",
     "@types/react": "*",
     "@types/react-dom": "*",

--- a/polaris.shopify.com/CHANGELOG.md
+++ b/polaris.shopify.com/CHANGELOG.md
@@ -1,13 +1,5 @@
 # polaris.shopify.com
 
-## 0.37.1
-
-### Patch Changes
-
-- Updated dependencies [[`31021ccaa`](https://github.com/Shopify/polaris/commit/31021ccaae1e9bdd70e3ce448f0498a053abb233)]:
-  - @shopify/polaris-icons@6.11.3
-  - @shopify/polaris@10.32.1
-
 ## 0.37.0
 
 ### Minor Changes

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polaris.shopify.com",
-  "version": "0.37.1",
+  "version": "0.37.0",
   "private": true,
   "scripts": {
     "build": "yarn gen-assets && playroom build && next build && cp -r public ./.next/standalone/polaris.shopify.com/ && mkdirp ./.next/standalone/polaris.shopify.com/.next && cp -r .next/static ./.next/standalone/polaris.shopify.com/.next/",
@@ -21,8 +21,8 @@
   "dependencies": {
     "@floating-ui/react-dom-interactions": "^0.10.1",
     "@headlessui/react": "^1.6.5",
-    "@shopify/polaris": "^10.32.1",
-    "@shopify/polaris-icons": "^6.11.3",
+    "@shopify/polaris": "^10.32.0",
+    "@shopify/polaris-icons": "^6.11.2",
     "@shopify/polaris-tokens": "^6.6.1",
     "@radix-ui/react-polymorphic": "^0.0.14",
     "@types/react-syntax-highlighter": "^15.5.6",


### PR DESCRIPTION
There was an issue with the Release workflow when publishing this version.  We need to revert this so that we can create a new release with the previous changes.

Reverts Shopify/polaris#8503