### PR TITLE
Fix `primary` `plain` `destructive` hover & active states

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -610,7 +610,7 @@
 
       &:hover,
       &:active {
-        --pc-button-text: var(--p-color-text);
+        --pc-button-text: var(--p-color-text-critical);
       }
       // stylelint-enable polaris/conventions/polaris/custom-property-allowed-list
 

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -607,6 +607,11 @@
       --pc-button-color-active: var(
         --p-color-bg-transparent-active-experimental
       );
+
+      &:hover,
+      &:active {
+        --pc-button-text: var(--p-color-text);
+      }
       // stylelint-enable polaris/conventions/polaris/custom-property-allowed-list
 
       // stylelint-disable-next-line selector-max-class -- se23 temporary styles


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/752

### WHAT is this pull request doing?

Fixes `primary` `plain` `destructive` hover & active states

### How to 🎩

- Verify in Storybook
- Do a dance for the button bug whack-a-mole deities
-  And then knock on some wood for good measure