### PR TITLE
Exported constants `DEFAULT_LOCALE` and `SUPPORTED_LOCALES`

### DIFF
--- a/.changeset/little-ducks-explode.md
+++ b/.changeset/little-ducks-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Exported constants `DEFAULT_LOCALE` and `SUPPORTED_LOCALES`

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -29,6 +29,8 @@ export type {
   FilterInterface,
 } from './types';
 
+export {DEFAULT_LOCALE, SUPPORTED_LOCALES} from './configure';
+
 // AppProvider contains CSS that affects element level CSS (e.g. `html`, `button`)
 // It should be first to ensure its CSS is first in compiled output
 // AppProvider contains CSS that affects element level CSS (e.g. `html`, `button`)

--- a/polaris-react/src/tests/configure.test.ts
+++ b/polaris-react/src/tests/configure.test.ts
@@ -3,7 +3,7 @@ import {resolve} from 'path';
 
 import yaml from 'js-yaml';
 
-import {DEFAULT_LOCALE, SUPPORTED_LOCALES} from '../configure';
+import {DEFAULT_LOCALE, SUPPORTED_LOCALES} from '..';
 
 describe('DEFAULT_LOCALE', () => {
   it('matches `source_language` in `translation.yml`', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Actually export the constants `DEFAULT_LOCALE` and `SUPPORTED_LOCALES`.
I mistakenly thought the `src/configure.ts` file was already being exported in #8999 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Export the constants `DEFAULT_LOCALE` and `SUPPORTED_LOCALES` - I also updated the test to validate the export.

### 🎩 checklist

- [ ] ~Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)~
- [ ] ~Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)~
- [ ] ~Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)~
- [ ] ~Updated the component's `README.md` with documentation changes~
- [ ] ~[Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide~
