### PR TITLE
add strong variation to strong

### DIFF
--- a/.changeset/thin-ducks-knock.md
+++ b/.changeset/thin-ducks-knock.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+add strong variation to the text tag

--- a/.changeset/thin-ducks-knock.md
+++ b/.changeset/thin-ducks-knock.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-add strong variation to the text tag
+Added support for rendering `Text` `as` a `strong` tag 

--- a/polaris-react/src/components/Text/Text.stories.tsx
+++ b/polaris-react/src/components/Text/Text.stories.tsx
@@ -41,6 +41,9 @@ export const Variants = () => (
     <Text as="p" variant="bodySm">
       Text with BodySm variant
     </Text>
+    <Text as="strong" variant="bodySm">
+      Text as a strong tag
+    </Text>
   </LegacyStack>
 );
 

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -14,6 +14,7 @@ type Element =
   | 'h6'
   | 'p'
   | 'span'
+  | 'strong'
   | 'legend';
 
 type Variant =

--- a/polaris-react/src/components/Text/tests/Text.test.tsx
+++ b/polaris-react/src/components/Text/tests/Text.test.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
@@ -15,14 +16,17 @@ describe('<Text />', () => {
     expect(headingText).toContainReactText(text);
   });
 
-  it('renders the specified html element', () => {
-    const bodyText = mountWithApp(
-      <Text as="p" variant="bodySm">
-        {text}
-      </Text>,
-    );
-    expect(bodyText.find('p')).not.toBeNull();
-  });
+  it.each<ComponentProps<typeof Text>['as']>(['p', 'strong'])(
+    'renders the specified html element',
+    (htmlTag) => {
+      const bodyText = mountWithApp(
+        <Text as={htmlTag} variant="bodySm">
+          {text}
+        </Text>,
+      );
+      expect(bodyText.find(htmlTag)).not.toBeNull();
+    },
+  );
 
   it('renders its children with variant text style', () => {
     const headingText = mountWithApp(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

I'd like to propose this PR that adds a new `strong` variation to the `<Text />` component. This allows for better semantics in case of strong (and important) text

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩


<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
