### PR TITLE
[StickyManager] set container top offset based on parent elements relative top

### DIFF
--- a/.changeset/tidy-clouds-attack.md
+++ b/.changeset/tidy-clouds-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `StickyManager` to offset top based on relative parent top

--- a/polaris-react/src/utilities/sticky-manager/sticky-manager.ts
+++ b/polaris-react/src/utilities/sticky-manager/sticky-manager.ts
@@ -89,8 +89,13 @@ export class StickyManager {
       return;
     }
 
+    const offsetTopToParent =
+      this.container instanceof HTMLDivElement
+        ? this.container.offsetTop
+        : getRectForNode(this.container).top;
+
+    const containerTop = offsetTopToParent + this.topBarOffset;
     const scrollTop = this.container ? scrollTopFor(this.container) : 0;
-    const containerTop = getRectForNode(this.container).top + this.topBarOffset;
 
     this.stickyItems.forEach((stickyItem) => {
       const {handlePositioning} = stickyItem;

--- a/polaris-react/src/utilities/sticky-manager/tests/sticky-manager.test.tsx
+++ b/polaris-react/src/utilities/sticky-manager/tests/sticky-manager.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {StickyManager} from '../sticky-manager';
+
+function PlaceHolderNode() {
+  return <div />;
+}
+
+function StickyNode() {
+  return <div />;
+}
+
+function TestContainer() {
+  return (
+    <div>
+      <PlaceHolderNode />
+      <StickyNode />
+    </div>
+  );
+}
+
+describe('StickyManager', () => {
+  describe('when container is HTMLDivElement', () => {
+    it('calculates the top position of the sticky element based on relative parent top', () => {
+      const container = mountWithApp(<TestContainer />);
+
+      const containerNode = container.domNode!;
+      Object.defineProperty(containerNode, 'offsetTop', {value: 100});
+
+      const stickyNode = container.find(StickyNode)!.domNode!;
+      const placeHolderNode = container.find(PlaceHolderNode)!.domNode!;
+
+      const handlePositioning = jest.fn();
+
+      const manager = new StickyManager();
+      manager.registerStickyItem({
+        stickyNode,
+        placeHolderNode,
+        handlePositioning,
+        offset: false,
+        disableWhenStacked: false,
+      });
+
+      manager.setContainer(containerNode);
+
+      expect(handlePositioning).toHaveBeenCalledTimes(1);
+      expect(handlePositioning).toHaveBeenCalledWith(true, 100, 0, 0);
+    });
+  });
+
+  describe('when sticky node container is Document', () => {
+    it('calculates the top position of the sticky element based on the top of the Document', () => {
+      const container = mountWithApp(<TestContainer />);
+
+      const stickyNode = container.find(StickyNode)!.domNode!;
+      const placeHolderNode = container.find(PlaceHolderNode)!.domNode!;
+
+      const handlePositioning = jest.fn();
+
+      const manager = new StickyManager();
+      manager.registerStickyItem({
+        stickyNode,
+        placeHolderNode,
+        handlePositioning,
+        offset: false,
+        disableWhenStacked: false,
+      });
+
+      manager.setContainer(document);
+
+      expect(handlePositioning).toHaveBeenCalledTimes(1);
+      expect(handlePositioning).toHaveBeenCalledWith(true, 0, 0, 0);
+    });
+  });
+});


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/8932

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

[Spin](https://admin.web.sticky-manager-offset.matt-kubej.us.spin.dev/store/shop1/settings/custom_data)

Note: The spin instance has the `polaris--v10-44-0` branch checked out as seen within this [PR](https://github.com/Shopify/web/pull/89585).

1. Navigate to `settings/custom_data`
2. Scroll down until the table header reaches the top of the Settings Popover
3. Validate the table header sticks to the bottom of the Popover header without a gap
4. Navigate to `/products`
5. Scroll down until the table header reaches the top Navigation bar
6. Validate the table header sticks to the bottom of the top Navigation bar without a gap

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
