### PR TITLE
Establishes consistent spelling of focused and cleans up comment spacing

### DIFF
--- a/.changeset/spicy-beds-hammer.md
+++ b/.changeset/spicy-beds-hammer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Establishes consistent naming of focused and cleans up spacing in documentation

--- a/polaris-react/src/components/Button/tests/Button.test.tsx
+++ b/polaris-react/src/components/Button/tests/Button.test.tsx
@@ -379,7 +379,7 @@ describe('<Button />', () => {
   });
 
   describe('onFocus()', () => {
-    it('is called when the button is focussed', () => {
+    it('is called when the button is focused', () => {
       const onFocusSpy = jest.fn();
       const button = mountWithApp(<Button onFocus={onFocusSpy} />);
       button.find(UnstyledButton)!.trigger('onFocus');

--- a/polaris-react/src/components/Checkbox/Checkbox.tsx
+++ b/polaris-react/src/components/Checkbox/Checkbox.tsx
@@ -18,9 +18,9 @@ import {WithinListboxContext} from '../../utilities/listbox/context';
 import styles from './Checkbox.scss';
 
 export interface CheckboxProps {
-  /** Indicates the ID of the element that is controlled by the checkbox*/
+  /** Indicates the ID of the element that is controlled by the checkbox */
   ariaControls?: string;
-  /** Indicates the ID of the element that describes the checkbox*/
+  /** Indicates the ID of the element that describes the checkbox */
   ariaDescribedBy?: string;
   /** Label for the checkbox */
   label: React.ReactNode;
@@ -42,7 +42,7 @@ export interface CheckboxProps {
   error?: Error | boolean;
   /** Callback when checkbox is toggled */
   onChange?(newChecked: boolean, id: string): void;
-  /** Callback when checkbox is focussed */
+  /** Callback when checkbox is focused */
   onFocus?(): void;
   /** Callback when focus is removed */
   onBlur?(): void;

--- a/polaris-react/src/components/ChoiceList/ChoiceList.tsx
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.tsx
@@ -21,7 +21,7 @@ interface Choice {
   disabled?: boolean;
   /** Additional text to aide in use */
   helpText?: React.ReactNode;
-  /** Indicates that the choice is aria-describedBy the error message*/
+  /** Indicates that the choice is aria-describedBy the error message */
   describedByError?: boolean;
   /**  Method to render children with a choice */
   renderChildren?(isSelected: boolean): React.ReactNode | false;

--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -22,7 +22,7 @@ export interface LinkProps {
   target?: Target;
   /** Makes the link color the same as the current text color and adds an underline */
   monochrome?: boolean;
-  /** Removes text decoration underline to the link*/
+  /** Removes text decoration underline to the link */
   removeUnderline?: boolean;
   /** Callback when a link is clicked */
   onClick?(): void;

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
@@ -9,7 +9,7 @@ import styles from './Title.scss';
 export interface TitleProps {
   /** Page title, in large type */
   title?: string;
-  /** Page subtitle, in regular type*/
+  /** Page subtitle, in regular type */
   subtitle?: string;
   /** Important and non-interactive status information shown immediately after the title. */
   titleMetadata?: React.ReactNode;

--- a/polaris-react/src/components/RadioButton/RadioButton.tsx
+++ b/polaris-react/src/components/RadioButton/RadioButton.tsx
@@ -7,7 +7,7 @@ import {Choice, helpTextID} from '../Choice';
 import styles from './RadioButton.scss';
 
 export interface RadioButtonProps {
-  /** Indicates the ID of the element that describes the the radio button*/
+  /** Indicates the ID of the element that describes the the radio button */
   ariaDescribedBy?: string;
   /** Label for the radio button */
   label: React.ReactNode;
@@ -27,7 +27,7 @@ export interface RadioButtonProps {
   value?: string;
   /** Callback when the radio button is toggled */
   onChange?(newValue: boolean, id: string): void;
-  /** Callback when radio button is focussed */
+  /** Callback when radio button is focused */
   onFocus?(): void;
   /** Callback when focus is removed */
   onBlur?(): void;

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -32,7 +32,7 @@ import styles from './ResourceItem.scss';
 type Alignment = 'leading' | 'trailing' | 'center' | 'fill' | 'baseline';
 
 interface BaseProps {
-  /** Visually hidden text for screen readers used for item link*/
+  /** Visually hidden text for screen readers used for item link */
   accessibilityLabel?: string;
   /** Individual item name used by various text labels */
   name?: string;

--- a/polaris-react/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/polaris-react/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -461,7 +461,7 @@ describe('<Button />', () => {
   });
 
   describe('onFocus()', () => {
-    it('is called when the button is focussed', () => {
+    it('is called when the button is focused', () => {
       const onFocusSpy = jest.fn();
       const unstyledButton = mountWithApp(
         <UnstyledButton onFocus={onFocusSpy} />,
@@ -471,7 +471,7 @@ describe('<Button />', () => {
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('is called when the link is focussed', () => {
+    it('is called when the link is focused', () => {
       const onFocusSpy = jest.fn();
       const unstyledButton = mountWithApp(
         <UnstyledButton onFocus={onFocusSpy} url="https://google.com" />,

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -77,7 +77,7 @@ export interface BaseButton {
   ariaChecked?: 'false' | 'true';
   /** Callback when clicked */
   onClick?(): unknown;
-  /** Callback when button becomes focussed */
+  /** Callback when button becomes focused */
   onFocus?(): void;
   /** Callback when focus leaves button */
   onBlur?(): void;


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed multiple spellings of focused within the repository (i.e. focussed vs focused). Both variations are correct depending on the form of English, but focused seems to be more pervasively used. Additionally, there were some instances where a comment hugged `*/`, so I addressed those to make it slightly more readable.

### WHAT is this pull request doing?

Establishes consistent spelling of focused amongst the comments and addresses some spacing to improve readibility.

### How to 🎩

Nothing to tophat, other than to verify focused is spelled correctly and spacing looks correct.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
