### PR TITLE
Add as="div" option to Text component

### DIFF
--- a/.changeset/slow-meals-yell.md
+++ b/.changeset/slow-meals-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add as="div" option to Text component

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -13,7 +13,8 @@ type Element =
   | 'h6'
   | 'p'
   | 'span'
-  | 'legend';
+  | 'legend'
+  | 'div';
 
 type Variant =
   | 'headingXs'


### PR DESCRIPTION
### WHY are these changes introduced?

Enables the usage of the Text component for styling a section of text (consisting of multiple paragraphs).

```diff
- <div>
-   <Text variant="bodySm" color="subdued" as="p">Lorem</Text>
-   <Text variant="bodySm" color="subdued" as="p">ipsum</Text>
-   <Text variant="bodySm" color="subdued" as="p">dolor</Text>
- </div>

+ <Text variant="bodySm" color="subdued" as="div">
+   <p>Lorem</p>
+   <p>ipsum</p>
+   <p>dolor</p>
+ </Text>
```