### PR TITLE
[ActionList][Item] Add dismissOnMouseOut prop on Tooltip

### DIFF
--- a/.changeset/sharp-poets-study.md
+++ b/.changeset/sharp-poets-study.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+- Removed static tooltip on ActionList item

--- a/.changeset/sharp-poets-study.md
+++ b/.changeset/sharp-poets-study.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-- Removed static tooltip on ActionList item
+- Fixed tooltip not disappearing when mouse leaves `ActionList.Item`

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -183,6 +183,7 @@ export const TruncateText = ({children}: {children: string}) => {
       preferredPosition="above"
       hoverDelay={1000}
       content={children}
+      dismissOnMouseOut
     >
       <Text as="span" truncate>
         {children}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

Fixes https://github.com/Shopify/core-workflows/issues/930

### WHY are these changes introduced?

- Currently, when hovering over action list items, the tooltip stays on the item when moved over it. We want to dismiss it so that we can hover over the other items.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

- Adds the `dismissOnMouseOut` prop to the ActionList Item's tooltip

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

**Problem**
- [Spin URL](https://admin.web.actionlist.zakaria-warsame.us.spin.dev/store/shop1)
     - Enable `new_account_menu_and_store_switcher` beta and refresh the page
    - Click on the top bar user menu
    - Notice the problem by hovering over the truncated items' tooltip
   
**Solution**
- Go to this [Sandbox](https://codesandbox.io/s/naughty-carlos-3vr1v5?file=/App.tsx)
- Notice that `dismissOnMouseOut` will disable the static tooltip

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
