### PR TITLE
Set addition of layout rules for stylelint-polaris to major

### DIFF
--- a/.changeset/stale-tools-allow.md
+++ b/.changeset/stale-tools-allow.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/stylelint-polaris': minor
+'@shopify/stylelint-polaris': major
 ---
 
 Re-enabled layout warnings for coverage rules


### PR DESCRIPTION
We should make this a `major` since this could possibly break the CI of consuming projects where warnings aren't allowed:

```sh
stylelint --max-warnings=0
```