### PR TITLE
Use -- to ensure CI check is targeting a branch instead of files

### DIFF
--- a/.github/workflows/migrator-comment.yml
+++ b/.github/workflows/migrator-comment.yml
@@ -25,7 +25,7 @@ jobs:
         run: git fetch --all
 
       - name: Checkout the feature branch
-        run: git checkout ${{ github.head_ref }} --no-guess
+        run: git checkout ${{ github.head_ref }} --
 
       - name: Check for generic migrator comment in diff
         run: |


### PR DESCRIPTION
### WHY are these changes introduced?

The comment CI check is not properly checking out the target feature branch.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This appends `--` to the `git checkout` command to ensure the next argument is treated as a branch rather than a list of files.

This is to avoid the unique situation where the feature branch name is the same as the root-level directories (ex: feature branch is called `polaris-react` or `polaris-for-vscode`).