### PR TITLE
Replace caret icons

### DIFF
--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -3,6 +3,8 @@ import {
   CaretDownMinor,
   CaretUpMinor,
   SelectMinor,
+  ChevronDownMinor,
+  ChevronUpMinor,
 } from '@shopify/polaris-icons';
 
 import type {BaseButton, ConnectedDisclosure, IconSource} from '../../types';
@@ -165,13 +167,28 @@ export function Button({
     primarySuccess && styles.success,
   );
 
+  const disclosureUpIcon = polarisSummerEditions2023
+    ? ChevronUpMinor
+    : CaretUpMinor;
+  const disclosureDownIcon = polarisSummerEditions2023
+    ? ChevronDownMinor
+    : CaretDownMinor;
+
   const disclosureMarkup = disclosure ? (
     <span className={styles.Icon}>
       <div
         className={classNames(styles.DisclosureIcon, loading && styles.hidden)}
       >
         <Icon
-          source={loading ? 'placeholder' : getDisclosureIconSource(disclosure)}
+          source={
+            loading
+              ? 'placeholder'
+              : getDisclosureIconSource(
+                  disclosure,
+                  disclosureUpIcon,
+                  disclosureDownIcon,
+                )
+          }
         />
       </div>
     </span>
@@ -255,7 +272,11 @@ export function Button({
         tabIndex={disabled ? -1 : undefined}
       >
         <span className={styles.Icon}>
-          <Icon source={CaretDownMinor} />
+          <Icon
+            source={
+              polarisSummerEditions2023 ? ChevronDownMinor : CaretDownMinor
+            }
+          />
         </span>
       </button>
     );
@@ -340,10 +361,12 @@ function isIconSource(x: any): x is IconSource {
 
 function getDisclosureIconSource(
   disclosure: NonNullable<ButtonProps['disclosure']>,
+  upIcon: IconSource,
+  downIcon: IconSource,
 ) {
   if (disclosure === 'select') {
     return SelectMinor;
   }
 
-  return disclosure === 'up' ? CaretUpMinor : CaretDownMinor;
+  return disclosure === 'up' ? upIcon : downIcon;
 }

--- a/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
@@ -52,7 +52,7 @@ export function FilterPill({
 }: FilterPillProps) {
   const i18n = useI18n();
   const {mdDown} = useBreakpoints();
-  const {polarisSummerEditions2023: se23} = useFeatures();
+  const {polarisSummerEditions2023} = useFeatures();
 
   const elementRef = useRef<HTMLDivElement>(null);
   const {
@@ -113,12 +113,16 @@ export function FilterPill({
     styles.ToggleButton,
   );
 
-  const se23LabelVariant = mdDown && se23 ? 'bodyLg' : 'bodySm';
+  const se23LabelVariant =
+    mdDown && polarisSummerEditions2023 ? 'bodyLg' : 'bodySm';
   const labelVariant = mdDown ? 'bodyMd' : 'bodySm';
 
   const wrappedLabel = (
     <div className={styles.Label}>
-      <Text variant={se23 ? se23LabelVariant : labelVariant} as="span">
+      <Text
+        variant={polarisSummerEditions2023 ? se23LabelVariant : labelVariant}
+        as="span"
+      >
         {label}
       </Text>
     </div>
@@ -148,7 +152,11 @@ export function FilterPill({
                 {wrappedLabel}
                 <div className={styles.IconWrapper}>
                   <Icon
-                    source={se23 ? ChevronDownMinor : CaretDownMinor}
+                    source={
+                      polarisSummerEditions2023
+                        ? ChevronDownMinor
+                        : CaretDownMinor
+                    }
                     color="base"
                   />
                 </div>

--- a/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
@@ -1,5 +1,9 @@
 import React, {useState, useEffect, useRef} from 'react';
-import {CancelSmallMinor, CaretDownMinor} from '@shopify/polaris-icons';
+import {
+  CancelSmallMinor,
+  CaretDownMinor,
+  ChevronDownMinor,
+} from '@shopify/polaris-icons';
 
 import {useI18n} from '../../../../utilities/i18n';
 import {useToggle} from '../../../../utilities/use-toggle';
@@ -143,7 +147,10 @@ export function FilterPill({
               <>
                 {wrappedLabel}
                 <div className={styles.IconWrapper}>
-                  <Icon source={CaretDownMinor} color="base" />
+                  <Icon
+                    source={se23 ? ChevronDownMinor : CaretDownMinor}
+                    color="base"
+                  />
                 </div>
               </>
             )}

--- a/polaris-react/src/components/LegacyTabs/LegacyTabs.tsx
+++ b/polaris-react/src/components/LegacyTabs/LegacyTabs.tsx
@@ -1,11 +1,16 @@
 import React, {PureComponent} from 'react';
-import {HorizontalDotsMinor, CaretDownMinor} from '@shopify/polaris-icons';
+import {
+  HorizontalDotsMinor,
+  CaretDownMinor,
+  ChevronDownMinor,
+} from '@shopify/polaris-icons';
 
 import {Box} from '../Box';
 import {Icon} from '../Icon';
 import {Popover} from '../Popover';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
+import {UseFeatures} from '../../utilities/features';
 
 import type {TabDescriptor} from './types';
 import {getVisibleAndHiddenTabIndices} from './utilities';
@@ -130,7 +135,16 @@ class TabsInner extends PureComponent<CombinedProps, State> {
     const disclosureButtonContent = hasCustomDisclosure ? (
       <>
         {disclosureText}
-        <Icon source={CaretDownMinor} color="subdued" />
+        <UseFeatures>
+          {({polarisSummerEditions2023}) => (
+            <Icon
+              source={
+                polarisSummerEditions2023 ? ChevronDownMinor : CaretDownMinor
+              }
+              color="subdued"
+            />
+          )}
+        </UseFeatures>
       </>
     ) : (
       <Icon source={HorizontalDotsMinor} color="subdued" />

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,10 @@
 import React, {useEffect, useCallback, useRef, useReducer} from 'react';
 import type {KeyboardEvent, FocusEvent} from 'react';
-import {CaretDownMinor, PlusMinor} from '@shopify/polaris-icons';
+import {
+  CaretDownMinor,
+  ChevronDownMinor,
+  PlusMinor,
+} from '@shopify/polaris-icons';
 
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
@@ -12,6 +16,7 @@ import {Tooltip} from '../Tooltip';
 import {Text} from '../Text';
 import {Box} from '../Box';
 import {usePrevious} from '../../utilities/use-previous';
+import {useFeatures} from '../../utilities/features';
 
 import {getVisibleAndHiddenTabIndices} from './utilities';
 import type {TabProps, TabMeasurements} from './types';
@@ -69,6 +74,7 @@ export const Tabs = ({
   fitted,
   disclosureText,
 }: TabsProps) => {
+  const {polarisSummerEditions2023: se23} = useFeatures();
   const i18n = useI18n();
   const {mdDown} = useBreakpoints();
 
@@ -474,7 +480,10 @@ export const Tabs = ({
             styles['IconWrap-open'],
         )}
       >
-        <Icon source={CaretDownMinor} color="subdued" />
+        <Icon
+          source={se23 ? ChevronDownMinor : CaretDownMinor}
+          color="subdued"
+        />
       </div>
     </>
   );

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -74,7 +74,7 @@ export const Tabs = ({
   fitted,
   disclosureText,
 }: TabsProps) => {
-  const {polarisSummerEditions2023: se23} = useFeatures();
+  const {polarisSummerEditions2023} = useFeatures();
   const i18n = useI18n();
   const {mdDown} = useBreakpoints();
 
@@ -481,7 +481,7 @@ export const Tabs = ({
         )}
       >
         <Icon
-          source={se23 ? ChevronDownMinor : CaretDownMinor}
+          source={polarisSummerEditions2023 ? ChevronDownMinor : CaretDownMinor}
           color="subdued"
         />
       </div>

--- a/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
@@ -18,6 +18,7 @@ import {
   EditMinor,
   DeleteMinor,
   CaretDownMinor,
+  ChevronDownMinor,
 } from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
@@ -288,7 +289,7 @@ export const Tab = forwardRef(
     const disclosureMarkup =
       selected && actions?.length ? (
         <div className={classNames(styles.IconWrap)}>
-          <Icon source={CaretDownMinor} />
+          <Icon source={se23 ? ChevronDownMinor : CaretDownMinor} />
         </div>
       ) : null;
 

--- a/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
+++ b/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import {CaretDownMinor, CaretUpMinor} from '@shopify/polaris-icons';
+import {
+  CaretDownMinor,
+  CaretUpMinor,
+  ChevronDownMinor,
+  ChevronUpMinor,
+} from '@shopify/polaris-icons';
 
 import {Icon} from '../../../Icon';
 import styles from '../../TextField.scss';
+import {useFeatures} from '../../../../utilities/features';
 
 type HandleStepFn = (step: number) => void;
 
@@ -16,6 +22,8 @@ export interface SpinnerProps {
 
 export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
   function Spinner({onChange, onClick, onMouseDown, onMouseUp, onBlur}, ref) {
+    const {polarisSummerEditions2023: se23} = useFeatures();
+
     function handleStep(step: number) {
       return () => onChange(step);
     }
@@ -39,7 +47,7 @@ export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
           onBlur={onBlur}
         >
           <div className={styles.SpinnerIcon}>
-            <Icon source={CaretUpMinor} />
+            <Icon source={se23 ? ChevronUpMinor : CaretUpMinor} />
           </div>
         </div>
         <div
@@ -52,7 +60,7 @@ export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
           onBlur={onBlur}
         >
           <div className={styles.SpinnerIcon}>
-            <Icon source={CaretDownMinor} />
+            <Icon source={se23 ? ChevronDownMinor : CaretDownMinor} />
           </div>
         </div>
       </div>

--- a/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
+++ b/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
@@ -22,7 +22,7 @@ export interface SpinnerProps {
 
 export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
   function Spinner({onChange, onClick, onMouseDown, onMouseUp, onBlur}, ref) {
-    const {polarisSummerEditions2023: se23} = useFeatures();
+    const {polarisSummerEditions2023} = useFeatures();
 
     function handleStep(step: number) {
       return () => onChange(step);
@@ -47,7 +47,9 @@ export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
           onBlur={onBlur}
         >
           <div className={styles.SpinnerIcon}>
-            <Icon source={se23 ? ChevronUpMinor : CaretUpMinor} />
+            <Icon
+              source={polarisSummerEditions2023 ? ChevronUpMinor : CaretUpMinor}
+            />
           </div>
         </div>
         <div
@@ -60,7 +62,11 @@ export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
           onBlur={onBlur}
         >
           <div className={styles.SpinnerIcon}>
-            <Icon source={se23 ? ChevronDownMinor : CaretDownMinor} />
+            <Icon
+              source={
+                polarisSummerEditions2023 ? ChevronDownMinor : CaretDownMinor
+              }
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/598

### WHAT is this pull request doing?

Replaces usages of the `caret` icon to `chevron` behind the beta flag.

### How to 🎩

Check components in Storybook such as `Button`, `Filter`, `TextField` with stepper, `Tabs` and ensure they render the correct icon behind the beta flag.