### PR TITLE
[Layout foundations] Mark components with API changes as alpha

### DIFF
--- a/polaris.shopify.com/content/components/layout-and-structure/box.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/box.md
@@ -8,8 +8,8 @@ keywords:
   - responsive
   - tokens
 status:
-  value: Beta
-  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: box-with-color.tsx
     title: Color

--- a/polaris.shopify.com/content/components/layout-and-structure/card.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/card.md
@@ -23,8 +23,8 @@ keywords:
   - callout
   - call out
 status:
-  value: Beta
-  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: card-default.tsx
     title: Default

--- a/polaris.shopify.com/content/components/layout-and-structure/horizontal-grid.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/horizontal-grid.md
@@ -8,8 +8,8 @@ keywords:
   - grid
   - responsive
 status:
-  value: Beta
-  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: horizontal-grid-with-varying-gap.tsx
     title: Gap

--- a/polaris.shopify.com/content/components/layout-and-structure/horizontal-stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/horizontal-stack.md
@@ -15,8 +15,8 @@ keywords:
   - horizontal row of components
   - stack
 status:
-  value: Beta
-  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: horizontal-stack-with-non-wrapping.tsx
     title: Non-wrapping

--- a/polaris.shopify.com/content/components/layout-and-structure/vertical-stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/vertical-stack.md
@@ -12,8 +12,8 @@ keywords:
   - right-aligned stack
   - stack layout
 status:
-  value: Beta
-  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: vertical-stack-with-gap.tsx
     title: Gap


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #8951.
`VerticalStack`, `HorizontalStack` and `HorizontalGrid` will have upcoming API changes so reverting changes to move them to beta so that they remain alpha until the next major release.

### WHAT is this pull request doing?

Marks `VerticalStack`, `HorizontalStack`, `HorizontalGrid`, `Box`, and `Card` as alpha.
    <details>
      <summary>Alpha layout components</summary>
      <img src="https://user-images.githubusercontent.com/26749317/231876628-e0d629a3-d73d-4284-b047-4817e5cdea16.png" alt="Alpha layout components">
    </details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
