### PR TITLE
[IndexFilters] Some little UI tweaks

### DIFF
--- a/.changeset/friendly-badgers-walk.md
+++ b/.changeset/friendly-badgers-walk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed a few visual bugs in the `IndexFilters` component including preserving border radius when removing the search field and better alignment of children when removing the search field

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.scss
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.scss
@@ -31,10 +31,13 @@
 }
 
 .FiltersWrapper {
-  background: var(--p-surface);
   border-bottom: var(--p-border-divider);
   height: 53px;
   overflow: hidden;
+
+  @media #{$p-breakpoints-sm-down} {
+    background: var(--p-surface);
+  }
 
   @media #{$p-breakpoints-md-up} {
     height: auto;

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
@@ -271,12 +271,13 @@ export function AlphaFilters({
     </div>
   );
 
-  const mountedStateStyles = mountedState
-    ? {
-        ...defaultFilterStyles,
-        ...transitionFilterStyles[mountedState],
-      }
-    : undefined;
+  const mountedStateStyles =
+    mountedState && !hideQueryField
+      ? {
+          ...defaultFilterStyles,
+          ...transitionFilterStyles[mountedState],
+        }
+      : undefined;
 
   const pinnedFiltersMarkup = pinnedFilters.map(
     ({key: filterKey, ...pinnedFilter}) => {

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
@@ -359,7 +359,16 @@ export function AlphaFilters({
         </div>
         {hideQueryField ? (
           <Box paddingInlineEnd="2" paddingBlockStart="2">
-            <Inline>{additionalContent}</Inline>
+            <Inline
+              align="start"
+              blockAlign="center"
+              gap={{
+                xs: '4',
+                md: '3',
+              }}
+            >
+              {additionalContent}
+            </Inline>
           </Box>
         ) : null}
       </div>

--- a/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
@@ -344,7 +344,6 @@ export function Default() {
         tabs={tabs}
         selected={selected}
         onSelect={setSelected}
-        disableTabs={false}
         canCreateNewView
         onCreateNewView={onCreateNewView}
         filters={filters}
@@ -631,7 +630,6 @@ export function WithPinnedFilters() {
         tabs={tabs}
         selected={selected}
         onSelect={setSelected}
-        disableTabs={false}
         canCreateNewView
         onCreateNewView={onCreateNewView}
         filters={filters}
@@ -916,7 +914,6 @@ export function Disabled() {
         tabs={tabs}
         selected={selected}
         onSelect={setSelected}
-        disableTabs={false}
         canCreateNewView
         onCreateNewView={onCreateNewView}
         filters={filters}

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -411,7 +411,7 @@ export function IndexFilters({
                   disableQueryField={disabled || disableQueryField}
                   loading={loading || isActionLoading}
                   focused={filtersFocused}
-                  mountedState={state}
+                  mountedState={mdDown ? undefined : state}
                   borderlessQueryField
                 >
                   <Inline gap="3" align="start" blockAlign="center">

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -369,6 +369,7 @@ export function IndexFilters({
                             tooltipContent={searchFilterTooltip}
                             disabled={disabled}
                             hideFilters={hideFilters}
+                            hideQueryField={hideQueryField}
                             style={{
                               ...defaultStyle,
                               ...transitionStyles[state],

--- a/polaris-react/src/components/IndexFilters/components/SearchFilterButton/SearchFilterButton.tsx
+++ b/polaris-react/src/components/IndexFilters/components/SearchFilterButton/SearchFilterButton.tsx
@@ -14,6 +14,7 @@ export interface SearchFilterButtonProps {
   disabled?: boolean;
   tooltipContent: string;
   hideFilters?: boolean;
+  hideQueryField?: boolean;
   style: CSSProperties;
 }
 
@@ -24,6 +25,7 @@ export function SearchFilterButton({
   tooltipContent,
   style,
   hideFilters,
+  hideQueryField,
 }: SearchFilterButtonProps) {
   const activator = (
     <div style={style}>
@@ -33,7 +35,7 @@ export function SearchFilterButton({
         disabled={disabled}
       >
         <Inline gap="0">
-          <Icon source={SearchMinor} color="base" />
+          {hideQueryField ? null : <Icon source={SearchMinor} color="base" />}
           {hideFilters ? null : <Icon source={FilterMinor} color="base" />}
         </Inline>
       </FilterButton>


### PR DESCRIPTION
### WHY are these changes introduced?

There are couple of less-than-ideal states that the IndexFilters component can get in, and this PR updates the component to address them and improve them.

### WHAT is this pull request doing?

- Removes the background from the `AlphaFilters` component on medium-up devices so that the border-radius of the parent element is respected. (It is kept on md-down devices as it's sticky and required)
- Removes the slide down animation on medium-down devices for the `AlphaFilters` as part of the `IndexFilters` component.
- Adds a gap between `children` elements within the `AlphaFilters` if no query field is present.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
