### PR TITLE
Update `Toast`

### DIFF
--- a/polaris-react/src/components/Frame/components/Toast/Toast.scss
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.scss
@@ -12,6 +12,10 @@ $Backdrop-opacity: 0.88;
   margin-bottom: var(--p-space-5);
   box-shadow: var(--p-shadow-xl);
 
+  #{$se23} & {
+    border-radius: var(--p-border-radius-2);
+  }
+
   @media #{$p-breakpoints-sm-up} {
     padding: var(--p-space-3);
   }

--- a/polaris-react/src/components/Frame/components/Toast/Toast.scss
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.scss
@@ -24,6 +24,10 @@ $Backdrop-opacity: 0.88;
 .Action {
   margin-left: var(--p-space-2);
   color: var(--p-color-text-on-color);
+
+  #{$se23} & {
+    margin-left: var(--p-space-4);
+  }
 }
 
 .error {
@@ -32,11 +36,19 @@ $Backdrop-opacity: 0.88;
 
   .CloseButton {
     color: var(--p-color-icon-on-color);
+
+    #{$se23} & {
+      color: var(--p-color-icon-on-color);
+    }
   }
 }
 
 .LeadingIcon {
   margin-right: var(--p-space-2);
+
+  #{$se23} & {
+    margin-right: var(--p-space-1_5-experimental);
+  }
 
   svg {
     fill: currentColor;
@@ -55,6 +67,10 @@ $Backdrop-opacity: 0.88;
   color: var(--p-color-icon-subdued);
   cursor: pointer;
   margin-left: var(--p-space-2);
+
+  #{$se23} & {
+    color: var(--p-color-icon-inverse);
+  }
 
   svg {
     fill: currentColor;

--- a/polaris-react/src/components/Frame/components/Toast/Toast.tsx
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.tsx
@@ -1,5 +1,9 @@
 import React, {useEffect} from 'react';
-import {CancelSmallMinor, DiamondAlertMinor} from '@shopify/polaris-icons';
+import {
+  AlertMinor,
+  CancelSmallMinor,
+  DiamondAlertMinor,
+} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
 import {Key} from '../../../../types';
@@ -9,6 +13,7 @@ import {HorizontalStack} from '../../../HorizontalStack';
 import {Text} from '../../../Text';
 import {KeypressListener} from '../../../KeypressListener';
 import type {ToastProps} from '../../../../utilities/frame';
+import {useFeatures} from '../../../../utilities/features';
 
 import styles from './Toast.scss';
 
@@ -54,9 +59,17 @@ export function Toast({
     </button>
   );
 
+  const {polarisSummerEditions2023} = useFeatures();
+
   const actionMarkup = action ? (
     <div className={styles.Action}>
-      <Button plain monochrome size="slim" onClick={action.onAction}>
+      <Button
+        plain
+        monochrome
+        removeUnderline={polarisSummerEditions2023}
+        size="slim"
+        onClick={action.onAction}
+      >
         {action.content}
       </Button>
     </div>
@@ -64,7 +77,10 @@ export function Toast({
 
   const leadingIconMarkup = error ? (
     <div className={styles.LeadingIcon}>
-      <Icon source={DiamondAlertMinor} color="base" />
+      <Icon
+        source={polarisSummerEditions2023 ? AlertMinor : DiamondAlertMinor}
+        color="base"
+      />
     </div>
   ) : null;
 

--- a/polaris-react/src/components/Toast/Toast.stories.tsx
+++ b/polaris-react/src/components/Toast/Toast.stories.tsx
@@ -1,10 +1,29 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Button, ButtonGroup, Frame, Page, Toast} from '@shopify/polaris';
+import {
+  Button,
+  ButtonGroup,
+  Frame,
+  HorizontalStack,
+  Page,
+  Toast,
+} from '@shopify/polaris';
 
 export default {
   component: Toast,
 } as ComponentMeta<typeof Toast>;
+
+export function All() {
+  return (
+    <HorizontalStack gap="4">
+      <Default />
+      <WithAction />
+      <Error />
+      <MultipleMessages />
+      <WithCustomDuration />
+    </HorizontalStack>
+  );
+}
 
 export function Default() {
   const [active, setActive] = useState(false);
@@ -18,7 +37,7 @@ export function Default() {
   return (
     <div style={{height: '250px'}}>
       <Frame>
-        <Page title="Toast example">
+        <Page title="Default">
           <Button onClick={toggleActive}>Show Toast</Button>
           {toastMarkup}
         </Page>
@@ -52,7 +71,7 @@ export function MultipleMessages() {
   return (
     <div style={{height: '250px'}}>
       <Frame>
-        <Page title="Toast example">
+        <Page title="Multiple Messages">
           <ButtonGroup segmented>
             <Button onClick={toggleActiveOne}>Show toast 1</Button>
             <Button onClick={toggleActiveTwo}>Show toast 2</Button>
@@ -77,7 +96,7 @@ export function WithCustomDuration() {
   return (
     <div style={{height: '250px'}}>
       <Frame>
-        <Page title="Toast example">
+        <Page title="Custom Duration">
           <Button onClick={toggleActive}>Show Toast</Button>
           {toastMarkup}
         </Page>
@@ -106,7 +125,7 @@ export function WithAction() {
   return (
     <div style={{height: '250px'}}>
       <Frame>
-        <Page title="Toast example">
+        <Page title="Action">
           <Button onClick={toggleActive}>Show Toast</Button>
           {toastMarkup}
         </Page>
@@ -127,7 +146,7 @@ export function Error() {
   return (
     <div style={{height: '250px'}}>
       <Frame>
-        <Page title="Toast example">
+        <Page title="Error">
           <Button onClick={toggleActive}>Show Toast</Button>
           {toastMarkup}
         </Page>

--- a/polaris-react/src/components/Toast/Toast.stories.tsx
+++ b/polaris-react/src/components/Toast/Toast.stories.tsx
@@ -13,18 +13,6 @@ export default {
   component: Toast,
 } as ComponentMeta<typeof Toast>;
 
-export function All() {
-  return (
-    <HorizontalStack gap="4">
-      <Default />
-      <WithAction />
-      <Error />
-      <MultipleMessages />
-      <WithCustomDuration />
-    </HorizontalStack>
-  );
-}
-
 export function Default() {
   const [active, setActive] = useState(false);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-summer-editions/issues/232


### WHAT is this pull request doing?

- Updates space between message and action
- Updates space between icon and message
- Updates icon color for default and action variants
- Removes action underline
- Updates the icon on the error variant


### How to 🎩

Review on [Storybook](https://5d559397bae39100201eedc1-wlbsxxjbxb.chromatic.com/?path=/story/all-components-toast--default&globals=polarisSummerEditions2023:true)

> **Note**
> There is no "all" storybook tab because Toasts need to be wrapped in a Frame and you can't have multiple Frames on the same page. So you'll need to click through the default, action, and error examples. 

- Ensure beta flagged Toast styles render as expected
- Ensure no regressions to the existing Toast styles

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
