### PR TITLE
8883/fix pattern bullets

### DIFF
--- a/.changeset/violet-trainers-attend.md
+++ b/.changeset/violet-trainers-attend.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Pattern page ul's now have padding conforming to the rest of the site

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -247,6 +247,7 @@
   li {
     &::before {
       content: '\2022';
+      padding-right: 0.95em;
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8883 

### WHAT is this pull request doing?

Adds [padding](https://mxstbr.com/thoughts/margin/) to ::before element for `li` descendants of elements with the `UnorderedList` class. 
Before: 
![Screenshot 2023-04-11 at 11 36 19 am](https://user-images.githubusercontent.com/12119389/231032680-c5bf0bf5-5bcc-4daa-b49e-66dd1cfffaae.png)

After:
<img width="762" alt="Screenshot 2023-04-11 at 11 35 58 am" src="https://user-images.githubusercontent.com/12119389/231032596-38669f1c-a94e-451f-8a68-0aff47e2f5dc.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
