### PR TITLE
Add pointer events none to banner

### DIFF
--- a/polaris-react/src/components/Banner/Banner.scss
+++ b/polaris-react/src/components/Banner/Banner.scss
@@ -29,6 +29,7 @@
         position: absolute;
         border-radius: var(--p-border-radius-3);
         box-shadow: var(--p-shadow-card-md-experimental);
+        pointer-events: none;
 
         @media #{$p-breakpoints-sm-down} {
           border-radius: 0;


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [this](https://github.com/Shopify/polaris-summer-editions/issues/513)

### WHAT is this pull request doing?
use `pointer-events: none` on the banner's pseudo-element so that links and other inline interactions are clickable