### PR TITLE
Add workflow for encouraging issue activity and auto closing issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '31 3 * * *' # randomly chosen time of day
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 21
+          days-before-pr-stale: 30
+          days-before-close: 7
+          stale-issue-message: |-
+            This issue seems inactive. If it's still relevant, please add a comment saying so. Otherwise, take no action.
+            → If there's no activity within a week, then a bot will automatically close this.
+            Thanks for helping to improve Shopify's design system and dev experience.
+          stale-pr-message: |-
+            This PR seems inactive. If it's still relevant, please add a comment saying so. Otherwise, take no action.
+            → If there's no activity within a week, then a bot will automatically close this.
+            Thanks for helping to improve Shopify's design system and dev experience.
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          ascending: true
+          # The math seems a bit fuzzy, but this should amount to a max of 50 issues daily.
+          # But then the same issues get checked first so we don't end up progressing too quickly until we can close what we started.
+          # Hopefully https://github.com/actions/stale/issues/692 will be closed and fix some of this mess.
+          operations-per-run: 200


### PR DESCRIPTION
### WHAT is this pull request doing?

This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.

See the GitHub action here 👈 

> Marks issues and pull requests that have not had recent interaction

See example in [Shopify/cli repo](https://github.com/Shopify/cli/pull/1255#issuecomment-1455389833)

<img width="955" alt="Screenshot 2023-03-07 at 4 15 54 PM" src="https://user-images.githubusercontent.com/11774595/223554671-d373fafe-b807-4613-8a36-92df56dafb0a.png">

