### PR TITLE
Update `Badge` component

### DIFF
--- a/.changeset/large-teachers-push.md
+++ b/.changeset/large-teachers-push.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added experimental `strong` variants and `large` size to `Badge` component

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -28,7 +28,9 @@
         "warning": "Warning",
         "critical": "Critical",
         "attention": "Attention",
-        "new": "New"
+        "new": "New",
+        "readOnly": "Read-only",
+        "enabled": "Enabled"
       },
       "progressAndStatus": "{statusLabel} {progressLabel}"
     },

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -18,6 +18,7 @@
     color: var(--p-color-text-subdued);
     font-weight: var(--p-font-weight-medium);
     border-radius: var(--p-border-radius-2);
+    padding: var(--p-space-05) var(--p-space-1_5-experimental);
 
     // stylelint-disable-next-line -- se23 svg fill override
     svg {
@@ -236,6 +237,18 @@
   }
 }
 
+@mixin sizeLarge {
+  padding: var(--p-space-1) var(--p-space-2);
+}
+
+.sizeLarge-experimental {
+  @include sizeLarge;
+
+  #{$se23} & {
+    @include sizeLarge;
+  }
+}
+
 .withinFilter {
   border-radius: var(--p-border-radius-1);
 }
@@ -245,8 +258,16 @@
   // its bounding box.
   margin-left: calc(-1 * (var(--p-space-1)));
 
-  + *:not(.Icon) {
+  #{$se23} &:only-child {
+    margin-left: 0;
+  }
+
+  + * {
     margin-left: var(--p-space-1);
+
+    #{$se23} & {
+      margin-left: var(--p-space-1_5-experimental);
+    }
   }
 }
 

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -80,7 +80,7 @@
   background-color: var(--p-color-bg-info-strong);
 
   svg {
-    fill: var(--p-color-icon-info-strong-experimental);
+    fill: var(--p-color-text-info-strong);
   }
 }
 
@@ -111,7 +111,7 @@
   background-color: var(--p-color-bg-caution-strong);
 
   svg {
-    fill: var(--p-color-icon);
+    fill: var(--p-color-text-caution);
   }
 }
 
@@ -142,8 +142,7 @@
   background-color: var(--p-color-bg-warning-strong-experimental);
 
   svg {
-    // TODO: Should this be an experimental icon color?
-    fill: var(--p-color-text-warning-strong);
+    fill: var(--p-color-text-warning-experimental);
   }
 }
 
@@ -164,7 +163,7 @@
 
     // stylelint-disable-next-line -- se23 svg fill override
     svg {
-      fill: var(--p-color-icon-critical);
+      fill: var(--p-color-icon-critical-strong-experimental);
     }
   }
 }

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -44,6 +44,23 @@
   }
 }
 
+@mixin statusSuccess-strong {
+  color: var(--p-color-text-on-color);
+  background-color: var(--p-color-bg-success-strong);
+
+  svg {
+    fill: var(--p-color-icon-on-color);
+  }
+}
+
+.statusSuccess-strong-experimental {
+  @include statusSuccess-strong;
+
+  #{$se23} & {
+    @include statusSuccess-strong;
+  }
+}
+
 .statusInfo {
   background-color: var(--p-color-bg-info);
 
@@ -55,6 +72,23 @@
     svg {
       fill: var(--p-color-icon-info);
     }
+  }
+}
+
+@mixin statusInfo-strong {
+  color: var(--p-color-text-info-strong);
+  background-color: var(--p-color-bg-info-strong);
+
+  svg {
+    fill: var(--p-color-icon-info-strong-experimental);
+  }
+}
+
+.statusInfo-strong-experimental {
+  @include statusInfo-strong;
+
+  #{$se23} & {
+    @include statusInfo-strong;
   }
 }
 
@@ -72,6 +106,23 @@
   }
 }
 
+@mixin statusAttention-strong {
+  color: var(--p-color-text-caution-strong);
+  background-color: var(--p-color-bg-caution-strong);
+
+  svg {
+    fill: var(--p-color-icon);
+  }
+}
+
+.statusAttention-strong-experimental {
+  @include statusAttention-strong;
+
+  #{$se23} & {
+    @include statusAttention-strong;
+  }
+}
+
 .statusWarning {
   background-color: var(--p-color-bg-warning);
 
@@ -83,6 +134,24 @@
     svg {
       fill: var(--p-color-icon-warning);
     }
+  }
+}
+
+@mixin statusWarning-strong {
+  color: var(--p-color-text-warning-experimental);
+  background-color: var(--p-color-bg-warning-strong-experimental);
+
+  svg {
+    // TODO: Should this be an experimental icon color?
+    fill: var(--p-color-text-warning-strong);
+  }
+}
+
+.statusWarning-strong-experimental {
+  @include statusWarning-strong;
+
+  #{$se23} & {
+    @include statusWarning-strong;
   }
 }
 
@@ -100,6 +169,23 @@
   }
 }
 
+@mixin statusCritical-strong {
+  color: var(--p-color-text-on-color);
+  background-color: var(--p-color-bg-critical-strong);
+
+  svg {
+    fill: var(--p-color-icon-on-color);
+  }
+}
+
+.statusCritical-strong-experimental {
+  @include statusCritical-strong;
+
+  #{$se23} & {
+    @include statusCritical-strong;
+  }
+}
+
 .statusNew {
   border: none;
 
@@ -113,6 +199,40 @@
     svg {
       fill: var(--p-color-text-subdued);
     }
+  }
+}
+
+@mixin statusRead-only {
+  color: var(--p-color-text-subdued);
+  background-color: transparent;
+
+  svg {
+    // stylelint-disable-next-line -- TODO: What token should this be?
+    fill: rgba(255, 255, 255, 0.45);
+  }
+}
+
+.statusRead-only-experimental {
+  @include statusRead-only;
+
+  #{$se23} & {
+    @include statusRead-only;
+  }
+}
+
+@mixin statusEnabled {
+  color: var(--p-color-text);
+
+  svg {
+    fill: var(--p-color-icon-success);
+  }
+}
+
+.statusEnabled-experimental {
+  @include statusEnabled;
+
+  #{$se23} & {
+    @include statusEnabled;
   }
 }
 

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -207,8 +207,7 @@
   background-color: transparent;
 
   svg {
-    // stylelint-disable-next-line -- TODO: What token should this be?
-    fill: rgba(255, 255, 255, 0.45);
+    fill: var(--p-color-icon-subdued);
   }
 }
 

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -18,7 +18,6 @@
     color: var(--p-color-text-subdued);
     font-weight: var(--p-font-weight-medium);
     border-radius: var(--p-border-radius-2);
-    padding: var(--p-space-05) var(--p-space-1_5-experimental);
 
     // stylelint-disable-next-line -- se23 svg fill override
     svg {
@@ -258,15 +257,24 @@
   // its bounding box.
   margin-left: calc(-1 * (var(--p-space-1)));
 
-  #{$se23} &:only-child {
-    margin-left: 0;
+  #{$se23} & {
+    margin: calc(-1 * var(--p-space-05)) 0 calc(-1 * var(--p-space-05))
+      calc(-1 * var(--p-space-2));
+  }
+
+  .sizeLarge-experimental & {
+    margin: 0 var(--p-space-1) 0 calc(-1 * var(--p-space-05));
+
+    #{$se23} & {
+      margin: 0 var(--p-space-1) 0 calc(-1 * var(--p-space-05));
+    }
   }
 
   + * {
     margin-left: var(--p-space-1);
 
     #{$se23} & {
-      margin-left: var(--p-space-1_5-experimental);
+      margin-left: 0;
     }
   }
 }

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
+import type {BadgeProps} from '@shopify/polaris';
 import {
   Badge,
   HorizontalStack,
   LegacyCard,
   VerticalStack,
   Text,
+  Box,
 } from '@shopify/polaris';
 import {ClockMajor} from '@shopify/polaris-icons';
 
@@ -73,129 +75,130 @@ export function WithStatusAndProgressLabelOverride() {
   );
 }
 
+export type Entry<T> = [keyof T, T[keyof T]];
+export type Entries<T> = Entry<T>[];
+
+const statuses: {
+  [S in 'default' | NonNullable<BadgeProps['status']>]: string;
+} = {
+  default: 'Neutral',
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  attention: 'Attention',
+  critical: 'Critical',
+  new: 'New',
+  'read-only-experimental': 'Read-only',
+  'enabled-experimental': 'Enabled',
+  'info-strong-experimental': 'Info',
+  'success-strong-experimental': 'Success',
+  'warning-strong-experimental': 'Warning',
+  'attention-strong-experimental': 'Attention',
+  'critical-strong-experimental': 'Critical',
+};
+
+const statusEntries = Object.entries(statuses) as Entries<typeof statuses>;
+
+const progresses: {
+  [P in NonNullable<BadgeProps['progress']>]: string;
+} = {
+  complete: 'Complete',
+  partiallyComplete: 'Partially complete',
+  incomplete: 'Incomplete',
+};
+
+const progressEntries = Object.entries(progresses) as Entries<
+  typeof progresses
+>;
+
+const sizes: {
+  [P in Exclude<NonNullable<BadgeProps['size']>, 'small'>]: string;
+} = {
+  medium: 'Medium',
+  'large-experimental': 'Large',
+};
+
+const sizeEntries = Object.entries(sizes) as Entries<typeof sizes>;
+
 export function All() {
   return (
     <LegacyCard sectioned>
-      <VerticalStack gap="5">
-        <VerticalStack gap="2">
-          <Text as="h2" variant="headingXs">
-            Default by status
-          </Text>
-          <HorizontalStack gap="4">
-            <Badge>Fulfilled</Badge>
-            <Badge status="info">Informational</Badge>
-            <Badge status="success">Success</Badge>
-            <Badge status="warning">Warning</Badge>
-            <Badge status="attention">Attention</Badge>
-            <Badge status="critical">Critical</Badge>
-            <Badge status="new">New</Badge>
-          </HorizontalStack>
-        </VerticalStack>
-        <VerticalStack gap="2">
-          <Text as="h2" variant="headingXs">
-            Complete
-          </Text>
-          <HorizontalStack gap="4">
-            <Badge progress="complete">Fulfilled</Badge>
-            <Badge progress="complete" status="info">
-              Informational
-            </Badge>
-            <Badge progress="complete" status="success">
-              Success
-            </Badge>
-            <Badge progress="complete" status="warning">
-              Warning
-            </Badge>
-            <Badge progress="complete" status="attention">
-              Attention
-            </Badge>
-            <Badge progress="complete" status="critical">
-              Critical
-            </Badge>
-            <Badge progress="complete" status="new">
-              New
-            </Badge>
-          </HorizontalStack>
-        </VerticalStack>
-        <VerticalStack gap="2">
-          <Text as="h2" variant="headingXs">
-            Partially complete
-          </Text>
-          <HorizontalStack gap="4">
-            <Badge progress="partiallyComplete">Fulfilled</Badge>
-            <Badge progress="partiallyComplete" status="info">
-              Informational
-            </Badge>
-            <Badge progress="partiallyComplete" status="success">
-              Success
-            </Badge>
-            <Badge progress="partiallyComplete" status="warning">
-              Warning
-            </Badge>
-            <Badge progress="partiallyComplete" status="attention">
-              Attention
-            </Badge>
-            <Badge progress="partiallyComplete" status="critical">
-              Critical
-            </Badge>
-            <Badge progress="partiallyComplete" status="new">
-              New
-            </Badge>
-          </HorizontalStack>
-        </VerticalStack>
-        <VerticalStack gap="2">
-          <Text as="h2" variant="headingXs">
-            Incomplete
-          </Text>
-          <HorizontalStack gap="4">
-            <Badge progress="incomplete">Fulfilled</Badge>
-            <Badge progress="incomplete" status="info">
-              Informational
-            </Badge>
-            <Badge progress="incomplete" status="success">
-              Success
-            </Badge>
-            <Badge progress="incomplete" status="warning">
-              Warning
-            </Badge>
-            <Badge progress="incomplete" status="attention">
-              Attention
-            </Badge>
-            <Badge progress="incomplete" status="critical">
-              Critical
-            </Badge>
-            <Badge progress="incomplete" status="new">
-              New
-            </Badge>
-          </HorizontalStack>
-        </VerticalStack>
-        <VerticalStack gap="2">
-          <Text as="h2" variant="headingXs">
-            Custom icon
-          </Text>
-          <HorizontalStack gap="4">
-            <Badge icon={ClockMajor}>Fulfilled</Badge>
-            <Badge icon={ClockMajor} status="info">
-              Informational
-            </Badge>
-            <Badge icon={ClockMajor} status="success">
-              Success
-            </Badge>
-            <Badge icon={ClockMajor} status="warning">
-              Warning
-            </Badge>
-            <Badge icon={ClockMajor} status="attention">
-              Attention
-            </Badge>
-            <Badge icon={ClockMajor} status="critical">
-              Critical
-            </Badge>
-            <Badge icon={ClockMajor} status="new">
-              New
-            </Badge>
-          </HorizontalStack>
-        </VerticalStack>
-      </VerticalStack>
+      {sizeEntries.map(([size, sizeLabel]) => (
+        <Box key={size} paddingBlockEnd="2">
+          <VerticalStack gap="3">
+            <Text as="h2" variant="headingXl">
+              Size: {sizeLabel}
+            </Text>
+            <VerticalStack gap="2">
+              <Text as="h2" variant="headingXs">
+                Status only
+              </Text>
+              <HorizontalStack gap="2">
+                {statusEntries.map(([status, statusLabel]) => (
+                  <Badge
+                    key={status}
+                    size={size}
+                    status={status === 'default' ? undefined : status}
+                  >
+                    {statusLabel}
+                  </Badge>
+                ))}
+              </HorizontalStack>
+            </VerticalStack>
+            <VerticalStack gap="2">
+              <Text as="h2" variant="headingXs">
+                Status with progress
+              </Text>
+              {progressEntries.map(([progress]) => (
+                <HorizontalStack key={progress} gap="2">
+                  {statusEntries.map(([status, statusLabel]) => (
+                    <Badge
+                      key={status}
+                      size={size}
+                      progress={progress}
+                      status={status === 'default' ? undefined : status}
+                    >
+                      {statusLabel}
+                    </Badge>
+                  ))}
+                </HorizontalStack>
+              ))}
+            </VerticalStack>
+            <VerticalStack gap="2">
+              <Text as="h2" variant="headingXs">
+                Status with icon
+              </Text>
+              <HorizontalStack gap="2">
+                {statusEntries.map(([status, statusLabel]) => (
+                  <Badge
+                    key={status}
+                    size={size}
+                    icon={ClockMajor}
+                    status={status === 'default' ? undefined : status}
+                  >
+                    {statusLabel}
+                  </Badge>
+                ))}
+              </HorizontalStack>
+            </VerticalStack>
+            <VerticalStack gap="2">
+              <Text as="h2" variant="headingXs">
+                Status / Icon only
+              </Text>
+              <HorizontalStack gap="2">
+                {statusEntries.map(([status]) => (
+                  <Badge
+                    key={status}
+                    size={size}
+                    icon={ClockMajor}
+                    status={status === 'default' ? undefined : status}
+                  />
+                ))}
+              </HorizontalStack>
+            </VerticalStack>
+          </VerticalStack>
+        </Box>
+      ))}
     </LegacyCard>
   );
 }

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -85,8 +85,8 @@ const TempIcon = () => (
   </svg>
 );
 
-export type Entry<T> = [keyof T, T[keyof T]];
-export type Entries<T> = Entry<T>[];
+type Entry<T> = [keyof T, T[keyof T]];
+type Entries<T> = Entry<T>[];
 
 const statuses: {
   [S in 'default' | NonNullable<BadgeProps['status']>]: string;

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -10,6 +10,8 @@ import {
   Box,
 } from '@shopify/polaris';
 
+import {useFeatures} from '../../utilities/features';
+
 export default {
   component: Badge,
 } as ComponentMeta<typeof Badge>;
@@ -131,6 +133,12 @@ const sizes: {
 const sizeEntries = Object.entries(sizes) as Entries<typeof sizes>;
 
 export function All() {
+  const {polarisSummerEditions2023} = useFeatures();
+
+  const filteredStatusEntries = polarisSummerEditions2023
+    ? statusEntries
+    : statusEntries.filter(([status]) => !status.endsWith('-experimental'));
+
   return (
     <LegacyCard sectioned>
       {sizeEntries.map(([size, sizeLabel]) => (
@@ -144,7 +152,7 @@ export function All() {
                 Status only
               </Text>
               <HorizontalStack gap="2">
-                {statusEntries.map(([status, statusLabel]) => (
+                {filteredStatusEntries.map(([status, statusLabel]) => (
                   <Badge
                     key={status}
                     size={size}
@@ -161,7 +169,7 @@ export function All() {
               </Text>
               {progressEntries.map(([progress]) => (
                 <HorizontalStack key={progress} gap="2">
-                  {statusEntries.map(([status, statusLabel]) => (
+                  {filteredStatusEntries.map(([status, statusLabel]) => (
                     <Badge
                       key={status}
                       size={size}
@@ -179,7 +187,7 @@ export function All() {
                 Status with icon
               </Text>
               <HorizontalStack gap="2">
-                {statusEntries.map(([status, statusLabel]) => (
+                {filteredStatusEntries.map(([status, statusLabel]) => (
                   <Badge
                     key={status}
                     size={size}

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -76,15 +76,11 @@ export function WithStatusAndProgressLabelOverride() {
 
 const TempIcon = () => (
   <svg viewBox="0 0 20 20">
-    <path d="M11 13.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" fill="#5C5F62" />
-    <path
-      d="M10.75 6.25a.75.75 0 0 0-1.5 0v4a.75.75 0 0 0 1.5 0v-4Z"
-      fill="#5C5F62"
-    />
+    <path d="M11 13.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" />
+    <path d="M10.75 6.25a.75.75 0 0 0-1.5 0v4a.75.75 0 0 0 1.5 0v-4Z" />
     <path
       fill-rule="evenodd"
       d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm0-1.5a6.5 6.5 0 1 0 0-13 6.5 6.5 0 0 0 0 13Z"
-      fill="#5C5F62"
     />
   </svg>
 );
@@ -197,7 +193,7 @@ export function All() {
             </VerticalStack>
             <VerticalStack gap="2">
               <Text as="h2" variant="headingXs">
-                Status / Icon only
+                Status with icon only
               </Text>
               <HorizontalStack gap="2">
                 {statusEntries.map(([status]) => (

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -9,7 +9,6 @@ import {
   Text,
   Box,
 } from '@shopify/polaris';
-import {ClockMajor} from '@shopify/polaris-icons';
 
 export default {
   component: Badge,
@@ -74,6 +73,21 @@ export function WithStatusAndProgressLabelOverride() {
     </Badge>
   );
 }
+
+const TempIcon = () => (
+  <svg viewBox="0 0 20 20">
+    <path d="M11 13.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" fill="#5C5F62" />
+    <path
+      d="M10.75 6.25a.75.75 0 0 0-1.5 0v4a.75.75 0 0 0 1.5 0v-4Z"
+      fill="#5C5F62"
+    />
+    <path
+      fill-rule="evenodd"
+      d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm0-1.5a6.5 6.5 0 1 0 0-13 6.5 6.5 0 0 0 0 13Z"
+      fill="#5C5F62"
+    />
+  </svg>
+);
 
 export type Entry<T> = [keyof T, T[keyof T]];
 export type Entries<T> = Entry<T>[];
@@ -173,7 +187,7 @@ export function All() {
                   <Badge
                     key={status}
                     size={size}
-                    icon={ClockMajor}
+                    icon={TempIcon}
                     status={status === 'default' ? undefined : status}
                   >
                     {statusLabel}
@@ -190,7 +204,7 @@ export function All() {
                   <Badge
                     key={status}
                     size={size}
-                    icon={ClockMajor}
+                    icon={TempIcon}
                     status={status === 'default' ? undefined : status}
                   />
                 ))}

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -182,24 +182,28 @@ export function All() {
                 </HorizontalStack>
               ))}
             </VerticalStack>
-            <VerticalStack gap="2">
-              <Text as="h2" variant="headingXs">
-                Status with icon
-              </Text>
-              <HorizontalStack gap="2">
-                {filteredStatusEntries.map(([status, statusLabel]) => (
-                  <Badge
-                    key={status}
-                    size={size}
-                    icon={TempIcon}
-                    status={status === 'default' ? undefined : status}
-                  >
-                    {statusLabel}
-                  </Badge>
-                ))}
-              </HorizontalStack>
-            </VerticalStack>
-            <VerticalStack gap="2">
+            {/* Remove `size` condition when micro icons are available */}
+            {size === 'large-experimental' && (
+              <VerticalStack gap="2">
+                <Text as="h2" variant="headingXs">
+                  Status with icon
+                </Text>
+                <HorizontalStack gap="2">
+                  {filteredStatusEntries.map(([status, statusLabel]) => (
+                    <Badge
+                      key={status}
+                      size={size}
+                      icon={TempIcon}
+                      status={status === 'default' ? undefined : status}
+                    >
+                      {statusLabel}
+                    </Badge>
+                  ))}
+                </HorizontalStack>
+              </VerticalStack>
+            )}
+            {/* TODO: Re-enable the following examples when designs are available (post se23) */}
+            {/* <VerticalStack gap="2">
               <Text as="h2" variant="headingXs">
                 Status with icon only
               </Text>
@@ -213,7 +217,7 @@ export function All() {
                   />
                 ))}
               </HorizontalStack>
-            </VerticalStack>
+            </VerticalStack> */}
           </VerticalStack>
         </Box>
       ))}

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -204,7 +204,7 @@ export function All() {
                 Status with icon only
               </Text>
               <HorizontalStack gap="2">
-                {statusEntries.map(([status]) => (
+                {filteredStatusEntries.map(([status]) => (
                   <Badge
                     key={status}
                     size={size}

--- a/polaris-react/src/components/Badge/Badge.tsx
+++ b/polaris-react/src/components/Badge/Badge.tsx
@@ -23,8 +23,6 @@ interface NonMutuallyExclusiveProps {
   /** Icon to display to the left of the badge’s content. */
   icon?: IconSource;
   /**
-   * @deprecated
-   * Medium or small size.
    * @default 'medium'
    */
   size?: Size;

--- a/polaris-react/src/components/Badge/Badge.tsx
+++ b/polaris-react/src/components/Badge/Badge.tsx
@@ -6,6 +6,7 @@ import {WithinFilterContext} from '../../utilities/within-filter-context';
 import {Text} from '../Text';
 import {Icon} from '../Icon';
 import type {IconSource} from '../../types';
+import {useFeatures} from '../../utilities/features';
 
 import styles from './Badge.scss';
 import type {Progress, Size, Status} from './types';
@@ -36,6 +37,30 @@ export type BadgeProps = NonMutuallyExclusiveProps &
     | {icon?: IconSource; progress?: undefined}
   );
 
+const progressIconMap: {[P in Progress]: IconSource} = {
+  complete: () => (
+    <svg viewBox="0 0 20 20">
+      <path d="M6 10c0-.93 0-1.395.102-1.776a3 3 0 0 1 2.121-2.122C8.605 6 9.07 6 10 6c.93 0 1.395 0 1.776.102a3 3 0 0 1 2.122 2.122C14 8.605 14 9.07 14 10s0 1.395-.102 1.777a3 3 0 0 1-2.122 2.12C11.395 14 10.93 14 10 14s-1.395 0-1.777-.102a3 3 0 0 1-2.12-2.121C6 11.395 6 10.93 6 10Z" />
+    </svg>
+  ),
+  partiallyComplete: () => (
+    <svg viewBox="0 0 20 20">
+      <path
+        fillRule="evenodd"
+        d="m8.888 6.014-.017-.018-.02.02c-.253.013-.45.038-.628.086a3 3 0 0 0-2.12 2.122C6 8.605 6 9.07 6 10s0 1.395.102 1.777a3 3 0 0 0 2.121 2.12C8.605 14 9.07 14 10 14c.93 0 1.395 0 1.776-.102a3 3 0 0 0 2.122-2.121C14 11.395 14 10.93 14 10c0-.93 0-1.395-.102-1.776a3 3 0 0 0-2.122-2.122C11.395 6 10.93 6 10 6c-.475 0-.829 0-1.112.014ZM8.446 7.34a1.75 1.75 0 0 0-1.041.94l4.314 4.315c.443-.2.786-.576.941-1.042L8.446 7.34Zm4.304 2.536L10.124 7.25c.908.001 1.154.013 1.329.06a1.75 1.75 0 0 1 1.237 1.237c.047.175.059.42.06 1.329ZM8.547 12.69c.182.05.442.06 1.453.06h.106L7.25 9.894V10c0 1.01.01 1.27.06 1.453a1.75 1.75 0 0 0 1.237 1.237Z"
+      />
+    </svg>
+  ),
+  incomplete: () => (
+    <svg viewBox="0 0 20 20">
+      <path
+        fillRule="evenodd"
+        d="M8.547 12.69c.183.05.443.06 1.453.06s1.27-.01 1.453-.06a1.75 1.75 0 0 0 1.237-1.237c.05-.182.06-.443.06-1.453s-.01-1.27-.06-1.453a1.75 1.75 0 0 0-1.237-1.237c-.182-.05-.443-.06-1.453-.06s-1.27.01-1.453.06A1.75 1.75 0 0 0 7.31 8.547c-.05.183-.06.443-.06 1.453s.01 1.27.06 1.453a1.75 1.75 0 0 0 1.237 1.237ZM6.102 8.224C6 8.605 6 9.07 6 10s0 1.395.102 1.777a3 3 0 0 0 2.122 2.12C8.605 14 9.07 14 10 14s1.395 0 1.777-.102a3 3 0 0 0 2.12-2.121C14 11.395 14 10.93 14 10c0-.93 0-1.395-.102-1.776a3 3 0 0 0-2.121-2.122C11.395 6 10.93 6 10 6c-.93 0-1.395 0-1.776.102a3 3 0 0 0-2.122 2.122Z"
+      />
+    </svg>
+  ),
+};
+
 export function Badge({
   children,
   status,
@@ -45,13 +70,12 @@ export function Badge({
   statusAndProgressLabelOverride,
 }: BadgeProps) {
   const i18n = useI18n();
+  const {polarisSummerEditions2023} = useFeatures();
   const withinFilter = useContext(WithinFilterContext);
 
   const className = classNames(
     styles.Badge,
     status && styles[variationName('status', status)],
-    icon && styles.icon,
-    // TODO: remove support for the size prop in the next major release
     size && size !== DEFAULT_SIZE && styles[variationName('size', size)],
     withinFilter && styles.withinFilter,
   );
@@ -67,7 +91,15 @@ export function Badge({
   );
 
   if (progress && !icon) {
-    accessibilityMarkup = (
+    accessibilityMarkup = polarisSummerEditions2023 ? (
+      // TODO: Move this to CSS and add condition for medium and large sizes
+      <span style={{margin: '-2px 0 -2px -6px'}}>
+        <Icon
+          accessibilityLabel={accessibilityLabel}
+          source={progressIconMap[progress]}
+        />
+      </span>
+    ) : (
       <span className={styles.PipContainer}>
         <Pip
           progress={progress}

--- a/polaris-react/src/components/Badge/Badge.tsx
+++ b/polaris-react/src/components/Badge/Badge.tsx
@@ -92,8 +92,7 @@ export function Badge({
 
   if (progress && !icon) {
     accessibilityMarkup = polarisSummerEditions2023 ? (
-      // TODO: Move this to CSS and add condition for medium and large sizes
-      <span style={{margin: '-2px 0 -2px -6px'}}>
+      <span className={styles.Icon}>
         <Icon
           accessibilityLabel={accessibilityLabel}
           source={progressIconMap[progress]}

--- a/polaris-react/src/components/Badge/types.ts
+++ b/polaris-react/src/components/Badge/types.ts
@@ -32,4 +32,4 @@ export enum ProgressValue {
   Complete = 'complete',
 }
 
-export type Size = 'small' | 'medium';
+export type Size = 'small' | 'medium' | Experimental<'large'>;

--- a/polaris-react/src/components/Badge/types.ts
+++ b/polaris-react/src/components/Badge/types.ts
@@ -1,10 +1,19 @@
+type Experimental<T extends string> = `${T}-experimental`;
+
 export type Status =
   | 'info'
   | 'success'
   | 'warning'
   | 'critical'
   | 'attention'
-  | 'new';
+  | 'new'
+  | Experimental<'info-strong'>
+  | Experimental<'success-strong'>
+  | Experimental<'warning-strong'>
+  | Experimental<'critical-strong'>
+  | Experimental<'attention-strong'>
+  | Experimental<'read-only'>
+  | Experimental<'enabled'>;
 
 export enum StatusValue {
   Info = 'info',

--- a/polaris-react/src/components/Badge/types.ts
+++ b/polaris-react/src/components/Badge/types.ts
@@ -7,13 +7,15 @@ export type Status =
   | 'critical'
   | 'attention'
   | 'new'
-  | Experimental<'info-strong'>
-  | Experimental<'success-strong'>
-  | Experimental<'warning-strong'>
-  | Experimental<'critical-strong'>
-  | Experimental<'attention-strong'>
-  | Experimental<'read-only'>
-  | Experimental<'enabled'>;
+  | Experimental<
+      | 'info-strong'
+      | 'success-strong'
+      | 'warning-strong'
+      | 'critical-strong'
+      | 'attention-strong'
+      | 'read-only'
+      | 'enabled'
+    >;
 
 export enum StatusValue {
   Info = 'info',
@@ -22,6 +24,13 @@ export enum StatusValue {
   Critical = 'critical',
   Attention = 'attention',
   New = 'new',
+  InfoStrongExperimental = 'info-strong-experimental',
+  SuccessStrongExperimental = 'success-strong-experimental',
+  WarningStrongExperimental = 'warning-strong-experimental',
+  CriticalStrongExperimental = 'critical-strong-experimental',
+  AttentionStrongExperimental = 'attention-strong-experimental',
+  ReadOnlyExperimental = 'read-only-experimental',
+  EnabledExperimental = 'enabled-experimental',
 }
 
 export type Progress = 'incomplete' | 'partiallyComplete' | 'complete';

--- a/polaris-react/src/components/Badge/utils.ts
+++ b/polaris-react/src/components/Badge/utils.ts
@@ -33,23 +33,30 @@ export function getDefaultAccessibilityLabel(
 
   switch (status) {
     case StatusValue.Info:
+    case StatusValue.InfoStrongExperimental:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.info');
       break;
     case StatusValue.Success:
+    case StatusValue.SuccessStrongExperimental:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.success');
       break;
     case StatusValue.Warning:
+    case StatusValue.WarningStrongExperimental:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.warning');
       break;
     case StatusValue.Critical:
+    case StatusValue.CriticalStrongExperimental:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.critical');
       break;
     case StatusValue.Attention:
+    case StatusValue.AttentionStrongExperimental:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.attention');
       break;
     case StatusValue.New:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.new');
       break;
+
+    // TODO: Add ReadOnlyExperimental and EnabledExperimental
   }
 
   if (!status && progress) {

--- a/polaris-react/src/components/Badge/utils.ts
+++ b/polaris-react/src/components/Badge/utils.ts
@@ -55,8 +55,12 @@ export function getDefaultAccessibilityLabel(
     case StatusValue.New:
       statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.new');
       break;
-
-    // TODO: Add ReadOnlyExperimental and EnabledExperimental
+    case StatusValue.ReadOnlyExperimental:
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.readOnly');
+      break;
+    case StatusValue.EnabledExperimental:
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.enabled');
+      break;
   }
 
   if (!status && progress) {


### PR DESCRIPTION
- Added experimental `strong` `status` props
- Added experimental `large` `size` prop
- Converted `progress` Pips to Icons

TODO:
- [x] Update `progressIconMap` when official icons are exposed from `@shopify/polaris-icons`
  - Update: Discussed with @sarahill and decided to temporarily leave the hard coded `svg`s in the `progressIconMap`
- [x] Add `ReadOnlyExperimental` and `EnabledExperimental` cases and translations to `getDefaultAccessibilityLabel`

[Storybook](https://5d559397bae39100201eedc1-uvonuiwexb.chromatic.com/?path=/story/all-components-badge--all&globals=polarisSummerEditions2023:true)

<img width="1261" alt="image" src="https://github.com/Shopify/polaris/assets/32409546/7cbcb2d2-1511-499d-bebd-8ffcd9f53ce1">

