### PR TITLE
[IndexTable][Cell] Fix experimental flush cell styles overriding chil…

### DIFF
--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -570,8 +570,8 @@ $loading-panel-height: 53px;
 
   #{$se23} & {
     padding: 0;
-    // stylelint-disable-next-line selector-max-combinators -- se23 override
-    :first-child {
+
+    &:first-child {
       padding: 0;
     }
   }


### PR DESCRIPTION
Fixes The `IndexTable.Cell` resetting padding to 0. 

[Spinstance](https://admin.web.polaris--v11-3-0.chloe-rice.us.spin.dev/store/shop1/products/104)

| [Before](https://admin.web.web-rxnj.sam-rose.us.spin.dev/store/shop1/products/1)| [After](https://admin.web.polaris--v11-3-0.chloe-rice.us.spin.dev/store/shop1/products/104)|
|--------|--------|
|<img width="956" alt="Screenshot 2023-06-27 at 5 04 35 PM" src="https://github.com/Shopify/web/assets/18447883/216fb873-5e17-4772-af2f-0bf602f2572f">| <img width="932" alt="Screenshot 2023-06-27 at 5 04 14 PM" src="https://github.com/Shopify/web/assets/18447883/7c2e12da-e542-4e9a-8a21-76f4178c3f06"> | 