### PR TITLE
[Text] Add inheritance examples

### DIFF
--- a/.changeset/rich-boats-play.md
+++ b/.changeset/rich-boats-play.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Added inheritance examples to Text component

--- a/polaris-react/src/components/Text/Text.stories.tsx
+++ b/polaris-react/src/components/Text/Text.stories.tsx
@@ -107,8 +107,10 @@ export const WithColor = () => (
 
 export const WithInheritance = () => (
   <Text as="p" variant="heading2xl" color="warning">
-    <Text as="p">This is a 2xl heading</Text>
-    <Text as="p">This is also a 2xl heading</Text>
+    <LegacyStack vertical>
+      <Text as="span">This is a 2xl heading</Text>
+      <Text as="span">This is also a 2xl heading</Text>
+    </LegacyStack>
   </Text>
 );
 

--- a/polaris-react/src/components/Text/Text.stories.tsx
+++ b/polaris-react/src/components/Text/Text.stories.tsx
@@ -105,6 +105,13 @@ export const WithColor = () => (
   </LegacyStack>
 );
 
+export const WithInheritance = () => (
+  <Text as="p" variant="heading2xl" color="warning">
+    <Text as="p">This is a 2xl heading</Text>
+    <Text as="p">This is also a 2xl heading</Text>
+  </Text>
+);
+
 export const WithTruncate = () => (
   <Text as="p" truncate>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam tincidunt vel

--- a/polaris.shopify.com/content/components/typography/text.md
+++ b/polaris.shopify.com/content/components/typography/text.md
@@ -43,11 +43,15 @@ examples:
     title: Color
     description: >-
       Use to set text color.
+  - fileName: text-inheritance.tsx
+    title: Inheritance
+    description: >-
+      Inherits props from a parent Text container
 ---
 
 ## Variant tokens
 
-Each variant uses a predetermined combination of the [font tokens](/tokens/font) to set the font size and line height. Heading variants have a set font weight but can be overridden by using the `fontWeight` prop.
+Each variant uses a predetermined combination of the [font tokens](/tokens/font) to set the font size and line height. Heading variants have a set font weight but can be overridden by using the `fontWeight` prop. Nested Text components will inherit properties from its parent Text container.
 
 | Variant      | Font size token     | px value | rem value | Font line height token | Font weight token          | Reponsive |
 | ------------ | ------------------- | -------- | --------- | ---------------------- | -------------------------- | --------- |

--- a/polaris.shopify.com/pages/examples/text-inheritance.tsx
+++ b/polaris.shopify.com/pages/examples/text-inheritance.tsx
@@ -1,12 +1,14 @@
-import {Text} from '@shopify/polaris';
+import {LegacyStack, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextExample() {
   return (
     <Text as="p" variant="heading2xl" color="warning">
-      <Text as="p">This is a 2xl heading</Text>
-      <Text as="p">This is also a 2xl heading</Text>
+      <LegacyStack vertical>
+        <Text as="span">This is a 2xl heading</Text>
+        <Text as="span">This is also a 2xl heading</Text>
+      </LegacyStack>
     </Text>
   );
 }

--- a/polaris.shopify.com/pages/examples/text-inheritance.tsx
+++ b/polaris.shopify.com/pages/examples/text-inheritance.tsx
@@ -1,0 +1,14 @@
+import {Text} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TextExample() {
+  return (
+    <Text as="p" variant="heading2xl" color="warning">
+      <Text as="p">This is a 2xl heading</Text>
+      <Text as="p">This is also a 2xl heading</Text>
+    </Text>
+  );
+}
+
+export default withPolarisExample(TextExample);


### PR DESCRIPTION
Text inherits parent properties like variant, alignment, color etc... we should document this