### PR TITLE
fix: codesandbox examples

### DIFF
--- a/.changeset/tricky-pigs-shake.md
+++ b/.changeset/tricky-pigs-shake.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed typescript converted codesandbox examples

--- a/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx
+++ b/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx
@@ -55,11 +55,11 @@ const CodesandboxButton = (props: Props) => {
         } as any,
         isBinary: false,
       },
-      'App.js': {
+      'App.tsx': {
         content: getAppCode(code),
         isBinary: false,
       },
-      'index.js': {
+      'index.tsx': {
         content: indexCode,
         isBinary: false,
       },
@@ -78,7 +78,7 @@ const CodesandboxButton = (props: Props) => {
       className={className}
     >
       <input type="hidden" name="parameters" value={parameters} />
-      <input type="hidden" name="query" value="module=App.js" />
+      <input type="hidden" name="query" value="module=App.tsx" />
       <button type="submit" className={styles.Button}>
         Edit in CodeSandbox
       </button>


### PR DESCRIPTION
## Problem
Navigate to a newly converted TS example and click on Edit in Codesandbox:

![image](https://screenshot.click/16-51-r0k5o-ua3hd.png)

## Why

Examples pages are getting converted to Typescript, breaking our JS playgrounds.

## Proposed fix

JS is backwards compatible, or will at least render with some missing types, for now. 

This converts the sandbox files to TS