### PR TITLE
[General] Remove comments after cleanup

### DIFF
--- a/.changeset/red-clocks-battle.md
+++ b/.changeset/red-clocks-battle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Removed comments after stylelint rule changes that are breaking the rules

--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -166,7 +166,6 @@ $disabled-fade: 0.6;
 .Badge {
   margin-left: var(--p-space-2);
   display: inline-flex;
-  // stylelint-disable-next-line -- ensures badges are the same height as the text
   height: var(--p-font-line-height-2);
   margin-top: calc(var(--p-space-2) + var(--p-space-05));
   margin-right: var(--p-space-4);
@@ -214,7 +213,6 @@ $disabled-fade: 0.6;
 }
 
 .ItemInnerWrapper {
-  // stylelint-disable-next-line -- required for absolute positioning of actions
   position: relative;
   display: flex;
   flex-wrap: nowrap;
@@ -255,9 +253,7 @@ $disabled-fade: 0.6;
 }
 
 .SecondaryActions {
-  // stylelint-disable-next-line -- horizontal action icons layout
   display: flex;
-  // stylelint-disable-next-line -- ensures correct height of actions
   height: nav(mobile-height);
 
   &:last-child {
@@ -265,15 +261,12 @@ $disabled-fade: 0.6;
   }
 
   @media #{$p-breakpoints-md-up} {
-    // stylelint-disable-next-line -- ensures correct height of actions
     height: nav(desktop-height);
   }
 }
 
 .ItemWithFloatingActions {
-  // stylelint-disable-next-line -- required for absolute positioning of actions
   position: relative;
-  // stylelint-disable-next-line -- position actions to to the right of label
   display: flex;
   flex-wrap: nowrap;
 
@@ -285,11 +278,8 @@ $disabled-fade: 0.6;
 .ItemInnerWrapper-display-actions-on-hover {
   @media #{$p-breakpoints-md-up} {
     .SecondaryActions {
-      // stylelint-disable-next-line -- position floating actions at top right
       position: absolute;
-      // stylelint-disable-next-line -- position floating actions at top right
       top: 0;
-      // stylelint-disable-next-line -- position floating actions at top right
       right: 0;
       background: var(--p-background-hovered);
       visibility: hidden;
@@ -300,15 +290,10 @@ $disabled-fade: 0.6;
       &::before {
         content: '';
         pointer-events: none;
-        // stylelint-disable-next-line -- required for fade effect
         position: absolute;
-        // stylelint-disable-next-line -- required for fade effect
         right: 100%;
-        // stylelint-disable-next-line -- required for fade effect
         display: block;
-        // stylelint-disable-next-line -- required for fade effect
         height: 100%;
-        // stylelint-disable-next-line -- required for fade effect
         width: var(--p-space-8);
         // stylelint-disable-next-line -- required for fade effect
         background: linear-gradient(

--- a/polaris-react/src/components/Tooltip/Tooltip.scss
+++ b/polaris-react/src/components/Tooltip/Tooltip.scss
@@ -1,5 +1,4 @@
 .TooltipContainer {
-  // stylelint-disable-next-line -- The rule "property-disallowed-list" is not applicable since there does not exist a layout component that only sets the display property
   display: flex;
 }
 

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -21,17 +21,13 @@
 
   &::after {
     content: '';
-    // stylelint-disable-next-line -- No Polaris layout component offers this
     position: absolute;
-    // stylelint-disable-next-line -- No Polaris layout component offers this
     top: calc(var(--p-space-4) * -1);
     // stylelint-disable-next-line -- No Polaris layout component offers this
     left: calc(
       var(--pc-tooltip-chevron-x-pos) - var(--p-space-2) - var(--p-space-4)
     );
-    // stylelint-disable-next-line -- No Polaris layout component offers this
     height: 0;
-    // stylelint-disable-next-line -- No Polaris layout component offers this
     width: 0;
     border-width: var(--p-space-2);
     border-style: solid;
@@ -40,9 +36,7 @@
 
   &.positionedAbove {
     &::after {
-      // stylelint-disable-next-line -- No Polaris layout component offers this
       top: auto;
-      // stylelint-disable-next-line -- No Polaris layout component offers this
       bottom: calc(var(--p-space-4) * -1);
       border-color: var(--p-surface) transparent transparent transparent;
     }


### PR DESCRIPTION
### WHY are these changes introduced?

After https://github.com/Shopify/polaris/pull/8657 merged, there still seems to be some comments that are falling foul of the rules, causing the linter stage to fail. This PR just removes those offending comments.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
