### PR TITLE
Correctly stretch content on Component group page to 100% width of page

### DIFF
--- a/.changeset/violet-peas-dream.md
+++ b/.changeset/violet-peas-dream.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Correctly stretch content on Component group page to 100% width of page

--- a/.changeset/violet-peas-dream.md
+++ b/.changeset/violet-peas-dream.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-Correctly stretch content on Component group page to 100% width of page
+Fixed grid alignment on component group page

--- a/polaris.shopify.com/pages/components/[group]/index.tsx
+++ b/polaris.shopify.com/pages/components/[group]/index.tsx
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import globby from 'globby';
 import path from 'path';
-import {AlphaStack, Text} from '@shopify/polaris';
+import {Text} from '@shopify/polaris';
 import {Grid, GridItem} from '../../../src/components/Grid';
 import Page from '../../../src/components/Page';
 import TipBanner from '../../../src/components/TipBanner/TipBanner';
@@ -11,6 +11,7 @@ import {stripMarkdownLinks} from '../../../src/utils/various';
 import PageMeta from '../../../src/components/PageMeta';
 import Longform from '../../../src/components/Longform';
 import Markdown from '../../../src/components/Markdown';
+import {Stack} from '../../../src/components/Stack';
 
 interface Group {
   title?: string;
@@ -45,12 +46,12 @@ export default function GroupPage({
   const relatedResources = frontMatter?.relatedResources;
   const groupsMarkup = groups?.map(({title, description, components, tip}) => (
     <>
-      <AlphaStack gap="4">
+      <Stack gap="4">
         <Text as="h4" variant="headingLg">
           {title}
         </Text>
         <p>{description}</p>
-      </AlphaStack>
+      </Stack>
       <Grid condensed>
         {components?.map((component) => {
           const componentSlug = component.replace(/ /g, '-').toLowerCase();
@@ -101,7 +102,7 @@ export default function GroupPage({
 
   const relatedResourcesMarkup = relatedResources
     ? relatedResources && (
-        <AlphaStack gap="4">
+        <Stack gap="4">
           <Text as="h4" variant="headingLg">
             Related Resources
           </Text>
@@ -115,7 +116,7 @@ export default function GroupPage({
               </li>
             ))}
           </ul>
-        </AlphaStack>
+        </Stack>
       )
     : null;
 
@@ -125,8 +126,8 @@ export default function GroupPage({
         title={frontMatter?.title}
         description={frontMatter?.description}
       />
-      <AlphaStack gap="16">
-        <AlphaStack gap="4">
+      <Stack gap="16">
+        <Stack gap="4">
           {frontMatter?.description && (
             <Longform firstParagraphIsLede>
               <Markdown>{frontMatter?.description}</Markdown>
@@ -134,9 +135,9 @@ export default function GroupPage({
           )}
 
           {groupsMarkup || componentsFromPaths}
-        </AlphaStack>
+        </Stack>
         {relatedResourcesMarkup}
-      </AlphaStack>
+      </Stack>
     </Page>
   );
 }


### PR DESCRIPTION
The documentation page for Groups of Components wasn't stretching to be 100% of the page width, causing early wrapping of thumbnail tiles.

This PR fixes it by ensuring `alignt-items: stretch` (the css default) is set on the flex container.

## Before

<img width="481" alt="Screenshot 2023-03-01 at 4 44 58 pm" src="https://user-images.githubusercontent.com/612020/222055502-30c4dc9b-4636-47b6-8854-4087e2fcf245.png">


## After

<img width="483" alt="Screenshot 2023-03-01 at 4 44 43 pm" src="https://user-images.githubusercontent.com/612020/222055525-7c783d29-dbae-4715-a6e0-1503d1946c07.png">
