### PR TITLE
[color-icon-magic] Edited the icon-magic color to use purple-500

### DIFF
--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -604,7 +604,7 @@ export const color: {
     description: '',
   },
   'color-icon-magic': {
-    value: colors.purple[600],
+    value: colors.purple[500],
     description: '',
   },
   'color-text': {


### PR DESCRIPTION
The Figma UI has the Magic Icon using Purple 500.  The code has it at Purple 600, which is showing up a tone too dark.

### WHY are these changes introduced?

The color for Magic icon should be purple-500. It is correct in the Figma UI Kit:
![image](https://user-images.githubusercontent.com/5823560/235632862-76195fd2-fa3a-415f-9356-f04a2feee5fa.png)
The token in code is referencing purple-600 and is too dark
![image](https://user-images.githubusercontent.com/5823560/235632999-51bb8b44-a0a2-461f-b176-c78aa2cac2d6.png)


### WHAT is this pull request doing?

Simply updated the token reference so `color-icon-magic` is using `colors.purple[500]`.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
