### PR TITLE
Create utils for pretty output when running gen-assets child processes locally

### DIFF
--- a/.changeset/nice-apples-collect.md
+++ b/.changeset/nice-apples-collect.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Create utils for pretty output when running gen-assets child processes locally

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -17,7 +17,7 @@
     "create-component": "generact --root src/components src/components/Template/Template.tsx",
     "gen-sitemap": "yarn next-sitemap",
     "get-props": "tsc ./scripts/get-props/src/get-props.ts --target esnext --module node16 --types \"react\" --outDir ./scripts/tmp && node ./scripts/tmp/scripts/get-props/src/get-props.js && rm -rf ./scripts/tmp",
-    "gen-assets": "node scripts/gen-assets.mjs && yarn get-props"
+    "gen-assets": "yarn get-props && node scripts/gen-assets.mjs"
   },
   "dependencies": {
     "@floating-ui/react-dom-interactions": "^0.10.1",
@@ -46,6 +46,7 @@
     "remark-gfm": "^3.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "remark-unwrap-images": "^3.0.1",
+    "terminate": "^2.6.1",
     "use-dark-mode": "^2.3.1"
   },
   "devDependencies": {
@@ -58,6 +59,7 @@
     "@types/prismjs": "^1.26.0",
     "@types/react": "18.0.15",
     "babel-plugin-preval": "^5.1.0",
+    "chalk": "^5.2.0",
     "chokidar": "^3.5.3",
     "eslint": "8.10.0",
     "eslint-config-next": "^13.0.0",
@@ -66,9 +68,11 @@
     "generact": "^0.4.0",
     "get-site-urls": "3.0.0-alpha.1",
     "globby": "^11.1.0",
+    "is-ci": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash.set": "^4.3.2",
     "marked": "^4.0.16",
+    "ora": "^6.2.0",
     "p-map": "^5.5.0",
     "playroom": "^0.28.0",
     "puppeteer": "^16.0.0",

--- a/polaris.shopify.com/scripts/gen-assets.mjs
+++ b/polaris.shopify.com/scripts/gen-assets.mjs
@@ -1,10 +1,10 @@
-import genSiteMap from './gen-site-map.mjs';
 import genCacheJson from './gen-cache-json.mjs';
+import genSiteMap from './gen-site-map.mjs';
 import genOgImages from './gen-og-images.mjs';
 
-const genAssets = async () => {
-  await Promise.all([genSiteMap(), genCacheJson()]);
-  await genOgImages();
-};
-
-await genAssets();
+// Generate nav & cache files which the docs site depend on to run
+await genCacheJson();
+// Build the docs site, then generate the sitemap.xml
+await genSiteMap();
+// Use the sitemap.xml to generate Open Graph images
+await genOgImages();

--- a/polaris.shopify.com/scripts/gen-site-map.mjs
+++ b/polaris.shopify.com/scripts/gen-site-map.mjs
@@ -1,21 +1,41 @@
-import {execa} from 'execa';
-import path from 'path';
+import {prettyExeca, startLocalServer} from './util.mjs';
 
 const genSiteMap = async () => {
   const outputFile = 'public/sitemap.xml';
 
-  const nextBin = path.join(process.cwd(), 'node_modules/.bin/next');
-  const server = execa(nextBin, ['dev']);
+  const server = startLocalServer('dev');
+  server.catch((err) => {
+    if (!server.killed) {
+      console.error(err.stderr);
+      process.exit(-1);
+    }
+  });
 
-  const {stdout} = await execa('npx', [
-    'get-site-urls',
-    'http://localhost:3000',
-    `--output=${outputFile}`,
-    '--alias=https://polaris.shopify.com',
-  ]);
-  console.log(stdout);
-
-  await server.kill();
+  try {
+    await prettyExeca(
+      'npx',
+      [
+        'get-site-urls',
+        'http://localhost:3000',
+        `--output=${outputFile}`,
+        '--alias=https://polaris.shopify.com',
+      ],
+      {
+        stdout: 'inherit',
+        stderr: 'inherit',
+        pretty: {
+          text: 'Generating sitemap',
+          successText: 'Sitemap generated',
+          failText: 'Unable to generate sitemap',
+        },
+      },
+    );
+  } finally {
+    if (server) {
+      // Kill the yarn command _and_ the child process running node
+      await server.kill();
+    }
+  }
 };
 
 export default genSiteMap;

--- a/polaris.shopify.com/scripts/get-props/src/get-props.ts
+++ b/polaris.shopify.com/scripts/get-props/src/get-props.ts
@@ -281,8 +281,16 @@ if (isExecutedThroughCommandLine) {
   ]).then((files) => {
     let filesWithoutTests = files.filter((file) => !file.endsWith('test.tsx'));
     const ast = getProps(filesWithoutTests);
-    const filePath = path.join(__dirname, '../../../../../.cache/props.json');
-    fs.writeFileSync(filePath, JSON.stringify(ast, undefined, 2));
+
+    const cacheDir = path.join(__dirname, '../../../../../.cache');
+    if (!fs.existsSync(cacheDir)) {
+      fs.mkdirSync(cacheDir, {recursive: true});
+    }
+
+    fs.writeFileSync(
+      path.join(cacheDir, 'props.json'),
+      JSON.stringify(ast, undefined, 2),
+    );
   });
 }
 

--- a/polaris.shopify.com/scripts/util.mjs
+++ b/polaris.shopify.com/scripts/util.mjs
@@ -1,0 +1,115 @@
+import readline from 'node:readline';
+import {execa} from 'execa';
+import ora from 'ora';
+import chalk from 'chalk';
+import isCI from 'is-ci';
+import terminate from 'terminate/promise.js';
+
+const isTTY = process.stdout.isTTY && !isCI;
+
+function enhancedProcessKill(prc) {
+  prc.kill = async (signal = 'SIGKILL') => {
+    prc.killed = true;
+    // Kill the yarn command _and_ the child process running node
+    await terminate(prc.pid, signal);
+  };
+  return prc;
+}
+
+// opts.pretty = true | { text: '', successText: '', failText: '' }
+// When opts.pretty is set, will output command execution status. If running in
+// a TTY, will do it with a spinner.
+export function prettyExeca(cmd, args = [], opts = {}) {
+  // act as a pass-through for execa when the pretty flag isn't set
+  if (!opts.pretty) {
+    return enhancedProcessKill(execa(cmd, args, opts));
+  }
+
+  if (isTTY) {
+    // hijack output so we can pretty print it next to the spinner later
+    opts = {
+      ...opts,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    };
+  }
+
+  const defaultPrettyText = `${cmd} ${args.join(' ')}`;
+  const spinner = ora();
+  spinner.start(opts.pretty.text ?? defaultPrettyText);
+
+  // Start the process
+  const prc = enhancedProcessKill(execa(cmd, args, opts));
+
+  prc
+    .then(() => {
+      spinner.succeed(opts.pretty.successText ?? defaultPrettyText);
+    })
+    .catch(() => {
+      spinner.fail(opts.pretty.failText ?? defaultPrettyText);
+    });
+
+  if (isTTY) {
+    // accumulate stderr in case we need to dump it out later
+    const getStdErr = streamToStringGetter(prc.stderr);
+
+    // intercept lines of output to stdout, and write it to the spinner
+    // We need an extra 'done' semaphore because the process can apparently keep
+    // outputing even after its finished :surprised-pikachu:
+    let done = false;
+    const lineReader = readline.createInterface({
+      input: prc.stdout,
+      crlfDelay: Infinity,
+    });
+
+    lineReader.on('line', (line) => {
+      if (!done) {
+        spinner.text = `${opts.pretty.text ?? defaultPrettyText} ${chalk.dim(
+          // Avoid wrapping by truncating and removing newlines
+          line.slice(0, 64).replace('\n', ' '),
+        )}`;
+      }
+    });
+
+    prc
+      .then(() => {
+        done = true;
+        lineReader.close();
+      })
+      .catch(async () => {
+        done = true;
+        lineReader.close();
+        const message = getStdErr();
+        console.error(message);
+      });
+  }
+
+  return prc;
+}
+
+// Accumulate a stream, converting it into a string on request
+function streamToStringGetter(stream) {
+  const chunks = [];
+  stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+  return () => Buffer.concat(chunks).toString('utf8');
+}
+
+export function genAssets() {
+  return prettyExeca('yarn', ['gen-assets'], {
+    stdout: 'inherit',
+    stderr: 'inherit',
+    pretty: {
+      text: 'Generating site assets',
+      successText: 'Generated site assets',
+      failText: "Couldn't generate site assets",
+    },
+  });
+}
+
+export function startLocalServer(command = 'start') {
+  return prettyExeca('yarn', ['next', command], {
+    stdout: 'ignore',
+    stderr: 'pipe',
+    shell: true,
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7408,6 +7408,11 @@ chalk@^5.0.0, chalk@^5.0.1:
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
   integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==
 
+chalk@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
+  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
+
 change-case@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
@@ -9209,7 +9214,7 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==
 
-duplexer@^0.1.2:
+duplexer@^0.1.2, duplexer@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
@@ -9987,6 +9992,19 @@ eval@0.1.6:
   integrity sha512-o0XUw+5OGkXw4pJZzQoXUk+H87DHuC+7ZE//oSrRGtatTmr12oTnLfg6QOq9DyTt0c/p4TwzgmkKrBzWTSizyQ==
   dependencies:
     require-like ">= 0.1.1"
+
+event-stream@=3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  integrity sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
 
 event-target-shim@^5.0.0:
   version "5.0.1"
@@ -10923,6 +10941,11 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+  integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
 
 frontmatter@^0.0.3:
   version "0.0.3"
@@ -14892,6 +14915,11 @@ map-or-similar@^1.5.0:
   resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
   integrity sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -16742,6 +16770,21 @@ ora@^6.0.1, ora@^6.1.0:
     strip-ansi "^7.0.1"
     wcwidth "^1.0.1"
 
+ora@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-6.2.0.tgz#6d727902151d5b1badc599ace4df45a34d53f556"
+  integrity sha512-c1qb/1rdE+EFDYiLXh10VY459uMh7DN9zlgd8mZJLoeiPpYllN8eAOiih2Rkah5ywxRm5tHN5C9zPheDq8d1MA==
+  dependencies:
+    chalk "^5.0.0"
+    cli-cursor "^4.0.0"
+    cli-spinners "^2.6.1"
+    is-interactive "^2.0.0"
+    is-unicode-supported "^1.1.0"
+    log-symbols "^5.1.0"
+    stdin-discarder "^0.1.0"
+    strip-ansi "^7.0.1"
+    wcwidth "^1.0.1"
+
 os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
@@ -17311,6 +17354,13 @@ pathe@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-0.2.0.tgz#30fd7bbe0a0d91f0e60bae621f5d19e9e225c339"
   integrity sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==
+
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
+  dependencies:
+    through "~2.3"
 
 pbkdf2@^3.0.3:
   version "3.1.2"
@@ -18249,6 +18299,13 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+ps-tree@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
+  integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
+  dependencies:
+    event-stream "=3.3.4"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -20314,6 +20371,13 @@ split2@^4.0.0:
   resolved "https://registry.yarnpkg.com/split2/-/split2-4.1.0.tgz#101907a24370f85bb782f08adaabe4e281ecf809"
   integrity sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -20439,6 +20503,13 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
+stdin-discarder@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.1.0.tgz#22b3e400393a8e28ebf53f9958f3880622efde21"
+  integrity sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==
+  dependencies:
+    bl "^5.0.0"
+
 stdout-stream@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.1.tgz#5ac174cdd5cd726104aa0c0b2bd83815d8d535de"
@@ -20458,6 +20529,13 @@ stream-browserify@^2.0.1:
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  integrity sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-each@^1.1.0:
   version "1.2.3"
@@ -21099,6 +21177,13 @@ terminal-link@^3.0.0:
     ansi-escapes "^5.0.0"
     supports-hyperlinks "^2.2.0"
 
+terminate@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/terminate/-/terminate-2.6.1.tgz#99a4eb1647011b95f47401f6beb9f23e0362fbc0"
+  integrity sha512-0kdr49oam98yvjkVY+gfUaT3SMaJI6Sc+yijJjU+qhat+0NQKQn60OsIZZeKyVgTO0/33nRa3HowRbpw3A7u9A==
+  dependencies:
+    ps-tree "^1.2.0"
+
 terser-webpack-plugin@^1.4.3:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b"
@@ -21203,7 +21288,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@^2.3.6, through@^2.3.8:
+through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=


### PR DESCRIPTION
When running `yarn workspace polaris.shopify.com gen-assets` the output is noisy and uninformative (it often looks like the `og-images` step has frozen because it takes so long).

This change produces pretty output when running in a non-CI TTY (ie; your local terminal):

![nice](https://user-images.githubusercontent.com/612020/227416720-3825f8e1-d655-43f1-aea7-4c9e9f3e8301.gif)

_(Note: The output is unchanged in CI / non-TTY. ie; the full output is dumped to the console when running in CI, so there is no change there)_

It also introduces a couple of utilities for doing this nice output which will come in handy for an upcoming PR that adds another useful CLI command for our docs site.

If any of the commands error out, it will dump the full stderr log for easy debugging:

<img width="478" alt="Screenshot 2023-03-24 at 2 46 24 pm" src="https://user-images.githubusercontent.com/612020/227419468-185d1395-3d83-4635-b5b8-b83097572b8e.png">
