### PR TITLE
Fix <Code> renderer on Patterns pages to support code blocks without meta

### DIFF
--- a/.changeset/brown-wasps-refuse.md
+++ b/.changeset/brown-wasps-refuse.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix <Code> renderer on Patterns pages to support code blocks without meta

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -23,6 +23,7 @@ import {PatternVariantFontMatter, PatternFrontMatter} from '../../types';
 import PageMeta from '../PageMeta';
 import {Stack, Row} from '../Stack';
 import {Box} from '../Box';
+import Code from '../Code';
 import {Lede} from '../Lede';
 import {Heading} from '../Heading';
 import PatternsExample from '../PatternsExample';
@@ -60,10 +61,17 @@ function codeAsContext(): Plugin {
       meta: Record<string, any>;
     }[] = [];
     visit(tree, 'code', (node, index, parent) => {
-      try {
-        codes.push({node, index: index!, parent, meta: JSON.parse(node.meta)});
-      } catch (error) {
-        // Just ignore this block
+      if (node.meta) {
+        try {
+          codes.push({
+            node,
+            index: index!,
+            parent,
+            meta: JSON.parse(node.meta),
+          });
+        } catch (error) {
+          // Just ignore this block
+        }
       }
     });
 
@@ -263,7 +271,7 @@ const BaseMarkdown = ({
             <Image fill src={src} alt={alt ?? ''} />
           </div>
         ) : null,
-      code: function Code({
+      code: function MdCode({
         inline,
         // @ts-expect-error Unsure how to tell react-markdown this prop is
         // being injected by a plugin
@@ -301,7 +309,9 @@ const BaseMarkdown = ({
           );
         }
 
-        return <code>{(children?.[0] as string) ?? ''}</code>;
+        return (
+          <Code code={{title: '', code: (children?.[0] as string) ?? ''}} />
+        );
       },
       ...components,
     }}


### PR DESCRIPTION
### WHY are these changes introduced?

If adding content to a pattern page which looks like:

    ```
    <Foo />
    ```

The output would be:

    <code>
    <Foo />
    </code>

Which is incorrect; the syntax highlighting is missing.

### WHAT is this pull request doing?

This change ensures we use our syntax highlighted code component to render non-meta data code examples on Patterns pages.