### PR TITLE
[IndexFilters] Support sort-only mode

### DIFF
--- a/.changeset/chilled-jobs-fetch.md
+++ b/.changeset/chilled-jobs-fetch.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Updated `IndexFilters` to support hiding both filters and search field

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
@@ -129,8 +129,6 @@ export function AlphaFilters({
   const [localPinnedFilters, setLocalPinnedFilters] = useState<string[]>([]);
   const hasMounted = useRef(false);
 
-  const enabledFilters = filters.filter((filter) => !filter.disabled);
-
   useEffect(() => {
     hasMounted.current = true;
   });
@@ -143,14 +141,14 @@ export function AlphaFilters({
   };
   const appliedFilterKeys = appliedFilters?.map(({key}) => key);
 
-  const pinnedFiltersFromPropsAndAppliedFilters = enabledFilters.filter(
+  const pinnedFiltersFromPropsAndAppliedFilters = filters.filter(
     ({pinned, key}) =>
       (Boolean(pinned) || appliedFilterKeys?.includes(key)) &&
       // Filters that are pinned in local state display at the end of our list
       !localPinnedFilters.find((filterKey) => filterKey === key),
   );
   const pinnedFiltersFromLocalState = localPinnedFilters
-    .map((key) => enabledFilters.find((filter) => filter.key === key))
+    .map((key) => filters.find((filter) => filter.key === key))
     .reduce<FilterInterface[]>(
       (acc, filter) => (filter ? [...acc, filter] : acc),
       [],
@@ -161,7 +159,7 @@ export function AlphaFilters({
     ...pinnedFiltersFromLocalState,
   ];
 
-  const additionalFilters = enabledFilters
+  const additionalFilters = filters
     .filter((filter) => !pinnedFilters.find(({key}) => key === filter.key))
     .map((filter) => ({
       content: filter.label,
@@ -204,7 +202,7 @@ export function AlphaFilters({
     onClearAll?.();
   };
 
-  const shouldShowAddButton = enabledFilters.some((filter) => !filter.pinned);
+  const shouldShowAddButton = filters.some((filter) => !filter.pinned);
 
   const additionalContent = useMemo(() => {
     return (

--- a/polaris-react/src/components/AlphaFilters/components/FilterPill/FilterPill.tsx
+++ b/polaris-react/src/components/AlphaFilters/components/FilterPill/FilterPill.tsx
@@ -162,6 +162,10 @@ export function FilterPill({
     </Button>
   );
 
+  if (disabled) {
+    return null;
+  }
+
   return (
     <div ref={elementRef}>
       <Popover

--- a/polaris-react/src/components/AlphaFilters/components/FilterPill/tests/FilterPill.test.tsx
+++ b/polaris-react/src/components/AlphaFilters/components/FilterPill/tests/FilterPill.test.tsx
@@ -68,11 +68,9 @@ describe('<Filters />', () => {
       });
     });
 
-    it('will pass the disabled prop to the activator', () => {
+    it('will return null if disabled', () => {
       const wrapper = mountWithApp(<FilterPill {...defaultProps} disabled />);
-      expect(wrapper).toContainReactComponent(UnstyledButton, {
-        disabled: true,
-      });
+      expect(wrapper!.domNode).toBeNull();
     });
 
     it('will invoked the onClick prop when clicked, if present', () => {

--- a/polaris-react/src/components/AlphaFilters/tests/AlphaFilters.test.tsx
+++ b/polaris-react/src/components/AlphaFilters/tests/AlphaFilters.test.tsx
@@ -140,7 +140,7 @@ describe('<AlphaFilters />', () => {
     });
   });
 
-  it('will not render a disabled filter', () => {
+  it('will not render a disabled filter if pinned', () => {
     const scrollSpy = jest.fn();
     HTMLElement.prototype.scroll = scrollSpy;
     const filters = [
@@ -148,7 +148,7 @@ describe('<AlphaFilters />', () => {
       {
         key: 'disabled',
         label: 'Disabled',
-        pinned: false,
+        pinned: true,
         disabled: true,
         filter: <div>Filter</div>,
       },
@@ -157,6 +157,8 @@ describe('<AlphaFilters />', () => {
     const wrapper = mountWithApp(
       <AlphaFilters {...defaultProps} filters={filters} />,
     );
+
+    expect(wrapper).toContainReactComponentTimes(FilterPill, 2);
 
     wrapper.act(() => {
       wrapper
@@ -173,10 +175,6 @@ describe('<AlphaFilters />', () => {
       ],
     });
 
-    expect(wrapper).not.toContainReactComponent(ActionList, {
-      items: expect.arrayContaining([
-        expect.objectContaining({content: 'Disabled'}),
-      ]),
-    });
+    expect(wrapper.findAll(FilterPill)[1].domNode).toBeNull();
   });
 });

--- a/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
@@ -948,3 +948,148 @@ export function Disabled() {
     }
   }
 }
+
+export function WithQueryFieldAndFiltersHidden() {
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+  const [itemStrings, setItemStrings] = useState([
+    'All',
+    'Unpaid',
+    'Open',
+    'Closed',
+    'Local delivery',
+    'Local pickup',
+  ]);
+  const deleteView = (index: number) => {
+    const newItemStrings = [...itemStrings];
+    newItemStrings.splice(index, 1);
+    setItemStrings(newItemStrings);
+    setSelected(0);
+  };
+
+  const duplicateView = async (name: string) => {
+    setItemStrings([...itemStrings, name]);
+    setSelected(itemStrings.length);
+    await sleep(1);
+    return true;
+  };
+
+  const tabs: AlphaTabProps[] = itemStrings.map((item, index) => ({
+    content: item,
+    index,
+    onAction: () => {},
+    id: `${item}-${index}`,
+    isLocked: index === 0,
+    actions:
+      index === 0
+        ? []
+        : [
+            {
+              type: 'rename',
+              onAction: () => {},
+              onPrimaryAction: async (value: string) => {
+                const newItemsStrings = tabs.map((item, idx) => {
+                  if (idx === index) {
+                    return value;
+                  }
+                  return item.content;
+                });
+                await sleep(1);
+                setItemStrings(newItemsStrings);
+                return true;
+              },
+            },
+            {
+              type: 'duplicate',
+              onPrimaryAction: async (name) => {
+                await sleep(1);
+                duplicateView(name);
+                return true;
+              },
+            },
+            {
+              type: 'edit',
+            },
+            {
+              type: 'delete',
+              onPrimaryAction: async (id: string) => {
+                await sleep(1);
+                deleteView(index);
+                return true;
+              },
+            },
+          ],
+  }));
+  const [selected, setSelected] = useState(0);
+  const onCreateNewView = async (value: string) => {
+    await sleep(500);
+    setItemStrings([...itemStrings, value]);
+    setSelected(itemStrings.length);
+    return true;
+  };
+  const sortOptions: IndexFiltersProps['sortOptions'] = [
+    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+  ];
+  const [sortSelected, setSortSelected] = useState(['order asc']);
+  const {mode, setMode} = useSetIndexFiltersMode();
+  const onHandleCancel = () => {};
+
+  const onHandleSave = async () => {
+    await sleep(1);
+    return true;
+  };
+
+  const primaryAction: IndexFiltersProps['primaryAction'] =
+    selected === 0
+      ? {
+          type: 'save-as',
+          onAction: onCreateNewView,
+          disabled: false,
+          loading: false,
+        }
+      : {
+          type: 'save',
+          onAction: onHandleSave,
+          disabled: false,
+          loading: false,
+        };
+
+  return (
+    <Card>
+      <IndexFilters
+        sortOptions={sortOptions}
+        sortSelected={sortSelected}
+        queryValue=""
+        queryPlaceholder="Searching in all"
+        onQueryChange={() => {}}
+        onQueryClear={() => {}}
+        onSort={setSortSelected}
+        primaryAction={primaryAction}
+        cancelAction={{
+          onAction: onHandleCancel,
+          disabled: false,
+          loading: false,
+        }}
+        tabs={tabs}
+        selected={selected}
+        onSelect={setSelected}
+        canCreateNewView
+        onCreateNewView={onCreateNewView}
+        filters={[]}
+        onClearAll={() => {}}
+        mode={mode}
+        setMode={setMode}
+        hideQueryField
+        hideFilters
+      />
+      <Table />
+    </Card>
+  );
+}

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -363,18 +363,20 @@ export function IndexFilters({
                       {isLoading && !mdDown && <Spinner size="small" />}
                       {mode === IndexFiltersMode.Default ? (
                         <>
-                          <SearchFilterButton
-                            onClick={handleClickFilterButton}
-                            aria-label={searchFilterAriaLabel}
-                            tooltipContent={searchFilterTooltip}
-                            disabled={disabled}
-                            hideFilters={hideFilters}
-                            hideQueryField={hideQueryField}
-                            style={{
-                              ...defaultStyle,
-                              ...transitionStyles[state],
-                            }}
-                          />
+                          {hideFilters && hideQueryField ? null : (
+                            <SearchFilterButton
+                              onClick={handleClickFilterButton}
+                              aria-label={searchFilterAriaLabel}
+                              tooltipContent={searchFilterTooltip}
+                              disabled={disabled}
+                              hideFilters={hideFilters}
+                              hideQueryField={hideQueryField}
+                              style={{
+                                ...defaultStyle,
+                                ...transitionStyles[state],
+                              }}
+                            />
+                          )}
                           {sortMarkup}
                         </>
                       ) : null}

--- a/polaris.shopify.com/content/components/selection-and-input/index-filters.md
+++ b/polaris.shopify.com/content/components/selection-and-input/index-filters.md
@@ -26,6 +26,9 @@ examples:
   - fileName: index-filters-with-no-filters.tsx
     title: With no filters
     description: An IndexFilters component with only view management, search, and sorting.
+  - fileName: index-filters-with-no-search-or-filters.tsx
+    title: With no search or filters
+    description: An IndexFilters component with only view management and sorting.
 ---
 
 Merchants use filters to:

--- a/polaris.shopify.com/pages/examples/index-filters-default.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-default.tsx
@@ -52,7 +52,7 @@ function IndexFiltersDefault() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -66,9 +66,9 @@ function IndexFiltersDefault() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },

--- a/polaris.shopify.com/pages/examples/index-filters-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-disabled.tsx
@@ -52,7 +52,7 @@ function IndexFiltersDisabled() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -66,9 +66,9 @@ function IndexFiltersDisabled() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },

--- a/polaris.shopify.com/pages/examples/index-filters-with-filtering-mode.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-filtering-mode.tsx
@@ -53,7 +53,7 @@ function IndexFiltersWithFilteringMode() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -67,9 +67,9 @@ function IndexFiltersWithFilteringMode() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },

--- a/polaris.shopify.com/pages/examples/index-filters-with-no-filters.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-no-filters.tsx
@@ -49,7 +49,7 @@ function IndexFiltersWithNoFiltersExample() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -63,9 +63,9 @@ function IndexFiltersWithNoFiltersExample() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },

--- a/polaris.shopify.com/pages/examples/index-filters-with-no-search-or-filters.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-no-search-or-filters.tsx
@@ -1,21 +1,17 @@
 import {
-  TextField,
   IndexTable,
   LegacyCard,
   IndexFilters,
   useSetIndexFiltersMode,
   useIndexResourceState,
   Text,
-  ChoiceList,
-  RangeSlider,
   Badge,
-  IndexFiltersMode,
 } from '@shopify/polaris';
 import type {IndexFiltersProps, AlphaTabProps} from '@shopify/polaris';
-import {useState, useCallback} from 'react';
+import {useState} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function IndexTableWithFilteringExample() {
+function IndexFiltersWithNoSearchOrFiltersExample() {
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
   const [itemStrings, setItemStrings] = useState([
@@ -104,7 +100,7 @@ function IndexTableWithFilteringExample() {
     {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
   ];
   const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode(IndexFiltersMode.Filtering);
+  const {mode, setMode} = useSetIndexFiltersMode();
   const onHandleCancel = () => {};
 
   const onHandleSave = async () => {
@@ -126,117 +122,15 @@ function IndexTableWithFilteringExample() {
           disabled: false,
           loading: false,
         };
-  const [accountStatus, setAccountStatus] = useState<string[]>([]);
-  const [moneySpent, setMoneySpent] = useState<[number, number] | undefined>(
-    undefined,
-  );
-  const [taggedWith, setTaggedWith] = useState<string | undefined>('');
-  const [queryValue, setQueryValue] = useState<string | undefined>(undefined);
-
-  const handleAccountStatusChange = useCallback(
-    (value: string[]) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value: [number, number]) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value: string) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value: string) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(() => setAccountStatus([]), []);
-  const handleMoneySpentRemove = useCallback(
-    () => setMoneySpent(undefined),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-    handleMoneySpentRemove,
-    handleAccountStatusRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters =
-    taggedWith && !isEmpty(taggedWith)
-      ? [
-          {
-            key: 'taggedWith',
-            label: disambiguateLabel('taggedWith', taggedWith),
-            onRemove: handleTaggedWithRemove,
-          },
-        ]
-      : [];
 
   const orders = [
     {
       id: '1020',
-      order: '#1020',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1020
+        </Text>
+      ),
       date: 'Jul 20 at 4:34pm',
       customer: 'Jaydon Stanton',
       total: '$969.44',
@@ -245,7 +139,11 @@ function IndexTableWithFilteringExample() {
     },
     {
       id: '1019',
-      order: '#1019',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1019
+        </Text>
+      ),
       date: 'Jul 20 at 3:46pm',
       customer: 'Ruben Westerfelt',
       total: '$701.19',
@@ -254,7 +152,11 @@ function IndexTableWithFilteringExample() {
     },
     {
       id: '1018',
-      order: '#1018',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1018
+        </Text>
+      ),
       date: 'Jul 20 at 3.44pm',
       customer: 'Leo Carder',
       total: '$798.24',
@@ -262,7 +164,6 @@ function IndexTableWithFilteringExample() {
       fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
     },
   ];
-
   const resourceName = {
     singular: 'order',
     plural: 'orders',
@@ -301,9 +202,9 @@ function IndexTableWithFilteringExample() {
       <IndexFilters
         sortOptions={sortOptions}
         sortSelected={sortSelected}
-        queryValue={queryValue}
+        queryValue=""
         queryPlaceholder="Searching in all"
-        onQueryChange={handleQueryValueChange}
+        onQueryChange={() => {}}
         onQueryClear={() => {}}
         onSort={setSortSelected}
         primaryAction={primaryAction}
@@ -317,11 +218,13 @@ function IndexTableWithFilteringExample() {
         onSelect={setSelected}
         canCreateNewView
         onCreateNewView={onCreateNewView}
-        filters={filters}
-        appliedFilters={appliedFilters}
-        onClearAll={handleFiltersClearAll}
+        filters={[]}
+        appliedFilters={[]}
+        onClearAll={() => {}}
         mode={mode}
         setMode={setMode}
+        hideFilters
+        hideQueryField
       />
       <IndexTable
         resourceName={resourceName}
@@ -343,27 +246,6 @@ function IndexTableWithFilteringExample() {
       </IndexTable>
     </LegacyCard>
   );
-
-  function disambiguateLabel(key: string, value: string | string[]): string {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return (value as string[]).map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value as string;
-    }
-  }
-
-  function isEmpty(value: string): boolean {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
 }
 
-export default withPolarisExample(IndexTableWithFilteringExample);
+export default withPolarisExample(IndexFiltersWithNoSearchOrFiltersExample);

--- a/polaris.shopify.com/pages/examples/index-filters-with-no-search.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-no-search.tsx
@@ -52,7 +52,7 @@ function IndexFiltersDefault() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -66,9 +66,9 @@ function IndexFiltersDefault() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },

--- a/polaris.shopify.com/pages/examples/index-filters-with-pinned-filters.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-pinned-filters.tsx
@@ -52,7 +52,7 @@ function IndexFiltersWithPinnedFilters() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -66,9 +66,9 @@ function IndexFiltersWithPinnedFilters() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },

--- a/polaris.shopify.com/pages/examples/index-table-condensed-with-views-search-filter-sorting.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-condensed-with-views-search-filter-sorting.tsx
@@ -54,7 +54,7 @@ function IndexTableWithViewsSearchFilterSorting() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -68,9 +68,9 @@ function IndexTableWithViewsSearchFilterSorting() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },

--- a/polaris.shopify.com/pages/examples/index-table-with-loading-state.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-loading-state.tsx
@@ -52,7 +52,7 @@ function IndexTableWithLoadingExample() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -66,9 +66,9 @@ function IndexTableWithLoadingExample() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },

--- a/polaris.shopify.com/pages/examples/index-table-with-views-search-filter-sorting.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-views-search-filter-sorting.tsx
@@ -52,7 +52,7 @@ function IndexTableWithViewsSearchFilterSorting() {
             {
               type: 'rename',
               onAction: () => {},
-              onPrimaryAction: async (value: string) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 const newItemsStrings = tabs.map((item, idx) => {
                   if (idx === index) {
                     return value;
@@ -66,9 +66,9 @@ function IndexTableWithViewsSearchFilterSorting() {
             },
             {
               type: 'duplicate',
-              onPrimaryAction: async (name) => {
+              onPrimaryAction: async (value: string): Promise<boolean> => {
                 await sleep(1);
-                duplicateView(name);
+                duplicateView(value);
                 return true;
               },
             },


### PR DESCRIPTION
### WHY are these changes introduced?

We want to support the use case of not having any searching or filtering functionality, but still retaining the Tabs and the sorting functionality. We already support both the `hideQueryField` and `hideFilters` props, but hadn't correctly handled the use-case when both are true. We now will remove the toggle button to switch to the filter mode, so that the UI is only the Tabs and the Sort button.

Whilst I was working around this component, I also fixed a bug around the disabling of disabled filter pills. The desired effect is to render the component, but return `null` from the component, rather than render nothing at all. This prevents a bug where if a filter was previously disabled and then becomes enabled, the Popover would automatically open without any user interaction.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
