### PR TITLE
[polaris.shopify.com] Fix resource index layout pattern thumbnail

### DIFF
--- a/polaris.shopify.com/content/patterns/resource-index-layout/index.md
+++ b/polaris.shopify.com/content/patterns/resource-index-layout/index.md
@@ -3,7 +3,7 @@ title: Resource index layout
 description: Organize and take action on resource objects
 lede: Lets merchants organize and take action on resource objects.
 url: /patterns/resource-index-layout
-previewImg: /images/patterns/pattern-thumbnail-resource-index.png
+previewImg: /images/patterns/resource-index-layout/pattern-thumbnail-resource-index.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8215
 variants:
   - 'variants/default.md'


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [8916](https://github.com/Shopify/polaris/issues/8916)

### WHAT is this pull request doing?

Fixes the path to the thumbnail image for the index layout pattern

| Before | After |
| -- | -- |
| <img width="1173" alt="Screenshot 2023-04-11 at 10 39 52 AM" src="https://user-images.githubusercontent.com/20652326/231199704-6ada7d09-83be-4cfd-b4aa-484777f0a08a.png"> |  <img width="1180" alt="Screenshot 2023-04-11 at 10 39 41 AM" src="https://user-images.githubusercontent.com/20652326/231199751-309acabd-9b80-420f-999a-217d9d4b20f1.png"> |

