### PR TITLE
[VerticalStack] fix: use null for style defaults to accommodate sanitizeCustomProperties

### DIFF
--- a/.changeset/hip-buttons-deny.md
+++ b/.changeset/hip-buttons-deny.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed inconsistent style prop between client and server rendering of `VerticalStack` component

--- a/polaris-react/src/components/VerticalStack/VerticalStack.tsx
+++ b/polaris-react/src/components/VerticalStack/VerticalStack.tsx
@@ -61,8 +61,8 @@ export const VerticalStack = ({
   );
 
   const style = {
-    '--pc-vertical-stack-align': align ? `${align}` : '',
-    '--pc-vertical-stack-inline-align': inlineAlign ? `${inlineAlign}` : '',
+    '--pc-vertical-stack-align': align ? `${align}` : null,
+    '--pc-vertical-stack-inline-align': inlineAlign ? `${inlineAlign}` : null,
     '--pc-vertical-stack-order': reverseOrder ? 'column-reverse' : 'column',
     ...getResponsiveProps('vertical-stack', 'gap', 'space', gap),
   } as React.CSSProperties;


### PR DESCRIPTION
### WHY are these changes introduced?

Using the `<VerticalStack>` component with the [Remix](https://github.com/remix-run/remix) framework produces a warning in the console.

The issue occurs when you fail to specify BOTH of the optional props `align` and `inlineAlign`.

For example, `<VerticalStack inlineAlign="center" gap="0"></VerticalStack>` would produce the following error:

```
react-dom.development.js:86 Warning: Prop `style` did not match. Server: "--pc-vertical-stack-inline-align:center;--pc-vertical-stack-order:column    " Client: "--pc-vertical-stack-align:;--pc-vertical-stack-inline-align:center;--pc-vertical-stack-order:column"
```

This is due to the fact that the defaults are defined in this component as an empty string `''` instead of `null`.  This causes the utility function `sanitizeCustomProperties` (which will only check if `value != null`) to retain the props with empty string values instead of removing them as intended, resulting in a sanitized `style` object structure like:

```json
{
  "--pc-vertical-stack-align": "",
  "--pc-vertical-stack-inline-align": "",
  "--pc-vertical-stack-order": "column"
}
```

It seems `React.createElement` will discard these empty string properties on the server rendered component, but NOT on the client rendered component, resulting in the mismatch. 

This also impacts other Polaris components that utilize `<VerticalStack>` without specifying both the `align` and `inlineAlign` props.  For example, using the `<EmptyState>` Polaris component will also trigger this warning.

### WHAT is this pull request doing?

Changed the style defaults from `''` to `null` so `sanitizeCustomProperties` can work properly.

All other components are fine.  They seem to be using `null` or `undefined` for defaults, which sanitize properly. 