### PR TITLE
Update Layout

### DIFF
--- a/polaris-react/src/components/Layout/Layout.scss
+++ b/polaris-react/src/components/Layout/Layout.scss
@@ -75,6 +75,11 @@ $relative-size: $primary-basis / $secondary-basis;
   }
 
   + .AnnotatedSection {
+    #{$se23} & {
+      border-top: var(--p-border-width-1) solid var(--p-color-border-subdued);
+      padding-top: var(--p-space-4);
+    }
+
     @media #{$p-breakpoints-sm-up} {
       padding-top: var(--p-space-4);
       border-top: var(--p-border-width-1) solid var(--p-color-border-subdued);
@@ -103,6 +108,10 @@ $relative-size: $primary-basis / $secondary-basis;
 
   #{$se23} & {
     padding: var(--p-space-4) var(--p-space-4) 0;
+
+    @media #{$p-breakpoints-md-down} {
+      padding-left: 0;
+    }
   }
 
   @media #{$p-breakpoints-sm-up} {

--- a/polaris-react/src/components/Layout/Layout.stories.tsx
+++ b/polaris-react/src/components/Layout/Layout.stories.tsx
@@ -431,7 +431,7 @@ export function Annotated() {
     <Page fullWidth>
       <Layout>
         <Layout.AnnotatedSection
-          id="storeDetails"
+          id="storeDetails-annotated"
           title="Store details"
           description="Shopify and your customers will use this information to contact you."
         >
@@ -466,7 +466,7 @@ export function AnnotatedWithBannerAtTheTop() {
           </Banner>
         </Layout.Section>
         <Layout.AnnotatedSection
-          id="storeDetails"
+          id="storeDetails-annotatedWithBanner"
           title="Store details"
           description="Shopify and your customers will use this information to contact you."
         >

--- a/polaris-react/src/components/Layout/Layout.stories.tsx
+++ b/polaris-react/src/components/Layout/Layout.stories.tsx
@@ -11,11 +11,60 @@ import {
   TextContainer,
   TextField,
   Thumbnail,
+  VerticalStack,
 } from '@shopify/polaris';
 
 export default {
   component: Layout,
 } as ComponentMeta<typeof Layout>;
+
+export function All() {
+  return (
+    <VerticalStack gap="8">
+      <VerticalStack gap="4">
+        <Text as="h2" variant="headingXl">
+          One column
+        </Text>
+        <OneColumn />
+      </VerticalStack>
+
+      <VerticalStack gap="2">
+        <Text as="h2" variant="headingXl">
+          Two columns with primary and secondary widths
+        </Text>
+        <TwoColumnsWithPrimaryAndSecondaryWidths />
+      </VerticalStack>
+
+      <VerticalStack gap="4">
+        <Text as="h2" variant="headingXl">
+          Two columns with equal width
+        </Text>
+        <TwoColumnsWithEqualWidth />
+      </VerticalStack>
+
+      <VerticalStack gap="2">
+        <Text as="h2" variant="headingXl">
+          Three columns with equal width
+        </Text>
+        <ThreeColumnsWithEqualWidth />
+      </VerticalStack>
+
+      <VerticalStack gap="2">
+        <Text as="h2" variant="headingXl">
+          Annotated
+        </Text>
+        <Annotated />
+      </VerticalStack>
+
+      <VerticalStack gap="2">
+        <Text as="h2" variant="headingXl">
+          Annotated with banner at the top
+        </Text>
+        <AnnotatedWithBannerAtTheTop />
+      </VerticalStack>
+    </VerticalStack>
+  );
+}
 
 export function OneColumn() {
   return (

--- a/polaris-react/src/components/Layout/Layout.stories.tsx
+++ b/polaris-react/src/components/Layout/Layout.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   Banner,
+  Box,
   LegacyCard,
   FormLayout,
   Text,
@@ -11,7 +12,6 @@ import {
   TextContainer,
   TextField,
   Thumbnail,
-  VerticalStack,
 } from '@shopify/polaris';
 
 export default {
@@ -20,49 +20,43 @@ export default {
 
 export function All() {
   return (
-    <VerticalStack gap="8">
-      <VerticalStack gap="4">
-        <Text as="h2" variant="headingXl">
-          One column
-        </Text>
-        <OneColumn />
-      </VerticalStack>
+    <>
+      <Text as="h2" variant="headingXl">
+        One column
+      </Text>
+      <OneColumn />
+      <Box paddingBlockEnd="8" />
 
-      <VerticalStack gap="2">
-        <Text as="h2" variant="headingXl">
-          Two columns with primary and secondary widths
-        </Text>
-        <TwoColumnsWithPrimaryAndSecondaryWidths />
-      </VerticalStack>
+      <Text as="h2" variant="headingXl">
+        Two columns with primary and secondary widths
+      </Text>
+      <TwoColumnsWithPrimaryAndSecondaryWidths />
+      <Box paddingBlockEnd="8" />
 
-      <VerticalStack gap="4">
-        <Text as="h2" variant="headingXl">
-          Two columns with equal width
-        </Text>
-        <TwoColumnsWithEqualWidth />
-      </VerticalStack>
+      <Text as="h2" variant="headingXl">
+        Two columns with equal width
+      </Text>
+      <TwoColumnsWithEqualWidth />
+      <Box paddingBlockEnd="8" />
 
-      <VerticalStack gap="2">
-        <Text as="h2" variant="headingXl">
-          Three columns with equal width
-        </Text>
-        <ThreeColumnsWithEqualWidth />
-      </VerticalStack>
+      <Text as="h2" variant="headingXl">
+        Three columns with equal width
+      </Text>
+      <ThreeColumnsWithEqualWidth />
+      <Box paddingBlockEnd="8" />
 
-      <VerticalStack gap="2">
-        <Text as="h2" variant="headingXl">
-          Annotated
-        </Text>
-        <Annotated />
-      </VerticalStack>
+      <Text as="h2" variant="headingXl">
+        Annotated
+      </Text>
+      <Annotated />
+      <Box paddingBlockEnd="8" />
 
-      <VerticalStack gap="2">
-        <Text as="h2" variant="headingXl">
-          Annotated with banner at the top
-        </Text>
-        <AnnotatedWithBannerAtTheTop />
-      </VerticalStack>
-    </VerticalStack>
+      <Text as="h2" variant="headingXl">
+        Annotated with banner at the top
+      </Text>
+      <AnnotatedWithBannerAtTheTop />
+      <Box paddingBlockEnd="8" />
+    </>
   );
 }
 

--- a/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -42,11 +42,7 @@ export function AnnotatedSection({
           <TextContainer
             spacing={polarisSummerEditions2023 ? 'tight' : undefined}
           >
-            <Text
-              id={id}
-              variant={polarisSummerEditions2023 ? 'bodyLg' : 'headingMd'}
-              as="h2"
-            >
+            <Text id={id} variant="headingMd" as="h2">
               {title}
             </Text>
             {descriptionMarkup && (

--- a/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/polaris-react/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -4,6 +4,7 @@ import {Box} from '../../../Box';
 import {Text} from '../../../Text';
 // eslint-disable-next-line import/no-deprecated
 import {TextContainer} from '../../../TextContainer';
+import {useFeatures} from '../../../../utilities/features';
 import styles from '../../Layout.scss';
 
 export interface AnnotatedSectionProps {
@@ -19,15 +20,33 @@ export function AnnotatedSection({
   description,
   id,
 }: AnnotatedSectionProps) {
+  const {polarisSummerEditions2023} = useFeatures();
   const descriptionMarkup =
-    typeof description === 'string' ? <p>{description}</p> : description;
+    // eslint-disable-next-line no-nested-ternary
+    typeof description === 'string' ? (
+      polarisSummerEditions2023 ? (
+        <Text as="p" variant="bodyMd">
+          {description}
+        </Text>
+      ) : (
+        <p>{description}</p>
+      )
+    ) : (
+      description
+    );
 
   return (
     <div className={styles.AnnotatedSection}>
       <div className={styles.AnnotationWrapper}>
         <div className={styles.Annotation}>
-          <TextContainer>
-            <Text id={id} variant="headingMd" as="h2">
+          <TextContainer
+            spacing={polarisSummerEditions2023 ? 'tight' : undefined}
+          >
+            <Text
+              id={id}
+              variant={polarisSummerEditions2023 ? 'bodyLg' : 'headingMd'}
+              as="h2"
+            >
               {title}
             </Text>
             {descriptionMarkup && (


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [#220](https://github.com/Shopify/polaris-summer-editions/issues/220).

### WHAT is this pull request doing?

Updates style for Layout.
A lot of the style updates were already implemented in [9317](https://github.com/Shopify/polaris/pull/9317) but this adds some small fixes to spacing and the text content styles for annotated sections.
[Figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Uplift-Components-%5Bgen3%E2%80%93alpha%5D?type=design&node-id=78394-31942&t=tNIWcyt9W0XLHvXQ-0)

### How to 🎩

[Layout mega story](https://5d559397bae39100201eedc1-ixswvinthh.chromatic.com/?path=/story/all-components-layout--all)

**⚠️ Note:** Focus on:
- Spacing for annotated with banner story at the xs breakpoint
- Overall type styles and spacing for Annotated and Annotated with banner stories at all breakpoints

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
