### PR TITLE
[IndexTable] prevents right-aligned header sort icon flicker on hover after selection

### DIFF
--- a/.changeset/chilly-masks-fly.md
+++ b/.changeset/chilly-masks-fly.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[IndexTable] fixes sort icon flicker on right-aligned heading hover after selection

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -292,10 +292,6 @@ $loading-panel-height: 53px;
       opacity: 1;
     }
   }
-
-  .TableHeadingSortIcon-heading-align-end {
-    animation: hide-right-aligned-sort-button-icon var(--p-duration-50);
-  }
 }
 
 .TableHeadingSortButton-heading-align-end {
@@ -341,7 +337,7 @@ $loading-panel-height: 53px;
   height: var(--p-space-5);
   width: var(--p-space-5);
 
-  &:not(.TableHeadingSortIcon-heading-align-end),
+  &:not(.TableHeadingSortIcon-heading-align-end:hover),
   &:not(.TableHeadingSortButton-heading-align-end-previously-sorted) {
     transition: opacity var(--p-duration-50) var(--p-ease);
   }
@@ -807,27 +803,5 @@ $scroll-bar-size: var(--p-space-2);
 
   100% {
     opacity: 1;
-  }
-}
-
-/* stylelint-disable-next-line polaris/motion/at-rule-disallowed-list -- custom animation for right-aligned header */
-@keyframes hide-right-aligned-sort-button-icon {
-  0% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-
-  20% {
-    opacity: 0;
-    transform: translateX(0);
-  }
-
-  90% {
-    transform: translateX(calc(var(--p-space-5) * -1));
-  }
-
-  100% {
-    opacity: 0;
-    transform: translateX(calc(var(--p-space-5) * -1));
   }
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -314,7 +314,7 @@ $loading-panel-height: 53px;
   content: '';
   position: absolute;
   top: 0;
-  left: 95%;
+  left: calc(100% - var(--p-space-2));
   height: 100%;
   width: var(--p-space-6);
   display: block;

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -945,7 +945,6 @@ function IndexTableBase({
           className={classNames(
             styles.TableHeadingSortIcon,
             heading?.alignment === 'end' &&
-              !isRenderAfterSelectEvent &&
               styles['TableHeadingSortIcon-heading-align-end'],
             isCurrentlySorted && styles['TableHeadingSortIcon-visible'],
           )}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

tl;dr These changes add the final polish to the right-aligned table header updates.

Conditionally applying the class with the right-aligned sort icon fade out animation triggered a flash of the sort icon when the user clicked on a single row or the "select all" checkbox, then clicked on a sortable table header other than the impacted right-aligned one(s). Because the keyframe animation starts with the sort icon visible, the initial opacity value is `1.0`, and that's where the flicker originated.

I was able to apply the default sort icon fade transition to the right-aligned header on hover-end only. This eliminates the flicker and makes the sort icon fade consistent and agnostic to the order of user events (sequence of sort and selection clicks).

The logic to detect a render after a selection is still needed to prevent the sort button's slide animation from firing.

Additionally, I adjusted the left position calculation of the right-aligned sort button's `::before` pseudo-element to ensure consistency. The first iteration placement was relative to the size of the button, but the updated version is offset from the right edge of the button.

#### Before

https://user-images.githubusercontent.com/100380574/227277947-a402c4a4-8b54-4ffd-8e66-5c9086de24ac.mov


#### After

https://user-images.githubusercontent.com/100380574/227343185-ffc9d693-1e6f-4450-a2e8-484b09d7d02c.mov

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
