### PR TITLE
[Tooltip] Update component when active prop is changed

### DIFF
--- a/.changeset/six-forks-mate.md
+++ b/.changeset/six-forks-mate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated tooltip's visibility (open/closed state) when `active` prop is updated

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {QuestionMarkMinor} from '@shopify/polaris-icons';
 import type {ComponentMeta} from '@storybook/react';
 import {
@@ -11,7 +11,9 @@ import {
   Box,
   HorizontalStack,
   VerticalStack,
+  Popover,
 } from '@shopify/polaris';
+import type {TooltipProps} from '@shopify/polaris';
 
 export default {
   component: Tooltip,
@@ -485,6 +487,10 @@ export function PersistOnClick() {
 }
 
 export function ActiveStates() {
+  const [popoverActive, setPopoverActive] = useState(false);
+  const [tooltipActive, setTooltipActive] =
+    useState<TooltipProps['active']>(true);
+
   return (
     <Box paddingBlockStart="24">
       <HorizontalStack gap="24">
@@ -504,6 +510,44 @@ export function ActiveStates() {
         >
           <Text variant="bodyLg" fontWeight="bold" as="span">
             Active undefined
+          </Text>
+        </Tooltip>
+        <Tooltip
+          content="This tooltip should hide when popover is active"
+          active={tooltipActive}
+        >
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            <Popover
+              active={popoverActive}
+              activator={
+                <button
+                  onClick={() => {
+                    setPopoverActive(true);
+                    setTooltipActive(false);
+                  }}
+                >
+                  Popover Activator
+                </button>
+              }
+              autofocusTarget="first-node"
+              preferredPosition="below"
+              preferredAlignment="left"
+              onClose={() => {
+                setPopoverActive(false);
+                setTooltipActive(true);
+              }}
+            >
+              <div style={{padding: '12px'}}>
+                <VerticalStack>
+                  <Text variant="bodyMd" fontWeight="bold" as="span">
+                    popoverActive: {popoverActive.toString()}
+                  </Text>
+                  <Text variant="bodyMd" fontWeight="bold" as="span">
+                    tooltipActive: {tooltipActive?.toString()}
+                  </Text>
+                </VerticalStack>
+              </div>
+            </Popover>
           </Text>
         </Tooltip>
       </HorizontalStack>

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -137,10 +137,6 @@ export function Tooltip({
     };
   }, []);
 
-  useEffect(() => {
-    if (originalActive === false && active) handleBlur();
-  }, [originalActive, active, handleBlur]);
-
   const handleOpen = useCallback(() => {
     setShouldAnimate(!presenceList.tooltip && !active);
     onOpen?.();
@@ -164,6 +160,13 @@ export function Tooltip({
     },
     [handleBlur, handleClose, persistOnClick, togglePersisting],
   );
+
+  useEffect(() => {
+    if (originalActive === false && active) {
+      handleClose();
+      handleBlur();
+    }
+  }, [originalActive, active, handleClose, handleBlur]);
 
   const portal = activatorNode ? (
     <Portal idPrefix="tooltip">

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -137,6 +137,10 @@ export function Tooltip({
     };
   }, []);
 
+  useEffect(() => {
+    if (originalActive === false && active) handleBlur();
+  }, [originalActive, active, handleBlur]);
+
   const handleOpen = useCallback(() => {
     setShouldAnimate(!presenceList.tooltip && !active);
     onOpen?.();

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -47,6 +47,20 @@ describe('<Tooltip />', () => {
     );
   });
 
+  it('does not render when active prop is updated to false', () => {
+    const tooltip = mountWithApp(
+      <Tooltip content="Inner content" active={undefined}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    findWrapperComponent(tooltip)!.trigger('onMouseOver');
+    expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div');
+
+    tooltip.setProps({active: false});
+    expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
+  });
+
   it('passes preventInteraction to TooltipOverlay when dismissOnMouseOut is true', () => {
     const tooltip = mountWithApp(
       <Tooltip dismissOnMouseOut content="Inner content" active>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This will fix an issue where the tooltip activator includes a popover. Currently, when the popover is opened, both the tooltip and popover contents will render. More details can be found in the linked issue.

Fixes https://github.com/Shopify/polaris/issues/9472

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR adds a `useEffect` that will ensure that the tooltip is no longer visible when the `active` prop is updated.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
