### PR TITLE
[polaris.shopify.com] Fix pattern examples

### DIFF
--- a/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
@@ -50,7 +50,7 @@ This pattern uses the [`AlphaStack`](/components/layout-and-structure/alpha-stac
   <AlphaStack gap="16" align="center">
     <Columns columns={{ xs: "1fr", md: "2fr 5fr" }}>
       <Box as="section" paddingInlineStart={{ xs: 4, sm: 0 }} paddingInlineEnd={{ xs: 2, sm: 0 }}>
-        <AlphaStack gap="4">
+        <AlphaStack align="start" gap="4">
           <Text as="h3" variant="headingMd">
             InterJambs
           </Text>
@@ -68,7 +68,7 @@ This pattern uses the [`AlphaStack`](/components/layout-and-structure/alpha-stac
     </Columns>
     <Columns columns={{ xs: "1fr", md: "2fr 5fr" }}>
     <Box as="section" paddingInlineStart={{ xs: 2, sm: 0 }} paddingInlineEnd={{ xs: 2, sm: 0 }}>
-        <AlphaStack gap="4">
+        <AlphaStack align="start" gap="4">
           <Text as="h3" variant="headingMd">
             Dimensions
           </Text>

--- a/polaris.shopify.com/content/patterns/date-picking/variants/date-range.md
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/date-range.md
@@ -323,8 +323,8 @@ function DateRangePicker() {
             )}
           </Box>
           <Box padding={{xs: 5}} maxWidth={mdDown ? '320px' : '516px'}>
-            <AlphaStack fullWidth gap="4">
-              <Inline>
+            <AlphaStack align="start" fullWidth gap="4">
+              <Inline gap="2">
                 <div style={{flexGrow: 1}}>
                   <TextField
                     role="combobox"


### PR DESCRIPTION
We removed some defaults to layout components but didn't see the markdown examples 