### PR TITLE
Remove Turborepo command filters for CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
         run: yarn build
 
       - name: Lint
-        run: yarn lint --filter=[HEAD^1]
+        run: yarn lint
 
       - name: Type check
         run: yarn type-check
 
       - name: Test
-        run: yarn test --filter=[HEAD^1]
+        run: yarn test


### PR DESCRIPTION
### WHY are these changes introduced?

The `--filter` on our CI build, lint, and testing has left some key packages unchecked. This has resulted in some lint and build errors that we had to retroactively fix.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This removes the `--filter` for each command in our CI check.