### PR TITLE
Fix overlapping checkbox when sticky header is present

### DIFF
--- a/.changeset/lemon-panthers-push.md
+++ b/.changeset/lemon-panthers-push.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Passed heading alignment props to sticky header. Fix overlapping checkbox when sticky header is present.

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -225,7 +225,6 @@ $loading-panel-height: 53px;
 
 .TableHeading {
   background: var(--p-color-bg-subdued);
-  z-index: var(--p-z-index-1);
   padding: var(--p-space-2) var(--p-space-4);
   text-align: left;
   font-weight: var(--p-font-weight-medium);

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -1076,10 +1076,13 @@ function IndexTableBase({
       tableHeadingRects.current && tableHeadingRects.current.length > position
         ? {minWidth: tableHeadingRects.current[position].offsetWidth}
         : undefined;
+    const headingAlignment = heading.alignment || 'start';
 
     const headingContent = renderHeadingContent(heading, index);
     const stickyHeadingClassName = classNames(
       styles.TableHeading,
+      headingAlignment === 'center' && styles['TableHeading-align-center'],
+      headingAlignment === 'end' && styles['TableHeading-align-end'],
       index === 0 && styles['StickyTableHeading-second'],
       index === 0 && !selectable && styles.unselectable,
     );


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #9026 

... and _possibly_ #9027 I am still testing, but it seems to have resolved this issue. Though, I think the real issue is that #9027 is just difficult to replicate consistently.

🔗 [Spin link](https://admin.web.sticky-index-table.sam-rose.us.spin.dev/store/shop1/products?selectedView=all)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR

- fixes overlapping checkbox when sticky header is present
- passes heading alignment props to sticky header

### Screenshots

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/11774595/235016021-a91e7890-1155-4a4b-8d40-6125e79bc224.gif" alt="before" />
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/11774595/235016017-68aa347c-08ea-41e8-80fd-4c42c6ff1169.gif" alt="after" />
</details>
