### PR TITLE
Fix test for TopBar

### DIFF
--- a/polaris-react/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/polaris-react/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -121,6 +121,16 @@ describe('<Menu />', () => {
     expect(menu).toContainReactComponent(Message);
   });
 
+  describe('isFullHeight', () => {
+    it('passes isFullHeight to popover as true', () => {
+      const menu = mountWithApp(<Menu {...defaultProps} open />);
+
+      expect(menu).toContainReactComponent(Popover, {
+        fullHeight: true,
+      });
+    });
+  });
+
   describe('accessibilityLabel', () => {
     it('passes accessibilityLabel to the popover activator', () => {
       const menu = mountWithApp(


### PR DESCRIPTION
### WHY are these changes introduced?

The `TopBar` `Menu` height was changed to always be fullHeight in a prior [PR](https://github.com/Shopify/polaris/pull/8953). A test checking for a `false` value on `fullHeight` was causing CI to fail.

### WHAT is this pull request doing?

Updates `TopBar` `Menu` test.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
