### PR TITLE
[polaris.shopify.com] Fix component lifecycle url in alpha banners

### DIFF
--- a/.changeset/tough-mugs-greet.md
+++ b/.changeset/tough-mugs-greet.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed links to component lifecycle page in alpha component banners

--- a/polaris.shopify.com/content/components/deprecated/index.md
+++ b/polaris.shopify.com/content/components/deprecated/index.md
@@ -3,5 +3,5 @@ title: Deprecated
 expanded: true
 order: 12
 description: >-
-  Deprecated components will be removed in future major versions of Polaris. These components could be deprecated for a [number of reasons](https://polaris.shopify.com/getting-started/components-lifecycle#requirements-for-deprecation) and should be avoided. These components will show warnings in the component file and provide details for alternative usage. For more information, check out the [component lifecycle](https://polaris.shopify.com/getting-started/components-lifecycle#deprecated).
+  Deprecated components will be removed in future major versions of Polaris. These components could be deprecated for a [number of reasons](https://polaris.shopify.com/getting-started/components-lifecycle#requirements-for-deprecation) and should be avoided. These components will show warnings in the component file and provide details for alternative usage. For more information, check out the [component lifecycles](https://polaris.shopify.com/getting-started/components-lifecycle#deprecated).
 ---

--- a/polaris.shopify.com/content/components/layout-and-structure/alpha-card.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/alpha-card.md
@@ -22,7 +22,7 @@ keywords:
   - call out
 status:
   value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [Component lifecycle](/getting-started/components-lifecycle).
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: alpha-card-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/alpha-stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/alpha-stack.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [Component lifecycle](/getting-started/components-lifecycle).
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: alpha-stack-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/bleed.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/bleed.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [Component lifecycle](/getting-started/components-lifecycle).
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: bleed-vertical.tsx
     title: Vertical

--- a/polaris.shopify.com/content/components/layout-and-structure/box.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/box.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [Component lifecycle](/getting-started/components-lifecycle).
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: box-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/columns.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/columns.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our Component lifecycle](/getting-started/components-lifecycle).
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: columns-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/divider.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/divider.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [Component lifecycle](/getting-started/components-lifecycle).
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: divider-with-border-styles.tsx
     title: Style

--- a/polaris.shopify.com/content/components/layout-and-structure/inline.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/inline.md
@@ -6,7 +6,7 @@ keywords:
   - layout
 status:
   value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [Component lifecycle](/getting-started/components-lifecycle).
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: inline-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/typography/text.md
+++ b/polaris.shopify.com/content/components/typography/text.md
@@ -21,7 +21,7 @@ keywords:
   - list
 status:
   value: Beta
-  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. To learn more please read about our [Component lifecycle](/getting-started/components-lifecycle)
+  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. To learn more please read about our [component lifecycles](/getting-started/components-lifecycle)
 examples:
   - fileName: text-heading.tsx
     title: Heading


### PR DESCRIPTION
### WHY are these changes introduced?

Noticed a broken URL in the alpha banner of Columns for the component lifecycle page.
Also updated the copy for all the URLs to match what is in LegacyCard and LegacyStack based off this [feedback](https://github.com/Shopify/polaris/pull/8570#discussion_r1127084700) for consistency.

<img width="1195" alt="columns-1" src="https://user-images.githubusercontent.com/26749317/223420647-00579282-fa42-40e3-858b-4d5e1bb55681.png">

### WHAT is this pull request doing?

Fixes typo in Columns alpha banner.
Updated copy in alpha component banner from `Component lifecycle` to `component lifecycles`.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
