### PR TITLE
[OptionList] Add `onPointerEnterOption` and `onFocusOption` handlers

### DIFF
--- a/.changeset/chilled-pants-invite.md
+++ b/.changeset/chilled-pants-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[OptionList] Add `onPointerEnterOption` prop

--- a/.changeset/nasty-gorillas-worry.md
+++ b/.changeset/nasty-gorillas-worry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[OptionList] Add `onFocusOption` prop

--- a/polaris-react/src/components/OptionList/OptionList.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.tsx
@@ -39,6 +39,8 @@ export interface OptionListProps {
   verticalAlign?: Alignment;
   /** Callback when selection is changed */
   onChange(selected: string[]): void;
+  /** Callback when pointer enters an option */
+  onPointerEnterOption?(selected: string): void;
 }
 
 export function OptionList({
@@ -52,6 +54,7 @@ export function OptionList({
   verticalAlign,
   onChange,
   id: idProp,
+  onPointerEnterOption,
 }: OptionListProps) {
   const [normalizedOptions, setNormalizedOptions] = useState(
     createNormalizedOptions(options, sections, title),
@@ -87,6 +90,18 @@ export function OptionList({
       onChange([selectedValue]);
     },
     [normalizedOptions, selected, allowMultiple, onChange],
+  );
+
+  const handlePointerEnter = useCallback(
+    (sectionIndex: number, optionIndex: number) => {
+      if (!onPointerEnterOption) return;
+
+      const selectedValue =
+        normalizedOptions[sectionIndex].options[optionIndex].value;
+
+      onPointerEnterOption(selectedValue);
+    },
+    [normalizedOptions, onPointerEnterOption],
   );
 
   const optionsExist = normalizedOptions.length > 0;
@@ -127,6 +142,7 @@ export function OptionList({
                 allowMultiple={allowMultiple}
                 verticalAlign={verticalAlign}
                 role={optionRole}
+                onPointerEnter={handlePointerEnter}
               />
             );
           });

--- a/polaris-react/src/components/OptionList/OptionList.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.tsx
@@ -41,6 +41,8 @@ export interface OptionListProps {
   onChange(selected: string[]): void;
   /** Callback when pointer enters an option */
   onPointerEnterOption?(selected: string): void;
+  /** Callback when focusing an option */
+  onFocusOption?(selected: string): void;
 }
 
 export function OptionList({
@@ -55,6 +57,7 @@ export function OptionList({
   onChange,
   id: idProp,
   onPointerEnterOption,
+  onFocusOption,
 }: OptionListProps) {
   const [normalizedOptions, setNormalizedOptions] = useState(
     createNormalizedOptions(options, sections, title),
@@ -104,6 +107,18 @@ export function OptionList({
     [normalizedOptions, onPointerEnterOption],
   );
 
+  const handleFocus = useCallback(
+    (sectionIndex: number, optionIndex: number) => {
+      if (!onFocusOption) return;
+
+      const selectedValue =
+        normalizedOptions[sectionIndex].options[optionIndex].value;
+
+      onFocusOption(selectedValue);
+    },
+    [normalizedOptions, onFocusOption],
+  );
+
   const optionsExist = normalizedOptions.length > 0;
 
   const optionsMarkup = optionsExist
@@ -143,6 +158,7 @@ export function OptionList({
                 verticalAlign={verticalAlign}
                 role={optionRole}
                 onPointerEnter={handlePointerEnter}
+                onFocus={handleFocus}
               />
             );
           });

--- a/polaris-react/src/components/OptionList/components/Option/Option.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/Option.tsx
@@ -28,6 +28,8 @@ export interface OptionProps {
   onClick(section: number, option: number): void;
   /** Callback when pointer enters the option */
   onPointerEnter(section: number, option: number): void;
+  /** Callback when option is focused */
+  onFocus(section: number, option: number): void;
 }
 
 export function Option({
@@ -45,6 +47,7 @@ export function Option({
   index,
   verticalAlign,
   onPointerEnter,
+  onFocus,
 }: OptionProps) {
   const {value: focused, toggle: toggleFocused} = useToggle(false);
 
@@ -63,6 +66,12 @@ export function Option({
 
     onPointerEnter(section, index);
   }, [disabled, onPointerEnter, section, index]);
+
+  const handleFocus = useCallback(() => {
+    toggleFocused();
+
+    onFocus(section, index);
+  }, [toggleFocused, onFocus, section, index]);
 
   const mediaMarkup = media ? (
     <div className={styles.Media}>{media}</div>
@@ -110,7 +119,7 @@ export function Option({
       className={singleSelectClassName}
       onClick={handleClick}
       disabled={disabled}
-      onFocus={toggleFocused}
+      onFocus={handleFocus}
       onBlur={toggleFocused}
       aria-pressed={active}
     >

--- a/polaris-react/src/components/OptionList/components/Option/Option.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/Option.tsx
@@ -26,6 +26,8 @@ export interface OptionProps {
   verticalAlign?: Alignment;
   role?: string;
   onClick(section: number, option: number): void;
+  /** Callback when pointer enters the option */
+  onPointerEnter(section: number, option: number): void;
 }
 
 export function Option({
@@ -42,6 +44,7 @@ export function Option({
   section,
   index,
   verticalAlign,
+  onPointerEnter,
 }: OptionProps) {
   const {value: focused, toggle: toggleFocused} = useToggle(false);
 
@@ -52,6 +55,14 @@ export function Option({
 
     onClick(section, index);
   }, [disabled, index, onClick, section]);
+
+  const handlePointerEnter = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+
+    onPointerEnter(section, index);
+  }, [disabled, onPointerEnter, section, index]);
 
   const mediaMarkup = media ? (
     <div className={styles.Media}>{media}</div>
@@ -111,7 +122,12 @@ export function Option({
   const scrollMarkup = active ? <Scrollable.ScrollTo /> : null;
 
   return (
-    <li key={id} className={styles.Option} tabIndex={-1}>
+    <li
+      key={id}
+      className={styles.Option}
+      tabIndex={-1}
+      onPointerEnter={handlePointerEnter}
+    >
       {scrollMarkup}
       {optionMarkup}
     </li>

--- a/polaris-react/src/components/OptionList/components/Option/tests/Option.test.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/tests/Option.test.tsx
@@ -15,6 +15,7 @@ describe('<Option />', () => {
     index: 0,
     onClick: noop,
     onPointerEnter: noop,
+    onFocus: noop,
   };
 
   it('renders a checkbox if allowMultiple is true', () => {
@@ -98,6 +99,21 @@ describe('<Option />', () => {
       listItem.trigger('onPointerEnter');
 
       expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onFocus', () => {
+    it('is called with section and index', () => {
+      const spy = jest.fn();
+      const {section, index} = defaultProps;
+
+      const listItem = mountWithApp(
+        <Option {...defaultProps} onFocus={spy} />,
+      ).find('button')!;
+      listItem.trigger('onFocus');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(section, index);
     });
   });
 

--- a/polaris-react/src/components/OptionList/components/Option/tests/Option.test.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/tests/Option.test.tsx
@@ -14,6 +14,7 @@ describe('<Option />', () => {
     section: 0,
     index: 0,
     onClick: noop,
+    onPointerEnter: noop,
   };
 
   it('renders a checkbox if allowMultiple is true', () => {
@@ -72,6 +73,32 @@ describe('<Option />', () => {
     input.trigger('onChange');
 
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  describe('onPointerEnter', () => {
+    it('is called with section and index if option is not disabled', () => {
+      const spy = jest.fn();
+      const {section, index} = defaultProps;
+
+      const listItem = mountWithApp(
+        <Option {...defaultProps} onPointerEnter={spy} />,
+      ).find('li')!;
+      listItem.trigger('onPointerEnter');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(section, index);
+    });
+
+    it('is not called if option is disabled', () => {
+      const spy = jest.fn();
+
+      const listItem = mountWithApp(
+        <Option {...defaultProps} onPointerEnter={spy} disabled />,
+      ).find('li')!;
+      listItem.trigger('onPointerEnter');
+
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   it('sets the pass through props for Checkbox if multiple items are allowed', () => {

--- a/polaris-react/src/components/OptionList/tests/OptionList.test.tsx
+++ b/polaris-react/src/components/OptionList/tests/OptionList.test.tsx
@@ -265,6 +265,20 @@ describe('<OptionList />', () => {
     expect(spy).toHaveBeenCalledWith(firstOption(options, sections));
   });
 
+  it('calls onFocusOption with options and sections', () => {
+    const spy = jest.fn();
+    const {options, sections} = defaultProps;
+
+    const option = mountWithApp(
+      <OptionList {...defaultProps} onFocusOption={spy} />,
+    ).find(Option);
+
+    option?.find('button')!.trigger('onFocus');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(firstOption(options, sections));
+  });
+
   describe('allowMultiple', () => {
     it('renders options and sections', () => {
       const {options, sections} = defaultProps;

--- a/polaris-react/src/components/OptionList/tests/OptionList.test.tsx
+++ b/polaris-react/src/components/OptionList/tests/OptionList.test.tsx
@@ -251,6 +251,20 @@ describe('<OptionList />', () => {
     expect(spy).toHaveBeenCalledWith([firstOption(options, sections)]);
   });
 
+  it('calls onPointerEnterOption with options and sections', () => {
+    const spy = jest.fn();
+    const {options, sections} = defaultProps;
+
+    const option = mountWithApp(
+      <OptionList {...defaultProps} onPointerEnterOption={spy} />,
+    ).find(Option);
+
+    option?.find('li')!.trigger('onPointerEnter');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(firstOption(options, sections));
+  });
+
   describe('allowMultiple', () => {
     it('renders options and sections', () => {
       const {options, sections} = defaultProps;
@@ -507,6 +521,27 @@ describe('<OptionList />', () => {
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy).toHaveBeenCalledWith(newSelected);
+      });
+    });
+  });
+
+  describe('onPointerEnterOption', () => {
+    it('does not select the item', () => {
+      const spy = jest.fn();
+      const {options, sections} = defaultProps;
+
+      const optionList = mountWithApp(
+        <OptionList {...defaultProps} onPointerEnterOption={spy} />,
+      );
+
+      const option = optionList.find(Option);
+
+      option?.find('li')!.trigger('onPointerEnter');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(firstOption(options, sections));
+      expect(optionList).toHaveReactProps({
+        selected: [],
       });
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Part of: https://github.com/Shopify/online-store-web/issues/15842

The new visual section picker in the theme editor will show a preview of the currently hovered section. In order to do that it needs to access the value of the currently hovered option.

<details>
<summary>Video</summary>

https://user-images.githubusercontent.com/22640631/232768434-fa1b16f9-543a-4214-ab1b-eed23709404c.mov

</details>


### WHAT is this pull request doing?

Add `onPointerEnter` handler to `OptionList`, that returns the value of the targeted Option. When provided, the callback is also executed on focus to be accessible when navigating with the keyboard.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

[☁️ Spin instance - integration in the Online store](https://admin.web.apr-13.mathilde-buenerd.eu.spin.dev/store/shop1/themes/1/editor)

#### Tophat steps:

**Desktop**

- Open [☁️ Spin instance - integration in the Online store](https://admin.web.apr-13.mathilde-buenerd.eu.spin.dev/store/shop1/themes/1/editor)
- Click "Add section" on the sidebar
- Hover the OptionList → the preview is changing
- Navigate the OptionList with the tab key to move focus → the preview is changing

<details>
<summary>Video - How to tophat (hover)</summary>

https://user-images.githubusercontent.com/22640631/232770083-a9157886-8c8f-4c19-adec-5db93edda11b.mov

</details>

<details>
<summary>Video - How to tophat (keyboard navigation)</summary>

https://user-images.githubusercontent.com/22640631/232771593-d759ea63-f244-42cb-b7f8-34dab6b45341.mov

</details>


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
