### PR TITLE
[Index Table] - Prevent rows being selectable if table is condensed

### DIFF
--- a/.changeset/dull-carrots-approve.md
+++ b/.changeset/dull-carrots-approve.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Prevented row select on index tables when condensed as bulk actions no longer show when condensed
+Fixed `IndexTable.Row` being selectable on small screens

--- a/.changeset/dull-carrots-approve.md
+++ b/.changeset/dull-carrots-approve.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Prevented row select on index tables when condensed as bulk actions no longer show when condensed

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -1161,7 +1161,7 @@ export function IndexTable({
 }: IndexTableProps) {
   return (
     <IndexProvider
-      selectable={selectable}
+      selectable={selectable && !condensed}
       itemCount={itemCount}
       selectedItemsCount={selectedItemsCount}
       resourceName={passedResourceName}

--- a/polaris-react/src/components/IndexTable/components/Row/Row.tsx
+++ b/polaris-react/src/components/IndexTable/components/Row/Row.tsx
@@ -89,7 +89,7 @@ export const Row = memo(function Row({
     selectable && condensed && styles.condensedRow,
     selected && styles['TableRow-selected'],
     subdued && styles['TableRow-subdued'],
-    hovered && styles['TableRow-hovered'],
+    hovered && !condensed && styles['TableRow-hovered'],
     disabled && styles['TableRow-disabled'],
     status && styles[variationName('status', status)],
     !selectable &&

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -21,6 +21,7 @@ import {SelectionType} from '../../../utilities/index-provider';
 import {AfterInitialMount} from '../../AfterInitialMount';
 import {UnstyledButton} from '../../UnstyledButton';
 import {Tooltip} from '../../Tooltip';
+import {IndexProvider} from '../../IndexProvider';
 
 jest.mock('../utilities', () => ({
   ...jest.requireActual('../utilities'),
@@ -572,6 +573,18 @@ describe('<IndexTable>', () => {
       );
 
       expect(index).not.toContainReactComponent(BulkActions);
+    });
+
+    it('prevents rows from being selectable', () => {
+      const index = mountWithApp(
+        <IndexTable {...defaultIndexTableProps} condensed>
+          {mockTableItems.map(mockRenderCondensedRow)}
+        </IndexTable>,
+      );
+
+      expect(index).toContainReactComponent(IndexProvider, {
+        selectable: false,
+      });
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/8805

Bulk Actions were previously removed when the table is condensed, but rows are still selectable. 

https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/IndexTable/IndexTable.tsx#L581-L608

This means users can select rows on mobile, and see the selected checkbox, but no actions are possible.

This PR means rows are only selectable if the `condensed` prop is falsey.

It also removed the hover styles in this situation, which were changing the background colour when the row was clicked on, but clicking didn't do anything.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Updates the `selectable` prop on the `<IndexProvider />` to check the `condensed` value.




<details>
<summary>
<strong>Old behaviour</strong><br />
This can be seen in the `small screen` example at https://polaris.shopify.com/components/tables/index-table

</summary>
<img src="https://screenshot.click/28-39-1zyjm-00m5t.gif" width="400px" />

</details>


<details>
<summary>
<strong>New behaviour</strong>
</summary>
<img src="https://screenshot.click/30-16-lt49v-prwhn.gif" width="400px" />

</details>



### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->



https://5d559397bae39100201eedc1-dwgnwrvfwo.chromatic.com/?path=/story/all-components-indextable--small-screen-with-all-of-its-elements

In small screen the rows should not be selectable. 

Behaviour has not changed for non-condensed tables.



</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
