### PR TITLE
[AlphaStack] Add withDivider prop to insert Dividers between stack children

### DIFF
--- a/.changeset/cold-dingos-knock.md
+++ b/.changeset/cold-dingos-knock.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+<AlphaStack> now accepts `withDivider` prop to automatically insert <Divider /> between stack children (with optional style).

--- a/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.stories.tsx
@@ -101,3 +101,35 @@ export function WithAlignEnd() {
     </AlphaStack>
   );
 }
+
+export function WithDivider() {
+  return (
+    <AlphaStack gap="4" withDivider>
+      <Box background="surface" padding="1">
+        01
+      </Box>
+      <Box background="surface" padding="1">
+        02
+      </Box>
+      <Box background="surface" padding="1">
+        03
+      </Box>
+    </AlphaStack>
+  );
+}
+
+export function WithStyledDivider() {
+  return (
+    <AlphaStack gap="4" withDivider="dark">
+      <Box background="surface" padding="1">
+        01
+      </Box>
+      <Box background="surface" padding="1">
+        02
+      </Box>
+      <Box background="surface" padding="1">
+        03
+      </Box>
+    </AlphaStack>
+  );
+}

--- a/polaris-react/src/components/AlphaStack/AlphaStack.tsx
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.tsx
@@ -1,6 +1,7 @@
-import React, {createElement} from 'react';
+import React, {Fragment, createElement} from 'react';
 import type {SpacingSpaceScale} from '@shopify/polaris-tokens';
 
+import {Divider, type DividerProps} from '../Divider';
 import {
   classNames,
   sanitizeCustomProperties,
@@ -32,6 +33,11 @@ export interface AlphaStackProps extends React.AriaAttributes {
    * @default false
    */
   reverseOrder?: boolean;
+  /** Render a <Divider /> between each stack child. Setting to `true` will
+   * render the default style of <Divider />
+   * @default false
+   */
+  withDivider?: boolean | DividerProps['borderStyle'];
 }
 
 export const AlphaStack = ({
@@ -41,6 +47,7 @@ export const AlphaStack = ({
   gap,
   id,
   reverseOrder = false,
+  withDivider = false,
   ...restProps
 }: AlphaStackProps) => {
   const className = classNames(
@@ -55,6 +62,25 @@ export const AlphaStack = ({
     ...getResponsiveProps('stack', 'gap', 'space', gap),
   } as React.CSSProperties;
 
+  let dividedChildren = children;
+
+  if (withDivider) {
+    const dividerProps =
+      typeof withDivider === 'boolean' ? {} : {borderStyle: withDivider};
+
+    dividedChildren = React.Children.map(children, (child, index) => {
+      if (index === 0) {
+        return child;
+      }
+      return (
+        <Fragment key={index}>
+          <Divider {...dividerProps} />
+          {child}
+        </Fragment>
+      );
+    });
+  }
+
   return createElement(
     as,
     {
@@ -62,6 +88,6 @@ export const AlphaStack = ({
       style: sanitizeCustomProperties(style),
       ...restProps,
     },
-    children,
+    dividedChildren,
   );
 };

--- a/polaris-react/src/components/AlphaStack/tests/AlphaStack.test.tsx
+++ b/polaris-react/src/components/AlphaStack/tests/AlphaStack.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {AlphaStack} from '../AlphaStack';
+import {Divider} from '../../Divider';
 
 const text = 'This is a stack';
-const children = <p>{text}</p>;
+const children = [<p key="1">{text}</p>, <p key="2">{text}</p>];
 
 describe('<AlphaStack />', () => {
   it('renders children', () => {
@@ -48,6 +49,22 @@ describe('<AlphaStack />', () => {
         '--pc-stack-gap-md': 'var(--p-space-8)',
         '--pc-stack-gap-xs': 'var(--p-space-2)',
       }) as React.CSSProperties,
+    });
+  });
+
+  it('renders n-1 dividers', () => {
+    const stack = mountWithApp(<AlphaStack withDivider>{children}</AlphaStack>);
+
+    expect(stack).toContainReactComponentTimes(Divider, children.length - 1);
+  });
+
+  it('renders dividers with given style', () => {
+    const stack = mountWithApp(
+      <AlphaStack withDivider="dark">{children}</AlphaStack>,
+    );
+
+    expect(stack).toContainReactComponentTimes(Divider, children.length - 1, {
+      borderStyle: 'dark',
     });
   });
 });

--- a/polaris.shopify.com/content/components/layout-and-structure/alpha-stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/alpha-stack.md
@@ -23,6 +23,11 @@ examples:
     title: Align
     description: >-
       Control the horizontal alignment of children using the `align` prop.
+  - fileName: alpha-stack-with-divider.tsx
+    title: With divider
+    description: >-
+      Automatically insert a `<Divider />` between children using the
+      `withDivider` prop.
 ---
 
 ## Best practices

--- a/polaris.shopify.com/pages/examples/alpha-stack-with-divider.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-stack-with-divider.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {AlphaStack, Box} from '@shopify/polaris';
+
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+function AlphaStackWithDividerExample() {
+  return (
+    <AlphaStack gap="4" withDivider="divider">
+      <Box background="surface-success">&nbsp;</Box>
+      <Box background="surface-success">&nbsp;</Box>
+      <Box background="surface-success">&nbsp;</Box>
+    </AlphaStack>
+  );
+}
+
+export default withPolarisExample(AlphaStackWithDividerExample);


### PR DESCRIPTION
### WHY are these changes introduced?

It's currently possible to add `<Divider />`s manually to stacks;

```tsx
<AlphaStack>
  <Box />
  <Divider />
  <Box />
  <Divider />
  <Box />
</AlphaStack>
```

However, this comes with two big caveats:

1. No enforcement of consistency for all dividers.
    Human error could easily lead to rendering dividers with different `borderStyle` props, especially if those components are far apart / complex. It's even possible to accidentally forget a divider when there should be one:
    ```tsx
    <AlphaStack gap="4">
      <Box />
      <Divider borderStyle="dark" />
      <Box />
      <Divider borderStyle="dark" />
      <Box />
      <Divider borderStyle="dark" />
      <Box />
      <Box />
      <Divider borderStyle="divider" />
      <Box />
    </AlphaStack>
    ```
    _([sandbox link](https://polaris.shopify.com/sandbox?code=N4Igxg9gJgpiBcIA8BBANgBwBYEMDKALjmANYAEA5jhgLwA6IALAwHx0B2ZZSAQhAB5kARsRIUAThACu7KPRABnKeIBmxGAFp2MKQXE40rAGTshCjAG4kAej782nbgBEAlgDcXsccIjivhAE80GHkoHHESBjJrBy5eAWFRCWlZeSVVdS0dPQNjU3MrWwFY53dPGG8hX38CIJCGMIiomI44u0TSZJk5BnS1ME1tXX1DEBYTM0sbOxKkVw8vHz8KwODQ8MiQaNn2kU7JbrTlfsHskbzJwpnW7l2kg9Te48yhnNHx-Kmi%2Bxu5ssWqstxKt6iAoP8Ks0dgk9mIHj1FM8BllhrkxhMCtNihwbOhsPgiKQWCAADQgAhYGAAWxgCgQAG0QGgIGADDB4DB2CAALpkgDungpdPg9O5AF8gA))_
1. Requires the parent/rendering component to know where to insert dividers.
    When rendering lists of items within a stack, it requires custom logic to insert dividers between each element:
    ```tsx
    const items = ["foo", "bar", "baz", "zip"];
    return (
      <AlphaStack gap="8">
        {items.map((item, index) => {
          if (index === 0) {
            return item;
          }
          return (
            <>
              <Divider />
              {item}
            </>
          );
        })}
      </AlphaStack>
    );
    ```
    _([sandbox link](https://polaris.shopify.com/sandbox?code=N4Igxg9gJgpiBcJgAoBmBXAdmALgSwkwAIBlHAQzAGsARGAWwmQEojgAdYoyTAZxyJ4cDXkQC8RANrsQqCBBkAaIjIBG5AE5KVIdQC9tMvXgAOMgLoBuTkSIaYOdBuLIbtogB4AggBsTAC3IySioiAHNyEzEZAA4ZAD43dzYhEQA6ekjkZFT6ZTxMWAAPVjF4tiTkwVQiHMKYIvExCQAGVg4uKvd7R2dBYXprTqqAX0rknqcXcaqPROGu2w8aPAA3PFgNIgB6ecWq4FyxhdndmdtmIa6R5mPkj23fAKCKaj2iS84blmOQRRAcP4GDBeAhJCAfBAwOQfDB4DBMCBzP8AO4bQGg%2BCScwjIA))_

By enabling automatic insertion of dividers, both of these caveats become non-issues; The parent can defer _where_ to render dividers to the `<Stack>` component, and consistency is enforced by the `<Stack>` component:

```tsx
<AlphaStack withDivider>
  <Box />
  <Box />
  <Box />
</AlphaStack>
```

```tsx
const items = ["foo", "bar", "baz", "zip"];
return (
  <AlphaStack withDivider>
    {items.map(item => <Box>{item}</Box>)}
  </AlphaStack>
);
```

### WHAT is this pull request doing?

Added the `withDivider` prop to `<AlphaStack>`:

- Default: `false`
- When `false`, current beahviour is identical
- When `true`, renders a `<Divider />` between each child element
- Can provide a string which sets the divider style (uses the type from `Divider`'s `borderStyle` prop).

✅ Added Storybook story, tests, and documentation.

### Prior work

- In https://github.com/Shopify/polaris/pull/8588, it was decided that adding new props to `AlphaStack` was not a direction we wanted to go in. This PR is opposed to that decision.
- Other design systems provide the same/similar functionality (automatically inserting dividers with a prop):
  - [Chakra UI's `divider` prop on `<Stack>`](https://chakra-ui.com/docs/components/stack/usage#stack-dividers)
  - [Braid's `dividers` prop on `<Stack>`](https://seek-oss.github.io/braid-design-system/components/Stack#dividers)
  - [MUI's `divider` prop on `<Stack>`](https://mui.com/material-ui/react-stack/#dividers)
