### PR TITLE
[IndexTable] Recalculate column widths when the sticky header is rendered

### DIFF
--- a/.changeset/four-birds-deliver.md
+++ b/.changeset/four-birds-deliver.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Recalculated IndexTable column widths when the sticky header is rendered.

--- a/.changeset/four-birds-deliver.md
+++ b/.changeset/four-birds-deliver.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Recalculated IndexTable column widths when the sticky header is rendered.
+Recalculated IndexTable sticky header column widths inside of a `useIsomorphicLayoutEffect` after the table is updated.

--- a/polaris-react/.storybook/preview.js
+++ b/polaris-react/.storybook/preview.js
@@ -57,25 +57,23 @@ function ReactRenderProfiler(Story, context) {
 
 export const globalTypes = {
   strictMode: {
-    name: 'React.StrictMode',
     defaultValue: true,
     toolbar: {
+      title: 'React.StrictMode',
       items: [
         {title: 'Disabled', value: false},
         {title: 'Enabled', value: true},
       ],
-      showName: true,
     },
   },
   profiler: {
-    name: 'React.Profiler',
     defaultValue: false,
     toolbar: {
+      title: 'React.Profiler',
       items: [
         {title: 'Disabled', value: false},
         {title: 'Enabled', value: true},
       ],
-      showName: true,
     },
   },
   ...gridOptions,

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -36,30 +36,6 @@ export function Default() {
       orders: 30,
       amountSpent: '$140',
     },
-    {
-      id: '2562',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-    {
-      id: '2564',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
   ];
   const resourceName = {
     singular: 'customer',

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -36,6 +36,30 @@ export function Default() {
       orders: 30,
       amountSpent: '$140',
     },
+    {
+      id: '2562',
+      url: '#',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+    {
+      id: '2563',
+      url: '#',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+    {
+      id: '2564',
+      url: '#',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
   ];
   const resourceName = {
     singular: 'customer',

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -5,6 +5,7 @@ import {tokens, toPx, motion} from '@shopify/polaris-tokens';
 
 import {debounce} from '../../utilities/debounce';
 import {useToggle} from '../../utilities/use-toggle';
+import {useIsomorphicLayoutEffect} from '../../utilities/use-isomorphic-layout-effect';
 import {useI18n} from '../../utilities/i18n';
 import {Badge} from '../Badge';
 import {Checkbox as PolarisCheckbox} from '../Checkbox';
@@ -450,7 +451,7 @@ function IndexTableBase({
     scrollingContainer.current = false;
   }, []);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     tableHeadings.current = getTableHeadingsBySelector(
       tableElement.current,
       '[data-index-table-heading]',
@@ -461,6 +462,7 @@ function IndexTableBase({
     );
     resizeTableHeadings();
   }, [
+    children,
     headings,
     resizeTableHeadings,
     firstStickyHeaderElement,

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -753,7 +753,7 @@ function IndexTableBase({
   const sharedMarkup = (
     <>
       <EventListener event="resize" handler={handleResize} />
-      <AfterInitialMount>{stickyHeaderMarkup}</AfterInitialMount>
+      {stickyHeaderMarkup}
     </>
   );
 

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -171,7 +171,6 @@ function IndexTableBase({
   const loadingElement = useRef<HTMLDivElement>(null);
 
   const [tableInitialized, setTableInitialized] = useState(false);
-  const [stickyHeaderInitialized, setStickyHeaderInitialized] = useState(false);
   const [stickyWrapper, setStickyWrapper] = useState<HTMLElement | null>(null);
   const [hideScrollContainer, setHideScrollContainer] =
     useState<boolean>(false);
@@ -220,15 +219,6 @@ function IndexTableBase({
       }
     },
     [tableInitialized],
-  );
-
-  const stickyHeaderRef = useCallback(
-    (node: Element | null) => {
-      if (node !== null && !stickyHeaderInitialized) {
-        setStickyHeaderInitialized(true);
-      }
-    },
-    [stickyHeaderInitialized],
   );
 
   const handleSelectAllItemsInStore = useCallback(() => {
@@ -462,12 +452,10 @@ function IndexTableBase({
     );
     resizeTableHeadings();
   }, [
-    children,
     headings,
     resizeTableHeadings,
     firstStickyHeaderElement,
     tableInitialized,
-    stickyHeaderInitialized,
   ]);
 
   useEffect(() => {
@@ -621,11 +609,7 @@ function IndexTableBase({
     ) : null;
 
   const stickyHeaderMarkup = (
-    <div
-      ref={stickyHeaderRef}
-      className={stickyTableClassNames}
-      role="presentation"
-    >
+    <div className={stickyTableClassNames} role="presentation">
       <Sticky boundingElement={stickyWrapper}>
         {(isSticky: boolean) => {
           const stickyHeaderClassNames = classNames(

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -170,6 +170,7 @@ function IndexTableBase({
   const loadingElement = useRef<HTMLDivElement>(null);
 
   const [tableInitialized, setTableInitialized] = useState(false);
+  const [stickyHeaderInitialized, setStickyHeaderInitialized] = useState(false);
   const [stickyWrapper, setStickyWrapper] = useState<HTMLElement | null>(null);
   const [hideScrollContainer, setHideScrollContainer] =
     useState<boolean>(false);
@@ -218,6 +219,15 @@ function IndexTableBase({
       }
     },
     [tableInitialized],
+  );
+
+  const stickyHeaderRef = useCallback(
+    (node: Element | null) => {
+      if (node !== null && !stickyHeaderInitialized) {
+        setStickyHeaderInitialized(true);
+      }
+    },
+    [stickyHeaderInitialized],
   );
 
   const handleSelectAllItemsInStore = useCallback(() => {
@@ -455,6 +465,7 @@ function IndexTableBase({
     resizeTableHeadings,
     firstStickyHeaderElement,
     tableInitialized,
+    stickyHeaderInitialized,
   ]);
 
   useEffect(() => {
@@ -608,7 +619,11 @@ function IndexTableBase({
     ) : null;
 
   const stickyHeaderMarkup = (
-    <div className={stickyTableClassNames} role="presentation">
+    <div
+      ref={stickyHeaderRef}
+      className={stickyTableClassNames}
+      role="presentation"
+    >
       <Sticky boundingElement={stickyWrapper}>
         {(isSticky: boolean) => {
           const stickyHeaderClassNames = classNames(

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -1086,11 +1086,6 @@ function IndexTableBase({
   }
 
   function renderStickyHeading(heading: IndexTableHeading, index: number) {
-    const position = index + 1;
-    const headingStyle =
-      tableHeadingRects.current && tableHeadingRects.current.length > position
-        ? {minWidth: tableHeadingRects.current[position].offsetWidth}
-        : undefined;
     const headingAlignment = heading.alignment || 'start';
 
     const headingContent = renderHeadingContent(heading, index);
@@ -1106,7 +1101,6 @@ function IndexTableBase({
       <div
         className={stickyHeadingClassName}
         key={getHeadingKey(heading)}
-        style={headingStyle}
         data-index-table-sticky-heading
       >
         {headingContent}


### PR DESCRIPTION
Closes #9027 

- Recalculate column widths when the sticky header is rendered
- Update Storybook toolbar config

🔗 Spin link: https://admin.web.sticky-cols.sam-rose.us.spin.dev/store/shop1/products?selectedView=all
