### PR TITLE
[Grid] Deprecate areas prop

### DIFF
--- a/.changeset/nasty-rockets-prove.md
+++ b/.changeset/nasty-rockets-prove.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Deprecated areas prop on Grid component
+Deprecated `Grid` `areas` prop

--- a/.changeset/nasty-rockets-prove.md
+++ b/.changeset/nasty-rockets-prove.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Deprecated areas prop on Grid component

--- a/polaris-react/src/components/Grid/Grid.tsx
+++ b/polaris-react/src/components/Grid/Grid.tsx
@@ -18,7 +18,10 @@ type Gap = {
 };
 
 export interface GridProps {
-  /* Set grid-template-areas */
+  /**
+   * Set grid-template-areas
+   * @deprecated Use nested layout components instead
+   */
   areas?: Areas;
   /* Number of columns */
   columns?: Columns;

--- a/polaris-react/src/components/Grid/components/Cell/Cell.tsx
+++ b/polaris-react/src/components/Grid/components/Cell/Cell.tsx
@@ -24,6 +24,10 @@ interface Columns {
 }
 
 export interface CellProps {
+  /**
+   * Set grid-template-areas
+   * @deprecated Use nested layout components instead
+   */
   area?: string;
   column?: Cell;
   columnSpan?: Columns;


### PR DESCRIPTION
Grid areas can be [not-great](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility#re-ordering_content_in_css_grid_layout) for accessibility. We can achieve similar things with nested layout components and should push our consumers to go that route.

They're also not used in the BlockLayout component that checkout / app kit has
https://shopify.dev/docs/api/checkout-ui-extensions/components/structure/grid