### PR TITLE
[Layout foundations] Migrate `Stack` to `LegacyStack`

### DIFF
--- a/.changeset/dry-pants-beg.md
+++ b/.changeset/dry-pants-beg.md
@@ -1,6 +1,6 @@
 ---
-'@shopify/polaris': minor
-'polaris.shopify.com': minor
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
 ---
 
 Migrated usage of `Stack` to `LegacyStack`

--- a/.changeset/dry-pants-beg.md
+++ b/.changeset/dry-pants-beg.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Migrated usage of `Stack` to `LegacyStack`

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -34,7 +34,7 @@ import {
   SkeletonBodyText,
   SkeletonDisplayText,
   SkeletonPage,
-  Stack,
+  LegacyStack,
   Text,
   // eslint-disable-next-line import/no-deprecated
   TextContainer,
@@ -520,9 +520,9 @@ export function DetailsPage() {
 
   const fileUpload = !files.length && <DropZone.FileUpload />;
   const uploadedFiles = files.length > 0 && (
-    <Stack vertical>
+    <LegacyStack vertical>
       {files.map((file, index) => (
-        <Stack alignment="center" key={index}>
+        <LegacyStack alignment="center" key={index}>
           <Thumbnail
             size="small"
             alt={file.name}
@@ -539,9 +539,9 @@ export function DetailsPage() {
               {file.size} bytes
             </Text>
           </div>
-        </Stack>
+        </LegacyStack>
       ))}
-    </Stack>
+    </LegacyStack>
   );
 
   // ---- Page markup ----

--- a/polaris-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/polaris-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,6 +1,12 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Autocomplete, Icon, Stack, Tag, TextContainer} from '@shopify/polaris';
+import {
+  Autocomplete,
+  Icon,
+  LegacyStack,
+  Tag,
+  TextContainer,
+} from '@shopify/polaris';
 import {
   CirclePlusMinor,
   DeleteMinor,
@@ -138,7 +144,7 @@ export function WithMultipleTags() {
 
   const verticalContentMarkup =
     selectedOptions.length > 0 ? (
-      <Stack spacing="extraTight" alignment="center">
+      <LegacyStack spacing="extraTight" alignment="center">
         {selectedOptions.map((option) => {
           let tagLabel = '';
           tagLabel = option.replace('_', ' ');
@@ -149,7 +155,7 @@ export function WithMultipleTags() {
             </Tag>
           );
         })}
-      </Stack>
+      </LegacyStack>
     ) : null;
 
   const textField = (
@@ -454,11 +460,11 @@ export function WithLazyLoading() {
     : null;
   const optionList = options.slice(0, visibleOptionIndex);
   const selectedTagMarkup = hasSelectedOptions ? (
-    <Stack spacing="extraTight">{tagsMarkup}</Stack>
+    <LegacyStack spacing="extraTight">{tagsMarkup}</LegacyStack>
   ) : null;
 
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       {selectedTagMarkup}
       <Autocomplete
         allowMultiple
@@ -471,7 +477,7 @@ export function WithLazyLoading() {
         onLoadMoreResults={handleLoadMoreResults}
         willLoadMoreResults={willLoadMoreResults}
       />
-    </Stack>
+    </LegacyStack>
   );
 
   function titleCase(string) {

--- a/polaris-react/src/components/Avatar/Avatar.stories.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.stories.tsx
@@ -1,6 +1,12 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {ActionList, Avatar, Button, Popover, Stack} from '@shopify/polaris';
+import {
+  ActionList,
+  Avatar,
+  Button,
+  Popover,
+  LegacyStack,
+} from '@shopify/polaris';
 
 export default {
   component: Avatar,
@@ -57,77 +63,77 @@ export function Square() {
 
 export function SquareWithInitials() {
   return (
-    <Stack vertical>
-      <Stack.Item>
+    <LegacyStack vertical>
+      <LegacyStack.Item>
         <Avatar
           shape="square"
           initials="OE"
           name="Oluwayemisi Eun-Jung"
           size="extraSmall"
         />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar
           shape="square"
           initials="OE"
           name="Oluwayemisi Eun-Jung"
           size="small"
         />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar
           shape="square"
           initials="OE"
           name="Oluwayemisi Eun-Jung"
           size="medium"
         />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar
           shape="square"
           initials="OE"
           name="Oluwayemisi Eun-Jung"
           size="large"
         />
-      </Stack.Item>
-    </Stack>
+      </LegacyStack.Item>
+    </LegacyStack>
   );
 }
 
 export function Sizes() {
   return (
-    <Stack vertical>
-      <Stack.Item>
+    <LegacyStack vertical>
+      <LegacyStack.Item>
         <Avatar name="Farrah" size="extraSmall" />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar name="Farrah" size="small" />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar name="Farrah" size="medium" />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar name="Farrah" size="large" />
-      </Stack.Item>
-    </Stack>
+      </LegacyStack.Item>
+    </LegacyStack>
   );
 }
 
 export function SizesWithInitials() {
   return (
-    <Stack vertical>
-      <Stack.Item>
+    <LegacyStack vertical>
+      <LegacyStack.Item>
         <Avatar initials="OE" name="Oluwayemisi Eun-Jung" size="extraSmall" />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar initials="OE" name="Oluwayemisi Eun-Jung" size="small" />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar initials="OE" name="Oluwayemisi Eun-Jung" size="medium" />
-      </Stack.Item>
-      <Stack.Item>
+      </LegacyStack.Item>
+      <LegacyStack.Item>
         <Avatar initials="OE" name="Oluwayemisi Eun-Jung" size="large" />
-      </Stack.Item>
-    </Stack>
+      </LegacyStack.Item>
+    </LegacyStack>
   );
 }

--- a/polaris-react/src/components/Bleed/Bleed.stories.tsx
+++ b/polaris-react/src/components/Bleed/Bleed.stories.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {AlphaCard, Bleed, Box, Divider, Stack, Text} from '@shopify/polaris';
+import {
+  AlphaCard,
+  Bleed,
+  Box,
+  Divider,
+  LegacyStack,
+  Text,
+} from '@shopify/polaris';
 
 export default {
   component: Bleed,
@@ -55,7 +62,7 @@ export function WithHorizontalDirection() {
 
 export function WithSpecificDirection() {
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <Text variant="bodyMd" as="p">
         Block Start
       </Text>
@@ -88,7 +95,7 @@ export function WithSpecificDirection() {
           <div style={styles} />
         </Bleed>
       </Box>
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris-react/src/components/Card/Card.stories.tsx
+++ b/polaris-react/src/components/Card/Card.stories.tsx
@@ -10,7 +10,7 @@ import {
   List,
   Popover,
   ResourceList,
-  Stack,
+  LegacyStack,
   Text,
   TextContainer,
 } from '@shopify/polaris';
@@ -80,19 +80,19 @@ export function WithCustomFooterActions() {
   return (
     <Card title="Secure your account with 2-step authentication">
       <Card.Section>
-        <Stack spacing="loose" vertical>
+        <LegacyStack spacing="loose" vertical>
           <p>
             Two-step authentication adds an extra layer of security when logging
             in to your account. A special code will be required each time you
             log in, ensuring only you can access your account.
           </p>
-          <Stack distribution="trailing">
+          <LegacyStack distribution="trailing">
             <ButtonGroup>
               <Button>Enable two-step authentication</Button>
               <Button plain>Learn more</Button>
             </ButtonGroup>
-          </Stack>
-        </Stack>
+          </LegacyStack>
+        </LegacyStack>
       </Card.Section>
     </Card>
   );
@@ -278,12 +278,12 @@ export function WithCustomReactNodeTitle() {
     <Card title="Products">
       <Card.Section
         title={
-          <Stack>
+          <LegacyStack>
             <Icon source={ProductsMajor} />
             <Text variant="headingSm" as="h3">
               New Products
             </Text>
-          </Stack>
+          </LegacyStack>
         }
       >
         <List>
@@ -352,10 +352,10 @@ export function WithAllElements() {
                 url={url}
                 accessibilityLabel={`View Sales for ${sales}`}
               >
-                <Stack>
-                  <Stack.Item fill>{sales}</Stack.Item>
-                  <Stack.Item>{amount}</Stack.Item>
-                </Stack>
+                <LegacyStack>
+                  <LegacyStack.Item fill>{sales}</LegacyStack.Item>
+                  <LegacyStack.Item>{amount}</LegacyStack.Item>
+                </LegacyStack>
               </ResourceList.Item>
             );
           }}

--- a/polaris-react/src/components/Card/components/Header/Header.tsx
+++ b/polaris-react/src/components/Card/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import React, {isValidElement} from 'react';
 import type {DisableableAction} from '../../../../types';
 import {buttonsFrom} from '../../../Button';
 import {ButtonGroup} from '../../../ButtonGroup';
-import {Stack} from '../../../Stack';
+import {LegacyStack} from '../../../LegacyStack';
 import {Text} from '../../../Text';
 import styles from '../../Card.scss';
 
@@ -36,11 +36,11 @@ export function Header({children, title, actions}: CardHeaderProps) {
 
   const headingMarkup =
     actionMarkup || children ? (
-      <Stack alignment="baseline">
-        <Stack.Item fill>{titleMarkup}</Stack.Item>
+      <LegacyStack alignment="baseline">
+        <LegacyStack.Item fill>{titleMarkup}</LegacyStack.Item>
         {actionMarkup}
         {children}
-      </Stack>
+      </LegacyStack>
     ) : (
       titleMarkup
     );

--- a/polaris-react/src/components/Card/components/Section/Section.tsx
+++ b/polaris-react/src/components/Card/components/Section/Section.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {classNames} from '../../../../utilities/css';
 import type {ComplexAction} from '../../../../types';
 import {buttonsFrom} from '../../../Button';
-import {Stack} from '../../../Stack';
+import {LegacyStack} from '../../../LegacyStack';
 import {ButtonGroup} from '../../../ButtonGroup';
 import {Text} from '../../../Text';
 import styles from '../../Card.scss';
@@ -61,10 +61,10 @@ export function Section({
     titleMarkup || actionMarkup ? (
       <div className={styles.SectionHeader}>
         {actionMarkup ? (
-          <Stack alignment="baseline">
-            <Stack.Item fill>{titleMarkup}</Stack.Item>
+          <LegacyStack alignment="baseline">
+            <LegacyStack.Item fill>{titleMarkup}</LegacyStack.Item>
             {actionMarkup}
-          </Stack>
+          </LegacyStack>
         ) : (
           titleMarkup
         )}

--- a/polaris-react/src/components/Collapsible/Collapsible.stories.tsx
+++ b/polaris-react/src/components/Collapsible/Collapsible.stories.tsx
@@ -5,7 +5,7 @@ import {
   LegacyCard,
   Collapsible,
   Link,
-  Stack,
+  LegacyStack,
   TextContainer,
 } from '@shopify/polaris';
 
@@ -21,7 +21,7 @@ export function Default() {
   return (
     <div style={{height: '200px'}}>
       <LegacyCard sectioned>
-        <Stack vertical>
+        <LegacyStack vertical>
           <Button
             onClick={handleToggle}
             ariaExpanded={open}
@@ -47,7 +47,7 @@ export function Default() {
               <Link url="#">Test link</Link>
             </TextContainer>
           </Collapsible>
-        </Stack>
+        </LegacyStack>
       </LegacyCard>
     </div>
   );

--- a/polaris-react/src/components/Combobox/Combobox.stories.tsx
+++ b/polaris-react/src/components/Combobox/Combobox.stories.tsx
@@ -5,7 +5,7 @@ import {
   EmptySearchResult,
   Icon,
   Listbox,
-  Stack,
+  LegacyStack,
   Tag,
   TextContainer,
   Text,
@@ -296,7 +296,7 @@ export function WithMultiSelect() {
         ) : null}
       </Combobox>
       <TextContainer>
-        <Stack>{tagsMarkup}</Stack>
+        <LegacyStack>{tagsMarkup}</LegacyStack>
       </TextContainer>
     </div>
   );
@@ -410,7 +410,7 @@ export function WithMultiSelectAndManualSelection() {
         ) : null}
       </Combobox>
       <TextContainer>
-        <Stack>{tagsMarkup}</Stack>
+        <LegacyStack>{tagsMarkup}</LegacyStack>
       </TextContainer>
     </div>
   );
@@ -507,13 +507,13 @@ export function WithMultiSelectAndVerticalContent() {
 
   const verticalContentMarkup =
     selectedTags.length > 0 ? (
-      <Stack spacing="extraTight" alignment="center">
+      <LegacyStack spacing="extraTight" alignment="center">
         {selectedTags.map((tag) => (
           <Tag key={`option-${tag}`} onRemove={removeTag(tag)}>
             {tag}
           </Tag>
         ))}
-      </Stack>
+      </LegacyStack>
     ) : null;
 
   const optionMarkup =

--- a/polaris-react/src/components/EmptySearchResult/EmptySearchResult.tsx
+++ b/polaris-react/src/components/EmptySearchResult/EmptySearchResult.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {useI18n} from '../../utilities/i18n';
 import {Text} from '../Text';
 import {Image} from '../Image';
-import {Stack} from '../Stack';
+import {LegacyStack} from '../LegacyStack';
 
 import {emptySearch} from './illustrations';
 
@@ -28,7 +28,7 @@ export function EmptySearchResult({
   ) : null;
 
   return (
-    <Stack alignment="center" vertical>
+    <LegacyStack alignment="center" vertical>
       {illustrationMarkup}
       <Text variant="headingLg" as="p">
         {title}
@@ -36,6 +36,6 @@ export function EmptySearchResult({
       <Text variant="bodyMd" color="subdued" as="span">
         {descriptionMarkup}
       </Text>
-    </Stack>
+    </LegacyStack>
   );
 }

--- a/polaris-react/src/components/Filters/Filters.tsx
+++ b/polaris-react/src/components/Filters/Filters.tsx
@@ -24,7 +24,7 @@ import {Badge} from '../Badge';
 import {Focus} from '../Focus';
 // eslint-disable-next-line import/no-deprecated
 import {Sheet} from '../Sheet';
-import {Stack} from '../Stack';
+import {LegacyStack} from '../LegacyStack';
 import {Key} from '../../types';
 import {KeypressListener} from '../KeypressListener';
 
@@ -575,10 +575,10 @@ class FiltersInner extends Component<CombinedProps, State> {
 
     return (
       <div ref={this.focusNode}>
-        <Stack vertical spacing="tight">
+        <LegacyStack vertical spacing="tight">
           {filter.filter}
           {clearButtonMarkup}
-        </Stack>
+        </LegacyStack>
       </div>
     );
   }

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -2,7 +2,7 @@ import React, {useCallback} from 'react';
 
 import {Button} from '../../../Button';
 import {Image} from '../../../Image';
-import {Stack} from '../../../Stack';
+import {LegacyStack} from '../../../LegacyStack';
 import {Text} from '../../../Text';
 import {classNames} from '../../../../utilities/css';
 import {ContextualSaveBarProps, useFrame} from '../../../../utilities/frame';
@@ -123,11 +123,11 @@ export function ContextualSaveBar({
             </Text>
           )}
           <div className={styles.ActionContainer}>
-            <Stack spacing="tight" wrap={false}>
+            <LegacyStack spacing="tight" wrap={false}>
               {secondaryMenu}
               {discardActionMarkup}
               {saveActionMarkup}
-            </Stack>
+            </LegacyStack>
           </div>
         </div>
       </div>

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -12,7 +12,7 @@ import {EmptySearchResult} from '../EmptySearchResult';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
 import {SelectAllActions} from '../SelectAllActions';
-import {Stack} from '../Stack';
+import {LegacyStack} from '../LegacyStack';
 import {Sticky} from '../Sticky';
 import {Spinner} from '../Spinner';
 import {Text} from '../Text';
@@ -467,7 +467,7 @@ function IndexTableBase({
       style={stickyColumnHeaderStyle}
       data-index-table-sticky-heading
     >
-      <Stack spacing="none" wrap={false} alignment="center">
+      <LegacyStack spacing="none" wrap={false} alignment="center">
         {selectable && (
           <div
             className={styles.FirstStickyHeaderElement}
@@ -491,7 +491,7 @@ function IndexTableBase({
             {renderHeadingContent(headings[0], 0)}
           </div>
         )}
-      </Stack>
+      </LegacyStack>
     </div>
   );
   const stickyHeadingsMarkup = headings.map(renderStickyHeading);
@@ -868,12 +868,12 @@ function IndexTableBase({
 
     if (heading.new) {
       headingContent = (
-        <Stack wrap={false} alignment="center">
+        <LegacyStack wrap={false} alignment="center">
           <span>{heading.title}</span>
           <Badge status="new">
             {i18n.translate('Polaris.IndexTable.onboardingBadgeText')}
           </Badge>
-        </Stack>
+        </LegacyStack>
       );
     } else if (heading.hidden) {
       headingContent = (

--- a/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
@@ -10,7 +10,7 @@ import {
   List,
   Popover,
   ResourceList,
-  Stack,
+  LegacyStack,
   Text,
   TextContainer,
 } from '@shopify/polaris';
@@ -80,19 +80,19 @@ export function WithCustomFooterActions() {
   return (
     <LegacyCard title="Secure your account with 2-step authentication">
       <LegacyCard.Section>
-        <Stack spacing="loose" vertical>
+        <LegacyStack spacing="loose" vertical>
           <p>
             Two-step authentication adds an extra layer of security when logging
             in to your account. A special code will be required each time you
             log in, ensuring only you can access your account.
           </p>
-          <Stack distribution="trailing">
+          <LegacyStack distribution="trailing">
             <ButtonGroup>
               <Button>Enable two-step authentication</Button>
               <Button plain>Learn more</Button>
             </ButtonGroup>
-          </Stack>
-        </Stack>
+          </LegacyStack>
+        </LegacyStack>
       </LegacyCard.Section>
     </LegacyCard>
   );
@@ -281,12 +281,12 @@ export function WithCustomReactNodeTitle() {
     <LegacyCard title="Products">
       <LegacyCard.Section
         title={
-          <Stack>
+          <LegacyStack>
             <Icon source={ProductsMajor} />
             <Text variant="headingSm" as="h3">
               New Products
             </Text>
-          </Stack>
+          </LegacyStack>
         }
       >
         <List>
@@ -355,10 +355,10 @@ export function WithAllElements() {
                 url={url}
                 accessibilityLabel={`View Sales for ${sales}`}
               >
-                <Stack>
-                  <Stack.Item fill>{sales}</Stack.Item>
-                  <Stack.Item>{amount}</Stack.Item>
-                </Stack>
+                <LegacyStack>
+                  <LegacyStack.Item fill>{sales}</LegacyStack.Item>
+                  <LegacyStack.Item>{amount}</LegacyStack.Item>
+                </LegacyStack>
               </ResourceList.Item>
             );
           }}

--- a/polaris-react/src/components/LegacyCard/components/Header/Header.tsx
+++ b/polaris-react/src/components/LegacyCard/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import React, {isValidElement} from 'react';
 import type {DisableableAction} from '../../../../types';
 import {buttonsFrom} from '../../../Button';
 import {ButtonGroup} from '../../../ButtonGroup';
-import {Stack} from '../../../Stack';
+import {LegacyStack} from '../../../LegacyStack';
 import {Text} from '../../../Text';
 import styles from '../../LegacyCard.scss';
 
@@ -28,11 +28,11 @@ export function Header({children, title, actions}: LegacyCardHeaderProps) {
 
   const headingMarkup =
     actionMarkup || children ? (
-      <Stack alignment="baseline">
-        <Stack.Item fill>{titleMarkup}</Stack.Item>
+      <LegacyStack alignment="baseline">
+        <LegacyStack.Item fill>{titleMarkup}</LegacyStack.Item>
         {actionMarkup}
         {children}
-      </Stack>
+      </LegacyStack>
     ) : (
       titleMarkup
     );

--- a/polaris-react/src/components/LegacyCard/components/Section/Section.tsx
+++ b/polaris-react/src/components/LegacyCard/components/Section/Section.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {classNames} from '../../../../utilities/css';
 import type {ComplexAction} from '../../../../types';
 import {buttonsFrom} from '../../../Button';
-import {Stack} from '../../../Stack';
+import {LegacyStack} from '../../../LegacyStack';
 import {ButtonGroup} from '../../../ButtonGroup';
 import {Text} from '../../../Text';
 import styles from '../../LegacyCard.scss';
@@ -53,10 +53,10 @@ export function Section({
     titleMarkup || actionMarkup ? (
       <div className={styles.SectionHeader}>
         {actionMarkup ? (
-          <Stack alignment="baseline">
-            <Stack.Item fill>{titleMarkup}</Stack.Item>
+          <LegacyStack alignment="baseline">
+            <LegacyStack.Item fill>{titleMarkup}</LegacyStack.Item>
             {actionMarkup}
-          </Stack>
+          </LegacyStack>
         ) : (
           titleMarkup
         )}

--- a/polaris-react/src/components/Listbox/Listbox.stories.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.stories.tsx
@@ -7,7 +7,7 @@ import {
   TextField,
   Icon,
   Listbox,
-  Stack,
+  LegacyStack,
   AutoSelection,
 } from '@shopify/polaris';
 import {CirclePlusMinor, SearchMinor} from '@shopify/polaris-icons';
@@ -45,10 +45,10 @@ export function WithAction() {
         Item 2
       </Listbox.Option>
       <Listbox.Action value="ActionValue">
-        <Stack spacing="tight">
+        <LegacyStack spacing="tight">
           <Icon source={CirclePlusMinor} color="base" />
           <div>Add item</div>
-        </Stack>
+        </LegacyStack>
       </Listbox.Action>
     </Listbox>
   );

--- a/polaris-react/src/components/MediaCard/MediaCard.tsx
+++ b/polaris-react/src/components/MediaCard/MediaCard.tsx
@@ -11,7 +11,7 @@ import {Text} from '../Text';
 import {Popover} from '../Popover';
 import {ActionList} from '../ActionList';
 import {ButtonGroup} from '../ButtonGroup';
-import {Stack} from '../Stack';
+import {LegacyStack} from '../LegacyStack';
 
 import styles from './MediaCard.scss';
 
@@ -143,11 +143,11 @@ export function MediaCard({
         <div className={infoContainerClassName}>
           <LegacyCard.Section>
             {popoverActionsMarkup}
-            <Stack vertical spacing="tight">
+            <LegacyStack vertical spacing="tight">
               {headerMarkup}
               <p className={styles.Description}>{description}</p>
               {actionMarkup}
-            </Stack>
+            </LegacyStack>
           </LegacyCard.Section>
         </div>
       </div>

--- a/polaris-react/src/components/Modal/Modal.stories.tsx
+++ b/polaris-react/src/components/Modal/Modal.stories.tsx
@@ -8,7 +8,7 @@ import {
   DropZone,
   FormLayout,
   Modal,
-  Stack,
+  LegacyStack,
   Text,
   TextContainer,
   TextField,
@@ -92,8 +92,8 @@ export function WithPrimaryAction() {
         }}
       >
         <Modal.Section>
-          <Stack vertical>
-            <Stack.Item>
+          <LegacyStack vertical>
+            <LegacyStack.Item>
               <TextContainer>
                 <Text variant="bodyMd" as="span">
                   You can share this discount link with your customers via email
@@ -101,8 +101,8 @@ export function WithPrimaryAction() {
                   at checkout.
                 </Text>
               </TextContainer>
-            </Stack.Item>
-            <Stack.Item fill>
+            </LegacyStack.Item>
+            <LegacyStack.Item fill>
               <TextField
                 ref={node}
                 label="Discount link"
@@ -116,8 +116,8 @@ export function WithPrimaryAction() {
                   </Button>
                 }
               />
-            </Stack.Item>
-          </Stack>
+            </LegacyStack.Item>
+          </LegacyStack>
         </Modal.Section>
       </Modal>
     </div>
@@ -174,8 +174,8 @@ export function WithPrimaryAndSecondaryActions() {
         ]}
       >
         <Modal.Section>
-          <Stack vertical>
-            <Stack.Item>
+          <LegacyStack vertical>
+            <LegacyStack.Item>
               <ChoiceList
                 title="Export"
                 choices={[
@@ -186,8 +186,8 @@ export function WithPrimaryAndSecondaryActions() {
                 selected={selectedExport}
                 onChange={handleSelectedExport}
               />
-            </Stack.Item>
-            <Stack.Item>
+            </LegacyStack.Item>
+            <LegacyStack.Item>
               <ChoiceList
                 title="Export as"
                 choices={[
@@ -201,8 +201,8 @@ export function WithPrimaryAndSecondaryActions() {
                 selected={selectedExportAs}
                 onChange={handleSelectedExportAs}
               />
-            </Stack.Item>
-          </Stack>
+            </LegacyStack.Item>
+          </LegacyStack>
         </Modal.Section>
       </Modal>
     </div>
@@ -239,7 +239,7 @@ export function Large() {
         ]}
       >
         <Modal.Section>
-          <Stack vertical>
+          <LegacyStack vertical>
             <DropZone
               accept=".csv"
               errorOverlayText="File type must be .csv"
@@ -253,7 +253,7 @@ export function Large() {
               label="Overwrite existing customers that have the same email or phone"
               onChange={handleCheckbox}
             />
-          </Stack>
+          </LegacyStack>
         </Modal.Section>
       </Modal>
     </div>
@@ -290,7 +290,7 @@ export function Small() {
         ]}
       >
         <Modal.Section>
-          <Stack vertical>
+          <LegacyStack vertical>
             <DropZone
               accept=".csv"
               errorOverlayText="File type must be .csv"
@@ -304,7 +304,7 @@ export function Small() {
               label="Overwrite existing customers that have the same email or phone"
               onChange={handleCheckbox}
             />
-          </Stack>
+          </LegacyStack>
         </Modal.Section>
       </Modal>
     </div>

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -6,7 +6,7 @@ import {
   LegacyCard,
   Page,
   PageActions,
-  Stack,
+  LegacyStack,
 } from '@shopify/polaris';
 import {PlusMinor, ArrowDownMinor, ExternalMinor} from '@shopify/polaris-icons';
 
@@ -99,12 +99,12 @@ export function WithoutPrimaryActionInHeader() {
       }}
     >
       <LegacyCard sectioned title="Fulfill order">
-        <Stack alignment="center">
-          <Stack.Item fill>
+        <LegacyStack alignment="center">
+          <LegacyStack.Item fill>
             <p>Buy postage and ship remaining 2 items</p>
-          </Stack.Item>
+          </LegacyStack.Item>
           <Button primary>Continue</Button>
-        </Stack>
+        </LegacyStack>
       </LegacyCard>
     </Page>
   );

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -5,7 +5,7 @@ import type {
   DisableableAction,
   LoadableAction,
 } from '../../types';
-import {Stack} from '../Stack';
+import {LegacyStack} from '../LegacyStack';
 import {ButtonGroup} from '../ButtonGroup';
 import {buttonsFrom} from '../Button';
 import {isInterface} from '../../utilities/is-interface';
@@ -44,10 +44,10 @@ export function PageActions({
 
   return (
     <div className={styles.PageActions}>
-      <Stack distribution="trailing" spacing="tight">
+      <LegacyStack distribution="trailing" spacing="tight">
         {secondaryActionsMarkup}
         {primaryActionMarkup}
-      </Stack>
+      </LegacyStack>
     </div>
   );
 }

--- a/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
+++ b/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {ButtonGroup} from '../../ButtonGroup';
-import {Stack} from '../../Stack';
+import {LegacyStack} from '../../LegacyStack';
 import {buttonsFrom} from '../../Button';
 import {PageActions} from '../PageActions';
 
@@ -12,15 +12,15 @@ jest.mock('../../Button', () => ({
 }));
 
 describe('<PageActions />', () => {
-  describe('<Stack />', () => {
+  describe('<LegacyStack />', () => {
     it('renders a stack component', () => {
       const pageActions = mountWithApp(<PageActions />);
-      expect(pageActions).toContainReactComponentTimes(Stack, 1);
+      expect(pageActions).toContainReactComponentTimes(LegacyStack, 1);
     });
 
     it('passes spacing tight to Stack', () => {
       const pageActions = mountWithApp(<PageActions />);
-      const stack = pageActions.find(Stack);
+      const stack = pageActions.find(LegacyStack);
       expect(stack).toHaveReactProps({
         spacing: 'tight',
       });

--- a/polaris-react/src/components/RadioButton/RadioButton.stories.tsx
+++ b/polaris-react/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {RadioButton, Stack} from '@shopify/polaris';
+import {RadioButton, LegacyStack} from '@shopify/polaris';
 
 export default {
   component: RadioButton,
@@ -15,7 +15,7 @@ export function Default() {
   );
 
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <RadioButton
         label="Accounts are disabled"
         helpText="Customers will only be able to check out as guests."
@@ -32,6 +32,6 @@ export function Default() {
         checked={value === 'optional'}
         onChange={handleChange}
       />
-    </Stack>
+    </LegacyStack>
   );
 }

--- a/polaris-react/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/polaris-react/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,6 +1,11 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {LegacyCard, RangeSlider, Stack, TextField} from '@shopify/polaris';
+import {
+  LegacyCard,
+  RangeSlider,
+  LegacyStack,
+  TextField,
+} from '@shopify/polaris';
 
 export default {
   component: RangeSlider,
@@ -181,7 +186,7 @@ export function WithDualThumb() {
           step={step}
           onChange={handleRangeSliderChange}
         />
-        <Stack distribution="equalSpacing" spacing="extraLoose">
+        <LegacyStack distribution="equalSpacing" spacing="extraLoose">
           <TextField
             label="Min money spent"
             type="number"
@@ -206,7 +211,7 @@ export function WithDualThumb() {
             onBlur={handleUpperTextFieldBlur}
             autoComplete="off"
           />
-        </Stack>
+        </LegacyStack>
       </div>
     </LegacyCard>
   );

--- a/polaris-react/src/components/Select/Select.stories.tsx
+++ b/polaris-react/src/components/Select/Select.stories.tsx
@@ -7,7 +7,7 @@ import {
   InlineError,
   Link,
   Select,
-  Stack,
+  LegacyStack,
   TextField,
   Text,
 } from '@shopify/polaris';
@@ -131,7 +131,7 @@ export function WithSeparateValidationError() {
   const unitSelectID = 'unit';
   const errorMessage = generateErrorMessage();
   const formGroupMarkup = (
-    <Stack vertical spacing="extraTight">
+    <LegacyStack vertical spacing="extraTight">
       <FormLayout>
         <FormLayout.Group condensed>
           <TextField
@@ -154,7 +154,7 @@ export function WithSeparateValidationError() {
         </FormLayout.Group>
       </FormLayout>
       <InlineError message={errorMessage} fieldID={unitSelectID} />
-    </Stack>
+    </LegacyStack>
   );
 
   return <LegacyCard sectioned>{formGroupMarkup}</LegacyCard>;

--- a/polaris-react/src/components/Tag/Tag.stories.tsx
+++ b/polaris-react/src/components/Tag/Tag.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Icon, Stack, Tag} from '@shopify/polaris';
+import {Icon, LegacyStack, Tag} from '@shopify/polaris';
 import {WandMinor} from '@shopify/polaris-icons';
 
 export default {
@@ -35,7 +35,7 @@ export function Removable() {
     </Tag>
   ));
 
-  return <Stack spacing="tight">{tagMarkup}</Stack>;
+  return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;
 }
 
 export function Clickable() {
@@ -49,10 +49,10 @@ export function WithLink() {
 export function WithCustomContent() {
   return (
     <Tag url="#">
-      <Stack spacing="extraTight">
+      <LegacyStack spacing="extraTight">
         <Icon source={WandMinor} />
         <span>Wholesale</span>
-      </Stack>
+      </LegacyStack>
     </Tag>
   );
 }
@@ -80,5 +80,5 @@ export function RemovableWithLink() {
     </Tag>
   ));
 
-  return <Stack spacing="tight">{tagMarkup}</Stack>;
+  return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;
 }

--- a/polaris-react/src/components/Text/Text.stories.tsx
+++ b/polaris-react/src/components/Text/Text.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Stack, Text} from '@shopify/polaris';
+import {LegacyStack, Text} from '@shopify/polaris';
 
 export default {
   component: Text,
 } as ComponentMeta<typeof Text>;
 
 export const Variants = () => (
-  <Stack vertical>
+  <LegacyStack vertical>
     <Text as="h1" variant="heading4xl">
       Text with Heading4xl variant
     </Text>
@@ -41,11 +41,11 @@ export const Variants = () => (
     <Text as="p" variant="bodySm">
       Text with BodySm variant
     </Text>
-  </Stack>
+  </LegacyStack>
 );
 
 export const WithAlignment = () => (
-  <Stack vertical>
+  <LegacyStack vertical>
     <Text as="p" variant="bodyLg" alignment="start">
       Manage your Shopify store on-the-go with real-time notifications, access
       to your dashboard, and order management, all from your smartphone.
@@ -62,11 +62,11 @@ export const WithAlignment = () => (
       Manage your Shopify store on-the-go with real-time notifications, access
       to your dashboard, and order management, all from your smartphone.
     </Text>
-  </Stack>
+  </LegacyStack>
 );
 
 export const WithFontWeight = () => (
-  <Stack vertical>
+  <LegacyStack vertical>
     <Text as="p" variant="bodyMd" fontWeight="bold">
       Sales this year
     </Text>
@@ -79,11 +79,11 @@ export const WithFontWeight = () => (
     <Text as="p" variant="bodyMd" fontWeight="regular">
       Sales this year
     </Text>
-  </Stack>
+  </LegacyStack>
 );
 
 export const WithColor = () => (
-  <Stack vertical>
+  <LegacyStack vertical>
     <Text as="p" variant="bodyMd" color="subdued">
       Use to de-emphasize a piece of text that is less important to merchants
       than other nearby text. May also be used to indicate when normal content
@@ -102,7 +102,7 @@ export const WithColor = () => (
       Use in combination with a symbol showing a decreasing value to indicate a
       downward trend.
     </Text>
-  </Stack>
+  </LegacyStack>
 );
 
 export const WithTruncate = () => (

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -7,7 +7,7 @@ import {
   FormLayout,
   InlineError,
   Select,
-  Stack,
+  LegacyStack,
   Tag,
   TextField,
 } from '@shopify/polaris';
@@ -40,7 +40,7 @@ export function Number() {
   const handleChange1 = useCallback((newValue) => setValue1(newValue), []);
 
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <TextField
         label="First Quantity"
         type="number"
@@ -55,7 +55,7 @@ export function Number() {
         onChange={handleChange1}
         autoComplete="off"
       />
-    </Stack>
+    </LegacyStack>
   );
 }
 
@@ -161,8 +161,8 @@ export function WithRightAlignedText() {
   );
 
   return (
-    <Stack>
-      <Stack.Item fill>Price</Stack.Item>
+    <LegacyStack>
+      <LegacyStack.Item fill>Price</LegacyStack.Item>
       <TextField
         label="Price"
         labelHidden
@@ -171,7 +171,7 @@ export function WithRightAlignedText() {
         autoComplete="off"
         align="right"
       />
-    </Stack>
+    </LegacyStack>
   );
 }
 
@@ -247,11 +247,11 @@ export function WithVerticalContent() {
 
   const verticalContentMarkup =
     tags.length > 0 ? (
-      <Stack spacing="extraTight" alignment="center">
+      <LegacyStack spacing="extraTight" alignment="center">
         {tags.map((tag) => (
           <Tag key={tag}>{tag}</Tag>
         ))}
-      </Stack>
+      </LegacyStack>
     ) : null;
 
   return (
@@ -345,8 +345,8 @@ export function WithSeparateValidationError() {
     : '';
 
   const formGroupMarkup = (
-    <Stack wrap={false} alignment="leading" spacing="loose">
-      <Stack.Item fill>
+    <LegacyStack wrap={false} alignment="leading" spacing="loose">
+      <LegacyStack.Item fill>
         <FormLayout>
           <FormLayout.Group condensed>
             <Select
@@ -377,9 +377,9 @@ export function WithSeparateValidationError() {
         <div style={{marginTop: '4px'}}>
           <InlineError message={errorMessage} fieldID={textFieldID} />
         </div>
-      </Stack.Item>
+      </LegacyStack.Item>
       <Button icon={DeleteMinor} accessibilityLabel="Remove item" />
-    </Stack>
+    </LegacyStack>
   );
 
   return (

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -5,7 +5,7 @@ import {
   Button,
   ButtonGroup,
   Icon,
-  Stack,
+  LegacyStack,
   TextField,
   Text,
   Tooltip,
@@ -28,9 +28,9 @@ export function Default() {
 
 export function Width() {
   return (
-    <Stack spacing="extraLoose" distribution="fill">
+    <LegacyStack spacing="extraLoose" distribution="fill">
       <Tooltip active content="This content has the default width">
-        <Stack spacing="extraTight">
+        <LegacyStack spacing="extraTight">
           <Text variant="bodyLg" fontWeight="medium" as="span">
             Tooltip with
           </Text>{' '}
@@ -41,11 +41,10 @@ export function Width() {
             content width
           </Text>
           <Icon source={QuestionMarkMinor} color="base" />
-        </Stack>
+        </LegacyStack>
       </Tooltip>
-
       <Tooltip active content="This content has the wide width" width="wide">
-        <Stack spacing="extraTight">
+        <LegacyStack spacing="extraTight">
           <Text variant="bodyLg" fontWeight="medium" as="span">
             Tooltip with
           </Text>{' '}
@@ -56,17 +55,17 @@ export function Width() {
             content width
           </Text>
           <Icon source={QuestionMarkMinor} color="base" />
-        </Stack>
+        </LegacyStack>
       </Tooltip>
-    </Stack>
+    </LegacyStack>
   );
 }
 
 export function Padding() {
   return (
-    <Stack spacing="extraLoose" distribution="fill">
+    <LegacyStack spacing="extraLoose" distribution="fill">
       <Tooltip active content="This content has default padding">
-        <Stack spacing="extraTight">
+        <LegacyStack spacing="extraTight">
           <Text variant="bodyLg" fontWeight="medium" as="span">
             Tooltip with
           </Text>{' '}
@@ -77,15 +76,14 @@ export function Padding() {
             content padding
           </Text>
           <Icon source={QuestionMarkMinor} color="base" />
-        </Stack>
+        </LegacyStack>
       </Tooltip>
-
       <Tooltip
         active
         content="This content has padding of 4 (space-4 / 16px)"
         padding="4"
       >
-        <Stack spacing="extraTight">
+        <LegacyStack spacing="extraTight">
           <Text variant="bodyLg" fontWeight="medium" as="span">
             Tooltip with
           </Text>{' '}
@@ -96,20 +94,20 @@ export function Padding() {
             content padding
           </Text>
           <Icon source={QuestionMarkMinor} color="base" />
-        </Stack>
+        </LegacyStack>
       </Tooltip>
-    </Stack>
+    </LegacyStack>
   );
 }
 
 export function BorderRadius() {
   return (
-    <Stack spacing="extraLoose" distribution="fill">
+    <LegacyStack spacing="extraLoose" distribution="fill">
       <Tooltip
         active
         content="This content has the default (radius-1) border radius"
       >
-        <Stack spacing="extraTight">
+        <LegacyStack spacing="extraTight">
           <Text variant="bodyLg" fontWeight="medium" as="span">
             Tooltip with
           </Text>{' '}
@@ -120,15 +118,14 @@ export function BorderRadius() {
             border radius
           </Text>
           <Icon source={QuestionMarkMinor} color="base" />
-        </Stack>
+        </LegacyStack>
       </Tooltip>
-
       <Tooltip
         active
         content="This content has a border radius of 2 (radius-2)"
         borderRadius="2"
       >
-        <Stack spacing="extraTight">
+        <LegacyStack spacing="extraTight">
           <Text variant="bodyLg" fontWeight="medium" as="span">
             Tooltip with
           </Text>{' '}
@@ -139,9 +136,9 @@ export function BorderRadius() {
             border radius
           </Text>
           <Icon source={QuestionMarkMinor} color="base" />
-        </Stack>
+        </LegacyStack>
       </Tooltip>
-    </Stack>
+    </LegacyStack>
   );
 }
 
@@ -174,19 +171,19 @@ export function VisibleOnlyWithChildInteraction() {
 
 export function WithHoverDelay() {
   return (
-    <Stack vertical>
-      <Stack vertical>
+    <LegacyStack vertical>
+      <LegacyStack vertical>
         <Text variant="headingMd" fontWeight="bold" as="h1">
           TEXT EXAMPLE
         </Text>
-        <Stack>
+        <LegacyStack>
           <Tooltip content="This should appear right away.">
             <Text variant="bodyMd" fontWeight="semibold" as="span">
               No delay
             </Text>
           </Tooltip>
-        </Stack>
-        <Stack>
+        </LegacyStack>
+        <LegacyStack>
           <Tooltip
             hoverDelay={1000}
             content="This should appear after 1 second."
@@ -195,28 +192,27 @@ export function WithHoverDelay() {
               1 second hover delay
             </Text>
           </Tooltip>
-        </Stack>
-      </Stack>
-
-      <Stack vertical>
+        </LegacyStack>
+      </LegacyStack>
+      <LegacyStack vertical>
         <Text variant="headingMd" fontWeight="bold" as="h1">
           BUTTON EXAMPLE
         </Text>
-        <Stack>
+        <LegacyStack>
           <Tooltip content="This should appear right away.">
             <Button>No delay</Button>
           </Tooltip>
-        </Stack>
-        <Stack>
+        </LegacyStack>
+        <LegacyStack>
           <Tooltip
             hoverDelay={2000}
             content="This should appear after 2 seconds."
           >
             <Button>2 seconds hover delay</Button>
           </Tooltip>
-        </Stack>
-      </Stack>
-    </Stack>
+        </LegacyStack>
+      </LegacyStack>
+    </LegacyStack>
   );
 }
 
@@ -237,7 +233,7 @@ export function ActivatorAsDiv() {
 export function WithSuffix() {
   return (
     <Box padding="16">
-      <Stack>
+      <LegacyStack>
         <ButtonGroup segmented fullWidth>
           <Tooltip content="Bold" suffix="⌘B" activatorWrapper="div">
             <Button>B</Button>
@@ -268,7 +264,7 @@ export function WithSuffix() {
             <Button>S</Button>
           </Tooltip>
         </ButtonGroup>
-      </Stack>
+      </LegacyStack>
     </Box>
   );
 }
@@ -276,7 +272,7 @@ export function WithSuffix() {
 export function Alignment() {
   return (
     <Box padding="0">
-      <Stack>
+      <LegacyStack>
         <ButtonGroup segmented fullWidth>
           <Tooltip content="Content is longer than the activator" suffix="⌘B">
             <Button>Bold</Button>
@@ -297,7 +293,7 @@ export function Alignment() {
             <Button>Strikethrough</Button>
           </Tooltip>
         </ButtonGroup>
-      </Stack>
+      </LegacyStack>
     </Box>
   );
 }

--- a/polaris-react/src/components/TopBar/components/Menu/components/Message/Message.tsx
+++ b/polaris-react/src/components/TopBar/components/Menu/components/Message/Message.tsx
@@ -5,7 +5,7 @@ import {Button} from '../../../../../Button';
 import {Text} from '../../../../../Text';
 import {Link} from '../../../../../Link';
 import {Popover} from '../../../../../Popover';
-import {Stack} from '../../../../../Stack';
+import {LegacyStack} from '../../../../../LegacyStack';
 // eslint-disable-next-line import/no-deprecated
 import {TextContainer} from '../../../../../TextContainer';
 
@@ -36,7 +36,7 @@ export function Message({
   return (
     <div className={styles.Section}>
       <Popover.Section>
-        <Stack vertical spacing="tight">
+        <LegacyStack vertical spacing="tight">
           <TextContainer>
             <Text variant="headingMd" as="h2">
               {title}
@@ -50,7 +50,7 @@ export function Message({
           <Button plain onClick={onClick}>
             {actionContent}
           </Button>
-        </Stack>
+        </LegacyStack>
       </Popover.Section>
     </div>
   );

--- a/polaris-react/src/components/VideoThumbnail/VideoThumbnail.tsx
+++ b/polaris-react/src/components/VideoThumbnail/VideoThumbnail.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../utilities/duration';
 import {useMediaQuery} from '../../utilities/media-query';
 import {Icon} from '../Icon';
-import {Stack} from '../Stack';
+import {LegacyStack} from '../LegacyStack';
 import {Text} from '../Text';
 
 import styles from './VideoThumbnail.scss';
@@ -78,7 +78,7 @@ export function VideoThumbnail({
 
   const timeStampMarkup = videoLength ? (
     <div className={styles.Timestamp}>
-      <Stack alignment="center" spacing="extraTight">
+      <LegacyStack alignment="center" spacing="extraTight">
         <span className={styles.PlayIcon}>
           <Icon source={PlayMinor} />
         </span>
@@ -89,7 +89,7 @@ export function VideoThumbnail({
         >
           {secondsToTimestamp(videoLength)}
         </Text>
-      </Stack>
+      </LegacyStack>
     </div>
   ) : null;
 

--- a/polaris.shopify.com/content/components/layout-and-structure/inline.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/inline.md
@@ -32,4 +32,4 @@ examples:
 
 ## Related components
 
-- To display elements vertically, [use the AlphaStack component](https://polaris.shopify.com/components/alphastack)
+- To display elements vertically, [use the AlphaStack component](https://polaris.shopify.com/components/layout-and-structure/alpha-stack)

--- a/polaris.shopify.com/content/content/alternative-text.md
+++ b/polaris.shopify.com/content/content/alternative-text.md
@@ -144,13 +144,13 @@ Images with more complexity need some consideration. For example, groups of imag
 
 ```jsx
 <div role="img" aria-labelledby="star_id">
-  <Stack>
+  <LegacyStack>
     <Icon source={StarFilledMinor} alt="">
     <Icon source={StarFilledMinor} alt="">
     <Icon source={StarFilledMinor} alt="">
     <Icon source={StarOutlineMinor} alt="">
     <Icon source={StarOutlineMinor} alt="">
-  </Stack>
+  </LegacyStack>
 </div>
 <div id="star_id">3 of 5 stars</div>
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/layout-declaration-property-value-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/layout-declaration-property-value-disallowed-list.md
@@ -9,7 +9,7 @@ keywords:
 
 ```diff
 // Do
-+ <Stack />
++ <LegacyStack />
 // Don't
 - width: 100%;
 ```

--- a/polaris.shopify.com/pages/examples/autocomplete-with-lazy-loading.tsx
+++ b/polaris.shopify.com/pages/examples/autocomplete-with-lazy-loading.tsx
@@ -1,4 +1,4 @@
-import {Autocomplete, Tag, Stack} from '@shopify/polaris';
+import {Autocomplete, Tag, LegacyStack} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -96,11 +96,11 @@ function AutoCompleteLazyLoadExample() {
     : null;
   const optionList = options.slice(0, visibleOptionIndex);
   const selectedTagMarkup = hasSelectedOptions ? (
-    <Stack spacing="extraTight">{tagsMarkup}</Stack>
+    <LegacyStack spacing="extraTight">{tagsMarkup}</LegacyStack>
   ) : null;
 
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       {selectedTagMarkup}
       <Autocomplete
         allowMultiple
@@ -113,7 +113,7 @@ function AutoCompleteLazyLoadExample() {
         onLoadMoreResults={handleLoadMoreResults}
         willLoadMoreResults={willLoadMoreResults}
       />
-    </Stack>
+    </LegacyStack>
   );
 
   function titleCase(string) {

--- a/polaris.shopify.com/pages/examples/autocomplete-with-multiple-tags.tsx
+++ b/polaris.shopify.com/pages/examples/autocomplete-with-multiple-tags.tsx
@@ -1,4 +1,4 @@
-import {Stack, Tag, Autocomplete} from '@shopify/polaris';
+import {LegacyStack, Tag, Autocomplete} from '@shopify/polaris';
 import {useState, useCallback, useMemo} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -50,7 +50,7 @@ function MultiAutocompleteExample() {
 
   const verticalContentMarkup =
     selectedOptions.length > 0 ? (
-      <Stack spacing="extraTight" alignment="center">
+      <LegacyStack spacing="extraTight" alignment="center">
         {selectedOptions.map((option) => {
           let tagLabel = '';
           tagLabel = option.replace('_', ' ');
@@ -61,7 +61,7 @@ function MultiAutocompleteExample() {
             </Tag>
           );
         })}
-      </Stack>
+      </LegacyStack>
     ) : null;
 
   const textField = (

--- a/polaris.shopify.com/pages/examples/box-with-padding.tsx
+++ b/polaris.shopify.com/pages/examples/box-with-padding.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AlphaStack, Box, Stack, Text, Inline} from '@shopify/polaris';
+import {AlphaStack, Box, LegacyStack, Text, Inline} from '@shopify/polaris';
 
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 

--- a/polaris.shopify.com/pages/examples/card-with-all-elements.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-all-elements.tsx
@@ -5,7 +5,7 @@ import {
   ActionList,
   TextContainer,
   ResourceList,
-  Stack,
+  LegacyStack,
   List,
 } from '@shopify/polaris';
 import React from 'react';
@@ -68,10 +68,10 @@ function CardExample() {
                 url={url}
                 accessibilityLabel={`View Sales for ${sales}`}
               >
-                <Stack>
-                  <Stack.Item fill>{sales}</Stack.Item>
-                  <Stack.Item>{amount}</Stack.Item>
-                </Stack>
+                <LegacyStack>
+                  <LegacyStack.Item fill>{sales}</LegacyStack.Item>
+                  <LegacyStack.Item>{amount}</LegacyStack.Item>
+                </LegacyStack>
               </ResourceList.Item>
             );
           }}

--- a/polaris.shopify.com/pages/examples/card-with-custom-footer-actions.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-custom-footer-actions.tsx
@@ -1,26 +1,26 @@
-import {Card, Stack, ButtonGroup, Button} from '@shopify/polaris';
+import {LegacyCard, LegacyStack, ButtonGroup, Button} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function CardExample() {
   return (
-    <Card title="Secure your account with 2-step authentication">
-      <Card.Section>
-        <Stack spacing="loose" vertical>
+    <LegacyCard title="Secure your account with 2-step authentication">
+      <LegacyCard.Section>
+        <LegacyStack spacing="loose" vertical>
           <p>
             Two-step authentication adds an extra layer of security when logging
             in to your account. A special code will be required each time you
             log in, ensuring only you can access your account.
           </p>
-          <Stack distribution="trailing">
+          <LegacyStack distribution="trailing">
             <ButtonGroup>
               <Button>Enable two-step authentication</Button>
               <Button plain>Learn more</Button>
             </ButtonGroup>
-          </Stack>
-        </Stack>
-      </Card.Section>
-    </Card>
+          </LegacyStack>
+        </LegacyStack>
+      </LegacyCard.Section>
+    </LegacyCard>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/card-with-custom-react-node-title.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-custom-react-node-title.tsx
@@ -1,4 +1,4 @@
-import {Card, Stack, Icon, List, Text} from '@shopify/polaris';
+import {Card, LegacyStack, Icon, List, Text} from '@shopify/polaris';
 import {ProductsMajor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -8,12 +8,12 @@ function CardExample() {
     <Card title="Products">
       <Card.Section
         title={
-          <Stack>
+          <LegacyStack>
             <Icon source={ProductsMajor} />
             <Text variant="headingXs" as="h3">
               New Products
             </Text>
-          </Stack>
+          </LegacyStack>
         }
       >
         <List>

--- a/polaris.shopify.com/pages/examples/collapsible-default.tsx
+++ b/polaris.shopify.com/pages/examples/collapsible-default.tsx
@@ -1,6 +1,6 @@
 import {
   LegacyCard,
-  Stack,
+  LegacyStack,
   Button,
   Collapsible,
   TextContainer,
@@ -17,7 +17,7 @@ function CollapsibleExample() {
   return (
     <div style={{height: '200px'}}>
       <LegacyCard sectioned>
-        <Stack vertical>
+        <LegacyStack vertical>
           <Button
             onClick={handleToggle}
             ariaExpanded={open}
@@ -40,7 +40,7 @@ function CollapsibleExample() {
               <Link url="#">Test link</Link>
             </TextContainer>
           </Collapsible>
-        </Stack>
+        </LegacyStack>
       </LegacyCard>
     </div>
   );

--- a/polaris.shopify.com/pages/examples/combobox-with-manual-selection.tsx
+++ b/polaris.shopify.com/pages/examples/combobox-with-manual-selection.tsx
@@ -4,7 +4,7 @@ import {
   Combobox,
   Icon,
   TextContainer,
-  Stack,
+  LegacyStack,
   AutoSelection,
 } from '@shopify/polaris';
 import {SearchMinor} from '@shopify/polaris-icons';
@@ -119,7 +119,7 @@ function MultiComboboxExample() {
         ) : null}
       </Combobox>
       <TextContainer>
-        <Stack>{tagsMarkup}</Stack>
+        <LegacyStack>{tagsMarkup}</LegacyStack>
       </TextContainer>
     </div>
   );

--- a/polaris.shopify.com/pages/examples/combobox-with-multi-select-and-manual-selection.tsx
+++ b/polaris.shopify.com/pages/examples/combobox-with-multi-select-and-manual-selection.tsx
@@ -4,7 +4,7 @@ import {
   Combobox,
   Icon,
   TextContainer,
-  Stack,
+  LegacyStack,
 } from '@shopify/polaris';
 import {SearchMinor} from '@shopify/polaris-icons';
 import {useState, useCallback, useMemo} from 'react';
@@ -118,7 +118,7 @@ function MultiManualComboboxExample() {
         ) : null}
       </Combobox>
       <TextContainer>
-        <Stack>{tagsMarkup}</Stack>
+        <LegacyStack>{tagsMarkup}</LegacyStack>
       </TextContainer>
     </div>
   );

--- a/polaris.shopify.com/pages/examples/combobox-with-multi-select-and-vertical-content.tsx
+++ b/polaris.shopify.com/pages/examples/combobox-with-multi-select-and-vertical-content.tsx
@@ -1,5 +1,5 @@
 import {
-  Stack,
+  LegacyStack,
   Tag,
   Listbox,
   EmptySearchResult,
@@ -94,13 +94,13 @@ function MultiselectTagComboboxExample() {
 
   const verticalContentMarkup =
     selectedTags.length > 0 ? (
-      <Stack spacing="extraTight" alignment="center">
+      <LegacyStack spacing="extraTight" alignment="center">
         {selectedTags.map((tag) => (
           <Tag key={`option-${tag}`} onRemove={removeTag(tag)}>
             {tag}
           </Tag>
         ))}
-      </Stack>
+      </LegacyStack>
     ) : null;
 
   const optionMarkup =

--- a/polaris.shopify.com/pages/examples/combobox-with-multi-select.tsx
+++ b/polaris.shopify.com/pages/examples/combobox-with-multi-select.tsx
@@ -1,5 +1,5 @@
 import {
-  Stack,
+  LegacyStack,
   Tag,
   Listbox,
   Combobox,
@@ -119,7 +119,7 @@ function MultiAutoComboboxExample() {
         ) : null}
       </Combobox>
       <TextContainer>
-        <Stack>{tagsMarkup}</Stack>
+        <LegacyStack>{tagsMarkup}</LegacyStack>
       </TextContainer>
     </div>
   );

--- a/polaris.shopify.com/pages/examples/drop-zone-accepts-only-svg-files.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-accepts-only-svg-files.tsx
@@ -1,4 +1,11 @@
-import {Stack, Thumbnail, Banner, List, DropZone, Text} from '@shopify/polaris';
+import {
+  LegacyStack,
+  Thumbnail,
+  Banner,
+  List,
+  DropZone,
+  Text,
+} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -16,9 +23,9 @@ function DropZoneAcceptingSVGFilesExample() {
   );
 
   const uploadedFiles = files.length > 0 && (
-    <Stack vertical>
+    <LegacyStack vertical>
       {files.map((file, index) => (
-        <Stack alignment="center" key={index}>
+        <LegacyStack alignment="center" key={index}>
           <Thumbnail
             size="small"
             alt={file.name}
@@ -30,9 +37,9 @@ function DropZoneAcceptingSVGFilesExample() {
               {file.size} bytes
             </Text>
           </div>
-        </Stack>
+        </LegacyStack>
       ))}
-    </Stack>
+    </LegacyStack>
   );
 
   const errorMessage = hasError && (
@@ -51,7 +58,7 @@ function DropZoneAcceptingSVGFilesExample() {
   );
 
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       {errorMessage}
       <DropZone
         accept="image/svg+xml"
@@ -61,7 +68,7 @@ function DropZoneAcceptingSVGFilesExample() {
       >
         {uploadedFiles}
       </DropZone>
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/drop-zone-default.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-default.tsx
@@ -1,4 +1,4 @@
-import {DropZone, Stack, Thumbnail, Text} from '@shopify/polaris';
+import {DropZone, LegacyStack, Thumbnail, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -17,9 +17,9 @@ function DropZoneExample() {
   const fileUpload = !files.length && <DropZone.FileUpload />;
   const uploadedFiles = files.length > 0 && (
     <div style={{padding: '0'}}>
-      <Stack vertical>
+      <LegacyStack vertical>
         {files.map((file, index) => (
-          <Stack alignment="center" key={index}>
+          <LegacyStack alignment="center" key={index}>
             <Thumbnail
               size="small"
               alt={file.name}
@@ -35,9 +35,9 @@ function DropZoneExample() {
                 {file.size} bytes
               </Text>
             </div>
-          </Stack>
+          </LegacyStack>
         ))}
-      </Stack>
+      </LegacyStack>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/drop-zone-nested.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-nested.tsx
@@ -1,4 +1,10 @@
-import {DropZone, Stack, Thumbnail, LegacyCard, Text} from '@shopify/polaris';
+import {
+  DropZone,
+  LegacyStack,
+  Thumbnail,
+  LegacyCard,
+  Text,
+} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -16,9 +22,9 @@ function NestedDropZoneExample() {
 
   const fileUpload = !files.length && <DropZone.FileUpload />;
   const uploadedFiles = files.length > 0 && (
-    <Stack vertical>
+    <LegacyStack vertical>
       {files.map((file, index) => (
-        <Stack alignment="center" key={index}>
+        <LegacyStack alignment="center" key={index}>
           <Thumbnail
             size="small"
             alt={file.name}
@@ -34,9 +40,9 @@ function NestedDropZoneExample() {
               {file.size} bytes
             </Text>
           </div>
-        </Stack>
+        </LegacyStack>
       ))}
-    </Stack>
+    </LegacyStack>
   );
 
   return (

--- a/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-dialog-trigger.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-dialog-trigger.tsx
@@ -1,4 +1,10 @@
-import {Stack, Thumbnail, LegacyCard, DropZone, Text} from '@shopify/polaris';
+import {
+  LegacyStack,
+  Thumbnail,
+  LegacyCard,
+  DropZone,
+  Text,
+} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -20,9 +26,9 @@ function DropZoneWithCustomFileDialogExample() {
   const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
 
   const uploadedFiles = files.length > 0 && (
-    <Stack vertical>
+    <LegacyStack vertical>
       {files.map((file, index) => (
-        <Stack alignment="center" key={index}>
+        <LegacyStack alignment="center" key={index}>
           <Thumbnail
             size="small"
             alt={file.name}
@@ -38,9 +44,9 @@ function DropZoneWithCustomFileDialogExample() {
               {file.size} bytes
             </Text>
           </div>
-        </Stack>
+        </LegacyStack>
       ))}
-    </Stack>
+    </LegacyStack>
   );
 
   return (
@@ -52,7 +58,8 @@ function DropZoneWithCustomFileDialogExample() {
           content: 'Upload Image',
           onAction: toggleOpenFileDialog,
         },
-      ]}>
+      ]}
+    >
       <DropZone
         openFileDialog={openFileDialog}
         onDrop={handleDropZoneDrop}

--- a/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-upload-text.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-custom-file-upload-text.tsx
@@ -1,4 +1,4 @@
-import {DropZone, Stack, Thumbnail, Text} from '@shopify/polaris';
+import {DropZone, LegacyStack, Thumbnail, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -19,9 +19,9 @@ function DropZoneExample() {
   );
 
   const uploadedFiles = files.length > 0 && (
-    <Stack vertical>
+    <LegacyStack vertical>
       {files.map((file, index) => (
-        <Stack alignment="center" key={index}>
+        <LegacyStack alignment="center" key={index}>
           <Thumbnail
             size="small"
             alt={file.name}
@@ -37,9 +37,9 @@ function DropZoneExample() {
               {file.size} bytes
             </Text>
           </div>
-        </Stack>
+        </LegacyStack>
       ))}
-    </Stack>
+    </LegacyStack>
   );
 
   return (

--- a/polaris.shopify.com/pages/examples/drop-zone-with-drop-on-page.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-drop-on-page.tsx
@@ -1,4 +1,4 @@
-import {Stack, Thumbnail, DropZone, Page, Text} from '@shopify/polaris';
+import {LegacyStack, Thumbnail, DropZone, Page, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -15,9 +15,9 @@ function DropZoneWithDropOnPageExample() {
   const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
 
   const uploadedFiles = files.length > 0 && (
-    <Stack vertical>
+    <LegacyStack vertical>
       {files.map((file, index) => (
-        <Stack alignment="center" key={index}>
+        <LegacyStack alignment="center" key={index}>
           <Thumbnail
             size="small"
             alt={file.name}
@@ -33,9 +33,9 @@ function DropZoneWithDropOnPageExample() {
               {file.size} bytes
             </Text>
           </div>
-        </Stack>
+        </LegacyStack>
       ))}
-    </Stack>
+    </LegacyStack>
   );
 
   const uploadMessage = !uploadedFiles && <DropZone.FileUpload />;

--- a/polaris.shopify.com/pages/examples/drop-zone-with-image-file-upload.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-image-file-upload.tsx
@@ -1,4 +1,11 @@
-import {DropZone, Stack, Thumbnail, Banner, List, Text} from '@shopify/polaris';
+import {
+  DropZone,
+  LegacyStack,
+  Thumbnail,
+  Banner,
+  List,
+  Text,
+} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -17,9 +24,9 @@ function DropZoneWithImageFileUpload() {
 
   const fileUpload = !files.length && <DropZone.FileUpload />;
   const uploadedFiles = files.length > 0 && (
-    <Stack vertical>
+    <LegacyStack vertical>
       {files.map((file, index) => (
-        <Stack alignment="center" key={index}>
+        <LegacyStack alignment="center" key={index}>
           <Thumbnail
             size="small"
             alt={file.name}
@@ -31,9 +38,9 @@ function DropZoneWithImageFileUpload() {
               {file.size} bytes
             </Text>
           </div>
-        </Stack>
+        </LegacyStack>
       ))}
-    </Stack>
+    </LegacyStack>
   );
 
   const errorMessage = hasError && (
@@ -52,13 +59,13 @@ function DropZoneWithImageFileUpload() {
   );
 
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       {errorMessage}
       <DropZone accept="image/*" type="image" onDrop={handleDrop}>
         {uploadedFiles}
         {fileUpload}
       </DropZone>
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/drop-zone-with-single-file-upload.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-with-single-file-upload.tsx
@@ -1,4 +1,4 @@
-import {DropZone, Stack, Thumbnail, Text} from '@shopify/polaris';
+import {DropZone, LegacyStack, Thumbnail, Text} from '@shopify/polaris';
 import {NoteMinor} from '@shopify/polaris-icons';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -16,7 +16,7 @@ function DropZoneExample() {
 
   const fileUpload = !file && <DropZone.FileUpload />;
   const uploadedFile = file && (
-    <Stack>
+    <LegacyStack>
       <Thumbnail
         size="small"
         alt={file.name}
@@ -32,7 +32,7 @@ function DropZoneExample() {
           {file.size} bytes
         </Text>
       </div>
-    </Stack>
+    </LegacyStack>
   );
 
   return (

--- a/polaris.shopify.com/pages/examples/legacy-card-with-all-elements.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-card-with-all-elements.tsx
@@ -5,7 +5,7 @@ import {
   ActionList,
   TextContainer,
   ResourceList,
-  Stack,
+  LegacyStack,
   List,
 } from '@shopify/polaris';
 import React from 'react';
@@ -68,10 +68,10 @@ function LegacyCardExample() {
                 url={url}
                 accessibilityLabel={`View Sales for ${sales}`}
               >
-                <Stack>
-                  <Stack.Item fill>{sales}</Stack.Item>
-                  <Stack.Item>{amount}</Stack.Item>
-                </Stack>
+                <LegacyStack>
+                  <LegacyStack.Item fill>{sales}</LegacyStack.Item>
+                  <LegacyStack.Item>{amount}</LegacyStack.Item>
+                </LegacyStack>
               </ResourceList.Item>
             );
           }}

--- a/polaris.shopify.com/pages/examples/legacy-card-with-custom-footer-actions.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-card-with-custom-footer-actions.tsx
@@ -1,4 +1,4 @@
-import {LegacyCard, Stack, ButtonGroup, Button} from '@shopify/polaris';
+import {LegacyCard, LegacyStack, ButtonGroup, Button} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -6,19 +6,19 @@ function LegacyCardExample() {
   return (
     <LegacyCard title="Secure your account with 2-step authentication">
       <LegacyCard.Section>
-        <Stack spacing="loose" vertical>
+        <LegacyStack spacing="loose" vertical>
           <p>
             Two-step authentication adds an extra layer of security when logging
             in to your account. A special code will be required each time you
             log in, ensuring only you can access your account.
           </p>
-          <Stack distribution="trailing">
+          <LegacyStack distribution="trailing">
             <ButtonGroup>
               <Button>Enable two-step authentication</Button>
               <Button plain>Learn more</Button>
             </ButtonGroup>
-          </Stack>
-        </Stack>
+          </LegacyStack>
+        </LegacyStack>
       </LegacyCard.Section>
     </LegacyCard>
   );

--- a/polaris.shopify.com/pages/examples/legacy-card-with-custom-react-node-title.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-card-with-custom-react-node-title.tsx
@@ -1,4 +1,4 @@
-import {LegacyCard, Stack, Icon, List, Text} from '@shopify/polaris';
+import {LegacyCard, LegacyStack, Icon, List, Text} from '@shopify/polaris';
 import {ProductsMajor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -8,12 +8,12 @@ function LegacyCardExample() {
     <LegacyCard title="Products">
       <LegacyCard.Section
         title={
-          <Stack>
+          <LegacyStack>
             <Icon source={ProductsMajor} />
             <Text variant="headingXs" as="h3">
               New Products
             </Text>
-          </Stack>
+          </LegacyStack>
         }
       >
         <List>

--- a/polaris.shopify.com/pages/examples/listbox-with-action.tsx
+++ b/polaris.shopify.com/pages/examples/listbox-with-action.tsx
@@ -1,4 +1,4 @@
-import {Listbox, Stack, Icon} from '@shopify/polaris';
+import {Listbox, LegacyStack, Icon} from '@shopify/polaris';
 import {CirclePlusMinor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -11,10 +11,10 @@ function ListboxWithActionExample() {
         Item 2
       </Listbox.Option>
       <Listbox.Action value="ActionValue">
-        <Stack spacing="tight">
+        <LegacyStack spacing="tight">
           <Icon source={CirclePlusMinor} color="base" />
           <div>Add item</div>
-        </Stack>
+        </LegacyStack>
       </Listbox.Action>
     </Listbox>
   );

--- a/polaris.shopify.com/pages/examples/listbox-with-search.tsx
+++ b/polaris.shopify.com/pages/examples/listbox-with-search.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {
-  Stack,
+  LegacyStack,
   Icon,
   Page,
   LegacyCard,

--- a/polaris.shopify.com/pages/examples/modal-large.tsx
+++ b/polaris.shopify.com/pages/examples/modal-large.tsx
@@ -1,4 +1,4 @@
-import {Button, Modal, Stack, DropZone, Checkbox} from '@shopify/polaris';
+import {Button, Modal, LegacyStack, DropZone, Checkbox} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -32,7 +32,7 @@ function LargeModalExample() {
         ]}
       >
         <Modal.Section>
-          <Stack vertical>
+          <LegacyStack vertical>
             <DropZone
               accept=".csv"
               errorOverlayText="File type must be .csv"
@@ -46,7 +46,7 @@ function LargeModalExample() {
               label="Overwrite existing customers that have the same email or phone"
               onChange={handleCheckbox}
             />
-          </Stack>
+          </LegacyStack>
         </Modal.Section>
       </Modal>
     </div>

--- a/polaris.shopify.com/pages/examples/modal-small.tsx
+++ b/polaris.shopify.com/pages/examples/modal-small.tsx
@@ -1,4 +1,4 @@
-import {Button, Modal, Stack, DropZone, Checkbox} from '@shopify/polaris';
+import {Button, Modal, LegacyStack, DropZone, Checkbox} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -32,7 +32,7 @@ function SmallModalExample() {
         ]}
       >
         <Modal.Section>
-          <Stack vertical>
+          <LegacyStack vertical>
             <DropZone
               accept=".csv"
               errorOverlayText="File type must be .csv"
@@ -46,7 +46,7 @@ function SmallModalExample() {
               label="Overwrite existing customers that have the same email or phone"
               onChange={handleCheckbox}
             />
-          </Stack>
+          </LegacyStack>
         </Modal.Section>
       </Modal>
     </div>

--- a/polaris.shopify.com/pages/examples/modal-with-primary-action.tsx
+++ b/polaris.shopify.com/pages/examples/modal-with-primary-action.tsx
@@ -1,4 +1,10 @@
-import {Button, Modal, Stack, TextContainer, TextField} from '@shopify/polaris';
+import {
+  Button,
+  Modal,
+  LegacyStack,
+  TextContainer,
+  TextField,
+} from '@shopify/polaris';
 import {useState, useCallback, useRef} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -37,8 +43,8 @@ function ModalWithPrimaryActionExample() {
         }}
       >
         <Modal.Section>
-          <Stack vertical>
-            <Stack.Item>
+          <LegacyStack vertical>
+            <LegacyStack.Item>
               <TextContainer>
                 <p>
                   You can share this discount link with your customers via email
@@ -46,8 +52,8 @@ function ModalWithPrimaryActionExample() {
                   at checkout.
                 </p>
               </TextContainer>
-            </Stack.Item>
-            <Stack.Item fill>
+            </LegacyStack.Item>
+            <LegacyStack.Item fill>
               <TextField
                 ref={node}
                 label="Discount link"
@@ -61,8 +67,8 @@ function ModalWithPrimaryActionExample() {
                   </Button>
                 }
               />
-            </Stack.Item>
-          </Stack>
+            </LegacyStack.Item>
+          </LegacyStack>
         </Modal.Section>
       </Modal>
     </div>

--- a/polaris.shopify.com/pages/examples/modal-with-primary-and-secondary-actions.tsx
+++ b/polaris.shopify.com/pages/examples/modal-with-primary-and-secondary-actions.tsx
@@ -1,4 +1,4 @@
-import {Button, Modal, Stack, ChoiceList} from '@shopify/polaris';
+import {Button, Modal, LegacyStack, ChoiceList} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -52,8 +52,8 @@ function ModalWithPrimaryAndSecondaryActionsExample() {
         ]}
       >
         <Modal.Section>
-          <Stack vertical>
-            <Stack.Item>
+          <LegacyStack vertical>
+            <LegacyStack.Item>
               <ChoiceList
                 title="Export"
                 choices={[
@@ -64,8 +64,8 @@ function ModalWithPrimaryAndSecondaryActionsExample() {
                 selected={selectedExport}
                 onChange={handleSelectedExport}
               />
-            </Stack.Item>
-            <Stack.Item>
+            </LegacyStack.Item>
+            <LegacyStack.Item>
               <ChoiceList
                 title="Export as"
                 choices={[
@@ -79,8 +79,8 @@ function ModalWithPrimaryAndSecondaryActionsExample() {
                 selected={selectedExportAs}
                 onChange={handleSelectedExportAs}
               />
-            </Stack.Item>
-          </Stack>
+            </LegacyStack.Item>
+          </LegacyStack>
         </Modal.Section>
       </Modal>
     </div>

--- a/polaris.shopify.com/pages/examples/page-without-primary-action-in-header.tsx
+++ b/polaris.shopify.com/pages/examples/page-without-primary-action-in-header.tsx
@@ -1,4 +1,4 @@
-import {Page, LegacyCard, Stack, Button} from '@shopify/polaris';
+import {Page, LegacyCard, LegacyStack, Button} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -18,12 +18,12 @@ function PageExample() {
       }}
     >
       <LegacyCard sectioned title="Fulfill order">
-        <Stack alignment="center">
-          <Stack.Item fill>
+        <LegacyStack alignment="center">
+          <LegacyStack.Item fill>
             <p>Buy postage and ship remaining 2 items</p>
-          </Stack.Item>
+          </LegacyStack.Item>
           <Button primary>Continue</Button>
-        </Stack>
+        </LegacyStack>
       </LegacyCard>
     </Page>
   );

--- a/polaris.shopify.com/pages/examples/radio-button-default.tsx
+++ b/polaris.shopify.com/pages/examples/radio-button-default.tsx
@@ -1,4 +1,4 @@
-import {Stack, RadioButton} from '@shopify/polaris';
+import {LegacyStack, RadioButton} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -11,7 +11,7 @@ function RadioButtonExample() {
   );
 
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <RadioButton
         label="Accounts are disabled"
         helpText="Customers will only be able to check out as guests."
@@ -28,7 +28,7 @@ function RadioButtonExample() {
         checked={value === 'optional'}
         onChange={handleChange}
       />
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/range-slider-with-dual-thumb.tsx
+++ b/polaris.shopify.com/pages/examples/range-slider-with-dual-thumb.tsx
@@ -1,4 +1,9 @@
-import {LegacyCard, RangeSlider, Stack, TextField} from '@shopify/polaris';
+import {
+  LegacyCard,
+  RangeSlider,
+  LegacyStack,
+  TextField,
+} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -83,7 +88,7 @@ function DualThumbRangeSliderExample() {
           step={step}
           onChange={handleRangeSliderChange}
         />
-        <Stack distribution="equalSpacing" spacing="extraLoose">
+        <LegacyStack distribution="equalSpacing" spacing="extraLoose">
           <TextField
             label="Min money spent"
             type="number"
@@ -108,7 +113,7 @@ function DualThumbRangeSliderExample() {
             onBlur={handleUpperTextFieldBlur}
             autoComplete="off"
           />
-        </Stack>
+        </LegacyStack>
       </div>
     </LegacyCard>
   );

--- a/polaris.shopify.com/pages/examples/select-with-separate-validation-error.tsx
+++ b/polaris.shopify.com/pages/examples/select-with-separate-validation-error.tsx
@@ -1,5 +1,5 @@
 import {
-  Stack,
+  LegacyStack,
   FormLayout,
   TextField,
   Select,
@@ -21,7 +21,7 @@ function SeparateValidationErrorExample() {
   const unitSelectID = 'unit';
   const errorMessage = generateErrorMessage();
   const formGroupMarkup = (
-    <Stack vertical spacing="extraTight">
+    <LegacyStack vertical spacing="extraTight">
       <FormLayout>
         <FormLayout.Group condensed>
           <TextField
@@ -44,7 +44,7 @@ function SeparateValidationErrorExample() {
         </FormLayout.Group>
       </FormLayout>
       <InlineError message={errorMessage} fieldID={unitSelectID} />
-    </Stack>
+    </LegacyStack>
   );
 
   return <LegacyCard sectioned>{formGroupMarkup}</LegacyCard>;

--- a/polaris.shopify.com/pages/examples/sheet-with-searchable-listbox.tsx
+++ b/polaris.shopify.com/pages/examples/sheet-with-searchable-listbox.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback} from 'react';
 import {
   TextField,
-  Stack,
+  LegacyStack,
   Listbox,
   Page,
   Sheet,

--- a/polaris.shopify.com/pages/examples/tag-removable-with-link.tsx
+++ b/polaris.shopify.com/pages/examples/tag-removable-with-link.tsx
@@ -1,4 +1,4 @@
-import {Tag, Stack} from '@shopify/polaris';
+import {Tag, LegacyStack} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -25,7 +25,7 @@ function RemovableTagWithLinkExample() {
     </Tag>
   ));
 
-  return <Stack spacing="tight">{tagMarkup}</Stack>;
+  return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;
 }
 
 export default withPolarisExample(RemovableTagWithLinkExample);

--- a/polaris.shopify.com/pages/examples/tag-removable.tsx
+++ b/polaris.shopify.com/pages/examples/tag-removable.tsx
@@ -1,4 +1,4 @@
-import {Tag, Stack} from '@shopify/polaris';
+import {Tag, LegacyStack} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -26,7 +26,7 @@ function RemovableTagExample() {
     </Tag>
   ));
 
-  return <Stack spacing="tight">{tagMarkup}</Stack>;
+  return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;
 }
 
 export default withPolarisExample(RemovableTagExample);

--- a/polaris.shopify.com/pages/examples/tag-with-custom-content.tsx
+++ b/polaris.shopify.com/pages/examples/tag-with-custom-content.tsx
@@ -1,4 +1,4 @@
-import {Tag, Stack, Icon} from '@shopify/polaris';
+import {Tag, LegacyStack, Icon} from '@shopify/polaris';
 import {WandMinor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
@@ -6,10 +6,10 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function TagExample() {
   return (
     <Tag url="#">
-      <Stack spacing="extraTight">
+      <LegacyStack spacing="extraTight">
         <Icon source={WandMinor} />
         <span>Wholesale</span>
-      </Stack>
+      </LegacyStack>
     </Tag>
   );
 }

--- a/polaris.shopify.com/pages/examples/text-align.tsx
+++ b/polaris.shopify.com/pages/examples/text-align.tsx
@@ -1,10 +1,10 @@
-import {Text, Stack} from '@shopify/polaris';
+import {Text, LegacyStack} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextExample() {
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <Text variant="bodyLg" as="p" alignment="start">
         Manage your Shopify store on-the-go with real-time notifications, access
         to your dashboard, and order management, all from your smartphone.
@@ -21,7 +21,7 @@ function TextExample() {
         Manage your Shopify store on-the-go with real-time notifications, access
         to your dashboard, and order management, all from your smartphone.
       </Text>
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/text-body.tsx
+++ b/polaris.shopify.com/pages/examples/text-body.tsx
@@ -1,10 +1,10 @@
-import {Text, Stack} from '@shopify/polaris';
+import {Text, LegacyStack} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextExample() {
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <Text variant="bodyLg" as="p">
         Shopify POS is the easiest way to sell your products in person.
         Available for iPad, iPhone, and Android.
@@ -17,7 +17,7 @@ function TextExample() {
         Shopify POS is the easiest way to sell your products in person.
         Available for iPad, iPhone, and Android.
       </Text>
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/text-color.tsx
+++ b/polaris.shopify.com/pages/examples/text-color.tsx
@@ -1,10 +1,10 @@
-import {Text, Stack} from '@shopify/polaris';
+import {Text, LegacyStack} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextExample() {
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <Text variant="bodyMd" as="p" color="subdued">
         Use to de-emphasize a piece of text that is less important to merchants
         than other nearby text. May also be used to indicate when normal content
@@ -23,7 +23,7 @@ function TextExample() {
         Use in combination with a symbol showing a decreasing value to indicate
         a downward trend.
       </Text>
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/text-field-with-right-aligned-text.tsx
+++ b/polaris.shopify.com/pages/examples/text-field-with-right-aligned-text.tsx
@@ -1,4 +1,4 @@
-import {Stack, TextField} from '@shopify/polaris';
+import {LegacyStack, TextField} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -11,8 +11,8 @@ function RightAlignExample() {
   );
 
   return (
-    <Stack>
-      <Stack.Item fill>Price</Stack.Item>
+    <LegacyStack>
+      <LegacyStack.Item fill>Price</LegacyStack.Item>
       <TextField
         label="Price"
         labelHidden
@@ -21,7 +21,7 @@ function RightAlignExample() {
         autoComplete="off"
         align="right"
       />
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/text-field-with-separate-validation-error.tsx
+++ b/polaris.shopify.com/pages/examples/text-field-with-separate-validation-error.tsx
@@ -1,5 +1,5 @@
 import {
-  Stack,
+  LegacyStack,
   FormLayout,
   Select,
   TextField,
@@ -39,8 +39,8 @@ function SeparateValidationErrorExample() {
     : '';
 
   const formGroupMarkup = (
-    <Stack wrap={false} alignment="leading" spacing="loose">
-      <Stack.Item fill>
+    <LegacyStack wrap={false} alignment="leading" spacing="loose">
+      <LegacyStack.Item fill>
         <FormLayout>
           <FormLayout.Group condensed>
             <Select
@@ -71,9 +71,9 @@ function SeparateValidationErrorExample() {
         <div style={{marginTop: '4px'}}>
           <InlineError message={errorMessage} fieldID={textFieldID} />
         </div>
-      </Stack.Item>
+      </LegacyStack.Item>
       <Button icon={DeleteMinor} accessibilityLabel="Remove item" />
-    </Stack>
+    </LegacyStack>
   );
 
   return (

--- a/polaris.shopify.com/pages/examples/text-field-with-vertical-content.tsx
+++ b/polaris.shopify.com/pages/examples/text-field-with-vertical-content.tsx
@@ -1,4 +1,4 @@
-import {Stack, Tag, TextField} from '@shopify/polaris';
+import {LegacyStack, Tag, TextField} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -13,11 +13,11 @@ function VerticalContentExample() {
 
   const verticalContentMarkup =
     tags.length > 0 ? (
-      <Stack spacing="extraTight" alignment="center">
+      <LegacyStack spacing="extraTight" alignment="center">
         {tags.map((tag) => (
           <Tag key={tag}>{tag}</Tag>
         ))}
-      </Stack>
+      </LegacyStack>
     ) : null;
 
   return (

--- a/polaris.shopify.com/pages/examples/text-heading.tsx
+++ b/polaris.shopify.com/pages/examples/text-heading.tsx
@@ -1,10 +1,10 @@
-import {Text, Stack} from '@shopify/polaris';
+import {Text, LegacyStack} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextExample() {
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <Text variant="heading4xl" as="h1">
         Online store dashboard
       </Text>
@@ -29,7 +29,7 @@ function TextExample() {
       <Text variant="headingXs" as="h6">
         Online store dashboard
       </Text>
-    </Stack>
+    </LegacyStack>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/text-weight.tsx
+++ b/polaris.shopify.com/pages/examples/text-weight.tsx
@@ -1,10 +1,10 @@
-import {Text, Stack} from '@shopify/polaris';
+import {Text, LegacyStack} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextExample() {
   return (
-    <Stack vertical>
+    <LegacyStack vertical>
       <Text variant="bodyMd" as="p" fontWeight="bold">
         Sales this year
       </Text>
@@ -17,7 +17,7 @@ function TextExample() {
       <Text variant="bodyMd" as="p" fontWeight="regular">
         Sales this year
       </Text>
-    </Stack>
+    </LegacyStack>
   );
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of [8183](https://github.com/Shopify/polaris/issues/8183).

Updates all usages of `Stack` to `LegacyStack` for future deprecation and removal of `Stack`.

### WHAT is this pull request doing?

Uses the [rename component migration](https://github.com/Shopify/polaris/pull/8229) snapshot.
The following commands were used to run migrations:
```sh
npx @shopify/polaris-migrator@0.0.0-snapshot-release-20230221182348 react-rename-component ./polaris-react/src/**/*.{ts,tsx}' --renameFrom="Stack" --renameTo="LegacyStack" --renamePropsFrom="StackProps" --renamePropsTo="LegacyStackProps"
```
```sh
npx @shopify/polaris-migrator@0.0.0-snapshot-release-20230221182348 react-rename-component './polaris.shopify.com/pages/examples/**.{ts,tsx}' --renameFrom="Stack" --renameTo="LegacyStack" --renamePropsFrom="StackProps" --renamePropsTo="LegacyStackProps"
```

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide