### PR TITLE
Use calculated snapshot to prefix release with the next calculated ver…

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,9 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
+  "snapshot": {
+    "useCalculatedVersion": true
+  },
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always"
   }


### PR DESCRIPTION
Use calculated snapshot to prefix release with the next calculated version.

See the changeset docs here for more info:
https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#usecalculatedversion-optional-boolean

I saw this configuration being used in [App Bridge here](https://github.com/Shopify/app-bridge/pull/3128#issuecomment-1529822788) and thought it would be a good thing for Polaris as well.

### Before

A snapshot would use the version `0.0.0` always when creating a new snapshot. 

`@shopify/polaris@0.0.0-snapshot-release-20230428002234`

### After

A snapshot will use the next calculated version of the package. This will make it easier to identify which version a snapshot will be associated.

```
@shopify/polaris@11.0.0-snapshot-release-20230428002234
```