### PR TITLE
[Banner updates] Fix content horizontal stack

### DIFF
--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -266,6 +266,17 @@ export function All() {
       </Text>
       <AllBanners icon={DiscountsMajor} onDismiss={() => {}} />
       <Text as="h2" variant="headingMd">
+        With links
+      </Text>
+      <AllBanners
+        onDismiss={() => {}}
+        children={
+          <>
+            Text with <Link url="">monochrome link</Link>.
+          </>
+        }
+      />
+      <Text as="h2" variant="headingMd">
         In card
       </Text>
       <LegacyCard sectioned>
@@ -294,6 +305,19 @@ export function All() {
       </Text>
       <LegacyCard sectioned>
         <AllBanners icon={DiscountsMinor} onDismiss={() => {}} />
+      </LegacyCard>
+      <Text as="h2" variant="headingMd">
+        In card with links
+      </Text>
+      <LegacyCard sectioned>
+        <AllBanners
+          onDismiss={() => {}}
+          children={
+            <>
+              Text with <Link url="">monochrome link</Link>.
+            </>
+          }
+        />
       </LegacyCard>
     </VerticalStack>
   );

--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
@@ -90,7 +90,7 @@ export function BannerExperimental({
             <VerticalStack gap="2">
               <VerticalStack gap="05">
                 {bannerTitle}
-                {children}
+                <div>{children}</div>
               </VerticalStack>
               {actionButtons}
             </VerticalStack>
@@ -128,7 +128,7 @@ export function BannerExperimental({
         {hasContent && (
           <Box padding={{xs: '3', sm: '4'}} paddingBlockStart="3">
             <VerticalStack gap="2">
-              {children}
+              <div>{children}</div>
               {actionButtons}
             </VerticalStack>
           </Box>


### PR DESCRIPTION
### WHY are these changes introduced?

Before, children nodes were horizontally stacking since they were a child of a horizontal stack. This wraps `children` in a `Box` to keep the multi node children styled consistently. I also added stories for content links which is a common multi children node pattern to pass into the `Banner`.

> Ignore the wonky dismiss button, that will be fixed in [this issue](https://github.com/Shopify/polaris-summer-editions/issues/91)

### WHAT is this pull request doing?
<img width="1017" alt="Screenshot 2023-06-02 at 11 21 04 AM" src="https://github.com/Shopify/polaris/assets/20652326/8c83ea2f-d236-4408-b335-710774f8715d">
<img width="1020" alt="Screenshot 2023-06-02 at 11 19 21 AM" src="https://github.com/Shopify/polaris/assets/20652326/6464cb9e-3197-4b90-9ce5-4d68d028b289">

### How to 🎩



### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
