### PR TITLE
Export i18n constants `DEFAULT_LOCALE` and `SUPPORTED_LOCALES`

### DIFF
--- a/.changeset/rich-rules-drop.md
+++ b/.changeset/rich-rules-drop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Exported constants `DEFAULT_LOCALE` and `SUPPORTED_LOCALES`

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -98,6 +98,7 @@
     "chromatic": "^6.5.4",
     "create-file-webpack": "^1.0.2",
     "globby": "^11.1.0",
+    "js-yaml": "^4.1.0",
     "node-sass": "^7.0.1",
     "postcss": "^8.3.1",
     "postcss-loader": "^4.2.0",

--- a/polaris-react/src/configure.ts
+++ b/polaris-react/src/configure.ts
@@ -14,3 +14,28 @@ if (typeof window !== 'undefined') {
 }
 
 export const polarisVersion = '{{POLARIS_VERSION}}';
+
+export const DEFAULT_LOCALE = 'en';
+export const SUPPORTED_LOCALES = [
+  'cs',
+  'da',
+  'de',
+  'en',
+  'es',
+  'fi',
+  'fr',
+  'it',
+  'ja',
+  'ko',
+  'nb',
+  'nl',
+  'pl',
+  'pt-BR',
+  'pt-PT',
+  'sv',
+  'th',
+  'tr',
+  'vi',
+  'zh-CN',
+  'zh-TW',
+];

--- a/polaris-react/src/tests/configure.test.ts
+++ b/polaris-react/src/tests/configure.test.ts
@@ -1,0 +1,30 @@
+import {readFileSync, readdirSync} from 'fs';
+import {resolve} from 'path';
+
+import yaml from 'js-yaml';
+
+import {DEFAULT_LOCALE, SUPPORTED_LOCALES} from '../configure';
+
+describe('DEFAULT_LOCALE', () => {
+  it('matches `source_language` in `translation.yml`', () => {
+    const translationYmlPath = resolve(__dirname, '../../../translation.yml');
+    const sourceLanguage = (
+      yaml.load(readFileSync(translationYmlPath, 'utf8')) as any
+    ).source_language;
+
+    expect(DEFAULT_LOCALE).toBe(sourceLanguage);
+  });
+});
+
+describe('SUPPORTED_LOCALES', () => {
+  it('matches the locale files in `/locales`', () => {
+    const localesPath = resolve(__dirname, '../../locales');
+    const locales = Array.from(
+      readdirSync(localesPath, {withFileTypes: true})
+        .filter((dirEnt) => dirEnt.isFile() && dirEnt.name.endsWith('.json'))
+        .map((dirEnt) => dirEnt.name.replace('.json', '')),
+    );
+
+    expect(SUPPORTED_LOCALES).toStrictEqual(locales);
+  });
+});


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When the consuming application needs to dynamically import Polaris locales, based on the user's locale, to provide to the Polaris `AppProvider`, it can be helpful to match the user's locale against a list of Polaris's supported locales, and to fall back to loading Polaris's default locale.

Rather than hard-code Polaris's default and supported locales in the consuming application, it would be better to import them as constants from `@shopify/polaris`. See [this PR](https://github.com/Shopify/shopify-frontend-template-react/pull/176/files#diff-561729603791a0baf5dfdb0f2b73341f9cf80d7c0f9ab2f6ec03fb67b1f316e5R78) for an example implementation.

### WHAT is this pull request doing?

- Export the constants `DEFAULT_LOCALE` and `SUPPORTED_LOCALES` in `src/configure.ts`
- Validate the constants in `src/tests/configure.test.ts`:
  - Compare `DEFAULT_LOCALE` to the `translation.yml` property `source_language`
  - Compare `SUPPORTED_LOCALES` to the JSON file names present in `polaris-react/locales`
- Add `js-yaml` as a dev dependency

I did not update any existing documentation; there might be an opportunity in the future to update the `AppProvider` documentation to be more platform-agnostic, but I didn't think this was the right PR or time to do that.

### WHAT should reviewers focus on?

What do you think of the names `DEFAULT_LOCALE` and `SUPPORTED_LOCALES`? Should they be given names less likely to have collisions, such as `DEFAULT_POLARIS_LOCALE` and `SUPPORTED_POLARIS_LOCALES`? I needed to alias the Polaris constants in [this PR](https://github.com/Shopify/shopify-frontend-template-react/pull/176/files#diff-561729603791a0baf5dfdb0f2b73341f9cf80d7c0f9ab2f6ec03fb67b1f316e5R6-R9) because I was using constants with the same names for my application.

### 🎩 details

Tested the snapshot in [this PR](https://github.com/Shopify/shopify-frontend-template-react/pull/176/files#diff-561729603791a0baf5dfdb0f2b73341f9cf80d7c0f9ab2f6ec03fb67b1f316e5R6).

### 🎩 checklist

- [ ] ~Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)~
- [ ] ~Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)~
- [ ] ~Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)~
- [ ] ~Updated the component's `README.md` with documentation changes~
- [ ] ~[Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide~
