### PR TITLE
Turn flag off on polaris.shopify.com

### DIFF
--- a/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
+++ b/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
@@ -7,7 +7,10 @@ export const withPolarisExample = (Component: ComponentType) => {
   const PolarisHOC = (props: any) => {
     return (
       <>
-        <AppProvider i18n={translations}>
+        <AppProvider
+          i18n={translations}
+          features={{polarisSummerEditions2023: false}}
+        >
           <div className={styles.Container}>
             <div id="polaris-example" className={styles.Example}>
               <Component {...props} />


### PR DESCRIPTION
Not sure why this is needed but polaris.shopify.com is showing incorrect button styles