### PR TITLE
[Page] Remove divider and divider spacing from page

### DIFF
--- a/polaris-react/src/components/Page/Page.scss
+++ b/polaris-react/src/components/Page/Page.scss
@@ -44,4 +44,9 @@ body {
 .divider {
   border-top: var(--p-border-width-1) solid var(--p-color-border-subdued);
   padding-top: var(--p-space-8);
+
+  #{$se23} & {
+    border-top: 0;
+    padding-top: 0;
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [this issue](https://github.com/Shopify/polaris-summer-editions/issues/699)

### WHAT is this pull request doing?

I think we should remove the divider variation for Page by removing the divider and extra padding that comes with it experimentally. This variation is mostly used in settings, and looks out of place with our experimental spacing. I've based this new spacing off of the [new settings designs](https://github.com/Shopify/polaris-summer-editions/issues/699). 

Other option, we could run a migration deprecating the `divider` prop (we should do this eventually anyhow), but this might be less work while we have the experimental flag

See [this issue](https://github.com/Shopify/polaris-summer-editions/issues/699) for before and after

### How to 🎩
https://5d559397bae39100201eedc1-aliiagsgoy.chromatic.com/?path=/story/all-components-page--with-divider&globals=polarisSummerEditions2023:true

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
