### PR TITLE
[WIP] Created `integer` type for `<TextField />`

### DIFF
--- a/.changeset/spicy-radios-work.md
+++ b/.changeset/spicy-radios-work.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added integer type to TextField

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -485,7 +485,8 @@ export function TextField({
     }
   };
 
-  const inputPattern = pattern ?? (type === 'integer' ? '[0-9]*' : pattern);
+  const inputPattern =
+    pattern ?? (type === 'integer' ? '^[-]?[0-9]*' : pattern);
 
   const input = createElement(multiline ? 'textarea' : 'input', {
     name,
@@ -579,7 +580,7 @@ export function TextField({
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     const {value} = event.currentTarget;
-    const integerSpec = /^[-0]?[0-9]*$/;
+    const integerSpec = /^[-]?[0-9]*$/;
 
     if (onChange) {
       if (

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
+import type {TextFieldProps} from '../../..';
 import {Connected} from '../../Connected';
 import {InlineError} from '../../InlineError';
 import {Labelled} from '../../Labelled';
@@ -785,8 +786,8 @@ describe('<TextField />', () => {
             id="MyTextField"
             label="TextField"
             type="number"
-            onChange={spy}
             autoComplete="off"
+            onChange={spy}
           />,
         );
         element
@@ -1097,13 +1098,451 @@ describe('<TextField />', () => {
           const spy = jest.fn();
           const element = mountWithApp(
             <TextField
-              id="MyTextField"
               label="TextField"
               type="number"
               value="3"
               onChange={spy}
               autoComplete="off"
             />,
+          );
+
+          element
+            .findAll('div', {role: 'button'})[1]
+            .trigger('onMouseDown', {button: 0});
+
+          documentEvent.mouseup();
+
+          jest.runOnlyPendingTimers();
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('integer', () => {
+      const defaultIntegerProps: TextFieldProps = {
+        id: 'MyIntegerTextField',
+        label: 'IntegerTextField',
+        type: 'integer',
+        autoComplete: 'off',
+        value: '3',
+        onChange: noop,
+      };
+
+      it('returns an input with type="text', () => {
+        const element = mountWithApp(<TextField {...defaultIntegerProps} />);
+
+        expect(element).toContainReactComponent('input', {
+          type: 'text',
+        });
+      });
+
+      it('rounds the step value to the nearest integer', () => {
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} step={1.5} />,
+        );
+
+        expect(element).toContainReactComponent('input', {
+          step: 2,
+        });
+      });
+
+      it('sets a default integer inputPattern if no pattern is passed', () => {
+        const element = mountWithApp(<TextField {...defaultIntegerProps} />);
+
+        expect(element).toContainReactComponent('input', {
+          pattern: '^[-]?[0-9]*',
+        });
+      });
+
+      it('uses the passed inputPattern if one is passed', () => {
+        const pattern = '[0-9]*';
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} pattern={pattern} />,
+        );
+
+        expect(element).toContainReactComponent('input', {
+          pattern,
+        });
+      });
+
+      it('sets the inputMode to numeric by default no inputMode is passed', () => {
+        const element = mountWithApp(<TextField {...defaultIntegerProps} />);
+
+        expect(element).toContainReactComponent('input', {
+          inputMode: 'numeric',
+        });
+      });
+
+      it('uses the passed inputMode if one is passed', () => {
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} inputMode="decimal" />,
+        );
+
+        expect(element).toContainReactComponent('input', {
+          inputMode: 'decimal',
+        });
+      });
+
+      it('calls onChange if the value is a valid integer', () => {
+        const onChangeSpy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} onChange={onChangeSpy} />,
+        );
+
+        element.find('input')!.trigger('onChange', {
+          currentTarget: {
+            value: '4',
+          },
+        });
+
+        expect(onChangeSpy).toHaveBeenCalledWith('4', 'MyIntegerTextField');
+      });
+
+      it('calls onChange if the value is a minus sign', () => {
+        const onChangeSpy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} onChange={onChangeSpy} />,
+        );
+
+        element.find('input')!.trigger('onChange', {
+          currentTarget: {
+            value: '-',
+          },
+        });
+
+        expect(onChangeSpy).toHaveBeenCalledWith('-', 'MyIntegerTextField');
+      });
+
+      it('calls onChange with 0 if -0 is passed as the value', () => {
+        const onChangeSpy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} onChange={onChangeSpy} />,
+        );
+
+        element.find('input')!.trigger('onChange', {
+          currentTarget: {
+            value: '-0',
+          },
+        });
+
+        expect(onChangeSpy).toHaveBeenCalledWith('0', 'MyIntegerTextField');
+      });
+
+      it('calls onChange with 0 if a value of multiple zeros are passed', () => {
+        const onChangeSpy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} onChange={onChangeSpy} />,
+        );
+
+        element.find('input')!.trigger('onChange', {
+          currentTarget: {
+            value: '000000000',
+          },
+        });
+
+        expect(onChangeSpy).toHaveBeenCalledWith('0', 'MyIntegerTextField');
+      });
+
+      it('does not call onChange if the value is not a valid integer', () => {
+        const onChangeSpy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} onChange={onChangeSpy} />,
+        );
+
+        element.find('input')!.trigger('onChange', {
+          currentTarget: {
+            value: 'string',
+          },
+        });
+
+        expect(onChangeSpy).not.toHaveBeenCalledWith();
+      });
+
+      it('adds an increment button that increases the value', () => {
+        const onChangeSpy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} onChange={onChangeSpy} />,
+        );
+        element!
+          .find('div', {
+            role: 'button',
+          })!
+          .trigger('onClick');
+        expect(onChangeSpy).toHaveBeenCalledWith('4', 'MyIntegerTextField');
+      });
+
+      it('adds a decrement button that increases the value', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            id="MyIntegerTextField"
+            label="IntegerTextField"
+            type="integer"
+            value="3"
+            onChange={spy}
+            autoComplete="off"
+          />,
+        );
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[1]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenCalledWith('2', 'MyIntegerTextField');
+      });
+
+      it('does not call the onChange if the value is not valid', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            label="IntegerTextField"
+            type="integer"
+            value="not a number"
+            onChange={spy}
+            autoComplete="off"
+          />,
+        );
+
+        element!
+          .find('div', {
+            role: 'button',
+          })!
+          .trigger('onClick');
+
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('handles incrementing from no value', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            {...defaultIntegerProps}
+            value={undefined}
+            onChange={spy}
+          />,
+        );
+        element
+          .findAll('div', {
+            role: 'button',
+          })[0]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenCalledWith('1', 'MyIntegerTextField');
+      });
+
+      it('passes the step prop to the input', () => {
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} step={6} />,
+        );
+
+        expect(element).toContainReactComponent('input', {
+          step: 6,
+        });
+      });
+
+      it('passes the a rounded step prop to the input', () => {
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} step={6.4} />,
+        );
+
+        expect(element).toContainReactComponent('input', {
+          step: 6,
+        });
+      });
+
+      it('uses the step prop when incrementing', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            {...defaultIntegerProps}
+            value="1"
+            step={1}
+            onChange={spy}
+          />,
+        );
+        element!
+          .find('div', {
+            role: 'button',
+          })!
+          .trigger('onClick');
+        expect(spy).toHaveBeenCalledWith('2', 'MyIntegerTextField');
+      });
+
+      it('respects a min value', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            {...defaultIntegerProps}
+            min={2}
+            value="2"
+            onChange={spy}
+          />,
+        );
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[1]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenLastCalledWith('2', 'MyIntegerTextField');
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[0]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenLastCalledWith('3', 'MyIntegerTextField');
+      });
+
+      it('respects a max value', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            {...defaultIntegerProps}
+            onChange={spy}
+            value="2"
+            max={2}
+          />,
+        );
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[0]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenLastCalledWith('2', 'MyIntegerTextField');
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[1]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenLastCalledWith('1', 'MyIntegerTextField');
+      });
+
+      it('brings an invalid value up to the min', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            {...defaultIntegerProps}
+            value="-1"
+            min={2}
+            onChange={spy}
+          />,
+        );
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[0]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenLastCalledWith('2', 'MyIntegerTextField');
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[1]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenLastCalledWith('2', 'MyIntegerTextField');
+      });
+
+      it('brings an invalid value down to the max', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} max={2} onChange={spy} />,
+        );
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[0]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenLastCalledWith('2', 'MyIntegerTextField');
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[1]!
+          .trigger('onClick');
+        expect(spy).toHaveBeenLastCalledWith('2', 'MyIntegerTextField');
+      });
+
+      it('removes increment and decrement buttons when disabled', () => {
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} disabled />,
+        );
+        expect(element).not.toContainReactComponent('[role="button"]');
+      });
+
+      it('removes increment and decrement buttons when readOnly', () => {
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} readOnly />,
+        );
+        expect(element).not.toContainReactComponent(Spinner);
+      });
+
+      it('removes spinner buttons when step is 0', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} step={0} onChange={spy} />,
+        );
+        expect(element).not.toContainReactComponent(Spinner);
+      });
+
+      it('decrements on mouse down', () => {
+        jest.useFakeTimers();
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} onChange={spy} />,
+        );
+        element
+          .findAll('div', {role: 'button'})[1]
+          .trigger('onMouseDown', {button: 0});
+
+        jest.runOnlyPendingTimers();
+        expect(spy).toHaveBeenCalledWith('2', 'MyIntegerTextField');
+      });
+
+      it('stops decrementing on mouse up', () => {
+        jest.useFakeTimers();
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField {...defaultIntegerProps} onChange={spy} />,
+        );
+
+        const buttonDiv = element.findAll('div', {role: 'button'})[1];
+
+        buttonDiv.trigger('onMouseDown', {button: 0});
+        buttonDiv.trigger('onMouseUp');
+
+        jest.runOnlyPendingTimers();
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      describe('document events', () => {
+        type EventCallback = (mockEventData?: {[key: string]: any}) => void;
+
+        const documentEvent: {[eventType: string]: EventCallback} = {};
+
+        beforeAll(() => {
+          jest
+            .spyOn(document, 'addEventListener')
+            .mockImplementation(
+              (eventType: string, callback: EventCallback) => {
+                documentEvent[eventType] = callback;
+              },
+            );
+        });
+
+        afterAll(() => {
+          (document.addEventListener as jest.Mock).mockRestore();
+        });
+
+        it('stops decrementing on mouse up anywhere in document', () => {
+          jest.useFakeTimers();
+          const spy = jest.fn();
+          const element = mountWithApp(
+            <TextField {...defaultIntegerProps} onChange={spy} />,
           );
 
           element


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/inventory-roadmap/issues/431

This PR adds a new `integer` type to the `<TextField />` component. This has been added for the following reasons:

1. To fix issues caused by using the `type="number"` field that are caused by React generated number fields, specifically the issue which causes the value to change if a user scrolls whilst hovering over a focused input. This leads to input values being altered without realising. Not using `type="number"` is also recommended for [this reason](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#accessibility).

    <img src="https://screenshot.click/08-50-6w9a1-cdcsb.gif" width="500px" />


2. Better input validation. `-+eE.` are all values allowed in a number input, but these values are not captured in the `onChange` handler, so additional keypress validation needs to be added to allow/disallow/validate these values. This new type only allows `-` outside of 0-9 digits, and this value can easily be validated against in the `<TextField />` onChange handler.
3. Reduced need for validation. A lot of uses of the `type="number"` do not need exponentials, decimals or values with a `+`. This creates a type with a simpler API.
4. Non-breaking. Introducing a new type, rather than altering the existing number type will be a non-breaking change, this is important because:  
    i. Other uses of `type="number"` may use the wider range of allowed input values (as the number input matches the number spec for [floating point numbers](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-floating-point-number)). Especially valid uses of decimals for inputting values such as weight.
    ii. Altering the type to allow text, which then fires the `onChange` callback when entering a value such as `-` can break existing validation that have been added to handle non-numeric values in a number input. In addition new validation may be required to handle the `-` if switching to the new type. This prevents breaking changes to existing implementations.


Initial explorations looked into creating a non-Polaris wrapper to achieve this, but we want to retain the `Spinner` component to step values.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR uses this [article from the UK GOV Design System](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/) as a jumping off point.

This component also is opinionated in providing some default values.

* Adds a new type to `<TextField />` called `integer`. When used this sets the created input type to `<input type="text" />`
* Includes the `Spinner` component to allow stepping of values when the type is `integer`
* Adds a `roundedStep` to prevent decimal values being introduced when using the new type
* `Pattern` defaults to `'^[-0]?[0-9]*'` if the type is `integer`, but this can be overwritten by a supplied pattern
* `InputMode` is set to `numeric` by default, but this can be overwritten by a supplied pattern
* Validates inputs against the input pattern `^[-]?[0-9]*` to only allow valid integers (or an empty input) to be entered.

There are no visual changes/differences between the `number` and `integer` types.


> **Note**
Another considerations was to create a `decimal` type that included all these changes, but allowed for `.` to be entered. Users could then still validate themselves against this if they wanted to prevent decimal values. But creating a type called decimal that would be largely used to explicitly exclude them seemed like an anti-pattern.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
