### PR TITLE
[Tooltip] make it open above anchor by default

### DIFF
--- a/.changeset/itchy-cheetahs-add.md
+++ b/.changeset/itchy-cheetahs-add.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Change default value of Tooltip position to `above`

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   Tooltip,
   Box,
+  HorizontalStack,
 } from '@shopify/polaris';
 
 export default {
@@ -235,31 +236,104 @@ export function WithSuffix() {
     <Box padding="16" background="bg">
       <LegacyStack>
         <ButtonGroup segmented fullWidth>
-          <Tooltip content="Bold" suffix="⌘B" activatorWrapper="div">
+          <Tooltip
+            content={
+              <HorizontalStack gap="2">
+                Bold
+                <Text as="span" variant="bodyMd" color="subdued">
+                  ⌘B
+                </Text>
+              </HorizontalStack>
+            }
+            activatorWrapper="div"
+          >
             <Button>B</Button>
           </Tooltip>
-          <Tooltip content="Italic" suffix="⌘I">
+          <Tooltip
+            content={
+              <HorizontalStack gap="2">
+                Italic
+                <Text as="span" variant="bodyMd" color="subdued">
+                  ⌘I
+                </Text>
+              </HorizontalStack>
+            }
+          >
             <Button>I</Button>
           </Tooltip>
-          <Tooltip content="Underline" suffix="⌘U">
-            <Button>U</Button>
-          </Tooltip>
-          <Tooltip content="Strikethrough" suffix="⌘S">
-            <Button>S</Button>
-          </Tooltip>
-          <Tooltip content="Bold" preferredPosition="above" suffix="⌘B">
-            <Button>B</Button>
-          </Tooltip>
-          <Tooltip content="Italic" preferredPosition="above" suffix="⌘U">
-            <Button>I</Button>
-          </Tooltip>
-          <Tooltip content="Underline" preferredPosition="above" suffix="⌘U">
+          <Tooltip
+            content={
+              <HorizontalStack gap="2">
+                Underline
+                <Text as="span" variant="bodyMd" color="subdued">
+                  ⌘U
+                </Text>
+              </HorizontalStack>
+            }
+          >
             <Button>U</Button>
           </Tooltip>
           <Tooltip
-            content="Strikethrough"
+            content={
+              <HorizontalStack gap="2">
+                Strikethrough
+                <Text as="span" variant="bodyMd" color="subdued">
+                  ⌘S
+                </Text>
+              </HorizontalStack>
+            }
+          >
+            <Button>S</Button>
+          </Tooltip>
+          <Tooltip
+            content={
+              <HorizontalStack gap="2">
+                Bold
+                <Text as="span" variant="bodyMd" color="subdued">
+                  ⌘B
+                </Text>
+              </HorizontalStack>
+            }
             preferredPosition="above"
-            suffix="⌘S"
+          >
+            <Button>B</Button>
+          </Tooltip>
+          <Tooltip
+            content={
+              <HorizontalStack gap="2">
+                Italic
+                <Text as="span" variant="bodyMd" color="subdued">
+                  ⌘I
+                </Text>
+              </HorizontalStack>
+            }
+            preferredPosition="above"
+          >
+            <Button>I</Button>
+          </Tooltip>
+          <Tooltip
+            content={
+              <HorizontalStack gap="2">
+                Underline
+                <Text as="span" variant="bodyMd" color="subdued">
+                  ⌘U
+                </Text>
+              </HorizontalStack>
+            }
+            preferredPosition="above"
+          >
+            <Button>U</Button>
+          </Tooltip>
+          <Tooltip
+            content={
+              <HorizontalStack gap="2">
+                Strikethrough
+                <Text as="span" variant="bodyMd" color="subdued">
+                  ⌘S
+                </Text>
+              </HorizontalStack>
+            }
+            preferredPosition="above"
           >
             <Button>S</Button>
           </Tooltip>
@@ -274,22 +348,22 @@ export function Alignment() {
     <Box padding="0">
       <LegacyStack>
         <ButtonGroup segmented fullWidth>
-          <Tooltip content="Content is longer than the activator" suffix="⌘B">
+          <Tooltip content="Content is longer than the activator">
             <Button>Bold</Button>
           </Tooltip>
-          <Tooltip content="Italic" suffix="⌘I">
+          <Tooltip content="Italic">
             <Button>Italic</Button>
           </Tooltip>
-          <Tooltip content="Underline" suffix="⌘U">
+          <Tooltip content="Underline">
             <Button>Activator is longer than the Tooltip</Button>
           </Tooltip>
-          <Tooltip content="Content is longer than the activator" suffix="⌘S">
+          <Tooltip content="Content is longer than the activator">
             <Button>Strikethrough</Button>
           </Tooltip>
-          <Tooltip content="Content is longer than the activator" suffix="⌘S">
+          <Tooltip content="Content is longer than the activator">
             <Button>Strikethrough</Button>
           </Tooltip>
-          <Tooltip content="Content is longer than the activator" suffix="⌘S">
+          <Tooltip content="Content is longer than the activator">
             <Button>Strikethrough</Button>
           </Tooltip>
         </ButtonGroup>

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -19,154 +19,171 @@ export default {
 
 export function Default() {
   return (
-    <Tooltip active content="This order has shipping labels.">
-      <Text variant="bodyLg" fontWeight="bold" as="span">
-        Order #1001
-      </Text>
-    </Tooltip>
+    <Box paddingBlockStart="24">
+      <Tooltip active content="This order has shipping labels.">
+        <Text variant="bodyLg" fontWeight="bold" as="span">
+          Order #1001
+        </Text>
+      </Tooltip>
+    </Box>
   );
 }
 
 export function Width() {
   return (
-    <LegacyStack spacing="extraLoose" distribution="fill">
-      <Tooltip active content="This content has the default width">
-        <LegacyStack spacing="extraTight">
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            Tooltip with
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
-            default
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            content width
-          </Text>
-          <Icon source={QuestionMarkMinor} color="base" />
-        </LegacyStack>
-      </Tooltip>
-      <Tooltip active content="This content has the wide width" width="wide">
-        <LegacyStack spacing="extraTight">
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            Tooltip with
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
-            wide
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            content width
-          </Text>
-          <Icon source={QuestionMarkMinor} color="base" />
-        </LegacyStack>
-      </Tooltip>
-    </LegacyStack>
+    <Box paddingBlockStart="24">
+      <HorizontalStack gap="8">
+        <Tooltip
+          active
+          content="This content has the default width and will break into a new line at 200px width"
+        >
+          <LegacyStack spacing="extraTight">
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              Tooltip with
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
+              default
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              content width
+            </Text>
+            <Icon source={QuestionMarkMinor} color="base" />
+          </LegacyStack>
+        </Tooltip>
+        <Tooltip
+          active
+          content="This content has the wide width and will break into a new line at 275px width"
+          width="wide"
+        >
+          <LegacyStack spacing="extraTight">
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              Tooltip with
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
+              wide
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              content width
+            </Text>
+            <Icon source={QuestionMarkMinor} color="base" />
+          </LegacyStack>
+        </Tooltip>
+      </HorizontalStack>
+    </Box>
   );
 }
 
 export function Padding() {
   return (
-    <LegacyStack spacing="extraLoose" distribution="fill">
-      <Tooltip active content="This content has default padding">
-        <LegacyStack spacing="extraTight">
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            Tooltip with
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
-            default
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            content padding
-          </Text>
-          <Icon source={QuestionMarkMinor} color="base" />
-        </LegacyStack>
-      </Tooltip>
-      <Tooltip
-        active
-        content="This content has padding of 4 (space-4 / 16px)"
-        padding="4"
-      >
-        <LegacyStack spacing="extraTight">
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            Tooltip with
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
-            4
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            content padding
-          </Text>
-          <Icon source={QuestionMarkMinor} color="base" />
-        </LegacyStack>
-      </Tooltip>
-    </LegacyStack>
+    <Box paddingBlockStart="24">
+      <HorizontalStack gap="8">
+        <Tooltip active content="This content has default padding">
+          <LegacyStack spacing="extraTight">
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              Tooltip with
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
+              default
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              content padding
+            </Text>
+            <Icon source={QuestionMarkMinor} color="base" />
+          </LegacyStack>
+        </Tooltip>
+        <Tooltip
+          active
+          content="This content has padding of 4 (space-4 / 16px)"
+          padding="4"
+        >
+          <LegacyStack spacing="extraTight">
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              Tooltip with
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
+              4
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              content padding
+            </Text>
+            <Icon source={QuestionMarkMinor} color="base" />
+          </LegacyStack>
+        </Tooltip>
+      </HorizontalStack>
+    </Box>
   );
 }
 
 export function BorderRadius() {
   return (
-    <LegacyStack spacing="extraLoose" distribution="fill">
-      <Tooltip
-        active
-        content="This content has the default (radius-1) border radius"
-      >
-        <LegacyStack spacing="extraTight">
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            Tooltip with
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
-            default
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            border radius
-          </Text>
-          <Icon source={QuestionMarkMinor} color="base" />
-        </LegacyStack>
-      </Tooltip>
-      <Tooltip
-        active
-        content="This content has a border radius of 2 (radius-2)"
-        borderRadius="2"
-      >
-        <LegacyStack spacing="extraTight">
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            Tooltip with
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
-            2
-          </Text>{' '}
-          <Text variant="bodyLg" fontWeight="medium" as="span">
-            border radius
-          </Text>
-          <Icon source={QuestionMarkMinor} color="base" />
-        </LegacyStack>
-      </Tooltip>
-    </LegacyStack>
+    <Box paddingBlockStart="24">
+      <HorizontalStack gap="8">
+        <Tooltip
+          active
+          content="This content has the default (radius-1) border radius"
+        >
+          <LegacyStack spacing="extraTight">
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              Tooltip with
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
+              default
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              border radius
+            </Text>
+            <Icon source={QuestionMarkMinor} color="base" />
+          </LegacyStack>
+        </Tooltip>
+        <Tooltip
+          active
+          content="This content has a border radius of 2 (radius-2)"
+          borderRadius="2"
+        >
+          <LegacyStack spacing="extraTight">
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              Tooltip with
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="bold" as="span" color="success">
+              2
+            </Text>{' '}
+            <Text variant="bodyLg" fontWeight="medium" as="span">
+              border radius
+            </Text>
+            <Icon source={QuestionMarkMinor} color="base" />
+          </LegacyStack>
+        </Tooltip>
+      </HorizontalStack>
+    </Box>
   );
 }
 
 export function VisibleOnlyWithChildInteraction() {
   return (
-    <div style={{width: '200px'}}>
-      <ButtonGroup segmented fullWidth>
-        <Tooltip content="Bold" dismissOnMouseOut>
-          <Button>B</Button>
-        </Tooltip>
-        <Tooltip content="Italic" dismissOnMouseOut>
-          <Button>I</Button>
-        </Tooltip>
-        <Tooltip content="Underline" dismissOnMouseOut>
-          <Button>U</Button>
-        </Tooltip>
-        <Tooltip content="Strikethrough" dismissOnMouseOut>
-          <Button>S</Button>
-        </Tooltip>
-      </ButtonGroup>
-      <TextField
-        label="Product title"
-        autoComplete="off"
-        labelHidden
-        multiline
-      />
-    </div>
+    <Box paddingBlockStart="24">
+      <div style={{width: '200px'}}>
+        <ButtonGroup segmented fullWidth>
+          <Tooltip content="Bold" dismissOnMouseOut>
+            <Button>B</Button>
+          </Tooltip>
+          <Tooltip content="Italic" dismissOnMouseOut>
+            <Button>I</Button>
+          </Tooltip>
+          <Tooltip content="Underline" dismissOnMouseOut>
+            <Button>U</Button>
+          </Tooltip>
+          <Tooltip content="Strikethrough" dismissOnMouseOut>
+            <Button>S</Button>
+          </Tooltip>
+        </ButtonGroup>
+        <TextField
+          label="Product title"
+          autoComplete="off"
+          labelHidden
+          multiline
+        />
+      </div>
+    </Box>
   );
 }
 
@@ -219,15 +236,17 @@ export function WithHoverDelay() {
 
 export function ActivatorAsDiv() {
   return (
-    <Tooltip
-      active
-      content="This tooltip is rendered as a div"
-      activatorWrapper="div"
-    >
-      <Text variant="bodyLg" fontWeight="bold" as="span">
-        Order #1001
-      </Text>
-    </Tooltip>
+    <Box paddingBlockStart="24">
+      <Tooltip
+        active
+        content="This tooltip is rendered as a div"
+        activatorWrapper="div"
+      >
+        <Text variant="bodyLg" fontWeight="bold" as="span">
+          Order #1001
+        </Text>
+      </Tooltip>
+    </Box>
   );
 }
 
@@ -294,7 +313,7 @@ export function WithSuffix() {
                 </Text>
               </HorizontalStack>
             }
-            preferredPosition="above"
+            preferredPosition="below"
           >
             <Button>B</Button>
           </Tooltip>
@@ -307,7 +326,7 @@ export function WithSuffix() {
                 </Text>
               </HorizontalStack>
             }
-            preferredPosition="above"
+            preferredPosition="below"
           >
             <Button>I</Button>
           </Tooltip>
@@ -320,7 +339,7 @@ export function WithSuffix() {
                 </Text>
               </HorizontalStack>
             }
-            preferredPosition="above"
+            preferredPosition="below"
           >
             <Button>U</Button>
           </Tooltip>
@@ -333,7 +352,7 @@ export function WithSuffix() {
                 </Text>
               </HorizontalStack>
             }
-            preferredPosition="above"
+            preferredPosition="below"
           >
             <Button>S</Button>
           </Tooltip>
@@ -345,7 +364,7 @@ export function WithSuffix() {
 
 export function Alignment() {
   return (
-    <Box padding="0">
+    <Box paddingBlockStart="24">
       <LegacyStack>
         <ButtonGroup segmented fullWidth>
           <Tooltip content="Content is longer than the activator">
@@ -374,20 +393,27 @@ export function Alignment() {
 
 export function HasUnderline() {
   return (
-    <Tooltip active content="This tooltip has an underline" hasUnderline>
-      <Text variant="bodyLg" fontWeight="bold" as="span">
-        Order #1001
-      </Text>
-    </Tooltip>
+    <Box paddingBlockStart="24">
+      <Tooltip active content="This tooltip has an underline" hasUnderline>
+        <Text variant="bodyLg" fontWeight="bold" as="span">
+          Order #1001
+        </Text>
+      </Tooltip>
+    </Box>
   );
 }
 
 export function PersistOnClick() {
   return (
-    <Tooltip content="This tooltip can be clicked to stay open" persistOnClick>
-      <Text variant="bodyLg" fontWeight="bold" as="span">
-        Order #1001
-      </Text>
-    </Tooltip>
+    <Box paddingBlockStart="24">
+      <Tooltip
+        content="This tooltip can be clicked to stay open"
+        persistOnClick
+      >
+        <Text variant="bodyLg" fontWeight="bold" as="span">
+          Order #1001
+        </Text>
+      </Tooltip>
+    </Box>
   );
 }

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -5,12 +5,12 @@ import {
   Button,
   ButtonGroup,
   Icon,
-  LegacyStack,
   TextField,
   Text,
   Tooltip,
   Box,
   HorizontalStack,
+  VerticalStack,
 } from '@shopify/polaris';
 
 export default {
@@ -37,7 +37,7 @@ export function Width() {
           active
           content="This content has the default width and will break into a new line at 200px width"
         >
-          <LegacyStack spacing="extraTight">
+          <HorizontalStack gap="1">
             <Text variant="bodyLg" fontWeight="medium" as="span">
               Tooltip with
             </Text>{' '}
@@ -48,14 +48,14 @@ export function Width() {
               content width
             </Text>
             <Icon source={QuestionMarkMinor} color="base" />
-          </LegacyStack>
+          </HorizontalStack>
         </Tooltip>
         <Tooltip
           active
           content="This content has the wide width and will break into a new line at 275px width"
           width="wide"
         >
-          <LegacyStack spacing="extraTight">
+          <HorizontalStack gap="1">
             <Text variant="bodyLg" fontWeight="medium" as="span">
               Tooltip with
             </Text>{' '}
@@ -66,7 +66,7 @@ export function Width() {
               content width
             </Text>
             <Icon source={QuestionMarkMinor} color="base" />
-          </LegacyStack>
+          </HorizontalStack>
         </Tooltip>
       </HorizontalStack>
     </Box>
@@ -78,7 +78,7 @@ export function Padding() {
     <Box paddingBlockStart="24">
       <HorizontalStack gap="8">
         <Tooltip active content="This content has default padding">
-          <LegacyStack spacing="extraTight">
+          <HorizontalStack gap="1">
             <Text variant="bodyLg" fontWeight="medium" as="span">
               Tooltip with
             </Text>{' '}
@@ -89,14 +89,14 @@ export function Padding() {
               content padding
             </Text>
             <Icon source={QuestionMarkMinor} color="base" />
-          </LegacyStack>
+          </HorizontalStack>
         </Tooltip>
         <Tooltip
           active
           content="This content has padding of 4 (space-4 / 16px)"
           padding="4"
         >
-          <LegacyStack spacing="extraTight">
+          <HorizontalStack gap="1">
             <Text variant="bodyLg" fontWeight="medium" as="span">
               Tooltip with
             </Text>{' '}
@@ -107,7 +107,7 @@ export function Padding() {
               content padding
             </Text>
             <Icon source={QuestionMarkMinor} color="base" />
-          </LegacyStack>
+          </HorizontalStack>
         </Tooltip>
       </HorizontalStack>
     </Box>
@@ -122,7 +122,7 @@ export function BorderRadius() {
           active
           content="This content has the default (radius-1) border radius"
         >
-          <LegacyStack spacing="extraTight">
+          <HorizontalStack gap="1">
             <Text variant="bodyLg" fontWeight="medium" as="span">
               Tooltip with
             </Text>{' '}
@@ -133,14 +133,14 @@ export function BorderRadius() {
               border radius
             </Text>
             <Icon source={QuestionMarkMinor} color="base" />
-          </LegacyStack>
+          </HorizontalStack>
         </Tooltip>
         <Tooltip
           active
           content="This content has a border radius of 2 (radius-2)"
           borderRadius="2"
         >
-          <LegacyStack spacing="extraTight">
+          <HorizontalStack gap="1">
             <Text variant="bodyLg" fontWeight="medium" as="span">
               Tooltip with
             </Text>{' '}
@@ -151,7 +151,7 @@ export function BorderRadius() {
               border radius
             </Text>
             <Icon source={QuestionMarkMinor} color="base" />
-          </LegacyStack>
+          </HorizontalStack>
         </Tooltip>
       </HorizontalStack>
     </Box>
@@ -189,19 +189,19 @@ export function VisibleOnlyWithChildInteraction() {
 
 export function WithHoverDelay() {
   return (
-    <LegacyStack vertical>
-      <LegacyStack vertical>
+    <VerticalStack gap="4">
+      <VerticalStack gap="2">
         <Text variant="headingMd" fontWeight="bold" as="h1">
           TEXT EXAMPLE
         </Text>
-        <LegacyStack>
+        <HorizontalStack>
           <Tooltip content="This should appear right away.">
             <Text variant="bodyMd" fontWeight="semibold" as="span">
               No delay
             </Text>
           </Tooltip>
-        </LegacyStack>
-        <LegacyStack>
+        </HorizontalStack>
+        <HorizontalStack>
           <Tooltip
             hoverDelay={1000}
             content="This should appear after 1 second."
@@ -210,27 +210,28 @@ export function WithHoverDelay() {
               1 second hover delay
             </Text>
           </Tooltip>
-        </LegacyStack>
-      </LegacyStack>
-      <LegacyStack vertical>
+        </HorizontalStack>
+      </VerticalStack>
+
+      <VerticalStack gap="2">
         <Text variant="headingMd" fontWeight="bold" as="h1">
           BUTTON EXAMPLE
         </Text>
-        <LegacyStack>
+        <HorizontalStack>
           <Tooltip content="This should appear right away.">
             <Button>No delay</Button>
           </Tooltip>
-        </LegacyStack>
-        <LegacyStack>
+        </HorizontalStack>
+        <HorizontalStack>
           <Tooltip
             hoverDelay={2000}
             content="This should appear after 2 seconds."
           >
             <Button>2 seconds hover delay</Button>
           </Tooltip>
-        </LegacyStack>
-      </LegacyStack>
-    </LegacyStack>
+        </HorizontalStack>
+      </VerticalStack>
+    </VerticalStack>
   );
 }
 
@@ -253,7 +254,7 @@ export function ActivatorAsDiv() {
 export function WithSuffix() {
   return (
     <Box padding="16" background="bg">
-      <LegacyStack>
+      <HorizontalStack>
         <ButtonGroup segmented fullWidth>
           <Tooltip
             content={
@@ -357,7 +358,7 @@ export function WithSuffix() {
             <Button>S</Button>
           </Tooltip>
         </ButtonGroup>
-      </LegacyStack>
+      </HorizontalStack>
     </Box>
   );
 }
@@ -365,7 +366,7 @@ export function WithSuffix() {
 export function Alignment() {
   return (
     <Box paddingBlockStart="24">
-      <LegacyStack>
+      <HorizontalStack>
         <ButtonGroup segmented fullWidth>
           <Tooltip content="Content is longer than the activator">
             <Button>Bold</Button>
@@ -386,7 +387,7 @@ export function Alignment() {
             <Button>Strikethrough</Button>
           </Tooltip>
         </ButtonGroup>
-      </LegacyStack>
+      </HorizontalStack>
     </Box>
   );
 }

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -29,7 +29,7 @@ export interface TooltipProps {
   dismissOnMouseOut?: TooltipOverlayProps['preventInteraction'];
   /**
    * The direction the tooltip tries to display
-   * @default 'below'
+   * @default 'above'
    */
   preferredPosition?: TooltipOverlayProps['preferredPosition'];
   /**

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -74,7 +74,7 @@ export function Tooltip({
   dismissOnMouseOut,
   active: originalActive,
   hoverDelay,
-  preferredPosition = 'below',
+  preferredPosition = 'above',
   activatorWrapper = 'span',
   accessibilityLabel,
   width = 'default',

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -28,7 +28,7 @@ export interface TooltipOverlayProps {
 export function TooltipOverlay({
   active,
   activator,
-  preferredPosition = 'below',
+  preferredPosition = 'above',
   preventInteraction,
   id,
   children,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #9092 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

The PR changes the default value of the `preferredPosition` prop in `Tooltip` and in `TooltipOverlay` from "below" to "above"

And just so it's possible to see the change in storybook, I updated the stories there to create some space for the Tooltip to be rendered above the anchor. And since I was updated it I replaced all the uses of `LegacyStack` with the new Stack components

<img width="270" alt="Screenshot 2023-05-03 at 15 12 37" src="https://user-images.githubusercontent.com/6597467/235932971-33b632a8-f78c-4f22-8eb7-eb96a88f2b65.png">
<img width="633" alt="Screenshot 2023-05-03 at 15 12 52" src="https://user-images.githubusercontent.com/6597467/235933008-0295902d-20e9-4907-9554-6878dfccc376.png">
<img width="622" alt="Screenshot 2023-05-03 at 15 13 05" src="https://user-images.githubusercontent.com/6597467/235933024-64686005-1fc0-4caa-b61c-4e3ec1ce7126.png">
<img width="438" alt="Screenshot 2023-05-03 at 15 13 47" src="https://user-images.githubusercontent.com/6597467/235933038-cd1a39cb-e000-48db-85d7-584833766eb4.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
