### PR TITLE
[Listbox] Added gap between selected icon and child contents

### DIFF
--- a/polaris-react/src/components/Listbox/Listbox.stories.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.stories.tsx
@@ -10,6 +10,7 @@ import {
   LegacyStack,
   AutoSelection,
   VerticalStack,
+  HorizontalStack,
   Text,
   Box,
 } from '@shopify/polaris';
@@ -52,7 +53,7 @@ export function All() {
         <Text as="h2" variant="headingXl">
           With custom element
         </Text>
-        <WithCustomElement />
+        <WithCustomOptions />
         <Box paddingBlockEnd="3" />
       </VerticalStack>
 
@@ -113,22 +114,70 @@ export function WithAction() {
   );
 }
 
-export function WithCustomElement() {
+export function WithCustomOptions() {
+  interface CustomerSegment {
+    id: string;
+    label: string;
+    value: string;
+    subscribers: number;
+  }
+
+  const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
+
+  const segments: CustomerSegment[] = [
+    {
+      label: 'All customers',
+      id: 'gid://shopify/CustomerSegment/1',
+      value: '0',
+      subscribers: 23,
+    },
+    {
+      label: 'VIP customers',
+      id: 'gid://shopify/CustomerSegment/2',
+      value: '1',
+      subscribers: 16,
+    },
+    {
+      label: 'New customers',
+      id: 'gid://shopify/CustomerSegment/3',
+      value: '2',
+      subscribers: 2,
+    },
+    {
+      label: 'Abandoned carts - last 30 days',
+      id: 'gid://shopify/CustomerSegment/4',
+      value: '3',
+      subscribers: 108,
+    },
+  ];
+
+  const handleSegmentSelect = (segmentIndex: string) => {
+    setSelectedSegmentIndex(Number(segmentIndex));
+  };
+
   return (
-    <Listbox accessibilityLabel="Listbox with custom element example">
-      <Listbox.Action value="ActionValue" divider>
-        Add item
-      </Listbox.Action>
-      <Listbox.Option value="UniqueValue-1">
-        <div>Item 1</div>
-      </Listbox.Option>
-      <Listbox.Option value="UniqueValue-2">
-        <div>Item 2</div>
-      </Listbox.Option>
-      <Listbox.Option value="UniqueValue-3">
-        <div>Item 3</div>
-      </Listbox.Option>
-      <Listbox.Loading accessibilityLabel="items are loading" />
+    <Listbox
+      onSelect={handleSegmentSelect}
+      accessibilityLabel="Listbox with custom element example"
+    >
+      {segments.map(({label, id, value, subscribers}) => {
+        const selected = segments[selectedSegmentIndex].value === value;
+
+        return (
+          <Listbox.Option key={id} value={value} selected={selected}>
+            <Listbox.TextOption selected={selected}>
+              <Box width="100%">
+                <HorizontalStack gap="2" align="space-between">
+                  {label}
+                  <Text as="span" color="subdued">
+                    {`${subscribers} subscribers`}
+                  </Text>
+                </HorizontalStack>
+              </Box>
+            </Listbox.TextOption>
+          </Listbox.Option>
+        );
+      })}
     </Listbox>
   );
 }

--- a/polaris-react/src/components/Listbox/components/TextOption/TextOption.tsx
+++ b/polaris-react/src/components/Listbox/components/TextOption/TextOption.tsx
@@ -40,7 +40,7 @@ export const TextOption = memo(function TextOption({
   const optionMarkup =
     polarisSummerEditions2023 && selected ? (
       <Box width="100%">
-        <HorizontalStack align="space-between">
+        <HorizontalStack wrap={false} align="space-between" gap="2">
           {children}
           <HorizontalStack align="end">
             <Icon source={TickMinor} />


### PR DESCRIPTION
### WHAT is this pull request doing?

Adds a gap between the selected check icon and the child markup and prevents the icon from wrapping.

| Before | After |
|--------|--------|
| <img width="602" alt="Screenshot 2023-06-20 at 7 51 15 PM" src="https://github.com/Shopify/polaris/assets/18447883/128f5ed9-945a-46ad-99b6-f3dedd63c4e5"> | <img width="599" alt="Screenshot 2023-06-20 at 7 50 41 PM" src="https://github.com/Shopify/polaris/assets/18447883/a2010290-1cc2-45ef-b1eb-5f94ee28e12b">| 
|<img width="799" alt="Screenshot 2023-06-20 at 7 48 54 PM" src="https://github.com/Shopify/polaris/assets/18447883/ac6d16ef-002f-471c-8b1c-62aa3a888728">||

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
