### PR TITLE
[TextField] Add onStepperChange optional prop, and support Spinbutton pattern keyboard interactions

### DIFF
--- a/.changeset/beige-eggs-join.md
+++ b/.changeset/beige-eggs-join.md
@@ -2,6 +2,6 @@
 '@shopify/polaris': minor
 ---
 
-Add onSpinButtonClick as optional prop for TextField
+Add onSpinnerChange as optional prop for TextField
 Add largeStep as option prop for TextField
 Add Spinner keypress interactions for Home, End, Page Up, Page Down

--- a/.changeset/beige-eggs-join.md
+++ b/.changeset/beige-eggs-join.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add onStepperChange as optional prop for TextField

--- a/.changeset/beige-eggs-join.md
+++ b/.changeset/beige-eggs-join.md
@@ -2,4 +2,6 @@
 '@shopify/polaris': minor
 ---
 
-Add onStepperChange as optional prop for TextField
+Add onSpinButtonClick as optional prop for TextField
+Add largeStep as option prop for TextField
+Add Spinner keypress interactions for Home, End, Page Up, Page Down

--- a/.changeset/beige-eggs-join.md
+++ b/.changeset/beige-eggs-join.md
@@ -2,6 +2,6 @@
 '@shopify/polaris': minor
 ---
 
-Add onSpinnerChange as optional prop for TextField
-Add largeStep as option prop for TextField
-Add Spinner keypress interactions for Home, End, Page Up, Page Down
+- Added an optional `onSpinnerChange` prop to`TextField`
+- Added an optional `largeStep` prop to `TextField`
+- Added `TextField` `Spinner` keypress interactions for Home, End, Page Up, Page Down

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -165,7 +165,7 @@ interface NonMutuallyExclusiveProps {
   /** Callback fired when value is changed */
   onChange?(value: string, id: string): void;
   /** When provided, callback fired instead of onChange when value is changed via the number step control  */
-  onSpinButtonClick?(value: string, id: string): void;
+  onSpinnerChange?(value: string, id: string): void;
   /** Callback fired when input is focused */
   onFocus?: (event?: React.FocusEvent) => void;
   /** Callback fired when input is blurred */
@@ -234,7 +234,7 @@ export function TextField({
   suggestion,
   onClearButtonClick,
   onChange,
-  onSpinButtonClick,
+  onSpinnerChange,
   onFocus,
   onBlur,
   borderless,
@@ -360,7 +360,7 @@ export function TextField({
 
   const handleNumberChange = useCallback(
     (steps: number, stepAmount = normalizedStep) => {
-      if (onChange == null && onSpinButtonClick == null) {
+      if (onChange == null && onSpinnerChange == null) {
         return;
       }
       // Returns the length of decimal places in a number
@@ -380,8 +380,8 @@ export function TextField({
         Math.max(numericValue + steps * stepAmount, Number(normalizedMin)),
       );
 
-      if (onSpinButtonClick != null) {
-        onSpinButtonClick(String(newValue.toFixed(decimalPlaces)), id);
+      if (onSpinnerChange != null) {
+        onSpinnerChange(String(newValue.toFixed(decimalPlaces)), id);
       } else if (onChange != null) {
         onChange(String(newValue.toFixed(decimalPlaces)), id);
       }
@@ -391,7 +391,7 @@ export function TextField({
       normalizedMax,
       normalizedMin,
       onChange,
-      onSpinButtonClick,
+      onSpinnerChange,
       normalizedStep,
       value,
     ],
@@ -671,16 +671,16 @@ export function TextField({
 
     const {key, which} = event;
     if ((which === Key.Home || key === 'Home') && min !== undefined) {
-      if (onSpinButtonClick != null) {
-        onSpinButtonClick(String(min), id);
+      if (onSpinnerChange != null) {
+        onSpinnerChange(String(min), id);
       } else if (onChange != null) {
         onChange(String(min), id);
       }
     }
 
     if ((which === Key.End || key === 'End') && max !== undefined) {
-      if (onSpinButtonClick != null) {
-        onSpinButtonClick(String(max), id);
+      if (onSpinnerChange != null) {
+        onSpinnerChange(String(max), id);
       } else if (onChange != null) {
         onChange(String(max), id);
       }

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -162,6 +162,8 @@ interface NonMutuallyExclusiveProps {
   onClearButtonClick?(id: string): void;
   /** Callback fired when value is changed */
   onChange?(value: string, id: string): void;
+  /** When provided, callback fired instead of onChange when value is changed via the number step control  */
+  onStepperChange?(value: string, id: string): void;
   /** Callback fired when input is focused */
   onFocus?: (event?: React.FocusEvent) => void;
   /** Callback fired when input is blurred */
@@ -229,6 +231,7 @@ export function TextField({
   suggestion,
   onClearButtonClick,
   onChange,
+  onStepperChange,
   onFocus,
   onBlur,
   borderless,
@@ -354,7 +357,7 @@ export function TextField({
 
   const handleNumberChange = useCallback(
     (steps: number) => {
-      if (onChange == null) {
+      if (onChange == null && onStepperChange == null) {
         return;
       }
       // Returns the length of decimal places in a number
@@ -374,9 +377,21 @@ export function TextField({
         Math.max(numericValue + steps * normalizedStep, Number(normalizedMin)),
       );
 
-      onChange(String(newValue.toFixed(decimalPlaces)), id);
+      if (onStepperChange != null) {
+        onStepperChange(String(newValue.toFixed(decimalPlaces)), id);
+      } else if (onChange != null) {
+        onChange(String(newValue.toFixed(decimalPlaces)), id);
+      }
     },
-    [id, normalizedMax, normalizedMin, onChange, normalizedStep, value],
+    [
+      id,
+      normalizedMax,
+      normalizedMin,
+      onChange,
+      onStepperChange,
+      normalizedStep,
+      value,
+    ],
   );
 
   const handleButtonRelease = useCallback(() => {

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -1074,7 +1074,7 @@ describe('<TextField />', () => {
         expect(spy).not.toHaveBeenCalled();
       });
 
-      describe('onSpinButtonClick()', () => {
+      describe('onSpinnerChange()', () => {
         it('is called with the new value when incrementing by step', () => {
           const spy = jest.fn();
           const element = mountWithApp(
@@ -1084,7 +1084,7 @@ describe('<TextField />', () => {
               type="number"
               value="2"
               step={4}
-              onSpinButtonClick={spy}
+              onSpinnerChange={spy}
               autoComplete="off"
             />,
           );
@@ -1103,7 +1103,7 @@ describe('<TextField />', () => {
               type="number"
               value="2"
               step={4}
-              onSpinButtonClick={onStepperSpy}
+              onSpinnerChange={onStepperSpy}
               onChange={onChangeSpy}
               autoComplete="off"
             />,
@@ -1124,7 +1124,7 @@ describe('<TextField />', () => {
               type="number"
               value="2"
               step={4}
-              onSpinButtonClick={onStepperSpy}
+              onSpinnerChange={onStepperSpy}
               onChange={onChangeSpy}
               autoComplete="off"
             />,
@@ -1225,7 +1225,7 @@ describe('<TextField />', () => {
           expect(spy).toHaveBeenCalledWith('100', 'MyTextField');
         });
 
-        it('calls onSpinButtonClick(min) if Home is pressed and min was provided', () => {
+        it('calls onSpinnerChange(min) if Home is pressed and min was provided', () => {
           const spy = jest.fn();
           const textField = mountWithApp(
             <TextField
@@ -1235,7 +1235,7 @@ describe('<TextField />', () => {
               value="10"
               min={1}
               step={1}
-              onSpinButtonClick={spy}
+              onSpinnerChange={spy}
               autoComplete="off"
             />,
           );
@@ -1246,7 +1246,7 @@ describe('<TextField />', () => {
           expect(spy).toHaveBeenCalledWith('1', 'MyTextField');
         });
 
-        it('calls onSpinButtonClick(max) if End is pressed and max was provided', () => {
+        it('calls onSpinnerChange(max) if End is pressed and max was provided', () => {
           const spy = jest.fn();
           const textField = mountWithApp(
             <TextField
@@ -1256,7 +1256,7 @@ describe('<TextField />', () => {
               value="10"
               max={100}
               step={1}
-              onSpinButtonClick={spy}
+              onSpinnerChange={spy}
               autoComplete="off"
             />,
           );

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -9,6 +9,7 @@ import {Tag} from '../../Tag';
 import {Resizer, Spinner} from '../components';
 import {TextField} from '../TextField';
 import styles from '../TextField.scss';
+import {Key} from '../../../types';
 
 describe('<TextField />', () => {
   it('allows specific props to pass through properties on the input', () => {
@@ -1073,7 +1074,7 @@ describe('<TextField />', () => {
         expect(spy).not.toHaveBeenCalled();
       });
 
-      describe('onStepperChange()', () => {
+      describe('onSpinButtonClick()', () => {
         it('is called with the new value when incrementing by step', () => {
           const spy = jest.fn();
           const element = mountWithApp(
@@ -1083,7 +1084,7 @@ describe('<TextField />', () => {
               type="number"
               value="2"
               step={4}
-              onStepperChange={spy}
+              onSpinButtonClick={spy}
               autoComplete="off"
             />,
           );
@@ -1102,7 +1103,7 @@ describe('<TextField />', () => {
               type="number"
               value="2"
               step={4}
-              onStepperChange={onStepperSpy}
+              onSpinButtonClick={onStepperSpy}
               onChange={onChangeSpy}
               autoComplete="off"
             />,
@@ -1123,7 +1124,7 @@ describe('<TextField />', () => {
               type="number"
               value="2"
               step={4}
-              onStepperChange={onStepperSpy}
+              onSpinButtonClick={onStepperSpy}
               onChange={onChangeSpy}
               autoComplete="off"
             />,
@@ -1136,6 +1137,134 @@ describe('<TextField />', () => {
           });
           expect(onStepperSpy).not.toHaveBeenCalled();
           expect(onChangeSpy).toHaveBeenCalledWith('6', 'MyTextField');
+        });
+      });
+
+      describe('keydown events', () => {
+        it('decrements by largeStep when provided and Page Down is pressed', () => {
+          const spy = jest.fn();
+          const textField = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="10"
+              step={1}
+              largeStep={4}
+              onChange={spy}
+              autoComplete="off"
+            />,
+          );
+          textField.find('input')!.trigger('onKeyDown', {
+            key: 'PageDown',
+            which: Key.PageDown,
+          });
+          expect(spy).toHaveBeenCalledWith('6', 'MyTextField');
+        });
+
+        it('increments by largeStep when provided and Page Up is pressed', () => {
+          const spy = jest.fn();
+          const textField = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="10"
+              step={1}
+              largeStep={4}
+              onChange={spy}
+              autoComplete="off"
+            />,
+          );
+          textField.find('input')!.trigger('onKeyDown', {
+            key: 'PageUp',
+            which: Key.PageUp,
+          });
+          expect(spy).toHaveBeenCalledWith('14', 'MyTextField');
+        });
+
+        it('calls onChange(min) if Home is pressed and min was provided', () => {
+          const spy = jest.fn();
+          const textField = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="10"
+              min={1}
+              step={1}
+              onChange={spy}
+              autoComplete="off"
+            />,
+          );
+          textField.find('input')!.trigger('onKeyDown', {
+            key: 'Home',
+            which: Key.Home,
+          });
+          expect(spy).toHaveBeenCalledWith('1', 'MyTextField');
+        });
+
+        it('calls onChange(max) if End is pressed and max was provided', () => {
+          const spy = jest.fn();
+          const textField = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="10"
+              max={100}
+              step={1}
+              onChange={spy}
+              autoComplete="off"
+            />,
+          );
+          textField.find('input')!.trigger('onKeyDown', {
+            key: 'End',
+            which: Key.End,
+          });
+          expect(spy).toHaveBeenCalledWith('100', 'MyTextField');
+        });
+
+        it('calls onSpinButtonClick(min) if Home is pressed and min was provided', () => {
+          const spy = jest.fn();
+          const textField = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="10"
+              min={1}
+              step={1}
+              onSpinButtonClick={spy}
+              autoComplete="off"
+            />,
+          );
+          textField.find('input')!.trigger('onKeyDown', {
+            key: 'Home',
+            which: Key.Home,
+          });
+          expect(spy).toHaveBeenCalledWith('1', 'MyTextField');
+        });
+
+        it('calls onSpinButtonClick(max) if End is pressed and max was provided', () => {
+          const spy = jest.fn();
+          const textField = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="10"
+              max={100}
+              step={1}
+              onSpinButtonClick={spy}
+              autoComplete="off"
+            />,
+          );
+          textField.find('input')!.trigger('onKeyDown', {
+            key: 'End',
+            which: Key.End,
+          });
+          expect(spy).toHaveBeenCalledWith('100', 'MyTextField');
         });
       });
 

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -1073,6 +1073,72 @@ describe('<TextField />', () => {
         expect(spy).not.toHaveBeenCalled();
       });
 
+      describe('onStepperChange()', () => {
+        it('is called with the new value when incrementing by step', () => {
+          const spy = jest.fn();
+          const element = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="2"
+              step={4}
+              onStepperChange={spy}
+              autoComplete="off"
+            />,
+          );
+
+          element.findAll('div', {role: 'button'})[0].trigger('onClick');
+          expect(spy).toHaveBeenCalledWith('6', 'MyTextField');
+        });
+
+        it('is called with the new value instead of onChange when incrementing by step', () => {
+          const onStepperSpy = jest.fn();
+          const onChangeSpy = jest.fn();
+          const element = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="2"
+              step={4}
+              onStepperChange={onStepperSpy}
+              onChange={onChangeSpy}
+              autoComplete="off"
+            />,
+          );
+
+          element.findAll('div', {role: 'button'})[0].trigger('onClick');
+          expect(onStepperSpy).toHaveBeenCalledWith('6', 'MyTextField');
+          expect(onChangeSpy).not.toHaveBeenCalled();
+        });
+
+        it('is not called when new values are typed', () => {
+          const onStepperSpy = jest.fn();
+          const onChangeSpy = jest.fn();
+          const element = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="number"
+              value="2"
+              step={4}
+              onStepperChange={onStepperSpy}
+              onChange={onChangeSpy}
+              autoComplete="off"
+            />,
+          );
+
+          element.find('input')!.trigger('onChange', {
+            currentTarget: {
+              value: '6',
+            },
+          });
+          expect(onStepperSpy).not.toHaveBeenCalled();
+          expect(onChangeSpy).toHaveBeenCalledWith('6', 'MyTextField');
+        });
+      });
+
       describe('document events', () => {
         type EventCallback = (mockEventData?: {[key: string]: any}) => void;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris/issues/8760: Optionally provide a separate event handler for changes via the stepper control
Edit: this PR was extended to support [Spinbutton pattern keyboard interactions](https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/#aboutthispattern)

Related to the needs of [this epic](https://github.com/Shopify/core-issues/issues/52731).
  - We have a UX case that requires a number input to only allow multiples of a given number, or at minimum "autocorrect" valid inputs. 
  - The `onChange` prop by itself is not a sufficient handler to do this considering you could correct a value before the user is done typing. Consider the case where step is 5 and the user is trying to type 25. If you autocorrect during `onChange` you would correct them to 5 after they press 2, and then the subsequent typed 0 will take them to 50.
  - Dynamically changing the step value to get the user back on correct multiples also doesn't work considering you'd need different step values between moving upward and downward.
  - If we can differentiate between a typed change, and a change via the stepper, we can adjust incoming changes from the stepper to be back at increments of the step value.
  - There is a spin instance linked in that epic that has this change. I can walk you through how we're using it to get the intended UX if desired.

### WHAT is this pull request doing?

This PR adds an option `onStepperChange` prop for use when `TextField`'s type is a number. When `onStepperChange` is provided it will be called instead of onChange when the user is incrementing up or down via the stepper control.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

The provided playground code will at least demonstrate the split handling between `onChange` and `onStepperChange`

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, TextField} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <TextField
        id="MyTextField"
        label="TextField"
        type="number"
        value="4"
        step={4}
        onStepperChange={(value) => {
          console.log(`${value} came from the stepper`);
        }}
        onChange={(value) => {
          console.log(`${value} came via typed input`);
        }}
        autoComplete="off"
      />
      ,
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
