### PR TITLE
[Tooltip] Fix rendering when `active` prop is false

### DIFF
--- a/.changeset/giant-keys-perform.md
+++ b/.changeset/giant-keys-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Tooltip` rendering when `active` prop is false

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -418,3 +418,30 @@ export function PersistOnClick() {
     </Box>
   );
 }
+
+export function ActiveStates() {
+  return (
+    <Box paddingBlockStart="24">
+      <HorizontalStack gap="24">
+        <Tooltip content="This tooltip should never render" active={false}>
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Active false
+          </Text>
+        </Tooltip>
+        <Tooltip content="This tooltip should render on load and hover" active>
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Active true
+          </Text>
+        </Tooltip>
+        <Tooltip
+          content="This tooltip should render on hover"
+          active={undefined}
+        >
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Active undefined
+          </Text>
+        </Tooltip>
+      </HorizontalStack>
+    </Box>
+  );
+}

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -89,7 +89,7 @@ export function Tooltip({
   const WrapperComponent: any = activatorWrapper;
   const {
     value: active,
-    setTrue: handleFocus,
+    setTrue: setActiveTrue,
     setFalse: handleBlur,
   } = useToggle(Boolean(originalActive));
 
@@ -107,6 +107,12 @@ export function Tooltip({
   const [shouldAnimate, setShouldAnimate] = useState(Boolean(!originalActive));
   const hoverDelayTimeout = useRef<NodeJS.Timeout | null>(null);
   const hoverOutTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  const handleFocus = useCallback(() => {
+    if (originalActive !== false) {
+      setActiveTrue();
+    }
+  }, [originalActive, setActiveTrue]);
 
   useEffect(() => {
     const firstFocusable = activatorContainer.current

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -35,6 +35,18 @@ describe('<Tooltip />', () => {
     expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
   });
 
+  it('does not render when active is false', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" active={false}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
+      'div',
+    );
+  });
+
   it('passes preventInteraction to TooltipOverlay when dismissOnMouseOut is true', () => {
     const tooltip = mountWithApp(
       <Tooltip dismissOnMouseOut content="Inner content" active>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

While working on a PR for rendering tooltips, we came across a scenario where [we wouldn't want the tooltip to render when a popover was open](https://screenshot.click/18-32-ch9wp-z2b51.mp4).

Fixes https://github.com/Shopify/polaris/issues/3577

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR updates the `<Tooltip>` so that it takes the `active` prop value into account when determining whether or not to render the tooltip. The [following scenarios are also represented in storybook](https://screenshot.click/18-37-dfeh5-vqdks.mp4).

- If false, the tooltip will never render
- If true, the tooltip will render on initial load and hover
- If undefined, the tooltip will render on hover.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Page, Tooltip, Button} from '../src';

export function Playground() {
  const [active, setActive] = useState<boolean>(false);
  const handleClick = () => {
    setActive(!active);
  };
  return (
    <Page title="Playground">
      <Tooltip active={active} content="This order has shipping labels.">
        <Button onClick={handleClick}>
          {active ? 'Click to deactivate tooltip' : 'Click to activate tooltip'}
        </Button>
      </Tooltip>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
