### PR TITLE
[IndexTable] Fix IndexTable scrollbar resize show/hide logic

### DIFF
--- a/.changeset/hip-walls-tell.md
+++ b/.changeset/hip-walls-tell.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fixed scrollbar displaying incorrectly when resizing Index Table
+Fixed scrollbar container displaying incorrectly when resizing Index Table

--- a/.changeset/hip-walls-tell.md
+++ b/.changeset/hip-walls-tell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed scrollbar displaying incorrectly when resizing Index Table

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -670,7 +670,8 @@ $scroll-bar-size: var(--p-space-2);
 }
 
 .scrollBarContainerHidden {
-  display: none;
+  height: 0;
+  padding: 0;
 }
 
 .ScrollBar {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8751

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

The `scrollBarContainer.current.offsetWidth` was evaluating to `0` when the hidden styles were applied. This is due to using `display: none`. The issue is fixed by using a height of 0 and padding 0.

🎩  Spin link with the snapshot package installed: https://admin.web.main.sam-rose.us.spin.dev/store/shop1

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/11774595/228633141-da163e30-d6d0-4dec-90d4-d9bdd52d2a0c.gif) | ![after](https://user-images.githubusercontent.com/11774595/228633130-da2198ae-3007-4147-95a7-c51e2736cbc6.gif) |
