### PR TITLE
Refine migrator-comment workflow

### DIFF
--- a/.github/workflows/migrator-comment.yml
+++ b/.github/workflows/migrator-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check for generic migrator comment in diff
         run: |
           commits="origin/${{ github.base_ref }}...origin/${{ github.head_ref }}"
-          files=$(git diff --name-only "$commits" -- "*.scss")
+          files=$(git diff --name-only --diff-filter=d "$commits" -- "*.scss")
 
           if [ -n "$files" ]; then
             echo "SCSS files where modified."
@@ -40,7 +40,7 @@ jobs:
             exit 0
           fi
 
-          filesWithComment=$(git diff --unified=0 "$commits" -- $(echo $files) | grep "^\+.*$COMMENT")
+          filesWithComment=$(git diff --unified=0 --diff-filter=d "$commits" -- $(echo $files) | grep "^\+.*$COMMENT")
 
           if [ -n "$filesWithComment" ]; then
             echo "A migrator comment '$COMMENT' was added to a SCSS file in this PR."

--- a/.github/workflows/migrator-comment.yml
+++ b/.github/workflows/migrator-comment.yml
@@ -29,9 +29,8 @@ jobs:
 
       - name: Check for generic migrator comment in diff
         run: |
-          # The "|| true" is used so that matches are saved but it always exit with status 0.
-          # Without this, grep will exit with a status of 1 when no matches are found, ending the script.
-          files=$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }} | grep "\.scss$" || true)
+          commits="origin/${{ github.base_ref }}...origin/${{ github.head_ref }}"
+          files=$(git diff --name-only "$commits" -- "*.scss")
 
           if [ -n "$files" ]; then
             echo "SCSS files where modified."
@@ -41,7 +40,7 @@ jobs:
             exit 0
           fi
 
-          filesWithComment=$(git diff --unified=0 origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- "$files" | grep "^\+.*$COMMENT")
+          filesWithComment=$(git diff --unified=0 "$commits" -- $(echo $files) | grep "^\+.*$COMMENT")
 
           if [ -n "$filesWithComment" ]; then
             echo "A migrator comment '$COMMENT' was added to a SCSS file in this PR."


### PR DESCRIPTION
While experimenting with the underlying `migrator-comment.yml` shell script locally, I couldn't get the `filesWithComment=$(...)` command to work because `"$files"` was being interpreted as a single file. This PR updates the `git diff -- <paths>` command to `git diff -- $(echo $files)` and introduces a `commits` var to DRY up the `diff` command. Additionally, I updated the first `git diff ... || true` to `git diff -- "*.scss"` which seems to play nice with the default GitHub action `set -e` shell configuration.