### PR TITLE
Refactor Pattern MDX rendering to remove some duplication and table magic

### DIFF
--- a/.changeset/bright-geese-hang.md
+++ b/.changeset/bright-geese-hang.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Refactor Pattern MDX rendering to remove some duplication and table magic

--- a/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
@@ -105,10 +105,8 @@ function AppSettingsLayoutExample() {
 
 ### Useful to know
 
-|                                                  |                                                                                                            |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| Don't include a description unless it's helpful. | ![Section header with no description on an app settings page](/images/patterns/app-settings-usage-1.png)   |
-| Place grouped settings within cards.             | ![App settings page with section headings and grouped settings](/images/patterns/app-settings-usage-2.png) |
-| Stack all setting groups vertically on the page. | ![App settings page with two vertically stacked sections](/images/patterns/app-settings-usage-3.png)       |
+- <span>Don't include a description unless it's helpful.</span> ![Section header with no description on an app settings page](/images/patterns/app-settings-usage-1.png)
+- <span>Place grouped settings within cards.</span> ![App settings page with section headings and grouped settings](/images/patterns/app-settings-usage-2.png)
+- <span>Stack all setting groups vertically on the page.</span> ![App settings page with two vertically stacked sections](/images/patterns/app-settings-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/date-picking/variants/date-list.md
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/date-list.md
@@ -120,10 +120,8 @@ function DateListPicker() {
 
 ### Useful to know
 
-|                                                                                                                                 |                                                                                                                                     |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| In the button preview, set a default date range that a merchant will most likely use.                                           | ![Button showing a calendar icon labeled “Today”](/images/patterns/date-list-usage-1.png)                                           |
-| Single dates should be at the top of the list, followed by date ranges from smallest to largest ranges.                         | ![Option list with common suggested dates followed by ranges](/images/patterns/date-list-usage-2.png)                               |
-| A date list can be modified to serve unique situations, like providing suggested search queries in the customer segment editor. | ![Customer segment editor with a date list showing common ranges and related code snippets](/images/patterns/date-list-usage-3.png) |
+- <span>In the button preview, set a default date range that a merchant will most likely use.</span> ![Button showing a calendar icon labeled “Today”](/images/patterns/date-list-usage-1.png)
+- <span>Single dates should be at the top of the list, followed by date ranges from smallest to largest ranges.</span> ![Option list with common suggested dates followed by ranges](/images/patterns/date-list-usage-2.png)
+- <span>A date list can be modified to serve unique situations, like providing suggested search queries in the customer segment editor.</span> ![Customer segment editor with a date list showing common ranges and related code snippets](/images/patterns/date-list-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/date-picking/variants/date-range.md
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/date-range.md
@@ -389,10 +389,8 @@ function DateRangePicker() {
 
 ### Useful to know
 
-|                                                                                                |                                                                                                      |
-| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Pin any relevant, merchant-specific dates to the top of the option list.                       | ![List of date options such as “BFCM (2023)”](/images/patterns/date-range-usage-1.png)               |
-| If a date cannot be selected, indicate it with the [disabled text color token](/tokens/colors) | ![Single-month calendar with a range of unselectable dates](/images/patterns/date-range-usage-2.png) |
-| If a merchant enters a nonexistent date, revert to the previously selected date.               | ![Calendar with date inputs reading an incorrect date](/images/patterns/date-range-usage-3.png)      |
+- <span>Pin any relevant, merchant-specific dates to the top of the option list.</span> ![List of date options such as “BFCM (2023)”](/images/patterns/date-range-usage-1.png)
+- <span>If a date cannot be selected, indicate it with the [disabled text color token](/tokens/colors)</span> ![Single-month calendar with a range of unselectable dates](/images/patterns/date-range-usage-2.png)
+- <span>If a merchant enters a nonexistent date, revert to the previously selected date.</span> ![Calendar with date inputs reading an incorrect date](/images/patterns/date-range-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/date-picking/variants/single-date.md
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/single-date.md
@@ -137,9 +137,7 @@ function DatePickerExample() {
 
 ### Useful to know
 
-|                                                                                                        |                                                                                                                                                        |
-| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Labels need to simply depict the task at hand. Whether that be a start date, end date, start time etc. | ![Date input labeled “Expiry date”](/images/patterns/single-list-usage-1.png)                                                                          |
-| This pattern can be duplicated to allow users to add an end date or time.                              | ![“Active dates” section with “start date” and “end date” inputs, toggled on with a “Set end date” checkbox](/images/patterns/single-list-usage-2.png) |
+- <span>Labels need to simply depict the task at hand. Whether that be a start date, end date, start time etc.</span> ![Date input labeled “Expiry date”](/images/patterns/single-list-usage-1.png)
+- <span>This pattern can be duplicated to allow users to add an end date or time.</span> ![“Active dates” section with “start date” and “end date” inputs, toggled on with a “Set end date” checkbox](/images/patterns/single-list-usage-2.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/resource-details-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/resource-details-layout/variants/default.md
@@ -142,12 +142,10 @@ function ResourceDetailsLayout() {
 
 ### Useful to know
 
-|                                                                                                  |                                                                                                                                                         |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Always use the default width. Full width tends to waste space and make the page harder to parse. | ![Details page with margins on either side of the main content](/images/patterns/resource-detail-usage-1.png)                                           |
-| Group similar content in the same card.                                                          | ![Diagram showing multiple cards compared to a single card that groups the same content](/images/patterns/resource-detail-usage-2.png)                  |
-| Put information that defines the resource object in the primary column.                          | ![Product detail example](/images/patterns/resource-detail-usage-3.png)                                                                                 |
-| Put supporting information such as status, metadata, and summaries in the secondary column.      | ![Product details page with the secondary column outlined](/images/patterns/resource-detail-usage-4.png)                                                |
-| Arrange content in order of importance.                                                          | ![Product details page with “Very important section” card placed above “Somewhat important section” card](/images/patterns/resource-detail-usage-5.png) |
+- <span>Always use the default width. Full width tends to waste space and make the page harder to parse.</span> ![Details page with margins on either side of the main content](/images/patterns/resource-detail-usage-1.png)
+- <span>Group similar content in the same card.</span> ![Diagram showing multiple cards compared to a single card that groups the same content](/images/patterns/resource-detail-usage-2.png)
+- <span>Put information that defines the resource object in the primary column.</span> ![Product detail example](/images/patterns/resource-detail-usage-3.png)
+- <span>Put supporting information such as status, metadata, and summaries in the secondary column.</span> ![Product details page with the secondary column outlined](/images/patterns/resource-detail-usage-4.png)
+- <span>Arrange content in order of importance.</span> ![Product details page with “Very important section” card placed above “Somewhat important section” card](/images/patterns/resource-detail-usage-5.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/resource-index-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/resource-index-layout/variants/default.md
@@ -56,10 +56,8 @@ This pattern uses the [`Layout`](/components/layout-and-structure/layout), [`Pag
 
 ### Useful to know
 
-|                                                                                                                                   |                                                                                                              |
-| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Use the resource type as page title.                                                                                              | ![“Orders” and “Gift cards” pages](/images/patterns/resource-index-usage-1.png)                              |
-| Always use the primary action in the top right corner for resource creation. Remove the button if there is no such functionality. | ![“Add product” primary action button on a resource index page](/images/patterns/resource-index-usage-2.png) |
-| Set the page width to normal if the index doesn’t need full width.                                                                | ![Index page with margins on either side of the main content](/images/patterns/resource-index-usage-3.png)   |
+- <span>Use the resource type as page title.</span> ![“Orders” and “Gift cards” pages](/images/patterns/resource-index-usage-1.png)
+- <span>Always use the primary action in the top right corner for resource creation. Remove the button if there is no such functionality.</span> ![“Add product” primary action button on a resource index page](/images/patterns/resource-index-usage-2.png)
+- <span>Set the page width to normal if the index doesn’t need full width.</span> ![Index page with margins on either side of the main content](/images/patterns/resource-index-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -57,13 +57,6 @@
   }
 }
 
-.UsageTable {
-  td:first-child {
-    width: 0;
-    white-space: nowrap;
-  }
-}
-
 .TabList {
   --border-subdued: rgba(201, 204, 207, 1);
 
@@ -172,54 +165,63 @@
   }
 }
 
-.UsageGuidelinesGrid {
-  display: grid;
-  column-gap: var(--p-space-4);
-  row-gap: var(--p-space-8);
+.UsefulToKnow {
+  & > ul {
+    display: grid;
+    column-gap: var(--p-space-4);
+    row-gap: var(--p-space-8);
 
-  --txt-column-width: 35%;
-  /*
+    --txt-column-width: 35%;
+    /*
    * Rules of the grid:
    * The second (img) column should never be bigger than 30rem.
    * The first (text) column should never shrink below 35% of the container.
    * The first (text) column should grow to fill the remaining space (1fr).
    * The second (img) column should never shrink below 20rem. */
-  grid-template-columns:
-    minmax(
-      // Give this column a minimum width (thin container)
-      var(--txt-column-width),
-      // Grow to fill the remaining space when possible (wide container)
-      1fr
-    )
-    minmax(
-      min(
-        // Minimum size of 20rem to keep it legible
-        20rem,
-        // Except when the container is too thin: let it shrinnk so the text
-        // column can still take up its desired minimum width
-        calc(100% - var(--txt-column-width))
-      ),
-      // Maximum width (wide container) - avoids gigantic images
-      30rem
-    );
+    grid-template-columns:
+      minmax(
+        // Give this column a minimum width (thin container)
+        var(--txt-column-width),
+        // Grow to fill the remaining space when possible (wide container)
+        1fr
+      )
+      minmax(
+        min(
+          // Minimum size of 20rem to keep it legible
+          20rem,
+          // Except when the container is too thin: let it shrinnk so the text
+          // column can still take up its desired minimum width
+          calc(100% - var(--txt-column-width))
+        ),
+        // Maximum width (wide container) - avoids gigantic images
+        30rem
+      );
 
-  @media screen and (max-width: $breakpointMobile) {
-    grid-template-columns: 1fr;
-    row-gap: var(--p-space-4);
-  }
+    @media screen and (max-width: $breakpointMobile) {
+      grid-template-columns: 1fr;
+      row-gap: var(--p-space-4);
+    }
 
-  .UsageGuidelinesRow {
-    display: contents;
-  }
+    & > li {
+      display: contents;
+      &::before {
+        display: none;
+      }
 
-  .ImageWrapper {
-    aspect-ratio: 485/315;
-    position: relative;
-    background: var(--p-surface-depressed);
-    display: block;
-    overflow: hidden;
-    > img {
-      object-fit: cover;
+      & > span {
+        display: contents;
+      }
+    }
+
+    .ImageWrapper {
+      aspect-ratio: 485/315;
+      position: relative;
+      background: var(--p-surface-depressed);
+      display: block;
+      overflow: hidden;
+      > img {
+        object-fit: cover;
+      }
     }
   }
 }

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Fragment,
-  useState,
-  createContext,
-  useContext,
-  useEffect,
-} from 'react';
+import React, {useState, createContext, useContext, useEffect} from 'react';
 import {Tab} from '@headlessui/react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -181,17 +175,24 @@ const Variants = (props: {patternData: Props['data']}) => {
     <Container patternData={props.patternData}>
       {(variant) => (
         <Stack gap="8" className={styles.Variant}>
-          <VariantMarkdown
+          <PatternMarkdown
+            patternData={props.patternData}
             patternName={`${props.patternData.title}${
               variant.data.title ? ` > ${variant.data.title}` : ''
             }`}
           >
             {variant.content}
-          </VariantMarkdown>
+          </PatternMarkdown>
         </Stack>
       )}
     </Container>
   );
+};
+
+type MDXComponents = {
+  [key: string]: React.ComponentType<
+    React.PropsWithChildren<{[key: string]: any}>
+  >;
 };
 
 const BaseMarkdown = ({
@@ -202,11 +203,7 @@ const BaseMarkdown = ({
 }: {
   children: string;
   components?: React.ComponentProps<typeof Markdown>['components'];
-  mdxComponents?: {
-    [key: string]: React.ComponentType<
-      React.PropsWithChildren<{[key: string]: any}>
-    >;
-  };
+  mdxComponents?: MDXComponents;
   patternName?: string;
 }) => (
   <Markdown
@@ -320,84 +317,48 @@ const BaseMarkdown = ({
   </Markdown>
 );
 
+const defaultMdxComponents: MDXComponents = {
+  Stack: ({gap, children}) => <Stack gap={gap}>{children}</Stack>,
+  Hero: ({children}) => <Box className={styles.Hero}>{children}</Box>,
+  HowItHelps: ({children}) => (
+    <Stack gap="4" className={styles.HowItHelps}>
+      {children}
+    </Stack>
+  ),
+  Usage: ({children}) => (
+    <Stack gap="4" className={styles.Usage}>
+      {children}
+    </Stack>
+  ),
+  UsefulToKnow: ({children}) => (
+    <Stack gap="4" className={styles.UsefulToKnow}>
+      {children}
+    </Stack>
+  ),
+  DefinitionTable: ({children}) => (
+    <Box className={styles.DefinitionTable}>{children}</Box>
+  ),
+};
+
 const PatternMarkdown = ({
   children,
   patternData,
+  patternName,
 }: {
   children: string;
   patternData: Props['data'];
+  patternName?: string;
 }) => (
   <BaseMarkdown
+    patternName={patternName ?? ''}
     mdxComponents={{
+      ...defaultMdxComponents,
       Variants: () => <Variants patternData={patternData} />,
-      Stack: ({gap, children}) => <Stack gap={gap}>{children}</Stack>,
     }}
   >
     {children}
   </BaseMarkdown>
 );
-
-const VariantMarkdown = ({
-  children,
-  patternName,
-}: {
-  children: string;
-  patternName: string;
-}) => {
-  return (
-    <BaseMarkdown
-      patternName={patternName}
-      components={{
-        // We're using table as a handy shortcut for rendering a CSS grid
-        // But that grid is actually rendered as an unordered list of items!
-        // Should probably just be MDX at this point...
-        table: ({children}) => (
-          <Box as="ul" className={styles.UsageGuidelinesGrid}>
-            {children}
-          </Box>
-        ),
-        // don't need this extra wrapping element, so pass it through
-        tbody: ({children}) => <Fragment>{children}</Fragment>,
-        // We don't use theads here
-        thead: () => null,
-        tr: ({children}) => (
-          <Box as="li" className={styles.UsageGuidelinesRow}>
-            {children}
-          </Box>
-        ),
-        td: ({children, node}) =>
-          node?.children?.[0].type === 'text' ? (
-            <p>{children}</p>
-          ) : (
-            <Fragment>{children}</Fragment>
-          ),
-      }}
-      mdxComponents={{
-        Hero: ({children}) => <Box className={styles.Hero}>{children}</Box>,
-        HowItHelps: ({children}) => (
-          <Stack gap="4" className={styles.HowItHelps}>
-            {children}
-          </Stack>
-        ),
-        Usage: ({children}) => (
-          <Stack gap="4" className={styles.Usage}>
-            {children}
-          </Stack>
-        ),
-        UsefulToKnow: ({children}) => (
-          <Stack gap="4" className={styles.UsefulToKnow}>
-            {children}
-          </Stack>
-        ),
-        DefinitionTable: ({children}) => (
-          <Box className={styles.DefinitionTable}>{children}</Box>
-        ),
-      }}
-    >
-      {children}
-    </BaseMarkdown>
-  );
-};
 
 export default function PatternPage(props: Props) {
   const [showCode, toggleCode] = useState(true);


### PR DESCRIPTION
### WHY are these changes introduced?

The initial implementation was overly complex trying to hijack table layouts. The nested markdown renderers were also restrictive in what visual elements could be rendered where.

### WHAT is this pull request doing?

We now use lists for the "Useful to know" section which make the markdown easier to understand, and less custom markdown handlers.

Also consolidated the markdown renderers to enable rendering all visual elements anywhere on the page, not just inside the "Variants" section.