### PR TITLE
[CheckableButton] Be less opinionated about height so callsites can adjust dynamically

### DIFF
--- a/polaris-react/src/components/CheckableButton/CheckableButton.scss
+++ b/polaris-react/src/components/CheckableButton/CheckableButton.scss
@@ -20,8 +20,11 @@
   width: auto;
 
   #{$se23} & {
-    min-height: 24px;
-    min-width: 24px;
+    // Checkable Button has no opinion on its own height, it simply fills its
+    // container
+    min-height: auto;
+    min-width: auto;
+    height: 100%;
   }
 
   svg {

--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -238,6 +238,12 @@ $item-wrapper-loading-height: 64px;
 .CheckableButtonWrapper {
   display: none;
 
+  #{$se23} & {
+    // Checkable button has no opinion on its height, so we just fill the
+    // container
+    height: 100%;
+  }
+
   @media #{$p-breakpoints-sm-up} {
     flex: 1;
     display: block;


### PR DESCRIPTION
It's consumed in `<SelectAllActions>` which similarly unopinionated about the height.

It's also consumed in `<ResourceList>` directly which this PR includes one small change to realign it.

Since `<SelectAllActions>` is also consumed by `<IndexTable>`, that component will be updated/fixed as part of https://github.com/Shopify/polaris/pull/9486

`<CheckableButton>` is not consumed by any Shopify apps (confirmed by querying grokt with `<CheckableButton -r:polaris lang:tsx`).

`<SelectAllActions>` is used in one place in `web` (query grokt for `<SelectAllActions -r:polaris lang:tsx`), which may be fixable with the following changes to `app/shared/components/ResourceListWithHeader/ResourceListWithHeader.scss` (a combination of this PR + https://github.com/Shopify/polaris/pull/9453):

```diff
 .SelectAllActionsWrapper {
   position: relative;
   // stylelint-disable-next-line -- generated by polaris-migrator DO NOT COPY
   z-index: variables.resource-list(bulk-actions-wrapper-stacking-order);
   width: 100%;
 
   @media #{media-queries.$p-breakpoints-sm-up} {
     flex: 0 1 auto;
     align-self: flex-start;
   }
+
+  #{$se23} & {
+    display: flex;
+    align-self: auto;
+  }
 }
 
 .CheckableButtonWrapper {
   display: none;

+  #{$se23} & {
+    // Checkable button has no opinion on its height, so we just fill the
+    // container
+    height: 100%;
+  }
```