### PR TITLE
Make SideBySide markdown component available across docs site

### DIFF
--- a/.changeset/three-owls-listen.md
+++ b/.changeset/three-owls-listen.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Make SideBySide markdown component available across docs site

--- a/polaris.shopify.com/src/components/Markdown/Markdown.module.scss
+++ b/polaris.shopify.com/src/components/Markdown/Markdown.module.scss
@@ -1,0 +1,3 @@
+.MarkdownImage {
+  width: 100%;
+}

--- a/polaris.shopify.com/src/components/Markdown/components/index.tsx
+++ b/polaris.shopify.com/src/components/Markdown/components/index.tsx
@@ -1,0 +1,11 @@
+import {type PropsWithChildren, type ComponentType} from 'react';
+import {Stack} from '../../Stack';
+import styles from './styles.module.scss';
+
+export const SideBySide: ComponentType<
+  PropsWithChildren<{className: string}>
+> = ({children, className}) => (
+  <Stack gap="4" className={[styles.SideBySide, className]}>
+    {children}
+  </Stack>
+);

--- a/polaris.shopify.com/src/components/Markdown/components/styles.module.scss
+++ b/polaris.shopify.com/src/components/Markdown/components/styles.module.scss
@@ -1,0 +1,51 @@
+@import '../../../styles/variables.scss';
+
+.SideBySide {
+  & > ul {
+    display: grid;
+    column-gap: var(--p-space-4);
+    row-gap: var(--p-space-8);
+
+    --txt-column-width: 35%;
+    /*
+   * Rules of the grid:
+   * The second (img) column should never be bigger than 30rem.
+   * The first (text) column should never shrink below 35% of the container.
+   * The first (text) column should grow to fill the remaining space (1fr).
+   * The second (img) column should never shrink below 20rem. */
+    grid-template-columns:
+      minmax(
+        // Give this column a minimum width (thin container)
+        var(--txt-column-width),
+        // Grow to fill the remaining space when possible (wide container)
+        1fr
+      )
+      minmax(
+        min(
+          // Minimum size of 20rem to keep it legible
+          20rem,
+          // Except when the container is too thin: let it shrinnk so the text
+          // column can still take up its desired minimum width
+          calc(100% - var(--txt-column-width))
+        ),
+        // Maximum width (wide container) - avoids gigantic images
+        30rem
+      );
+
+    @media screen and (max-width: $breakpointMobile) {
+      grid-template-columns: 1fr;
+      row-gap: var(--p-space-4);
+    }
+
+    & > li {
+      display: contents;
+      &::before {
+        display: none;
+      }
+
+      & > span {
+        display: contents;
+      }
+    }
+  }
+}

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -127,29 +127,25 @@
 }
 
 .HowItHelps {
-  .ImageWrapper {
+  & > img {
     display: block;
     border: 1px solid var(--p-border-subdued);
-    position: relative;
-    flex: auto;
-    overflow: hidden;
     aspect-ratio: 361.9/180.9;
-    width: 100%;
     border-radius: 0.25rem;
     background: var(--p-surface-depressed);
-    > img {
-      width: 100%;
-      object-fit: fill;
-    }
   }
   ol {
+    --counter-offset: calc(24px + var(--p-space-2));
     list-style: none;
     counter-reset: item;
     li {
       counter-increment: item;
+      padding-left: var(--counter-offset);
       &::before {
         width: 24px;
         height: 24px;
+        position: absolute;
+        margin-left: calc(-1 * var(--counter-offset));
         content: counter(item);
         font-weight: 700;
         color: rgba(153, 35, 247, 1);
@@ -166,68 +162,8 @@
 }
 
 .UsefulToKnow {
-  & > ul {
-    display: grid;
-    column-gap: var(--p-space-4);
-    row-gap: var(--p-space-8);
-
-    --txt-column-width: 35%;
-    /*
-   * Rules of the grid:
-   * The second (img) column should never be bigger than 30rem.
-   * The first (text) column should never shrink below 35% of the container.
-   * The first (text) column should grow to fill the remaining space (1fr).
-   * The second (img) column should never shrink below 20rem. */
-    grid-template-columns:
-      minmax(
-        // Give this column a minimum width (thin container)
-        var(--txt-column-width),
-        // Grow to fill the remaining space when possible (wide container)
-        1fr
-      )
-      minmax(
-        min(
-          // Minimum size of 20rem to keep it legible
-          20rem,
-          // Except when the container is too thin: let it shrinnk so the text
-          // column can still take up its desired minimum width
-          calc(100% - var(--txt-column-width))
-        ),
-        // Maximum width (wide container) - avoids gigantic images
-        30rem
-      );
-
-    @media screen and (max-width: $breakpointMobile) {
-      grid-template-columns: 1fr;
-      row-gap: var(--p-space-4);
-    }
-
-    & > li {
-      display: contents;
-      &::before {
-        display: none;
-      }
-
-      & > span {
-        display: contents;
-      }
-    }
-
-    .ImageWrapper {
-      aspect-ratio: 485/315;
-      position: relative;
-      background: var(--p-surface-depressed);
-      display: block;
-      overflow: hidden;
-      > img {
-        object-fit: cover;
-      }
-    }
-  }
-}
-
-.UsefulToKnow {
-  .ImageWrapper {
+  img {
+    background: var(--p-surface-depressed);
     border-radius: var(--border-radius-400);
     border: 1px solid #c9cccf;
   }

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -1,12 +1,12 @@
 import React, {useState, createContext, useContext, useEffect} from 'react';
 import {Tab} from '@headlessui/react';
-import Image from 'next/image';
 import Link from 'next/link';
+
 import {
   remarkDefinitionList,
   defListHastHandlers,
 } from 'remark-definition-list';
-import remarkUnwrapImages from 'remark-unwrap-images';
+
 import {useRouter} from 'next/router';
 import {visit} from 'unist-util-visit';
 import type {Node, Parent} from 'unist-util-visit';
@@ -15,7 +15,7 @@ import type {Plugin} from 'unified';
 import InlinePill from '../InlinePill';
 import {PatternVariantFontMatter, PatternFrontMatter} from '../../types';
 import PageMeta from '../PageMeta';
-import {Stack, Row} from '../Stack';
+import {Stack} from '../Stack';
 import {Box} from '../Box';
 import Code from '../Code';
 import {Lede} from '../Lede';
@@ -24,6 +24,7 @@ import PatternsExample from '../PatternsExample';
 import Page from '../Page';
 import styles from './PatternPage.module.scss';
 import Markdown from '../Markdown';
+import {SideBySide} from '../Markdown/components';
 
 export interface Props {
   data: Omit<PatternFrontMatter, 'variants'> & {
@@ -207,16 +208,11 @@ const BaseMarkdown = ({
   patternName?: string;
 }) => (
   <Markdown
-    remarkPlugins={[codeAsContext, remarkUnwrapImages, remarkDefinitionList]}
+    remarkPlugins={[codeAsContext, remarkDefinitionList]}
     // @ts-expect-error incompatible type to remark-rehype in remark-definition-list package.
     remarkRehypeOptions={{handlers: defListHastHandlers}}
+    mdxComponents={mdxComponents}
     components={{
-      // @ts-expect-error react-markdown doesn't understand custom attributes
-      div: ({as, ...props}) => {
-        // poor man's MDX
-        const Component = mdxComponents?.[as] ?? Box;
-        return <Component {...props} />;
-      },
       h1: ({children, id}) => (
         <Heading id={id} as="h1">
           {children}
@@ -247,11 +243,6 @@ const BaseMarkdown = ({
           {children}
         </Stack>
       ),
-      li: ({children, ordered, ...props}) => (
-        <Row as="li" gap={ordered ? '2' : '0'} {...props}>
-          <span>{children}</span>
-        </Row>
-      ),
       dl: ({children}) => (
         <Box as="dl" className={styles.DefinitionList}>
           {children}
@@ -262,12 +253,6 @@ const BaseMarkdown = ({
           {children}
         </Box>
       ),
-      img: ({src, alt}) =>
-        src ? (
-          <div className={styles.ImageWrapper}>
-            <Image fill src={src} alt={alt ?? ''} />
-          </div>
-        ) : null,
       code: function MdCode({
         inline,
         // @ts-expect-error Unsure how to tell react-markdown this prop is
@@ -331,9 +316,7 @@ const defaultMdxComponents: MDXComponents = {
     </Stack>
   ),
   UsefulToKnow: ({children}) => (
-    <Stack gap="4" className={styles.UsefulToKnow}>
-      {children}
-    </Stack>
+    <SideBySide className={styles.UsefulToKnow}>{children}</SideBySide>
   ),
   DefinitionTable: ({children}) => (
     <Box className={styles.DefinitionTable}>{children}</Box>


### PR DESCRIPTION
Pattern page introduced some useful MDX-like markdown components for documentation that are desirable in other parts of the docs site.

This PR migrates the "Useful To Know" section styling to a new component called `SideBySide` for use in Markdown:

```
<div as="SideBySide">

- <span>Foo bar zip</span> ![web context bar](/images/content/actionable-language/web-context-bar@2x.png)
- <span>Foo bar zip</span> ![web context bar](/images/content/actionable-language/web-context-bar@2x.png)
- <span>Foo bar zip</span> ![web context bar](/images/content/actionable-language/web-context-bar@2x.png)
- <span>Foo bar zip</span> ![web context bar](/images/content/actionable-language/web-context-bar@2x.png)

</div>
```

Looks like this:

<img width="579" alt="Screenshot 2023-03-16 at 3 36 02 pm" src="https://user-images.githubusercontent.com/612020/225515598-3499275d-eaf5-4798-b3f6-d1bcc080e1cf.png">
