### PR TITLE
[Layout foundations] Mark `Bleed` and `Divider` as alpha

### DIFF
--- a/polaris.shopify.com/content/components/layout-and-structure/bleed.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/bleed.md
@@ -5,8 +5,8 @@ category: Layout and structure
 keywords:
   - layout
 status:
-  value: Beta
-  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: bleed-horizontal.tsx
     title: Horizontal

--- a/polaris.shopify.com/content/components/layout-and-structure/divider.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/divider.md
@@ -7,8 +7,8 @@ keywords:
   - divider
   - border
 status:
-  value: Beta
-  message: This component is ready for wider adoption, usage is encouraged for most cases. Breaking changes are possible in minor version updates. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
 examples:
   - fileName: divider-with-border-color.tsx
     title: Color


### PR DESCRIPTION
### WHY are these changes introduced?

API changes are expected for the `Bleed` and `Divider` components.
Reverts their status from beta back to alpha.

### WHAT is this pull request doing?
<img width="1919" alt="25-42-cgs7u-dggrj" src="https://user-images.githubusercontent.com/26749317/234358956-228f0b88-74fc-405e-a1d8-1696af277344.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
