### PR TITLE
Add `experimental` to colour aliases

### DIFF
--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -68,14 +68,17 @@ export type ColorBackgroundAlias =
   | 'bg-success-subdued-active'
   | 'bg-success-subdued-hover'
   | 'bg-warning'
-  | 'experimental-bg-input-hover'
-  | 'experimental-bg-input-active'
-  | 'experimental-bg-transparent'
-  | 'experimental-bg-transparent-subdued'
-  | 'experimental-bg-transparent-hover'
-  | 'experimental-bg-transparent-active'
-  | 'experimental-bg-inverse-transparent-hover'
-  | 'experimental-bg-inverse-transparent-active';
+  | Extract<
+      ColorExperimentalAlias,
+      | 'experimental-bg-input-hover'
+      | 'experimental-bg-input-active'
+      | 'experimental-bg-transparent'
+      | 'experimental-bg-transparent-subdued'
+      | 'experimental-bg-transparent-hover'
+      | 'experimental-bg-transparent-active'
+      | 'experimental-bg-inverse-transparent-hover'
+      | 'experimental-bg-inverse-transparent-active'
+    >;
 
 export type ColorBorderAlias =
   | 'border'
@@ -153,14 +156,25 @@ export type ColorTextAlias =
   | 'text-subdued'
   | 'text-success'
   | 'text-success-strong'
-  | 'text-warning-strong'
-  | 'experimental-subdued-link';
+  | 'text-warning-strong';
+
+type ColorExperimentalAlias =
+  | 'experimental-subdued-link'
+  | 'experimental-bg-input-hover'
+  | 'experimental-bg-input-active'
+  | 'experimental-bg-transparent'
+  | 'experimental-bg-transparent-subdued'
+  | 'experimental-bg-transparent-hover'
+  | 'experimental-bg-transparent-active'
+  | 'experimental-bg-inverse-transparent-hover'
+  | 'experimental-bg-inverse-transparent-active';
 
 export type ColorTokenName =
   | `color-${ColorBackgroundAlias}`
   | `color-${ColorBorderAlias}`
   | `color-${ColorIconAlias}`
-  | `color-${ColorTextAlias}`;
+  | `color-${ColorTextAlias}`
+  | `color-${ColorExperimentalAlias}`;
 
 export type ColorTokenGroup = {
   [TokenName in ColorTokenName]: string;

--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -67,7 +67,15 @@ export type ColorBackgroundAlias =
   | 'bg-success-subdued'
   | 'bg-success-subdued-active'
   | 'bg-success-subdued-hover'
-  | 'bg-warning';
+  | 'bg-warning'
+  | 'experimental-bg-input-hover'
+  | 'experimental-bg-input-active'
+  | 'experimental-bg-transparent'
+  | 'experimental-bg-transparent-subdued'
+  | 'experimental-bg-transparent-hover'
+  | 'experimental-bg-transparent-active'
+  | 'experimental-bg-inverse-transparent-hover'
+  | 'experimental-bg-inverse-transparent-active';
 
 export type ColorBorderAlias =
   | 'border'
@@ -145,25 +153,14 @@ export type ColorTextAlias =
   | 'text-subdued'
   | 'text-success'
   | 'text-success-strong'
-  | 'text-warning-strong';
-
-type ColorExperimentalAlias =
-  | 'subdued-link'
-  | 'bg-input-hover'
-  | 'bg-input-active'
-  | 'bg-transparent'
-  | 'bg-transparent-subdued'
-  | 'bg-transparent-hover'
-  | 'bg-transparent-active'
-  | 'bg-inverse-transparent-hover'
-  | 'bg-inverse-transparent-active';
+  | 'text-warning-strong'
+  | 'experimental-subdued-link';
 
 export type ColorTokenName =
   | `color-${ColorBackgroundAlias}`
   | `color-${ColorBorderAlias}`
   | `color-${ColorIconAlias}`
-  | `color-${ColorTextAlias}`
-  | `color-experimental-${ColorExperimentalAlias}`;
+  | `color-${ColorTextAlias}`;
 
 export type ColorTokenGroup = {
   [TokenName in ColorTokenName]: string;

--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -68,17 +68,7 @@ export type ColorBackgroundAlias =
   | 'bg-success-subdued-active'
   | 'bg-success-subdued-hover'
   | 'bg-warning'
-  | Extract<
-      ColorExperimentalAlias,
-      | 'experimental-bg-input-hover'
-      | 'experimental-bg-input-active'
-      | 'experimental-bg-transparent'
-      | 'experimental-bg-transparent-subdued'
-      | 'experimental-bg-transparent-hover'
-      | 'experimental-bg-transparent-active'
-      | 'experimental-bg-inverse-transparent-hover'
-      | 'experimental-bg-inverse-transparent-active'
-    >;
+  | ColorExperimentalBackgroundAlias;
 
 export type ColorBorderAlias =
   | 'border'
@@ -158,8 +148,7 @@ export type ColorTextAlias =
   | 'text-success-strong'
   | 'text-warning-strong';
 
-type ColorExperimentalAlias =
-  | 'experimental-subdued-link'
+type ColorExperimentalBackgroundAlias =
   | 'experimental-bg-input-hover'
   | 'experimental-bg-input-active'
   | 'experimental-bg-transparent'
@@ -173,8 +162,7 @@ export type ColorTokenName =
   | `color-${ColorBackgroundAlias}`
   | `color-${ColorBorderAlias}`
   | `color-${ColorIconAlias}`
-  | `color-${ColorTextAlias}`
-  | `color-${ColorExperimentalAlias}`;
+  | `color-${ColorTextAlias}`;
 
 export type ColorTokenGroup = {
   [TokenName in ColorTokenName]: string;
@@ -854,10 +842,6 @@ export const color: {
     description: '',
   },
   // Experimental tokens
-  'color-experimental-subdued-link': {
-    value: colorsExperimental.blue[12],
-    description: '',
-  },
   'color-experimental-bg-input-hover': {
     value: colorsExperimental.gray[3](),
     description: '',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

prefixing the `experimental` keyword on the color Aliases allows us to use the experimental tokens where the Alias types are used. For example, on the [Box component](https://polaris.shopify.com/components/layout-and-structure/box) you could now use the experimental tokens as a background without type errors.

```
<Box background={'experimental-bg-input-hover'} />
```
