### PR TITLE
[UserMenu] Update Topbar User Menu and Action List to reflect new designs

### DIFF
--- a/.changeset/famous-hairs-jam.md
+++ b/.changeset/famous-hairs-jam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated top bar menu active state

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -58,11 +58,6 @@
     svg {
       fill: var(--p-color-icon-interactive);
     }
-
-    &::before {
-      // stylelint-disable-next-line -- alignment for left tab style https://github.com/Shopify/polaris/pull/3619
-      @include list-selected-indicator;
-    }
   }
 
   &.destructive {

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -1,7 +1,5 @@
 @import '../../styles/common';
 
-$content-max-width: 176px;
-
 .Item {
   // stylelint-disable -- Polaris component custom properties
   --pc-action-list-image-size: 20px;
@@ -125,8 +123,4 @@ $content-max-width: 176px;
   min-width: 0;
   max-width: 100%;
   flex: 1 1 auto;
-
-  .Trimmed {
-    max-width: $content-max-width;
-  }
 }

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -1,5 +1,7 @@
 @import '../../styles/common';
 
+$content-max-width: 176px;
+
 .Item {
   // stylelint-disable -- Polaris component custom properties
   --pc-action-list-image-size: 20px;
@@ -123,4 +125,8 @@
   min-width: 0;
   max-width: 100%;
   flex: 1 1 auto;
+
+  .Trimmed {
+    max-width: $content-max-width;
+  }
 }

--- a/polaris-react/src/components/ActionList/ActionList.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.tsx
@@ -49,7 +49,7 @@ export function ActionList({
   const sectionMarkup = finalSections.map((section, index) => {
     return section.items.length > 0 ? (
       <Section
-        key={section.title || index}
+        key={typeof section.title === 'string' ? section.title : index}
         section={section}
         hasMultipleSections={hasMultipleSections}
         actionRole={actionRole}

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -12,6 +12,8 @@ import styles from '../../ActionList.scss';
 import {handleMouseUpByBlurring} from '../../../../utilities/focus';
 import {HorizontalStack} from '../../../HorizontalStack';
 import {Box} from '../../../Box';
+import {Tooltip} from '../../../Tooltip';
+import {Truncate} from '../../../Truncate';
 
 export type ItemProps = ActionListItemDescriptor;
 
@@ -34,6 +36,7 @@ export function Item({
   ellipsis,
   active,
   role,
+  truncate = false,
 }: ItemProps) {
   const className = classNames(
     styles.Item,
@@ -62,7 +65,15 @@ export function Item({
     );
   }
 
-  const contentText = ellipsis && content ? `${content}…` : content;
+  let contentText = null;
+
+  if (ellipsis && content) {
+    contentText = `${content}…`;
+  } else if (content) {
+    contentText = truncate ? truncateText(content) : content;
+  } else {
+    contentText = content;
+  }
 
   const contentMarkup = helpText ? (
     <>
@@ -102,7 +113,7 @@ export function Item({
   const textMarkup = <span className={styles.Text}>{contentMarkup}</span>;
 
   const contentElement = (
-    <HorizontalStack blockAlign="center" gap="4">
+    <HorizontalStack blockAlign="center" gap="4" wrap={!truncate}>
       {prefixMarkup}
       {textMarkup}
       {badgeMarkup}
@@ -147,3 +158,14 @@ export function Item({
     </>
   );
 }
+
+const truncateText = (text: string) => {
+  const trimmedText = text.trim();
+  return trimmedText.length > 50 ? (
+    <Tooltip content={trimmedText} zIndexOverride={514}>
+      <Truncate>{trimmedText}</Truncate>
+    </Tooltip>
+  ) : (
+    trimmedText
+  );
+};

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -161,11 +161,11 @@ export function Item({
 
 const truncateText = (text: string) => {
   const trimmedText = text.trim();
-  return trimmedText.length > 50 ? (
+  return (
     <Tooltip content={trimmedText} zIndexOverride={514}>
-      <Truncate>{trimmedText}</Truncate>
+      <div className={styles.Trimmed}>
+        <Truncate>{trimmedText}</Truncate>
+      </div>
     </Tooltip>
-  ) : (
-    trimmedText
   );
 };

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -162,10 +162,15 @@ export function Item({
 const truncateText = (text: string) => {
   const trimmedText = text.trim();
   return (
-    <Tooltip content={trimmedText} zIndexOverride={514}>
-      <div className={styles.Trimmed}>
+    <Tooltip
+      content={trimmedText}
+      zIndexOverride={514}
+      preferredPosition="above"
+      hoverDelay={1000}
+    >
+      <Text truncate as="p" variant="bodyMd">
         <Truncate>{trimmedText}</Truncate>
-      </div>
+      </Text>
     </Tooltip>
   );
 };

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {TickSmallMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
 import type {ActionListItemDescriptor} from '../../../../types';
@@ -80,11 +81,23 @@ export function Item({
     </span>
   );
 
-  const suffixMarkup = suffix && (
-    <Box>
-      <span className={styles.Suffix}>{suffix}</span>
-    </Box>
-  );
+  let suffixMarkup: React.ReactNode | null = null;
+
+  if (active) {
+    suffixMarkup = (
+      <Box>
+        <span className={styles.Suffix}>
+          <Icon source={TickSmallMinor} />
+        </span>
+      </Box>
+    );
+  } else if (suffix) {
+    suffixMarkup = suffix && (
+      <Box>
+        <span className={styles.Suffix}>{suffix}</span>
+      </Box>
+    );
+  }
 
   const textMarkup = <span className={styles.Text}>{contentMarkup}</span>;
 

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -4,6 +4,7 @@ import {mountWithApp} from 'tests/utilities';
 import {Item} from '../Item';
 import {Text} from '../../../../Text';
 import {UnstyledLink} from '../../../../UnstyledLink';
+import {Truncate} from '../../../../Truncate';
 
 describe('<Item />', () => {
   it('adds a style property when the image prop is present', () => {
@@ -101,6 +102,16 @@ describe('<Item />', () => {
     expect(item).toContainReactComponent(UnstyledLink, {
       onClick: null,
     });
+  });
+
+  it('truncates content when truncate is true', () => {
+    const item = mountWithApp(
+      <Item
+        content="Test longer than usual string that probably overflows."
+        truncate
+      />,
+    );
+    expect(item).toContainReactComponent(Truncate);
   });
 });
 

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -4,7 +4,6 @@ import {mountWithApp} from 'tests/utilities';
 import {Item} from '../Item';
 import {Text} from '../../../../Text';
 import {UnstyledLink} from '../../../../UnstyledLink';
-import {Truncate} from '../../../../Truncate';
 
 describe('<Item />', () => {
   it('adds a style property when the image prop is present', () => {
@@ -111,7 +110,7 @@ describe('<Item />', () => {
         truncate
       />,
     );
-    expect(item).toContainReactComponent(Truncate);
+    expect(item).toContainReactComponent(Text, {truncate: true});
   });
 });
 

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -61,7 +61,7 @@ export function Section({
     <Box
       paddingBlockStart="4"
       paddingInlineStart="4"
-      paddingBlockEnd={'2'}
+      paddingBlockEnd="2"
       paddingInlineEnd="4"
     >
       <Text as="p" variant="headingXs">

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -61,7 +61,7 @@ export function Section({
     <Box
       paddingBlockStart="4"
       paddingInlineStart="4"
-      paddingBlockEnd="2"
+      paddingBlockEnd={'2'}
       paddingInlineEnd="4"
     >
       <Text as="p" variant="headingXs">

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -55,17 +55,19 @@ export function Default() {
     <TopBar.UserMenu
       actions={[
         {
-          helpText: 'Jaded Pixel',
           items: [
             {
               active: true,
               content: 'Jaded Pixel',
               prefix: <Avatar size="small" name="Jaded Pixel" />,
               suffix: <Icon source={TickSmallMinor} />,
+              truncate: true,
             },
             {
-              content: 'Jaded Pixel 2.0',
+              content:
+                'Jaded Pixel 2.0 Jaded Pixel 2.0 Jaded Pixel 2.0 Jaded Pixel Pixel 2.0',
               prefix: <Avatar size="small" name="Jaded Pixel 2.0" />,
+              truncate: true,
             },
             {
               content: 'View all 3 stores',
@@ -84,7 +86,6 @@ export function Default() {
         },
         {
           title: 'Dharma Johnson',
-          helpText: 'dharma@jadedpixel.com',
           items: [{content: 'Manage account'}, {content: 'Log out'}],
         },
       ]}

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -58,15 +58,13 @@ export function Default() {
           items: [
             {
               active: true,
-              content:
-                'Jaded Pixel Jaded Pixel Jaded Pixel Jaded Pixel Jaded Pixel Jaded Pixel',
+              content: 'Jaded Pixel',
               prefix: <Avatar size="small" name="Jaded Pixel" />,
               suffix: <Icon source={TickSmallMinor} />,
               truncate: true,
             },
             {
-              content:
-                'Jaded Pixel 2.0 Jaded Pixel 2.0 Jaded Pixel 2.0 Jaded Pixel Pixel 2.0',
+              content: 'Jaded Pixel 2.0',
               prefix: <Avatar size="small" name="Jaded Pixel 2.0" />,
               truncate: true,
             },

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -1,7 +1,13 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {ActionList, Frame, Icon, TopBar, Text} from '@shopify/polaris';
-import {ArrowLeftMinor, QuestionMarkMajor} from '@shopify/polaris-icons';
+import {ActionList, Frame, Icon, TopBar, Text, Avatar} from '@shopify/polaris';
+import {
+  ArrowLeftMinor,
+  QuestionMarkMajor,
+  EditMinor,
+  TickSmallMinor,
+  SearchMinor,
+} from '@shopify/polaris-icons';
 
 export default {
   component: TopBar,
@@ -49,15 +55,42 @@ export function Default() {
     <TopBar.UserMenu
       actions={[
         {
-          items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
+          helpText: 'Jaded Pixel',
+          items: [
+            {
+              active: true,
+              content: 'Jaded Pixel',
+              prefix: <Avatar size="small" name="Jaded Pixel" />,
+              suffix: <Icon source={TickSmallMinor} />,
+            },
+            {
+              content: 'Jaded Pixel 2.0',
+              prefix: <Avatar size="small" name="Jaded Pixel 2.0" />,
+            },
+            {
+              content: 'View all 3 stores',
+              prefix: <Icon source={SearchMinor} />,
+            },
+          ],
         },
         {
           items: [{content: 'Community forums'}],
         },
+        {
+          items: [{content: 'Help Center'}],
+        },
+        {
+          items: [{content: 'Keyboard shortcuts'}],
+        },
+        {
+          title: 'Dharma Johnson',
+          helpText: 'dharma@jadedpixel.com',
+          items: [{content: 'Manage account'}, {content: 'Log out'}],
+        },
       ]}
       name="Dharma"
       detail="Jaded Pixel"
-      initials="D"
+      initials="JP"
       open={isUserMenuOpen}
       onToggle={toggleIsUserMenuOpen}
     />

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -58,7 +58,8 @@ export function Default() {
           items: [
             {
               active: true,
-              content: 'Jaded Pixel',
+              content:
+                'Jaded Pixel Jaded Pixel Jaded Pixel Jaded Pixel Jaded Pixel Jaded Pixel',
               prefix: <Avatar size="small" name="Jaded Pixel" />,
               suffix: <Icon source={TickSmallMinor} />,
               truncate: true,

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -43,12 +43,12 @@ export function UserMenu({
   onToggle,
   open,
   accessibilityLabel,
-  activatorContent,
+  customActivator,
 }: UserMenuProps) {
   const showIndicator = Boolean(message);
 
-  const activatorContentMarkup = activatorContent ? (
-    activatorContent
+  const activatorContentMarkup = customActivator ? (
+    customActivator
   ) : (
     <>
       <MessageIndicator active={showIndicator}>

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import type {IconableAction} from '../../../../types';
 import {Avatar} from '../../../Avatar';
 import type {AvatarProps} from '../../../Avatar';
 import {MessageIndicator} from '../../../MessageIndicator';
 import {Menu} from '../Menu';
 import type {MenuProps} from '../Menu';
 import {Text} from '../../../Text';
+import type {ActionListProps} from '../../../ActionList';
 
 import styles from './UserMenu.scss';
 
 export interface UserMenuProps {
   /** An array of action objects that are rendered inside of a popover triggered by this menu */
-  actions: {items: IconableAction[]}[];
+  actions: ActionListProps['sections'];
   /** Accepts a message that facilitates direct, urgent communication with the merchant through the user menu */
   message?: MenuProps['message'];
   /** A string detailing the merchant’s full name to be displayed in the user menu */
@@ -29,6 +29,8 @@ export interface UserMenuProps {
   open: boolean;
   /** A callback function to handle opening and closing the user menu */
   onToggle(): void;
+  /** A custom activator that can be used when the default activator is not desired */
+  activatorContent?: React.ReactNode;
 }
 
 export function UserMenu({
@@ -41,10 +43,13 @@ export function UserMenu({
   onToggle,
   open,
   accessibilityLabel,
+  activatorContent,
 }: UserMenuProps) {
   const showIndicator = Boolean(message);
 
-  const activatorContentMarkup = (
+  const activatorContentMarkup = activatorContent ? (
+    activatorContent
+  ) : (
     <>
       <MessageIndicator active={showIndicator}>
         <Avatar

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -30,7 +30,7 @@ export interface UserMenuProps {
   /** A callback function to handle opening and closing the user menu */
   onToggle(): void;
   /** A custom activator that can be used when the default activator is not desired */
-  activatorContent?: React.ReactNode;
+  customActivator?: React.ReactNode;
 }
 
 export function UserMenu({

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -212,7 +212,7 @@ export interface ActionListItemDescriptor
 
 export interface ActionListSection {
   /** Section title */
-  title?: string;
+  title?: string | React.ReactNode;
   /** Collection of action items for the list */
   items: readonly ActionListItemDescriptor[];
 }

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -204,6 +204,8 @@ export interface ActionListItemDescriptor
   suffix?: React.ReactNode;
   /**  Add an ellipsis suffix to action content */
   ellipsis?: boolean;
+  /** Truncate action content */
+  truncate?: boolean;
   /** Whether the action is active or not */
   active?: boolean;
   /** Defines a role for the action */


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves https://github.com/Shopify/core-workflows/issues/881

<!--
  Context about the problem that’s being addressed.
-->

Before the launch of [Commerce Components by Shopify](https://www.shopify.com/commerce-components), there are a couple of prerequisites that require changes to Polaris. This PR addresses these changes.


I'm including screenshots of individual changes below but for in-depth specifications, please see this [Figma](https://www.figma.com/file/M2BnURpiYPiTT9z1D2iFNi/Enterprise-(CCS)-Nav?node-id=6147-204586&t=u93Eyd6k1WLXp39B-0).

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->


This PR updates the `Topbar.UserMenu` component as well as the `ActionList` to reflect the new store switcher experience.

The changes being made here are three fold:

- `Topbar.UserMenu`:  Allow a custom `activatorContent` prop to be passed enabling us to customize the order of the avatar and heading. Our activator will have a square shaped avatar as well as an updated Text. Otherwise, the default activator stays the same (It might be a good idea to have the new format as the default, in which case I can update the existing activator).

- `ActionList`: `title` is updated to accept a `React.Node` instead of string. Additionally a new `helpText` prop is added to accommodate email or other help texts.

- `ActionList`: the blue indicator that displays on active actions is removed. If there are any accessibility concerns regarding this, I'm happy to discuss.


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

- [Spin URL](https://admin.web.acc-menu.zakaria-warsame.us.spin.dev/store/shop1)
  - Notice how we're able to pass a custom activator with a squared avatar, and a different text style
  - The `title` "Test User" is also customized to use a different style. Passing just a string would still have the original style.
  - The selected item doesn't have a blue indicator

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
