### PR TITLE
[Layout foundations] Add related resources to layout components

### DIFF
--- a/.changeset/giant-cherries-tickle.md
+++ b/.changeset/giant-cherries-tickle.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Added 'Related resources' section to layout components

--- a/polaris.shopify.com/content/components/layout-and-structure/alpha-stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/alpha-stack.md
@@ -41,3 +41,7 @@ Stacks should:
 ## Related components
 
 - To display elements horizontally, [use the Inline component](https://polaris.shopify.com/components/inline)
+
+## Related resources
+
+- AlphaStack props are named following the convention of CSS logical properties, such as 'padding-inline-start' and 'padding-block-start'. Learn more about [CSS logicial properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).

--- a/polaris.shopify.com/content/components/layout-and-structure/bleed.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/bleed.md
@@ -25,3 +25,7 @@ examples:
 ## Bleed values
 
 Content should never go beyond the edges of the parent container. Choose a bleed value that works within the containing layout.
+
+## Related resources
+
+- Bleed props are named following the convention of CSS logical properties, such as 'margin-inline-start' and 'margin-block-start'. Learn more about [CSS logicial properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).

--- a/polaris.shopify.com/content/components/layout-and-structure/box.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/box.md
@@ -36,3 +36,7 @@ examples:
 ## Related components
 
 - For more specific use cases, [use the Card component](https://polaris.shopify.com/components/layout-and-structure/alpha-card)
+
+## Related resources
+
+- Box props are named following the convention of CSS logical properties, such as 'padding-inline-start' and 'padding-block-start'. Learn more about [CSS logicial properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).

--- a/polaris.shopify.com/content/components/layout-and-structure/inline.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/inline.md
@@ -40,3 +40,7 @@ examples:
 
 - To create the large-scale structure of pages, [use the Columns component](https://polaris.shopify.com/components/layout-and-structure/columns)
 - To display elements vertically, [use the AlphaStack component](https://polaris.shopify.com/components/alphastack)
+
+## Related resources
+
+- Inline props are named following the convention of CSS logical properties, such as 'padding-inline-start' and 'padding-block-start'. Learn more about [CSS logicial properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

There is some confusion about the naming convention of our layout components, in that instead of doing `paddingStart`, we chose to do `paddingInlineStart` and `paddingBlockStart`, for example.

This updates our documentation to add a "Related resources" section wherever applicable with links to CSS logical properties as documented on [mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).

### WHAT is this pull request doing?

Adds "Related resources" to layout components.
    <details>
      <summary>Box related resources</summary>
      <img src="https://user-images.githubusercontent.com/26749317/227588872-b193da3a-ec4b-42d1-aa14-6825b5957cb7.png" alt="Box related resources">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
