### PR TITLE
Fix npm release conflict with 7.0.0

### DIFF
--- a/.changeset/chilly-bikes-accept.md
+++ b/.changeset/chilly-bikes-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': patch
+---
+
+Fixed npm release conflict with 7.0.0


### PR DESCRIPTION
We need to release a patch of `@shopify/polaris-icons` due to a previous issue where `7.0.0` was accidentally released to npm.