### PR TITLE
Add deprecated v10 `motion` custom properties to `stylelint-polaris`

### DIFF
--- a/.changeset/empty-crabs-worry.md
+++ b/.changeset/empty-crabs-worry.md
@@ -1,0 +1,7 @@
+---
+'@shopify/stylelint-polaris': major
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Added deprecated v10 motion custom properties to stylelint-polaris

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
@@ -22,7 +22,7 @@ const TRANSITION_DURATION = 'var(--p-motion-duration-150)';
 const TRANSITION_MARGIN = '-36px';
 
 const defaultStyle = {
-  transition: `opacity ${TRANSITION_DURATION} var(--p-ease)`,
+  transition: `opacity ${TRANSITION_DURATION} var(--p-motion-ease)`,
   opacity: 0,
 };
 
@@ -35,7 +35,7 @@ const transitionStyles = {
 };
 
 const defaultFilterStyles = {
-  transition: `opacity ${TRANSITION_DURATION} var(--p-ease), margin ${TRANSITION_DURATION} var(--p-ease)`,
+  transition: `opacity ${TRANSITION_DURATION} var(--p-motion-ease), margin ${TRANSITION_DURATION} var(--p-motion-ease)`,
   opacity: 0,
   marginTop: TRANSITION_MARGIN,
 };

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -34,7 +34,7 @@ const DEFAULT_IGNORED_TAGS = ['INPUT', 'SELECT', 'TEXTAREA'];
 const TRANSITION_DURATION = 150;
 
 const defaultStyle = {
-  transition: `opacity ${TRANSITION_DURATION}ms var(--p-ease)`,
+  transition: `opacity ${TRANSITION_DURATION}ms var(--p-motion-ease)`,
   opacity: 0,
 };
 

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-at-rule-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-at-rule-disallowed-list.md
@@ -9,7 +9,7 @@ keywords:
 
 ```diff
 // Do
-+ animation: var(--p-keyframes-spin) var(--p-duration-500) linear infinite;
++ animation: var(--p-motion-keyframes-spin) var(--p-motion-duration-500) linear infinite;
 // Don't
 - @keyframes spin {
 -  from {

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-custom-property-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-custom-property-disallowed-list.md
@@ -1,0 +1,15 @@
+---
+title: motion/custom-property-disallowed-list
+description: Disallows use of legacy motion custom properties.
+keywords:
+  - stylelint
+  - motion
+  - motion rules
+---
+
+```diff
+// Do
++ transition: var(--p-motion-duration-500) var(--p-motion-ease);
+// Don't
+- transition: var(--p-duration-500) var(--p-ease);
+```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-declaration-property-unit-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-declaration-property-unit-disallowed-list.md
@@ -9,7 +9,7 @@ keywords:
 
 ```diff
 // Do
-+ transition-duration: var(--p-duration-200);
++ transition-duration: var(--p-motion-duration-200);
 // Don't
 - transition-duration: 200ms;
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-function-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-function-disallowed-list.md
@@ -9,7 +9,7 @@ keywords:
 
 ```diff
 // Do
-+ transition-duration: var(--p-duration-200);
++ transition-duration: var(--p-motion-duration-200);
 // Don't
 - transition-duration: 200ms;
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-global-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/motion-global-disallowed-list.md
@@ -9,7 +9,7 @@ keywords:
 
 ```diff
 // Do
-+ transition: var(--p-duration-500) var(--p-ease);
++ transition: var(--p-motion-duration-500) var(--p-motion-ease);
 // Don't
-- duration: $skeleton-shimmer-duration var(--p-ease);
+- duration: $skeleton-shimmer-duration var(--p-motion-ease);
 ```

--- a/stylelint-polaris/index.js
+++ b/stylelint-polaris/index.js
@@ -211,6 +211,33 @@ const disallowedVarsLayout = [
   '--p-icon-size-medium',
 ];
 
+const disallowedVarsMotion = [
+  // Legacy custom properties
+  '--p-linear',
+  '--p-ease-in-out',
+  '--p-ease-out',
+  '--p-ease-in',
+  '--p-ease',
+  '--p-duration-0',
+  '--p-duration-50',
+  '--p-duration-100',
+  '--p-duration-150',
+  '--p-duration-200',
+  '--p-duration-250',
+  '--p-duration-300',
+  '--p-duration-350',
+  '--p-duration-400',
+  '--p-duration-450',
+  '--p-duration-500',
+  '--p-duration-5000',
+  '--p-keyframes-bounce',
+  '--p-keyframes-fade-in',
+  '--p-keyframes-pulse',
+  '--p-keyframes-spin',
+  '--p-keyframes-appear-above',
+  '--p-keyframes-appear-below',
+];
+
 const disallowedVarsShadow = [
   // Legacy custom properties
   '--p-button-drop-shadow',
@@ -542,6 +569,10 @@ const stylelintPolarisCoverageOptions = {
       'at-rule-disallowed-list': ['keyframes'],
       'polaris/at-rule-disallowed-list': {
         include: ['skeleton-shimmer'].map(matchNameRegExp),
+      },
+      'polaris/custom-property-disallowed-list': {
+        disallowedProperties: disallowedVarsMotion,
+        disallowedValues: {'/.+/': disallowedVarsMotion},
       },
       'polaris/global-disallowed-list': [
         // Legacy mixin map-get data


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris/issues/8419

We want to ship this as a breaking change for `stylelint-polaris` prior to the v11 release to ease our major version upgrade of Polaris v11 in web.

### WHAT is this pull request doing?

Adds legacy v10  motion custom properties to `stylelint-polaris`.
