### PR TITLE
[Select] Improve spacing and types

### DIFF
--- a/.changeset/happy-adults-accept.md
+++ b/.changeset/happy-adults-accept.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Improve spacing and types on select component
+Improved spacing and types on `Select` component

--- a/.changeset/happy-adults-accept.md
+++ b/.changeset/happy-adults-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Improve spacing and types on select component

--- a/polaris-react/src/components/Select/Select.scss
+++ b/polaris-react/src/components/Select/Select.scss
@@ -74,7 +74,7 @@
 }
 
 .Prefix {
-  padding-right: var(--p-space-2);
+  padding-right: var(--p-space-1);
 }
 
 .Icon svg {

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -16,7 +16,7 @@ interface StrictOption {
   /** Machine value of the option; this is the value passed to `onChange` */
   value: string;
   /** Human-readable text for the option */
-  label: string | React.ReactNode;
+  label: React.ReactNode;
   /** Option will be visible, but not selectable */
   disabled?: boolean;
   /** Element to display to the left of the option label. Does not show in the dropdown. */

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -16,7 +16,7 @@ interface StrictOption {
   /** Machine value of the option; this is the value passed to `onChange` */
   value: string;
   /** Human-readable text for the option */
-  label: string;
+  label: string | React.ReactNode;
   /** Option will be visible, but not selectable */
   disabled?: boolean;
   /** Element to display to the left of the option label. Does not show in the dropdown. */


### PR DESCRIPTION
### WHY are these changes introduced?

There are two different changes here:

1. Set equal spacing to both size of the `prefix` when the select has an inline label.
Previously the spacing on the left side was smaller than the spacing on the right, which made the prefix look more related to the select label than to that specific option. Now both sides have equal spacing.
Before:
![](https://screenshot.click/26-54-xs84i-um2i0.png)
After:
![](https://screenshot.click/26-55-sgbwy-x2v7u.png)

2. Change type for `StrictOption.label` to allow the use of `React.ReactNode` too. 
This way we can use styled text on it
![](https://screenshot.click/26-56-ly7te-l30l0.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Spin: https://admin.web.select-changes.paqui-calabria.eu.spin.dev/store/shop1/collections/1
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';
import {EnableSelectionMinor} from '@shopify/polaris-icons';

import {Icon, Page, Select, Text} from '../src';

export function Playground() {
  const [selected, setSelected] = useState('newestUpdate');

  const handleSelectChange = useCallback(
    (value: string) => setSelected(value),
    [],
  );

  const options = [
    {
      label: 'Better spacing',
      value: 'adjustSpacing',
      prefix: <Icon source={EnableSelectionMinor} />,
    },
    {
      label: (
        <Text as="span" color="success" fontWeight="bold">
          Label as react node
        </Text>
      ),
      value: 'reactNodeLabel',
    },
  ];
  return (
    <Page title="Playground">
      <Select
        label="Sort by"
        labelInline
        options={options}
        onChange={handleSelectChange}
        value={selected}
      />
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
