### PR TITLE
Replace `@shopfiy/prettier-config` with in-repo config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "bracketSpacing": false,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@shopify/babel-preset": "^24.1.2",
     "@shopify/cli": "^3.10.1",
     "@shopify/eslint-plugin": "^42.0.1",
-    "@shopify/prettier-config": "^1.1.2",
     "@shopify/stylelint-plugin": "^11.0.0",
     "@shopify/typescript-configs": "^5.1.0",
     "@size-limit/preset-small-lib": "^5.0.3",
@@ -84,7 +83,6 @@
     "turbo": "^1.2.8",
     "typescript": "^4.6.3"
   },
-  "prettier": "@shopify/prettier-config",
   "size-limit": [
     {
       "name": "polaris-react-cjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3379,11 +3379,6 @@
     postcss-flexbugs-fixes "^5.0.2"
     postcss-will-change "^4.0.1"
 
-"@shopify/prettier-config@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@shopify/prettier-config/-/prettier-config-1.1.2.tgz#612f87c0cd1196e8b43c85425e587d0fa7f1172d"
-  integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
-
 "@shopify/react-testing@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@shopify/react-testing/-/react-testing-4.1.0.tgz#0564c5977f0cfbcda37c4b181b5ff52740ade970"


### PR DESCRIPTION
### WHY are these changes introduced?

I'm starting to push folks away from using web-configs packages as ownership of them is a bit fluffy.

### WHAT is this pull request doing?

This PR replaces [`@shopfiy/prettier-config`](https://unpkg.com/@shopify/prettier-config@1.1.2/index.json) with in-repo config. It's the same config, except I've omitted `"arrowParens": "always",` as that is already the default behaviour in Prettier v2.


### To test

See that lint passes as before.
