### PR TITLE
[KeyboardKey] Add back large variant

### DIFF
--- a/polaris-react/src/components/KeyboardKey/KeyboardKey.scss
+++ b/polaris-react/src/components/KeyboardKey/KeyboardKey.scss
@@ -20,6 +20,13 @@ $key-base-dimension: 28px;
   text-align: center;
   min-width: $key-base-dimension;
   user-select: none;
+
+  #{$se23} & {
+    background: var(--p-color-bg-subdued);
+    border-radius: var(--p-border-radius-1);
+    color: var(--p-color-text-subdued);
+    box-shadow: none;
+  }
 }
 
 .small {
@@ -33,10 +40,7 @@ $key-base-dimension: 28px;
   min-width: var(--p-space-5);
 
   #{$se23} & {
-    background: var(--p-color-bg-subdued);
-    border-radius: var(--p-border-radius-1);
-    color: var(--p-color-text-subdued);
-    padding: var(--p-space-05) var(--p-space-1);
     line-height: var(--p-font-size-200);
+    padding: var(--p-space-05) var(--p-space-1);
   }
 }

--- a/polaris-react/src/components/KeyboardKey/KeyboardKey.tsx
+++ b/polaris-react/src/components/KeyboardKey/KeyboardKey.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
-import {useFeatures} from '../../utilities/features';
 
 import styles from './KeyboardKey.scss';
 
@@ -12,17 +11,12 @@ export interface KeyboardKeyProps {
   size?: Size;
 }
 export function KeyboardKey({children = '', size}: KeyboardKeyProps) {
-  const {polarisSummerEditions2023} = useFeatures();
   const key =
-    !polarisSummerEditions2023 && !size && children.length > 1
+    !size && children.length > 1
       ? children.toLowerCase()
       : children.toUpperCase();
 
-  const className = classNames(
-    styles.KeyboardKey,
-    size && styles[size],
-    polarisSummerEditions2023 && styles.small,
-  );
+  const className = classNames(styles.KeyboardKey, size && styles[size]);
 
   return <kbd className={className}>{key}</kbd>;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [#108](https://github.com/Shopify/polaris-summer-editions/issues/108)

### WHAT is this pull request doing?

Add back in `28px`x`28px` default KeyboardKey for se23

[Figma
](https://www.figma.com/file/hL9XRyHGqU8wUtLdOgs0vI/Polaris-Uplift-Guidance-(WIP)?type=design&node-id=9233-115422&t=CkZSbhENXj2ITRMm-0)
[Storybook](https://5d559397bae39100201eedc1-buwsqftzsf.chromatic.com/?path=/story/all-components-keyboardkey--all&globals=polarisSummerEditions2023:true)
