### PR TITLE
chore: bump polaris-tokens to 7.2.0

### DIFF
--- a/.changeset/friendly-nails-repeat.md
+++ b/.changeset/friendly-nails-repeat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Added new experimental tokens


### PR DESCRIPTION
### WHY are these changes introduced?

Bump polaris-tokens to v7.2.0 to release experimental tokens to consumers.

### WHAT is this pull request doing?

Adds changeset.