### PR TITLE
Add back needless disables to all stylelint comments

### DIFF
--- a/.changeset/fast-glasses-rhyme.md
+++ b/.changeset/fast-glasses-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': major
+---
+
+Turn on reportNeedlessDisables for all comments

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -504,15 +504,7 @@ const stylelintPolarisCoverageOptions = {
 module.exports = {
   customSyntax: 'postcss-scss',
   reportDescriptionlessDisables: true,
-  reportNeedlessDisables: [
-    true,
-    {
-      // Report needless disables for all rules except layout coverage rules
-      // Note: This doesn't affect the default Stylelint behavior/reporting
-      // and is only need because we dynamically create these rule names
-      except: ['all', /^polaris\/layout\/.+$/],
-    },
-  ],
+  reportNeedlessDisables: true,
   reportInvalidScopeDisables: [
     true,
     {


### PR DESCRIPTION
### WHY are these changes introduced?

`// stylelint-disable` is overloading scss code and not doing anything many times

### WHAT is this pull request doing?

Stop shipping comments that do nothing or accidentally leave them around.
