### PR TITLE
[Popover] updates fullHeight styles to prevent scroll reset when popover content dimensions change

### DIFF
--- a/.changeset/silly-trainers-deny.md
+++ b/.changeset/silly-trainers-deny.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[Popover] Updates fullHeight styles to prevent scroll position reset when Popover content changes

--- a/polaris-react/src/components/Popover/Popover.scss
+++ b/polaris-react/src/components/Popover/Popover.scss
@@ -66,7 +66,7 @@ $vertical-motion-offset: -5px;
 }
 
 .Content-fullHeight {
-  max-height: none;
+  max-height: 100vh;
 }
 
 .Content-fluidContent {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [#1628](https://github.com/Shopify/merchant-communication/issues/1628)

<!--
  Context about the problem that’s being addressed.
-->

This change fixes an issue with the alerts feed where the scroll position resets to the top after the user scrolls to the bottom and the next set of alerts is queried or when a user manually toggles the read status of an individual alert.

This happens because the alerts feed's Popover passes the `fullHeight` prop, which sets the max-height value of the scrollable popover content element to `none`.  On secondary renders, the available space is recalculated by the `PositionedOverlay` component, and the `PopoverOverlay`'s renderPopover method briefly unsets the height of the scroll container as the available height is being calculated. The scroll position is lost at this point.

If `fullHeight` is not passed to the `Popover`, the scrollable element's styles are set with a max-height value of `500px`, and dynamic height calculations do not reset the scroll position.

Note: I ruled out recent Polaris changes as the root cause, and the impacted components of the alerts feed haven't been updated recently, so it's difficult to identify the what is causing this behavior. The issue is present in Chrome and Safari, and the fix from this PR fixes the issue in both browsers.

#### Before
Note the scroll bar returns to the top after each new set of alerts renders

https://user-images.githubusercontent.com/100380574/236571516-c94951df-f8a4-4646-a139-ab51e6657867.mp4

#### After

https://user-images.githubusercontent.com/100380574/236571558-8fd4804d-c17c-48d1-9f53-75a3bb97644a.mp4

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

- [ ] Navigate to the admin on [spin](https://admin.web.popover-scroll-fix.rick-caplan.us.spin.dev/store/shop1) - note this spin has [this snapshot version](https://github.com/Shopify/polaris/pull/9169#issuecomment-1536671219) of Polaris installed
- [ ] open the alerts feed and scroll down to trigger the loading of the next page
- [ ] confirm the scroll position is preserved after the next set of alerts render
- [ ] repeat until you see "No more alerts" at the bottom of the feed
- [ ] scroll to a point between the top and bottom of the feed, click on the checkmark icon of several individual alerts to change the read/unread status, and confirm the scroll position does not change

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
