### PR TITLE
Remove 'experimental' keyword from net new tokens

### DIFF
--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -163,7 +163,7 @@ export type ColorTokenName =
   | `color-${ColorBorderAlias}`
   | `color-${ColorIconAlias}`
   | `color-${ColorTextAlias}`
-  | `color-experimental-${ColorExperimentalAlias}`;
+  | `color-${ColorExperimentalAlias}`;
 
 export type ColorTokenGroup = {
   [TokenName in ColorTokenName]: string;
@@ -843,39 +843,39 @@ export const color: {
     description: '',
   },
   // Experimental tokens
-  'color-experimental-subdued-link': {
+  'color-subdued-link': {
     value: colorsExperimental.blue[12],
     description: '',
   },
-  'color-experimental-bg-input-hover': {
+  'color-bg-input-hover': {
     value: colorsExperimental.gray[3](),
     description: '',
   },
-  'color-experimental-bg-input-active': {
+  'color-bg-input-active': {
     value: colorsExperimental.gray[4](),
     description: '',
   },
-  'color-experimental-bg-transparent': {
+  'color-bg-transparent': {
     value: colorsExperimental.gray[16](),
     description: '',
   },
-  'color-experimental-bg-transparent-subdued': {
+  'color-bg-transparent-subdued': {
     value: colorsExperimental.gray[16]('0.05'),
     description: '',
   },
-  'color-experimental-bg-transparent-hover': {
+  'color-bg-transparent-hover': {
     value: colorsExperimental.gray[16]('0.05'),
     description: '',
   },
-  'color-experimental-bg-transparent-active': {
+  'color-bg-transparent-active': {
     value: colorsExperimental.gray[16]('0.07'),
     description: '',
   },
-  'color-experimental-bg-inverse-transparent-hover': {
+  'color-bg-inverse-transparent-hover': {
     value: colorsExperimental.gray[1]('0.1'),
     description: '',
   },
-  'color-experimental-bg-inverse-transparent-active': {
+  'color-bg-inverse-transparent-active': {
     value: colorsExperimental.gray[1]('0.2'),
     description: '',
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Using the real token names without the `experimental` prefix is easier and would limit cleanup find and replace later (we can just move the tokens in the `color.ts` file instead of renaming wherever its used). This might be a selfish request because I don't want to add in logic for Banners to account for conditionally adding a `experimental` prefix since I use tokens as props in a `tsx` file.

LMK if this is problematic and we actually need the `experimental` prefix!