### PR TITLE
[Storybook] Add `AnchorTargetOverrideDecorator` to update anchor `target` attributes

### DIFF
--- a/polaris-react/src/components/Link/Link.stories.tsx
+++ b/polaris-react/src/components/Link/Link.stories.tsx
@@ -4,6 +4,9 @@ import {Banner, Link} from '@shopify/polaris';
 
 export default {
   component: Link,
+  parameters: {
+    disableAnchorTargetOverride: true,
+  },
 } as ComponentMeta<typeof Link>;
 
 export function Default() {


### PR DESCRIPTION
### WHY are these changes introduced?

This change is introduced to ensure a consistent browsing experience for users viewing Storybook. Assuming that we want all anchor tags (`<a>`) within Storybook stories to open in the same tab. Currently, the` target` attribute of anchor tags is not consistently set, which can cause links to open in a new tab or window.

### WHAT is this pull request doing?

This PR introduces a new decorator, `AnchorTargetOverrideDecorator`, to Storybook the configuration. The decorator uses a `MutationObserver` to watch for changes in the component's DOM. When a change is detected, it finds all the anchor tags in the component and sets their `target` attribute to `_self`, if it isn't already set.

**Before**

https://github.com/Shopify/polaris/assets/2091116/03986533-4290-4e5e-a06b-a0cda927ec6e

**After**

https://github.com/Shopify/polaris/assets/2091116/d7a279c7-dac7-4ff6-b951-28f48465689f

----

This PR also introduces a new story parameter, `disableAnchorTargetOverride`. If a story sets this parameter to true, the `AnchorTargetOverrideDecorator` will not apply the target attribute override for that story. This allows individual stories to opt out of this behaviour if necessary.

```jsx
export const YourStory = () => (
  <div>
    <a href="https://example.com">Example Link</a>
  </div>
);

YourStory.parameters = {
  disableAnchorTargetOverride: true,
};
```

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
