### PR TITLE
[Button], [UnstyledButton], [PageActions]: Add `ref` for accessibility focus()

### DIFF
--- a/.changeset/thin-crabs-care.md
+++ b/.changeset/thin-crabs-care.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added 'ref' support for `Button`, `UnstyledButton`, `Page.secondaryActions`, `ActionList.items`.

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, {forwardRef} from 'react';
+import type {Ref, LegacyRef} from 'react';
 
 import {classNames} from '../../../../utilities/css';
 import type {ActionListItemDescriptor} from '../../../../types';
@@ -14,26 +15,29 @@ import {Box} from '../../../Box';
 
 export type ItemProps = ActionListItemDescriptor;
 
-export function Item({
-  id,
-  badge,
-  content,
-  accessibilityLabel,
-  helpText,
-  url,
-  onAction,
-  onMouseEnter,
-  icon,
-  image,
-  prefix,
-  suffix,
-  disabled,
-  external,
-  destructive,
-  ellipsis,
-  active,
-  role,
-}: ItemProps) {
+export const Item = forwardRef(function Item(
+  {
+    id,
+    badge,
+    content,
+    accessibilityLabel,
+    helpText,
+    url,
+    onAction,
+    onMouseEnter,
+    icon,
+    image,
+    prefix,
+    suffix,
+    disabled,
+    external,
+    destructive,
+    ellipsis,
+    active,
+    role,
+  }: ItemProps,
+  ref,
+) {
   const className = classNames(
     styles.Item,
     disabled && styles.disabled,
@@ -108,6 +112,7 @@ export function Item({
       aria-label={accessibilityLabel}
       onClick={disabled ? null : onAction}
       role={role}
+      ref={ref as Ref<HTMLAnchorElement>}
     >
       {contentElement}
     </UnstyledLink>
@@ -122,6 +127,7 @@ export function Item({
       onMouseUp={handleMouseUpByBlurring}
       role={role}
       onMouseEnter={onMouseEnter}
+      ref={ref as LegacyRef<HTMLButtonElement> | undefined}
     >
       {contentElement}
     </button>
@@ -133,4 +139,4 @@ export function Item({
       {control}
     </>
   );
-}
+});

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -39,7 +39,7 @@ export function Section({
     };
   };
   const actionMarkup = section.items.map(
-    ({content, helpText, onAction, ...item}, index) => {
+    ({content, helpText, onAction, id, ref, ...item}, index) => {
       return (
         <li
           key={`${content}-${index}`}
@@ -50,6 +50,7 @@ export function Section({
             helpText={helpText}
             role={actionRole}
             onAction={handleAction(onAction)}
+            ref={ref}
             {...item}
           />
         </li>

--- a/polaris-react/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/polaris-react/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 
 import type {
   ActionListItemDescriptor,
@@ -35,7 +35,6 @@ const ACTION_SPACING = 8;
 export function Actions({actions = [], groups = [], onActionRollup}: Props) {
   const i18n = useI18n();
   const actionsLayoutRef = useRef<HTMLDivElement>(null);
-  const menuGroupWidthRef = useRef<number>(0);
   const availableWidthRef = useRef<number>(0);
   const actionsAndGroupsLengthRef = useRef<number>(0);
   const timesMeasured = useRef(0);
@@ -115,12 +114,11 @@ export function Actions({actions = [], groups = [], onActionRollup}: Props) {
     let newRolledUpActions: (MenuActionDescriptor | MenuGroupDescriptor)[] = [];
 
     actionsAndGroups.forEach((action, index) => {
-      const canFitAction =
+      const newWidth =
         actionWidthsRef.current[index] +
-          menuGroupWidthRef.current +
-          ACTION_SPACING +
-          lastMenuGroupWidth <=
-        currentAvailableWidth;
+        ACTION_SPACING * 2 +
+        lastMenuGroupWidth;
+      const canFitAction = newWidth <= currentAvailableWidth;
 
       if (canFitAction) {
         currentAvailableWidth -=
@@ -154,23 +152,29 @@ export function Actions({actions = [], groups = [], onActionRollup}: Props) {
     actionsAndGroupsLengthRef.current = actionsAndGroups.length;
   }, [actions, groups, lastMenuGroup, lastMenuGroupWidth, onActionRollup]);
 
-  const handleResize = useMemo(
-    () =>
-      debounce(
-        () => {
-          if (!actionsLayoutRef.current) return;
-          availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
-          // Set timesMeasured to 0 to allow re-measuring
-          timesMeasured.current = 0;
-          measureActions();
-        },
-        50,
-        {leading: false, trailing: true},
-      ),
-    [measureActions],
+  // don't use debounce with an inline function, we only want to create one debouncedMeasureActions
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedMeasureActions = useCallback(
+    debounce(
+      () => {
+        if (!actionsLayoutRef.current) return;
+        availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
+        timesMeasured.current = 0;
+        measureActions();
+      },
+      50,
+      {leading: false, trailing: true},
+    ),
+    [measureActions, actionsLayoutRef],
   );
 
-  useEventListener('resize', handleResize);
+  const handleResize = useCallback(debouncedMeasureActions, [
+    debouncedMeasureActions,
+  ]);
+
+  useEventListener('resize', (event) => {
+    handleResize(event);
+  });
 
   useIsomorphicLayoutEffect(() => {
     if (!actionsLayoutRef.current) return;

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {forwardRef, useEffect, useRef} from 'react';
 
 import {classNames} from '../../../../utilities/css';
 import {Tooltip} from '../../../Tooltip';
@@ -13,43 +13,50 @@ interface SecondaryAction extends ButtonProps {
   getOffsetWidth?(width: number): void;
 }
 
-export function SecondaryAction({
-  children,
-  destructive,
-  helpText,
-  onAction,
-  getOffsetWidth,
-  ...rest
-}: SecondaryAction) {
-  const secondaryActionsRef = useRef<HTMLSpanElement>(null);
+export const SecondaryAction = forwardRef(
+  (
+    {
+      children,
+      destructive,
+      helpText,
+      onAction,
+      getOffsetWidth,
+      ...rest
+    }: SecondaryAction,
+    ref,
+  ) => {
+    const secondaryActionsRef = useRef<HTMLSpanElement>(null);
 
-  useEffect(() => {
-    if (!getOffsetWidth || !secondaryActionsRef.current) return;
+    useEffect(() => {
+      if (!getOffsetWidth || !secondaryActionsRef.current) return;
 
-    getOffsetWidth(secondaryActionsRef.current?.offsetWidth);
-  }, [getOffsetWidth]);
+      getOffsetWidth(secondaryActionsRef.current?.offsetWidth);
+    }, [getOffsetWidth]);
 
-  const buttonMarkup = (
-    <Button onClick={onAction} {...rest}>
-      {children}
-    </Button>
-  );
+    const buttonMarkup = (
+      <Button onClick={onAction} {...rest} ref={ref}>
+        {children}
+      </Button>
+    );
 
-  const actionMarkup = helpText ? (
-    <Tooltip content={helpText}>{buttonMarkup}</Tooltip>
-  ) : (
-    buttonMarkup
-  );
+    const actionMarkup = helpText ? (
+      <Tooltip content={helpText}>{buttonMarkup}</Tooltip>
+    ) : (
+      buttonMarkup
+    );
 
-  return (
-    <span
-      className={classNames(
-        styles.SecondaryAction,
-        destructive && styles.destructive,
-      )}
-      ref={secondaryActionsRef}
-    >
-      {actionMarkup}
-    </span>
-  );
-}
+    return (
+      <span
+        className={classNames(
+          styles.SecondaryAction,
+          destructive && styles.destructive,
+        )}
+        ref={secondaryActionsRef}
+      >
+        {actionMarkup}
+      </span>
+    );
+  },
+);
+
+SecondaryAction.displayName = 'SecondaryAction';

--- a/polaris-react/src/components/AlphaTabs/components/Item/Item.tsx
+++ b/polaris-react/src/components/AlphaTabs/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode, ReactElement, MutableRefObject} from 'react';
+import type {ReactNode, ReactElement, MutableRefObject, RefObject} from 'react';
 import React, {memo, useEffect, useRef} from 'react';
 
 import {classNames} from '../../../../utilities/css';
@@ -37,7 +37,7 @@ export const Item = memo(function Item({
 
   const sharedProps = {
     id,
-    ref: focusedNode,
+    ref: focusedNode as RefObject<HTMLAnchorElement>,
     onClick,
     className: classname,
     'aria-selected': false,

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {forwardRef, useCallback, useState} from 'react';
 import {
   CaretDownMinor,
   CaretUpMinor,
@@ -94,46 +94,49 @@ type ActionButtonProps = Pick<
 
 const DEFAULT_SIZE = 'medium';
 
-export function Button({
-  id,
-  children,
-  url,
-  disabled,
-  external,
-  download,
-  target,
-  submit,
-  loading,
-  pressed,
-  accessibilityLabel,
-  role,
-  ariaControls,
-  ariaExpanded,
-  ariaDescribedBy,
-  ariaChecked,
-  onClick,
-  onFocus,
-  onBlur,
-  onKeyDown,
-  onKeyPress,
-  onKeyUp,
-  onMouseEnter,
-  onTouchStart,
-  onPointerDown,
-  icon,
-  primary,
-  outline,
-  destructive,
-  disclosure,
-  plain,
-  monochrome,
-  removeUnderline,
-  size = DEFAULT_SIZE,
-  textAlign,
-  fullWidth,
-  connectedDisclosure,
-  dataPrimaryLink,
-}: ButtonProps) {
+export const Button = forwardRef(function Button(
+  {
+    id,
+    children,
+    url,
+    disabled,
+    external,
+    download,
+    submit,
+    loading,
+    pressed,
+    accessibilityLabel,
+    role,
+    ariaControls,
+    ariaExpanded,
+    ariaDescribedBy,
+    ariaChecked,
+    onClick,
+    onFocus,
+    onBlur,
+    onKeyDown,
+    onKeyPress,
+    onKeyUp,
+    onMouseEnter,
+    onTouchStart,
+    onPointerDown,
+    icon,
+    primary,
+    outline,
+    destructive,
+    disclosure,
+    plain,
+    monochrome,
+    removeUnderline,
+    size = DEFAULT_SIZE,
+    textAlign,
+    fullWidth,
+    connectedDisclosure,
+    dataPrimaryLink,
+    target,
+  }: ButtonProps,
+  ref,
+) {
   const i18n = useI18n();
 
   const isDisabled = disabled || loading;
@@ -302,7 +305,7 @@ export function Button({
   };
 
   const buttonMarkup = (
-    <UnstyledButton {...commonProps} {...linkProps} {...actionProps}>
+    <UnstyledButton {...commonProps} {...linkProps} {...actionProps} ref={ref}>
       <span className={styles.Content}>
         {spinnerSVGMarkup}
         {iconMarkup}
@@ -320,7 +323,7 @@ export function Button({
   ) : (
     buttonMarkup
   );
-}
+});
 
 function isIconSource(x: any): x is IconSource {
   return (

--- a/polaris-react/src/components/Modal/Modal.stories.tsx
+++ b/polaris-react/src/components/Modal/Modal.stories.tsx
@@ -388,9 +388,9 @@ export function WithActivatorRef() {
   }, []);
 
   const activator = (
-    <div ref={buttonRef}>
-      <Button onClick={handleOpen}>Open</Button>
-    </div>
+    <Button onClick={handleOpen} ref={buttonRef}>
+      Open
+    </Button>
   );
 
   return (
@@ -426,20 +426,20 @@ export function WithActivatorRef() {
 export function WithoutAnActivatorProp() {
   const [active, setActive] = useState(true);
 
-  const button = useRef();
+  const button = useRef<HTMLButtonElement>(null);
 
   const handleOpen = useCallback(() => setActive(true), []);
 
   const handleClose = useCallback(() => {
     setActive(false);
-    requestAnimationFrame(() => button.current.querySelector('button').focus());
+    requestAnimationFrame(() => button.current?.focus());
   }, []);
 
   return (
     <div style={{height: '500px'}}>
-      <div ref={button}>
-        <Button onClick={handleOpen}>Open</Button>
-      </div>
+      <Button onClick={handleOpen} ref={button}>
+        Open
+      </Button>
       <Modal
         instant
         open={active}

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -118,7 +118,11 @@ export const Modal: React.FunctionComponent<ModalProps> & {
         ? activator && activator.current
         : activatorRef.current;
     if (activatorElement) {
-      requestAnimationFrame(() => focusFirstFocusableNode(activatorElement));
+      requestAnimationFrame(() => {
+        activatorElement.focus
+          ? activatorElement.focus()
+          : focusFirstFocusableNode(activatorElement);
+      });
     }
   }, [activator]);
 

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Badge,
@@ -7,6 +7,9 @@ import {
   Page,
   PageActions,
   LegacyStack,
+  Modal,
+  TextContainer,
+  Text,
 } from '@shopify/polaris';
 import {PlusMinor, ArrowDownMinor, ExternalMinor} from '@shopify/polaris-icons';
 
@@ -106,6 +109,105 @@ export function WithoutPrimaryActionInHeader() {
           <Button primary>Continue</Button>
         </LegacyStack>
       </LegacyCard>
+    </Page>
+  );
+}
+
+export function WithActivatorRef() {
+  const [active, setActive] = useState(false);
+  const [active2, setActive2] = useState(true);
+  const [hasRolledUp, setHasRolledUp] = useState(false);
+
+  const onActionRollup = useCallback((hasRolledUp: boolean) => {
+    console.log('rolling up actions');
+    setHasRolledUp(hasRolledUp);
+  }, []);
+
+  const handleChange = useCallback(() => setActive(!active), [active]);
+  const handleChange2 = useCallback(() => setActive2(!active2), [active2]);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const buttonRef2 = useRef<HTMLButtonElement>(null);
+
+  return (
+    <Page
+      breadcrumbs={[{content: 'Orders', url: '#'}]}
+      title="#1085"
+      secondaryActions={[
+        {content: 'Print'},
+        {content: 'Fulfill'},
+        {content: 'Share'},
+        {content: 'Tweet'},
+        {
+          content: 'Unarchive',
+          id: 'unarchive',
+          ref: buttonRef2,
+          onAction: () => setActive2(true),
+        },
+        {
+          id: 'cancel-order',
+          content: 'Cancel order',
+          ref: buttonRef2,
+          onAction: () => setActive(true),
+        },
+      ]}
+      pagination={{
+        hasPrevious: true,
+        hasNext: true,
+      }}
+      onActionRollup={onActionRollup}
+    >
+      <LegacyCard sectioned title="Fulfill order">
+        <LegacyStack alignment="center">
+          <LegacyStack.Item fill>
+            <p>Buy postage and ship remaining 2 items</p>
+          </LegacyStack.Item>
+          <Button primary>Continue</Button>
+        </LegacyStack>
+      </LegacyCard>
+      <Modal
+        activator={buttonRef}
+        open={active}
+        onClose={handleChange}
+        title="Delete 3/4 inch Leather pet collar?"
+        primaryAction={{
+          content: 'Delete product',
+          onAction: handleChange,
+        }}
+        secondaryActions={[{content: 'Cancel', onAction: handleChange}]}
+      >
+        <Modal.Section>
+          <Text variant="bodyMd" as="p">
+            Are you sure you want to delete{' '}
+            <Text as="span" fontWeight="bold">
+              3/4 inch Leather pet collar
+            </Text>
+            ? This can&apos;t be undone.
+          </Text>
+        </Modal.Section>
+      </Modal>
+
+      <Modal
+        activator={buttonRef2}
+        open={active2}
+        onClose={handleChange2}
+        title="Unarchive inch Leather pet collar?"
+        primaryAction={{
+          content: 'Unarchive product',
+          onAction: handleChange2,
+        }}
+        secondaryActions={[{content: 'Cancel', onAction: handleChange2}]}
+      >
+        <Modal.Section>
+          <Text variant="bodyMd" as="p">
+            Are you sure you want to delete{' '}
+            <Text as="span" fontWeight="bold">
+              1 inch Leather pet collar
+            </Text>
+            ? This can&apos;t be undone.
+          </Text>
+        </Modal.Section>
+      </Modal>
     </Page>
   );
 }

--- a/polaris-react/src/components/PageActions/PageActions.stories.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.stories.tsx
@@ -1,6 +1,12 @@
-import React from 'react';
+import React, {useState, useCallback, useRef} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Button, PageActions} from '@shopify/polaris';
+import {
+  Button,
+  PageActions,
+  Modal,
+  TextContainer,
+  Text,
+} from '@shopify/polaris';
 
 export default {
   component: PageActions,
@@ -19,6 +25,55 @@ export function Default() {
         },
       ]}
     />
+  );
+}
+
+export function WithActivatorRef() {
+  const [active, setActive] = useState(false);
+
+  const handleChange = useCallback(() => setActive(!active), [active]);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <PageActions
+        primaryAction={{
+          content: 'Save',
+        }}
+        secondaryActions={[
+          {
+            content: 'Delete product',
+            outline: true,
+            destructive: true,
+            ref: buttonRef,
+            onAction: () => setActive(true),
+          },
+        ]}
+      />
+      <div style={{height: '500px'}}>
+        <Modal
+          activator={buttonRef}
+          open={active}
+          onClose={handleChange}
+          title="Delete 3/4 inch Leather pet collar?"
+          primaryAction={{
+            content: 'Delete product',
+            onAction: handleChange,
+          }}
+          secondaryActions={[{content: 'Cancel', onAction: handleChange}]}
+        >
+          <Modal.Section>
+            <Text variant="bodyMd" as="p">
+              Are you sure you want to delete{' '}
+              <Text as="span" fontWeight="bold">
+                3/4 inch Leather pet collar
+              </Text>
+              ? This can&apos;t be undone.
+            </Text>
+          </Modal.Section>
+        </Modal>
+      </div>
+    </>
   );
 }
 

--- a/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef, forwardRef, useImperativeHandle} from 'react';
 
 import type {BaseButton} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
@@ -13,94 +13,116 @@ export interface UnstyledButtonProps extends BaseButton {
   [key: string]: any;
 }
 
-export function UnstyledButton({
-  id,
-  children,
-  className,
-  url,
-  external,
-  target,
-  download,
-  submit,
-  disabled,
-  loading,
-  pressed,
-  accessibilityLabel,
-  role,
-  ariaControls,
-  ariaExpanded,
-  ariaDescribedBy,
-  ariaChecked,
-  onClick,
-  onFocus,
-  onBlur,
-  onKeyDown,
-  onKeyPress,
-  onKeyUp,
-  onMouseEnter,
-  onTouchStart,
-  ...rest
-}: UnstyledButtonProps) {
-  let buttonMarkup;
+export const UnstyledButton = forwardRef(
+  (
+    {
+      id,
+      children,
+      className,
+      url,
+      external,
+      download,
+      submit,
+      disabled,
+      loading,
+      pressed,
+      accessibilityLabel,
+      role,
+      ariaControls,
+      ariaExpanded,
+      ariaDescribedBy,
+      ariaChecked,
+      onClick,
+      onFocus,
+      onBlur,
+      onKeyDown,
+      onKeyPress,
+      onKeyUp,
+      onMouseEnter,
+      onTouchStart,
+      overrideRef,
+      target,
+      ...rest
+    }: UnstyledButtonProps,
+    ref,
+  ) => {
+    let buttonMarkup;
+    const localButtonRef: React.RefObject<HTMLButtonElement> = useRef(null);
+    const localLinkRef: React.RefObject<HTMLAnchorElement> = useRef(null);
 
-  const commonProps = {
-    id,
-    className,
-    'aria-label': accessibilityLabel,
-  };
-  const interactiveProps = {
-    ...commonProps,
-    role,
-    onClick,
-    onFocus,
-    onBlur,
-    onMouseUp: handleMouseUpByBlurring,
-    onMouseEnter,
-    onTouchStart,
-  };
+    useImperativeHandle(ref, () => {
+      return {
+        focus: () =>
+          url
+            ? localLinkRef?.current?.focus()
+            : localButtonRef?.current?.focus(),
+      };
+    });
 
-  const handleClick = useDisableClick(disabled, onClick);
+    const commonProps = {
+      id,
+      className,
+      'aria-label': accessibilityLabel,
+    };
+    const interactiveProps = {
+      ...commonProps,
+      role,
+      onClick,
+      onFocus,
+      onBlur,
+      onMouseUp: handleMouseUpByBlurring,
+      onMouseEnter,
+      onTouchStart,
+    };
 
-  if (url) {
-    buttonMarkup = disabled ? (
-      // Render an `<a>` so toggling disabled/enabled state changes only the
-      // `href` attribute instead of replacing the whole element.
-      <a {...commonProps}>{children}</a>
-    ) : (
-      <UnstyledLink
-        {...interactiveProps}
-        url={url}
-        external={external}
-        target={target}
-        download={download}
-        {...rest}
-      >
-        {children}
-      </UnstyledLink>
-    );
-  } else {
-    buttonMarkup = (
-      <button
-        {...interactiveProps}
-        aria-disabled={disabled}
-        type={submit ? 'submit' : 'button'}
-        aria-busy={loading ? true : undefined}
-        aria-controls={ariaControls}
-        aria-expanded={ariaExpanded}
-        aria-describedby={ariaDescribedBy}
-        aria-checked={ariaChecked}
-        aria-pressed={pressed}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onKeyPress={onKeyPress}
-        onClick={handleClick}
-        tabIndex={disabled ? -1 : undefined}
-        {...rest}
-      >
-        {children}
-      </button>
-    );
-  }
+    const handleClick = useDisableClick(disabled, onClick);
 
-  return buttonMarkup;
-}
+    if (url) {
+      buttonMarkup = disabled ? (
+        // Render an `<a>` so toggling disabled/enabled state changes only the
+        // `href` attribute instead of replacing the whole element.
+        <a {...commonProps} ref={localLinkRef}>
+          {children}
+        </a>
+      ) : (
+        <UnstyledLink
+          {...interactiveProps}
+          url={url}
+          external={external}
+          download={download}
+          target={target}
+          {...rest}
+          ref={localLinkRef}
+        >
+          {children}
+        </UnstyledLink>
+      );
+    } else {
+      buttonMarkup = (
+        <button
+          {...interactiveProps}
+          aria-disabled={disabled}
+          type={submit ? 'submit' : 'button'}
+          aria-busy={loading ? true : undefined}
+          aria-controls={ariaControls}
+          aria-expanded={ariaExpanded}
+          aria-describedby={ariaDescribedBy}
+          aria-checked={ariaChecked}
+          aria-pressed={pressed}
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
+          onKeyPress={onKeyPress}
+          onClick={handleClick}
+          tabIndex={disabled ? -1 : undefined}
+          ref={localButtonRef}
+          {...rest}
+        >
+          {children}
+        </button>
+      );
+    }
+
+    return buttonMarkup;
+  },
+);
+UnstyledButton.displayName = 'UnstyledButton';

--- a/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
@@ -15,10 +15,13 @@ export interface UnstyledLinkProps extends LinkLikeComponentProps {}
 // but eslint-plugin-react doesn't know that just yet
 // eslint-disable-next-line react/display-name
 export const UnstyledLink = memo(
-  forwardRef<unknown, UnstyledLinkProps>(function UnstyledLink(props, _ref) {
+  forwardRef<HTMLAnchorElement, UnstyledLinkProps>(function UnstyledLink(
+    props,
+    ref,
+  ) {
     const LinkComponent = useLink();
     if (LinkComponent) {
-      return <LinkComponent {...unstyled.props} {...props} />;
+      return <LinkComponent {...unstyled.props} {...props} ref={ref} />;
     }
 
     const {external, url, target: targetProp, ...rest} = props;
@@ -34,7 +37,14 @@ export const UnstyledLink = memo(
     const rel = target === '_blank' ? 'noopener noreferrer' : undefined;
 
     return (
-      <a target={target} {...rest} href={url} rel={rel} {...unstyled.props} />
+      <a
+        target={target}
+        {...rest}
+        href={url}
+        rel={rel}
+        {...unstyled.props}
+        ref={ref}
+      />
     );
   }),
 );

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -1,3 +1,4 @@
+import type {RefObject} from 'react';
 import type React from 'react';
 
 /* eslint-disable @shopify/strict-component-boundaries */
@@ -108,6 +109,8 @@ export interface Action {
   external?: boolean;
   /** Where to display the url */
   target?: Target;
+  /** Ref to set on the button element */
+  ref?: RefObject<HTMLElement>;
   /** Callback when an action takes place */
   onAction?(): void;
   /** Callback when mouse enter */

--- a/polaris.shopify.com/content/components/actions/page-actions.md
+++ b/polaris.shopify.com/content/components/actions/page-actions.md
@@ -25,6 +25,9 @@ examples:
   - fileName: page-actions-with-custom-secondary-action.tsx
     title: With custom secondary action
     description: Use to create a custom secondary action.
+  - fileName: page-actions-with-activator-ref.tsx
+    title: With Activator ref on secondary action
+    description: Use to provide a ref on a secondary action.
 ---
 
 ## Best practices

--- a/polaris.shopify.com/content/components/layout-and-structure/page.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/page.md
@@ -27,6 +27,9 @@ examples:
   - fileName: page-with-custom-primary-action.tsx
     title: With custom primary action
     description: Use to create a custom primary action.
+  - fileName: page-with-activator-ref.tsx
+    title: With activator ref
+    description: Use to create a page with activator ref.
   - fileName: page-without-primary-action-in-header.tsx
     title: Without primary action in header
     description: Use when a primary action functions better as part of the page content instead of in the page header.

--- a/polaris.shopify.com/pages/examples/modal-with-activator-ref.tsx
+++ b/polaris.shopify.com/pages/examples/modal-with-activator-ref.tsx
@@ -14,9 +14,9 @@ function ModalExample() {
   }, []);
 
   const activator = (
-    <div ref={buttonRef}>
-      <Button onClick={handleOpen}>Open</Button>
-    </div>
+    <Button onClick={handleOpen} ref={buttonRef}>
+      Open
+    </Button>
   );
 
   return (

--- a/polaris.shopify.com/pages/examples/modal-without-an-activator-prop.tsx
+++ b/polaris.shopify.com/pages/examples/modal-without-an-activator-prop.tsx
@@ -10,16 +10,14 @@ function ModalExample() {
 
   const handleClose = useCallback(() => {
     setActive(false);
-    requestAnimationFrame(() =>
-      button.current?.querySelector('button')?.focus(),
-    );
+    requestAnimationFrame(() => button.current?.focus());
   }, []);
 
   return (
     <div style={{height: '500px'}}>
-      <div ref={button}>
-        <Button onClick={handleOpen}>Open</Button>
-      </div>
+      <Button onClick={handleOpen} ref={button}>
+        Open
+      </Button>
       <Modal
         instant
         open={active}

--- a/polaris.shopify.com/pages/examples/page-actions-with-activator-ref.tsx
+++ b/polaris.shopify.com/pages/examples/page-actions-with-activator-ref.tsx
@@ -1,0 +1,54 @@
+import {Modal, PageActions, Text} from '@shopify/polaris';
+import React, {useCallback, useRef, useState} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function PageExample() {
+  const [active, setActive] = useState(false);
+
+  const handleChange = useCallback(() => setActive(!active), [active]);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <PageActions
+        primaryAction={{
+          content: 'Save',
+        }}
+        secondaryActions={[
+          {
+            content: 'Delete product',
+            outline: true,
+            destructive: true,
+            ref: buttonRef,
+            onAction: () => setActive(true),
+          },
+        ]}
+      />
+      <div style={{height: '500px'}}>
+        <Modal
+          activator={buttonRef}
+          open={active}
+          onClose={handleChange}
+          title="Delete 3/4 inch Leather pet collar?"
+          primaryAction={{
+            content: 'Delete product',
+            onAction: handleChange,
+          }}
+          secondaryActions={[{content: 'Cancel', onAction: handleChange}]}
+        >
+          <Modal.Section>
+            <Text variant="bodyMd" as="p">
+              Are you sure you want to delete{' '}
+              <Text as="span" fontWeight="bold">
+                3/4 inch Leather pet collar
+              </Text>
+              ? This can&apos;t be undone.
+            </Text>
+          </Modal.Section>
+        </Modal>
+      </div>
+    </>
+  );
+}
+
+export default withPolarisExample(PageExample);

--- a/polaris.shopify.com/pages/examples/page-with-activator-ref.tsx
+++ b/polaris.shopify.com/pages/examples/page-with-activator-ref.tsx
@@ -1,0 +1,69 @@
+import {
+  Page,
+  LegacyCard,
+  LegacyStack,
+  Button,
+  Modal,
+  Text,
+} from '@shopify/polaris';
+import React, {useCallback, useRef, useState} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function PageExample() {
+  const [active, setActive] = useState(true);
+
+  const handleChange = useCallback(() => setActive(!active), [active]);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  return (
+    <Page
+      breadcrumbs={[{content: 'Orders', url: '#'}]}
+      title="#1085"
+      secondaryActions={[
+        {content: 'Print'},
+        {content: 'Unarchive'},
+        {
+          id: 'cancel-order',
+          content: 'Cancel order',
+          ref: buttonRef,
+          onAction: () => setActive(true),
+        },
+      ]}
+      pagination={{
+        hasPrevious: true,
+        hasNext: true,
+      }}
+    >
+      <LegacyCard sectioned title="Fulfill order">
+        <LegacyStack alignment="center">
+          <LegacyStack.Item fill>
+            <p>Buy postage and ship remaining 2 items</p>
+          </LegacyStack.Item>
+          <Button primary>Continue</Button>
+        </LegacyStack>
+      </LegacyCard>
+      <Modal
+        activator={buttonRef}
+        open={active}
+        onClose={handleChange}
+        title="Delete 3/4 inch Leather pet collar?"
+        primaryAction={{
+          content: 'Delete product',
+          onAction: handleChange,
+        }}
+        secondaryActions={[{content: 'Cancel', onAction: handleChange}]}
+      >
+        <Modal.Section>
+          <Text variant="bodyMd" as="p">
+            Are you sure you want to delete{' '}
+            <Text as="span" fontWeight="bold">
+              3/4 inch Leather pet collar
+            </Text>
+            ? This can&apos;t be undone.
+          </Text>
+        </Modal.Section>
+      </Modal>
+    </Page>
+  );
+}
+
+export default withPolarisExample(PageExample);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When using buttons that open modals, we should be able to focus on the button after the modal has closed for accessibility reasons.

Added forwardRef support to `Button` and `UnstyledButton` and `UnstyledLink`.

I had to modify `Pages.secondaryActions` to include a ref as well, this should reduce the need to create custom secondary actions with `ref` being a baked in prop. Also, some follow up work to add ref to `ActionList.item`.

**Disclaimer: We're cutting the work done to keep popovers open due to a lot of jank with rollupactions and focus not being retained. This will deliver at least some value to actions/items that don't get slammed under a popover. Here's a branch `ks-popover-stay` with the popover work that doesn't quite work fully.**

helps me out on my work in https://github.com/Shopify/web/issues/37895
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adding ref support to `Button`, `UnstyledButton`, and any action that extends the `Action` type by using `forwardRef`. 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
https://screenshot.click/17-43-6y4gp-s2llx.mp4
You can see that Delete is focused again after hitting `esc` and I can press space bar to reopen the modal. This covers the changes to secondaryActions, as well as the button's properly using forwardRef to have a targetable base `<button/>`

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

I'm not sure how to share my playground from spin, but if you follow https://docs.google.com/document/d/19mM7_tRje10s2_1oXxjRewifo6Ub8hAAEanQvD3wvoc/edit with this branch, then access  <change your localhost if necessary>
http://localhost:6006/?path=/story/all-components-pageactions--secondary-with-activator
http://localhost:6006/?path=/story/all-components-modal--with-activator-ref

you can test the changes to both button and secondaryActions by hitting escape on the open modal, then pressing spacebar.

If you want to see the focus in action on Export in discounts, you can visit https://admin.web.ks-focus-2.ken-slawinski.us.spin.dev/store/shop1/discounts and click export, hit esc, and hit space again. More details [here](https://github.com/Shopify/web/pull/86490): (the work that necessitated changes here in polaris)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
