### PR TITLE
Convolute `destructive` and `outline` Button styles

### DIFF
--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -81,6 +81,91 @@ export function All() {
             </HorizontalStack>
           </Card>
         </VerticalStack>
+        <VerticalStack gap="4">
+          <Text as="h2">outline destructive</Text>
+          <Box padding="4">
+            <HorizontalStack gap="5" blockAlign="end">
+              <Button outline destructive>
+                Label
+              </Button>
+              <Button outline destructive disabled>
+                Label
+              </Button>
+              <Button outline destructive icon={PlusMinor}>
+                Label
+              </Button>
+              <Button outline destructive disabled icon={PlusMinor}>
+                Label
+              </Button>
+              <Button outline destructive disclosure>
+                Label
+              </Button>
+              <Button
+                outline
+                destructive
+                icon={CancelSmallMinor}
+                onClick={() => {}}
+                accessibilityLabel="Dismiss"
+              />
+              <Button
+                outline
+                destructive
+                icon={EditMajor}
+                onClick={() => {}}
+                accessibilityLabel="Dismiss"
+              />
+              <Button
+                outline
+                destructive
+                disabled
+                icon={PlusMinor}
+                onClick={() => {}}
+                accessibilityLabel="Dismiss"
+              />
+              <Button
+                outline
+                destructive
+                icon={DeleteMinor}
+                onClick={() => {}}
+                accessibilityLabel="Dismiss"
+              />
+            </HorizontalStack>
+          </Box>
+          <Card>
+            <HorizontalStack gap="5" blockAlign="end">
+              <Button outline destructive>
+                Label
+              </Button>
+              <Button outline destructive disabled>
+                Label
+              </Button>
+              <Button outline destructive icon={PlusMinor}>
+                Label
+              </Button>
+              <Button outline destructive disabled icon={PlusMinor}>
+                Label
+              </Button>
+              <Button outline destructive disclosure>
+                Label
+              </Button>
+              <Button
+                outline
+                destructive
+                icon={CancelSmallMinor}
+                onClick={() => {}}
+                accessibilityLabel="Dismiss"
+              />
+              <Button
+                outline
+                destructive
+                disabled
+                icon={EditMajor}
+                onClick={() => {}}
+                accessibilityLabel="Dismiss"
+              />
+            </HorizontalStack>
+          </Card>
+        </VerticalStack>
         <VerticalStack gap="2">
           <Text as="h2">destructive</Text>
           <Box padding="4">

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -163,7 +163,11 @@ export function Button({
     removeUnderline && styles.removeUnderline,
     primarySuccess && styles.primary,
     primarySuccess && styles.success,
-    polarisSummerEditions2023 && destructive && !outline && styles.primary,
+    polarisSummerEditions2023 &&
+      destructive &&
+      !outline &&
+      !plain &&
+      styles.primary,
     polarisSummerEditions2023 && outline && destructive && styles.destructive,
   );
 

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -163,6 +163,8 @@ export function Button({
     removeUnderline && styles.removeUnderline,
     primarySuccess && styles.primary,
     primarySuccess && styles.success,
+    polarisSummerEditions2023 && destructive && !outline && styles.primary,
+    polarisSummerEditions2023 && outline && destructive && styles.destructive,
   );
 
   const disclosureMarkup = disclosure ? (


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/561

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Update how destructive variants are applied behind the beta flag

### How to 🎩

- Review in [Storybook](https://5d559397bae39100201eedc1-ogflxybilo.chromatic.com/?path=/story/all-components-button--all&globals=polarisSummerEditions2023:true)
- `destructive` prop should render solid red button
- `desctructive` and `outline` should render default button with red destructive text
- Ensure no regressions to unflagged button destructive prop combinations