### PR TITLE
Restructure `Select` override selectors

### DIFF
--- a/.changeset/gorgeous-singers-invent.md
+++ b/.changeset/gorgeous-singers-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Restructured `Select` override selectors to patch Sass compilation issue

--- a/polaris-react/src/components/Select/Select.scss
+++ b/polaris-react/src/components/Select/Select.scss
@@ -20,7 +20,7 @@
     }
 
     // stylelint-disable-next-line -- se23 overrides
-    & .Input:active ~ .Backdrop {
+    .Input:active ~ .Backdrop {
       border: none;
       box-shadow: var(--p-shadow-inset-md);
       background-color: var(--p-color-bg-input-active-experimental);

--- a/polaris-react/src/components/Select/Select.scss
+++ b/polaris-react/src/components/Select/Select.scss
@@ -13,8 +13,7 @@
     display: none;
   }
 
-  #{$se23} &:not(.disabled),
-  #{$se23} &:not(.error) {
+  #{$se23} &:not(.disabled):not(.error) {
     // stylelint-disable-next-line -- se23 overrides
     &:hover .Backdrop {
       border-color: var(--p-color-border-input-hover);

--- a/polaris-react/src/components/Select/Select.scss
+++ b/polaris-react/src/components/Select/Select.scss
@@ -13,24 +13,18 @@
     display: none;
   }
 
-  #{$se23} & {
-    &:not(.disabled, .error) {
-      &:hover {
-        // stylelint-disable-next-line -- se23
-        .Backdrop {
-          border-color: var(--p-color-border-input-hover);
-        }
-      }
+  #{$se23} &:not(.disabled),
+  #{$se23} &:not(.error) {
+    // stylelint-disable-next-line -- se23 overrides
+    &:hover .Backdrop {
+      border-color: var(--p-color-border-input-hover);
+    }
 
-      // stylelint-disable-next-line -- se23
-      .Input:active {
-        // stylelint-disable-next-line -- se23
-        ~ .Backdrop {
-          border: none;
-          box-shadow: var(--p-shadow-inset-md);
-          background-color: var(--p-color-bg-input-active-experimental);
-        }
-      }
+    // stylelint-disable-next-line -- se23 overrides
+    & .Input:active ~ .Backdrop {
+      border: none;
+      box-shadow: var(--p-shadow-inset-md);
+      background-color: var(--p-color-bg-input-active-experimental);
     }
   }
 }


### PR DESCRIPTION
This PR restructures the `Select` component override selectors as a quick fix to a Sass compilation issue. We are still unpacking why the original selector is not compiling as expected, but here is what @sophschneider and I have discovered thus far:

**Selector:** ✅ `#{$se23} &:hover:not(.disabled) .Backdrop`

A single selector (`.disabled`) in the `:not()` pseudo-class selector list compiles as expected

![Screenshot 2023-06-28 at 10 15 51 AM](https://github.com/Shopify/polaris/assets/32409546/35a89c74-90ce-4235-8ca6-1ecf50ac90f4)

**Selector:** ❌ `#{$se23} &:hover:not(.disabled, .error) .Backdrop`

Multiple selectors (`.disabled, .error`) in the `:not()` pseudo-class selector list completely omits `:not()` when compiled

![Screenshot 2023-06-28 at 10 17 40 AM](https://github.com/Shopify/polaris/assets/32409546/0eece84a-b9d2-4716-87ec-1b97216f826e)

**Selector:** ✅ `#{$se23} &:hover:not(disabled) .Backdrop, #{$se23} &:hover:not(.error) .Backdrop`

~Splitting `:not()` into a separate grouped selector list compiles as expected with the tradeoff of doubling the override selector output.~ UPDATE: An improved pattern was found (see below).

![Screenshot 2023-06-28 at 10 19 42 AM](https://github.com/Shopify/polaris/assets/32409546/2820e8d6-bdb4-4507-8f8f-5b704c6f777b)

There are a few areas of interest we intent to explore for resolving the underlying issue. However, I think the proposed fix and tradeoffs outlined above are an acceptable patch, addresses the issue observed in staging, and can be followed up with a proper solution when it is found.

UPDATE:

**Selector:** ✅ `#{$se23} &:not(.disabled):not(.error)`

Chaining `:not()` pseudo-classes compiles as expected and avoids the duplicate override selector output

![image](https://github.com/Shopify/polaris/assets/32409546/c41b704e-770c-4698-b198-1cba7420439a)


