### PR TITLE
[Toast][InlineError]Update icon for critical state

### DIFF
--- a/.changeset/unlucky-fireants-kiss.md
+++ b/.changeset/unlucky-fireants-kiss.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-updated InlineError and Toast components to use DiamondAlertMinor icon
+Updated `InlineError` and `Toast` components to use `DiamondAlertMinor` icon

--- a/.changeset/unlucky-fireants-kiss.md
+++ b/.changeset/unlucky-fireants-kiss.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+updated InlineError and Toast components to use DiamondAlertMinor icon

--- a/polaris-react/src/components/Frame/components/Toast/Toast.tsx
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {CancelSmallMinor, AlertMinor} from '@shopify/polaris-icons';
+import {CancelSmallMinor, DiamondAlertMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
 import {Key} from '../../../../types';
@@ -64,7 +64,7 @@ export function Toast({
 
   const leadingIconMarkup = error ? (
     <div className={styles.LeadingIcon}>
-      <Icon source={AlertMinor} color="base" />
+      <Icon source={DiamondAlertMinor} color="base" />
     </div>
   ) : null;
 

--- a/polaris-react/src/components/InlineError/InlineError.tsx
+++ b/polaris-react/src/components/InlineError/InlineError.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AlertMinor} from '@shopify/polaris-icons';
+import {DiamondAlertMinor} from '@shopify/polaris-icons';
 
 import {Icon} from '../Icon';
 import type {Error} from '../../types';
@@ -21,7 +21,7 @@ export function InlineError({message, fieldID}: InlineErrorProps) {
   return (
     <div id={errorTextID(fieldID)} className={styles.InlineError}>
       <div className={styles.Icon}>
-        <Icon source={AlertMinor} />
+        <Icon source={DiamondAlertMinor} />
       </div>
       {message}
     </div>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Currently in Polaris different icons are used for the same status role, namely the critical role. In a critical banner the diamond alert icon is used while in the inlineError component the alert icon is used.

Fixes [8859](https://github.com/Shopify/polaris/issues/8859) <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This change simply changes the icon used in the `toast` and `inlineError` components 
### Before
<img width="303" alt="Screenshot 2023-04-05 at 10 30 29 AM" src="https://user-images.githubusercontent.com/5749440/230129824-d19c2a9b-73ef-41c4-bcbd-3af71a889e66.png">
<img width="267" alt="Screenshot 2023-04-05 at 10 30 21 AM" src="https://user-images.githubusercontent.com/5749440/230129829-cf6b4f91-08f6-4580-babf-fc43259f4fc6.png">

### After

<img width="239" alt="Screenshot 2023-04-05 at 10 29 04 AM" src="https://user-images.githubusercontent.com/5749440/230129895-3d97fefc-1ea5-49c7-b96a-3041608f73e4.png">
<img width="341" alt="Screenshot 2023-04-05 at 10 29 14 AM" src="https://user-images.githubusercontent.com/5749440/230129910-0dd8fb0c-4857-4069-9775-0d356c2e9001.png">



<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
