### PR TITLE
Update `ActionList` item suffix position

### DIFF
--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -109,16 +109,18 @@ export function Item({
   const textMarkup = <span className={styles.Text}>{contentMarkup}</span>;
 
   const contentElement = (
-    <HorizontalStack
-      blockAlign="center"
-      gap={polarisSummerEditions2023 ? '2' : '4'}
-      wrap={!truncate}
-    >
-      {prefixMarkup}
-      {textMarkup}
-      {badgeMarkup}
-      {suffixMarkup}
-    </HorizontalStack>
+    <Box width="100%">
+      <HorizontalStack
+        blockAlign="center"
+        gap={polarisSummerEditions2023 ? '2' : '4'}
+        wrap={!truncate}
+      >
+        {prefixMarkup}
+        {textMarkup}
+        {badgeMarkup}
+        {suffixMarkup}
+      </HorizontalStack>
+    </Box>
   );
 
   const scrollMarkup = active ? <Scrollable.ScrollTo /> : null;

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -109,18 +109,22 @@ export function Item({
   const textMarkup = <span className={styles.Text}>{contentMarkup}</span>;
 
   const contentElement = (
-    <Box width="100%">
-      <HorizontalStack
-        blockAlign="center"
-        gap={polarisSummerEditions2023 ? '2' : '4'}
-        wrap={!truncate}
-      >
-        {prefixMarkup}
-        {textMarkup}
-        {badgeMarkup}
-        {suffixMarkup}
-      </HorizontalStack>
-    </Box>
+    <HorizontalStack
+      blockAlign="center"
+      gap={polarisSummerEditions2023 ? '2' : '4'}
+      wrap={!truncate}
+    >
+      {prefixMarkup}
+      {textMarkup}
+      {badgeMarkup}
+      {suffixMarkup}
+    </HorizontalStack>
+  );
+
+  const contentWrapper = polarisSummerEditions2023 ? (
+    <Box width="100%">{contentElement}</Box>
+  ) : (
+    contentElement
   );
 
   const scrollMarkup = active ? <Scrollable.ScrollTo /> : null;
@@ -135,7 +139,7 @@ export function Item({
       onClick={disabled ? null : onAction}
       role={role}
     >
-      {contentElement}
+      {contentWrapper}
     </UnstyledLink>
   ) : (
     <button
@@ -149,7 +153,7 @@ export function Item({
       role={role}
       onMouseEnter={onMouseEnter}
     >
-      {contentElement}
+      {contentWrapper}
     </button>
   );
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/765

### WHAT is this pull request doing?

Fix positioning of `ActionList` item suffix

<img width="317" alt="Screenshot 2023-06-29 at 2 17 46 PM" src="https://github.com/Shopify/polaris/assets/3474483/e44e6f1c-56d1-4945-96e0-82c3f6d4e0c5">


### How to 🎩

Review in Storybook