### PR TITLE
Generate sitemap from production docs site build to ensure draft URLs aren't accidentally exposed.

### DIFF
--- a/.changeset/quick-turkeys-stare.md
+++ b/.changeset/quick-turkeys-stare.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Generate sitemap from production docs site build to ensure draft URLs aren't accidentally exposed.

--- a/polaris.shopify.com/scripts/gen-site-map.mjs
+++ b/polaris.shopify.com/scripts/gen-site-map.mjs
@@ -1,9 +1,15 @@
-import {prettyExeca, startLocalServer} from './util.mjs';
+import {prettyExeca, buildLocalServer, startLocalServer} from './util.mjs';
 
 const genSiteMap = async () => {
   const outputFile = 'public/sitemap.xml';
 
-  const server = startLocalServer('dev');
+  try {
+    await buildLocalServer();
+  } catch (error) {
+    process.exit(-1);
+  }
+
+  const server = startLocalServer();
   server.catch((err) => {
     if (!server.killed) {
       console.error(err.stderr);

--- a/polaris.shopify.com/scripts/util.mjs
+++ b/polaris.shopify.com/scripts/util.mjs
@@ -94,6 +94,18 @@ function streamToStringGetter(stream) {
   return () => Buffer.concat(chunks).toString('utf8');
 }
 
+export function buildLocalServer() {
+  return prettyExeca('yarn', ['next', 'build'], {
+    stdout: 'inherit',
+    stderr: 'inherit',
+    pretty: {
+      text: 'Building local server',
+      successText: 'Built local server',
+      failText: "Couldn't build local server",
+    },
+  });
+}
+
 export function genAssets() {
   return prettyExeca('yarn', ['gen-assets'], {
     stdout: 'inherit',


### PR DESCRIPTION
Depends on #8743.

The sitemap is now being generated from the production build instead of a local dev server. Otherwise, the functionality is identical.

This has the advantage of ensuring pages which may be marked as "draft" don't show up in production sitemaps ("draft" pages are visible in local dev mode), and it more closely mimics production.