### PR TITLE
[AlphaFilters]Add the optional onAddFilterClick callback

### DIFF
--- a/.changeset/warm-pillows-drop.md
+++ b/.changeset/warm-pillows-drop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added optional `onAddFilterClick` callback prop to the AlphaFilters component

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
@@ -102,6 +102,8 @@ export interface AlphaFiltersProps {
   /** Whether an asyncronous task is currently being run. */
   loading?: boolean;
   mountedState?: TransitionStatus;
+  /** Callback when the add filter button is clicked. */
+  onAddFilterClick?: () => void;
 }
 
 export function AlphaFilters({
@@ -124,6 +126,7 @@ export function AlphaFilters({
   loading,
   disableFilters,
   mountedState,
+  onAddFilterClick,
 }: AlphaFiltersProps) {
   const i18n = useI18n();
   const [popoverActive, setPopoverActive] = useState(false);
@@ -138,6 +141,7 @@ export function AlphaFilters({
     setPopoverActive((popoverActive) => !popoverActive);
 
   const handleAddFilterClick = () => {
+    onAddFilterClick?.();
     togglePopoverActive();
   };
   const appliedFilterKeys = appliedFilters?.map(({key}) => key);

--- a/polaris-react/src/components/AlphaFilters/tests/AlphaFilters.test.tsx
+++ b/polaris-react/src/components/AlphaFilters/tests/AlphaFilters.test.tsx
@@ -163,6 +163,23 @@ describe('<AlphaFilters />', () => {
     });
   });
 
+  it('triggers the onAddFilterClick callback when the add filter button is clicked', () => {
+    const callbackFunction = jest.fn();
+    const wrapper = mountWithApp(
+      <AlphaFilters {...defaultProps} onAddFilterClick={callbackFunction} />,
+    );
+    wrapper.act(() => {
+      wrapper
+        .find('button', {
+          'aria-label': 'Add filter',
+        })!
+        .trigger('onClick');
+    });
+
+    expect(callbackFunction).toHaveBeenCalled();
+    expect(wrapper).toContainReactComponent(ActionList);
+  });
+
   it('correctly invokes the onRemove callback when clicking on an applied filter', () => {
     const scrollSpy = jest.fn();
     HTMLElement.prototype.scroll = scrollSpy;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/Shopify/web/issues/91164

We need a callback to call a query with paginated filters choices when the `Add filter` button is clicked.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds the optional callback prop onAddFilterClick to the AlphaFilters, and conditionally calls it when present as the `Add filter` button is clicked, to be able to call a query from web.

