### PR TITLE
[Banner] Support wrapping long titles

### DIFF
--- a/.changeset/spicy-books-own.md
+++ b/.changeset/spicy-books-own.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Support wrapping long titles in Banner

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -85,7 +85,7 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
 
   if (title) {
     headingMarkup = (
-      <Text as="h2" variant="headingMd">
+      <Text as="h2" variant="headingMd" breakWord>
         {title}
       </Text>
     );

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -163,8 +163,8 @@
 }
 
 .break {
-  overflow-wrap: break-word;
-  word-break: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
 }
 
 .numeric {

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -164,6 +164,7 @@
 
 .break {
   overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .numeric {


### PR DESCRIPTION
### WHY are these changes introduced?

At some point [this fix was lost](https://github.com/Shopify/polaris/pull/1553/files) and the issue was found again in a recent bug hunt: 
> Although unlikely, long text (100 char) breaks the banner after saving discount code creation

### WHAT is this pull request doing?

This PR prevents very long `Banner` titles from overflowing

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

- Open the [Spin URL](https://admin.web.banner-length.stefan-legg.us.spin.dev/store/shop1)
- Go to create a new product, catalog, discount, or any other resource that would show a banner after creation
- Enter a very long single word title for the resource - approx more than 100 characters with no spaces
- Finish creating the resource
- Observe the created banner once you land on the details page. Verify that the title wraps rather than overflowing.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
