### PR TITLE
Add migration/codemod to replace motion custom properties

### DIFF
--- a/.changeset/stupid-meals-hear.md
+++ b/.changeset/stupid-meals-hear.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-codemods': minor
 ---
 
-Created a migration to replace deprecated `motion` custom properties in polaris-react v11.0.0
+Created a migration to replace deprecated `motion` custom properties in `@shopify/polaris` v11.0.0

--- a/.changeset/stupid-meals-hear.md
+++ b/.changeset/stupid-meals-hear.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-codemods': minor
+---
+
+Created a migration to replace deprecated `motion` custom properties in polaris-react v11.0.0

--- a/.changeset/stupid-meals-hear.md
+++ b/.changeset/stupid-meals-hear.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/polaris-codemods': minor
+'@shopify/polaris-migrator': minor
 ---
 
 Created a migration to replace deprecated `motion` custom properties in `@shopify/polaris` v11.0.0

--- a/polaris-codemods/src/codemods/11.0.0/transform.ts
+++ b/polaris-codemods/src/codemods/11.0.0/transform.ts
@@ -8,6 +8,7 @@ import * as v11ReactUpdatePageBreadcrumbs from '../v11-react-update-page-breadcr
 import * as v11StylesReplaceCustomPropertyBorder from '../v11-styles-replace-custom-property-border/transform';
 import * as v11StylesReplaceCustomPropertyDepth from '../v11-styles-replace-custom-property-depth/transform';
 import * as v11StylesReplaceCustomPropertyLegacy from '../v11-styles-replace-custom-property-legacy/transform';
+import * as v11StylesReplaceCustomPropertyMotion from '../v11-styles-replace-custom-property-motion/transform';
 import * as v11StylesReplaceCustomPropertyZIndex from '../v11-styles-replace-custom-property-z-index/transform';
 
 const transforms = [
@@ -15,6 +16,7 @@ const transforms = [
   v11StylesReplaceCustomPropertyBorder,
   v11StylesReplaceCustomPropertyDepth,
   v11StylesReplaceCustomPropertyLegacy,
+  v11StylesReplaceCustomPropertyMotion,
   v11StylesReplaceCustomPropertyZIndex,
 ];
 
@@ -41,6 +43,7 @@ export const extensions = Array.from(
     ...v11StylesReplaceCustomPropertyBorder.extensions,
     ...v11StylesReplaceCustomPropertyDepth.extensions,
     ...v11StylesReplaceCustomPropertyLegacy.extensions,
+    ...v11StylesReplaceCustomPropertyMotion.extensions,
     ...v11StylesReplaceCustomPropertyZIndex.extensions,
   ]),
 );

--- a/polaris-codemods/src/codemods/11.0.0/transform.ts
+++ b/polaris-codemods/src/codemods/11.0.0/transform.ts
@@ -6,6 +6,7 @@ import {scss, typescript} from '../../utilities/constants';
 import type {TransformInfoOptions} from '../../utilities/types';
 import * as v11ReactUpdatePageBreadcrumbs from '../v11-react-update-page-breadcrumbs/transform';
 import * as v11StylesReplaceCustomPropertyBorder from '../v11-styles-replace-custom-property-border/transform';
+import * as v11StylesReplaceCustomPropertyColor from '../v11-styles-replace-custom-property-color/transform';
 import * as v11StylesReplaceCustomPropertyDepth from '../v11-styles-replace-custom-property-depth/transform';
 import * as v11StylesReplaceCustomPropertyLegacy from '../v11-styles-replace-custom-property-legacy/transform';
 import * as v11StylesReplaceCustomPropertyMotion from '../v11-styles-replace-custom-property-motion/transform';
@@ -14,6 +15,7 @@ import * as v11StylesReplaceCustomPropertyZIndex from '../v11-styles-replace-cus
 const transforms = [
   v11ReactUpdatePageBreadcrumbs,
   v11StylesReplaceCustomPropertyBorder,
+  v11StylesReplaceCustomPropertyColor,
   v11StylesReplaceCustomPropertyDepth,
   v11StylesReplaceCustomPropertyLegacy,
   v11StylesReplaceCustomPropertyMotion,
@@ -41,6 +43,7 @@ export const extensions = Array.from(
   new Set([
     ...v11ReactUpdatePageBreadcrumbs.extensions,
     ...v11StylesReplaceCustomPropertyBorder.extensions,
+    ...v11StylesReplaceCustomPropertyColor.extensions,
     ...v11StylesReplaceCustomPropertyDepth.extensions,
     ...v11StylesReplaceCustomPropertyLegacy.extensions,
     ...v11StylesReplaceCustomPropertyMotion.extensions,

--- a/polaris-codemods/src/codemods/v11-styles-replace-custom-property-color/tests/transform.test.ts
+++ b/polaris-codemods/src/codemods/v11-styles-replace-custom-property-color/tests/transform.test.ts
@@ -1,0 +1,12 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v11-styles-replace-custom-property-color';
+const fixtures = ['v11-styles-replace-custom-property-color'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+    extension: 'scss',
+  });
+}

--- a/polaris-codemods/src/codemods/v11-styles-replace-custom-property-color/tests/v11-styles-replace-custom-property-color.input.scss
+++ b/polaris-codemods/src/codemods/v11-styles-replace-custom-property-color/tests/v11-styles-replace-custom-property-color.input.scss
@@ -1,0 +1,16 @@
+.basic {
+  color: var(--p-text);
+  color: var(--p-interactive);
+  background: var(--p-surface);
+  background: var(--p-interactive);
+  background-color: var(--p-surface);
+  border: var(--p-border-width-1) solid var(--p-border);
+  border: var(--p-border-width-1) solid var(--p-interactive);
+  border-color: var(--p-border);
+  outline: var(--p-border-width-1) solid var(--p-border);
+  outline: var(--p-border-width-1) solid var(--p-interactive);
+  outline-color: var(--p-border);
+  fill: var(--p-icon);
+  fill: var(--p-interactive);
+  box-shadow: inset 0 0 var(--p-border-width-1) var(--p-border);
+}

--- a/polaris-codemods/src/codemods/v11-styles-replace-custom-property-color/tests/v11-styles-replace-custom-property-color.output.scss
+++ b/polaris-codemods/src/codemods/v11-styles-replace-custom-property-color/tests/v11-styles-replace-custom-property-color.output.scss
@@ -1,0 +1,16 @@
+.basic {
+  color: var(--p-color-text);
+  color: var(--p-color-text-interactive);
+  background: var(--p-color-bg);
+  background: var(--p-color-bg-interactive);
+  background-color: var(--p-color-bg);
+  border: var(--p-border-width-1) solid var(--p-color-border);
+  border: var(--p-border-width-1) solid var(--p-color-border-interactive);
+  border-color: var(--p-color-border);
+  outline: var(--p-border-width-1) solid var(--p-color-border);
+  outline: var(--p-border-width-1) solid var(--p-color-border-interactive);
+  outline-color: var(--p-color-border);
+  fill: var(--p-color-icon);
+  fill: var(--p-color-icon-interactive);
+  box-shadow: inset 0 0 var(--p-border-width-1) var(--p-color-border);
+}

--- a/polaris-codemods/src/codemods/v11-styles-replace-custom-property-color/transform.ts
+++ b/polaris-codemods/src/codemods/v11-styles-replace-custom-property-color/transform.ts
@@ -1,0 +1,211 @@
+import type {FileInfo, API} from 'jscodeshift';
+
+import stylesReplaceCustomProperty from '../styles-replace-custom-property/transform';
+import {scss} from '../../utilities/constants';
+
+export const extensions = scss.extensions;
+
+export default function transformer(fileInfo: FileInfo, _: API) {
+  return stylesReplaceCustomProperty(fileInfo, _, {replacementMaps});
+}
+
+const allMap = {
+  '--p-backdrop': 'rgba(0, 0, 0, 0.5)',
+  '--p-overlay': 'rgba(255, 255, 255, 0.5)',
+  '--p-shadow-color-picker': 'rgba(0, 0, 0, 0.5)',
+  '--p-shadow-color-picker-dragger': 'rgba(33, 43, 54, 0.32)',
+  '--p-hint-from-direct-light': 'rgba(0, 0, 0, 0.15)',
+  /**
+   * Decorative colors are being converted to hard-coded values
+   * since they are only used for Avatar.
+   */
+  '--p-decorative-one-icon': 'rgba(126, 87, 0, 1)',
+  '--p-decorative-one-surface': 'rgba(255, 201, 107, 1)',
+  '--p-decorative-one-text': 'rgba(61, 40, 0, 1)',
+  '--p-decorative-two-icon': 'rgba(175, 41, 78, 1)',
+  '--p-decorative-two-surface': 'rgba(255, 196, 176, 1)',
+  '--p-decorative-two-text': 'rgba(73, 11, 28, 1)',
+  '--p-decorative-three-icon': 'rgba(0, 109, 65, 1)',
+  '--p-decorative-three-surface': 'rgba(146, 230, 181, 1)',
+  '--p-decorative-three-text': 'rgba(0, 47, 25, 1)',
+  '--p-decorative-four-icon': 'rgba(0, 106, 104, 1)',
+  '--p-decorative-four-surface': 'rgba(145, 224, 214, 1)',
+  '--p-decorative-four-text': 'rgba(0, 45, 45, 1)',
+  '--p-decorative-five-icon': 'rgba(174, 43, 76, 1)',
+  '--p-decorative-five-surface': 'rgba(253, 201, 208, 1)',
+  '--p-decorative-five-text': 'rgba(79, 14, 31, 1)',
+
+  // Color
+  '--p-text': '--p-color-text',
+  '--p-text-on-dark': '--p-color-text-inverse',
+  '--p-text-disabled': '--p-color-text-disabled',
+  '--p-text-subdued': '--p-color-text-subdued',
+  '--p-text-subdued-on-dark': '--p-color-text-inverse-subdued',
+  '--p-text-on-interactive': '--p-color-text-on-color',
+  '--p-text-on-primary': '--p-color-text-on-color',
+  '--p-text-primary': '--p-color-text-primary',
+  '--p-text-primary-hovered': '--p-color-text-primary-hover',
+  '--p-text-primary-pressed': '--p-color-text-primary',
+  '--p-text-critical': '--p-color-text-critical',
+  '--p-text-on-critical': '--p-color-text-on-color',
+  '--p-text-warning': '--p-color-text-caution',
+  '--p-text-highlight': '--p-color-text-info',
+  '--p-text-success': '--p-color-text-success',
+  '--p-interactive-on-dark': '--p-color-text-interactive-inverse',
+  '--p-interactive-critical-disabled': '--p-color-text-disabled',
+  '--p-interactive-critical-pressed': '--p-color-text-critical-active',
+  '--p-interactive-pressed-on-dark': '--p-color-text-interactive-inverse',
+
+  // Background
+  '--p-background': '--p-color-bg-app',
+  '--p-background-hovered': '--p-color-bg-app-hover',
+  '--p-background-pressed': '--p-color-bg-app-active',
+  '--p-background-selected': '--p-color-bg-app-selected',
+  '--p-surface': '--p-color-bg',
+  '--p-surface-dark': '--p-color-bg-inverse',
+  '--p-surface-neutral': '--p-color-bg-strong',
+  '--p-surface-neutral-hovered': '--p-color-bg-strong-hover',
+  '--p-surface-neutral-pressed': '--p-color-bg-strong-active',
+  '--p-surface-neutral-disabled': '--p-color-bg-disabled',
+  '--p-surface-neutral-subdued': '--p-color-bg-subdued',
+  '--p-surface-neutral-subdued-dark': '--p-color-bg-inverse',
+  '--p-surface-subdued': '--p-color-bg-subdued',
+  '--p-surface-disabled': '--p-color-bg-disabled',
+  '--p-surface-hovered': '--p-color-bg-hover',
+  '--p-surface-hovered-dark': '--p-color-bg-inverse-hover',
+  '--p-surface-pressed': '--p-color-bg-active',
+  '--p-surface-pressed-dark': '--p-color-bg-inverse-active',
+  '--p-surface-depressed': '--p-color-bg-inset',
+  '--p-surface-search-field': '--p-color-bg-inset',
+  '--p-surface-search-field-dark': '--p-color-bg-inverse',
+  '--p-surface-selected': '--p-color-bg-interactive-selected',
+  '--p-surface-selected-hovered': '--p-color-bg-interactive-subdued-hover',
+  '--p-surface-selected-pressed': '--p-color-bg-interactive-subdued-active',
+  '--p-action-secondary': '--p-color-bg-subdued',
+  '--p-action-secondary-disabled': '--p-color-bg-disabled',
+  '--p-action-secondary-hovered': '--p-color-bg-subdued-hover',
+  '--p-action-secondary-hovered-dark': '--p-color-bg-inverse-hover',
+  '--p-action-secondary-pressed': '--p-color-bg-subdued-active',
+  '--p-action-secondary-pressed-dark': '--p-color-bg-inverse-active',
+  '--p-action-secondary-depressed': '--p-color-bg-inset-strong',
+  '--p-surface-primary-selected': '--p-color-bg-primary-subdued-selected',
+  '--p-surface-primary-selected-hovered': '--p-color-bg-primary-subdued-hover',
+  '--p-surface-primary-selected-pressed': '--p-color-bg-primary-subdued-active',
+  '--p-surface-critical': '--p-color-bg-critical',
+  '--p-surface-critical-subdued': '--p-color-bg-critical-subdued',
+  '--p-surface-critical-subdued-hovered': '--p-color-bg-critical-subdued-hover',
+  '--p-surface-critical-subdued-pressed':
+    '--p-color-bg-critical-subdued-active',
+  '--p-surface-critical-subdued-depressed': '--p-color-bg-critical',
+  '--p-action-critical': '--p-color-bg-critical-strong',
+  '--p-action-critical-hovered': '--p-color-bg-critical-strong-hover',
+  '--p-action-critical-pressed': '--p-color-bg-critical-strong-active',
+  '--p-action-critical-depressed': '--p-color-bg-critical-strong-active',
+  '--p-surface-warning': '--p-color-bg-warning',
+  '--p-surface-warning-subdued': '--p-color-bg-caution-subdued',
+  '--p-surface-warning-subdued-hovered': '--p-color-bg-caution-subdued-hover',
+  '--p-surface-warning-subdued-pressed': '--p-color-bg-caution-subdued-active',
+  '--p-surface-highlight': '--p-color-bg-info',
+  '--p-surface-highlight-subdued': '--p-color-bg-info-subdued',
+  '--p-surface-highlight-subdued-hovered': '--p-color-bg-info-subdued-hover',
+  '--p-surface-highlight-subdued-pressed': '--p-color-bg-info-subdued-active',
+  '--p-surface-success': '--p-color-bg-success',
+  '--p-surface-success-subdued': '--p-color-bg-success-subdued',
+  '--p-surface-success-subdued-hovered': '--p-color-bg-success-subdued-hover',
+  '--p-surface-success-subdued-pressed': '--p-color-bg-success-subdued-active',
+  '--p-surface-attention': '--p-color-bg-caution',
+  '--p-action-critical-disabled': '--p-color-bg-disabled',
+  '--p-action-primary-disabled': '--p-color-bg-disabled',
+  '--p-action-primary-hovered': '--p-color-bg-primary-hover',
+  '--p-action-primary-pressed': '--p-color-bg-primary-active',
+  '--p-action-primary-depressed': '--p-color-bg-primary-active',
+  '--p-interactive-critical-hovered': '--p-color-bg-critical-strong-hover',
+
+  // Border
+  '--p-border': '--p-color-border',
+  '--p-border-on-dark': '--p-color-border-inverse',
+  '--p-border-neutral-subdued': '--p-color-border-strong',
+  '--p-border-hovered': '--p-color-border-hover',
+  '--p-border-disabled': '--p-color-border-disabled',
+  '--p-border-subdued': '--p-color-border-subdued',
+  '--p-border-depressed': '--p-color-border-inverse',
+  '--p-border-shadow': '--p-color-border-input',
+  '--p-border-shadow-subdued': '--p-color-border-input',
+  '--p-divider': '--p-color-border-subdued',
+  '--p-divider-dark': '--p-color-border-inverse',
+  '--p-focused': '--p-color-border-interactive-focus',
+  '--p-border-critical': '--p-color-border-critical',
+  '--p-border-critical-subdued': '--p-color-border-critical-subdued',
+  '--p-border-critical-disabled': '--p-color-border-disabled',
+  '--p-border-warning': '--p-color-border-caution',
+  '--p-border-warning-subdued': '--p-color-border-caution-subdued',
+  '--p-border-highlight': '--p-color-border-info',
+  '--p-border-highlight-subdued': '--p-color-border-info-subdued',
+  '--p-border-success': '--p-color-border-success',
+  '--p-border-success-subdued': '--p-color-border-success-subdued',
+
+  // Fill
+  '--p-icon': '--p-color-icon',
+  '--p-icon-on-dark': '--p-color-icon-inverse',
+  '--p-icon-hovered': '--p-color-icon-hover',
+  '--p-icon-disabled': '--p-color-icon-disabled',
+  '--p-icon-subdued': '--p-color-icon-subdued',
+  '--p-icon-on-interactive': '--p-color-icon-on-color',
+  '--p-icon-on-primary': '--p-color-icon-on-color',
+  '--p-icon-critical': '--p-color-icon-critical',
+  '--p-icon-on-critical': '--p-color-icon-on-color',
+  '--p-icon-warning': '--p-color-icon-caution',
+  '--p-icon-highlight': '--p-color-icon-info',
+  '--p-icon-success': '--p-color-icon-success',
+  '--p-icon-attention': '--p-color-icon-caution',
+  '--p-icon-pressed': '--p-color-icon-active',
+};
+
+const colorMap = {
+  ...allMap,
+  '--p-interactive': '--p-color-text-interactive',
+  '--p-interactive-disabled': '--p-color-text-interactive-disabled',
+  '--p-interactive-hovered': '--p-color-text-interactive-hover',
+  '--p-interactive-pressed': '--p-color-text-interactive-active',
+  '--p-action-primary': '--p-color-text-primary',
+  '--p-interactive-critical': '--p-color-text-critical',
+};
+
+const backgroundColorMap = {
+  ...allMap,
+  '--p-interactive': '--p-color-bg-interactive',
+  '--p-interactive-disabled': '--p-color-bg-interactive-disabled',
+  '--p-interactive-hovered': '--p-color-bg-interactive-hover',
+  '--p-interactive-pressed': '--p-color-bg-interactive-active',
+  '--p-action-primary': '--p-color-bg-primary',
+  '--p-interactive-critical': '--p-color-bg-critical',
+};
+
+const borderColorMap = {
+  ...allMap,
+  '--p-interactive': '--p-color-border-interactive',
+  '--p-interactive-disabled': '--p-color-border-interactive-disabled',
+  '--p-interactive-hovered': '--p-color-border-interactive-hover',
+  '--p-interactive-pressed': '--p-color-border-interactive-active',
+  '--p-action-primary': '--p-color-border-primary',
+  '--p-interactive-critical': '--p-color-border-critical',
+};
+
+const fillColorMap = {
+  ...allMap,
+  '--p-interactive': '--p-color-icon-interactive',
+  '--p-interactive-disabled': '--p-color-icon-interactive-disabled',
+  '--p-interactive-hovered': '--p-color-icon-interactive-hover',
+  '--p-interactive-pressed': '--p-color-icon-interactive-active',
+  '--p-action-primary': '--p-color-icon-primary',
+  '--p-interactive-critical': '--p-color-icon-critical',
+};
+
+const replacementMaps = {
+  color: colorMap,
+  '/^background/': backgroundColorMap,
+  '/^border/': borderColorMap,
+  '/^outline/': borderColorMap,
+  fill: fillColorMap,
+  '/.+/': allMap,
+};

--- a/polaris-codemods/src/codemods/v11-styles-replace-custom-property-motion/tests/transform.test.ts
+++ b/polaris-codemods/src/codemods/v11-styles-replace-custom-property-motion/tests/transform.test.ts
@@ -1,0 +1,12 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v11-styles-replace-custom-property-motion';
+const fixtures = ['v11-styles-replace-custom-property-motion'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+    extension: 'scss',
+  });
+}

--- a/polaris-codemods/src/codemods/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.input.scss
+++ b/polaris-codemods/src/codemods/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.input.scss
@@ -1,0 +1,25 @@
+.motion {
+  transition-timing-function: var(--p-linear);
+  transition-timing-function: var(--p-ease-in-out);
+  transition-timing-function: var(--p-ease-out);
+  transition-timing-function: var(--p-ease-in);
+  transition-timing-function: var(--p-ease);
+  transition-duration: var(--p-duration-0);
+  transition-duration: var(--p-duration-50);
+  transition-duration: var(--p-duration-100);
+  transition-duration: var(--p-duration-150);
+  transition-duration: var(--p-duration-200);
+  transition-duration: var(--p-duration-250);
+  transition-duration: var(--p-duration-300);
+  transition-duration: var(--p-duration-350);
+  transition-duration: var(--p-duration-400);
+  transition-duration: var(--p-duration-450);
+  transition-duration: var(--p-duration-500);
+  transition-duration: var(--p-duration-5000);
+  animation-name: var(--p-keyframes-bounce);
+  animation-name: var(--p-keyframes-fade-in);
+  animation-name: var(--p-keyframes-pulse);
+  animation-name: var(--p-keyframes-spin);
+  animation-name: var(--p-keyframes-appear-above);
+  animation-name: var(--p-keyframes-appear-below);
+}

--- a/polaris-codemods/src/codemods/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.output.scss
+++ b/polaris-codemods/src/codemods/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.output.scss
@@ -1,0 +1,25 @@
+.motion {
+  transition-timing-function: var(--p-motion-linear);
+  transition-timing-function: var(--p-motion-ease-in-out);
+  transition-timing-function: var(--p-motion-ease-out);
+  transition-timing-function: var(--p-motion-ease-in);
+  transition-timing-function: var(--p-motion-ease);
+  transition-duration: var(--p-motion-duration-0);
+  transition-duration: var(--p-motion-duration-50);
+  transition-duration: var(--p-motion-duration-100);
+  transition-duration: var(--p-motion-duration-150);
+  transition-duration: var(--p-motion-duration-200);
+  transition-duration: var(--p-motion-duration-250);
+  transition-duration: var(--p-motion-duration-300);
+  transition-duration: var(--p-motion-duration-350);
+  transition-duration: var(--p-motion-duration-400);
+  transition-duration: var(--p-motion-duration-450);
+  transition-duration: var(--p-motion-duration-500);
+  transition-duration: var(--p-motion-duration-5000);
+  animation-name: var(--p-motion-keyframes-bounce);
+  animation-name: var(--p-motion-keyframes-fade-in);
+  animation-name: var(--p-motion-keyframes-pulse);
+  animation-name: var(--p-motion-keyframes-spin);
+  animation-name: var(--p-motion-keyframes-appear-above);
+  animation-name: var(--p-motion-keyframes-appear-below);
+}

--- a/polaris-codemods/src/codemods/v11-styles-replace-custom-property-motion/transform.ts
+++ b/polaris-codemods/src/codemods/v11-styles-replace-custom-property-motion/transform.ts
@@ -1,0 +1,38 @@
+import type {FileInfo, API} from 'jscodeshift';
+
+import stylesReplaceCustomProperty from '../styles-replace-custom-property/transform';
+import {scss} from '../../utilities/constants';
+
+export const extensions = scss.extensions;
+
+export default function transformer(fileInfo: FileInfo, _: API) {
+  return stylesReplaceCustomProperty(fileInfo, _, {replacementMaps});
+}
+
+const replacementMaps = {
+  '/.+/': {
+    '--p-linear': '--p-motion-linear',
+    '--p-ease-in-out': '--p-motion-ease-in-out',
+    '--p-ease-out': '--p-motion-ease-out',
+    '--p-ease-in': '--p-motion-ease-in',
+    '--p-ease': '--p-motion-ease',
+    '--p-duration-0': '--p-motion-duration-0',
+    '--p-duration-50': '--p-motion-duration-50',
+    '--p-duration-100': '--p-motion-duration-100',
+    '--p-duration-150': '--p-motion-duration-150',
+    '--p-duration-200': '--p-motion-duration-200',
+    '--p-duration-250': '--p-motion-duration-250',
+    '--p-duration-300': '--p-motion-duration-300',
+    '--p-duration-350': '--p-motion-duration-350',
+    '--p-duration-400': '--p-motion-duration-400',
+    '--p-duration-450': '--p-motion-duration-450',
+    '--p-duration-500': '--p-motion-duration-500',
+    '--p-duration-5000': '--p-motion-duration-5000',
+    '--p-keyframes-bounce': '--p-motion-keyframes-bounce',
+    '--p-keyframes-fade-in': '--p-motion-keyframes-fade-in',
+    '--p-keyframes-pulse': '--p-motion-keyframes-pulse',
+    '--p-keyframes-spin': '--p-motion-keyframes-spin',
+    '--p-keyframes-appear-above': '--p-motion-keyframes-appear-above',
+    '--p-keyframes-appear-below': '--p-motion-keyframes-appear-below',
+  },
+};

--- a/polaris-migrator/src/migrations/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.input.scss
+++ b/polaris-migrator/src/migrations/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.input.scss
@@ -1,0 +1,25 @@
+.motion {
+  transition-timing-function: var(--p-linear);
+  transition-timing-function: var(--p-ease-in-out);
+  transition-timing-function: var(--p-ease-out);
+  transition-timing-function: var(--p-ease-in);
+  transition-timing-function: var(--p-ease);
+  transition-duration: var(--p-duration-0);
+  transition-duration: var(--p-duration-50);
+  transition-duration: var(--p-duration-100);
+  transition-duration: var(--p-duration-150);
+  transition-duration: var(--p-duration-200);
+  transition-duration: var(--p-duration-250);
+  transition-duration: var(--p-duration-300);
+  transition-duration: var(--p-duration-350);
+  transition-duration: var(--p-duration-400);
+  transition-duration: var(--p-duration-450);
+  transition-duration: var(--p-duration-500);
+  transition-duration: var(--p-duration-5000);
+  animation-name: var(--p-keyframes-bounce);
+  animation-name: var(--p-keyframes-fade-in);
+  animation-name: var(--p-keyframes-pulse);
+  animation-name: var(--p-keyframes-spin);
+  animation-name: var(--p-keyframes-appear-above);
+  animation-name: var(--p-keyframes-appear-below);
+}

--- a/polaris-migrator/src/migrations/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.output.scss
+++ b/polaris-migrator/src/migrations/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.output.scss
@@ -1,0 +1,25 @@
+.motion {
+  transition-timing-function: var(--p-motion-linear);
+  transition-timing-function: var(--p-motion-ease-in-out);
+  transition-timing-function: var(--p-motion-ease-out);
+  transition-timing-function: var(--p-motion-ease-in);
+  transition-timing-function: var(--p-motion-ease);
+  transition-duration: var(--p-motion-duration-0);
+  transition-duration: var(--p-motion-duration-50);
+  transition-duration: var(--p-motion-duration-100);
+  transition-duration: var(--p-motion-duration-150);
+  transition-duration: var(--p-motion-duration-200);
+  transition-duration: var(--p-motion-duration-250);
+  transition-duration: var(--p-motion-duration-300);
+  transition-duration: var(--p-motion-duration-350);
+  transition-duration: var(--p-motion-duration-400);
+  transition-duration: var(--p-motion-duration-450);
+  transition-duration: var(--p-motion-duration-500);
+  transition-duration: var(--p-motion-duration-5000);
+  animation-name: var(--p-motion-keyframes-bounce);
+  animation-name: var(--p-motion-keyframes-fade-in);
+  animation-name: var(--p-motion-keyframes-pulse);
+  animation-name: var(--p-motion-keyframes-spin);
+  animation-name: var(--p-motion-keyframes-appear-above);
+  animation-name: var(--p-motion-keyframes-appear-below);
+}

--- a/polaris-migrator/src/migrations/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.test.ts
+++ b/polaris-migrator/src/migrations/v11-styles-replace-custom-property-motion/tests/v11-styles-replace-custom-property-motion.test.ts
@@ -1,0 +1,12 @@
+import {check} from '../../../utilities/testUtils';
+
+const migration = 'v11-styles-replace-custom-property-motion';
+const fixtures = ['v11-styles-replace-custom-property-motion'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: 'scss',
+  });
+}

--- a/polaris-migrator/src/migrations/v11-styles-replace-custom-property-motion/v11-styles-replace-custom-property-motion.ts
+++ b/polaris-migrator/src/migrations/v11-styles-replace-custom-property-motion/v11-styles-replace-custom-property-motion.ts
@@ -1,0 +1,38 @@
+import type {FileInfo, API} from 'jscodeshift';
+
+import stylesReplaceCustomProperty from '../styles-replace-custom-property/styles-replace-custom-property';
+
+const replacementMaps = {
+  '/.+/': {
+    '--p-linear': '--p-motion-linear',
+    '--p-ease-in-out': '--p-motion-ease-in-out',
+    '--p-ease-out': '--p-motion-ease-out',
+    '--p-ease-in': '--p-motion-ease-in',
+    '--p-ease': '--p-motion-ease',
+    '--p-duration-0': '--p-motion-duration-0',
+    '--p-duration-50': '--p-motion-duration-50',
+    '--p-duration-100': '--p-motion-duration-100',
+    '--p-duration-150': '--p-motion-duration-150',
+    '--p-duration-200': '--p-motion-duration-200',
+    '--p-duration-250': '--p-motion-duration-250',
+    '--p-duration-300': '--p-motion-duration-300',
+    '--p-duration-350': '--p-motion-duration-350',
+    '--p-duration-400': '--p-motion-duration-400',
+    '--p-duration-450': '--p-motion-duration-450',
+    '--p-duration-500': '--p-motion-duration-500',
+    '--p-duration-5000': '--p-motion-duration-5000',
+    '--p-keyframes-bounce': '--p-motion-keyframes-bounce',
+    '--p-keyframes-fade-in': '--p-motion-keyframes-fade-in',
+    '--p-keyframes-pulse': '--p-motion-keyframes-pulse',
+    '--p-keyframes-spin': '--p-motion-keyframes-spin',
+    '--p-keyframes-appear-above': '--p-motion-keyframes-appear-above',
+    '--p-keyframes-appear-below': '--p-motion-keyframes-appear-below',
+  },
+};
+
+export default function v11StylesReplaceCustomPropertyMotion(
+  fileInfo: FileInfo,
+  _: API,
+) {
+  return stylesReplaceCustomProperty(fileInfo, _, {replacementMaps});
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris/issues/8405

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR creates a migration and codemod for deprecated custom properties in v11 within the motion token group using the generic codemod [`styles-replace-custom-property`](https://github.com/Shopify/polaris/pull/8265). It also adds the color migration to the new codemod folder. 

#### Motion

| Deprecated Token             | Replacement Value                   |
| ---------------------------- | ----------------------------------- |
| `--p-linear`                 | `--p-motion-linear`                 |
| `--p-ease-in-out`            | `--p-motion-ease-in-out`            |
| `--p-ease-out`               | `--p-motion-ease-out`               |
| `--p-ease-in`                | `--p-motion-ease-in`                |
| `--p-ease`                   | `--p-motion-ease`                   |
| `--p-duration-0`             | `--p-motion-duration-0`             |
| `--p-duration-50`            | `--p-motion-duration-50`            |
| `--p-duration-100`           | `--p-motion-duration-100`           |
| `--p-duration-150`           | `--p-motion-duration-150`           |
| `--p-duration-200`           | `--p-motion-duration-200`           |
| `--p-duration-250`           | `--p-motion-duration-250`           |
| `--p-duration-300`           | `--p-motion-duration-300`           |
| `--p-duration-350`           | `--p-motion-duration-350`           |
| `--p-duration-400`           | `--p-motion-duration-400`           |
| `--p-duration-450`           | `--p-motion-duration-450`           |
| `--p-duration-500`           | `--p-motion-duration-500`           |
| `--p-duration-5000`          | `--p-motion-duration-5000`          |
| `--p-keyframes-bounce`       | `--p-motion-keyframes-bounce`       |
| `--p-keyframes-fade-in`      | `--p-motion-keyframes-fade-in`      |
| `--p-keyframes-pulse`        | `--p-motion-keyframes-pulse`        |
| `--p-keyframes-spin`         | `--p-motion-keyframes-spin`         |
| `--p-keyframes-appear-above` | `--p-motion-keyframes-appear-above` |
| `--p-keyframes-appear-below` | `--p-motion-keyframes-appear-below` |
