### PR TITLE
[Select] Revert ReactNode label support on StrictOption

### DIFF
--- a/.changeset/clever-suits-sort.md
+++ b/.changeset/clever-suits-sort.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Reverted support for `ReactNode` labels on `Select` `options`

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -16,7 +16,7 @@ interface StrictOption {
   /** Machine value of the option; this is the value passed to `onChange` */
   value: string;
   /** Human-readable text for the option */
-  label: React.ReactNode;
+  label: string;
   /** Option will be visible, but not selectable */
   disabled?: boolean;
   /** Element to display to the left of the option label. Does not show in the dropdown. */


### PR DESCRIPTION
Reverts the type change to Select option labels inv #9095 