### PR TITLE
[Listbox.TextOption] & [OptionList] Adjusts colours of disabled options for better readability and a11y

### DIFF
--- a/.changeset/spicy-carrots-clap.md
+++ b/.changeset/spicy-carrots-clap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Adjusted colours of disabled `Listbox.TextOption` and `OptionList` components for better readability and a11y

--- a/polaris-react/src/components/Listbox/Listbox.stories.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.stories.tsx
@@ -349,3 +349,21 @@ export function WithSearch() {
     </LegacyCard>
   );
 }
+
+export function WithDisabledTextOption() {
+  return (
+    <LegacyCard>
+      <Listbox accessibilityLabel="Listbox with disabled item example">
+        <Listbox.Option value="UniqueValue-1">
+          <Listbox.TextOption>Item 1</Listbox.TextOption>
+        </Listbox.Option>
+        <Listbox.Option value="UniqueValue-2" disabled>
+          <Listbox.TextOption disabled>Item 2</Listbox.TextOption>
+        </Listbox.Option>
+        <Listbox.Option value="UniqueValue-3">
+          <Listbox.TextOption>Item 3</Listbox.TextOption>
+        </Listbox.Option>
+      </Listbox>
+    </LegacyCard>
+  );
+}

--- a/polaris-react/src/components/Listbox/components/TextOption/TextOption.scss
+++ b/polaris-react/src/components/Listbox/components/TextOption/TextOption.scss
@@ -51,7 +51,7 @@
   }
 
   &.disabled {
-    background-color: var(--p-color-bg-disabled);
+    background-color: transparent;
     color: var(--p-color-text-disabled);
     cursor: default;
   }

--- a/polaris-react/src/components/OptionList/OptionList.stories.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.stories.tsx
@@ -135,3 +135,24 @@ export function InAPopover() {
     </div>
   );
 }
+
+export function WithDisabledOption() {
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <LegacyCard>
+      <OptionList
+        title="Inventory Location"
+        onChange={setSelected}
+        options={[
+          {value: 'byward_market', label: 'Byward Market'},
+          {value: 'centretown', disabled: true, label: 'Centretown'},
+          {value: 'hintonburg', label: 'Hintonburg'},
+          {value: 'westboro', label: 'Westboro'},
+          {value: 'downtown', label: 'Downtown'},
+        ]}
+        selected={selected}
+      />
+    </LegacyCard>
+  );
+}

--- a/polaris-react/src/components/OptionList/components/Option/Option.scss
+++ b/polaris-react/src/components/OptionList/components/Option/Option.scss
@@ -78,7 +78,7 @@ $control-vertical-adjustment: 2px;
   }
 
   &.disabled {
-    background: var(--p-color-bg-disabled);
+    background: transparent;
     cursor: default;
     color: var(--p-color-text-disabled);
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/9096

### WHAT is this pull request doing?

Changes the background ~and color text~ of disabled `Listbox.TextOption` and `OptionList` components so they are not more relevant than regular ones and to improve contrast ratios for better a11y

From @heyjoethomas in the comments:

> I think removing the background color for the disabled state makes sense. The text color however should continue to use text-disabled token

**Final result:**

| `Listbox.TextOption` | `OptionList` |
| --- | --- |
| ![Screenshot 2023-05-08 at 10 26 56](https://user-images.githubusercontent.com/905006/236789637-ec35a259-4eb4-4ebb-8689-14328e5f951b.png) | ![Screenshot 2023-05-08 at 10 26 36](https://user-images.githubusercontent.com/905006/236789657-d723a2b9-1002-410d-8e43-a55604e78937.png) |

Here's a comparison of before/after and different options with their a11y color contrast ratios. I ended up going with both bg and text color `subdued` since it seems to better represent the disabled state and still has good contrast ratio. 

| BG | Text | UI | A11Y | 
| --- | --- | --- | --- |
| `--p-color-bg-disabled` | `--p-color-text-disabled` | **Before** ![Screenshot 2023-05-04 at 09 18 42](https://user-images.githubusercontent.com/905006/236191066-2de7b075-6ad0-4ac8-9b6e-f4de1c3d65ad.png) | ![Screenshot 2023-05-04 at 09 20 43](https://user-images.githubusercontent.com/905006/236191076-72349e2a-79ef-4da8-a6ad-b510829d12c8.png) |
| `transparent` | `--p-color-text-disabled` | **After**  ![Screenshot 2023-05-04 at 09 21 23](https://user-images.githubusercontent.com/905006/236191143-128647b6-d60f-4411-8e11-2d612fb77f10.png) | ![Screenshot 2023-05-04 at 09 21 16](https://user-images.githubusercontent.com/905006/236191155-d3f46a01-d562-415e-9ebb-cf9e6ab4d980.png) |
| `transparent` | `--p-color-text-subdued` | ![Screenshot 2023-05-04 at 09 22 47](https://user-images.githubusercontent.com/905006/236191289-3c9b2200-4483-4106-b9b8-b63d33f7faeb.png) | ![Screenshot 2023-05-04 at 09 22 56](https://user-images.githubusercontent.com/905006/236191404-cbf79ddb-b33e-4d0e-9d35-83d12772157f.png) |
| `--p-color-bg-subdued` | `--p-color-text-subdued` | ![Screenshot 2023-05-04 at 09 27 46](https://user-images.githubusercontent.com/905006/236191509-c5e01576-af4f-4413-9897-8134961a35c7.png) | ![Screenshot 2023-05-04 at 09 28 03](https://user-images.githubusercontent.com/905006/236191522-2b950c09-44e5-4771-a61c-bda94789879e.png) |

**I wonder if `disabled` values might be too prominent in other places as well and should be slightly dimmed because it feels weird to use other tokens for this 🤔** 

### How to 🎩

I've added an additional `WithDisabledTextOption` story to the `Listbox` component to check this out, but this can be tested in the playground with

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <LegacyCard>
        <Listbox accessibilityLabel="Listbox with disabled item example">
          <Listbox.Option value="UniqueValue-1">
            <Listbox.TextOption>Item 1</Listbox.TextOption>
          </Listbox.Option>
          <Listbox.Option value="UniqueValue-2" disabled>
            <Listbox.TextOption disabled>Item 2</Listbox.TextOption>
          </Listbox.Option>
          <Listbox.Option value="UniqueValue-3">
            <Listbox.TextOption>Item 3</Listbox.TextOption>
            </Listbox.Option>
        </Listbox>
      </LegacyCard>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
