### PR TITLE
Fix overlapping heading when scrolling horizontally IndexTable

### DIFF
--- a/.changeset/spotty-peas-cheer.md
+++ b/.changeset/spotty-peas-cheer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed overlapping heading when scrolling horizontally on unselectable IndexTable.

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -619,6 +619,8 @@ $loading-panel-height: 53px;
     &.TableHeading-unselectable {
       position: sticky;
       left: 0;
+      // stylelint-disable-next-line -- second column (first heading item) overlaps other headings on horizontal scroll
+      z-index: var(--pc-index-table-sticky-cell);
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #9471

Headings are overlapping the first sticky heading column when horizontally scrolling on `IndexTable` when `selectable={false}`

### WHAT is this pull request doing?

### Before

https://github.com/Shopify/polaris/assets/11774595/d2ff47b1-c9a8-407c-89cc-6a3de61194bd

### After

https://github.com/Shopify/polaris/assets/11774595/f37418eb-b095-4104-8489-30dd5c4c50d7

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Set the `selectable={false}` prop on the `IndexTable` in the `WithSortableHeadings` story in `IndexTable.stories.tsx`