### PR TITLE
[Stylelint] Added prefers-reduced-motion to allowed media queries

### DIFF
--- a/.changeset/sour-books-join.md
+++ b/.changeset/sour-books-join.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': patch
+---
+
+Added prefers-reduced-motion to media query allowed list for stylelint

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -397,9 +397,13 @@ const stylelintPolarisCoverageOptions = {
     {
       'polaris/media-query-allowed-list': {
         // Allowed media types and media conditions
-        // https://www.w3.org/TR/mediaquery5/#media
+        // https://www.w3.org/TR/mediaqueries-5/#media
         allowedMediaTypes: ['print', 'screen'],
-        allowedMediaFeatureNames: ['forced-colors', '-ms-high-contrast'],
+        allowedMediaFeatureNames: [
+          'forced-colors',
+          '-ms-high-contrast',
+          'prefers-reduced-motion',
+        ],
         allowedScssInterpolations: [
           // TODO: Add utility to @shopify/polaris-tokens to getMediaConditionNames
           matchNameRegExp(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Adds `prefers-reduced-motion` to the allowed media queries to allow styles to  enabled reduced motions for users who have this setting enabled .

If adding this to a media query in css currently, there is a warning that advises using a Polaris breakpoint token, however it doesn't look like there is a corresponding token. 


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds `prefers-reduced-motion` to `polaris/media-query-allowed-list`
Also updated link to Media Queries Level 5 as the previous link was broken.