### PR TITLE
Use minor release for sub v1 packages

### DIFF
--- a/.changeset/cool-starfishes-cry.md
+++ b/.changeset/cool-starfishes-cry.md
@@ -1,7 +1,7 @@
 ---
-'@shopify/polaris-cli': major
+'@shopify/polaris-cli': minor
 '@shopify/polaris': major
-'polaris.shopify.com': major
+'polaris.shopify.com': minor
 ---
 
 Removed support for multiple versions of TypeScript with `downlevel-dts`

--- a/.changeset/quiet-toes-play.md
+++ b/.changeset/quiet-toes-play.md
@@ -1,11 +1,11 @@
 ---
-'@shopify/polaris-cli': major
-'polaris-for-vscode': major
+'@shopify/polaris-cli': minor
+'polaris-for-vscode': minor
 '@shopify/polaris-icons': major
-'@shopify/polaris-migrator': major
+'@shopify/polaris-migrator': minor
 '@shopify/polaris': major
 '@shopify/polaris-tokens': major
-'polaris.shopify.com': major
+'polaris.shopify.com': minor
 '@shopify/stylelint-polaris': major
 ---
 


### PR DESCRIPTION
We don't need to bump sub v1 packages. Some of our packages should stay below v1 for now.