### PR TITLE
[AlphaFilters] Fixes incorrect vertical alignment within component

### DIFF
--- a/.changeset/little-ravens-repair.md
+++ b/.changeset/little-ravens-repair.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Tweaked the vertical alignment of elements within the `AlphaFilters` component

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.scss
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.scss
@@ -216,7 +216,6 @@
 
 .ClearAll {
   margin-left: var(--p-space-1);
-  transform: translateY(-1px);
 }
 
 @media #{$p-breakpoints-md-down} {

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.scss
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.scss
@@ -216,6 +216,7 @@
 
 .ClearAll {
   margin-left: var(--p-space-1);
+  transform: translateY(-1px);
 }
 
 @media #{$p-breakpoints-md-down} {

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
@@ -10,10 +10,10 @@ import {Text} from '../Text';
 import {UnstyledButton} from '../UnstyledButton';
 import {classNames} from '../../utilities/css';
 import type {AppliedFilterInterface, FilterInterface} from '../../types';
-import {Link} from '../Link';
 import {HorizontalStack} from '../HorizontalStack';
 import {Box} from '../Box';
 import {Spinner} from '../Spinner';
+import {Button} from '../Button';
 
 import {FilterPill, SearchField} from './components';
 import styles from './AlphaFilters.scss';
@@ -329,11 +329,14 @@ export function AlphaFilters({
             styles.MultiplePinnedFilterClearAll,
         )}
       >
-        <Link onClick={handleClearAllFilters} removeUnderline>
-          <Text variant="bodySm" fontWeight="semibold" as="span">
-            {i18n.translate('Polaris.Filters.clearFilters')}
-          </Text>
-        </Link>
+        <Button
+          size="micro"
+          plain
+          onClick={handleClearAllFilters}
+          removeUnderline
+        >
+          {i18n.translate('Polaris.Filters.clearFilters')}
+        </Button>
       </div>
     ) : null;
 

--- a/polaris-react/src/components/AlphaFilters/components/FilterPill/FilterPill.scss
+++ b/polaris-react/src/components/AlphaFilters/components/FilterPill/FilterPill.scss
@@ -73,7 +73,7 @@
   }
 
   .Label {
-    display: block;
+    display: flex;
     padding-left: var(--p-space-05);
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/88968

### WHAT is this pull request doing?

The label within active filter pills, and the "Clear all" button text were 1px lower than they should have been. This PR addresses that by putting them back where they should be.


Before: 
<img width="1963" alt="Screenshot 2023-04-11 at 10 38 30" src="https://user-images.githubusercontent.com/2562596/231123116-c2f1495e-7c00-4eb9-845a-e96d45b58d7d.png">

After:
<img width="1963" alt="Screenshot 2023-04-11 at 10 38 16" src="https://user-images.githubusercontent.com/2562596/231123201-14fea21d-6e42-4ef4-a65b-3b40507c74e3.png">


Storybook URL: https://5d559397bae39100201eedc1-kdasyocdfw.chromatic.com/?path=/story/all-components-alphafilters--with-a-resource-list

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
