### PR TITLE
[Layout] `Stack` order default

### DIFF
--- a/.changeset/plenty-impalas-provide.md
+++ b/.changeset/plenty-impalas-provide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated default stack order custom property

--- a/polaris-react/src/components/AlphaStack/AlphaStack.scss
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.scss
@@ -3,6 +3,7 @@
 .AlphaStack {
   // stylelint-disable -- Polaris component custom properties
   --pc-stack-align: initial;
+  --pc-stack-order: initial;
   --pc-stack-gap-xs: 0;
   --pc-stack-gap-sm: var(--pc-stack-gap-xs);
   --pc-stack-gap-md: var(--pc-stack-gap-sm);


### PR DESCRIPTION
### WHY are these changes introduced?

Prevents order from being inherited within nested `Stack`s

### WHAT is this pull request doing?

Sets default for `--pc-stack-order` to `initial`