### PR TITLE
Bump size limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,12 +88,12 @@
     {
       "name": "polaris-react-cjs",
       "path": "polaris-react/build/cjs/index.js",
-      "limit": "245 kB"
+      "limit": "250 kB"
     },
     {
       "name": "polaris-react-esm",
       "path": "polaris-react/build/esm/index.js",
-      "limit": "160 kB"
+      "limit": "165 kB"
     },
     {
       "name": "polaris-react-esnext",


### PR DESCRIPTION
### WHY are these changes introduced?

PRs were failing the size limit check because we were exceeding the threshold for `polaris-react-cjs` and `polaris-react-esm`.

<img width="1119" alt="07-24-vdiws-jft0u" src="https://user-images.githubusercontent.com/26749317/230608389-ac6fbe8b-858a-4f47-ae5a-2caf877a96ad.png">

### WHAT is this pull request doing?

Bumps size limit.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
