### PR TITLE
[Prototype]- [FullscreenBar] Pass text to fullscreenbar button and default to back

### DIFF
--- a/.changeset/eight-queens-admire.md
+++ b/.changeset/eight-queens-admire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added `buttonText` prop to `FullscreenBar` to support optional text for back button

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.tsx
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.tsx
@@ -11,9 +11,15 @@ export interface FullscreenBarProps {
   onAction: () => void;
   /** Render child elements */
   children?: React.ReactNode;
+  /** Button Text */
+  buttonText?: string;
 }
 
-export function FullscreenBar({onAction, children}: FullscreenBarProps) {
+export function FullscreenBar({
+  onAction,
+  children,
+  buttonText,
+}: FullscreenBarProps) {
   const i18n = useI18n();
 
   return (
@@ -24,7 +30,7 @@ export function FullscreenBar({onAction, children}: FullscreenBarProps) {
         aria-label={i18n.translate('Polaris.FullscreenBar.accessibilityLabel')}
       >
         <Icon source={ExitMajor} />
-        {i18n.translate('Polaris.FullscreenBar.back')}
+        {buttonText ? buttonText : i18n.translate('Polaris.FullscreenBar.back')}
       </button>
       {children}
     </div>

--- a/polaris-react/src/components/FullscreenBar/tests/FullscreenBar.test.tsx
+++ b/polaris-react/src/components/FullscreenBar/tests/FullscreenBar.test.tsx
@@ -20,4 +20,13 @@ describe('<FullscreenBar />', () => {
     bar.find('button')!.trigger('onClick');
     expect(mockOnAction).toHaveBeenCalledTimes(1);
   });
+
+  it('renders a button with the given text', () => {
+    const text = 'Exit';
+    const bar = mountWithApp(
+      <FullscreenBar onAction={() => {}} buttonText={text} />,
+    );
+
+    expect(bar).toContainReactText(text);
+  });
 });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
We would like to utilize the `Back` button as an exit button, and so we would like to set the text to say `Exit`. As of this time there is no easy and clean way to do this. 

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Creating a new optional parameter called `buttonText` that sets the button text for the FullscreenBar if passed, and if not defaults back to `Back`
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
