### PR TITLE
[Vertical Stack] Fix broken link to horizontal stack

### DIFF
--- a/polaris.shopify.com/content/components/layout-and-structure/vertical-stack.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/vertical-stack.md
@@ -40,7 +40,7 @@ Stacks should:
 
 ## Related components
 
-- To display elements horizontally, [use the HorizontalStack component](https://polaris.shopify.com/components/horizontal-stack)
+- To display elements horizontally, [use the HorizontalStack component](https://polaris.shopify.com/components/layout-and-structure/horizontal-stack)
 
 ## Related resources
 


### PR DESCRIPTION

### WHY are these changes introduced?

I didn't see an issue created, but when refactoring a component I noticed this link was broken in the docs 

### WHAT is this pull request doing?

updating hardcoded link 

### 🎩 checklist

I don't think these steps are applicable 
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
