### PR TITLE
[LegacyCard] Remove dividers for sections and subsections, `16px` spacing

### DIFF
--- a/.changeset/warm-toes-roll.md
+++ b/.changeset/warm-toes-roll.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[LegacyCard] Fix updated print styles and spacing

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -893,6 +893,7 @@
       margin: 0;
       padding: 0;
       min-height: var(--p-font-line-height-2);
+      min-width: var(--p-font-line-height-2);
     }
 
     svg {

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -8,6 +8,10 @@
 
   #{$se23} & {
     box-shadow: var(--p-shadow-card-sm-experimental);
+
+    @media print {
+      box-shadow: none;
+    }
   }
 
   + .LegacyCard {
@@ -150,6 +154,11 @@
 .Section-subdued:last-child {
   #{$se23} & {
     padding: var(--p-space-4);
+
+    @media print {
+      padding-top: var(--p-space-2);
+      padding-bottom: var(--p-space-2);
+    }
   }
 }
 

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -66,7 +66,7 @@
     padding: var(--p-space-5);
 
     #{$se23} & {
-      padding: var(--p-space-4);
+      padding: var(--p-space-2) var(--p-space-4);
     }
   }
 
@@ -74,6 +74,10 @@
     border-top: var(--p-border-width-1) solid var(--p-color-border-subdued);
 
     @media print {
+      border-top: 0;
+    }
+
+    #{$se23} & {
       border-top: 0;
     }
   }
@@ -91,6 +95,7 @@
   #{$se23} & {
     border-top-left-radius: var(--p-border-radius-3);
     border-top-right-radius: var(--p-border-radius-3);
+    padding-top: var(--p-space-4);
   }
 }
 
@@ -101,6 +106,7 @@
   #{$se23} & {
     border-bottom-left-radius: var(--p-border-radius-3);
     border-bottom-right-radius: var(--p-border-radius-3);
+    padding-bottom: var(--p-space-4);
   }
 }
 
@@ -135,6 +141,16 @@
     border-top: var(--p-border-width-1) solid var(--p-color-border-subdued);
     margin-top: var(--p-space-5);
   }
+
+  #{$se23} & {
+    border-top: 0;
+  }
+}
+
+.Section-subdued:last-child {
+  #{$se23} & {
+    padding: var(--p-space-4);
+  }
 }
 
 .SectionHeader {
@@ -164,6 +180,12 @@
 
     @media print {
       border-top: 0;
+    }
+
+    #{$se23} & {
+      border-top: 0;
+      margin-top: 0;
+      padding-top: var(--p-space-2);
     }
   }
 
@@ -196,6 +218,7 @@
 
     #{$se23} & {
       padding: var(--p-space-4);
+      border-top: 0;
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [this issue](https://github.com/Shopify/polaris-summer-editions/issues/617)

* Remove section and subsection dividers
* Create `16px` spacing between sections
* Fix print styles

### WHAT is this pull request doing?

|Before|After|
|-|-|
|<img width="1280" alt="Screenshot 2023-06-22 at 1 16 37 PM" src="https://github.com/Shopify/polaris/assets/20652326/b912deaf-f789-43fe-8a55-79e4502e7b34">|<img width="1275" alt="Screenshot 2023-06-22 at 1 16 49 PM" src="https://github.com/Shopify/polaris/assets/20652326/0dae9499-9461-47a6-ab7b-401b422d8a45">|
|<img width="1272" alt="Screenshot 2023-06-22 at 1 15 28 PM" src="https://github.com/Shopify/polaris/assets/20652326/4fc0ebaf-cc3a-4dee-a203-b74ac8fba744">|<img width="1275" alt="Screenshot 2023-06-22 at 1 15 35 PM" src="https://github.com/Shopify/polaris/assets/20652326/608dfea2-2c9a-4fa9-b09d-8d958ece5fdb">|
|<img width="531" alt="Screenshot 2023-06-22 at 1 18 54 PM" src="https://github.com/Shopify/polaris/assets/20652326/56ecf2ef-9e54-4ac9-bc86-1bf48b538c68">|<img width="533" alt="Screenshot 2023-06-22 at 1 18 39 PM" src="https://github.com/Shopify/polaris/assets/20652326/2eea1335-1810-477b-933f-df5302eeae96">|

### How to 🎩

Check out new spacing and divider removal in the Admin https://admin.web.web-wgj9.sophie-schneider.us.spin.dev/store/shop1/orders/10
Chromatic link LegacyCard in CI, turn on feature flag
 
### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
