### PR TITLE
[polaris.shopify.com] Add legacy documentation

### DIFF
--- a/.changeset/tender-moons-tease.md
+++ b/.changeset/tender-moons-tease.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Added `Legacy` status to component lifecycle page and banner/badge to `LegacyStack` and `LegacyCard`

--- a/polaris.shopify.com/content/components/layout-and-structure/legacy-card.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/legacy-card.md
@@ -21,6 +21,9 @@ keywords:
   - callout
   - call out
   - legacy card
+status:
+  value: Legacy
+  message: This is a legacy component and will be deprecated. The new [AlphaCard component](/components/layout-and-structure/alpha-card) can be used in combination with the new layout primitives to achieve similar results to LegacyCard. Learn more about our [Component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: legacy-card-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/legacy-card.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/legacy-card.md
@@ -23,7 +23,7 @@ keywords:
   - legacy card
 status:
   value: Legacy
-  message: This is a legacy component and will be deprecated. The new [AlphaCard component](/components/layout-and-structure/alpha-card) can be used in combination with the new layout primitives to achieve similar results to LegacyCard. Learn more about our [Component lifecycles](/getting-started/components-lifecycle).
+  message: This is a legacy component and will be deprecated. The new [AlphaCard component](/components/layout-and-structure/alpha-card) can be used in combination with the new layout primitives to achieve similar results to LegacyCard. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: legacy-card-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/legacy-stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/legacy-stack.md
@@ -18,6 +18,9 @@ keywords:
   - stack layout
   - layout
   - legacy stack
+status:
+  value: Legacy
+  message: This is a legacy component and will be deprecated. The new [AlphaStack component](/components/layout-and-structure/alpha-stack) can be used in combination with the new layout primitives to achieve similar results to LegacyStack. Learn more about our [Component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: legacy-stack-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/legacy-stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/legacy-stack.md
@@ -20,7 +20,7 @@ keywords:
   - legacy stack
 status:
   value: Legacy
-  message: This is a legacy component and will be deprecated. The new [AlphaStack component](/components/layout-and-structure/alpha-stack) can be used in combination with the new layout primitives to achieve similar results to LegacyStack. Learn more about our [Component lifecycles](/getting-started/components-lifecycle).
+  message: This is a legacy component and will be deprecated. The new [AlphaStack component](/components/layout-and-structure/alpha-stack) can be used in combination with the new layout primitives to achieve similar results to LegacyStack. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: legacy-stack-default.tsx
     title: Default

--- a/polaris.shopify.com/content/getting-started/components-lifecycle.md
+++ b/polaris.shopify.com/content/getting-started/components-lifecycle.md
@@ -8,6 +8,7 @@ keywords:
   - alpha
   - beta
   - stable
+  - legacy
   - deprecated
 order: 1
 ---
@@ -69,6 +70,18 @@ The component is bug free and works in most, if not all, environments. It’s re
 - Usability testing and feedback has been gathered on UX and DX
 - Documentation exists for component props, variants, accessibility guidelines, and usage
 - Manual and automated migration documentation exists
+
+---
+
+## Legacy
+
+The component will be deprecated and should be avoided.
+
+### Requirements for legacy components
+
+- Documentation exists for the legacy component and includes any alternative components
+- The deprecation date has been announced and is at least one month away from the release date of the package that deprecated the component
+- Manual and automated migration paths are documented and have been available for at least one month
 
 ---
 

--- a/polaris.shopify.com/src/components/StatusBadge/StatusBadge.module.scss
+++ b/polaris.shopify.com/src/components/StatusBadge/StatusBadge.module.scss
@@ -11,7 +11,8 @@
   }
 
   &[data-value='warning'],
-  &[data-value='deprecated'] {
+  &[data-value='deprecated'],
+  &[data-value='legacy'] {
     background: var(--surface-warning);
   }
 

--- a/polaris.shopify.com/src/components/StatusBanner/StatusBanner.module.scss
+++ b/polaris.shopify.com/src/components/StatusBanner/StatusBanner.module.scss
@@ -10,7 +10,8 @@
   }
 
   &[data-value='warning'],
-  &[data-value='deprecated'] {
+  &[data-value='deprecated'],
+  &[data-value='legacy'] {
     background: var(--surface-warning);
   }
 
@@ -19,7 +20,6 @@
     background: var(--surface-information);
   }
 
-  &[data-value='legacy'],
   &[data-value='information'] {
     background: var(--surface-information);
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Adds context for Legacy status on component lifecycle page and updates LegacyStack and LegacyCard component pages to suggest using AlphaStack and AlphaCard.

### WHAT is this pull request doing?

- Adds `Legacy` section to component lifecycle page
- Adds `legacy` to status banner and status badge
- Updates `LegacyStack` and `LegacyCard` to include banner marking it as legacy and suggesting `AlphaStack` and `AlphaCard` instead while also linking to component lifecycle page.

Here are screenshots of the updates:
    <details>
      <summary>Component lifecycle page</summary>
      <img src="https://user-images.githubusercontent.com/26749317/223225303-9ac73318-67db-4048-b984-77e2928fdd30.png" alt="Component lifecycle page">
    </details>
    <details>
      <summary>LegacyCard page with status banner and status badge</summary>
      <img src="https://user-images.githubusercontent.com/26749317/223225302-f2cd943e-4f68-48db-9b43-3257fa274652.png" alt="LegacyCard page with status banner and status badge">
    </details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
