### PR TITLE
Remove margin bottom from keyboard key

### DIFF
--- a/polaris-react/src/components/KeyboardKey/KeyboardKey.scss
+++ b/polaris-react/src/components/KeyboardKey/KeyboardKey.scss
@@ -26,6 +26,7 @@ $key-base-dimension: 28px;
     border-radius: var(--p-border-radius-1);
     color: var(--p-color-text-subdued);
     box-shadow: none;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Pre se23 keyboard key had a bottom shadow so a bottom margin was added to accommodate this. Since we removed the shadow in this version, we don't need a bottom margin to get center alignment anymore.
