### PR TITLE
[IndexFilters] Propagate the optional onAddFilterClick callback 

### DIFF
--- a/.changeset/young-yaks-poke.md
+++ b/.changeset/young-yaks-poke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added optional `onAddFilterClick` callback prop to the indexFilters component

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -64,6 +64,8 @@ export interface IndexFiltersProps
   onSortKeyChange?: (value: string) => void;
   /** Optional callback when using saved views and changing the sort direction */
   onSortDirectionChange?: (value: string) => void;
+  /** Callback when the add filter button is clicked, to be passed to AlphaFilters. */
+  onAddFilterClick?: () => void;
   /** The primary action to display  */
   primaryAction?: IndexFiltersPrimaryAction;
   /** The cancel action to display */
@@ -99,6 +101,7 @@ export function IndexFilters({
   onSort,
   onSortKeyChange,
   onSortDirectionChange,
+  onAddFilterClick,
   sortOptions,
   sortSelected,
   queryValue = '',
@@ -405,6 +408,7 @@ export function IndexFilters({
                   onQueryClear={handleClearSearch}
                   onQueryFocus={handleQueryFocus}
                   onQueryBlur={handleQueryBlur}
+                  onAddFilterClick={onAddFilterClick}
                   filters={filters}
                   appliedFilters={appliedFilters}
                   onClearAll={onClearAll}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/Shopify/web/issues/91164

<!--
  Context about the problem that’s being addressed.
-->
I recently added the callback to the `AlphaFilters` component and missed that in my use case the access to the component is only through the `IndexFilters` component, so in order to pass the callback as originally intended, I need to propagate it up to the `IndexFilters` component.


### WHAT is this pull request doing?


Adding the optional callback `onAddFilterClick` to the `IndexFilters` component and in turn passing it to `AphaFilters` if existing.
