### PR TITLE
Add tests to ensure SVGs in `polaris-icons` do not contain percentages

### DIFF
--- a/polaris-icons/tests/validate-svg-content.test.js
+++ b/polaris-icons/tests/validate-svg-content.test.js
@@ -134,6 +134,25 @@ allIconFiles.forEach(
         ).toStrictEqual([]);
       });
 
+      it('does not contain any percentages', () => {
+        expect(iconSource).not.toContain('%');
+      });
+
+      it('only has nodes that use numbers to represent values in the [fill-opacity] attributes', () => {
+        const nodesWithDisallowedValues = selectAll(
+          '[fillOpacity], [opacity]',
+          iconAst,
+        ).filter(({properties: {opacity, fillOpacity}}) =>
+          [opacity, fillOpacity]
+            .filter(Boolean)
+            .some((property) => typeof property !== 'number'),
+        );
+
+        expect(
+          nodeSources(nodesWithDisallowedValues, iconSource),
+        ).toStrictEqual([]);
+      });
+
       if (expectedFillColors) {
         const expectedFillsString = expectedFillColors.join(',');
 


### PR DESCRIPTION
### WHY are these changes introduced?

Follow-up to #8499

Percentage values are not supported in the Tiny SVG spec which makes icons containing percentages difficult to convert to formats supported by Android.

### WHAT is this pull request doing?

This PR adds 2 tests:
1. One test validates that no SVG file in `polaris-icons` contains a `%` character.  I think it's pretty safe to assume that we basically never want percentages in SVG files.  Probably leads to undefined behaviour in 99% of cases.
1. One test directly addresses the above issue by only allowing numeric values in `fill-opacity` and `opacity`.

One might argue that we only need one of the two tests.  If we choose to include only one, I'm leaning towards the first.

### How to 🎩

Pull the branch. Add a % value to one of the icons and run `yarn test` from the `polaris-icons` directory. The test should fail.