### PR TITLE
[Page actions] Visually separate secondary actions from primary ones

### DIFF
--- a/.changeset/thin-trees-dance.md
+++ b/.changeset/thin-trees-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Reverts #8115. Makes sure that the secondary and primary actions are separated from each other.

--- a/.changeset/thin-trees-dance.md
+++ b/.changeset/thin-trees-dance.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Reverts #8115. Makes sure that the secondary and primary actions are separated from each other.
+Reverts #8115. Updated the PageActions component to make sure that the secondary and primary actions are visually separated from each other.

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -42,9 +42,11 @@ export function PageActions({
     secondaryActionsMarkup = <>{secondaryActions}</>;
   }
 
+  const distribution = secondaryActionsMarkup ? 'equalSpacing' : 'trailing';
+
   return (
     <div className={styles.PageActions}>
-      <LegacyStack distribution="trailing" spacing="tight">
+      <LegacyStack distribution={distribution} spacing="tight">
         {secondaryActionsMarkup}
         {primaryActionMarkup}
       </LegacyStack>

--- a/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
+++ b/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
@@ -18,6 +18,26 @@ describe('<PageActions />', () => {
       expect(pageActions).toContainReactComponentTimes(LegacyStack, 1);
     });
 
+    it('uses equalSpacing distribution if secondaryActions are provided', () => {
+      const mockActions = [{content: 'Delete'}];
+
+      const pageActions = mountWithApp(
+        <PageActions secondaryActions={mockActions} />,
+      );
+      const stack = pageActions.find(LegacyStack);
+      expect(stack).toHaveReactProps({
+        distribution: 'equalSpacing',
+      });
+    });
+
+    it('uses trailing distribution if secondaryActions are not provided', () => {
+      const pageActions = mountWithApp(<PageActions />);
+      const stack = pageActions.find(LegacyStack);
+      expect(stack).toHaveReactProps({
+        distribution: 'trailing',
+      });
+    });
+
     it('passes spacing tight to Stack', () => {
       const pageActions = mountWithApp(<PageActions />);
       const stack = pageActions.find(LegacyStack);


### PR DESCRIPTION
Before:

<img width="1029" alt="image" src="https://github.com/Shopify/polaris/assets/875708/ea30418e-f8b8-4862-8e3c-9e9a863e9304">

After:

<img width="1021" alt="image" src="https://github.com/Shopify/polaris/assets/875708/71dca8a0-1b3a-4e95-b44e-b59db4e4cae1">

---

This PR reverts #8115, because:

> Destructive actions are currently grouped with the primary action. It makes it easy to accidentally perform a destructive action. It could lead to users being anxious about "pressing the wrong thing".

The previous PR intentionally introduced this behaviour, but we couldn't find any context on @ouellettejordan and I agree that it's bad UX.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
