### PR TITLE
Add `shadow` token page to doc site

### DIFF
--- a/.changeset/lucky-mugs-fold.md
+++ b/.changeset/lucky-mugs-fold.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Added a `shadow` token page

--- a/polaris.shopify.com/pages/tokens/shadow.tsx
+++ b/polaris.shopify.com/pages/tokens/shadow.tsx
@@ -1,0 +1,16 @@
+import type {NextPage} from 'next';
+import React from 'react';
+import TokensPage from '../../src/components/TokensPage';
+import PageMeta from '../../src/components/PageMeta';
+
+const Components: NextPage = () => {
+  return (
+    <>
+      <PageMeta title="Shadow tokens" />
+
+      <TokensPage tokenGroup={'shadow'} />
+    </>
+  );
+};
+
+export default Components;

--- a/polaris.shopify.com/src/components/TokensPage/TokensPage.module.scss
+++ b/polaris.shopify.com/src/components/TokensPage/TokensPage.module.scss
@@ -79,10 +79,12 @@
         padding: 0.66rem 0;
       }
 
-      li:nth-last-child(1),
-      li:nth-last-child(2),
-      li:nth-last-child(3),
-      li:nth-last-child(4) {
+      // Temporality disabling these styles until v11 ships and we get rid of the depth token group
+      // li:nth-last-child(1),
+      // li:nth-last-child(2),
+      // li:nth-last-child(3),
+      // li:nth-last-child(4) {
+      li:nth-last-child(1) {
         a {
           border-bottom: none;
         }

--- a/polaris.shopify.com/src/components/TokensPage/TokensPage.module.scss
+++ b/polaris.shopify.com/src/components/TokensPage/TokensPage.module.scss
@@ -37,6 +37,8 @@
 
   li {
     flex: 1;
+    // Temporality adding this style until v11 ships and we get rid of the depth token group
+    min-width: 125px;
   }
 
   a {

--- a/polaris.shopify.com/src/components/TokensPage/TokensPage.tsx
+++ b/polaris.shopify.com/src/components/TokensPage/TokensPage.tsx
@@ -14,6 +14,7 @@ interface Props {
     | 'depth'
     | 'font'
     | 'motion'
+    | 'shadow'
     | 'shape'
     | 'spacing'
     | 'zIndex';
@@ -46,6 +47,10 @@ const navItems: NavItem[] = [
   {
     title: 'Depth',
     url: `/tokens/depth`,
+  },
+  {
+    title: 'Shadow',
+    url: `/tokens/shadow`,
   },
   {
     title: 'Motion',
@@ -84,6 +89,7 @@ function TokensPage({tokenGroup}: Props) {
     depth: tokensToFilteredArray(filter, allTokens.depth),
     font: tokensToFilteredArray(filter, allTokens.font),
     motion: tokensToFilteredArray(filter, allTokens.motion),
+    shadow: tokensToFilteredArray(filter, allTokens.shadow),
     shape: tokensToFilteredArray(filter, allTokens.shape),
     spacing: tokensToFilteredArray(filter, allTokens.spacing),
     zIndex: tokensToFilteredArray(filter, allTokens.zIndex),


### PR DESCRIPTION
### WHY are these changes introduced?

As part of the `depth` migrations in #8601 we need to [link to a `shadow` token page](https://github.com/Shopify/polaris/pull/8601/files#diff-0f4bc0b422fb2f3107067344db31d5b898341144512c01d842270e79dac23eabR34) on polaris.shopify.com

### WHAT is this pull request doing?
Adds a `shadow` token tab and page on polaris.shopify.com. This page will replace the `depth` token page (which will be removed in v11). 

![localhost_3000_tokens_shadow](https://user-images.githubusercontent.com/21976492/223870427-ee3d0eb2-cf9b-45e5-b220-0a1272918471.png)
![localhost_3000_tokens_shadow (1)](https://user-images.githubusercontent.com/21976492/223870437-f1195d27-fa94-4c04-aed2-3abd2c542eff.png)

How the tabs wrap on smaller screen sizes isn't the most beautiful thing but I don't want to refactor the code when we're going to remove the `depth` token group in the next few weeks. 