### PR TITLE
Adjust CSS for expanded navigation section to remove unwanted space during collapse/expand

### DIFF
--- a/.changeset/smart-pillows-buy.md
+++ b/.changeset/smart-pillows-buy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Adjust CSS for expanded navigation section to remove unwanted space during collapse/expand

--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -381,14 +381,11 @@ $disabled-fade: 0.6;
   margin-left: 0;
   overflow-x: visible;
 
-  &.isExpanded {
-    margin-bottom: var(--p-space-2);
-  }
-
   .List {
     margin: 0;
     padding: 0;
     list-style: none;
+    margin-bottom: var(--p-space-2);
   }
 
   .Item {

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -303,7 +303,6 @@ export function Item({
 
     const SecondaryNavigationClassName = classNames(
       styles.SecondaryNavigation,
-      showExpanded && styles.isExpanded,
       !icon && styles['SecondaryNavigation-noIcon'],
     );
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves #8653

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

There is a synchronization issue in which we have a sort of half-open state for navigation sections. This moves the style from that half-open state to the fully-open state. 

The half-open state might still exist (because `Secondary` uses `Collapsible` which wants to do animations) but AFAIK it's not causing any unwanted behaviour.


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

This can be tested if you check out my Navigation storybook improvements in #8652 and cherry pick this commit over to that branch, or vice versa. Try switching between sections, and record a high-speed video of it to see the difference.

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
