### PR TITLE
Icon `primary` and `plain` button updates

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -550,6 +550,14 @@
         background: transparent;
       }
     }
+
+    &.iconOnly {
+      margin: calc(-1 * var(--p-space-1_5-experimental));
+      @media #{$p-breakpoints-md-up} {
+        margin-left: calc(-1 * var(--p-space-1));
+        margin-right: calc(-1 * var(--p-space-1));
+      }
+    }
   }
 }
 

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -893,10 +893,6 @@
 
     svg {
       fill: var(--p-color-icon);
-
-      #{$se23} & {
-        fill: var(--p-color-icon-interactive);
-      }
     }
 
     &:hover svg {

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -899,20 +899,20 @@
       fill: var(--p-color-icon-hover);
     }
 
-    #{$se23} &:hover,
-    #{$se23} &:focus:not(:active, .pressed, .disabled) {
-      // stylelint-disable-next-line selector-max-combinators -- se23
-      svg {
-        fill: var(--p-color-icon-interactive-hover);
-      }
-    }
-
     &:active svg,
     &.pressed svg {
       fill: var(--p-color-icon-active);
 
       #{$se23} & {
-        fill: var(--p-color-icon-interactive-active);
+        // Specificity bump
+        fill: var(--p-color-icon-active);
+      }
+    }
+
+    &:focus svg {
+      #{$se23} & {
+        // Specificity bump
+        fill: var(--p-color-icon-hover);
       }
     }
 
@@ -939,12 +939,12 @@
       fill: var(--p-color-bg-critical-strong-hover);
 
       #{$se23} & {
-        fill: var(--p-color-icon-critical-strong-hover-experimental);
+        fill: var(--p-color-icon-critical-strong-experimental);
       }
     }
 
     #{$se23} &:focus:not(:active, .pressed, .disabled) svg {
-      fill: var(--p-color-icon-critical-strong-hover-experimental);
+      fill: var(--p-color-icon-critical-strong-experimental);
     }
 
     &:active svg,
@@ -952,7 +952,7 @@
       fill: var(--p-color-bg-critical-strong-active);
 
       #{$se23} & {
-        fill: var(--p-color-icon-critical-strong-active-experimental);
+        fill: var(--p-color-icon-critical-strong-experimental);
       }
     }
 

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -231,37 +231,7 @@ export function All() {
 
         <VerticalStack gap="2">
           <Text as="h2">plain</Text>
-          <HorizontalStack gap="5" blockAlign="end">
-            <Button plain>Label</Button>
-            <Button plain disabled>
-              Label
-            </Button>
-            <Button plain icon={PlusMinor}>
-              Label
-            </Button>
-            <Button plain disabled icon={PlusMinor}>
-              Label
-            </Button>
-            <Button plain disclosure>
-              Label
-            </Button>
-            <Button plain disclosure disabled>
-              Label
-            </Button>
-            <Button
-              plain
-              icon={CancelSmallMinor}
-              onClick={() => {}}
-              accessibilityLabel="Dismiss"
-            />
-            <Button
-              plain
-              disabled
-              icon={CancelSmallMinor}
-              onClick={() => {}}
-              accessibilityLabel="Dismiss"
-            />
-          </HorizontalStack>
+          <Plain />
         </VerticalStack>
 
         <VerticalStack gap="2">
@@ -360,7 +330,41 @@ export function OutlineMonochrome() {
 }
 
 export function Plain() {
-  return <Button plain>View shipping settings</Button>;
+  return (
+    <Box padding="4">
+      <HorizontalStack gap="5" blockAlign="end">
+        <Button plain>Label</Button>
+        <Button plain disabled>
+          Label
+        </Button>
+        <Button plain icon={PlusMinor}>
+          Label
+        </Button>
+        <Button plain disabled icon={PlusMinor}>
+          Label
+        </Button>
+        <Button plain disclosure>
+          Label
+        </Button>
+        <Button plain disclosure disabled>
+          Label
+        </Button>
+        <Button
+          plain
+          icon={CancelSmallMinor}
+          onClick={() => {}}
+          accessibilityLabel="Dismiss"
+        />
+        <Button
+          plain
+          disabled
+          icon={CancelSmallMinor}
+          onClick={() => {}}
+          accessibilityLabel="Dismiss"
+        />
+      </HorizontalStack>
+    </Box>
+  );
 }
 
 export function PlainPrimary() {

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -383,21 +383,6 @@ export function PlainPrimary() {
           <Button primary plain disclosure>
             Label
           </Button>
-          <Button
-            primary
-            plain
-            icon={CancelSmallMinor}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            disabled
-            primary
-            plain
-            icon={EditMajor}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
         </HorizontalStack>
       </Box>
       <Card>
@@ -417,6 +402,10 @@ export function PlainPrimary() {
           <Button primary plain disclosure>
             Label
           </Button>
+        </HorizontalStack>
+      </Card>
+      <Card>
+        <HorizontalStack gap="5" blockAlign="end">
           <Button
             primary
             plain

--- a/polaris-react/src/components/DatePicker/DatePicker.scss
+++ b/polaris-react/src/components/DatePicker/DatePicker.scss
@@ -202,6 +202,7 @@
     font-size: var(--p-font-size-80-experimental);
     line-height: var(--p-font-line-height-2);
     font-weight: var(--p-font-weight-medium);
+    margin-top: 0;
   }
 }
 

--- a/polaris-react/src/components/MediaCard/MediaCard.tsx
+++ b/polaris-react/src/components/MediaCard/MediaCard.tsx
@@ -16,7 +16,6 @@ import {Box} from '../Box';
 import {HorizontalStack} from '../HorizontalStack';
 import {useFeatures} from '../../utilities/features';
 import {VerticalStack} from '../VerticalStack';
-import {Bleed} from '../Bleed';
 
 import styles from './MediaCard.scss';
 

--- a/polaris-react/src/components/MediaCard/MediaCard.tsx
+++ b/polaris-react/src/components/MediaCard/MediaCard.tsx
@@ -166,7 +166,7 @@ export function MediaCard({
     popoverActionsMarkup || dismissButtonMarkup ? (
       <Box
         position="absolute"
-        insetBlockStart="4"
+        insetBlockStart={polarisSummerEditions2023 ? undefined : '4'}
         insetInlineEnd="5"
         zIndex="var(--p-z-index-2)"
       >
@@ -187,9 +187,7 @@ export function MediaCard({
               <VerticalStack gap="2">
                 <HorizontalStack wrap={false} align="space-between" gap="2">
                   {headerMarkup}
-                  <Bleed marginBlock="1" marginInline="1">
-                    {popoverOrDismissMarkup}
-                  </Bleed>
+                  {popoverOrDismissMarkup}
                 </HorizontalStack>
                 <p className={styles.Description}>{description}</p>
                 {actionMarkup}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/317

### WHAT is this pull request doing?

- Adds some negative margin for cases of Buttons with the combination of `primary` `plain` where the content is only an icon so that the button aligns to the icon/content rather than the button block.
- Update colors of `plain` Buttons with only icon content from active blue to icon color

### How to 🎩

- Review [Storybook](https://5d559397bae39100201eedc1-hlcnwluung.chromatic.com/?path=/story/all-components-button--plain-primary&globals=polarisSummerEditions2023:true)