### PR TITLE
Fix min width for icon only plain buttons

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -893,6 +893,7 @@
       margin: 0;
       padding: 0;
       min-height: var(--p-font-line-height-2);
+      min-width: var(--p-font-line-height-2);
     }
 
     svg {


### PR DESCRIPTION
### WHY are these changes introduced?

icon only plain buttons had a min width of 28px. This updates to 20px. Follow up from https://github.com/Shopify/polaris/pull/9506
