### PR TITLE
Tabs (formerly AlphaTabs) disabled tabs on an individual level

### DIFF
--- a/.changeset/spotty-books-wave.md
+++ b/.changeset/spotty-books-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Tabs update disabled state

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -195,7 +195,7 @@ export const Tabs = ({
           key={`${index}-${tab.id}`}
           id={tab.id}
           panelID={children ? tabPanelID : undefined}
-          disabled={disabled}
+          disabled={disabled || tab.disabled}
           siblingTabHasFocus={tabToFocus > -1}
           focused={index === tabToFocus}
           selected={index === selected}


### PR DESCRIPTION
### WHY are these changes introduced?

When working on https://github.com/Shopify/core-issues/issues/53313, noticed the previous **LegacyTabs** doesn't support disabled state for tabs. **Tabs** does, but the props from the individual tab are not passed to the component that actually disables it.


### WHAT is this pull request doing?

We make sure that the optional prop for the tab (with structure TabProps) for disabled state gets passed along to the markup.


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
