### PR TITLE
Make `Popover` snappier by removing unmount delay

### DIFF
--- a/.changeset/healthy-zoos-end.md
+++ b/.changeset/healthy-zoos-end.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Removed the Exiting animation state from Popovers, causing them to close immediately instead of after a 100ms delay.

--- a/polaris-react/src/components/Popover/Popover.scss
+++ b/polaris-react/src/components/Popover/Popover.scss
@@ -31,12 +31,6 @@ $vertical-motion-offset: -5px;
   transform: none;
 }
 
-.PopoverOverlay-exiting {
-  opacity: 1;
-  transform: translateY(0);
-  transition-duration: var(--p-duration-0);
-}
-
 .measuring:not(.PopoverOverlay-exiting) {
   opacity: 0;
   transform: translateY($vertical-motion-offset);

--- a/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -74,7 +74,6 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
 
   private contentNode = createRef<HTMLDivElement>();
   private enteringTimer?: number;
-  private exitingTimer?: number;
   private overlayRef: React.RefObject<PositionedOverlay>;
 
   constructor(props: PopoverOverlayProps) {
@@ -113,12 +112,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
     }
 
     if (!this.props.active && oldProps.active) {
-      this.changeTransitionStatus(TransitionStatus.Exiting, () => {
-        this.clearTransitionTimeout();
-        this.exitingTimer = window.setTimeout(() => {
-          this.setState({transitionStatus: TransitionStatus.Exited});
-        }, parseInt(motion['duration-100'], 10));
-      });
+      this.setState({transitionStatus: TransitionStatus.Exited});
     }
   }
 
@@ -171,10 +165,6 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
   private clearTransitionTimeout() {
     if (this.enteringTimer) {
       window.clearTimeout(this.enteringTimer);
-    }
-
-    if (this.exitingTimer) {
-      window.clearTimeout(this.exitingTimer);
     }
   }
 


### PR DESCRIPTION
Popovers currently wait 100ms to unmount. When quickly moving between popovers, it creates the appearance of 2 popovers being visible at the same time, making it hard to know where to focus the attention.

https://user-images.githubusercontent.com/875708/229795118-862e67d2-c593-4efc-9b7b-a5436396088e.mp4

<br>

This PR removes the unmount delay. This delay exists to create space for an exit animation, but the Popover component doesn't have one, so it simply waits 100ms and then disappears without a transition.

With this change, the Popovers feel more snappy:

https://user-images.githubusercontent.com/875708/229795143-99930bf8-4cf0-4310-a082-e578affa5d43.mp4

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
