### PR TITLE
Update FullscreenBar

### DIFF
--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.scss
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.scss
@@ -6,6 +6,10 @@
   height: $top-bar-height;
   box-shadow: var(--p-shadow-sm);
   background-color: var(--p-color-bg);
+
+  #{$se23} & {
+    box-shadow: var(--p-shadow-xs);
+  }
 }
 
 .BackAction {
@@ -19,8 +23,20 @@
   background-color: var(--p-color-bg);
   font-weight: var(--p-font-weight-medium);
   cursor: pointer;
+
+  #{$se23} & {
+    border-right: var(--p-border-width-1) solid
+      var(--p-color-border-faint-experimental);
+    padding-left: var(--p-space-4);
+    padding-right: var(--p-space-4);
+  }
 }
 
 .BackAction :first-child {
   padding-right: var(--p-space-05);
+
+  #{$se23} & {
+    margin-right: var(--p-space-1_5-experimental);
+    padding-right: 0;
+  }
 }

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.stories.tsx
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.stories.tsx
@@ -6,12 +6,33 @@ import {
   ButtonGroup,
   FullscreenBar,
   Text,
+  VerticalStack,
 } from '@shopify/polaris';
 
 export default {
   component: FullscreenBar,
   parameters: {layout: 'fullscreen'},
 } as ComponentMeta<typeof FullscreenBar>;
+
+export function All() {
+  return (
+    <>
+      <VerticalStack gap="4">
+        <Text as="h2" variant="headingXl">
+          With children
+        </Text>
+        <WithChildren />
+      </VerticalStack>
+
+      <VerticalStack gap="2">
+        <Text as="h2" variant="headingXl">
+          No children
+        </Text>
+        <NoChildren />
+      </VerticalStack>
+    </>
+  );
+}
 
 export function WithChildren() {
   const [isFullscreen, setFullscreen] = useState(true);

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.stories.tsx
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.stories.tsx
@@ -9,6 +9,9 @@ import {
   VerticalStack,
 } from '@shopify/polaris';
 
+import {useBreakpoints} from '../../utilities/breakpoints';
+import {useFeatures} from '../../utilities/features';
+
 export default {
   component: FullscreenBar,
   parameters: {layout: 'fullscreen'},
@@ -36,10 +39,36 @@ export function All() {
 
 export function WithChildren() {
   const [isFullscreen, setFullscreen] = useState(true);
+  const {polarisSummerEditions2023} = useFeatures();
+  const breakpoints = useBreakpoints();
 
   const handleActionClick = useCallback(() => {
     setFullscreen(false);
   }, []);
+
+  const titleContentMarkup = breakpoints.mdUp ? (
+    <Text as="p" variant="headingMd">
+      Join our email list
+    </Text>
+  ) : null;
+
+  const titleMarkup = polarisSummerEditions2023 ? (
+    <div
+      style={{
+        marginLeft: 'var(--p-space-2)',
+        marginRight: 'var(--p-space-4)',
+        flexGrow: 1,
+      }}
+    >
+      {titleContentMarkup}
+    </div>
+  ) : (
+    <div style={{marginLeft: '1rem', flexGrow: 1}}>
+      <Text as="p" variant="headingLg">
+        Page title
+      </Text>
+    </div>
+  );
 
   const fullscreenBarMarkup = (
     <FullscreenBar onAction={handleActionClick}>
@@ -54,11 +83,7 @@ export function WithChildren() {
         }}
       >
         <Badge status="info">Draft</Badge>
-        <div style={{marginLeft: '1rem', flexGrow: 1}}>
-          <Text as="p" variant="headingLg">
-            Page title
-          </Text>
-        </div>
+        {titleMarkup}
         <ButtonGroup>
           <Button onClick={() => {}}>Secondary Action</Button>
           <Button primary onClick={() => {}}>

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.tsx
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import {ExitMajor} from '@shopify/polaris-icons';
 
 import {Icon} from '../Icon';
+import {Text} from '../Text';
 import {useI18n} from '../../utilities/i18n';
+import {useFeatures} from '../../utilities/features';
 
 import styles from './FullscreenBar.scss';
 
@@ -15,6 +17,15 @@ export interface FullscreenBarProps {
 
 export function FullscreenBar({onAction, children}: FullscreenBarProps) {
   const i18n = useI18n();
+  const {polarisSummerEditions2023} = useFeatures();
+
+  const backButtonMarkup = polarisSummerEditions2023 ? (
+    <Text as="span" variant="bodyLg">
+      {i18n.translate('Polaris.FullscreenBar.back')}
+    </Text>
+  ) : (
+    i18n.translate('Polaris.FullscreenBar.back')
+  );
 
   return (
     <div className={styles.FullscreenBar}>
@@ -24,7 +35,7 @@ export function FullscreenBar({onAction, children}: FullscreenBarProps) {
         aria-label={i18n.translate('Polaris.FullscreenBar.accessibilityLabel')}
       >
         <Icon source={ExitMajor} />
-        {i18n.translate('Polaris.FullscreenBar.back')}
+        {backButtonMarkup}
       </button>
       {children}
     </div>


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [#217](https://github.com/Shopify/polaris-summer-editions/issues/217).

### WHAT is this pull request doing?

Updates style for FullscreenBar.
Designs had title content hidden on small screens so I've update the story to only render title for `breakpoint-md` and up.
[Figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Uplift-Components-%5Bgen3%E2%80%93alpha%5D?type=design&node-id=71205-18746&t=rtEZTtFHTKSKVHD3-0)

**🚨 Note**: Button groups are stacked on breakpoint-xs but that's present in FullscreenBar in main without the flag on so it can be addressed in a subsequent PR or may already be handled with the small screen button PR. 
    <details>
      <summary>FullscreenBar — breakpoint-sm</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/a1aa85b0-ccb2-43d7-a425-07f1add7b4ea" alt="FullscreenBar — breakpoint-sm">
    </details>
    <details>
      <summary>FullscreenBar — breakpoint-lg</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/b2cab77d-bdc0-4f29-8880-32577303616f" alt="FullscreenBar — breakpoint-lg">
    </details>

### How to 🎩

[FullscreenBar mega story](https://5d559397bae39100201eedc1-lakytxazeb.chromatic.com/?path=/story/all-components-fullscreenbar--all&globals=polarisSummerEditions2023:true)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
