### PR TITLE
Fix size-limit action to only build Polaris and dependencies

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -28,4 +28,4 @@ jobs:
       - uses: andresz1/size-limit-action@v1.7.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          build_script: build -- --filter=@shopify/polaris...
+          build_script: size-limit

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "release": "turbo run build --filter='!polaris.shopify.com' && changeset publish",
     "preversion": "echo \"Error: use @changsets/cli to version packages\" && exit 1",
     "new-migration": "yarn workspace @shopify/polaris-migrator generate",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "size-limit": "turbo run build --filter=@shopify/polaris..."
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
Recent changes to the top level build script have caused the size limit action to ignore the turbo filter and run all workspace build scripts. This PR adds a custom `size-limit` run script and configures the size-limit-action accordingly.

Update: This change brought the running time from `~19m` to `~4m`

Before: Example logs of the `--filter` flag being ignored:
> Notice `polaris-cli`, `stylelint-polaris`, `polaris-for-vscode`, etc. is incorrectly included in the build task
<img width="928" alt="Screenshot 2023-03-15 at 11 43 46 AM" src="https://user-images.githubusercontent.com/32409546/225416751-6c7557f7-3d5b-4f77-a7b8-5f05f19b8319.png">

After:
![image](https://user-images.githubusercontent.com/32409546/225433048-a8193a03-0e38-4140-9929-b8ec9f31bbcd.png)
