### PR TITLE
[polaris.shopify.com] Fix width of listbox with search example

### DIFF
--- a/.changeset/thin-coats-flash.md
+++ b/.changeset/thin-coats-flash.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed width of Listbox with search example"

--- a/polaris.shopify.com/pages/examples/listbox-with-search.tsx
+++ b/polaris.shopify.com/pages/examples/listbox-with-search.tsx
@@ -264,7 +264,6 @@ function ListboxWithSearchExample() {
           shadow
           style={{
             position: 'relative',
-            width: '310px',
             height: '292px',
             padding: 'var(--p-space-2) 0',
             borderBottomLeftRadius: 'var(--p-border-radius-2)',


### PR DESCRIPTION
Thank you for reporting this! @oksanashopify 

### WHY are these changes introduced?

Fixes #8756

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

| Before | After |
| --- | --- |
| <img width="933" alt="before" src="https://user-images.githubusercontent.com/11774595/228564904-52116d15-6808-40d0-8a2b-3ce8f89e5a91.png"> | <img width="933" alt="after" src="https://user-images.githubusercontent.com/11774595/228564898-c3b1c846-3157-4450-95de-3e5e1a238451.png"> |