### PR TITLE
[ButtonGroup] Update `ButtonGroup` documentation examples

### DIFF
--- a/.changeset/wild-walls-train.md
+++ b/.changeset/wild-walls-train.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Updated `ButtonGroup` examples to include `Pressed with segmented buttons`

--- a/polaris.shopify.com/content/components/actions/button-group.md
+++ b/polaris.shopify.com/content/components/actions/button-group.md
@@ -27,7 +27,10 @@ examples:
     description: Use to emphasize several buttons as a thematically-related set among other controls.
   - fileName: button-group-outline-with-segmented-buttons.tsx
     title: Outline with segmented buttons
-    description: Use to emphasize several buttons as a thematically-related set among other controls.
+    description: Use to emphasize several buttons as a thematically-related set against shaded or colorful backgrounds.
+  - fileName: button-group-pressed-with-segmented-buttons.tsx
+    title: Pressed with segmented buttons
+    description: Pressed buttons can be used in combination to create a toggle for other parts of the user interface.
 ---
 
 ## Best practices

--- a/polaris.shopify.com/pages/examples/button-group-default.tsx
+++ b/polaris.shopify.com/pages/examples/button-group-default.tsx
@@ -2,7 +2,7 @@ import {ButtonGroup, Button} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function ButtonGroupExample() {
+function ButtonGroupDefaultExample() {
   return (
     <ButtonGroup>
       <Button>Cancel</Button>
@@ -11,4 +11,4 @@ function ButtonGroupExample() {
   );
 }
 
-export default withPolarisExample(ButtonGroupExample);
+export default withPolarisExample(ButtonGroupDefaultExample);

--- a/polaris.shopify.com/pages/examples/button-group-outline-with-segmented-buttons.tsx
+++ b/polaris.shopify.com/pages/examples/button-group-outline-with-segmented-buttons.tsx
@@ -2,7 +2,7 @@ import {ButtonGroup, Button} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function ButtonGroupExample() {
+function ButtonGroupOutlineWithSegmentedButtonsExample() {
   return (
     <ButtonGroup segmented>
       <Button outline>Bold</Button>
@@ -12,4 +12,6 @@ function ButtonGroupExample() {
   );
 }
 
-export default withPolarisExample(ButtonGroupExample);
+export default withPolarisExample(
+  ButtonGroupOutlineWithSegmentedButtonsExample,
+);

--- a/polaris.shopify.com/pages/examples/button-group-pressed-with-segmented-buttons.tsx
+++ b/polaris.shopify.com/pages/examples/button-group-pressed-with-segmented-buttons.tsx
@@ -1,0 +1,42 @@
+import {ButtonGroup, Button} from '@shopify/polaris';
+import {useCallback, useState} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function ButtonGroupPressedWithSegmentedButtonsExample() {
+  const [activeButtonIndex, setActiveButtonIndex] = useState(0);
+
+  const handleButtonClick = useCallback(
+    (index: number) => {
+      if (activeButtonIndex === index) return;
+      setActiveButtonIndex(index);
+    },
+    [activeButtonIndex],
+  );
+
+  return (
+    <ButtonGroup segmented>
+      <Button
+        pressed={activeButtonIndex === 0}
+        onClick={() => handleButtonClick(0)}
+      >
+        Bold
+      </Button>
+      <Button
+        pressed={activeButtonIndex === 1}
+        onClick={() => handleButtonClick(1)}
+      >
+        Italic
+      </Button>
+      <Button
+        pressed={activeButtonIndex === 2}
+        onClick={() => handleButtonClick(2)}
+      >
+        Underline
+      </Button>
+    </ButtonGroup>
+  );
+}
+
+export default withPolarisExample(
+  ButtonGroupPressedWithSegmentedButtonsExample,
+);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

[ButtonGroup](https://polaris.shopify.com/components/actions/button-group) documentation was missing an example of a specific use-case that users hoping to use the `ButtonGroup` component may find helpful

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Updates `ButtonGroup` documentation to include a new button group example `Pressed With Segmented Buttons` along with updating previous example descriptions

<img width="600" alt="Screenshot" src="https://user-images.githubusercontent.com/59836805/234672879-d2cf19f0-c540-4495-b013-7faae917a257.png">


https://user-images.githubusercontent.com/6844391/234679674-daf1fbdd-02d8-4d05-8c55-02dd2f00270e.mp4



<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->