### PR TITLE
[color-icon-magic] Updated color-icon-magic to the correct shade of purple[500]

### DIFF
--- a/.changeset/bright-lamps-drive.md
+++ b/.changeset/bright-lamps-drive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Updated color-icon-magic to the correct shade of purple[500]

--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -604,7 +604,7 @@ export const color: {
     description: '',
   },
   'color-icon-magic': {
-    value: colors.purple[600],
+    value: colors.purple[500],
     description: '',
   },
   'color-text': {


### PR DESCRIPTION
### WHY are these changes introduced?

The shade of purple in the codebase was not matched to the purple in the Figma UI Kit. The UI Kit uses the correct shade of purple, purple[500].
![image](https://user-images.githubusercontent.com/5823560/235660023-5424d79b-9628-4622-839a-689bde61adfb.png)
![image](https://user-images.githubusercontent.com/5823560/235660040-8806c68d-2275-4665-8f37-0518cb208a14.png)

### WHAT is this pull request doing?

Updated the color shade reference in the code to match the UI Kit.
Changed purple[600] to purple[500] 🤗 