### PR TITLE
Fix sticky header widths regression in IndexTable

### DIFF
--- a/.changeset/heavy-pumpkins-rush.md
+++ b/.changeset/heavy-pumpkins-rush.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fix regression where sticky header column widths are incorrect after bulk selection in IndexTable.
+Fixed regression where sticky header column widths were incorrectly resized after bulk selection in the `IndexTable`.

--- a/.changeset/heavy-pumpkins-rush.md
+++ b/.changeset/heavy-pumpkins-rush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix regression where sticky header column widths are incorrect after bulk selection in IndexTable.

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -739,7 +739,7 @@ function IndexTableBase({
   const sharedMarkup = (
     <>
       <EventListener event="resize" handler={handleResize} />
-      {stickyHeaderMarkup}
+      <AfterInitialMount>{stickyHeaderMarkup}</AfterInitialMount>
     </>
   );
 
@@ -1072,6 +1072,11 @@ function IndexTableBase({
   }
 
   function renderStickyHeading(heading: IndexTableHeading, index: number) {
+    const position = index + 1;
+    const headingStyle =
+      tableHeadingRects.current && tableHeadingRects.current.length > position
+        ? {minWidth: tableHeadingRects.current[position].offsetWidth}
+        : undefined;
     const headingAlignment = heading.alignment || 'start';
 
     const headingContent = renderHeadingContent(heading, index);
@@ -1087,6 +1092,7 @@ function IndexTableBase({
       <div
         className={stickyHeadingClassName}
         key={getHeadingKey(heading)}
+        style={headingStyle}
         data-index-table-sticky-heading
       >
         {headingContent}


### PR DESCRIPTION
### WHY are these changes introduced?

Related #9148 

Regression where the sticky headers on the `IndexTable` are no longer properly size after bulk selecting items.

### WHAT is this pull request doing?

Reverts changes made in #9148 that set dynamically set the sizing of the sticky headers.

### Before


https://github.com/Shopify/polaris/assets/11774595/a9fdeba6-e899-49f5-b3c5-80eda39c91a7


### After


https://github.com/Shopify/polaris/assets/11774595/db482335-9488-4ada-8b25-339454b20161


