### PR TITLE
[ActionList] [Item] Deprecate ellipsis and introduce a truncate prop

### DIFF
--- a/.changeset/dull-pumas-wave.md
+++ b/.changeset/dull-pumas-wave.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+---
+
+- Deprated ellipsis and introduced a truncate prop to `ActionList` items.
+- Added a custom width to the new `TopBar` user menu.

--- a/.changeset/dull-pumas-wave.md
+++ b/.changeset/dull-pumas-wave.md
@@ -2,5 +2,5 @@
 '@shopify/polaris': minor
 ---
 
-- Deprated ellipsis and introduced a truncate prop to `ActionList` items.
+- Deprecated ellipsis and introduced a truncate prop to `ActionList` items.
 - Added a custom width to the new `TopBar` user menu.

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -129,10 +129,3 @@
   max-width: 100%;
   flex: 1 1 auto;
 }
-
-.Truncate {
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -129,3 +129,7 @@
   max-width: 100%;
   flex: 1 1 auto;
 }
+
+.Truncate {
+  display: block;
+}

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -129,7 +129,3 @@
   max-width: 100%;
   flex: 1 1 auto;
 }
-
-.Truncate {
-  display: block;
-}

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -129,3 +129,10 @@
   max-width: 100%;
   flex: 1 1 auto;
 }
+
+.Truncate {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/polaris-react/src/components/ActionList/ActionList.stories.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.stories.tsx
@@ -15,6 +15,7 @@ import {
   ExportMinor,
   ImportMinor,
   EditMinor,
+  CustomersMajor,
 } from '@shopify/polaris-icons';
 
 export default {
@@ -169,6 +170,17 @@ export function WithSections() {
               items: [
                 {content: 'Edit', icon: EditMinor},
                 {content: 'Delete', icon: DeleteMinor},
+              ],
+            },
+            {
+              title: 'More options',
+              items: [
+                {
+                  content:
+                    'Manage several customers at once with a CSV file import',
+                  icon: CustomersMajor,
+                  truncate: 'end',
+                },
               ],
             },
           ]}

--- a/polaris-react/src/components/ActionList/ActionList.stories.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.stories.tsx
@@ -179,7 +179,7 @@ export function WithSections() {
                   content:
                     'Manage several customers at once with a CSV file import',
                   icon: CustomersMajor,
-                  truncate: 'end',
+                  truncate: true,
                 },
               ],
             },

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -159,6 +159,12 @@ export const TruncateText = ({children}: {children: string}) => {
     </span>
   );
 
+  const truncatedText = (
+    <Text as="span" truncate>
+      {isOverflowing ? children : text}
+    </Text>
+  );
+
   return isOverflowing ? (
     <Tooltip
       zIndexOverride={514}
@@ -166,13 +172,9 @@ export const TruncateText = ({children}: {children: string}) => {
       hoverDelay={1000}
       content={textRef.current?.innerText}
     >
-      <Text as="span" truncate>
-        {children}
-      </Text>
+      {truncatedText}
     </Tooltip>
   ) : (
-    <Text as="span" truncate>
-      {text}
-    </Text>
+    truncatedText
   );
 };

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -154,10 +154,8 @@ export const TruncateText = ({children}: {children: string}) => {
     }
   }, [children]);
   const text = (
-    <span ref={textRef}>
-      <Text as="span" truncate>
-        {children}
-      </Text>
+    <span ref={textRef} className={styles.Truncate}>
+      {children}
     </span>
   );
 
@@ -168,9 +166,13 @@ export const TruncateText = ({children}: {children: string}) => {
       hoverDelay={1000}
       content={textRef.current?.innerText}
     >
-      {text}
+      <Text as="span" truncate>
+        {children}
+      </Text>
     </Tooltip>
   ) : (
-    text
+    <Text as="span" truncate>
+      {text}
+    </Text>
   );
 };

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -176,7 +176,7 @@ export const TruncateText = ({
       hoverDelay={1000}
       content={textRef.current?.innerText}
     >
-      {position === 'middle' && truncatedText ? truncatedText : text}
+      {position === 'middle' ? <span>{truncatedText}</span> : text}
     </Tooltip>
   ) : (
     text

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -63,14 +63,14 @@ export function Item({
   }
 
   let contentText: string | React.ReactNode = content || '';
-  if (ellipsis) {
-    contentText = `${content}…`;
-  } else if (truncate && content) {
+  if (truncate && content) {
     contentText = (
       <Text as="span" variant="bodyMd" truncate>
         {content}
       </Text>
     );
+  } else if (ellipsis) {
+    contentText = `${content}…`;
   }
 
   const contentMarkup = helpText ? (

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef, useState} from 'react';
 
 import {classNames} from '../../../../utilities/css';
 import type {ActionListItemDescriptor} from '../../../../types';
@@ -11,6 +11,8 @@ import styles from '../../ActionList.scss';
 import {handleMouseUpByBlurring} from '../../../../utilities/focus';
 import {HorizontalStack} from '../../../HorizontalStack';
 import {Box} from '../../../Box';
+import {Tooltip} from '../../../Tooltip';
+import {useIsomorphicLayoutEffect} from '../../../../utilities/use-isomorphic-layout-effect';
 
 export type ItemProps = ActionListItemDescriptor;
 
@@ -64,11 +66,7 @@ export function Item({
 
   let contentText: string | React.ReactNode = content || '';
   if (truncate && content) {
-    contentText = (
-      <Text as="span" variant="bodyMd" truncate>
-        {content}
-      </Text>
-    );
+    contentText = <TruncateText>{content}</TruncateText>;
   } else if (ellipsis) {
     contentText = `${content}…`;
   }
@@ -144,3 +142,33 @@ export function Item({
     </>
   );
 }
+
+export const TruncateText = ({children}: {children: string}) => {
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  useIsomorphicLayoutEffect(() => {
+    if (textRef.current) {
+      setIsOverflowing(
+        textRef.current.scrollWidth > textRef.current.offsetWidth,
+      );
+    }
+  }, [children]);
+  const text = (
+    <span ref={textRef} className={styles.Truncate}>
+      {children}
+    </span>
+  );
+
+  return isOverflowing ? (
+    <Tooltip
+      zIndexOverride={514}
+      preferredPosition="above"
+      hoverDelay={1000}
+      content={textRef.current?.innerText}
+    >
+      {text}
+    </Tooltip>
+  ) : (
+    text
+  );
+};

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -154,14 +154,10 @@ export const TruncateText = ({children}: {children: string}) => {
     }
   }, [children]);
   const text = (
-    <span ref={textRef} className={styles.Truncate}>
-      {children}
-    </span>
-  );
-
-  const truncatedText = (
     <Text as="span" truncate>
-      {isOverflowing ? children : text}
+      <Box width="100%" ref={textRef}>
+        {children}
+      </Box>
     </Text>
   );
 
@@ -172,9 +168,11 @@ export const TruncateText = ({children}: {children: string}) => {
       hoverDelay={1000}
       content={textRef.current?.innerText}
     >
-      {truncatedText}
+      <Text as="span" truncate>
+        {children}
+      </Text>
     </Tooltip>
   ) : (
-    truncatedText
+    text
   );
 };

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -154,8 +154,10 @@ export const TruncateText = ({children}: {children: string}) => {
     }
   }, [children]);
   const text = (
-    <span ref={textRef} className={styles.Truncate}>
-      {children}
+    <span ref={textRef}>
+      <Text as="span" truncate>
+        {children}
+      </Text>
     </span>
   );
 

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -1,4 +1,5 @@
 import React, {useRef, useState} from 'react';
+import {zIndex} from '@shopify/polaris-tokens';
 
 import {classNames} from '../../../../utilities/css';
 import type {ActionListItemDescriptor} from '../../../../types';
@@ -163,10 +164,10 @@ export const TruncateText = ({children}: {children: string}) => {
 
   return isOverflowing ? (
     <Tooltip
-      zIndexOverride={514}
+      zIndexOverride={Number(zIndex['z-6'])}
       preferredPosition="above"
       hoverDelay={1000}
-      content={textRef.current?.innerText}
+      content={children}
     >
       <Text as="span" truncate>
         {children}

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import React from 'react';
 
 import {classNames} from '../../../../utilities/css';
 import type {ActionListItemDescriptor} from '../../../../types';

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -11,8 +11,6 @@ import styles from '../../ActionList.scss';
 import {handleMouseUpByBlurring} from '../../../../utilities/focus';
 import {HorizontalStack} from '../../../HorizontalStack';
 import {Box} from '../../../Box';
-import {Tooltip} from '../../../Tooltip';
-import {useIsomorphicLayoutEffect} from '../../../../utilities/use-isomorphic-layout-effect';
 
 export type ItemProps = ActionListItemDescriptor;
 
@@ -68,7 +66,11 @@ export function Item({
   if (ellipsis) {
     contentText = `${content}…`;
   } else if (truncate && content) {
-    contentText = <TruncateText position={truncate}>{content}</TruncateText>;
+    contentText = (
+      <Text as="span" variant="bodyMd" truncate>
+        {content}
+      </Text>
+    );
   }
 
   const contentMarkup = helpText ? (
@@ -140,60 +142,5 @@ export function Item({
       {scrollMarkup}
       {control}
     </>
-  );
-}
-
-export const TruncateText = ({
-  children,
-  position = 'end',
-}: {
-  children: string;
-  position?: 'end' | 'middle';
-}) => {
-  const textRef = useRef<HTMLSpanElement>(null);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-
-  useIsomorphicLayoutEffect(() => {
-    if (textRef.current) {
-      setIsOverflowing(
-        textRef.current.scrollWidth > textRef.current.offsetWidth,
-      );
-    }
-  }, [children]);
-
-  const text = (
-    <span ref={textRef} className={styles.Truncate}>
-      {children}
-    </span>
-  );
-
-  const truncatedText = middleTruncate(children, 40);
-
-  return isOverflowing ? (
-    <Tooltip
-      zIndexOverride={514}
-      preferredPosition="above"
-      hoverDelay={1000}
-      content={textRef.current?.innerText}
-    >
-      {position === 'middle' ? <span>{truncatedText}</span> : text}
-    </Tooltip>
-  ) : (
-    text
-  );
-};
-
-function middleTruncate(inputString: string, length: number, prefix = '…') {
-  const trimmedString = inputString.trim();
-  const stringLength = trimmedString.length;
-  const prefixLength = prefix.length;
-  if (stringLength <= length) return trimmedString;
-  const trimLength = (length - prefixLength) / 2;
-  const frontChars = Math.ceil(trimLength);
-  const backChars = Math.floor(trimLength);
-  return (
-    trimmedString.substr(0, frontChars) +
-    prefix +
-    trimmedString.substr(trimmedString.length - backChars)
   );
 }

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -33,7 +33,7 @@ export function Item({
   external,
   destructive,
   ellipsis,
-  truncate = 'end',
+  truncate,
   active,
   role,
 }: ItemProps) {
@@ -147,7 +147,7 @@ export const TruncateText = ({
   children,
   position = 'end',
 }: {
-  children: React.ReactNode;
+  children: string;
   position?: 'end' | 'middle';
 }) => {
   const textRef = useRef<HTMLSpanElement>(null);
@@ -167,6 +167,8 @@ export const TruncateText = ({
     </span>
   );
 
+  const truncatedText = middleTruncate(children, 40);
+
   return isOverflowing ? (
     <Tooltip
       zIndexOverride={514}
@@ -174,9 +176,7 @@ export const TruncateText = ({
       hoverDelay={1000}
       content={textRef.current?.innerText}
     >
-      {position === 'middle'
-        ? middleTruncate(textRef.current?.innerText || '', 40)
-        : text}
+      {position === 'middle' && truncatedText ? truncatedText : text}
     </Tooltip>
   ) : (
     text

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -113,9 +113,9 @@ describe('<Item />', () => {
 
   it('does not truncate content when the truncate prop is false', () => {
     const item = mountWithApp(<Item content="Test" truncate={false} />);
-    expect(item).toContainReactComponent(Text, {
+    expect(item).not.toContainReactComponent(Text, {
       children: 'Test',
-      truncate: false,
+      truncate: true,
     });
   });
 });

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -107,7 +107,7 @@ describe('<Item />', () => {
     const item = mountWithApp(
       <Item
         content="Test longer than usual string that probably overflows."
-        truncate={true}
+        truncate
       />,
     );
     expect(item).toContainReactComponent(TruncateText, {

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -110,6 +110,14 @@ describe('<Item />', () => {
       truncate: true,
     });
   });
+
+  it('does not truncate content when the truncate prop is false', () => {
+    const item = mountWithApp(<Item content="Test" truncate={false} />);
+    expect(item).toContainReactComponent(Text, {
+      children: 'Test',
+      truncate: false,
+    });
+  });
 });
 
 function noop() {}

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -126,6 +126,16 @@ describe('<Item />', () => {
       position: 'middle',
     });
   });
+
+  it('does not truncate content when truncate prop is not set', () => {
+    const item = mountWithApp(
+      <Item
+        content="Test longer than usual string that probably overflows."
+        truncate={undefined}
+      />,
+    );
+    expect(item).not.toContainReactComponent(TruncateText);
+  });
 });
 
 function noop() {}

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
-import {Item} from '../Item';
+import {Item, TruncateText} from '../Item';
 import {Text} from '../../../../Text';
 import {UnstyledLink} from '../../../../UnstyledLink';
 
@@ -103,20 +103,26 @@ describe('<Item />', () => {
     });
   });
 
-  it('truncates content when the truncate prop is true', () => {
-    const item = mountWithApp(<Item content="Test" truncate />);
-    expect(item).toContainReactComponent(Text, {
-      children: 'Test',
-      truncate: true,
+  it('truncates when the truncate prop is true', () => {
+    const item = mountWithApp(
+      <Item
+        content="Test longer than usual string that probably overflows."
+        truncate={true}
+      />,
+    );
+    expect(item).toContainReactComponent(TruncateText, {
+      children: 'Test longer than usual string that probably overflows.',
     });
   });
 
-  it('does not truncate content when the truncate prop is false', () => {
-    const item = mountWithApp(<Item content="Test" truncate={false} />);
-    expect(item).not.toContainReactComponent(Text, {
-      children: 'Test',
-      truncate: true,
-    });
+  it('does not truncate when the truncate prop is false', () => {
+    const item = mountWithApp(
+      <Item
+        content="Test longer than usual string that probably overflows."
+        truncate={false}
+      />,
+    );
+    expect(item).not.toContainReactComponent(TruncateText);
   });
 });
 

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
-import {Item, TruncateText} from '../Item';
+import {Item} from '../Item';
 import {Text} from '../../../../Text';
 import {UnstyledLink} from '../../../../UnstyledLink';
 
@@ -103,38 +103,12 @@ describe('<Item />', () => {
     });
   });
 
-  it('truncates at the end of content when truncate prop is set', () => {
-    const item = mountWithApp(
-      <Item
-        content="Test longer than usual string that probably overflows."
-        truncate="end"
-      />,
-    );
-    expect(item).toContainReactComponent(TruncateText, {
-      position: 'end',
+  it('truncates content when the truncate prop is true', () => {
+    const item = mountWithApp(<Item content="Test" truncate />);
+    expect(item).toContainReactComponent(Text, {
+      children: 'Test',
+      truncate: true,
     });
-  });
-
-  it('truncates in the middle of content when truncate prop is set', () => {
-    const item = mountWithApp(
-      <Item
-        content="Test longer than usual string that probably overflows."
-        truncate="middle"
-      />,
-    );
-    expect(item).toContainReactComponent(TruncateText, {
-      position: 'middle',
-    });
-  });
-
-  it('does not truncate content when truncate prop is not set', () => {
-    const item = mountWithApp(
-      <Item
-        content="Test longer than usual string that probably overflows."
-        truncate={undefined}
-      />,
-    );
-    expect(item).not.toContainReactComponent(TruncateText);
   });
 });
 

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
-import {Item} from '../Item';
+import {Item, TruncateText} from '../Item';
 import {Text} from '../../../../Text';
 import {UnstyledLink} from '../../../../UnstyledLink';
 
@@ -100,6 +100,30 @@ describe('<Item />', () => {
     );
     expect(item).toContainReactComponent(UnstyledLink, {
       onClick: null,
+    });
+  });
+
+  it('truncates at the end of content when truncate prop is set', () => {
+    const item = mountWithApp(
+      <Item
+        content="Test longer than usual string that probably overflows."
+        truncate="end"
+      />,
+    );
+    expect(item).toContainReactComponent(TruncateText, {
+      position: 'end',
+    });
+  });
+
+  it('truncates in the middle of content when truncate prop is set', () => {
+    const item = mountWithApp(
+      <Item
+        content="Test longer than usual string that probably overflows."
+        truncate="middle"
+      />,
+    );
+    expect(item).toContainReactComponent(TruncateText, {
+      position: 'middle',
     });
   });
 });

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -239,7 +239,7 @@ export function WithStoreItems() {
               name="Jaded Pixel"
             />
           ),
-          truncate: 'end',
+          truncate: true,
         },
         {
           content: 'Snow Devil- Americas, Europe, Asia-Pacific, and India',
@@ -251,7 +251,7 @@ export function WithStoreItems() {
               name="Snow Devil"
             />
           ),
-          truncate: 'middle',
+          truncate: true,
         },
         {
           content: 'All stores',

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -30,7 +30,7 @@ function TopBarWrapper({
   customActivator?: UserMenuProps['customActivator'];
   message?: UserMenuProps['message'];
 }) {
-  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(true);
   const [isSecondaryMenuOpen, setIsSecondaryMenuOpen] = useState(false);
   const [isSearchActive, setIsSearchActive] = useState(false);
   const [searchValue, setSearchValue] = useState('');
@@ -85,6 +85,7 @@ function TopBarWrapper({
       detail={detail && detail}
       initials={initials ? initials : 'JD'}
       customActivator={customActivator}
+      customWidth="300px"
       message={message}
       open={isUserMenuOpen}
       onToggle={toggleIsUserMenuOpen}
@@ -223,46 +224,4 @@ export function WithMessage() {
       }}
     />
   );
-}
-
-export function WithStoreItems() {
-  const userActions: UserMenuProps['actions'] = [
-    {
-      items: [
-        {
-          content: 'Jaded Pixel- Americas, Europe, Asia-Pacific, and India',
-          prefix: (
-            <Avatar
-              initials="JP"
-              size="small"
-              shape="square"
-              name="Jaded Pixel"
-            />
-          ),
-          truncate: true,
-        },
-        {
-          content: 'Snow Devil- Americas, Europe, Asia-Pacific, and India',
-          prefix: (
-            <Avatar
-              size="small"
-              shape="square"
-              initials="SD"
-              name="Snow Devil"
-            />
-          ),
-          truncate: true,
-        },
-        {
-          content: 'All stores',
-          prefix: <Icon source={StoreMinor} />,
-        },
-      ],
-    },
-    {
-      items: [{content: 'Community forums'}],
-    },
-  ];
-
-  return <TopBarWrapper userActions={userActions} name="Dharma" initials="D" />;
 }

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -1,7 +1,13 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {ActionList, Frame, Icon, TopBar, Text, Avatar} from '@shopify/polaris';
-import {ArrowLeftMinor, QuestionMarkMajor} from '@shopify/polaris-icons';
+import {
+  ArrowLeftMinor,
+  QuestionMarkMajor,
+  SearchMinor,
+  StoreMinor,
+  TickMinor,
+} from '@shopify/polaris-icons';
 
 import type {UserMenuProps} from '../../../build/ts/latest/src/components/TopBar';
 
@@ -193,7 +199,7 @@ export function WithCustomActivator() {
   );
 }
 
-export function withMessage() {
+export function WithMessage() {
   const userActions: UserMenuProps['actions'] = [
     {
       items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
@@ -217,4 +223,46 @@ export function withMessage() {
       }}
     />
   );
+}
+
+export function WithStoreItems() {
+  const userActions: UserMenuProps['actions'] = [
+    {
+      items: [
+        {
+          content: 'Jaded Pixel- Americas, Europe, Asia-Pacific, and India',
+          prefix: (
+            <Avatar
+              initials="JP"
+              size="small"
+              shape="square"
+              name="Jaded Pixel"
+            />
+          ),
+          truncate: 'end',
+        },
+        {
+          content: 'Snow Devil- Americas, Europe, Asia-Pacific, and India',
+          prefix: (
+            <Avatar
+              size="small"
+              shape="square"
+              initials="SD"
+              name="Snow Devil"
+            />
+          ),
+          truncate: 'middle',
+        },
+        {
+          content: 'All stores',
+          prefix: <Icon source={StoreMinor} />,
+        },
+      ],
+    },
+    {
+      items: [{content: 'Community forums'}],
+    },
+  ];
+
+  return <TopBarWrapper userActions={userActions} name="Dharma" initials="D" />;
 }

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -1,13 +1,7 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {ActionList, Frame, Icon, TopBar, Text, Avatar} from '@shopify/polaris';
-import {
-  ArrowLeftMinor,
-  QuestionMarkMajor,
-  SearchMinor,
-  StoreMinor,
-  TickMinor,
-} from '@shopify/polaris-icons';
+import {ArrowLeftMinor, QuestionMarkMajor} from '@shopify/polaris-icons';
 
 import type {UserMenuProps} from '../../../build/ts/latest/src/components/TopBar';
 

--- a/polaris-react/src/components/TopBar/components/Menu/Menu.scss
+++ b/polaris-react/src/components/TopBar/components/Menu/Menu.scss
@@ -82,6 +82,14 @@ $activator-variables: (
   }
 }
 
+.MenuItems {
+  // stylelint-disable -- Polaris component custom properties temporary override
+  [class*='Polaris-ActionList__Item'] {
+    --pc-action-list-item-min-height: var(--p-space-10) - var(--p-space-1);
+    // stylelint-enable
+  }
+}
+
 .Section {
   margin-top: var(--p-space-2);
   padding-top: var(--p-space-2);

--- a/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
+++ b/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import {ActionList} from '../../../ActionList';
 import type {ActionListProps} from '../../../ActionList';
 import {Popover} from '../../../Popover';
+import {Box} from '../../../Box';
 
 import {Message} from './components';
 import type {MessageProps} from './components';
 import styles from './Menu.scss';
-import {Box} from '../../../Box';
 
 const USER_MENU_POPOVER_WIDTH = '360px';
 
@@ -28,6 +28,8 @@ export interface MenuProps {
   onClose(): void;
   /** A string that provides the accessibility labeling */
   accessibilityLabel?: string;
+  /** A boolean property indicating whether a custom activator is being used */
+  hasCustomActivator?: boolean;
 }
 
 export function Menu(props: MenuProps) {
@@ -39,6 +41,7 @@ export function Menu(props: MenuProps) {
     activatorContent,
     message,
     accessibilityLabel,
+    hasCustomActivator,
   } = props;
 
   const badgeProps = message &&
@@ -77,9 +80,10 @@ export function Menu(props: MenuProps) {
       active={open}
       onClose={onClose}
       fixed
+      fullHeight
       preferredAlignment="right"
     >
-      <Box width={USER_MENU_POPOVER_WIDTH}>
+      <Box width={hasCustomActivator ? undefined : USER_MENU_POPOVER_WIDTH}>
         <ActionList onActionAnyItem={onClose} sections={actions} />
         {messageMarkup}
       </Box>

--- a/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
+++ b/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
@@ -9,8 +9,6 @@ import {Message} from './components';
 import type {MessageProps} from './components';
 import styles from './Menu.scss';
 
-const USER_MENU_POPOVER_WIDTH = '360px';
-
 export interface MenuProps {
   /** Accepts an activator component that renders inside of a button that opens the menu */
   activatorContent: React.ReactNode;
@@ -28,8 +26,8 @@ export interface MenuProps {
   onClose(): void;
   /** A string that provides the accessibility labeling */
   accessibilityLabel?: string;
-  /** A boolean property indicating whether a custom activator is being used */
-  hasCustomActivator?: boolean;
+  /** A custom width value that can be used to set the width of the menu */
+  customWidth?: string;
 }
 
 export function Menu(props: MenuProps) {
@@ -41,7 +39,7 @@ export function Menu(props: MenuProps) {
     activatorContent,
     message,
     accessibilityLabel,
-    hasCustomActivator,
+    customWidth,
   } = props;
 
   const badgeProps = message &&
@@ -83,10 +81,16 @@ export function Menu(props: MenuProps) {
       fullHeight
       preferredAlignment="right"
     >
-      <Box width={hasCustomActivator ? undefined : USER_MENU_POPOVER_WIDTH}>
-        <ActionList onActionAnyItem={onClose} sections={actions} />
-        {messageMarkup}
-      </Box>
+      <div className={styles.MenuItems}>
+        <Box width={customWidth}>
+          <ActionList
+            actionRole="menuitem"
+            onActionAnyItem={onClose}
+            sections={actions}
+          />
+          {messageMarkup}
+        </Box>
+      </div>
     </Popover>
   );
 }

--- a/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
+++ b/polaris-react/src/components/TopBar/components/Menu/Menu.tsx
@@ -7,6 +7,9 @@ import {Popover} from '../../../Popover';
 import {Message} from './components';
 import type {MessageProps} from './components';
 import styles from './Menu.scss';
+import {Box} from '../../../Box';
+
+const USER_MENU_POPOVER_WIDTH = '360px';
 
 export interface MenuProps {
   /** Accepts an activator component that renders inside of a button that opens the menu */
@@ -74,11 +77,12 @@ export function Menu(props: MenuProps) {
       active={open}
       onClose={onClose}
       fixed
-      fullHeight
       preferredAlignment="right"
     >
-      <ActionList onActionAnyItem={onClose} sections={actions} />
-      {messageMarkup}
+      <Box width={USER_MENU_POPOVER_WIDTH}>
+        <ActionList onActionAnyItem={onClose} sections={actions} />
+        {messageMarkup}
+      </Box>
     </Popover>
   );
 }

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -31,6 +31,8 @@ export interface UserMenuProps {
   onToggle(): void;
   /** A custom activator that can be used when the default activator is not desired */
   customActivator?: React.ReactNode;
+  /** A width value that customizes the width of the user menu */
+  customWidth?: string;
 }
 
 export function UserMenu({
@@ -44,6 +46,7 @@ export function UserMenu({
   open,
   accessibilityLabel,
   customActivator,
+  customWidth,
 }: UserMenuProps) {
   const showIndicator = Boolean(message);
 
@@ -85,7 +88,7 @@ export function UserMenu({
       actions={actions}
       message={message}
       accessibilityLabel={accessibilityLabel}
-      hasCustomActivator={Boolean(customActivator)}
+      customWidth={customWidth}
     />
   );
 }

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -85,6 +85,7 @@ export function UserMenu({
       actions={actions}
       message={message}
       accessibilityLabel={accessibilityLabel}
+      hasCustomActivator={Boolean(customActivator)}
     />
   );
 }

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -202,8 +202,10 @@ export interface ActionListItemDescriptor
   prefix?: React.ReactNode;
   /** Suffix source */
   suffix?: React.ReactNode;
-  /**  Add an ellipsis suffix to action content */
+  /** @deprecated Add an ellipsis suffix to action content. ellipsis only adds `...` without truncating. User truncate instead. */
   ellipsis?: boolean;
+  /** Truncate the action content either at the beginning or at the end */
+  truncate?: 'middle' | 'end';
   /** Whether the action is active or not */
   active?: boolean;
   /** Defines a role for the action */

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -205,7 +205,7 @@ export interface ActionListItemDescriptor
   /** @deprecated Add an ellipsis suffix to action content. ellipsis appends `...` without truncating. Use truncate instead. */
   ellipsis?: boolean;
   /** Truncate the action content either at the beginning or at the end */
-  truncate?: 'middle' | 'end';
+  truncate?: boolean;
   /** Whether the action is active or not */
   active?: boolean;
   /** Defines a role for the action */

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -202,7 +202,7 @@ export interface ActionListItemDescriptor
   prefix?: React.ReactNode;
   /** Suffix source */
   suffix?: React.ReactNode;
-  /** @deprecated Add an ellipsis suffix to action content. ellipsis only adds `...` without truncating. User truncate instead. */
+  /** @deprecated Add an ellipsis suffix to action content. ellipsis appends `...` without truncating. Use truncate instead. */
   ellipsis?: boolean;
   /** Truncate the action content either at the beginning or at the end */
   truncate?: 'middle' | 'end';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves https://github.com/Shopify/core-workflows/issues/881
Fixes https://github.com/Shopify/core-workflows/issues/930

The `ellipsis` prop currently doesn't do anything more than adding `...` to the content string. This functionality doesn't achieve much when the intention is to actually `truncate` the content string

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR introduces `truncate` as part of the `ActionListDescriptors` props. We can choose between `end` and `middle` truncation which is then dynamically applied to the item content. The function `middleTruncate` shortens the string based on character count.

We also set the `TopBar` user menu to a fixed width based on the mockups available on the original issue.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

- [Spin URL](https://admin.web.actionlist.zakaria-warsame.us.spin.dev/store/shop1)
  - Notice no changes made to the top bar user menu first
  - Enable `new_account_menu_and_store_switcher` beta and refresh the page
  - Click on the top bar user menu
  - The third store has `middle` truncate applied and the fourth `end`
  - Notice the width is now `360` px

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
