### PR TITLE
Update `startLocalServer` util to use 'dev' default arg

### DIFF
--- a/.changeset/cold-pumpkins-invent.md
+++ b/.changeset/cold-pumpkins-invent.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Updated `gen-site-map` script to use `dev` server to fix issue of sitemap.xml not being generated with urls

--- a/.changeset/cold-pumpkins-invent.md
+++ b/.changeset/cold-pumpkins-invent.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-Updated `gen-site-map` script to use `dev` server to fix issue of sitemap.xml not being generated with urls
+Updated `startLocalServer` script to use `dev` as default command to fix issue of sitemap.xml not being generated with urls

--- a/.changeset/cold-pumpkins-invent.md
+++ b/.changeset/cold-pumpkins-invent.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-Updated `startLocalServer` script to use `dev` as default command to fix issue of sitemap.xml not being generated with urls
+Updated `startLocalServer` script to use `dev` as default command to fix issue of sitemap.xml not being generated with urls for `v11-major` branch

--- a/polaris.shopify.com/scripts/gen-site-map.mjs
+++ b/polaris.shopify.com/scripts/gen-site-map.mjs
@@ -9,7 +9,7 @@ const genSiteMap = async () => {
     process.exit(-1);
   }
 
-  const server = startLocalServer('dev');
+  const server = startLocalServer();
   server.catch((err) => {
     if (!server.killed) {
       console.error(err.stderr);

--- a/polaris.shopify.com/scripts/gen-site-map.mjs
+++ b/polaris.shopify.com/scripts/gen-site-map.mjs
@@ -9,7 +9,7 @@ const genSiteMap = async () => {
     process.exit(-1);
   }
 
-  const server = startLocalServer();
+  const server = startLocalServer('dev');
   server.catch((err) => {
     if (!server.killed) {
       console.error(err.stderr);

--- a/polaris.shopify.com/scripts/util.mjs
+++ b/polaris.shopify.com/scripts/util.mjs
@@ -118,7 +118,7 @@ export function genAssets() {
   });
 }
 
-export function startLocalServer(command = 'start') {
+export function startLocalServer(command = 'dev') {
   return prettyExeca('yarn', ['next', command], {
     stdout: 'ignore',
     stderr: 'pipe',


### PR DESCRIPTION
### WHY are these changes introduced?

There are build issues on the `v11-major` branch due to the `gen-site-map` script not creating the URLs for `gen-og-images` to iterate through and create images from. Changing the script from the default `start` to `dev` for the `startLocalServer` util resolves this issue.

<img width="750" alt="27-17-ztxd7-gqhhs" src="https://user-images.githubusercontent.com/26749317/228034558-fe2e0490-d744-403b-828c-cea400127979.png">

### WHAT is this pull request doing?
Updates `command` default argument to be `'dev'` for `startLocalServer` util.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
