### PR TITLE
[IndexFilters] add -Example suffix to functions names

### DIFF
--- a/.changeset/sour-onions-admire.md
+++ b/.changeset/sour-onions-admire.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+add a -Example suffix to the names of IndexFilters' examples

--- a/polaris.shopify.com/pages/examples/index-filters-default.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-default.tsx
@@ -14,7 +14,7 @@ import type {IndexFiltersProps, AlphaTabProps} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function IndexFiltersDefault() {
+function IndexFiltersDefaultExample() {
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
   const [itemStrings, setItemStrings] = useState([
@@ -396,4 +396,4 @@ function IndexFiltersDefault() {
   }
 }
 
-export default withPolarisExample(IndexFiltersDefault);
+export default withPolarisExample(IndexFiltersDefaultExample);

--- a/polaris.shopify.com/pages/examples/index-filters-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-disabled.tsx
@@ -14,7 +14,7 @@ import type {IndexFiltersProps, AlphaTabProps} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function IndexFiltersDisabled() {
+function IndexFiltersDisabledExample() {
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
   const [itemStrings, setItemStrings] = useState([
@@ -397,4 +397,4 @@ function IndexFiltersDisabled() {
   }
 }
 
-export default withPolarisExample(IndexFiltersDisabled);
+export default withPolarisExample(IndexFiltersDisabledExample);

--- a/polaris.shopify.com/pages/examples/index-filters-with-filtering-mode.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-filtering-mode.tsx
@@ -15,7 +15,7 @@ import type {IndexFiltersProps, AlphaTabProps} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function IndexFiltersWithFilteringMode() {
+function IndexFiltersWithFilteringModeExample() {
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
   const [itemStrings, setItemStrings] = useState([
@@ -397,4 +397,4 @@ function IndexFiltersWithFilteringMode() {
   }
 }
 
-export default withPolarisExample(IndexFiltersWithFilteringMode);
+export default withPolarisExample(IndexFiltersWithFilteringModeExample);

--- a/polaris.shopify.com/pages/examples/index-filters-with-pinned-filters.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-pinned-filters.tsx
@@ -14,7 +14,7 @@ import type {IndexFiltersProps, AlphaTabProps} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function IndexFiltersWithPinnedFilters() {
+function IndexFiltersWithPinnedFiltersExample() {
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
   const [itemStrings, setItemStrings] = useState([
@@ -396,4 +396,4 @@ function IndexFiltersWithPinnedFilters() {
   }
 }
 
-export default withPolarisExample(IndexFiltersWithPinnedFilters);
+export default withPolarisExample(IndexFiltersWithPinnedFiltersExample);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

<img width="538" alt="Screenshot 2023-04-19 at 15 54 05" src="https://user-images.githubusercontent.com/6597467/233097196-1d7201fb-a06b-4efe-89d4-dab30814d165.png">

After giving support yesterday related to `IndexFilters` components I noticed that the Codesandbox examples of that component were not working

### WHAT is this pull request doing?

It adds "Example" to the end of the name of the function that defines the example code. Apparently this is necessary otherwise it will pass invalid code to CodesandboxButton. This might be happening in other examples, btw.

Should we create an eslint for this?

The issue happens [here](https://github.com/Shopify/polaris/blob/main/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx#L5-L10). When there is no function with Example on its name then the code just names the exported default function "Example", but there is no `function Example()` to be exported in the code passed to `CodesandboxButton`

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
