### PR TITLE
Update VideoThumbnail

### DIFF
--- a/polaris-react/src/components/VideoThumbnail/VideoThumbnail.scss
+++ b/polaris-react/src/components/VideoThumbnail/VideoThumbnail.scss
@@ -73,6 +73,11 @@ $progress-bar-height: 6px;
   text-align: center;
   transition: background-color var(--p-motion-duration-200)
     var(--p-motion-ease-in);
+
+  #{$se23} & {
+    background-color: var(--p-color-bg-backdrop-experimental);
+    border-radius: var(--p-border-radius-2);
+  }
 }
 
 .Progress {
@@ -91,6 +96,10 @@ $progress-bar-height: 6px;
   transform: scaleX(0);
   background-color: var(--p-color-border-info);
   transition: transform var(--p-motion-duration-500) var(--p-motion-ease);
+
+  #{$se23} & {
+    background-color: var(--p-color-bg-primary);
+  }
 }
 
 .ProgressBar,

--- a/polaris-react/src/components/VideoThumbnail/VideoThumbnail.stories.tsx
+++ b/polaris-react/src/components/VideoThumbnail/VideoThumbnail.stories.tsx
@@ -15,11 +15,19 @@ export function All() {
         </Text>
         <Default />
       </VerticalStack>
+
       <VerticalStack gap="4">
         <Text as="h2" variant="headingXl">
           With progress
         </Text>
         <WithProgress />
+      </VerticalStack>
+
+      <VerticalStack gap="4">
+        <Text as="h2" variant="headingXl">
+          Outside media card
+        </Text>
+        <OutsideMediaCard />
       </VerticalStack>
     </VerticalStack>
   );
@@ -64,5 +72,19 @@ export function WithProgress() {
         onClick={() => {}}
       />
     </MediaCard>
+  );
+}
+
+export function OutsideMediaCard() {
+  return (
+    <div style={{height: '254px', width: '450px'}}>
+      <VideoThumbnail
+        videoLength={80}
+        videoProgress={45}
+        showVideoProgress
+        thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        onClick={() => {}}
+      />
+    </div>
   );
 }

--- a/polaris-react/src/components/VideoThumbnail/VideoThumbnail.stories.tsx
+++ b/polaris-react/src/components/VideoThumbnail/VideoThumbnail.stories.tsx
@@ -39,6 +39,7 @@ export function Default() {
       <VideoThumbnail
         videoLength={80}
         thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        onClick={() => {}}
       />
     </MediaCard>
   );
@@ -60,6 +61,7 @@ export function WithProgress() {
         videoProgress={45}
         showVideoProgress
         thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        onClick={() => {}}
       />
     </MediaCard>
   );

--- a/polaris-react/src/components/VideoThumbnail/VideoThumbnail.stories.tsx
+++ b/polaris-react/src/components/VideoThumbnail/VideoThumbnail.stories.tsx
@@ -1,10 +1,29 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {MediaCard, VideoThumbnail} from '@shopify/polaris';
+import {MediaCard, Text, VerticalStack, VideoThumbnail} from '@shopify/polaris';
 
 export default {
   component: VideoThumbnail,
 } as ComponentMeta<typeof VideoThumbnail>;
+
+export function All() {
+  return (
+    <VerticalStack gap="8">
+      <VerticalStack gap="4">
+        <Text as="h2" variant="headingXl">
+          Default
+        </Text>
+        <Default />
+      </VerticalStack>
+      <VerticalStack gap="4">
+        <Text as="h2" variant="headingXl">
+          With progress
+        </Text>
+        <WithProgress />
+      </VerticalStack>
+    </VerticalStack>
+  );
+}
 
 export function Default() {
   return (

--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -152,6 +152,7 @@ export type ColorTextAlias =
   | ColorTextAliasExperimental;
 
 type ColorBackgroundAliasExperimental = Experimental<
+  | 'bg-backdrop'
   | 'bg-input-hover'
   | 'bg-input-active'
   | 'bg-transparent'
@@ -884,6 +885,10 @@ export const color: {
     description: '',
   },
   // Experimental tokens
+  'color-bg-backdrop-experimental': {
+    value: colorsExperimental.gray[16]('0.75'),
+    description: '',
+  },
   'color-bg-input-hover-experimental': {
     value: colorsExperimental.gray[3](),
     description: '',


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [#233](https://github.com/Shopify/polaris-summer-editions/issues/233).

### WHAT is this pull request doing?

Updates style for VideoThumbnail.
Adds `--p-color-bg-backdrop` experimental token.
[Figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Uplift-Components-%5Bgen3%E2%80%93alpha%5D?type=design&node-id=67330%3A21527&t=D6QUjA4wnUWJbsQr-1)

### How to 🎩

[VideoThumbnail mega story](https://5d559397bae39100201eedc1-ffpidhjzgw.chromatic.com/?path=/story/all-components-videothumbnail--all&globals=polarisSummerEditions2023:true)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
