### PR TITLE
Allow custom styles to be passed in markdown images

### DIFF
--- a/.changeset/chilled-pans-add.md
+++ b/.changeset/chilled-pans-add.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix npm badge width on Tools pages

--- a/polaris.shopify.com/src/components/Markdown/Markdown.tsx
+++ b/polaris.shopify.com/src/components/Markdown/Markdown.tsx
@@ -93,10 +93,10 @@ function Markdown({
             return <h3>{children}</h3>;
           }
         },
-        img: ({src, alt}) =>
+        img: ({src, alt, style}) =>
           src ? (
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={src} alt={alt ?? ''} className={styles.MarkdownImage} />
+            <img src={src} alt={alt ?? ''} className={styles.MarkdownImage} style={style} />
           ) : null,
         code: ({inline, children, className}) =>
           inline ? (


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes the widths of the npm package badges on the **Tools** pages.

Pages affected:

- https://polaris.shopify.com/tools/polaris-cli
- https://polaris.shopify.com/tools/polaris-migrator

| Before | After |
| --- | --- |
| <img width="933" alt="before" src="https://user-images.githubusercontent.com/11774595/228569769-ffbc8469-6433-413f-8089-3ac505426abe.png"> | <img width="933" alt="after" src="https://user-images.githubusercontent.com/11774595/228569764-cee2bbe4-309a-40fa-af37-4fe841dd8ba0.png"> |
