### PR TITLE
Update `plain` `button` alignment

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -677,6 +677,7 @@
 
   #{$se23} & {
     box-shadow: none;
+    // stylelint-disable-next-line -- polaris/conventions/polaris/custom-property-allowed-list
     margin: calc(-1 * var(--pc-button-vertical-padding))
       calc(-1 * var(--p-space-3));
   }

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -677,6 +677,8 @@
 
   #{$se23} & {
     box-shadow: none;
+    margin: calc(-1 * var(--pc-button-vertical-padding))
+      calc(-1 * var(--p-space-3));
   }
 
   svg {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/546

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fixes `plain` button alignment by updating negative margin to cancel out updated padding

### How to 🎩

- Verify `plain` buttons align under heading in [Storybook](https://5d559397bae39100201eedc1-gkoonxgyss.chromatic.com/?path=/story/all-components-button--all&globals=polarisSummerEditions2023:true) with beta flag turned on