### PR TITLE
[PortalsManager] Support for suspense by removing breaking synchronous re-render

### DIFF
--- a/.changeset/brown-tables-attack.md
+++ b/.changeset/brown-tables-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix PortalsManager to avoid setting state synchronously during a render pass which prevented it from working properly with Suspense.

--- a/polaris-react/src/components/PortalsManager/PortalsManager.tsx
+++ b/polaris-react/src/components/PortalsManager/PortalsManager.tsx
@@ -1,7 +1,8 @@
-import React, {useMemo, useState} from 'react';
+import React, {useMemo, useRef} from 'react';
 
 import {PortalsManagerContext} from '../../utilities/portals';
 import type {PortalsContainerElement} from '../../utilities/portals';
+import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
 
 import {PortalsContainer} from './components';
 
@@ -11,19 +12,23 @@ export interface PortalsManagerProps {
 }
 
 export function PortalsManager({children, container}: PortalsManagerProps) {
-  const [portalContainerElement, setPortalContainerElement] =
-    useState<PortalsContainerElement>(null);
+  const isMounted = useIsAfterInitialMount();
+  const ref = useRef<PortalsContainerElement>(null);
 
-  const currentContainer = container ?? portalContainerElement;
-  const contextValue = useMemo(
-    () => ({container: currentContainer}),
-    [currentContainer],
-  );
+  const contextValue = useMemo(() => {
+    if (container) {
+      return {container};
+    } else if (isMounted) {
+      return {container: ref.current};
+    } else {
+      return {container: null};
+    }
+  }, [container, isMounted]);
 
   return (
     <PortalsManagerContext.Provider value={contextValue}>
       {children}
-      {container ? null : <PortalsContainer ref={setPortalContainerElement} />}
+      {container ? null : <PortalsContainer ref={ref} />}
     </PortalsManagerContext.Provider>
   );
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fix to allow  render trees that contain `<Suspense>` elements  along with Polaris's AppProvider.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

When rendering an PortalManager (by means of an AppProvider) with a component tree that includes a Suspense node we get an error that Suspense received an update before it finished hydrating.

<img width="1473" alt="image" src="https://user-images.githubusercontent.com/3004111/236004909-a8f0f2f9-e1b3-4b82-b5af-61c984bc5e85.png">

```
Error: This Suspense boundary received an update before it finished hydrating. This caused the boundary to switch to client rendering. The usual way to fix this is to wrap the original update in startTransition.
 ```

This comes from the fact that we're using a state setting function as a ref which causes a synchronous re-render during the render pass of the component. In order to avoid this, we can use a ref along with the existing "is mounted?" helper to memoize the value to the component's mounted state. When this component has finished mounting, it will trigger an effect that will then allow it to re-calculate the context value and pass down the reference to the now-mounted node.

With the fix in this PR, we no longer get the error message:

<img width="1473" alt="image" src="https://user-images.githubusercontent.com/3004111/236005602-2f27d4a9-70a1-43f0-a962-9006669c0380.png">


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

The following repo provides a reproduction of this error as of the latest v10 (and v11 beta) of Polaris: https://github.com/ryanwilsonperkin/polaris-11-suspense-appprovider-bug

And here is a branch that uses the snapshot from this PR to resolve the issue: https://github.com/ryanwilsonperkin/polaris-11-suspense-appprovider-bug/pull/2

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
