### PR TITLE
[Button] Add `truncate`

### DIFF
--- a/.changeset/angry-pumpkins-arrive.md
+++ b/.changeset/angry-pumpkins-arrive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added a `truncate` prop to `Button`

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -125,6 +125,12 @@
   }
 }
 
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .textAlignLeft {
   justify-content: flex-start;
   text-align: left;
@@ -971,6 +977,10 @@
 .fullWidth {
   display: flex;
   width: 100%;
+}
+
+.truncateButton {
+  max-width: 100%;
 }
 
 .iconOnly {

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -473,6 +473,22 @@ export function Micro() {
   );
 }
 
+export function Truncate() {
+  return (
+    <Box
+      maxWidth="100px"
+      borderColor="border"
+      borderWidth="1"
+      borderRadius="1"
+      overflowX="hidden"
+    >
+      <Button truncate>
+        Some very long button text that will not fit and will need to truncate
+      </Button>
+    </Box>
+  );
+}
+
 export function Slim() {
   return <Button size="slim">Save variant</Button>;
 }

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -55,6 +55,8 @@ export interface ButtonProps extends BaseButton {
   dataPrimaryLink?: boolean;
   /** Extra visual weight combined with indication of a positive action */
   primarySuccess?: boolean;
+  /** Truncate text overflow with ellipsis */
+  truncate?: boolean;
 }
 
 interface CommonButtonProps
@@ -137,6 +139,7 @@ export function Button({
   connectedDisclosure,
   dataPrimaryLink,
   primarySuccess,
+  truncate,
 }: ButtonProps) {
   const i18n = useI18n();
 
@@ -163,6 +166,7 @@ export function Button({
     removeUnderline && styles.removeUnderline,
     primarySuccess && styles.primary,
     primarySuccess && styles.success,
+    truncate && styles.truncateButton,
   );
 
   const disclosureMarkup = disclosure ? (
@@ -192,6 +196,7 @@ export function Button({
     <span
       className={classNames(
         styles.Text,
+        truncate && styles.truncate,
         removeUnderline && styles.removeUnderline,
       )}
       // Fixes Safari bug that doesn't re-render button text to correct color


### PR DESCRIPTION
### WHY are these changes introduced?

Button does not have the option to truncate text. This can cause overflow, wrapped text or other odd UI variations. 

See [this](https://github.com/Shopify/web/pull/95263) PR

### WHAT is this pull request doing?

Add the ability to truncate button text

### Screeny

<img width="130" alt="Screenshot 2023-06-20 at 10 58 16 AM" src="https://github.com/Shopify/polaris/assets/24610840/4f4b0505-cca6-455a-a6b0-6bc0c048e46c">

### How to 🎩

View the `Truncate` button story!
