### PR TITLE
Move `experimental` prefix to suffix

### DIFF
--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -14,7 +14,7 @@
   color: var(--p-color-text);
 
   #{$se23} & {
-    background-color: var(--p-color-experimental-bg-transparent-subdued);
+    background-color: var(--p-color-bg-transparent-subdued-experimental);
     color: var(--p-color-text-subdued);
     font-weight: var(--p-font-weight-medium);
     border-radius: var(--p-border-radius-2);
@@ -73,7 +73,7 @@
   background-color: var(--p-color-bg-warning);
 
   #{$se23} & {
-    color: var(--p-color-experimental-text-warning);
+    color: var(--p-color-text-warning-experimental);
 
     // stylelint-disable-next-line -- se23 svg fill override
     svg {

--- a/polaris-react/src/components/Banner/Banner.scss
+++ b/polaris-react/src/components/Banner/Banner.scss
@@ -18,7 +18,7 @@
     }
 
     #{$se23} & {
-      box-shadow: var(--p-shadow-experimental-card-md);
+      box-shadow: var(--p-shadow-card-md-experimental);
     }
   } @else {
     border-radius: var(--p-border-radius-1);

--- a/polaris-react/src/components/Banner/components/BannerExperimental/utilities.ts
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/utilities.ts
@@ -47,19 +47,19 @@ const colorsByStatus: {[key in BannerStatus]: BannerColors} = {
     withinContentContainer: {
       background: 'bg-success-subdued',
       text: 'text-success',
-      icon: 'experimental-icon-success-strong',
+      icon: 'icon-success-strong-experimental',
     },
   },
   warning: {
     withinPage: {
-      background: 'experimental-bg-warning-strong',
+      background: 'bg-warning-strong-experimental',
       text: 'text-warning-strong',
       icon: 'text-warning-strong',
     },
     withinContentContainer: {
-      background: 'experimental-bg-warning-subdued',
-      text: 'experimental-text-warning',
-      icon: 'experimental-icon-warning-strong',
+      background: 'bg-warning-subdued-experimental',
+      text: 'text-warning-experimental',
+      icon: 'icon-warning-strong-experimental',
     },
   },
   critical: {
@@ -71,7 +71,7 @@ const colorsByStatus: {[key in BannerStatus]: BannerColors} = {
     withinContentContainer: {
       background: 'bg-critical-subdued',
       text: 'text-critical-strong',
-      icon: 'experimental-icon-critical-strong',
+      icon: 'icon-critical-strong-experimental',
     },
   },
   info: {
@@ -83,7 +83,7 @@ const colorsByStatus: {[key in BannerStatus]: BannerColors} = {
     withinContentContainer: {
       background: 'bg-info-subdued',
       text: 'text-info',
-      icon: 'experimental-icon-info-strong',
+      icon: 'icon-info-strong-experimental',
     },
   },
 };

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -6,7 +6,7 @@
   outline: var(--p-border-width-1) solid transparent;
 
   #{$se23} & {
-    box-shadow: var(--p-shadow-experimental-card-sm);
+    box-shadow: var(--p-shadow-card-sm-experimental);
   }
 
   + .LegacyCard {
@@ -74,7 +74,7 @@
 
     #{$se23} & {
       border-top: var(--p-border-width-1) solid
-        var(--p-color-experimental-border-faint);
+        var(--p-color-border-faint-experimental);
     }
 
     @media print {

--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -68,7 +68,7 @@ export type ColorBackgroundAlias =
   | 'bg-success-subdued-active'
   | 'bg-success-subdued-hover'
   | 'bg-warning'
-  | ColorExperimentalBackgroundAlias;
+  | ColorBackgroundAliasExperimental;
 
 export type ColorBorderAlias =
   | 'border'
@@ -98,8 +98,7 @@ export type ColorBorderAlias =
   | 'border-strong-hover'
   | 'border-subdued'
   | 'border-success'
-  | 'border-success-subdued'
-  | ColorExperimentalBorderAlias;
+  | 'border-success-subdued';
 
 export type ColorIconAlias =
   | 'icon'
@@ -149,31 +148,29 @@ export type ColorTextAlias =
   | 'text-success'
   | 'text-success-strong'
   | 'text-warning-strong'
-  | ColorExperimentalTextAlias;
+  | ColorTextAliasExperimental;
 
-type ColorExperimentalBackgroundAlias =
-  | 'experimental-bg-input-hover'
-  | 'experimental-bg-input-active'
-  | 'experimental-bg-transparent'
-  | 'experimental-bg-transparent-subdued'
-  | 'experimental-bg-transparent-hover'
-  | 'experimental-bg-transparent-active'
-  | 'experimental-bg-inverse-transparent-hover'
-  | 'experimental-bg-inverse-transparent-active'
-  | 'experimental-bg-success-strong-hover'
-  | 'experimental-bg-success-strong-active'
-  | 'experimental-bg-warning-strong'
-  | 'experimental-bg-warning-subdued';
+type ColorBackgroundAliasExperimental =
+  | 'bg-input-hover-experimental'
+  | 'bg-input-active-experimental'
+  | 'bg-transparent-experimental'
+  | 'bg-transparent-subdued-experimental'
+  | 'bg-transparent-hover-experimental'
+  | 'bg-transparent-active-experimental'
+  | 'bg-inverse-transparent-hover-experimental'
+  | 'bg-inverse-transparent-active-experimental'
+  | 'bg-success-strong-hover-experimental'
+  | 'bg-success-strong-active-experimental'
+  | 'bg-warning-strong-experimental'
+  | 'bg-warning-subdued-experimental';
 
-type ColorExperimentalTextAlias = 'experimental-text-warning';
+type ColorTextAliasExperimental = 'text-warning-experimental';
 
 type ColorExperimentalIconAlias =
-  | 'experimental-icon-info-strong'
-  | 'experimental-icon-success-strong'
-  | 'experimental-icon-warning-strong'
-  | 'experimental-icon-critical-strong';
-
-type ColorExperimentalBorderAlias = 'experimental-border-faint';
+  | 'icon-info-strong-experimental'
+  | 'icon-success-strong-experimental'
+  | 'icon-warning-strong-experimental'
+  | 'icon-critical-strong-experimental';
 
 export type ColorTokenName =
   | `color-${ColorBackgroundAlias}`
@@ -859,76 +856,72 @@ export const color: {
     description: '',
   },
   // Experimental tokens
-  'color-experimental-bg-input-hover': {
+  'color-bg-input-hover-experimental': {
     value: colorsExperimental.gray[3](),
     description: '',
   },
-  'color-experimental-bg-input-active': {
+  'color-bg-input-active-experimental': {
     value: colorsExperimental.gray[4](),
     description: '',
   },
-  'color-experimental-bg-transparent': {
+  'color-bg-transparent-experimental': {
     value: colorsExperimental.gray[16](),
     description: '',
   },
-  'color-experimental-bg-transparent-subdued': {
+  'color-bg-transparent-subdued-experimental': {
     value: colorsExperimental.gray[16]('0.05'),
     description: '',
   },
-  'color-experimental-bg-transparent-hover': {
+  'color-bg-transparent-hover-experimental': {
     value: colorsExperimental.gray[16]('0.05'),
     description: '',
   },
-  'color-experimental-bg-transparent-active': {
+  'color-bg-transparent-active-experimental': {
     value: colorsExperimental.gray[16]('0.07'),
     description: '',
   },
-  'color-experimental-bg-inverse-transparent-hover': {
+  'color-bg-inverse-transparent-hover-experimental': {
     value: colorsExperimental.gray[1]('0.1'),
     description: '',
   },
-  'color-experimental-bg-inverse-transparent-active': {
+  'color-bg-inverse-transparent-active-experimental': {
     value: colorsExperimental.gray[1]('0.2'),
     description: '',
   },
-  'color-experimental-bg-success-strong-hover': {
+  'color-bg-success-strong-hover-experimental': {
     value: colorsExperimental.green[13],
     description: '',
   },
-  'color-experimental-bg-success-strong-active': {
+  'color-bg-success-strong-active-experimental': {
     value: colorsExperimental.green[14],
     description: '',
   },
-  'color-experimental-bg-warning-subdued': {
+  'color-bg-warning-subdued-experimental': {
     value: colorsExperimental.orange[3],
     description: '',
   },
-  'color-experimental-bg-warning-strong': {
+  'color-bg-warning-strong-experimental': {
     value: colorsExperimental.orange[9],
     description: '',
   },
-  'color-experimental-text-warning': {
+  'color-text-warning-experimental': {
     value: colorsExperimental.orange[15],
     description: '',
   },
-  'color-experimental-icon-info-strong': {
+  'color-icon-info-strong-experimental': {
     value: colorsExperimental.azure[14],
     description: '',
   },
-  'color-experimental-icon-warning-strong': {
+  'color-icon-warning-strong-experimental': {
     value: colorsExperimental.orange[13],
     description: '',
   },
-  'color-experimental-icon-success-strong': {
+  'color-icon-success-strong-experimental': {
     value: colorsExperimental.green[14],
     description: '',
   },
-  'color-experimental-icon-critical-strong': {
+  'color-icon-critical-strong-experimental': {
     value: colorsExperimental.red[14],
-    description: '',
-  },
-  'color-experimental-border-faint': {
-    value: colorsExperimental.gray[7](),
     description: '',
   },
 };

--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -1,4 +1,4 @@
-import type {MetadataProperties} from '../types';
+import type {MetadataProperties, Experimental} from '../types';
 import * as colors from '../colors';
 import * as colorsExperimental from '../colors-experimental';
 
@@ -98,7 +98,8 @@ export type ColorBorderAlias =
   | 'border-strong-hover'
   | 'border-subdued'
   | 'border-success'
-  | 'border-success-subdued';
+  | 'border-success-subdued'
+  | ColorBorderAliasExperimental;
 
 export type ColorIconAlias =
   | 'icon'
@@ -120,7 +121,7 @@ export type ColorIconAlias =
   | 'icon-subdued'
   | 'icon-success'
   | 'icon-warning'
-  | ColorExperimentalIconAlias;
+  | ColorIconAliasExperimental;
 
 export type ColorTextAlias =
   | 'text'
@@ -150,27 +151,31 @@ export type ColorTextAlias =
   | 'text-warning-strong'
   | ColorTextAliasExperimental;
 
-type ColorBackgroundAliasExperimental =
-  | 'bg-input-hover-experimental'
-  | 'bg-input-active-experimental'
-  | 'bg-transparent-experimental'
-  | 'bg-transparent-subdued-experimental'
-  | 'bg-transparent-hover-experimental'
-  | 'bg-transparent-active-experimental'
-  | 'bg-inverse-transparent-hover-experimental'
-  | 'bg-inverse-transparent-active-experimental'
-  | 'bg-success-strong-hover-experimental'
-  | 'bg-success-strong-active-experimental'
-  | 'bg-warning-strong-experimental'
-  | 'bg-warning-subdued-experimental';
+type ColorBackgroundAliasExperimental = Experimental<
+  | 'bg-input-hover'
+  | 'bg-input-active'
+  | 'bg-transparent'
+  | 'bg-transparent-subdued'
+  | 'bg-transparent-hover'
+  | 'bg-transparent-active'
+  | 'bg-inverse-transparent-hover'
+  | 'bg-inverse-transparent-active'
+  | 'bg-success-strong-hover'
+  | 'bg-success-strong-active'
+  | 'bg-warning-strong'
+  | 'bg-warning-subdued'
+>;
 
-type ColorTextAliasExperimental = 'text-warning-experimental';
+type ColorTextAliasExperimental = Experimental<'text-warning'>;
 
-type ColorExperimentalIconAlias =
-  | 'icon-info-strong-experimental'
-  | 'icon-success-strong-experimental'
-  | 'icon-warning-strong-experimental'
-  | 'icon-critical-strong-experimental';
+type ColorIconAliasExperimental = Experimental<
+  | 'icon-info-strong'
+  | 'icon-success-strong'
+  | 'icon-warning-strong'
+  | 'icon-critical-strong'
+>;
+
+type ColorBorderAliasExperimental = Experimental<'border-faint'>;
 
 export type ColorTokenName =
   | `color-${ColorBackgroundAlias}`
@@ -922,6 +927,10 @@ export const color: {
   },
   'color-icon-critical-strong-experimental': {
     value: colorsExperimental.red[14],
+    description: '',
+  },
+  'color-border-faint-experimental': {
+    value: colorsExperimental.gray[7](),
     description: '',
   },
 };

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -1,6 +1,8 @@
-import type {MetadataProperties} from '../types';
+import type {MetadataProperties, Experimental} from '../types';
 
 type FontFamilyAlias = 'sans' | 'mono';
+
+type FontSizeScaleExperimental = Experimental<'70' | '80'>;
 
 export type FontSizeScale =
   | '75'
@@ -10,9 +12,8 @@ export type FontSizeScale =
   | '400'
   | '500'
   | '600'
-  | '700';
-
-type FontExperimentalSizeScale = '70' | '80';
+  | '700'
+  | FontSizeScaleExperimental;
 
 export type FontLineHeightScale = '1' | '2' | '3' | '4' | '5' | '6' | '7';
 
@@ -21,7 +22,6 @@ export type FontWeightAlias = 'regular' | 'medium' | 'semibold' | 'bold';
 export type FontTokenName =
   | `font-family-${FontFamilyAlias}`
   | `font-size-${FontSizeScale}`
-  | `font-experimental-size-${FontExperimentalSizeScale}`
   | `font-weight-${FontWeightAlias}`
   | `font-line-height-${FontLineHeightScale}`;
 
@@ -40,13 +40,13 @@ export const font: {
     value:
       "ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace",
   },
-  'font-experimental-size-70': {
+  'font-size-70-experimental': {
     value: '11px',
   },
   'font-size-75': {
     value: '12px',
   },
-  'font-experimental-size-80': {
+  'font-size-80-experimental': {
     value: '13px',
   },
   'font-size-100': {

--- a/polaris-tokens/src/token-groups/shadow.ts
+++ b/polaris-tokens/src/token-groups/shadow.ts
@@ -1,4 +1,6 @@
-import type {MetadataProperties} from '../types';
+import type {MetadataProperties, Experimental} from '../types';
+
+type ShadowAliasExperimental = Experimental<'card-sm' | 'card-md' | 'card-lg'>;
 
 export type ShadowAlias =
   | 'inset-lg'
@@ -11,12 +13,7 @@ export type ShadowAlias =
   | 'lg'
   | 'xl'
   | '2xl'
-  | ShadowExperimentalAlias;
-
-type ShadowExperimentalAlias =
-  | 'experimental-card-sm'
-  | 'experimental-card-md'
-  | 'experimental-card-lg';
+  | ShadowAliasExperimental;
 
 export type ShadowTokenName = `shadow-${ShadowAlias}`;
 
@@ -73,15 +70,15 @@ export const shadow: {
       '0px 32px 32px rgba(31, 33, 36, 0.15), 0px 32px 56px -2px rgba(31, 33, 36, 0.16)',
     valueExperimental: '0px 20px 20px -8px rgba(0, 0, 0, 0.28)',
   },
-  'shadow-experimental-card-sm': {
+  'shadow-card-sm-experimental': {
     value:
       '0px 1px 0px rgba(0, 0, 0, 0.07), inset 0px -1px 0px #D4D4D4, inset -1px 0px 0px #E3E3E3, inset 1px 0px 0px #E3E3E3, inset 0px 1px 0px #E3E3E3',
   },
-  'shadow-experimental-card-md': {
+  'shadow-card-md-experimental': {
     value:
       '0px 3px 1px -1px rgba(0, 0, 0, 0.07), inset 0px -1px 0px rgba(0, 0, 0, 0.16), inset 1px 0px 0px rgba(0, 0, 0, 0.1), inset -1px 0px 0px rgba(0, 0, 0, 0.1), inset 0px 1px 0px rgba(255, 255, 255, 0.3)',
   },
-  'shadow-experimental-card-lg': {
+  'shadow-card-lg-experimental': {
     value:
       '0px 4px 6px -2px rgba(0, 0, 0, 0.2), inset 0px -1px 0px #D4D4D4, inset -1px 0px 0px #E3E3E3, inset 1px 0px 0px #E3E3E3, inset 0px 1px 0px #E3E3E3',
   },

--- a/polaris-tokens/src/token-groups/space.ts
+++ b/polaris-tokens/src/token-groups/space.ts
@@ -1,4 +1,6 @@
-import type {MetadataProperties} from '../types';
+import type {MetadataProperties, Experimental} from '../types';
+
+type SpaceScaleExperimental = Experimental<'1_5'>;
 
 export type SpaceScale =
   | '0'
@@ -17,13 +19,10 @@ export type SpaceScale =
   | '20'
   | '24'
   | '28'
-  | '32';
+  | '32'
+  | SpaceScaleExperimental;
 
-type SpaceExperimentalScale = '1_5';
-
-export type SpaceTokenName =
-  | `space-${SpaceScale}`
-  | `space-experimental-${SpaceExperimentalScale}`;
+export type SpaceTokenName = `space-${SpaceScale}`;
 
 export type SpaceTokenGroup = {
   [TokenName in SpaceTokenName]: string;
@@ -44,7 +43,7 @@ export const space: {
   'space-1': {
     value: '4px',
   },
-  'space-experimental-1_5': {
+  'space-1_5-experimental': {
     value: '6px',
   },
   'space-2': {

--- a/polaris-tokens/src/types.ts
+++ b/polaris-tokens/src/types.ts
@@ -2,6 +2,7 @@ import type {Metadata} from './metadata';
 
 export type Entry<T> = [keyof T, T[keyof T]];
 export type Entries<T> = Entry<T>[];
+export type Experimental<T extends string> = `${T}-experimental`;
 
 export interface MetadataProperties {
   description?: string;


### PR DESCRIPTION
This PR moves the `experimental` prefix to a suffix for all new tokens. This slight difference promotes a more seamless integration with our existing token and component types. For example:

```ts
// With prefix
type FontExperimentalSizeScale = '4'
export type FontSizeScale = '1' | '2' | '3'

export type FontTokenName =
  | `font-size-${FontSizeScale}`
  | `font-experimental-size-${FontExperimentalSizeScale}`
  // Prefix requires addition here 👆 and potential component updates */
```

```ts
// With suffix
type FontSizeScaleExperimental = '4-experimental'
export type FontSizeScale = '1' | '2' | '3' | FontSizeScaleExperimental
// Suffix requires addition here 👆 and no component updates

export type FontTokenName = `font-size-${FontSizeScale}`
```