### PR TITLE
Fix CI comment check and add better user feedback

### DIFF
--- a/.github/workflows/migrator-comment.yml
+++ b/.github/workflows/migrator-comment.yml
@@ -40,11 +40,12 @@ jobs:
             exit 0
           fi
 
-          filesWithComment=$(git diff --unified=0 --diff-filter=d "$commits" -- $(echo $files) | grep "^\+.*$COMMENT")
+          filesWithComment=$(git diff --unified=0 --diff-filter=d "$commits" -- $(echo $files) | grep "^\+.*$COMMENT" || true)
 
           if [ -n "$filesWithComment" ]; then
             echo "A migrator comment '$COMMENT' was added to a SCSS file in this PR."
-            echo "Please replace this with a disable description."
+            echo "Please provide a description for any Stylelint disable comments."
+            echo "If this is not applicable, you can add the '🤖Skip Comment Check' label to this PR."
             exit 1
           else
             echo "All good, no migrator comments were added."


### PR DESCRIPTION
### WHY are these changes introduced?

The grep command for `filesWithComment` was exiting `1` when no files where found.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This prevents `grep` from exiting with a status code of `1`.