### PR TITLE
[TextField] Remove focus ring while disabled

### DIFF
--- a/.changeset/nervous-scissors-punch.md
+++ b/.changeset/nervous-scissors-punch.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Remove focus ring on TextField while disabled
+Removed focus styles on TextField while disabled

--- a/.changeset/nervous-scissors-punch.md
+++ b/.changeset/nervous-scissors-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Remove focus ring on TextField while disabled

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -289,7 +289,7 @@ export function TextField({
     readOnly && styles.readOnly,
     error && styles.error,
     multiline && styles.multiline,
-    focus && styles.focus,
+    focus && !disabled && styles.focus,
     borderless && styles.borderless,
   );
 


### PR DESCRIPTION
### WHY are these changes introduced?

When a text input is disabled while being focused, the `onBlur` event is not triggered, therefore the `focus` state doesn't change and keeps the focus-ring visible.

### WHAT is this pull request doing?

Previous
<img width="903" alt="disabled input with an focus ring on it" src="https://github.com/Shopify/polaris/assets/13103124/4cd16b53-d590-42a1-89be-f4d1e654f20a">

Fixed
<img width="890" alt="disabled input without the disabled ring" src="https://github.com/Shopify/polaris/assets/13103124/2984a35c-5ce9-4889-bd48-c52ffbf93350">

In case you need a use case for this, we have this scenario in search & discovery app: There's a form to introduce a list of terms, by writting each term and clicking a button or using enter. The input is disabled when you reach the max amount of terms. Therefore, when you introduce the last item and click enter, the input is disabled without being unfocused by the user, which causes the corner case and can lead to having two elements looking focused. [Video for a more clear understanding](https://screenshot.click/29-20-jb91h-t66jg.mp4)


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)


For reproduction on the `playground.tsx`

```jsx
import React, {useCallback, useState} from 'react';

import {Button, Form, Page, TextField} from '../src';

export function Playground() {
  const [value, setValue] = useState('Jaded Pixel');
  const [disabled, setDisabled] = useState(false);

  const handleChange = useCallback(
    (newValue: string) => setValue(newValue),
    [],
  );

  return (
    <Page title="Playground">
      <Form onSubmit={() => setDisabled(true)}>
        <TextField
          label="Store name"
          value={value}
          onChange={handleChange}
          autoComplete="off"
          disabled={disabled}
        />
      </Form>
      <Button onClick={() => setDisabled(false)}>Enable</Button>
    </Page>
  );
}
```


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
