### PR TITLE
[Layout foundations] Remove alignment defaults from Inline and AlphaStack

### DIFF
--- a/.changeset/fuzzy-dryers-tan.md
+++ b/.changeset/fuzzy-dryers-tan.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Removed alignment defaults from Inline and AlphaStack

--- a/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Badge, AlphaStack} from '@shopify/polaris';
+import {Box, AlphaStack} from '@shopify/polaris';
 
 export default {
   component: AlphaStack,
@@ -9,10 +9,15 @@ export default {
 export function Default() {
   return (
     <AlphaStack>
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 1
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 2
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 3
+      </Box>
     </AlphaStack>
   );
 }
@@ -20,10 +25,15 @@ export function Default() {
 export function WithGap() {
   return (
     <AlphaStack gap="8">
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 1
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 2
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 3
+      </Box>
     </AlphaStack>
   );
 }
@@ -31,10 +41,15 @@ export function WithGap() {
 export function WithResponsiveGap() {
   return (
     <AlphaStack gap={{xs: '4', md: '10'}}>
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 1
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 2
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 3
+      </Box>
     </AlphaStack>
   );
 }
@@ -42,10 +57,15 @@ export function WithResponsiveGap() {
 export function WithAlignCenter() {
   return (
     <AlphaStack gap="4" align="center">
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 1
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 2
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 3
+      </Box>
     </AlphaStack>
   );
 }
@@ -53,10 +73,15 @@ export function WithAlignCenter() {
 export function WithAlignEnd() {
   return (
     <AlphaStack gap="4" align="end">
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 1
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 2
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 3
+      </Box>
     </AlphaStack>
   );
 }
@@ -64,10 +89,15 @@ export function WithAlignEnd() {
 export function WithFullWidthChildren() {
   return (
     <AlphaStack gap="4" fullWidth>
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 1
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 2
+      </Box>
+      <Box background="backdrop" color="text-on-dark" padding="1">
+        Block 3
+      </Box>
     </AlphaStack>
   );
 }

--- a/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
@@ -10,13 +10,13 @@ export function Default() {
   return (
     <AlphaStack>
       <Box background="surface" padding="1">
-        Block 1
+        01
       </Box>
       <Box background="surface" padding="1">
-        Block 2
+        02
       </Box>
       <Box background="surface" padding="1">
-        Block 3
+        03
       </Box>
     </AlphaStack>
   );
@@ -26,13 +26,13 @@ export function WithGap() {
   return (
     <AlphaStack gap="8">
       <Box background="surface" padding="1">
-        Block 1
+        01
       </Box>
       <Box background="surface" padding="1">
-        Block 2
+        02
       </Box>
       <Box background="surface" padding="1">
-        Block 3
+        03
       </Box>
     </AlphaStack>
   );
@@ -42,13 +42,29 @@ export function WithResponsiveGap() {
   return (
     <AlphaStack gap={{xs: '4', md: '10'}}>
       <Box background="surface" padding="1">
-        Block 1
+        01
       </Box>
       <Box background="surface" padding="1">
-        Block 2
+        02
       </Box>
       <Box background="surface" padding="1">
-        Block 3
+        03
+      </Box>
+    </AlphaStack>
+  );
+}
+
+export function WithAlignStart() {
+  return (
+    <AlphaStack gap="4" align="start">
+      <Box background="surface" padding="1">
+        01
+      </Box>
+      <Box background="surface" padding="1">
+        02
+      </Box>
+      <Box background="surface" padding="1">
+        03
       </Box>
     </AlphaStack>
   );
@@ -58,13 +74,13 @@ export function WithAlignCenter() {
   return (
     <AlphaStack gap="4" align="center">
       <Box background="surface" padding="1">
-        Block 1
+        01
       </Box>
       <Box background="surface" padding="1">
-        Block 2
+        02
       </Box>
       <Box background="surface" padding="1">
-        Block 3
+        03
       </Box>
     </AlphaStack>
   );
@@ -74,13 +90,13 @@ export function WithAlignEnd() {
   return (
     <AlphaStack gap="4" align="end">
       <Box background="surface" padding="1">
-        Block 1
+        01
       </Box>
       <Box background="surface" padding="1">
-        Block 2
+        02
       </Box>
       <Box background="surface" padding="1">
-        Block 3
+        03
       </Box>
     </AlphaStack>
   );
@@ -90,13 +106,13 @@ export function WithFullWidthChildren() {
   return (
     <AlphaStack gap="4" fullWidth>
       <Box background="surface" padding="1">
-        Block 1
+        01
       </Box>
       <Box background="surface" padding="1">
-        Block 2
+        02
       </Box>
       <Box background="surface" padding="1">
-        Block 3
+        03
       </Box>
     </AlphaStack>
   );

--- a/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
@@ -9,13 +9,13 @@ export default {
 export function Default() {
   return (
     <AlphaStack>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 1
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 2
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 3
       </Box>
     </AlphaStack>
@@ -25,13 +25,13 @@ export function Default() {
 export function WithGap() {
   return (
     <AlphaStack gap="8">
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 1
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 2
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 3
       </Box>
     </AlphaStack>
@@ -41,13 +41,13 @@ export function WithGap() {
 export function WithResponsiveGap() {
   return (
     <AlphaStack gap={{xs: '4', md: '10'}}>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 1
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 2
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 3
       </Box>
     </AlphaStack>
@@ -57,13 +57,13 @@ export function WithResponsiveGap() {
 export function WithAlignCenter() {
   return (
     <AlphaStack gap="4" align="center">
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 1
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 2
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 3
       </Box>
     </AlphaStack>
@@ -73,13 +73,13 @@ export function WithAlignCenter() {
 export function WithAlignEnd() {
   return (
     <AlphaStack gap="4" align="end">
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 1
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 2
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 3
       </Box>
     </AlphaStack>
@@ -89,13 +89,13 @@ export function WithAlignEnd() {
 export function WithFullWidthChildren() {
   return (
     <AlphaStack gap="4" fullWidth>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 1
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 2
       </Box>
-      <Box background="backdrop" color="text-on-dark" padding="1">
+      <Box background="surface" padding="1">
         Block 3
       </Box>
     </AlphaStack>

--- a/polaris-react/src/components/AlphaStack/AlphaStack.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.tsx
@@ -22,9 +22,7 @@ export interface AlphaStackProps extends React.AriaAttributes {
    * @default 'div'
    */
   as?: Element;
-  /** Horizontal alignment of children
-   * @default 'start'
-   */
+  /** Horizontal alignment of children */
   align?: Align;
   /** Toggle children to be full width
    * @default false
@@ -43,7 +41,7 @@ export interface AlphaStackProps extends React.AriaAttributes {
 export const AlphaStack = ({
   as = 'div',
   children,
-  align = 'start',
+  align,
   fullWidth = false,
   gap,
   id,

--- a/polaris-react/src/components/AlphaStack/tests/AlphaStack.test.tsx
+++ b/polaris-react/src/components/AlphaStack/tests/AlphaStack.test.tsx
@@ -18,7 +18,6 @@ describe('<AlphaStack />', () => {
 
     expect(stack).toContainReactComponent('div', {
       style: expect.objectContaining({
-        '--pc-stack-align': 'start',
         '--pc-stack-order': 'column',
       }) as React.CSSProperties,
     });

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -29,7 +29,7 @@ export function Default() {
 
 export function WithAlignStart() {
   return (
-    <Inline align="start" gap="1">
+    <Inline align="start" blockAlign="center" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -40,7 +40,7 @@ export function WithAlignStart() {
 
 export function WithAlignCenter() {
   return (
-    <Inline align="center" gap="1">
+    <Inline align="center" blockAlign="center" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -51,7 +51,7 @@ export function WithAlignCenter() {
 
 export function WithAlignEnd() {
   return (
-    <Inline align="end" gap="1">
+    <Inline align="end" blockAlign="center" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {
-  Box,
-  Badge,
-  Icon,
-  Inline,
-  Thumbnail,
-  AlphaStack,
-} from '@shopify/polaris';
+import {Box, Badge, Icon, Inline, Thumbnail} from '@shopify/polaris';
 import {CapitalMajor, ImageMajor} from '@shopify/polaris-icons';
 
 export default {
@@ -90,9 +83,9 @@ export function WithAlignSpaceEvenly() {
   );
 }
 
-export function WithBlockAlignCenter() {
+export function WithBlockAlignStart() {
   return (
-    <Inline blockAlign="center" gap="1">
+    <Inline blockAlign="start" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -101,9 +94,9 @@ export function WithBlockAlignCenter() {
   );
 }
 
-export function WithBlockAlignStart() {
+export function WithBlockAlignCenter() {
   return (
-    <Inline blockAlign="start" gap="1">
+    <Inline blockAlign="center" gap="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -169,33 +162,22 @@ export function WithNonWrapping() {
 
 export function WithGap() {
   return (
-    <AlphaStack gap="4">
-      <Inline gap="8">
-        <Badge>Paid</Badge>
-        <Badge>Processing</Badge>
-        <Badge>Fulfilled</Badge>
-        <Badge>Completed</Badge>
-      </Inline>
-
-      <Inline gap={{xs: '2', md: '4'}}>
-        <Badge>Paid</Badge>
-        <Badge>Processing</Badge>
-        <Badge>Fulfilled</Badge>
-        <Badge>Completed</Badge>
-      </Inline>
-    </AlphaStack>
+    <Inline gap="8">
+      <Badge>Paid</Badge>
+      <Badge>Processing</Badge>
+      <Badge>Fulfilled</Badge>
+      <Badge>Completed</Badge>
+    </Inline>
   );
 }
 
 export function WithResponsiveGap() {
   return (
-    <AlphaStack gap="4">
-      <Inline gap={{xs: '2', md: '4'}}>
-        <Badge>Paid</Badge>
-        <Badge>Processing</Badge>
-        <Badge>Fulfilled</Badge>
-        <Badge>Completed</Badge>
-      </Inline>
-    </AlphaStack>
+    <Inline gap={{xs: '2', md: '4'}}>
+      <Badge>Paid</Badge>
+      <Badge>Processing</Badge>
+      <Badge>Fulfilled</Badge>
+      <Badge>Completed</Badge>
+    </Inline>
   );
 }

--- a/polaris-react/src/components/Inline/Inline.tsx
+++ b/polaris-react/src/components/Inline/Inline.tsx
@@ -19,13 +19,9 @@ type Gap = ResponsiveProp<SpacingSpaceScale>;
 
 export interface InlineProps {
   children?: React.ReactNode;
-  /** Horizontal alignment of children
-   * @default 'start'
-   */
+  /** Horizontal alignment of children */
   align?: Align;
-  /** Vertical alignment of children
-   * @default 'center'
-   */
+  /** Vertical alignment of children */
   blockAlign?: BlockAlign;
   /** The spacing between elements. Accepts a spacing token or an object of spacing tokens for different screen sizes.
    * @example
@@ -40,8 +36,8 @@ export interface InlineProps {
 }
 
 export const Inline = function Inline({
-  align = 'start',
-  blockAlign = 'center',
+  align,
+  blockAlign,
   gap,
   wrap = true,
   children,

--- a/polaris-react/src/components/Inline/tests/Inline.test.tsx
+++ b/polaris-react/src/components/Inline/tests/Inline.test.tsx
@@ -23,8 +23,6 @@ describe('<Inline />', () => {
 
     expect(stack).toContainReactComponent('div', {
       style: expect.objectContaining({
-        '--pc-inline-align': 'start',
-        '--pc-inline-block-align': 'center',
         '--pc-inline-wrap': 'wrap',
       }) as React.CSSProperties,
     });
@@ -54,8 +52,6 @@ describe('<Inline />', () => {
 
     expect(stack).toContainReactComponent('div', {
       style: expect.objectContaining({
-        '--pc-inline-align': 'start',
-        '--pc-inline-block-align': 'center',
         '--pc-inline-wrap': 'wrap',
         '--pc-inline-gap-xs': 'var(--p-space-2)',
         '--pc-inline-gap-md': 'var(--p-space-8)',

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -156,7 +156,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
 
     const body = loading ? (
       <Box padding="4">
-        <Inline gap="4" align="center">
+        <Inline gap="4" align="center" blockAlign="center">
           <Spinner />
         </Inline>
       </Box>

--- a/polaris-react/src/components/Modal/components/Header/Header.tsx
+++ b/polaris-react/src/components/Modal/components/Header/Header.tsx
@@ -23,7 +23,7 @@ export function Header({
 }: HeaderProps) {
   const titleHiddenMarkup = (
     <Box position="absolute" insetInlineEnd="0" zIndex="1">
-      <Inline gap="4" align="end">
+      <Inline gap="4" align="end" blockAlign="center">
         <CloseButton titleHidden={titleHidden} onClick={onClose} />
       </Inline>
     </Box>
@@ -42,7 +42,7 @@ export function Header({
       borderBlockEnd="divider"
     >
       <Columns columns={{xs: '1fr auto'}} gap="4">
-        <Inline gap="4">
+        <Inline gap="4" blockAlign="center">
           <Text id={id} as="h2" variant="headingLg" breakWord>
             {children}
           </Text>


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris/issues/8472

These default don't match the CSS spec defaults for these properties and are causing layout issues within our own repo, as well as outside of our repo

![image](https://user-images.githubusercontent.com/6844391/222172023-3d1bf5f6-4c05-4dc2-a8ea-ae1cb9f78aec.png)

cc @yurm04 this should help with text container migrations as well