### PR TITLE
Updates Polaris for VSCode completion items to new token groups

### DIFF
--- a/.changeset/poor-flies-invite.md
+++ b/.changeset/poor-flies-invite.md
@@ -1,0 +1,5 @@
+---
+'polaris-for-vscode': minor
+---
+
+Updates Polaris for VSCode completion items to new token groups

--- a/polaris-for-vscode/src/server.ts
+++ b/polaris-for-vscode/src/server.ts
@@ -71,7 +71,7 @@ const connection = createConnection(ProposedFeatures.all);
 const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
 
 type TokenGroupPatterns = {
-  [F in TokenGroupName]: RegExp;
+  [T in TokenGroupName]: RegExp;
 };
 
 const tokenGroupPatterns: TokenGroupPatterns = {

--- a/polaris-for-vscode/src/server.ts
+++ b/polaris-for-vscode/src/server.ts
@@ -15,7 +15,7 @@ import type {
 } from 'vscode-languageserver/node';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 
-const {legacy, ...restTokenGroups} = metadata;
+const {...restTokenGroups} = metadata;
 
 const groupedCompletionItemTokenGroups = restTokenGroups;
 
@@ -69,15 +69,12 @@ type GroupedCompletionItemPatterns = {
 
 const groupedCompletionItemPatterns: Omit<
   GroupedCompletionItemPatterns,
-  'shape'
+  'colors' | 'depth' | 'legacy' | 'shape'
 > = {
-  breakpoints: /width/,
   border: /border/,
+  breakpoints: /width/,
   color:
     /color|background|shadow|border|column-rule|filter|opacity|outline|text-decoration/,
-  colors:
-    /color|background|shadow|border|column-rule|filter|opacity|outline|text-decoration/,
-  depth: /shadow/,
   font: /font|line-height/,
   motion: /animation/,
   shadow: /shadow/,


### PR DESCRIPTION
### WHY are these changes introduced?

Now that our new token groups (`border`, `color`, `shadow`) are stable we want to encourage folks to start using them and update all of our Polaris for VSCode extension to reflect those changes.

### WHAT is this pull request doing?

Updates Polaris for VSCode completion items to new token groups (and removes old groups).