### PR TITLE
[Layout foundations] Update navigation component links

### DIFF
--- a/.changeset/cool-clouds-doubt.md
+++ b/.changeset/cool-clouds-doubt.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Updated links for `Navigation` component in style guide to reflect recent component category structure

--- a/polaris.shopify.com/content/components/navigation/top-bar.md
+++ b/polaris.shopify.com/content/components/navigation/top-bar.md
@@ -33,7 +33,7 @@ The top bar component must be passed to the [frame](https://polaris.shopify.com/
 The top bar component should:
 
 - Not provide global navigation for an application
-  - Use the [navigation component](https://polaris.shopify.com/components/navigation) instead
+  - Use the [navigation component](https://polaris.shopify.com/components/navigation/navigation) instead
 - Include search to help merchants find resources and navigate an application
 - Include a user menu component to indicate the logged-in merchant and provide them with global actions
 - Provide a color through the [app provider](https://polaris.shopify.com/components/app-provider) component to style the background
@@ -134,7 +134,7 @@ A text field component that is tailor-made for a search use-case.
 ## Related components
 
 - To provide the structure for the top bar component, as well as the primary navigation use the [frame](https://polaris.shopify.com/components/frame) component.
-- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/navigation) component.
+- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/navigation/navigation) component.
 - To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar) component.
 - To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
 - To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/loading) component.

--- a/polaris.shopify.com/content/components/utilities/frame.md
+++ b/polaris.shopify.com/content/components/utilities/frame.md
@@ -1,6 +1,6 @@
 ---
 title: Frame
-description: The frame component, while not visible in the user interface itself, provides the structure for an application. It wraps the main elements and houses the primary [navigation](https://polaris.shopify.com/components/navigation), [top bar](https://polaris.shopify.com/components/top-bar), [toast](https://polaris.shopify.com/components/feedback-indicators/toast), and [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar) components.
+description: The frame component, while not visible in the user interface itself, provides the structure for an application. It wraps the main elements and houses the primary [navigation](https://polaris.shopify.com/components/navigation/navigation), [top bar](https://polaris.shopify.com/components/top-bar), [toast](https://polaris.shopify.com/components/feedback-indicators/toast), and [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar) components.
 category: Utilities
 keywords:
   - navigation
@@ -30,7 +30,7 @@ examples:
 For the best experience when creating an application frame, use the following components:
 
 - [Top bar](https://polaris.shopify.com/components/top-bar)
-- [Navigation](https://polaris.shopify.com/components/navigation)
+- [Navigation](https://polaris.shopify.com/components/navigation/navigation)
 - [Contextual save bar](https://polaris.shopify.com/components/contextual-save-bar)
 - [Toast](https://polaris.shopify.com/components/feedback-indicators/toast)
 - [Loading](https://polaris.shopify.com/components/loading)
@@ -40,7 +40,7 @@ For the best experience when creating an application frame, use the following co
 ## Related components
 
 - To display the navigation component on small screens, to provide search and a user menu, or to style the [frame](https://polaris.shopify.com/components/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/top-bar) component.
-- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/navigation) component.
+- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/navigation/navigation) component.
 - To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/contextual-save-bar) component.
 - To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
 - To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/loading) component.

--- a/polaris.shopify.com/content/patterns-legacy/new-badge.md
+++ b/polaris.shopify.com/content/patterns-legacy/new-badge.md
@@ -35,7 +35,7 @@ Consider how the admin would look if it was cluttered with New badges or feature
 
 ### When not to use the New badge
 
-- Should never be used in the primary [navigation](/components/navigation) menu of the Shopify admin
+- Should never be used in the primary [navigation](/components/navigation/navigation) menu of the Shopify admin
 
 ## How long to use the New badge
 


### PR DESCRIPTION
### WHY are these changes introduced?

Some links for the `Navigation` component were reflecting the old component navigation structure and didn't have the `navigation` category included.

### WHAT is this pull request doing?

Updates links to reflect component categories for `Navigation` via `/components/navigation/navigation`. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
