### PR TITLE
[Navigation] Fix item selected border radius

### DIFF
--- a/.changeset/old-dots-tan.md
+++ b/.changeset/old-dots-tan.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed border-radius on navigation selected items

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -60,7 +60,7 @@ export function DetailsPage() {
   const [userMenuActive, setUserMenuActive] = useState(false);
   const [mobileNavigationActive, setMobileNavigationActive] = useState(false);
   const [modalActive, setModalActive] = useState(false);
-  const [navItemActive, setNavItemActive] = useState('');
+  const [navItemActive, setNavItemActive] = useState('products');
   const initialDescription =
     'The M60-A represents the benchmark and equilibrium between function and design for us at Rama Works. The gently exaggerated design of the frame is not understated, but rather provocative. Inspiration and evolution from previous models are evident in the beautifully articulated design and the well defined aesthetic, the fingerprint of our ‘Industrial Modern’ designs.';
   const [previewValue, setPreviewValue] = useState(initialDescription);

--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -98,13 +98,16 @@ $disabled-fade: 0.6;
   @include nav-item-attributes;
   position: relative;
 
-  border-radius: var(--p-border-radius-1);
-
   &:is(:hover, :focus-visible) {
     background: var(--p-background-hovered);
     color: var(--p-text);
     text-decoration: none;
   }
+}
+
+.Item,
+.ItemInnerWrapper {
+  border-radius: var(--p-border-radius-1);
 }
 
 .Item-selected {


### PR DESCRIPTION
Before | After
---|---
![image](https://screenshot.click/28-27-nlbzy-kwaa0.png) | ![image](https://screenshot.click/28-28-dj14b-1tq47.png)

Not sure how this didn't show up in the chromatic diffs but regression was introduced [here](https://github.com/Shopify/polaris/pull/8626). We need the radius styles on both the nav item and nav item inner wrapper. Why we need so much markup I'll never know