### PR TITLE
Temporarily add `UseFeatures` render prop

### DIFF
--- a/polaris-react/src/utilities/features/hooks.tsx
+++ b/polaris-react/src/utilities/features/hooks.tsx
@@ -1,5 +1,6 @@
 import {useContext} from 'react';
 
+import type {FeaturesConfig} from './types';
 import {FeaturesContext} from './context';
 
 export function useFeatures() {
@@ -10,4 +11,15 @@ export function useFeatures() {
   }
 
   return features;
+}
+
+/**
+ * Temporary child render prop for accessing features in class components.
+ */
+export function UseFeatures(props: {
+  children: (featuresConfig: FeaturesConfig) => JSX.Element;
+}) {
+  const features = useFeatures();
+
+  return props.children(features);
 }


### PR DESCRIPTION
This PR temporarily introduces a `UseFeatures` render prop for accessing `features` in class components:

```jsx
<UseFeatures>
  {(features) => (
    <Box borderRadius={features.se23 ? '3' : '2'} />
  )}
<UseFeatures>
```