### PR TITLE
add `inlang` to make the contribution of translations easier

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -16,7 +16,7 @@ export async function defineConfig(env) {
   };
 
   return {
-    referenceLanguage: "main",
+    referenceLanguage: "en",
     languages: await plugin.getLanguages({ ...env, pluginConfig }),
     readResources: (args) => plugin.readResources({ ...args, ...env, pluginConfig }),
     writeResources: (args) => plugin.writeResources({ ...args, ...env, pluginConfig }),

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,27 @@
+
+/**
+ * @type { import("@inlang/core/config").DefineConfig }
+ */
+export async function defineConfig(env) {
+  const plugin = await env.$import(
+    "https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@1/dist/index.js"
+  );
+
+  const { standardLintRules } = await env.$import(
+    "https://cdn.jsdelivr.net/gh/inlang/standard-lint-rules@1/dist/index.js"
+  );
+
+  const pluginConfig = {
+    pathPattern: "./polaris-react/locales/{language}.json",
+  };
+
+  return {
+    referenceLanguage: "main",
+    languages: await plugin.getLanguages({ ...env, pluginConfig }),
+    readResources: (args) => plugin.readResources({ ...args, ...env, pluginConfig }),
+    writeResources: (args) => plugin.writeResources({ ...args, ...env, pluginConfig }),
+    lint: {
+      rules: [standardLintRules()],
+    },
+  };
+}


### PR DESCRIPTION
Let me know what changes you request for merging this PR.

### Description
This pull request adds the possibility for contributors and translators to manage translations in a UI instead of files with no overhead for the maintainers.

To get a UI for translations contained in this repository, an [inlang.config.js](https://inlang.com/documentation/config) has been created at the root of the repository.

### Preview
The changes of this PR and a live instance of the editor can be previewed with the following link https://inlang.com/editor/github.com/NilsJacobsen/polaris. Note: This link should be changed to point to polars instead of NilsJacobsen after this PR has been merged.

### Limitations
**Certain actions are slow**
Inlang is running entirely on git, giving tremendous CI/CD and contribution power to localization (and potentially other verticals -> [the next git](https://www.youtube.com/watch?v=vJ3jGgCrz2I)). That means that the whole polaris repo is cloned into the browser which makes certain actions like the initial load and pushing changes slow. Those limitations will be fixed with future releases and require no input from polaris.

![pika-1680686287719-1x](https://user-images.githubusercontent.com/58360188/232016041-ec0c3da3-94a9-4492-85dd-d8478c66d945.jpeg)

### Badge
If you want to show the contributor the status of the translations, you could add a badge to your readme.
```
[![translation badge](https://inlang.com/badge?url=github.com/NilsJacobsen/polaris)](https://inlang.com/editor/github.com/NilsJacobsen/polaris?ref=badge)
```

Preview the messages on https://inlang.com/github.com/NilsJacobsen/polaris .