### PR TITLE
Update IndexTable bullk actions shadow

### DIFF
--- a/polaris-react/src/components/BulkActions/BulkActions.scss
+++ b/polaris-react/src/components/BulkActions/BulkActions.scss
@@ -59,6 +59,10 @@ $bulk-actions-button-stacking-order: (
   max-width: 100%;
   pointer-events: auto;
 
+  #{$se23} & {
+    box-shadow: var(--p-shadow-card-lg-experimental);
+  }
+
   @media #{$p-breakpoints-sm-down} {
     // stylelint-disable-next-line selector-max-combinators, selector-max-type -- the first item of button group on small screen needs to fill the space
     > div > div:first-child {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/602

### WHAT is this pull request doing?

Updates the shadow token value for the IndexTable bulk actions container

### How to 🎩

- Preview on Storybook and ensure Bulk Actions render as expected with the beta flag on