### PR TITLE
Fix `primary` `plain` hover and active text styles

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -563,6 +563,7 @@
     }
 
     &:active {
+      // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       --pc-button-text: var(--p-color-text);
       box-shadow: none;
       // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
@@ -575,6 +576,7 @@
     }
 
     &:hover {
+      // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       --pc-button-text: var(--p-color-text);
       box-shadow: none;
     }

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -563,6 +563,7 @@
     }
 
     &:active {
+      --pc-button-text: var(--p-color-text);
       box-shadow: none;
       // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       color: var(--pc-button-text);
@@ -574,6 +575,7 @@
     }
 
     &:hover {
+      --pc-button-text: var(--p-color-text);
       box-shadow: none;
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/737

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fix `primary` `plain` hover and active text styles

Before
<img width="464" alt="Screenshot 2023-06-28 at 10 01 40 AM" src="https://github.com/Shopify/polaris/assets/3474483/872f7cfd-8281-474f-9fb3-448a42815a6e">

After
<img width="474" alt="Screenshot 2023-06-28 at 10 00 44 AM" src="https://github.com/Shopify/polaris/assets/3474483/7077c21f-ae3f-4198-b3f0-fc6321aabcee">

### How to 🎩

Review in Storybook and ensure `primary` `plain` beta flag styles for `active` and `hover` state render as intended


