### PR TITLE
[FormLayout] updates

### DIFF
--- a/polaris-react/src/components/FormLayout/FormLayout.scss
+++ b/polaris-react/src/components/FormLayout/FormLayout.scss
@@ -1,13 +1,27 @@
+@import '../../styles/common';
+
 $item-min-size: 220px;
 
+// stylelint-disable -- se23 overrides
 .FormLayout {
-  margin-top: calc(-1 * var(--p-space-4));
-  margin-left: calc(-1 * var(--p-space-5));
+  --pc-form-layout-gap: var(--p-space-5);
+  --pc-form-layout-item-top: var(--p-space-4);
+  #{$se23} & {
+    --pc-form-layout-gap: var(--p-space-2);
+    --pc-form-layout-item-top: var(--p-space-2);
+  }
+
+  margin-top: calc(-1 * var(--pc-form-layout-item-top));
+  margin-left: calc(-1 * var(--pc-form-layout-gap));
 }
 
 .Title {
   margin-bottom: calc(-1 * var(--p-space-2));
-  padding: var(--p-space-4) var(--p-space-5) 0;
+  padding: var(--pc-form-layout-item-top) var(--pc-form-layout-gap) 0;
+
+  #{$se23} & {
+    margin-bottom: 0;
+  }
 }
 
 .Items {
@@ -17,9 +31,10 @@ $item-min-size: 220px;
 
 .Item {
   flex: 1 1 $item-min-size;
-  margin-top: var(--p-space-4);
-  margin-left: var(--p-space-5);
-  max-width: calc(100% - var(--p-space-5));
+  margin-top: var(--pc-form-layout-item-top);
+  margin-left: var(--pc-form-layout-gap);
+  max-width: calc(100% - var(--pc-form-layout-gap));
+  // stylelint-enable
 
   .grouped & {
     min-width: $item-min-size;

--- a/polaris-react/src/components/FormLayout/FormLayout.stories.tsx
+++ b/polaris-react/src/components/FormLayout/FormLayout.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {FormLayout, TextField} from '@shopify/polaris';
+import {Card, FormLayout, TextField, VerticalStack} from '@shopify/polaris';
 
 export default {
   component: FormLayout,
@@ -51,5 +51,57 @@ export function CondensedFieldGroup() {
         <TextField label="Unit" onChange={() => {}} autoComplete="off" />
       </FormLayout.Group>
     </FormLayout>
+  );
+}
+
+export function All() {
+  return (
+    <VerticalStack gap="5">
+      <Card>
+        <FormLayout>
+          <FormLayout.Group
+            title="Default group 1"
+            helpText="Form group help text"
+          >
+            <TextField label="Length" onChange={() => {}} autoComplete="off" />
+            <TextField label="Width" onChange={() => {}} autoComplete="off" />
+          </FormLayout.Group>
+          <FormLayout.Group title="Default group 2">
+            <TextField label="Length" onChange={() => {}} autoComplete="off" />
+            <TextField label="Width" onChange={() => {}} autoComplete="off" />
+            <TextField label="Height" onChange={() => {}} autoComplete="off" />
+            <TextField label="Unit" onChange={() => {}} autoComplete="off" />
+          </FormLayout.Group>
+        </FormLayout>
+      </Card>
+      <Card>
+        <FormLayout>
+          <FormLayout.Group
+            condensed
+            title="Condensed"
+            helpText="Form group help text"
+          >
+            <TextField label="Length" onChange={() => {}} autoComplete="off" />
+            <TextField label="Width" onChange={() => {}} autoComplete="off" />
+            <TextField label="Height" onChange={() => {}} autoComplete="off" />
+          </FormLayout.Group>
+        </FormLayout>
+      </Card>
+      <Card>
+        <FormLayout>
+          <FormLayout.Group
+            title="Form group title"
+            helpText="Form group help text"
+          >
+            <TextField
+              label="Field label"
+              onChange={() => {}}
+              autoComplete="off"
+              helpText="Field help text"
+            />
+          </FormLayout.Group>
+        </FormLayout>
+      </Card>
+    </VerticalStack>
   );
 }

--- a/polaris-react/src/components/FormLayout/components/Group/Group.tsx
+++ b/polaris-react/src/components/FormLayout/components/Group/Group.tsx
@@ -5,6 +5,7 @@ import {wrapWithComponent} from '../../../../utilities/components';
 import {Box} from '../../../Box';
 import {Item} from '../Item';
 import styles from '../../FormLayout.scss';
+import {useFeatures} from '../../../../utilities/features';
 
 export interface GroupProps {
   children?: React.ReactNode;
@@ -14,6 +15,7 @@ export interface GroupProps {
 }
 
 export function Group({children, condensed, title, helpText}: GroupProps) {
+  const {polarisSummerEditions2023} = useFeatures();
   const className = classNames(condensed ? styles.condensed : styles.grouped);
 
   const id = useId();
@@ -29,9 +31,9 @@ export function Group({children, condensed, title, helpText}: GroupProps) {
       <Box
         id={helpTextID}
         paddingBlockStart="2"
-        paddingInlineStart="5"
+        paddingInlineStart={polarisSummerEditions2023 ? '2' : '5'}
         paddingBlockEnd="0"
-        paddingInlineEnd="5"
+        paddingInlineEnd={polarisSummerEditions2023 ? '2' : '5'}
         color="text-subdued"
       >
         {helpText}


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [#216](https://github.com/Shopify/polaris-summer-editions/issues/216)

### WHAT is this pull request doing?

|Before|After|
|-|-|
|<img width="1257" alt="Screenshot 2023-06-09 at 1 13 10 PM" src="https://github.com/Shopify/polaris/assets/20652326/0e816829-06df-4ed8-a3e0-0fc4c02f4121">|<img width="1254" alt="Screenshot 2023-06-09 at 1 13 19 PM" src="https://github.com/Shopify/polaris/assets/20652326/8c3d2554-524e-408e-920e-596c31ef64fd">|

Updates styles to form layout. There isn't an explicit design for spacing in forms, but I used the mockups outlined in the [issue](https://github.com/Shopify/polaris-summer-editions/issues/216) as guidance. 

> Note: I've added help text and titles to the group so I could see their styling but it isn't very common to use those props

### How to 🎩

Storybook all story 

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
