### PR TITLE
Manage return focus to activator for Secondary actions

### DIFF
--- a/polaris-react/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
+++ b/polaris-react/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {LegacyRef, useCallback} from 'react';
 
 import type {ActionListSection, MenuGroupDescriptor} from '../../../../types';
 import {ActionList} from '../../../ActionList';
@@ -22,6 +22,8 @@ export interface MenuGroupProps extends MenuGroupDescriptor {
   getOffsetWidth?(width: number): void;
   /** Collection of sectioned action items */
   sections?: readonly ActionListSection[];
+  /** The element or the RefObject that activates the Modal */
+  groupActivatorRef?: LegacyRef<HTMLSpanElement> | undefined;
 }
 
 export function MenuGroup({
@@ -37,6 +39,7 @@ export function MenuGroup({
   onOpen,
   getOffsetWidth,
   sections,
+  groupActivatorRef,
 }: MenuGroupProps) {
   const handleClose = useCallback(() => {
     onClose(title);
@@ -70,6 +73,7 @@ export function MenuGroup({
       accessibilityLabel={accessibilityLabel}
       onClick={handleClick}
       getOffsetWidth={handleOffsetWidth}
+      activatorRef={groupActivatorRef}
     >
       {title}
     </SecondaryAction>

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {LegacyRef, useEffect, useRef} from 'react';
 
 import {classNames} from '../../../../utilities/css';
 import {Tooltip} from '../../../Tooltip';
@@ -9,6 +9,7 @@ import styles from './SecondaryAction.scss';
 
 interface SecondaryAction extends ButtonProps {
   helpText?: React.ReactNode;
+  activatorRef?: LegacyRef<HTMLSpanElement> | undefined;
   onAction?(): void;
   getOffsetWidth?(width: number): void;
 }
@@ -17,6 +18,7 @@ export function SecondaryAction({
   children,
   destructive,
   helpText,
+  activatorRef,
   onAction,
   getOffsetWidth,
   ...rest
@@ -30,9 +32,11 @@ export function SecondaryAction({
   }, [getOffsetWidth]);
 
   const buttonMarkup = (
-    <Button onClick={onAction} {...rest}>
-      {children}
-    </Button>
+    <span ref={activatorRef}>
+      <Button onClick={onAction} {...rest}>
+        {children}
+      </Button>
+    </span>
   );
 
   const actionMarkup = helpText ? (

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -1,3 +1,4 @@
+import type {LegacyRef} from 'react';
 import type React from 'react';
 
 /* eslint-disable @shopify/strict-component-boundaries */
@@ -218,7 +219,10 @@ export interface ComplexAction
     IconableAction,
     OutlineableAction,
     LoadableAction,
-    PlainAction {}
+    PlainAction {
+  /** The element or the RefObject that activates the Modal */
+  activatorRef?: LegacyRef<HTMLSpanElement> | undefined;
+}
 
 export interface MenuActionDescriptor extends ComplexAction, TooltipAction {
   /** Zero-indexed numerical position. Overrides the action's order in the menu */

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -246,6 +246,8 @@ export interface MenuGroupDescriptor extends BadgeAction {
   onActionAnyItem?: ActionListItemDescriptor['onAction'];
   /** Callback when the menu is clicked */
   onClick?(openActions: () => void): void;
+  /** The element or the RefObject that activates the Modal */
+  groupActivatorRef?: LegacyRef<HTMLSpanElement> | undefined;
 }
 
 export interface ConnectedDisclosure {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

**_Resolves:_** https://github.com/Shopify/polaris/issues/8105

_**TL;DR:**_ There is a focus management issue prevalent across the Admin. Many of the Page secondary actions in the Admin - e.g. Import, Export, Duplicate, etc. - open a modal, and currently there is no easy way to [return focus to the modal activator](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/#keyboard-interaction-7) when the activator is the secondary action of the Page component that doesn't support it.




<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- [commit 5151eaa0](https://github.com/Shopify/polaris/pull/8722/commits/5151eaa074d4718d58b7d05be3338bd6d3dc2b95): added activatorRef to SecondaryAction to manage return focus to activator.
Video how it works in Admin:

https://user-images.githubusercontent.com/104942025/226687638-970f1ec5-7609-4ed9-b16d-04fd397cff3e.mov


- [commit 8bfa834](https://github.com/Shopify/polaris/pull/8722/commits/8bfa834c5d593165091c22ee7d95240e22965328): added activatorRef to Grouped action to manage return focus to activator
Video how it works in Admin:

https://user-images.githubusercontent.com/104942025/226687935-e22c7cad-5446-43f4-a3e2-0983a6ad6786.mov


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
Run Polaris and[ corresponding web](https://github.com/Shopify/web/pull/87000) branches locally, please follow these instructions: [ Working with Polaris](https://web.docs.shopify.io/docs/guides/working-with-polaris).
[Spin URL](https://shop1.shopify.oa-add-fer-to-secondary-actions-new.oksana-azarova.us.spin.dev/admin/staff) for testing implementation for Product Detail "Duplicate" and "More Actions" -> "Fake App action" buttons


🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->
Note: There are only Page `secondaryActions `and `actionGroups` provided in a playground, as using these actions and Modal requires special web utilities. So it is better to use a [real web branch](https://github.com/Shopify/web/pull/87000) to test implementation.
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  const duplicateActivatorRef = useRef<HTMLElement | null>(null);
  const moreActionsActivatorRef = useRef<HTMLElement | null>(null);
  return (
    <>
      <Page
        breadcrumbs={[{content: 'Products', url: '#'}]}
        title="3/4 inch Leather pet collar"
        titleMetadata={<Badge status="success">Paid</Badge>}
        subtitle="Perfect for any pet"
        compactTitle
        primaryAction={{content: 'Save', disabled: true}}
        secondaryActions={[
          {
            content: 'Duplicate',
            accessibilityLabel: 'Secondary action label',
            onAction: () => alert('Duplicate action'),
            activatorRef: duplicateActivatorRef,
          },
        ]}
        actionGroups={[
          {
            title: 'More actions',
            actions: [
              {
                content: 'Share on Facebook',
                accessibilityLabel: 'Individual action label',
                onAction: () => alert('Share on Facebook action'),
              },
            ],
            groupActivatorRef: moreActionsActivatorRef,
          },
        ]}
      />
    </>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
