### PR TITLE
[ActionList.Item] Add contentOverflow options

### DIFF
--- a/.changeset/strange-insects-sip.md
+++ b/.changeset/strange-insects-sip.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added `contentOverflow: wrap | truncate` to `ActionListItemDescriptor`

--- a/polaris-react/src/components/ActionList/ActionList.stories.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.stories.tsx
@@ -332,3 +332,62 @@ export function WithAPrefixAndASuffix() {
     </div>
   );
 }
+
+export function WithWrappedOrTruncatedContent() {
+  return (
+    <div style={{height: '250px', maxWidth: '200px'}}>
+      <ActionList
+        actionRole="menuitem"
+        items={[
+          {
+            content:
+              'A very long string that will wrap within the same line as the prefix and suffix',
+            contentOverflow: 'wrap',
+            prefix: (
+              <Thumbnail
+                source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                size="small"
+                alt="Black leather pet collar"
+              />
+            ),
+            suffix: <Icon source={ChevronRightMinor} />,
+          },
+          {
+            content: 'A very long string that will truncate',
+            contentOverflow: 'truncate',
+            prefix: <Avatar customer name="Farrah" size="small" />,
+            suffix: <Icon source={ChevronRightMinor} />,
+          },
+          {
+            content:
+              'A very long string that will wrap within the same line as the prefix and suffix',
+            contentOverflow: 'wrap',
+            helpText: 'with help text',
+            prefix: (
+              <Thumbnail
+                source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                size="small"
+                alt="Black leather pet collar"
+              />
+            ),
+            suffix: <Icon source={ChevronRightMinor} />,
+          },
+          {
+            content: 'A very long string that will truncate',
+            helpText: 'with help text',
+            contentOverflow: 'truncate',
+            prefix: <Avatar customer name="Farrah" size="small" />,
+            suffix: <Icon source={ChevronRightMinor} />,
+          },
+          {
+            content: 'A very long string with truncate and ellipsis',
+            ellipsis: true,
+            contentOverflow: 'truncate',
+            prefix: <Avatar customer name="Farrah" size="small" />,
+            suffix: <Icon source={ChevronRightMinor} />,
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -18,6 +18,7 @@ export function Item({
   id,
   badge,
   content,
+  contentOverflow,
   accessibilityLabel,
   helpText,
   url,
@@ -61,17 +62,27 @@ export function Item({
     );
   }
 
+  const truncate = !ellipsis && contentOverflow === 'truncate';
+
   const contentText = ellipsis && content ? `${content}…` : content;
+
+  const contentWrapper = truncate ? (
+    <Text as="span" variant="bodyMd" truncate={truncate}>
+      {contentText}
+    </Text>
+  ) : (
+    contentText
+  );
 
   const contentMarkup = helpText ? (
     <>
-      <Box>{contentText}</Box>
+      <Box>{contentWrapper}</Box>
       <Text color="subdued" as="span">
         {helpText}
       </Text>
     </>
   ) : (
-    contentText
+    contentWrapper
   );
 
   const badgeMarkup = badge && (
@@ -88,8 +99,12 @@ export function Item({
 
   const textMarkup = <span className={styles.Text}>{contentMarkup}</span>;
 
+  const wrapContainer = Boolean(
+    !contentOverflow || (contentOverflow === 'truncate' && ellipsis),
+  );
+
   const contentElement = (
-    <HorizontalStack blockAlign="center" gap="4">
+    <HorizontalStack blockAlign="center" gap="4" wrap={wrapContainer}>
       {prefixMarkup}
       {textMarkup}
       {badgeMarkup}

--- a/polaris-react/src/components/ActionList/tests/ActionList.test.tsx
+++ b/polaris-react/src/components/ActionList/tests/ActionList.test.tsx
@@ -7,6 +7,8 @@ import {Badge} from '../../Badge';
 import {Item, Section} from '../components';
 import {Key} from '../../../types';
 import {KeypressListener} from '../../KeypressListener';
+import {HorizontalStack} from '../../HorizontalStack';
+import {Text} from '../../Text';
 
 describe('<ActionList />', () => {
   let mockOnActionAnyItem: jest.Mock;
@@ -235,5 +237,71 @@ describe('<ActionList />', () => {
     expect(document.activeElement).toStrictEqual(
       actionListButtons[actionListButtons.length - 1].domNode,
     );
+  });
+
+  it('wraps content when passed `overflow: wrap`', () => {
+    const actionList = mountWithApp(
+      <ActionList
+        items={[
+          {
+            content: 'Add discount',
+            contentOverflow: 'wrap',
+            badge: {status: 'new', content: 'badge'},
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="option"
+      />,
+    );
+    expect(actionList).toContainReactComponent(HorizontalStack, {
+      wrap: false,
+    });
+  });
+
+  it('truncates content when passed `contentOverflow: truncate`', () => {
+    const content = 'Add discount';
+    const actionList = mountWithApp(
+      <ActionList
+        items={[
+          {
+            content,
+            contentOverflow: 'truncate',
+            badge: {status: 'new', content: 'badge'},
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="option"
+      />,
+    );
+    expect(actionList).toContainReactComponent(Text, {
+      as: 'span',
+      variant: 'bodyMd',
+      truncate: true,
+      children: content,
+    });
+  });
+
+  it('does not truncate when passed `ellipsis`', () => {
+    const content = 'Add discount';
+    const actionList = mountWithApp(
+      <ActionList
+        items={[
+          {
+            content,
+            contentOverflow: 'truncate',
+            ellipsis: true,
+            badge: {status: 'new', content: 'badge'},
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="option"
+      />,
+    );
+    expect(actionList).not.toContainReactComponent(Text, {
+      as: 'span',
+      variant: 'bodyMd',
+      truncate: true,
+      children: content,
+    });
   });
 });

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -192,6 +192,8 @@ export interface ActionListItemDescriptor
     status: 'new';
     content: string;
   };
+  /** Control visual display of long content */
+  contentOverflow?: 'wrap' | 'truncate';
   /** Additional hint text to display with item */
   helpText?: React.ReactNode;
   /** @deprecated Source of the icon */


### PR DESCRIPTION
### WHY are these changes introduced?

At present, content in an ActionList.Item will wrap to a new line when the content overflows.

It would be great to have the flexibility to:

1. Wrap content, but keep on the same line as the prefix/suffix
2. Truncate content 

See `### Use Cases` for Theme Editor examples.


### WHAT is this pull request doing?

- Adds an optional `contentOverflow` prop to `ActionList.Item`
- Maintains existing `ellipsis` behaviour

| without contentOverflow | contentOverflow: wrap / truncate |
|---|---|
|![Screenshot 2023-04-20 at 10 52 32](https://user-images.githubusercontent.com/17032120/233331101-5897c87d-03df-4846-9234-b0bd81a161a9.jpg)|![Screenshot 2023-04-20 at 10 53 45](https://user-images.githubusercontent.com/17032120/233331115-c7bd57d0-61e3-4cf9-ae15-6e286e782332.jpg)|


| wrap + helpText | truncate + helpText | truncate + ellipses |
|---|---|---|
|![Screenshot 2023-04-20 at 11 08 06](https://user-images.githubusercontent.com/17032120/233336885-66506969-7b4a-4ca5-952d-4a79a6ae7bae.jpg)|![Screenshot 2023-04-20 at 11 08 08](https://user-images.githubusercontent.com/17032120/233335319-238d747b-e3f2-4f56-b413-c5b242043a21.jpg)|![Screenshot 2023-04-20 at 11 08 11](https://user-images.githubusercontent.com/17032120/233335357-20605a09-f8a2-4c05-87b9-ea384d3e2cba.jpg)|

### How to 🎩


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
       <div style={{height: '250px', maxWidth: '200px'}}>
      <ActionList
        actionRole="menuitem"
        items={[
          {
            content:
              'A very long string that will wrap within the same line as the prefix and suffix',
            contentOverflow: 'wrap',
            prefix: (
              <Thumbnail
                source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
                size="small"
                alt="Black leather pet collar"
              />
            ),
            suffix: <Icon source={ChevronRightMinor} />,
          },
          {
            content: 'A very long string that will truncate',
            contentOverflow: 'truncate',
            prefix: <Avatar customer name="Farrah" size="small" />,
            suffix: <Icon source={ChevronRightMinor} />,
          },
          {
            content:
              'A very long string that will wrap within the same line as the prefix and suffix',
            contentOverflow: 'wrap',
            helpText: 'with help text',
            prefix: (
              <Thumbnail
                source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
                size="small"
                alt="Black leather pet collar"
              />
            ),
            suffix: <Icon source={ChevronRightMinor} />,
          },
          {
            content: 'A very long string that will truncate',
            helpText: 'with help text',
            contentOverflow: 'truncate',
            prefix: <Avatar customer name="Farrah" size="small" />,
            suffix: <Icon source={ChevronRightMinor} />,
          },
          {
            content: 'A very long string with truncate and ellipsis',
            ellipsis: true,
            contentOverflow: 'truncate',
            prefix: <Avatar customer name="Farrah" size="small" />,
            suffix: <Icon source={ChevronRightMinor} />,
          },
        ]}
      />
    </div>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on mobile (Safari iPhone 14 in browser stack; Chrome on Android Galaxy S22 in BrowserStack)
- [x] Tested on multiple browsers (Chrome MacOS; Firefox MacOS; Safari MacOS)

### Use cases

**Theme Editor:**

| Theme Actions menu | Datasource Popover |
|---|---|
|![image](https://user-images.githubusercontent.com/17032120/233343719-891d9c47-1818-47e8-bc8c-75999166ebfc.png)|![image](https://user-images.githubusercontent.com/17032120/233343936-a019ecf5-10f3-4fe1-bb31-10e0be39ce3b.png)|



