### PR TITLE
[UnstyledLink] Correctly pass ref through to child component

### DIFF
--- a/.changeset/red-bats-tease.md
+++ b/.changeset/red-bats-tease.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Correctly pass ref through to UnstyledLink's child

--- a/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
@@ -15,10 +15,10 @@ export interface UnstyledLinkProps extends LinkLikeComponentProps {}
 // but eslint-plugin-react doesn't know that just yet
 // eslint-disable-next-line react/display-name
 export const UnstyledLink = memo(
-  forwardRef<unknown, UnstyledLinkProps>(function UnstyledLink(props, _ref) {
+  forwardRef<any, UnstyledLinkProps>(function UnstyledLink(props, _ref) {
     const LinkComponent = useLink();
     if (LinkComponent) {
-      return <LinkComponent {...unstyled.props} {...props} />;
+      return <LinkComponent {...unstyled.props} {...props} ref={_ref} />;
     }
 
     const {external, url, target: targetProp, ...rest} = props;
@@ -34,7 +34,14 @@ export const UnstyledLink = memo(
     const rel = target === '_blank' ? 'noopener noreferrer' : undefined;
 
     return (
-      <a target={target} {...rest} href={url} rel={rel} {...unstyled.props} />
+      <a
+        target={target}
+        {...rest}
+        href={url}
+        rel={rel}
+        {...unstyled.props}
+        ref={_ref}
+      />
     );
   }),
 );


### PR DESCRIPTION
Without this ref, the focus callback within `ResourceItem` was not being correctly called (it uses a ref to check which DOM node is focused).

Looks to be a [long standing issue](https://github.com/Shopify/polaris/blob/414583de7/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx), but only noticeable since [this change which attempted to rely on the ref](https://github.com/Shopify/polaris/commit/62cca1399#diff-20d72be5e3bfbff95d7e6e4d4ea52f29649e458a283708a685f4dcc1c052519eL326-R336).

**How I Got Here**

I was trying to tweak styles for the `ResourceItem`, but I couldn't get the focus ring to trigger (to be certain I wasn't breaking anything when changing border radii).

Using `git bisect` + some GitHub sleuthing I narrowed it down to [a v11 change](https://github.com/Shopify/polaris/pull/8396/files#diff-20d72be5e3bfbff95d7e6e4d4ea52f29649e458a283708a685f4dcc1c052519eL326-R336) as the "bad" commit which caused the missing focus ring.

At first I couldn't figure out how that made a difference until I realized the `ref` being passed, so I investigated `UnstyledLink` and sure enough; there was the issue: the ref was being ignored completely!