### PR TITLE
Revert "[Select] Improve spacing and types"

### DIFF
--- a/.changeset/happy-adults-accept.md
+++ b/.changeset/happy-adults-accept.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris': patch
----
-
-Improved spacing and types on `Select` component

--- a/polaris-react/src/components/Select/Select.scss
+++ b/polaris-react/src/components/Select/Select.scss
@@ -74,7 +74,7 @@
 }
 
 .Prefix {
-  padding-right: var(--p-space-1);
+  padding-right: var(--p-space-2);
 }
 
 .Icon svg {

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -16,7 +16,7 @@ interface StrictOption {
   /** Machine value of the option; this is the value passed to `onChange` */
   value: string;
   /** Human-readable text for the option */
-  label: React.ReactNode;
+  label: string;
   /** Option will be visible, but not selectable */
   disabled?: boolean;
   /** Element to display to the left of the option label. Does not show in the dropdown. */


### PR DESCRIPTION
Reverts Shopify/polaris#9095 to resolve type errors in web