### PR TITLE
Stale after 180 days and closed after 30 days of inactivity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,17 +21,15 @@ jobs:
       - uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-issue-stale: 21
-          days-before-pr-stale: 30
-          days-before-close: 7
+          days-before-issue-stale: 180
+          days-before-pr-stale: 180
+          days-before-close: 30
           stale-issue-message: |-
             This issue seems inactive. If it's still relevant, please add a comment saying so. Otherwise, take no action.
-            → If there's no activity within a week, then a bot will automatically close this.
-            Thanks for helping to improve Shopify's design system and dev experience.
+            → If there's no activity within 30 days the issue will be automatically closed.
           stale-pr-message: |-
             This PR seems inactive. If it's still relevant, please add a comment saying so. Otherwise, take no action.
-            → If there's no activity within a week, then a bot will automatically close this.
-            Thanks for helping to improve Shopify's design system and dev experience.
+            → If there's no activity within 30 days the PR will be automatically closed.
           stale-issue-label: 'no-issue-activity'
           stale-pr-label: 'no-pr-activity'
           ascending: true


### PR DESCRIPTION
The stale workflow was pretty aggressive and causing angst. Shopify uses 90 days to stale and 30 to close, but has processes for triaging and identifying owners. Without a process currently in place for Polaris lets keep this to 180 days to stale and 30 to close.

For more context [here is the Slack thread](https://shopify.slack.com/archives/C036CGUL4SE/p1681241948453399). Tangentially, here is the WIP (as of this writing) [Polaris Issue Triage Process](https://docs.google.com/document/d/1QW2P2KGOuiiv6Poa2AH_sII1aa8gnhZCvDlkZ2N4eRI/edit#heading=h.tyqbqxaaaxmr) if you want to weigh in or just take a look.