### PR TITLE
`ButtonGroup` and `pressed` Button styles

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -1096,6 +1096,11 @@
   .Button,
   .Button::after {
     border-radius: 0;
+
+    // Bump specificity
+    #{$se23} & {
+      border-radius: 0;
+    }
   }
 
   > :first-child .Button,
@@ -1103,6 +1108,11 @@
     border-radius: 0;
     border-top-left-radius: var(--p-border-radius-1);
     border-bottom-left-radius: var(--p-border-radius-1);
+
+    #{$se23} & {
+      border-top-left-radius: var(--p-border-radius-2);
+      border-bottom-left-radius: var(--p-border-radius-2);
+    }
   }
 
   > :last-child .Button,
@@ -1110,11 +1120,20 @@
     border-radius: 0;
     border-top-right-radius: var(--p-border-radius-1);
     border-bottom-right-radius: var(--p-border-radius-1);
+
+    #{$se23} & {
+      border-top-right-radius: var(--p-border-radius-2);
+      border-bottom-right-radius: var(--p-border-radius-2);
+    }
   }
 
   > :last-child:first-child .Button,
   > :last-child:first-child .Button::after {
     border-radius: var(--p-border-radius-1);
+
+    #{$se23} & {
+      border-radius: var(--p-border-radius-2);
+    }
   }
 }
 

--- a/polaris-react/src/styles/shared/_buttons.scss
+++ b/polaris-react/src/styles/shared/_buttons.scss
@@ -65,6 +65,12 @@
     svg {
       fill: currentColor;
     }
+
+    #{$se23} & {
+      background: var(--p-color-bg-strong-active);
+      box-shadow: var(--p-shadow-inset-md);
+      color: var(--p-color-text);
+    }
   }
 
   @media (-ms-high-contrast: active) {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves the following
https://github.com/Shopify/polaris-summer-editions/issues/83
https://github.com/Shopify/polaris-summer-editions/issues/85

### WHAT is this pull request doing?

- Adds `pressed` button styles
- Adds segmented styles for ButtonGroup

<img width="275" alt="Screenshot 2023-06-02 at 11 44 08 AM" src="https://github.com/Shopify/polaris/assets/3474483/cbf6139e-5198-4bdc-95c7-2ebd1506112c">|<img width="253" alt="Screenshot 2023-06-02 at 11 44 00 AM" src="https://github.com/Shopify/polaris/assets/3474483/056104eb-3b18-4f8c-9d5d-4bf3dc59873a">
:----:|:----:
Before|With Flag

### How to 🎩

- Verify in Storybook ( [ButtonGroup](https://5d559397bae39100201eedc1-orpdvhaqzo.chromatic.com/?path=/story/all-components-buttongroup--with-segmented-buttons&globals=polarisSummerEditions2023:true) | [Pressed](https://5d559397bae39100201eedc1-orpdvhaqzo.chromatic.com/?path=/story/all-components-button--pressed&globals=polarisSummerEditions2023:true) )
- Ensure no regressions when Feature flag is turned off