### PR TITLE
Remove supurfolous console warnings about duplicate types

### DIFF
--- a/.changeset/slow-vans-press.md
+++ b/.changeset/slow-vans-press.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Remove supurfolous console warnings about duplicate types

--- a/polaris.shopify.com/scripts/get-props/src/get-props.ts
+++ b/polaris.shopify.com/scripts/get-props/src/get-props.ts
@@ -45,15 +45,6 @@ export function getProps(filePaths: string[]): AllTypes {
     }
   }
 
-  Object.entries(ast).forEach(([name, value]) => {
-    const definitionCount = Object.keys(value).length;
-    if (definitionCount !== 1) {
-      console.warn(
-        `A type called "${name}" is defined in ${definitionCount} files`,
-      );
-    }
-  });
-
   return ast;
 
   function visit(


### PR DESCRIPTION
The `get-props` script which is run as part of the docs site build is very noisy; it reports on "duplicate types" which doesn't make sense because there _will always be_ duplicate types - types don't have to be global in the codebase.

This PR removes the noisy console warnings.

<img width="649" alt="Screenshot 2023-03-24 at 1 50 22 pm" src="https://user-images.githubusercontent.com/612020/227411832-f608f5c1-5ca7-4a58-8c4c-5a34f7c8e95e.png">
