### PR TITLE
[IndexTable] Support default sorting direction per column

### DIFF
--- a/.changeset/fuzzy-rockets-leave.md
+++ b/.changeset/fuzzy-rockets-leave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Update IndexTable heading to support default sorting direction

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1861,7 +1861,7 @@ export function WithSortableHeadings() {
         onSelectionChange={handleSelectionChange}
         headings={[
           {title: 'Name'},
-          {title: 'Date'},
+          {title: 'Date', defaultSortDirection: 'ascending'},
           {
             alignment: 'end',
             id: 'order-count',

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -57,6 +57,11 @@ interface IndexTableHeadingBase {
   tooltipContent?: React.ReactNode;
   tooltipWidth?: Width;
   tooltipPersistsOnClick?: boolean;
+  /**
+   * The direction to sort the table rows on first click or keypress of this column heading.
+   * When not specified, the value from IndexTable.defaultSortDirection will be used.
+   */
+  defaultSortDirection?: IndexTableSortDirection;
 }
 
 interface IndexTableHeadingTitleString extends IndexTableHeadingBase {
@@ -910,11 +915,12 @@ function IndexTableBase({
         !isCurrentlySorted && index === lastSortedColumnIndex.current;
 
       const isAscending = sortDirection === 'ascending';
-      let newDirection: IndexTableSortDirection = defaultSortDirection;
+
+      let newDirection: IndexTableSortDirection =
+        heading.defaultSortDirection ?? defaultSortDirection;
+
       let SourceComponent =
-        defaultSortDirection === 'ascending'
-          ? SortAscendingMajor
-          : SortDescendingMajor;
+        newDirection === 'ascending' ? SortAscendingMajor : SortDescendingMajor;
       if (isCurrentlySorted) {
         newDirection = isAscending ? 'descending' : 'ascending';
         SourceComponent =
@@ -985,7 +991,7 @@ function IndexTableBase({
 
       const tooltipDirection = isCurrentlySorted
         ? sortDirection!
-        : defaultSortDirection;
+        : newDirection;
 
       const sortTooltipContent = sortToggleLabels[index][tooltipDirection];
 

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -675,6 +675,26 @@ describe('<IndexTable>', () => {
           expect(index.findAll('th')[3]).toContainReactComponent(source);
         },
       );
+
+      it('uses column defaultSortDirection instead of table defaultSortDirection', () => {
+        const index = mountWithApp(
+          <IndexTable
+            {...defaultSortingProps}
+            defaultSortDirection="ascending"
+            headings={[
+              {title: 'Foo'},
+              {title: 'Bar'},
+              {title: 'Baz', defaultSortDirection: 'descending'},
+            ]}
+          >
+            {tableItems.map(mockRenderRow)}
+          </IndexTable>,
+        );
+
+        expect(index.findAll('th')[3]).toContainReactComponent(
+          SortDescendingMajor,
+        );
+      });
     });
 
     describe('onSort', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Currently, IndexTable supports a default sorting direction that is applied to all columns. 
There is a requirement for [usecase](https://www.figma.com/file/3QH9sHSCgqrL0tnzQP11Ff/Shop-Promise---Fulfill-by-in-Admin?node-id=1285-118389&t=6kIJdAslxdKukgeW-4) to use a different default value but just for a particular column.  (Fulfill by column in the design)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This PR introduces an optional default sorting direction property to the heading object. When provided, it will be used instead of the table default sorting direction.
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->
In the following video you can see that the date column has default sorting as ascending while the rest of the columns have it as descending

https://user-images.githubusercontent.com/10687598/227172647-419023f5-188c-4e6f-904e-2e2f4ed14f66.mp4



### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

- Clone this branch locally.
- Visit the new "With Sortable Headings" story in the IndexTable
- Based on the sorting label, confirm that the Date column default sorting is 'ascending' instead of the default from the table ('descending')
- Confirm that the default sorting for other columns function is descending
Note: it seems like the way the the data is compared for sorting is not correct as it seems to sort based on string length instead of the actual content

### 🎩 checklist - Not really needed for this type of change (?)

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
