### PR TITLE
Alphabetize translation files

### DIFF
--- a/.changeset/itchy-months-act.md
+++ b/.changeset/itchy-months-act.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Alphabetized locale files

--- a/polaris-react/locales/cs.json
+++ b/polaris-react/locales/cs.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Zavřít notifikaci"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Načítání",
       "connectedDisclosureAccessibilityLabel": "Související akce"
@@ -387,9 +390,6 @@
           "cancel": "Zrušit"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Zavřít notifikaci"
     }
   }
 }

--- a/polaris-react/locales/da.json
+++ b/polaris-react/locales/da.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Afvis meddelelse"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Indlæser",
       "connectedDisclosureAccessibilityLabel": "Relaterede handlinger"
@@ -385,9 +388,6 @@
           "cancel": "Annuller"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Afvis meddelelse"
     }
   }
 }

--- a/polaris-react/locales/de.json
+++ b/polaris-react/locales/de.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Benachrichtigung verwerfen"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Wird geladen",
       "connectedDisclosureAccessibilityLabel": "Ähnliche Aktionen"
@@ -385,9 +388,6 @@
           "cancel": "Abbrechen"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Benachrichtigung verwerfen"
     }
   }
 }

--- a/polaris-react/locales/es.json
+++ b/polaris-react/locales/es.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Descartar notificación"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Cargando",
       "connectedDisclosureAccessibilityLabel": "Acciones relacionadas"
@@ -386,9 +389,6 @@
           "cancel": "Cancelar"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Descartar notificación"
     }
   }
 }

--- a/polaris-react/locales/fi.json
+++ b/polaris-react/locales/fi.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Ohita ilmoitus"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Ladataan",
       "connectedDisclosureAccessibilityLabel": "Aiheeseen liittyvät toimenpiteet"
@@ -385,9 +388,6 @@
           "cancel": "Peruuta"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Ohita ilmoitus"
     }
   }
 }

--- a/polaris-react/locales/fr.json
+++ b/polaris-react/locales/fr.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Rejeter la notification"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Chargement en cours",
       "connectedDisclosureAccessibilityLabel": "Actions associées"
@@ -386,9 +389,6 @@
           "cancel": "Annuler"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Rejeter la notification"
     }
   }
 }

--- a/polaris-react/locales/it.json
+++ b/polaris-react/locales/it.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Elimina notifica"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Caricamento in corso",
       "connectedDisclosureAccessibilityLabel": "Azioni correlate"
@@ -386,9 +389,6 @@
           "cancel": "Annulla"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Elimina notifica"
     }
   }
 }

--- a/polaris-react/locales/ja.json
+++ b/polaris-react/locales/ja.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "通知を閉じる"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "読み込み中",
       "connectedDisclosureAccessibilityLabel": "関連したアクション"
@@ -385,9 +388,6 @@
           "cancel": "キャンセル"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "通知を閉じる"
     }
   }
 }

--- a/polaris-react/locales/ko.json
+++ b/polaris-react/locales/ko.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "알림 무시"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "로드 중",
       "connectedDisclosureAccessibilityLabel": "관련 작업"
@@ -385,9 +388,6 @@
           "cancel": "취소"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "알림 무시"
     }
   }
 }

--- a/polaris-react/locales/nb.json
+++ b/polaris-react/locales/nb.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Avvis varsel"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Laster inn",
       "connectedDisclosureAccessibilityLabel": "Relaterte handlinger"
@@ -385,9 +388,6 @@
           "cancel": "Avbryt"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Avvis varsel"
     }
   }
 }

--- a/polaris-react/locales/nl.json
+++ b/polaris-react/locales/nl.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Melding sluiten"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Laden",
       "connectedDisclosureAccessibilityLabel": "Gerelateerde acties"
@@ -385,9 +388,6 @@
           "cancel": "Annuleren"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Melding sluiten"
     }
   }
 }

--- a/polaris-react/locales/pl.json
+++ b/polaris-react/locales/pl.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Odrzuć powiadomienie"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Ładowanie",
       "connectedDisclosureAccessibilityLabel": "Powiązane czynności"
@@ -387,9 +390,6 @@
           "cancel": "Anuluj"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Odrzuć powiadomienie"
     }
   }
 }

--- a/polaris-react/locales/pt-BR.json
+++ b/polaris-react/locales/pt-BR.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Dispensar notificação"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Carregando",
       "connectedDisclosureAccessibilityLabel": "Ações relacionadas"
@@ -386,9 +389,6 @@
           "cancel": "Cancelar"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Dispensar notificação"
     }
   }
 }

--- a/polaris-react/locales/pt-PT.json
+++ b/polaris-react/locales/pt-PT.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Ignorar notificação"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "A carregar",
       "connectedDisclosureAccessibilityLabel": "Ações relacionadas"
@@ -386,9 +389,6 @@
           "cancel": "Cancelar"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Ignorar notificação"
     }
   }
 }

--- a/polaris-react/locales/sv.json
+++ b/polaris-react/locales/sv.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Avvisa avisering"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Laddar",
       "connectedDisclosureAccessibilityLabel": "Relaterade åtgärder"
@@ -385,9 +388,6 @@
           "cancel": "Avbryt"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Avvisa avisering"
     }
   }
 }

--- a/polaris-react/locales/th.json
+++ b/polaris-react/locales/th.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "ปิดการแจ้งเตือน"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "กำลังโหลด",
       "connectedDisclosureAccessibilityLabel": "การดำเนินการที่เกี่ยวข้อง"
@@ -385,9 +388,6 @@
           "cancel": "ยกเลิก"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "ปิดการแจ้งเตือน"
     }
   }
 }

--- a/polaris-react/locales/tr.json
+++ b/polaris-react/locales/tr.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} - {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Bildirimi kapat"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Yükleniyor",
       "connectedDisclosureAccessibilityLabel": "İlgili işlemler"
@@ -385,9 +388,6 @@
           "cancel": "İptal"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Bildirimi kapat"
     }
   }
 }

--- a/polaris-react/locales/vi.json
+++ b/polaris-react/locales/vi.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "Bỏ qua thông báo"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "Đang tải",
       "connectedDisclosureAccessibilityLabel": "Thao tác có liên quan"
@@ -385,9 +388,6 @@
           "cancel": "Hủy"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "Bỏ qua thông báo"
     }
   }
 }

--- a/polaris-react/locales/zh-CN.json
+++ b/polaris-react/locales/zh-CN.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "忽略通知"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "正在加载",
       "connectedDisclosureAccessibilityLabel": "相关操作"
@@ -385,9 +388,6 @@
           "cancel": "取消"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "忽略通知"
     }
   }
 }

--- a/polaris-react/locales/zh-TW.json
+++ b/polaris-react/locales/zh-TW.json
@@ -24,6 +24,9 @@
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },
+    "Banner": {
+      "dismissButton": "關閉通知"
+    },
     "Button": {
       "spinnerAccessibilityLabel": "載入中",
       "connectedDisclosureAccessibilityLabel": "相關動作"
@@ -385,9 +388,6 @@
           "cancel": "取消"
         }
       }
-    },
-    "Banner": {
-      "dismissButton": "關閉通知"
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Translation bot added `Banner` translations to end of file instead of alphabetical order. This PR moves them into order in the non `en` json files