### PR TITLE
Add Stylelint quiet flag to hide warnings from CI log

### DIFF
--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -53,7 +53,7 @@
     "dev": "yarn run storybook",
     "lint": "run-p lint:*",
     "lint:js": "TIMING=1 eslint --cache .",
-    "lint:styles": "stylelint '**/*.{css,scss}'",
+    "lint:styles": "stylelint '**/*.{css,scss}' --quiet",
     "test": "jest",
     "clean": "rm -rf .turbo node_modules build build-internal",
     "start": "serve ./build-internal/storybook/static -l ${PORT:=6006}",


### PR DESCRIPTION
### WHY are these changes introduced?

The `stylelint-polaris` layout warnings are cluttering the CI console.

### WHAT is this pull request doing?

This PR adds the `--quiet` flag to the `polaris-react` lint:styles script. This hides warnings but keeps errors logged to standard out. 