### PR TITLE
Widen stylelint peerDependency range to include v15

### DIFF
--- a/.changeset/few-ties-deliver.md
+++ b/.changeset/few-ties-deliver.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': patch
+---
+
+Widen stylelint peerDependency range to include v15

--- a/stylelint-polaris/package.json
+++ b/stylelint-polaris/package.json
@@ -37,7 +37,7 @@
     "@shopify/polaris-tokens": "^6.13.0"
   },
   "peerDependencies": {
-    "stylelint": "^14.15.0"
+    "stylelint": "^14.15.0 || ^15.0.0"
   },
   "jest": {
     "preset": "jest-preset-stylelint"


### PR DESCRIPTION
### WHY are these changes introduced?

Web is using stylelint v15 (released 2023-02). Doing an install of stylelint-polaris in web raises a warning:

```
warning " > @shopify/stylelint-polaris@12.0.0" has incorrect peer dependency "stylelint@^14.15.0".
```

### WHAT is this pull request doing?

This PR widens the peerDependency range to allow for stylelint v15.