### PR TITLE
[TopBar] Remove background-color transition and fix search input on Safari

### DIFF
--- a/.changeset/funny-rabbits-deliver.md
+++ b/.changeset/funny-rabbits-deliver.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Remove TopBar background-color transition and fix search input on Safari

--- a/.changeset/funny-rabbits-deliver.md
+++ b/.changeset/funny-rabbits-deliver.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Remove TopBar background-color transition and fix search input on Safari
+Removed TopBar background-color transition and fix search input on Safari

--- a/polaris-react/src/components/TopBar/TopBar.scss
+++ b/polaris-react/src/components/TopBar/TopBar.scss
@@ -9,8 +9,6 @@ $icon-size: 20px;
   height: $top-bar-height;
   box-shadow: var(--p-shadow-sm);
   background-color: var(--p-color-bg);
-  transition: var(--p-motion-duration-200) background-color
-    var(--p-motion-ease-in-out);
 
   #{$se23} & {
     background-color: var(--p-color-bg-inverse);

--- a/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
@@ -116,7 +116,6 @@ $search-icon-width-se23: calc(#{$icon-size-se23} + var(--p-space-3));
   will-change: fill, color;
   transition: fill var(--p-motion-duration-200) var(--p-motion-ease),
     color var(--p-motion-duration-200) var(--p-motion-ease);
-  appearance: textfield;
 
   #{$se23} & {
     padding: 0 $search-icon-width-se23 0 $search-icon-width-se23;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes for issues detected during the implementation of se23 in the Admin.

### WHAT is this pull request doing?

This PR removes the transition effect of the `background-color` when loading the `TopBar` with the se23 feature enabled. The transition effect caused a strange experience when loading the Admin, as the background color shifted from light to dark.

This PR also addresses an issue detected on Safari. The property `appearance` was adding a lot of `border-radius` to the input element. The `appearance` property doesn't seem to be necessary as well since all the native input styles seem to be overridden correctly already. 

https://github.com/Shopify/polaris/assets/2091116/ad16d94a-7654-46e2-9f98-f96e02479132

On the video above it's possible to see the border-radius being applied when the `appearance` is set to `textfield` on Safari Mobile. 

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
