### PR TITLE
Add new spacing / border tokens and aliases

### DIFF
--- a/polaris-tokens/src/token-groups/border.ts
+++ b/polaris-tokens/src/token-groups/border.ts
@@ -10,7 +10,15 @@ export type BorderRadiusScale =
   | '6'
   | 'full';
 
-export type BorderWidthScale = '1' | '2' | '3' | '4' | '5';
+export type BorderWidthScale =
+  | '075'
+  | '0_75'
+  | '1'
+  | '1_5'
+  | '2'
+  | '3'
+  | '4'
+  | '5';
 
 export type BorderTokenName =
   | `border-radius-${BorderRadiusScale}`
@@ -47,8 +55,17 @@ export const border: {
   'border-radius-full': {
     value: '9999px',
   },
+  'border-width-075': {
+    value: '0.75px',
+  },
+  'border-width-0_75': {
+    value: '0.75px',
+  },
   'border-width-1': {
     value: '1px',
+  },
+  'border-width-1_5': {
+    value: '1.5px',
   },
   'border-width-2': {
     value: '2px',

--- a/polaris-tokens/src/token-groups/border.ts
+++ b/polaris-tokens/src/token-groups/border.ts
@@ -12,7 +12,7 @@ export type BorderRadiusScale =
 
 export type BorderWidthScale = '1' | '2' | '3' | '4' | '5';
 
-export type BorderExperimentalWidthScale = '0_75' | '1_5';
+type BorderExperimentalWidthScale = '1_5';
 
 export type BorderTokenName =
   | `border-radius-${BorderRadiusScale}`
@@ -49,9 +49,6 @@ export const border: {
   },
   'border-radius-full': {
     value: '9999px',
-  },
-  'border-experimental-width-0_75': {
-    value: '0.75px',
   },
   'border-width-1': {
     value: '1px',

--- a/polaris-tokens/src/token-groups/border.ts
+++ b/polaris-tokens/src/token-groups/border.ts
@@ -12,12 +12,12 @@ export type BorderRadiusScale =
 
 export type BorderWidthScale = '1' | '2' | '3' | '4' | '5';
 
-export type BorderWidthExperimentalScale = '0_75' | '1_5';
+export type BorderExperimentalWidthScale = '0_75' | '1_5';
 
 export type BorderTokenName =
   | `border-radius-${BorderRadiusScale}`
   | `border-width-${BorderWidthScale}`
-  | `border-width-experimental-${BorderWidthExperimentalScale}`;
+  | `border-experimental-width-${BorderExperimentalWidthScale}`;
 
 export type BorderTokenGroup = {
   [TokenName in BorderTokenName]: string;
@@ -50,13 +50,13 @@ export const border: {
   'border-radius-full': {
     value: '9999px',
   },
-  'border-width-experimental-0_75': {
+  'border-experimental-width-0_75': {
     value: '0.75px',
   },
   'border-width-1': {
     value: '1px',
   },
-  'border-width-experimental-1_5': {
+  'border-experimental-width-1_5': {
     value: '1.5px',
   },
   'border-width-2': {

--- a/polaris-tokens/src/token-groups/border.ts
+++ b/polaris-tokens/src/token-groups/border.ts
@@ -10,19 +10,14 @@ export type BorderRadiusScale =
   | '6'
   | 'full';
 
-export type BorderWidthScale =
-  | '075'
-  | '0_75'
-  | '1'
-  | '1_5'
-  | '2'
-  | '3'
-  | '4'
-  | '5';
+export type BorderWidthScale = '1' | '2' | '3' | '4' | '5';
+
+export type BorderWidthExperimentalScale = '0_75' | '1_5';
 
 export type BorderTokenName =
   | `border-radius-${BorderRadiusScale}`
-  | `border-width-${BorderWidthScale}`;
+  | `border-width-${BorderWidthScale}`
+  | `border-width-experimental-${BorderWidthExperimentalScale}`;
 
 export type BorderTokenGroup = {
   [TokenName in BorderTokenName]: string;
@@ -55,16 +50,13 @@ export const border: {
   'border-radius-full': {
     value: '9999px',
   },
-  'border-width-075': {
-    value: '0.75px',
-  },
-  'border-width-0_75': {
+  'border-width-experimental-0_75': {
     value: '0.75px',
   },
   'border-width-1': {
     value: '1px',
   },
-  'border-width-1_5': {
+  'border-width-experimental-1_5': {
     value: '1.5px',
   },
   'border-width-2': {

--- a/polaris-tokens/src/token-groups/space.ts
+++ b/polaris-tokens/src/token-groups/space.ts
@@ -19,7 +19,7 @@ export type SpaceScale =
   | '28'
   | '32';
 
-export type SpaceExperimentalScale = '1_5';
+type SpaceExperimentalScale = '1_5';
 
 export type SpaceTokenName =
   | `space-${SpaceScale}`

--- a/polaris-tokens/src/token-groups/space.ts
+++ b/polaris-tokens/src/token-groups/space.ts
@@ -3,8 +3,11 @@ import type {MetadataProperties} from '../types';
 export type SpaceScale =
   | '0'
   | '025'
+  | '0_25'
   | '05'
+  | '0_5'
   | '1'
+  | '1_5'
   | '2'
   | '3'
   | '4'
@@ -34,11 +37,20 @@ export const space: {
   'space-025': {
     value: '1px',
   },
+  'space-0_25': {
+    value: '1px',
+  },
   'space-05': {
+    value: '2px',
+  },
+  'space-0_5': {
     value: '2px',
   },
   'space-1': {
     value: '4px',
+  },
+  'space-1_5': {
+    value: '6px',
   },
   'space-2': {
     value: '8px',

--- a/polaris-tokens/src/token-groups/space.ts
+++ b/polaris-tokens/src/token-groups/space.ts
@@ -3,11 +3,8 @@ import type {MetadataProperties} from '../types';
 export type SpaceScale =
   | '0'
   | '025'
-  | '0_25'
   | '05'
-  | '0_5'
   | '1'
-  | '1_5'
   | '2'
   | '3'
   | '4'
@@ -22,7 +19,11 @@ export type SpaceScale =
   | '28'
   | '32';
 
-export type SpaceTokenName = `space-${SpaceScale}`;
+export type SpaceExperimentalScale = '1_5';
+
+export type SpaceTokenName =
+  | `space-${SpaceScale}`
+  | `space-experimental-${SpaceExperimentalScale}`;
 
 export type SpaceTokenGroup = {
   [TokenName in SpaceTokenName]: string;
@@ -37,19 +38,13 @@ export const space: {
   'space-025': {
     value: '1px',
   },
-  'space-0_25': {
-    value: '1px',
-  },
   'space-05': {
-    value: '2px',
-  },
-  'space-0_5': {
     value: '2px',
   },
   'space-1': {
     value: '4px',
   },
-  'space-1_5': {
+  'space-experimental-1_5': {
     value: '6px',
   },
   'space-2': {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/70
Fixes https://github.com/Shopify/polaris-summer-editions/issues/69

Couple of options here, and I don't love this one but I figured I'd put the exploration up anyway. 

We need a value of 6px which would mean a token 1.5. Our current naming convention doesn't really support adding a decimal value that isn't zero trailing. i.e. we have space-05 representing 0.5 but space-15 would mean something completely different. 

This adds underscore aliases to decimal values that already exist and also adds a value for `space-1_5`


The other option, since this is a one off would just be to use calc() to get 6px out of the current tokens but we'll still need a decimal solution for borders
