### PR TITLE
[LegacyCard] overflow clip to protect border radius

### DIFF
--- a/.changeset/wicked-turkeys-try.md
+++ b/.changeset/wicked-turkeys-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Protect border radius of `LegacyCard` with overflow clip

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -4,6 +4,7 @@
   background-color: var(--p-color-bg);
   box-shadow: var(--p-shadow-md);
   outline: var(--p-border-width-1) solid transparent;
+  overflow: clip;
 
   + .LegacyCard {
     margin-top: var(--p-space-4);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/9252

It is possible for child elements to sit on top and overflow the corners of the `LegacyCard`, which hid the border radius. This specifically addressed the use case of an IndexTable within a LegacyCard, but as seen within [Chromatic](https://shopify.chromatic.com/build?appId=5d559397bae39100201eedc1&number=17058) there were other areas that had overflow issues such as [SkeletonTabs](https://shopify.chromatic.com/test?appId=5d559397bae39100201eedc1&id=646e566ea99fb9a2fe5d19ac).

Note: It does look like the Chromatic build highlights changes that do not appear to be related to the changes within this PR.

As @nickpresta highlighted below, using `hidden` will cause issue with `position: sticky`, so this PR utilizes `clip`. This does mean that any sticky elements that are children of this card would also be clipped, but will continue to be sticky.

### WHAT is this pull request doing?

Prevents child elements of `LegacyCard` from overflowing onto the corners of the container. This insures the border radius stays in tact.

https://www.w3.org/TR/css-backgrounds-3/#corner-clipping

### How to 🎩

- [Storybook](https://storybook.web.legacy-card-overflow-clip.matt-kubej.us.spin.dev/?path=/story/all-components-legacycard--default)
- [Spin](https://admin.web.legacy-card-overflow-clip.matt-kubej.us.spin.dev/store/shop1/products/inventory?location_id=1)
- [Chromatic](https://shopify.chromatic.com/build?appId=5d559397bae39100201eedc1&number=17227)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
