### PR TITLE
[UserMenu] Allow activator content to be passed in Top bar menu

### DIFF
--- a/.changeset/wicked-knives-begin.md
+++ b/.changeset/wicked-knives-begin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+updates user menu to accept activator content prop

--- a/.changeset/wicked-knives-begin.md
+++ b/.changeset/wicked-knives-begin.md
@@ -2,4 +2,5 @@
 '@shopify/polaris': minor
 ---
 
-updates user menu to accept activator content prop
+- Added `customActivator` prop to `TopBar.UserMenu`
+- Added support for setting a `ReactNode ` on `ActionList` `Section` `title`

--- a/polaris-react/src/components/ActionList/ActionList.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.tsx
@@ -49,7 +49,7 @@ export function ActionList({
   const sectionMarkup = finalSections.map((section, index) => {
     return section.items.length > 0 ? (
       <Section
-        key={section.title || index}
+        key={typeof section.title === 'string' ? section.title : index}
         section={section}
         hasMultipleSections={hasMultipleSections}
         actionRole={actionRole}

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -57,18 +57,27 @@ export function Section({
     },
   );
 
-  const titleMarkup = section.title ? (
-    <Box
-      paddingBlockStart="4"
-      paddingInlineStart="4"
-      paddingBlockEnd="2"
-      paddingInlineEnd="4"
-    >
-      <Text as="p" variant="headingXs">
-        {section.title}
-      </Text>
-    </Box>
-  ) : null;
+  let titleMarkup: string | React.ReactNode = null;
+
+  if (section.title) {
+    titleMarkup =
+      typeof section.title === 'string' ? (
+        <Box
+          paddingBlockStart="4"
+          paddingInlineStart="4"
+          paddingBlockEnd="2"
+          paddingInlineEnd="4"
+        >
+          <Text as="p" variant="headingXs">
+            {section.title}
+          </Text>
+        </Box>
+      ) : (
+        <Box as="ul" padding="2">
+          {section.title}
+        </Box>
+      );
+  }
 
   let sectionRole: 'menu' | 'presentation' | undefined;
   switch (actionRole) {

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -73,9 +73,7 @@ export function Section({
           </Text>
         </Box>
       ) : (
-        <Box as="ul" padding="2">
-          {section.title}
-        </Box>
+        <Box padding="2">{section.title}</Box>
       );
   }
 

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -3,7 +3,7 @@ import type {ComponentMeta} from '@storybook/react';
 import {ActionList, Frame, Icon, TopBar, Text, Avatar} from '@shopify/polaris';
 import {ArrowLeftMinor, QuestionMarkMajor} from '@shopify/polaris-icons';
 
-import {UserMenuProps} from '../../../build/ts/latest/src/components/TopBar';
+import type {UserMenuProps} from '../../../build/ts/latest/src/components/TopBar';
 
 export default {
   component: TopBar,

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -168,9 +168,20 @@ export function WithCustomActivator() {
 
   const customActivator = (
     <>
-      <Avatar size="small" initials="JD" name="Dharma" />
+      <Avatar size="small" initials="D" name="Dharma" />
       <span style={{marginLeft: '0.5rem'}}>
-        <p style={{fontWeight: '500', whiteSpace: 'nowrap'}}>Dharma</p>
+        <Text as="p" alignment="start" fontWeight="medium" truncate>
+          Dharma
+        </Text>
+        <Text
+          as="p"
+          variant="bodySm"
+          alignment="start"
+          color="subdued"
+          truncate
+        >
+          Jaded Pixel
+        </Text>
       </span>
     </>
   );
@@ -180,7 +191,6 @@ export function WithCustomActivator() {
       userActions={userActions}
       name="Dharma"
       detail="Jaded Pixel"
-      initials="JD"
       customActivator={customActivator}
     />
   );

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {ActionList, Frame, Icon, TopBar, Text, Avatar} from '@shopify/polaris';
 import {ArrowLeftMinor, QuestionMarkMajor} from '@shopify/polaris-icons';
+
 import {UserMenuProps} from '../../../build/ts/latest/src/components/TopBar';
 
 export default {
@@ -73,11 +74,17 @@ function TopBarWrapper({
             ]
       }
       name={name ? name : 'Dharma'}
-      detail={detail ? detail : 'Jaded Pixel'}
+      detail={detail && detail}
       initials={initials ? initials : 'JD'}
       customActivator={customActivator}
       open={isUserMenuOpen}
       onToggle={toggleIsUserMenuOpen}
+      message={{
+        title: 'Message title',
+        description: 'Message description',
+        link: {to: 'https://www.shopify.com', content: 'Link content'},
+        action: {content: 'Action content', onAction: () => {}},
+      }}
     />
   );
 
@@ -146,17 +153,40 @@ export function Default() {
       items: [{content: 'Community forums'}],
     },
   ];
+  return <TopBarWrapper userActions={userActions} name="Dharma" initials="D" />;
+}
+
+export function WithCustomActivator() {
+  const userActions: UserMenuProps['actions'] = [
+    {
+      items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
+    },
+    {
+      items: [{content: 'Community forums'}],
+    },
+  ];
+
+  const customActivator = (
+    <>
+      <Avatar size="small" initials="JD" name="Dharma" />
+      <span style={{marginLeft: '0.5rem'}}>
+        <p style={{fontWeight: '500', whiteSpace: 'nowrap'}}>Dharma</p>
+      </span>
+    </>
+  );
+
   return (
     <TopBarWrapper
       userActions={userActions}
-      name="Dharm"
+      name="Dharma"
       detail="Jaded Pixel"
-      initials="D"
+      initials="JD"
+      customActivator={customActivator}
     />
   );
 }
 
-export function WithCustomActivator() {
+export function withMessage() {
   const userActions: UserMenuProps['actions'] = [
     {
       items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -1,13 +1,26 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {ActionList, Frame, Icon, TopBar, Text} from '@shopify/polaris';
+import {ActionList, Frame, Icon, TopBar, Text, Avatar} from '@shopify/polaris';
 import {ArrowLeftMinor, QuestionMarkMajor} from '@shopify/polaris-icons';
+import {UserMenuProps} from '../../../build/ts/latest/src/components/TopBar';
 
 export default {
   component: TopBar,
 } as ComponentMeta<typeof TopBar>;
 
-export function Default() {
+function TopBarWrapper({
+  userActions,
+  name,
+  detail,
+  initials,
+  customActivator,
+}: {
+  userActions?: UserMenuProps['actions'];
+  name?: UserMenuProps['name'];
+  detail?: UserMenuProps['detail'];
+  initials?: UserMenuProps['initials'];
+  customActivator?: UserMenuProps['customActivator'];
+}) {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const [isSecondaryMenuOpen, setIsSecondaryMenuOpen] = useState(false);
   const [isSearchActive, setIsSearchActive] = useState(false);
@@ -47,17 +60,22 @@ export function Default() {
 
   const userMenuMarkup = (
     <TopBar.UserMenu
-      actions={[
-        {
-          items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
-        },
-        {
-          items: [{content: 'Community forums'}],
-        },
-      ]}
-      name="Dharma"
-      detail="Jaded Pixel"
-      initials="D"
+      actions={
+        userActions
+          ? userActions
+          : [
+              {
+                items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
+              },
+              {
+                items: [{content: 'Community forums'}],
+              },
+            ]
+      }
+      name={name ? name : 'Dharma'}
+      detail={detail ? detail : 'Jaded Pixel'}
+      initials={initials ? initials : 'JD'}
+      customActivator={customActivator}
       open={isUserMenuOpen}
       onToggle={toggleIsUserMenuOpen}
     />
@@ -116,5 +134,54 @@ export function Default() {
     <div style={{height: '250px'}}>
       <Frame topBar={topBarMarkup} logo={logo} />
     </div>
+  );
+}
+
+export function Default() {
+  const userActions: UserMenuProps['actions'] = [
+    {
+      items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
+    },
+    {
+      items: [{content: 'Community forums'}],
+    },
+  ];
+  return (
+    <TopBarWrapper
+      userActions={userActions}
+      name="Dharm"
+      detail="Jaded Pixel"
+      initials="D"
+    />
+  );
+}
+
+export function WithCustomActivator() {
+  const userActions: UserMenuProps['actions'] = [
+    {
+      items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
+    },
+    {
+      items: [{content: 'Community forums'}],
+    },
+  ];
+
+  const customActivator = (
+    <>
+      <span style={{marginRight: '0.5rem'}}>
+        <p style={{fontWeight: '500', whiteSpace: 'nowrap'}}>Dharma</p>
+      </span>
+      <Avatar shape="square" size="small" initials="JD" name="Dharma" />
+    </>
+  );
+
+  return (
+    <TopBarWrapper
+      userActions={userActions}
+      name="Dharma"
+      detail="Jaded Pixel"
+      initials="JD"
+      customActivator={customActivator}
+    />
   );
 }

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -15,12 +15,14 @@ function TopBarWrapper({
   detail,
   initials,
   customActivator,
+  message,
 }: {
   userActions?: UserMenuProps['actions'];
   name?: UserMenuProps['name'];
   detail?: UserMenuProps['detail'];
   initials?: UserMenuProps['initials'];
   customActivator?: UserMenuProps['customActivator'];
+  message?: UserMenuProps['message'];
 }) {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const [isSecondaryMenuOpen, setIsSecondaryMenuOpen] = useState(false);
@@ -77,14 +79,9 @@ function TopBarWrapper({
       detail={detail && detail}
       initials={initials ? initials : 'JD'}
       customActivator={customActivator}
+      message={message}
       open={isUserMenuOpen}
       onToggle={toggleIsUserMenuOpen}
-      message={{
-        title: 'Message title',
-        description: 'Message description',
-        link: {to: 'https://www.shopify.com', content: 'Link content'},
-        action: {content: 'Action content', onAction: () => {}},
-      }}
     />
   );
 
@@ -206,22 +203,18 @@ export function withMessage() {
     },
   ];
 
-  const customActivator = (
-    <>
-      <span style={{marginRight: '0.5rem'}}>
-        <p style={{fontWeight: '500', whiteSpace: 'nowrap'}}>Dharma</p>
-      </span>
-      <Avatar shape="square" size="small" initials="JD" name="Dharma" />
-    </>
-  );
-
   return (
     <TopBarWrapper
       userActions={userActions}
       name="Dharma"
       detail="Jaded Pixel"
       initials="JD"
-      customActivator={customActivator}
+      message={{
+        title: 'Message title',
+        description: 'Message description',
+        link: {to: 'https://www.shopify.com', content: 'Link content'},
+        action: {content: 'Action content', onClick: () => {}},
+      }}
     />
   );
 }

--- a/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
+++ b/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
@@ -57,8 +57,6 @@ export function Menu(props: MenuProps) {
     />
   );
 
-  const isFullHeight = Boolean(message);
-
   return (
     <Popover
       activator={
@@ -76,7 +74,7 @@ export function Menu(props: MenuProps) {
       active={open}
       onClose={onClose}
       fixed
-      fullHeight={isFullHeight}
+      fullHeight
       preferredAlignment="right"
     >
       <ActionList onActionAnyItem={onClose} sections={actions} />

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.scss
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.scss
@@ -2,7 +2,7 @@
 
 .Details {
   max-width: 160px;
-  margin-left: var(--p-space-2);
+  margin-right: var(--p-space-2);
 
   @media #{$p-breakpoints-md-down} {
     display: none;

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -29,6 +29,8 @@ export interface UserMenuProps {
   open: boolean;
   /** A callback function to handle opening and closing the user menu */
   onToggle(): void;
+  /** A custom activator that can be used when the default activator is not desired */
+  activatorContent?: React.ReactNode;
 }
 
 export function UserMenu({
@@ -41,10 +43,13 @@ export function UserMenu({
   onToggle,
   open,
   accessibilityLabel,
+  activatorContent,
 }: UserMenuProps) {
   const showIndicator = Boolean(message);
 
-  const activatorContentMarkup = (
+  const activatorContentMarkup = activatorContent ? (
+    activatorContent
+  ) : (
     <>
       <MessageIndicator active={showIndicator}>
         <Avatar

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -30,7 +30,7 @@ export interface UserMenuProps {
   /** A callback function to handle opening and closing the user menu */
   onToggle(): void;
   /** A custom activator that can be used when the default activator is not desired */
-  activatorContent?: React.ReactNode;
+  customActivator?: React.ReactNode;
 }
 
 export function UserMenu({
@@ -43,12 +43,12 @@ export function UserMenu({
   onToggle,
   open,
   accessibilityLabel,
-  activatorContent,
+  customActivator,
 }: UserMenuProps) {
   const showIndicator = Boolean(message);
 
-  const activatorContentMarkup = activatorContent ? (
-    activatorContent
+  const activatorContentMarkup = customActivator ? (
+    customActivator
   ) : (
     <>
       <MessageIndicator active={showIndicator}>

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -51,13 +51,6 @@ export function UserMenu({
     customActivator
   ) : (
     <>
-      <MessageIndicator active={showIndicator}>
-        <Avatar
-          size="small"
-          source={avatar}
-          initials={initials && initials.replace(' ', '')}
-        />
-      </MessageIndicator>
       <span className={styles.Details}>
         <Text as="p" alignment="start" fontWeight="medium" truncate>
           {name}
@@ -72,6 +65,14 @@ export function UserMenu({
           {detail}
         </Text>
       </span>
+      <MessageIndicator active={showIndicator}>
+        <Avatar
+          shape="square"
+          size="small"
+          initials={initials && initials.replace(' ', '')}
+          source={avatar}
+        />
+      </MessageIndicator>
     </>
   );
 

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -212,7 +212,7 @@ export interface ActionListItemDescriptor
 
 export interface ActionListSection {
   /** Section title */
-  title?: string;
+  title?: string | React.ReactNode;
   /** Collection of action items for the list */
   items: readonly ActionListItemDescriptor[];
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves https://github.com/Shopify/core-workflows/issues/881
Follow up to: https://github.com/Shopify/polaris/pull/8856

<!--
  Context about the problem that’s being addressed.
-->

Part of [Commerce Components by Shopify](https://www.shopify.com/commerce-components); which requires some customization to the user menu

### WHAT is this pull request doing?

`Topbar.UserMenu`:  Allow a custom `activatorContent` prop to be passed enabling customization of the order of the avatar and heading.

`ActionList`: `title` is updated to accept a `React.Node` instead of string.


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

- [Spin URL](https://admin.web.acc-menu.zakaria-warsame.us.spin.dev/store/shop1)
  - Notice how we're able to pass a custom activator with a squared avatar, and a different text style
  - The `title` "Test User" is also customized to use a different style. Passing just a string would still have the original style.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
