### PR TITLE
Remove dead link from content file

### DIFF
--- a/polaris.shopify.com/content/content/alternative-text.md
+++ b/polaris.shopify.com/content/content/alternative-text.md
@@ -251,7 +251,6 @@ The following Polaris components come props to set alt text or aria labels, alon
 - [Avatar](https://polaris.shopify.com/components/images-and-icons/avatar)
 - [Button](/components/actions/button)
 - [Icon](/components/images-and-icons/icon)
-- [Image](/components/images-and-icons/image)
 - [Link](https://polaris.shopify.com/components/navigation/link)
 - [Thumbnail](https://polaris.shopify.com/components/images-and-icons/thumbnail)
 - [Video Thumbnail](https://polaris.shopify.com/components/images-and-icons/video-thumbnail)


### PR DESCRIPTION
CI was failing with this error:

```
polaris.shopify.com:build: ❌ Failed to load these URLs:
polaris.shopify.com:build:  - 404: http://localhost:3000/components/images-and-icons/image
```

'tis fixed now.