### PR TITLE
Add `stylelint-polaris` version matchup docs

### DIFF
--- a/.changeset/old-suns-burn.md
+++ b/.changeset/old-suns-burn.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Added a version matchup table to `stylelint-polaris` documentation

--- a/polaris.shopify.com/content/tools/stylelint-polaris/index.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/index.md
@@ -21,7 +21,7 @@ keywords:
 [<img src="https://img.shields.io/npm/v/@shopify/stylelint-polaris.svg?labelColor=f9f9f9&color=dcf5f0" alt="npm version" style="width: 95px" />](https://www.npmjs.com/package/@shopify/stylelint-polaris/)
 
 <picture>
-  <source srcset="/images/tools/stylelint-polaris/stylelint-demo.png" media="(prefers-reduced-motion: reduce)"></source> 
+  <source srcset="/images/tools/stylelint-polaris/stylelint-demo.png" media="(prefers-reduced-motion: reduce)"></source>
   <img srcset="/images/tools/stylelint-polaris/stylelint-demo.gif" alt="Demo of Stylelint Polaris">
 </picture>
 
@@ -93,6 +93,23 @@ There are over 40 rules configured in Stylelint Polaris to help you avoid errors
 - [Spacing](/tools/stylelint-polaris/rules#spacing)
 - [Typography](/tools/stylelint-polaris/rules#typography)
 - [Z-index](/tools/stylelint-polaris/rules#z-index)
+
+## Version Matchups
+
+| @shopify/stylelint-polaris | @shopify/polaris |
+| -------------------------- | ---------------- |
+| 1.0.0                      | ^9.13.0          |
+| 2.0.0                      | ^9.16.0          |
+| 3.0.0                      | ^9.19.0          |
+| 4.0.0                      | ^9.20.0          |
+| 5.0.0                      | ^10.14.0         |
+| 6.0.0                      | ^10.28.1         |
+| 7.0.0                      | ^10.31.0         |
+| 8.0.0                      | ^10.32.0         |
+| 9.0.0                      | ^10.36.0         |
+| 10.0.0                     | ^10.44.0         |
+
+_\*@shopify/stylelint-polaris v5.0.0 was the first stable version available for external distribution_
 
 ## Development
 

--- a/polaris.shopify.com/content/tools/stylelint-polaris/index.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/index.md
@@ -98,18 +98,18 @@ There are over 40 rules configured in Stylelint Polaris to help you avoid errors
 
 | @shopify/stylelint-polaris | @shopify/polaris |
 | -------------------------- | ---------------- |
-| 1.0.0                      | ^9.13.0          |
-| 2.0.0                      | ^9.16.0          |
-| 3.0.0                      | ^9.19.0          |
-| 4.0.0                      | ^9.20.0          |
-| 5.0.0                      | ^10.14.0         |
-| 6.0.0                      | ^10.28.1         |
-| 7.0.0                      | ^10.31.0         |
-| 8.0.0                      | ^10.32.0         |
-| 9.0.0                      | ^10.36.0         |
-| 10.0.0                     | ^10.44.0         |
+| 1.0.0                      | 9.13.0          |
+| 2.0.0                      | 9.16.0          |
+| 3.0.0                      | 9.19.0          |
+| 4.0.0                      | 9.20.0          |
+| 5.0.0                      | 10.14.0         |
+| 6.0.0                      | 10.28.1         |
+| 7.0.0                      | 10.31.0         |
+| 8.0.0                      | 10.32.0         |
+| 9.0.0                      | 10.36.0         |
+| 10.0.0                     | 10.44.0         |
 
-_\*@shopify/stylelint-polaris v5.0.0 was the first stable version available for external distribution_
+_\*@shopify/stylelint-polaris v5.0.0 was the first stable release_
 
 ## Development
 


### PR DESCRIPTION
### WHY are these changes introduced?
To help consumers keep their `stylelint-polaris` and `polaris-react` versions correctly in sync we should provide a table that documents which versions work together. 

### WHAT is this pull request doing?
Creates a version matchup table as part of our `stylelint-polaris` documentation on polaris.shopify.com:

<img width="1736" alt="Screenshot 2023-04-13 at 4 26 02 PM" src="https://user-images.githubusercontent.com/21976492/231896884-60560073-1ac8-4c80-a781-09d1147d873f.png">



