### PR TITLE
[Layout foundations] Mark layout components beta

### DIFF
--- a/.changeset/tender-humans-cough.md
+++ b/.changeset/tender-humans-cough.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Marked layout components (`Box`, `Bleed`, `Card`, `Columns`, `Divider`, `Inline`, `Stack`) as beta

--- a/polaris.shopify.com/content/components/layout-and-structure/bleed.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/bleed.md
@@ -5,8 +5,8 @@ category: Layout and structure
 keywords:
   - layout
 status:
-  value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Beta
+  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: bleed-horizontal.tsx
     title: Horizontal

--- a/polaris.shopify.com/content/components/layout-and-structure/box.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/box.md
@@ -8,8 +8,8 @@ keywords:
   - responsive
   - tokens
 status:
-  value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Beta
+  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: box-with-color.tsx
     title: Color

--- a/polaris.shopify.com/content/components/layout-and-structure/card.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/card.md
@@ -23,8 +23,8 @@ keywords:
   - callout
   - call out
 status:
-  value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Beta
+  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: card-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/columns.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/columns.md
@@ -8,8 +8,8 @@ keywords:
   - grid
   - responsive
 status:
-  value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Beta
+  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: columns-with-varying-gap.tsx
     title: Gap

--- a/polaris.shopify.com/content/components/layout-and-structure/divider.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/divider.md
@@ -7,8 +7,8 @@ keywords:
   - divider
   - border
 status:
-  value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Beta
+  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: divider-with-border-styles.tsx
     title: Style

--- a/polaris.shopify.com/content/components/layout-and-structure/inline.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/inline.md
@@ -15,8 +15,8 @@ keywords:
   - horizontal row of components
   - stack
 status:
-  value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Beta
+  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: inline-with-non-wrapping.tsx
     title: Non-wrapping

--- a/polaris.shopify.com/content/components/layout-and-structure/stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/stack.md
@@ -12,8 +12,8 @@ keywords:
   - right-aligned stack
   - stack layout
 status:
-  value: Alpha
-  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Beta
+  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: stack-with-gap.tsx
     title: Gap


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #8630.

Marks layout components as beta.

### WHAT is this pull request doing?

Marks `Box`, `Bleed`, `Card`, `Columns`, `Divider`, `Inline`, `Stack` as beta.
    <details>
      <summary>Beta components</summary>
      <img src="https://user-images.githubusercontent.com/26749317/224385296-b2c4f75f-9f0f-45cb-a895-97e0ffa9de83.png" alt="Beta components">
    </details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
