### PR TITLE
Update icon `Badge` alignment

### DIFF
--- a/.changeset/spotty-squids-explain.md
+++ b/.changeset/spotty-squids-explain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed vertical alignment issue with `svg` element in `Badge` component

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -261,10 +261,9 @@
   }
 
   #{$se23} & svg {
-    // stylelint-disable -- Corrects conflicting alignment with ancestor elements
+    // Corrects conflicting alignment with ancestor elements
     display: inline-block;
     vertical-align: top;
-    // stylelint-enable
   }
 
   .sizeLarge-experimental & {

--- a/polaris-react/src/components/Badge/Badge.scss
+++ b/polaris-react/src/components/Badge/Badge.scss
@@ -260,6 +260,13 @@
       calc(-1 * var(--p-space-2));
   }
 
+  #{$se23} & svg {
+    // stylelint-disable -- Corrects conflicting alignment with ancestor elements
+    display: inline-block;
+    vertical-align: top;
+    // stylelint-enable
+  }
+
   .sizeLarge-experimental & {
     margin: 0 var(--p-space-1) 0 calc(-1 * var(--p-space-05));
 


### PR DESCRIPTION
Closes https://github.com/Shopify/polaris-summer-editions/issues/671

This PR fixes the vertical alignment issue with `svg` elements in the `Badge` component. @sophschneider and I tentatively narrowed the issue down to the Polaris Icon component overriding `svg` elements with `display: block`, which affected the baseline alignment of other inline elements within the parent container.

To fix this issue, we applied a local override with `display: inline-block` and `vertical-align: top` directly to the `svg` element in the existing `.Icon` wrapper/selector. This ensures that the `svg` element is aligned to the top of the line box, while still allowing it to be inline with other text or elements.