### PR TITLE
[AppProvider] Default props for features

### DIFF
--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -41,6 +41,12 @@ export interface AppProviderProps {
 }
 
 export class AppProvider extends Component<AppProviderProps, State> {
+  static defaultProps: Partial<AppProviderProps> = {
+    features: {
+      polarisSummerEditions2023: false,
+    },
+  };
+
   private stickyManager: StickyManager;
   private scrollLockManager: ScrollLockManager;
 
@@ -97,12 +103,7 @@ export class AppProvider extends Component<AppProviderProps, State> {
   };
 
   render() {
-    const {
-      children,
-      features = {
-        polarisSummerEditions2023: false,
-      },
-    } = this.props;
+    const {children, features} = this.props;
 
     const {intl, link} = this.state;
 

--- a/polaris.shopify.com/playroom/FrameComponent.tsx
+++ b/polaris.shopify.com/playroom/FrameComponent.tsx
@@ -14,10 +14,7 @@ export default function FrameComponent({
     updateGrowFrameHeight(`${document.body.scrollHeight}px`);
   });
   return (
-    <AppProvider
-      i18n={theme || enTranslations}
-      features={{polarisSummerEditions2023: false}}
-    >
+    <AppProvider i18n={theme || enTranslations}>
       <div id="polaris-sandbox-wrapper">{children}</div>
     </AppProvider>
   );

--- a/polaris.shopify.com/playroom/FrameComponent.tsx
+++ b/polaris.shopify.com/playroom/FrameComponent.tsx
@@ -14,7 +14,10 @@ export default function FrameComponent({
     updateGrowFrameHeight(`${document.body.scrollHeight}px`);
   });
   return (
-    <AppProvider i18n={theme || enTranslations}>
+    <AppProvider
+      i18n={theme || enTranslations}
+      features={{polarisSummerEditions2023: false}}
+    >
       <div id="polaris-sandbox-wrapper">{children}</div>
     </AppProvider>
   );

--- a/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
+++ b/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
@@ -7,10 +7,7 @@ export const withPolarisExample = (Component: ComponentType) => {
   const PolarisHOC = (props: any) => {
     return (
       <>
-        <AppProvider
-          i18n={translations}
-          features={{polarisSummerEditions2023: false}}
-        >
+        <AppProvider i18n={translations}>
           <div className={styles.Container}>
             <div id="polaris-example" className={styles.Example}>
               <Component {...props} />


### PR DESCRIPTION
`classList.toggle` was not working for `undefined` feature objects in the sandboxes on polaris.shopify.com. This change ensures that `features` always fallback to `polarisSummerEditions2023: false`