### PR TITLE
Add diffThreshold to storybook

### DIFF
--- a/.changeset/slimy-comics-cough.md
+++ b/.changeset/slimy-comics-cough.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Increased precision of chromatic snapshot diffs

--- a/polaris-react/.storybook/preview.js
+++ b/polaris-react/.storybook/preview.js
@@ -90,7 +90,11 @@ const viewPorts = Object.entries({
   };
 });
 
-export const parameters = {viewport: {viewports: {...viewPorts}}};
+export const parameters = {
+  viewport: {viewports: {...viewPorts}},
+  // Increases precision of rendered snapshot diffs. Default is 0.063
+  chromatic: {diffThreshold: 0.03},
+};
 
 export const decorators = [
   GridOverlayDecorator,


### PR DESCRIPTION
This is still a test but I think needs to be merged into main before we can compare against it. I will follow up with a test PR to test this. This new threshold will catch smaller changes like 4px border-radius changes that weren't caught in [this pr](https://github.com/Shopify/polaris/pull/8626)

I compared the two snapshots using the chromatic tool [here](https://6262c53f521620003ac2ff49-ukmsdlppcb.chromatic.com/?path=/story/stories-diff-threshold-check--test-yours-out)

https://user-images.githubusercontent.com/6844391/228541322-b5fddce0-10cb-4b41-bfda-8873ee6651b0.mp4

