### PR TITLE
Add more guidance around “learn more” links

### DIFF
--- a/.changeset/long-adults-work.md
+++ b/.changeset/long-adults-work.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Updated guidance for "Learn more" links.

--- a/polaris.shopify.com/content/content/actionable-language.md
+++ b/polaris.shopify.com/content/content/actionable-language.md
@@ -251,12 +251,12 @@ It’s better for [internationalization](/foundations/internationalization) to h
 
 #### Do
 
-- Learn more about [Fraud Protect](https://www.shopify.com/fraud-protect).
+- Avoid chargeback costs with [Shopify Protect](https://www.shopify.com/fraud-protect).
 - Manage the [channels](/) you use to sell products and services.
 
 #### Don’t
 
-- [Learn more about Fraud Protect](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
+- [Learn more about Shopify Protect](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
 - [Manage the channels](/) you use to sell products and services.
 
 <!-- end -->

--- a/polaris.shopify.com/content/content/actionable-language.md
+++ b/polaris.shopify.com/content/content/actionable-language.md
@@ -279,6 +279,36 @@ Links that aren’t in full sentences should use the {verb + noun} pattern and n
 
 <!-- end -->
 
+### “Learn more” links
+
+When linking out to documentation from help text in the admin, link the relevant key words. In general, don’t add another sentence starting with “Learn more...”, because it’s repetitive and takes up unnecessary space.
+
+<!-- dodont -->
+
+#### Do
+
+- This is a [read-only environment variable](https://shopify.dev/docs/custom-storefronts/oxygen/storefronts#environment-variables). It can’t be edited or deleted.
+
+#### Don’t
+
+- This is a read-only environment variable. It can’t be edited or deleted. Learn more about [read-only environment variables](https://shopify.dev/docs/custom-storefronts/oxygen/storefronts#environment-variables).
+
+<!-- end -->
+
+Only add a “Learn more...” sentence if the help text addresses more than one concept, each of which could be linked to their own help doc. In that situation, pick the most appropriate link and contextualize it with “Learn more...”.
+
+<!-- dodont -->
+
+#### Do
+
+- Storefront API tokens are unique per Hydrogen storefront but their permission scopes are shared by all Hydrogen storefronts. Learn more about [Storefront API tokens](https://shopify.dev/docs/api/usage/authentication#access-tokens-for-the-storefront-api).
+
+#### Don’t
+
+- [Storefront API tokens](https://shopify.dev/docs/api/usage/authentication#access-tokens-for-the-storefront-api) are unique per [Hydrogen storefront](https://shopify.dev/docs/custom-storefronts/oxygen/storefronts) but their [permission scopes](https://shopify.dev/docs/api/usage/access-scopes#unauthenticated-access-scopes) are shared across all Hydrogen storefronts.
+
+<!-- end -->
+
 ---
 
 ## Confirmations

--- a/polaris.shopify.com/content/content/help-content.md
+++ b/polaris.shopify.com/content/content/help-content.md
@@ -72,11 +72,11 @@ This example also illustrates that there’s still only a subset of merchants th
 ​
 “Learn more” links take merchants to the Shopify Help Center or Shopify.dev for more detailed information than we can offer in the UI.
 
-Make sure “learn more” links go to a page or heading that’s specific to the topic.
+Make sure “Learn more” links go to a page or heading that’s specific to the topic.
 
 The Help Center is a rich resource, but for a merchant it’s not always a convenient time to read documentation. Landing on a dense page of information without knowing where to start is frustrating and disorienting. If there isn’t a page or heading specific to the topic you’re providing help for, work with the documentation team to create the right content.
 
-See the content guidelines for links for more about [formatting “learn more” links](/content/actionable-language#-learn-more--links).
+See the content guidelines for links for more about [formatting “Learn more” links](/content/actionable-language#-learn-more--links).
 
 ### “Learn more” badges for settings
 
@@ -85,7 +85,7 @@ See the content guidelines for links for more about [formatting “learn more”
 
 ![“Learn more” badge interaction pattern](/images/foundations/patterns/help-content/learn-more-badges.png)
 
-Use “learn more” badges:
+Use “Learn more” badges:
 ​
 
 - Only in settings experiences, and only in card headers
@@ -93,5 +93,5 @@ Use “learn more” badges:
 
 Best practices:
 
-- Use regular “learn more” links for help topics specific to only a part of a card
-- Some cards benefit from a “learn more” badge in the heading in combination with “learn more” links or other help content in the card body
+- Use regular “Learn more” links for help topics specific to only a part of a card
+- Some cards benefit from a “Learn more” badge in the heading in combination with “Learn more” links or other help content in the card body

--- a/polaris.shopify.com/content/content/help-content.md
+++ b/polaris.shopify.com/content/content/help-content.md
@@ -70,11 +70,13 @@ This example also illustrates that there’s still only a subset of merchants th
 ## “Learn more” links
 
 ​
-“Learn more” links take merchants to the Shopify Help Center for more detailed information than we can offer in the UI.
+“Learn more” links take merchants to the Shopify Help Center or Shopify.dev for more detailed information than we can offer in the UI.
 
-Make sure “learn more” links go to a Help Center page or heading that’s specific to the topic.
+Make sure “learn more” links go to a page or heading that’s specific to the topic.
 
 The Help Center is a rich resource, but for a merchant it’s not always a convenient time to read documentation. Landing on a dense page of information without knowing where to start is frustrating and disorienting. If there isn’t a page or heading specific to the topic you’re providing help for, work with the documentation team to create the right content.
+
+See the content guidelines for links for more about [formatting “learn more” links](/content/actionable-language#-learn-more--links).
 
 ### “Learn more” badges for settings
 


### PR DESCRIPTION
### WHY are these changes introduced?

In the process of [making some changes](https://github.com/Shopify/web/pull/88320) to some “learn more” links in the Hydrogen channel, I thought the guidance around this type of link could be a little more specific and actionable. This PR proposes some updates to our [content guidelines for Links](https://polaris.shopify.com/content/actionable-language#links), and cross-references with the [“Help content” page](https://polaris.shopify.com/content/help-content#-learn-more--links).

### WHAT is this pull request doing?

**Added to https://polaris.shopify.com/content/actionable-language#links**
<img width="914" alt="learn-more" src="https://user-images.githubusercontent.com/547470/229219336-0f07d804-6e5d-4d78-a38b-597f0b10c4da.png">

**Added to https://polaris.shopify.com/content/help-content#-learn-more--links**
<img width="908" alt="learn-more-help" src="https://user-images.githubusercontent.com/547470/229219331-0709a3d7-68c5-4435-a4f3-cdd8289bd9a0.png">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
