### PR TITLE
Update `z-index` token page visuals with new tokens

### DIFF
--- a/.changeset/eleven-apes-unite.md
+++ b/.changeset/eleven-apes-unite.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Added z-index token page visuals for new tokens

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -551,9 +551,9 @@ function TokenPreview({name, value}: TokenPreviewProps) {
   }
 
   // Z-index
-  else if (name.includes('z-')) {
+  else if (name.includes('z-index-')) {
     const layerCount = 12;
-    const number = parseInt(name.replace('z-', ''));
+    const number = parseInt(name.replace('z-index-', ''));
     return (
       <div
         {...previewDivAttributes}


### PR DESCRIPTION
### WHY are these changes introduced?

In preparation for the old `z-index` tokens being removed in v11 we should make sure that doc site visuals work for the new tokens.


### WHAT is this pull request doing?

**Before** 
<img width="1350" alt="Screenshot 2023-04-21 at 3 26 37 PM" src="https://user-images.githubusercontent.com/21976492/233737404-4ee3cf3a-798a-45c5-8a2d-d80333e01d06.png">


**After** 
<img width="1322" alt="Screenshot 2023-04-21 at 3 26 46 PM" src="https://user-images.githubusercontent.com/21976492/233737400-bc5b5a84-37b5-444d-9123-c0b4932433d9.png">

