### PR TITLE
Remove outline on `primary plain` `disabled` button

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -523,8 +523,10 @@
     }
 
     &.disabled {
-      // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
+      // stylelint-disable polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       --pc-button-text: var(--p-color-text-disabled);
+      --pc-button-border-disabled-border-box-shadow: none;
+      // stylelint-enable polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       background: transparent;
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/481

### WHAT is this pull request doing?

Remove outline on `primary plain` `disabled` button

### How to 🎩

Verify in [Storybook](https://5d559397bae39100201eedc1-jfklqpajds.chromatic.com/?path=/story/all-components-button--plain-primary&globals=polarisSummerEditions2023:true)