### PR TITLE
[AlphaFilters] support sectioned filters

### DIFF
--- a/.changeset/loud-dancers-live.md
+++ b/.changeset/loud-dancers-live.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added support for sectioning the `filters` of `IndexFilters` and `AlphaFilters`

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.stories.tsx
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.stories.tsx
@@ -1225,3 +1225,229 @@ export function WithQueryFieldDisabled() {
     }
   }
 }
+
+export function WithAdditionalFilterSections() {
+  const [accountStatus, setAccountStatus] = useState(null);
+  const [accountId, setAccountId] = useState(null);
+  const [moneySpent, setMoneySpent] = useState(null);
+  const [taggedWith, setTaggedWith] = useState(null);
+  const [queryValue, setQueryValue] = useState(null);
+
+  const handleAccountStatusChange = useCallback(
+    (value) => setAccountStatus(value),
+    [],
+  );
+  const handleAccountIdChange = useCallback((value) => setAccountId(value), []);
+  const handleMoneySpentChange = useCallback(
+    (value) => setMoneySpent(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value) => setQueryValue(value),
+    [],
+  );
+  const handleAccountStatusRemove = useCallback(
+    () => setAccountStatus(null),
+    [],
+  );
+  const handleAccountIdRemove = useCallback(() => setAccountId(null), []);
+  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+  const handleFiltersClearAll = useCallback(() => {
+    handleAccountStatusRemove();
+    handleAccountIdRemove();
+    handleMoneySpentRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAccountStatusRemove,
+    handleAccountIdRemove,
+    handleMoneySpentRemove,
+    handleQueryValueRemove,
+    handleTaggedWithRemove,
+  ]);
+
+  const filters = [
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith || ''}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+    },
+    {
+      key: 'accountStatus',
+      label: 'Account status',
+      section: 'Account filters',
+      filter: (
+        <ChoiceList
+          title="Account status"
+          titleHidden
+          choices={[
+            {label: 'Enabled', value: 'enabled'},
+            {label: 'Not invited', value: 'not invited'},
+            {label: 'Invited', value: 'invited'},
+            {label: 'Declined', value: 'declined'},
+          ]}
+          selected={accountStatus || []}
+          onChange={handleAccountStatusChange}
+          allowMultiple
+        />
+      ),
+    },
+    {
+      key: 'accountId',
+      label: 'Account ID',
+      section: 'Account filters',
+      filter: (
+        <TextField
+          label="Account ID"
+          value={accountId || ''}
+          onChange={handleAccountIdChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+    },
+    {
+      key: 'moneySpent',
+      label: 'Money spent',
+      section: 'Money filters',
+      filter: (
+        <RangeSlider
+          label="Money spent is between"
+          labelHidden
+          value={moneySpent || [0, 500]}
+          prefix="$"
+          output
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleMoneySpentChange}
+        />
+      ),
+    },
+  ];
+
+  const appliedFilters = [];
+  if (!isEmpty(accountStatus)) {
+    const key = 'accountStatus';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountStatus),
+      onRemove: handleAccountStatusRemove,
+    });
+  }
+  if (!isEmpty(accountId)) {
+    const key = 'accountId';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountId),
+      onRemove: handleAccountIdRemove,
+    });
+  }
+  if (!isEmpty(moneySpent)) {
+    const key = 'moneySpent';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, moneySpent),
+      onRemove: handleMoneySpentRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, taggedWith),
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+
+  return (
+    <div style={{height: '568px'}}>
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <AlphaFilters
+              queryValue={queryValue || ''}
+              queryPlaceholder="Searching in all"
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleFiltersQueryChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleFiltersClearAll}
+            />
+          }
+          flushFilters
+          items={[
+            {
+              id: 341,
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: 256,
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <Text as="h3" fontWeight="bold">
+                  {name}
+                </Text>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </LegacyCard>
+    </div>
+  );
+
+  function disambiguateLabel(key, value) {
+    switch (key) {
+      case 'moneySpent':
+        return `Money spent is between $${value[0]} and $${value[1]}`;
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'accountStatus':
+        return value.map((val) => `Customer ${val}`).join(', ');
+      case 'accountId':
+        return `Account id: ${value}`;
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(value) {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}

--- a/polaris-react/src/components/AlphaFilters/tests/AlphaFilters.test.tsx
+++ b/polaris-react/src/components/AlphaFilters/tests/AlphaFilters.test.tsx
@@ -256,4 +256,69 @@ describe('<AlphaFilters />', () => {
 
     expect(wrapper.findAll(FilterPill)[1].domNode).toBeNull();
   });
+
+  it('renders filters with sections', () => {
+    const filtersWithSections = [
+      {
+        key: 'sectionfilter1',
+        label: 'SF1',
+        pinned: false,
+        filter: <div>SF1</div>,
+        section: 'Section One',
+      },
+      {
+        key: 'sectionfilter2',
+        label: 'SF2',
+        pinned: false,
+        filter: <div>SF1</div>,
+        section: 'Section Two',
+      },
+      {
+        key: 'sectionfilter3',
+        label: 'SF3',
+        pinned: false,
+        filter: <div>SF3</div>,
+        section: 'Section One',
+      },
+    ];
+
+    const wrapper = mountWithApp(
+      <AlphaFilters
+        {...defaultProps}
+        filters={[...defaultProps.filters, ...filtersWithSections]}
+      />,
+    );
+
+    wrapper.act(() => {
+      wrapper
+        .find('button', {
+          'aria-label': 'Add filter',
+        })!
+        .trigger('onClick');
+    });
+
+    expect(wrapper).toContainReactComponent(ActionList, {
+      sections: [
+        expect.objectContaining({
+          title: 'Section One',
+          items: [
+            expect.objectContaining({
+              content: filtersWithSections[0].label,
+            }),
+            expect.objectContaining({
+              content: filtersWithSections[2].label,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          title: 'Section Two',
+          items: [
+            expect.objectContaining({
+              content: filtersWithSections[1].label,
+            }),
+          ],
+        }),
+      ],
+    });
+  });
 });

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -404,4 +404,6 @@ export interface FilterInterface {
   onAction?: () => void;
   /** Suffix source */
   suffix?: React.ReactNode;
+  /** Optional section heading that this filter will go under  */
+  section?: string;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/9196
Resolves https://github.com/Shopify/custom-data-issues/issues/742

### WHAT is this pull request doing?

This pull request adds an optional `section` key to the filter interface for the `filters` prop on the `AlphaFilters` component—and therefore also to `IndexFilters` which inherits `AlphaFilters` props. This allows the filters to be organized by section, using the existing `sections` prop on `ActionList`.

![Screenshot 2023-05-11 at 12 50 09](https://github.com/Shopify/polaris/assets/22176050/0ecd6ef5-167e-4f6a-8e22-7c7ff55322a6)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

The component can be tested in the story for `AlphaFilters` under the heading "With Additional Filter Sections."

Verify:

1. Additional filter sections appear in the "Add filters" popover, separated with headings and section dividers. They should appear after the non-sectioned, unpinned filters.
2. These filters should work as usual:
  a. A selected filter should "pin" and show in a badge next to the "Add filters" button
  b. A selected filter should no longer appear in the "Add filters" popover
3. If a filter section is empty, that section should not show up at all.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
