### PR TITLE
[ResourceList] replace variable padding with variable height

### DIFF
--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -84,12 +84,13 @@ $item-wrapper-loading-height: 64px;
   background-color: var(--p-color-bg);
   border-radius: var(--p-border-radius-2);
   #{$se23} & {
-    min-height: 54px;
+    // This container conditionally includes a Select component for sorting
+    // It's 32px above md-up and 36px below
+    // This hardcoded min-height is to ensure the Select has uniform padding when it's 36px high
+    min-height: 52px;
     align-items: center;
     padding: var(--p-space-2) var(--p-space-3);
-    // This container conditionally includes a Select component for sorting
-    // We need dynamic height here to ensure the Select component and its container
-    // have consistent top and bottom spacing at each breakpoint.
+    // We reduce the min-height here to account for the Select shrinking to 32px at this breakpoint.
     @media #{$p-breakpoints-md-up} {
       min-height: 48px;
     }

--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -84,14 +84,14 @@ $item-wrapper-loading-height: 64px;
   background-color: var(--p-color-bg);
   border-radius: var(--p-border-radius-2);
   #{$se23} & {
-    min-height: 48px;
+    min-height: 54px;
     align-items: center;
+    padding: var(--p-space-2) var(--p-space-3);
     // This container conditionally includes a Select component for sorting
-    // We need dynamic padding values here to ensure the Select component and its container
-    // have adequate top and bottom spacing at each breakpoint.
-    padding: var(--p-space-1_5-experimental) var(--p-space-3);
+    // We need dynamic height here to ensure the Select component and its container
+    // have consistent top and bottom spacing at each breakpoint.
     @media #{$p-breakpoints-md-up} {
-      padding: var(--p-space-2) var(--p-space-3);
+      min-height: 48px;
     }
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/441
Changes the resourceList HeaderWrapper to be variable height 
See https://github.com/Shopify/polaris/pull/9453#issuecomment-1593867916

### WHAT is this pull request doing?

- HeaderWrapper to be `48px` in `md-up` and `52px` on breakpoints below this 
- Change vertical padding to be `p-space-8` at all breakpoints.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
