### PR TITLE
Add target property to Action, add target prop to Banner, Button, Unstyled Button, Link and UnstyledLink

### DIFF
--- a/.changeset/nine-wolves-knock.md
+++ b/.changeset/nine-wolves-knock.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Add support for target property in the Action type. Added target prop to Button, UnstyledButton and UnstyledLink.
+Added support for setting a `target` on anchors rendered by `Button`, `Link`, `UnstyledButton` and `UnstyledLink`

--- a/.changeset/nine-wolves-knock.md
+++ b/.changeset/nine-wolves-knock.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Add support for target property in the Action type. Added target prop to Button, UnstyledButton and UnstyledLink.

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -195,6 +195,7 @@ function SecondaryActionFrom({action}: {action: Action}) {
         className={styles.SecondaryAction}
         url={action.url}
         external={action.external}
+        target={action.target}
       >
         <span className={styles.Text}>{action.content}</span>
       </UnstyledLink>

--- a/polaris-react/src/components/Banner/tests/Banner.test.tsx
+++ b/polaris-react/src/components/Banner/tests/Banner.test.tsx
@@ -226,6 +226,33 @@ describe('<Banner />', () => {
     });
   });
 
+  it('creates a link with custom target in secondaryAction', () => {
+    const bannerWithSecondaryAction = mountWithApp(
+      <Banner
+        title="Test"
+        action={{
+          content: 'Primary action',
+        }}
+        secondaryAction={{
+          content: 'Secondary external link',
+          url: 'https://test.com',
+          target: '_top',
+        }}
+      >
+        Hello World
+      </Banner>,
+    );
+
+    const unstyledLink = bannerWithSecondaryAction
+      .find(UnstyledLink)!
+      .find('a');
+
+    expect(unstyledLink).toHaveReactProps({
+      target: '_top',
+      rel: undefined,
+    });
+  });
+
   it('renders an unstyled button with contentContext', () => {
     const bannerWithContentContext = mountWithApp(
       <WithinContentContext.Provider value>

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -72,7 +72,10 @@ interface CommonButtonProps
   'data-primary-link'?: boolean;
 }
 
-type LinkButtonProps = Pick<ButtonProps, 'url' | 'external' | 'download'>;
+type LinkButtonProps = Pick<
+  ButtonProps,
+  'url' | 'external' | 'download' | 'target'
+>;
 
 type ActionButtonProps = Pick<
   ButtonProps,
@@ -98,6 +101,7 @@ export function Button({
   disabled,
   external,
   download,
+  target,
   submit,
   loading,
   pressed,
@@ -281,6 +285,7 @@ export function Button({
     url,
     external,
     download,
+    target,
   };
   const actionProps: ActionButtonProps = {
     submit,

--- a/polaris-react/src/components/Button/tests/Button.test.tsx
+++ b/polaris-react/src/components/Button/tests/Button.test.tsx
@@ -75,6 +75,13 @@ describe('<Button />', () => {
     });
   });
 
+  describe('target', () => {
+    it('passes prop', () => {
+      const button = mountWithApp(<Button target="_top" />);
+      expect(button).toContainReactComponent(UnstyledButton, {target: '_top'});
+    });
+  });
+
   describe('disabled', () => {
     it('renders <UnstyledButton /> when url is not passed', () => {
       const button = mountWithApp(<Button disabled />);

--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {BannerContext} from '../../utilities/banner-context';
 import {classNames} from '../../utilities/css';
 import {UnstyledLink} from '../UnstyledLink';
+import type {Target} from '../../types';
 
 import styles from './Link.scss';
 
@@ -15,6 +16,8 @@ export interface LinkProps {
   children?: React.ReactNode;
   /** Makes the link open in a new tab */
   external?: boolean;
+  /** Where to display the url */
+  target?: Target;
   /** Makes the link color the same as the current text color and adds an underline */
   monochrome?: boolean;
   /** Removes text decoration underline to the link*/
@@ -32,6 +35,7 @@ export function Link({
   children,
   onClick,
   external,
+  target,
   id,
   monochrome,
   removeUnderline,
@@ -55,6 +59,7 @@ export function Link({
             className={className}
             url={url}
             external={external}
+            target={target}
             id={id}
             aria-label={accessibilityLabel}
             data-primary-link={dataPrimaryLink}

--- a/polaris-react/src/components/Link/tests/Link.test.tsx
+++ b/polaris-react/src/components/Link/tests/Link.test.tsx
@@ -51,6 +51,32 @@ describe('<Link />', () => {
     });
   });
 
+  describe('target', () => {
+    it('adds target blank and noopener noreferrer', () => {
+      const link = mountWithApp(
+        <Link url="https://help.shopify.com/" target="_blank">
+          Shopify Help Center
+        </Link>,
+      );
+      const htmlLink = link.find('a');
+
+      expect(htmlLink?.props.target).toBe('_blank');
+      expect(htmlLink?.props.rel).toBe('noopener noreferrer');
+    });
+
+    it('does not override external prop', () => {
+      const link = mountWithApp(
+        <Link url="https://help.shopify.com/" external target="_top">
+          Shopify Help Center
+        </Link>,
+      );
+      const htmlLink = link.find('a');
+
+      expect(htmlLink?.props.target).toBe('_blank');
+      expect(htmlLink?.props.rel).toBe('noopener noreferrer');
+    });
+  });
+
   describe('monochrome link', () => {
     it('outputs a monochrome unstyled link if rendered within a banner', () => {
       const link = mountWithApp(

--- a/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
@@ -19,6 +19,7 @@ export function UnstyledButton({
   className,
   url,
   external,
+  target,
   download,
   submit,
   disabled,
@@ -70,6 +71,7 @@ export function UnstyledButton({
         {...interactiveProps}
         url={url}
         external={external}
+        target={target}
         download={download}
         {...rest}
       >

--- a/polaris-react/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/polaris-react/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -122,7 +122,7 @@ describe('<Button />', () => {
     });
 
     it('is false when not set', () => {
-      const button = mountWithApp(<UnstyledButton url="https://google.com" />);
+      const button = mountWithApp(<UnstyledButton url={mockUrl} />);
       expect(button).toContainReactComponent(UnstyledLink, {
         external: undefined,
       });
@@ -140,6 +140,41 @@ describe('<Button />', () => {
       expect(button).toContainReactComponent('a');
       expect(button).not.toContainReactComponent(UnstyledLink, {
         external: undefined,
+      });
+    });
+  });
+
+  describe('target', () => {
+    const mockUrl = 'https://google.com';
+
+    it('gets passed into the UnstyledLink', () => {
+      const button = mountWithApp(
+        <UnstyledButton url={mockUrl} target="_top" />,
+      );
+      expect(button).toContainReactComponent(UnstyledLink, {
+        target: '_top',
+      });
+    });
+
+    it('is undefined when not set', () => {
+      const button = mountWithApp(<UnstyledButton url={mockUrl} />);
+      expect(button).toContainReactComponent(UnstyledLink, {
+        target: undefined,
+      });
+    });
+
+    it('is not passed when `url` is missing', () => {
+      const button = mountWithApp(<UnstyledButton target="_top" />);
+      expect(button).toContainReactComponent('button');
+    });
+
+    it('is not passed when `url + disabled`', () => {
+      const button = mountWithApp(
+        <UnstyledButton url={mockUrl} target="_top" disabled />,
+      );
+      expect(button).toContainReactComponent('a');
+      expect(button).not.toContainReactComponent(UnstyledLink, {
+        target: undefined,
       });
     });
   });

--- a/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
@@ -31,8 +31,7 @@ export const UnstyledLink = memo(
       target = targetProp ?? undefined;
     }
 
-    const rel =
-      external || targetProp === '_blank' ? 'noopener noreferrer' : undefined;
+    const rel = target === '_blank' ? 'noopener noreferrer' : undefined;
 
     return (
       <a target={target} {...rest} href={url} rel={rel} {...unstyled.props} />

--- a/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
@@ -21,9 +21,19 @@ export const UnstyledLink = memo(
       return <LinkComponent {...unstyled.props} {...props} />;
     }
 
-    const {external, url, ...rest} = props;
-    const target = external ? '_blank' : undefined;
-    const rel = external ? 'noopener noreferrer' : undefined;
+    const {external, url, target: targetProp, ...rest} = props;
+
+    let target;
+
+    if (external) {
+      target = '_blank';
+    } else {
+      target = targetProp ?? undefined;
+    }
+
+    const rel =
+      external || targetProp === '_blank' ? 'noopener noreferrer' : undefined;
+
     return (
       <a target={target} {...rest} href={url} rel={rel} {...unstyled.props} />
     );

--- a/polaris-react/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/polaris-react/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -43,6 +43,63 @@ describe('<UnstyledLink />', () => {
     });
   });
 
+  describe('target', () => {
+    it('adds rel and target attributes', () => {
+      const anchorElement = mountWithApp(
+        <UnstyledLink target="_blank" url="https://shopify.com" />,
+      );
+
+      expect(anchorElement).toContainReactComponent('a', {
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      });
+    });
+
+    it('does not add rel when target is _top', () => {
+      const anchorElement = mountWithApp(
+        <UnstyledLink target="_top" url="https://shopify.com" />,
+      );
+
+      expect(anchorElement).toContainReactComponent('a', {
+        target: '_top',
+        rel: undefined,
+      });
+    });
+
+    it('does not add rel when target is _self', () => {
+      const anchorElement = mountWithApp(
+        <UnstyledLink target="_self" url="https://shopify.com" />,
+      );
+
+      expect(anchorElement).toContainReactComponent('a', {
+        target: '_self',
+        rel: undefined,
+      });
+    });
+
+    it('does not add rel when target is _parent', () => {
+      const anchorElement = mountWithApp(
+        <UnstyledLink target="_parent" url="https://shopify.com" />,
+      );
+
+      expect(anchorElement).toContainReactComponent('a', {
+        target: '_parent',
+        rel: undefined,
+      });
+    });
+
+    it('does not override external', () => {
+      const anchorElement = mountWithApp(
+        <UnstyledLink target="_parent" external url="https://shopify.com" />,
+      );
+
+      expect(anchorElement).toContainReactComponent('a', {
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      });
+    });
+  });
+
   describe('download', () => {
     it('adds true as a boolean attribute', () => {
       const anchorElement = mountWithApp(

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -37,6 +37,8 @@ export type IconSource =
 
 export type HeadingTagName = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
 
+export type Target = '_blank' | '_self' | '_parent' | '_top';
+
 export type Error =
   | string
   | React.ReactElement
@@ -49,6 +51,8 @@ export interface BaseButton {
   url?: string;
   /** Forces url to open in a new tab */
   external?: boolean;
+  /** Where to display the url */
+  target?: Target;
   /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
   download?: string | boolean;
   /** Allows the button to submit a form */
@@ -102,6 +106,8 @@ export interface Action {
   url?: string;
   /** Forces url to open in a new tab */
   external?: boolean;
+  /** Where to display the url */
+  target?: Target;
   /** Callback when an action takes place */
   onAction?(): void;
   /** Callback when mouse enter */

--- a/polaris-react/src/utilities/link/types.ts
+++ b/polaris-react/src/utilities/link/types.ts
@@ -1,3 +1,5 @@
+import type {Target} from '../../types';
+
 export interface LinkLikeComponentProps
   extends React.HTMLProps<HTMLAnchorElement> {
   /** The url to link to */
@@ -6,6 +8,8 @@ export interface LinkLikeComponentProps
   children?: React.ReactNode;
   /** Makes the link open in a new tab */
   external?: boolean;
+  /** Where to display the url */
+  target?: Target;
   /** Makes the browser download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value. */
   download?: string | boolean;
   [key: string]: any;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Fixes https://github.com/Shopify/mobile/issues/16487

This PR aims to be a short-term solution to fix the issue that exists today in production. In the long-term, [this RFC ](https://github.com/Shopify/ui-api-design/discussions/8)proposes replacing the `external` property with `target`.

These changes are necessary to support a specific workflow for Shopify App Store links that are contained within an embedded Android web view. These links for the Shopify App Store set the `external` flag to `true` which  translates to `target=_blank`. When opening in a new tab from a webview, the Android App Bridge can't access the URL which renders the link inop. You can see this in the production Android app if you navigate to Store > Settings > Apps and sales channels, and then tap "Shopify App Store".

With the new `target` prop, we can set `target=_top` which will allow the Android App Bridge to correctly handle the link to the Shopify App Store.

More context can be found [here](https://docs.google.com/document/d/1FlGg_I-x2k2yQlZDeNJilbXsZmW40O4-cClUHFudS1k/edit).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adds support for a `target` prop which allows us to use any of the HTML target attributes. For the sake of backwards compatibility, this change does not include modifying the existing `external` prop. In the case that the `external` prop is set to `true`, it will take priority over the new `target` prop. 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Unit tests should be enough to cover these changes and ensure that we are not overriding `external=true`

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
