### PR TITLE
[Text] Add in table to map variants to font tokens

### DIFF
--- a/.changeset/popular-geckos-tease.md
+++ b/.changeset/popular-geckos-tease.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Added in chart to map `Text` variants to font tokens

--- a/polaris.shopify.com/content/components/typography/text.md
+++ b/polaris.shopify.com/content/components/typography/text.md
@@ -45,6 +45,26 @@ examples:
       Use to set text color.
 ---
 
+## Variant tokens
+
+Each variant uses a predetermined combination of the [font tokens](/tokens/font) to set the size and line height. Heading variants have a set font weight but can be overridden by using the `fontWeight` prop.
+
+| Variant      | Font size token     | px value | rem value | Font line height token | Font weight token          | Reponsive |
+| ------------ | ------------------- | -------- | --------- | ---------------------- | -------------------------- | --------- |
+| `heading4Xl` | `--p-font-size-700` | 40       | 2.5       | `--p-line-height-7`    | `--p-font-weight-bold`     | Yes       |
+| `heading3Xl` | `--p-font-size-600` | 32       | 2         | `--p-line-height-6`    | `--p-font-weight-semibold` | Yes       |
+| `heading2Xl` | `--p-font-size-500` | 28       | 1.75      | `--p-line-height-5`    | `--p-font-weight-semibold` | Yes       |
+| `headingXl`  | `--p-font-size-400` | 24       | 1.5       | `--p-line-height-4`    | `--p-font-weight-semibold` | Yes       |
+| `headingLg`  | `--p-font-size-300` | 20       | 1.25      | `--p-line-height-3`    | `--p-font-weight-semibold` | Yes       |
+| `headingMd`  | `--p-font-size-200` | 16       | 1         | `--p-line-height-3`    | `--p-font-weight-semibold` | No        |
+| `headingSm`  | `--p-font-size-100` | 14       | 0.875     | `--p-line-height-2`    | `--p-font-weight-semibold` | No        |
+| `headingXs`  | `--p-font-size-75`  | 12       | 0.75      | `--p-line-height-1`    | `--p-font-weight-semibold` | No        |
+| `bodyLg`     | `--p-font-size-200` | 16       | 1         | `--p-line-height-2`    | `--p-font-weight-regular`  | No        |
+| `bodyMd`     | `--p-font-size-100` | 14       | 0.875     | `--p-line-height-2`    | `--p-font-weight-regular`  | No        |
+| `bodySm`     | `--p-font-size-75`  | 12       | 0.75      | `--p-line-height-1`    | `--p-font-weight-regular`  | No        |
+
+---
+
 ## Mapping from previous type components
 
 These are suggested replacements for existing text style components, but ultimately the best replacement should be evaluated based on the context of the usage. The `Text` component also requires setting the semantically appropriate html element through the `as` prop.

--- a/polaris.shopify.com/content/components/typography/text.md
+++ b/polaris.shopify.com/content/components/typography/text.md
@@ -47,7 +47,7 @@ examples:
 
 ## Variant tokens
 
-Each variant uses a predetermined combination of the [font tokens](/tokens/font) to set the size and line height. Heading variants have a set font weight but can be overridden by using the `fontWeight` prop.
+Each variant uses a predetermined combination of the [font tokens](/tokens/font) to set the font size and line height. Heading variants have a set font weight but can be overridden by using the `fontWeight` prop.
 
 | Variant      | Font size token     | px value | rem value | Font line height token | Font weight token          | Reponsive |
 | ------------ | ------------------- | -------- | --------- | ---------------------- | -------------------------- | --------- |


### PR DESCRIPTION
### WHY are these changes introduced?

Adds in table to show what tokens each `Text` variant maps to for clarity.

### WHAT is this pull request doing?

New table:
    <details>
      <summary>Text variant chart</summary>
      <img src="https://user-images.githubusercontent.com/26749317/223731990-be8ef776-8e4a-4af1-8f17-04ff6ad3395d.png" alt="Text variant chart">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
