### PR TITLE
fix appprovider stories

### DIFF
--- a/polaris-react/src/components/AppProvider/AppProvider.stories.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.stories.tsx
@@ -1,11 +1,10 @@
-import React, {useState} from 'react';
+import React from 'react';
 import type {Args, ComponentMeta} from '@storybook/react';
 import {
   AppProvider,
   Avatar,
-  Button,
   LegacyCard,
-  AlphaCard,
+  Card,
   Page,
   ResourceList,
   Text,
@@ -180,7 +179,7 @@ export const WithSummerEditionsFeature = {
   render: (_args: Args, {globals: {polarisSummerEditions2023}}) => {
     const CheckFeature = () => {
       return (
-        <AlphaCard>
+        <Card>
           <VerticalStack gap="4">
             <Text
               as="h2"
@@ -192,7 +191,7 @@ export const WithSummerEditionsFeature = {
               }`}
             </Text>
           </VerticalStack>
-        </AlphaCard>
+        </Card>
       );
     };
     return (


### PR DESCRIPTION
### WHY are these changes introduced?

AppProvider stories importing AlphaCard, conflicts with rename in latest v11-major. 

### WHAT is this pull request doing?
* Resolves this in the affected stories, by importing the correct Card component. 
* Removes unused imports `useState` and `Button` from the AppProvider.stories.tsx file 