### PR TITLE
Add new page descriptions

### DIFF
--- a/.changeset/afraid-penguins-visit.md
+++ b/.changeset/afraid-penguins-visit.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Added missing page descriptions.

--- a/polaris.shopify.com/content/components/actions/index.md
+++ b/polaris.shopify.com/content/components/actions/index.md
@@ -1,5 +1,6 @@
 ---
 title: Actions
+description: Perform tasks or take actions within the Shopify admin.
 expanded: true
 order: 1
 ---

--- a/polaris.shopify.com/content/components/feedback-indicators/index.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/index.md
@@ -1,5 +1,6 @@
 ---
 title: Feedback indicators
+description: Inform merchants about the status of a process, provide feedback on actions and tasks, or indicate progress.
 expanded: true
 order: 5
 ---

--- a/polaris.shopify.com/content/components/images-and-icons/index.md
+++ b/polaris.shopify.com/content/components/images-and-icons/index.md
@@ -1,5 +1,6 @@
 ---
 title: Images and icons
+description: Represent visual content, such as avatars and thumbnails for images or video.
 expanded: true
 order: 4
 ---

--- a/polaris.shopify.com/content/components/index.md
+++ b/polaris.shopify.com/content/components/index.md
@@ -1,5 +1,6 @@
 ---
 title: Components
+description: Components are the reusable building blocks for creating Shopify admin experiences.
 order: 7
 icon: AppsMajor
 ---

--- a/polaris.shopify.com/content/components/lists/index.md
+++ b/polaris.shopify.com/content/components/lists/index.md
@@ -1,5 +1,6 @@
 ---
 title: Lists
+description: Provide merchants with easy-to-use interfaces for selecting options, organizing information, and interacting with data.
 expanded: true
 order: 8
 ---

--- a/polaris.shopify.com/content/components/navigation/index.md
+++ b/polaris.shopify.com/content/components/navigation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Navigation
+description: Access resources and move between sections, pages, or views in a structured and intuitive way.
 expanded: true
 order: 9
 ---

--- a/polaris.shopify.com/content/components/overlays/index.md
+++ b/polaris.shopify.com/content/components/overlays/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overlays
+description: Display contextual elements on top of the main admin interface that provide additional information or functionality.
 expanded: true
 order: 10
 ---

--- a/polaris.shopify.com/content/components/selection-and-input/index.md
+++ b/polaris.shopify.com/content/components/selection-and-input/index.md
@@ -1,5 +1,6 @@
 ---
 title: Selection and input
+description: Choose or enter information using elements like checkboxes, text fields, and more.
 expanded: true
 order: 3
 ---

--- a/polaris.shopify.com/content/components/tables/index.md
+++ b/polaris.shopify.com/content/components/tables/index.md
@@ -1,5 +1,6 @@
 ---
 title: Tables
+description: Display, organize, and sort data for merchants to analyze and take action on.
 expanded: true
 order: 7
 ---

--- a/polaris.shopify.com/content/components/typography/index.md
+++ b/polaris.shopify.com/content/components/typography/index.md
@@ -1,6 +1,6 @@
 ---
 title: Typography
-description: Typography components
+description: Establish hierarchy and communicate importance through text presentation.
 expanded: true
 order: 6
 ---

--- a/polaris.shopify.com/content/components/utilities/index.md
+++ b/polaris.shopify.com/content/components/utilities/index.md
@@ -1,5 +1,6 @@
 ---
 title: Utilities
+description: Utilities are core tools for managing the structure of the admin and global settings.
 expanded: true
 order: 11
 ---

--- a/polaris.shopify.com/content/contributing/code-of-conduct.md
+++ b/polaris.shopify.com/content/contributing/code-of-conduct.md
@@ -1,5 +1,6 @@
 ---
 title: Code of Conduct
+description: Respectful behaviors and interactions help us provide a welcoming community for all contributors.
 keywords:
   - open source
 order: 0

--- a/polaris.shopify.com/content/icons.md
+++ b/polaris.shopify.com/content/icons.md
@@ -1,5 +1,6 @@
 ---
 title: Icons
+description: Use icons to increase visual appeal and improve navigation, comprehension, and engagement.
 order: 9
 icon: IconsMajor
 ---

--- a/polaris.shopify.com/content/tokens.md
+++ b/polaris.shopify.com/content/tokens.md
@@ -1,5 +1,6 @@
 ---
 title: Tokens
+description: Tokens are variables that represent design decisions such as color, typography, and spacing, in a consistent and reusable way.
 order: 8
 icon: EyeDropperMinor
 url: /tokens/colors


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8812

### WHAT is this pull request doing?

Adds missing page descriptions to pages in polaris.shopify.com.