### PR TITLE
[Popover] Fix PopoverOverlay not closing

### DIFF
--- a/.changeset/grumpy-squids-dance.md
+++ b/.changeset/grumpy-squids-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed PopoverOverlay not closing

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,50 +1,11 @@
-import type {ReactNode} from 'react';
-import React, {useState} from 'react';
+import React from 'react';
 
-import {Popover, UnstyledButton} from '../src';
+import {Page} from '../src';
 
 export function Playground() {
-  return <DefinitionPopover definition="hello world" title="hello world" />;
-}
-
-export interface Props {
-  /** A title to be displayed in the popover */
-  title: string;
-  /** The content to be displayed in the popover */
-  definition: ReactNode;
-}
-
-export function DefinitionPopover({title, definition}: Props) {
-  const [hoverActive, setHoverActive] = useState(false);
-
-  function handleClose() {
-    setHoverActive(false);
-  }
-
-  function handleActivatorMouseEnter() {
-    setHoverActive(true);
-  }
-
-  function handleActivatorMouseLeave() {
-    setHoverActive(false);
-  }
-
   return (
-    <Popover
-      active={hoverActive}
-      activator={
-        <UnstyledButton
-          aria-describedby="hi"
-          type="button"
-          onMouseEnter={handleActivatorMouseEnter}
-          onMouseLeave={handleActivatorMouseLeave}
-        >
-          {title}
-        </UnstyledButton>
-      }
-      onClose={handleClose}
-    >
-      {definition}
-    </Popover>
+    <Page title="Playground">
+      {/* Add the code you want to test in here */}
+    </Page>
   );
 }

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -22,12 +22,10 @@ export function DefinitionPopover({title, definition}: Props) {
   }
 
   function handleActivatorMouseEnter() {
-    console.log('handleActivatorMouseEnter');
     setHoverActive(true);
   }
 
   function handleActivatorMouseLeave() {
-    console.log('handleActivatorMouseLeave');
     setHoverActive(false);
   }
 

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,11 +1,52 @@
-import React from 'react';
+import type {ReactNode} from 'react';
+import React, {useState} from 'react';
 
-import {Page} from '../src';
+import {Popover, UnstyledButton} from '../src';
 
 export function Playground() {
+  return <DefinitionPopover definition="hello world" title="hello world" />;
+}
+
+export interface Props {
+  /** A title to be displayed in the popover */
+  title: string;
+  /** The content to be displayed in the popover */
+  definition: ReactNode;
+}
+
+export function DefinitionPopover({title, definition}: Props) {
+  const [hoverActive, setHoverActive] = useState(false);
+
+  function handleClose() {
+    setHoverActive(false);
+  }
+
+  function handleActivatorMouseEnter() {
+    console.log('handleActivatorMouseEnter');
+    setHoverActive(true);
+  }
+
+  function handleActivatorMouseLeave() {
+    console.log('handleActivatorMouseLeave');
+    setHoverActive(false);
+  }
+
   return (
-    <Page title="Playground">
-      {/* Add the code you want to test in here */}
-    </Page>
+    <Popover
+      active={hoverActive}
+      activator={
+        <UnstyledButton
+          aria-describedby="hi"
+          type="button"
+          onMouseEnter={handleActivatorMouseEnter}
+          onMouseLeave={handleActivatorMouseLeave}
+        >
+          {title}
+        </UnstyledButton>
+      }
+      onClose={handleClose}
+    >
+      {definition}
+    </Popover>
   );
 }

--- a/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -112,6 +112,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
     }
 
     if (!this.props.active && oldProps.active) {
+      this.clearTransitionTimeout();
       this.setState({transitionStatus: TransitionStatus.Exited});
     }
   }


### PR DESCRIPTION
Fixing bug where popovers weren't closing

`this.clearTransitionTimeout();` was removed in https://github.com/Shopify/polaris/pull/8842, this adds it back in

## Before
![definition popover demo](https://user-images.githubusercontent.com/20652326/233750396-4d837471-022e-4376-a317-72f8690e6caf.gif)

## After
![def popover demo](https://user-images.githubusercontent.com/20652326/233750389-c290b6bd-d89c-422d-9b4e-f67381a89029.gif)

## Playground code
<details><summary>Playground code</summary>
```
import React, {useState} from 'react';

import {Popover, UnstyledButton} from '../src';

export function Playground() {
  const [hoverActive, setHoverActive] = useState(false);

  function handleClose() {
    setHoverActive(false);
  }

  function handleActivatorMouseEnter() {
    setHoverActive(true);
  }

  function handleActivatorMouseLeave() {
    setHoverActive(false);
  }

  return (
    <Popover
      active={hoverActive}
      activator={
        <UnstyledButton
          aria-describedby="hi"
          type="button"
          onMouseEnter={handleActivatorMouseEnter}
          onMouseLeave={handleActivatorMouseLeave}
        >
          hello world
        </UnstyledButton>
      }
      onClose={handleClose}
    >
      hello world
    </Popover>
  );
}
```
</details>