### PR TITLE
Fix margins on plain icon only buttons

### DIFF
--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
@@ -140,8 +140,7 @@ function DefaultBanner({
           borderRadiusStartEnd={smUp ? '3' : undefined}
           borderRadiusEndStart={!hasContent && smUp ? '3' : undefined}
           borderRadiusEndEnd={!hasContent && smUp ? '3' : undefined}
-          padding="2"
-          paddingInlineEnd={smUp ? '2' : '1'}
+          padding="3"
         >
           <HorizontalStack
             align="space-between"
@@ -149,12 +148,10 @@ function DefaultBanner({
             gap="2"
             wrap={false}
           >
-            <Box padding="1" paddingInlineStart={smUp ? '1' : '0'}>
-              <HorizontalStack gap="1" wrap={false}>
-                {bannerIcon}
-                {bannerTitle}
-              </HorizontalStack>
-            </Box>
+            <HorizontalStack gap="1" wrap={false}>
+              {bannerIcon}
+              {bannerTitle}
+            </HorizontalStack>
             {dismissButton}
           </HorizontalStack>
         </Box>
@@ -198,13 +195,13 @@ function InlineIconBanner({
   useEventListener('resize', handleResize);
 
   return (
-    <Box width="100%" padding="2" borderRadius="3">
+    <Box width="100%" padding="3" borderRadius="3">
       <HorizontalStack
         align="space-between"
         blockAlign={blockAlign}
         wrap={false}
       >
-        <Box padding="1" width="100%">
+        <Box width="100%">
           <HorizontalStack gap="2" wrap={false} blockAlign={blockAlign}>
             <div ref={iconNode}>
               <Box background={backgroundColor} borderRadius="2" padding="1">
@@ -238,25 +235,23 @@ function WithinContentContainerBanner({
     <Box
       width="100%"
       background={backgroundColor}
-      padding="1"
+      padding="2"
       borderRadius="2"
       color={textColor}
     >
       <HorizontalStack align="space-between" blockAlign="start" wrap={false}>
-        <Box padding="1" width="100%">
-          <HorizontalStack gap="1_5-experimental" wrap={false}>
-            {bannerIcon}
-            <Box width="100%">
-              <VerticalStack gap="2">
-                <VerticalStack gap="05">
-                  {bannerTitle}
-                  <div>{children}</div>
-                </VerticalStack>
-                {actionButtons}
+        <HorizontalStack gap="1_5-experimental" wrap={false}>
+          {bannerIcon}
+          <Box width="100%">
+            <VerticalStack gap="2">
+              <VerticalStack gap="05">
+                {bannerTitle}
+                <div>{children}</div>
               </VerticalStack>
-            </Box>
-          </HorizontalStack>
-        </Box>
+              {actionButtons}
+            </VerticalStack>
+          </Box>
+        </HorizontalStack>
         {dismissButton}
       </HorizontalStack>
     </Box>

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -554,11 +554,7 @@
     }
 
     &.iconOnly {
-      margin: calc(-1 * var(--p-space-1_5-experimental));
-      @media #{$p-breakpoints-md-up} {
-        margin-left: calc(-1 * var(--p-space-1));
-        margin-right: calc(-1 * var(--p-space-1));
-      }
+      margin: calc(-1 * var(--p-space-1));
     }
   }
 }
@@ -892,6 +888,11 @@
 
   &.iconOnly {
     margin: calc(-1 * var(--p-space-2));
+
+    #{$se23} & {
+      // stylelint-disable-next-line -- custom px to align icons with line height
+      margin: calc(-1 * 3px) calc(-1 * var(--p-space-1_5-experimental));
+    }
 
     svg {
       fill: var(--p-color-icon);

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -890,8 +890,9 @@
     margin: calc(-1 * var(--p-space-2));
 
     #{$se23} & {
-      // stylelint-disable-next-line -- custom px to align icons with line height
-      margin: calc(-1 * 3px) calc(-1 * var(--p-space-1_5-experimental));
+      margin: 0;
+      padding: 0;
+      min-height: var(--p-font-line-height-2);
     }
 
     svg {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-summer-editions/issues/594
Resolves https://github.com/Shopify/polaris-summer-editions/issues/595

### WHAT is this pull request doing?

* Simplify workarounds in `Banner` for plain icon only primary buttons
* Fix `primary plain iconOnly` button alignment on mobile
* Fix `plain iconOnly` button alignment to be horizontally aligned to text elements like pre se23

### How to 🎩

Spin https://admin.web.web-tkwy.sophie-schneider.us.spin.dev/store/shop1/orders/10
Banner storybook https://5d559397bae39100201eedc1-irogtfeeeg.chromatic.com/?path=/story/all-components-banner--all&globals=polarisSummerEditions2023:true

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
