### PR TITLE
[polaris.shopify.com] Fix ResourceList type and imports

### DIFF
--- a/.changeset/hungry-donkeys-kneel.md
+++ b/.changeset/hungry-donkeys-kneel.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed typing for `ResourceList` examples

--- a/polaris.shopify.com/pages/examples/resource-item-default.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-default.tsx
@@ -1,5 +1,5 @@
 import {LegacyCard, ResourceList, ResourceItem, Text} from '@shopify/polaris';
-import {ResourceListSelectedItems} from '@shopify/polaris/build/ts/latest/src/utilities/resource-list';
+import type {ResourceListProps} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -13,9 +13,9 @@ const items = [
 ];
 
 function ResourceItemExample() {
-  const [selectedItems, setSelectedItems] = useState<ResourceListSelectedItems>(
-    [],
-  );
+  const [selectedItems, setSelectedItems] = useState<
+    ResourceListProps['selectedItems']
+  >([]);
 
   return (
     <LegacyCard>

--- a/polaris.shopify.com/pages/examples/resource-list-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-all-of-its-elements.tsx
@@ -8,14 +8,14 @@ import {
   ResourceItem,
   Text,
 } from '@shopify/polaris';
-import {ResourceListSelectedItems} from '@shopify/polaris/build/ts/latest/src/utilities/resource-list';
+import type {ResourceListProps} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListExample() {
-  const [selectedItems, setSelectedItems] = useState<ResourceListSelectedItems>(
-    [],
-  );
+  const [selectedItems, setSelectedItems] = useState<
+    ResourceListProps['selectedItems']
+  >([]);
   const [sortValue, setSortValue] = useState('DATE_MODIFIED_DESC');
   const [taggedWith, setTaggedWith] = useState<string | undefined>('VIP');
   const [queryValue, setQueryValue] = useState<string | undefined>(undefined);

--- a/polaris.shopify.com/pages/examples/resource-list-with-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-bulk-actions.tsx
@@ -5,14 +5,14 @@ import {
   ResourceItem,
   Text,
 } from '@shopify/polaris';
-import {ResourceListSelectedItems} from '@shopify/polaris/build/ts/latest/src/utilities/resource-list';
+import type {ResourceListProps} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListWithBulkActionsExample() {
-  const [selectedItems, setSelectedItems] = useState<ResourceListSelectedItems>(
-    [],
-  );
+  const [selectedItems, setSelectedItems] = useState<
+    ResourceListProps['selectedItems']
+  >([]);
 
   const resourceName = {
     singular: 'customer',

--- a/polaris.shopify.com/pages/examples/resource-list-with-loading-state.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-loading-state.tsx
@@ -5,14 +5,14 @@ import {
   ResourceItem,
   Text,
 } from '@shopify/polaris';
-import {ResourceListSelectedItems} from '@shopify/polaris/build/ts/latest/src/utilities/resource-list';
+import type {ResourceListProps} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListWithLoadingExample() {
-  const [selectedItems, setSelectedItems] = useState<ResourceListSelectedItems>(
-    [],
-  );
+  const [selectedItems, setSelectedItems] = useState<
+    ResourceListProps['selectedItems']
+  >([]);
 
   const resourceName = {
     singular: 'customer',

--- a/polaris.shopify.com/pages/examples/resource-list-with-multiselect.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-multiselect.tsx
@@ -5,14 +5,14 @@ import {
   ResourceItem,
   Text,
 } from '@shopify/polaris';
-import {ResourceListSelectedItems} from '@shopify/polaris/build/ts/latest/src/utilities/resource-list';
+import type {ResourceListProps} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListExample() {
-  const [selectedItems, setSelectedItems] = useState<ResourceListSelectedItems>(
-    [],
-  );
+  const [selectedItems, setSelectedItems] = useState<
+    ResourceListProps['selectedItems']
+  >([]);
 
   const resourceName = {
     singular: 'customer',

--- a/polaris.shopify.com/pages/examples/resource-list-with-selection-and-no-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-selection-and-no-bulk-actions.tsx
@@ -5,14 +5,14 @@ import {
   ResourceItem,
   Text,
 } from '@shopify/polaris';
-import {ResourceListSelectedItems} from '@shopify/polaris/build/ts/latest/src/utilities/resource-list';
+import type {ResourceListProps} from '@shopify/polaris';
 import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function ResourceListWithSelectionExample() {
-  const [selectedItems, setSelectedItems] = useState<ResourceListSelectedItems>(
-    [],
-  );
+  const [selectedItems, setSelectedItems] = useState<
+    ResourceListProps['selectedItems']
+  >([]);
 
   const resourceName = {
     singular: 'customer',


### PR DESCRIPTION
### WHY are these changes introduced?

These imports are causing build issues for the v11 branch.
<img width="1126" alt="16-41-2bhfz-ztpvr" src="https://user-images.githubusercontent.com/26749317/225747820-2822c885-ac3e-436b-a95a-6185ffcdb0b2.png">

### WHAT is this pull request doing?

Uses `ResourceListProps` to type examples.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
