### PR TITLE
[Layout foundations] Allow string integers to be passed into the columns prop

### DIFF
--- a/.changeset/tough-ducks-boil.md
+++ b/.changeset/tough-ducks-boil.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Accounted for string numbers to be passed into columns prop

--- a/polaris-react/src/components/Columns/Columns.tsx
+++ b/polaris-react/src/components/Columns/Columns.tsx
@@ -76,11 +76,11 @@ function formatColumns(columns?: Columns): ResponsiveValue {
 function getColumnValue(columns?: ColumnsType) {
   if (!columns) return undefined;
 
-  if (typeof columns === 'string') return columns;
-
-  if (typeof columns === 'number') {
-    return `repeat(${columns}, minmax(0, 1fr))`;
+  if (typeof columns === 'number' || !isNaN(Number(columns))) {
+    return `repeat(${Number(columns)}, minmax(0, 1fr))`;
   }
+
+  if (typeof columns === 'string') return columns;
 
   return columns
     .map((column) => {


### PR DESCRIPTION
Copilot was helping me whip up a columns playground and popped in numbers as strings to the columns prop. Took me a second to figure out why it wasn't working. This adds a check and formats any strings as numbers if it can i.e.

```jsx
import React from 'react';

import {Columns, Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Columns columns={{xs: '1', sm: '2', md: '3', lg: '4', xl: '5'}}>
        <div>1</div>
        <div>2</div>
        <div>3</div>
        <div>4</div>
        <div>5</div>
      </Columns>
    </Page>
  );
}
```