### PR TITLE
change deprecated status to legacy for patterns-legacy content

### DIFF
--- a/.changeset/five-deers-speak.md
+++ b/.changeset/five-deers-speak.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix legacy patterns wrongly being categorised as deprecated. These are now correctly labeled "legacy"

--- a/polaris.shopify.com/content/patterns-legacy/loading.md
+++ b/polaris.shopify.com/content/patterns-legacy/loading.md
@@ -4,8 +4,8 @@ description: Navigating the Shopify admin should be fast, meaningful, and focuse
 icon: RefreshMajor
 noIndex: true
 status:
-  value: Deprecated
-  message: This pattern is no longer supported.
+  value: Legacy
+  message: This is a legacy pattern.
 keywords:
   - page loading
   - loading

--- a/polaris.shopify.com/content/patterns-legacy/new-badge.md
+++ b/polaris.shopify.com/content/patterns-legacy/new-badge.md
@@ -4,8 +4,8 @@ description: The New badge can be used to inform merchants about the release of 
 icon: StarFilledMinor
 noIndex: true
 status:
-  value: Deprecated
-  message: This pattern is no longer supported.
+  value: Legacy
+  message: This is a legacy pattern.
 keywords:
   - new badge
   - new features

--- a/polaris.shopify.com/content/patterns-legacy/pickers.md
+++ b/polaris.shopify.com/content/patterns-legacy/pickers.md
@@ -4,8 +4,8 @@ description: Picker experiences help merchants browse, find, and select from mul
 icon: LocationMajor
 noIndex: true
 status:
-  value: Deprecated
-  message: This pattern is no longer supported.
+  value: Legacy
+  message: This is a legacy pattern.
 keywords:
   - customer segments
   - locations

--- a/polaris.shopify.com/content/patterns-legacy/text-fields.md
+++ b/polaris.shopify.com/content/patterns-legacy/text-fields.md
@@ -4,8 +4,8 @@ description: Text fields combine the field label (the title) and the input area.
 icon: FormsMajor
 noIndex: true
 status:
-  value: Deprecated
-  message: This pattern is no longer supported.
+  value: Legacy
+  message: This is a legacy pattern.
 keywords:
   - text fields
   - search


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Previously the patterns under the `patterns-legacy` folder were wrongly attributed with the `deprecated` status, this PR changes this to correctly be the `legacy` status for all of these patterns. 
![Screenshot 2023-03-06 at 10 26 05 am](https://user-images.githubusercontent.com/12119389/222992032-4ff3d483-c1db-4967-b1d6-0ca54ca92464.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
