### PR TITLE
[AlphaCard] Hide overflow on AlphaCard

### DIFF
--- a/.changeset/strong-fans-scream.md
+++ b/.changeset/strong-fans-scream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Hide AlphaCard overflow

--- a/polaris-react/src/components/AlphaCard/AlphaCard.stories.tsx
+++ b/polaris-react/src/components/AlphaCard/AlphaCard.stories.tsx
@@ -80,14 +80,12 @@ export function WithSubduedSection() {
           </List>
         </Box>
       </AlphaStack>
-      <Bleed marginBlockEnd="5" marginInline="5">
+      <Bleed
+        marginBlockEnd={{xs: '4', sm: '5'}}
+        marginInline={{xs: '4', sm: '5'}}
+      >
         <Divider />
-        <Box
-          background="surface-subdued"
-          borderRadiusEndStart="2"
-          borderRadiusEndEnd="2"
-          padding="5"
-        >
+        <Box background="surface-subdued" padding={{xs: '4', sm: '5'}}>
           <AlphaStack gap="2">
             <Text variant="headingSm" as="h3">
               Deactivated staff accounts

--- a/polaris-react/src/components/AlphaCard/AlphaCard.tsx
+++ b/polaris-react/src/components/AlphaCard/AlphaCard.tsx
@@ -55,6 +55,8 @@ export const AlphaCard = ({
       padding={padding}
       shadow="md"
       borderRadius={hasBorderRadius ? defaultBorderRadius : undefined}
+      overflowX="hidden"
+      overflowY="hidden"
     >
       {children}
     </Box>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes overflowing elements on the `AlphaCard` component.

[Example sandbox](https://polaris.shopify.com/sandbox?code=N4Igxg9gJgpiBcIBOMAuBXJA7ABACgB0sAeAQQBsAHACwEMBhWpKAPiJx2ICEIAPHSrShQAllgDmXchDABrAKJYoAXgIgALGra4OnAM6CsLehCyoYZ4gHoDtI%2B05WevbR27kYMKA44BbJuJiAJJY5GIwysDAOLx68DhqmiAANDh6vvFqAKxqOAC%2BeT44-kiBWFIyCkqR0bGZGmqp6fU5IPmFOq66xAAiIgBuIrBIOFZdbs44AEa0cuJIEOjVanqYAGazMAC0q1NQ6F65gsJi4jUxcQkNKWkZV63t47oAyhC%2BMDhrEBDmSEXWzi6AI8Xm01goNAYTFYRAAlABuIggPJAA)

There's an existing pattern in the admin of a subdued "footer" on a card. Previously this was done with a `Card.SubSection`. With `AlphaCard` we need to implement this with a `Bleed`ed `Box` to put the background to the edge, or apply a `0` padding to the `AlphaCard`. The background of these children then unfortunately overflows the `AlphaCard`'s rounded corners.

### WHAT is this pull request doing?
This PR sets the `overflowX` and `overflowY` on the `AlphaCard`'s inner `Box`, which clips the child content. This means a `Box` positioned in the corner will be clipped to the rounded corner.
<img width="479" alt="image" src="https://user-images.githubusercontent.com/3304890/228673551-59a45533-6b5d-4689-a62b-ec7e82e0056f.png">

I elected to just be opinionated here as this is an opinionated component, and just set the overflow on the child box instead of passing a prop in through to the `Box`. I don't know of any use of the `AlphaCard` where we'd want to not clip the children to the card shape, or to allow scrolling of the card content. Anything this custom could be built manually with a `Box`.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
