### PR TITLE
[Tooltip][persistOnClick] Fix conditionals

### DIFF
--- a/.changeset/quick-buttons-promise.md
+++ b/.changeset/quick-buttons-promise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Tooltip` with `persistOnClick` set causing an error when clicked

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -193,11 +193,14 @@ export function Tooltip({
       onBlur={() => {
         handleClose();
         handleBlur();
-        persistOnClick && togglePersisting();
+
+        if (persistOnClick) {
+          togglePersisting();
+        }
       }}
       onMouseLeave={handleMouseLeave}
       onMouseOver={handleMouseEnterFix}
-      onMouseDown={persistOnClick && togglePersisting}
+      onMouseDown={persistOnClick ? togglePersisting : undefined}
       ref={setActivator}
       onKeyUp={handleKeyUp}
       className={wrapperClassNames}

--- a/polaris.shopify.com/content/components/overlays/tooltip.md
+++ b/polaris.shopify.com/content/components/overlays/tooltip.md
@@ -18,6 +18,9 @@ examples:
   - fileName: tooltip-visible-only-with-child-interaction.tsx
     title: Visible only with child interaction
     description: Use when the tooltip overlays interactive elements when active, for example a form input. The `dismissOnMouseOut` prop prevents the tooltip from remaining active when mouse hover or focus leaves its `children` and enters the tooltip's content.
+  - fileName: tooltip-with-persistence-on-click.tsx
+    title: With persistence on click
+    description: Use to present a tooltip that remains open if activated by click or keypress.
   - fileName: tooltip-with-suffix.tsx
     title: With suffix
     description: Use when merchants benefit from information supplemental to the tooltip content. For example, to present a keyboard shortcut beside the content of a tooltip that describes an icon button.

--- a/polaris.shopify.com/pages/examples/tooltip-with-persistence-on-click.tsx
+++ b/polaris.shopify.com/pages/examples/tooltip-with-persistence-on-click.tsx
@@ -1,0 +1,17 @@
+import {Tooltip, Text} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TooltipExample() {
+  return (
+    <div style={{padding: '75px 0'}}>
+      <Tooltip persistOnClick active content="This order has shipping labels.">
+        <Text fontWeight="bold" as="span">
+          Order #1001
+        </Text>
+      </Tooltip>
+    </div>
+  );
+}
+
+export default withPolarisExample(TooltipExample);


### PR DESCRIPTION
### WHY are these changes introduced?

Clicking on a Tooltip when persistOnClick is true results in an error because the && conditional operator is causing the callback set on the `onMouseDown`  prop to evaluate to a boolean:

```console
Warning: Expected `onMouseDown` listener to be a function, instead got `false`.

If you used to conditionally omit it with onMouseDown={condition && value}, pass onMouseDown={condition ? value : undefined} instead.
    at span
    at Tooltip (https://84sd27.csb.app/node_modules/@shopify/polaris/build/esm/components/Tooltip/Tooltip.js:25:29)
    at div
    at TooltipExample
    at EphemeralPresenceManager (https://84sd27.csb.app/node_modules/@shopify/polaris/build/esm/components/EphemeralPresenceManager/EphemeralPresenceManager.js:19:46)
    at FocusManager (https://84sd27.csb.app/node_modules/@shopify/polaris/build/esm/components/FocusManager/FocusManager.js:16:34)
    at PortalsManager (https://84sd27.csb.app/node_modules/@shopify/polaris/build/esm/components/PortalsManager/PortalsManager.js:17:36)
    at MediaQueryProvider (https://84sd27.csb.app/node_modules/@shopify/polaris/build/esm/components/MediaQueryProvider/MediaQueryProvider.js:19:67)
    at AppProvider (https://84sd27.csb.app/node_modules/@shopify/polaris/build/esm/components/AppProvider/AppProvider.js:33:5)
```

### WHAT is this pull request doing?

This PR updates the conditional calling/setting of related callback from using && operator to a ternary operator.

### Tophatting instructions 🎩 

- `git checkout fix-persist-on-click`
- `yarn build && yarn turbo run dev --filter=polaris.shopify.com` 
- Navigate to the "Persist on click" example in the Tooltip documentation. Clicking should no longer result in an error thrown.