### PR TITLE
[TopBar] Fix user menu Avatar size

### DIFF
--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -75,7 +75,7 @@ export function UserMenu({
       <MessageIndicator active={showIndicator}>
         <Avatar
           shape="square"
-          size={polarisSummerEditions2023 ? 'extraSmall' : 'small'}
+          size={polarisSummerEditions2023 ? 'medium' : 'small'}
           initials={initials && initials.replace(' ', '')}
           source={avatar}
         />


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris-summer-editions/issues/758

### WHY are these changes introduced?

Size of the Avatar is currently set to `extraSmall` when the uplift beta is enabled. The correct value is `medium`.

[Figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Uplift-Components-%5Bgen3%E2%80%93alpha%5D?type=design&node-id=28822-336&mode=design&t=448BHwrwPtf5LWty-0)

**Before**

<img width="347" alt="Screenshot 2023-06-29 at 6 00 34 PM" src="https://github.com/Shopify/polaris/assets/2091116/45432e87-25ed-47a9-be34-a41b73d1ead2">


**After**

<img width="350" alt="Screenshot 2023-06-29 at 5 59 32 PM" src="https://github.com/Shopify/polaris/assets/2091116/51169b6d-1bad-4511-82bd-452d14348852">

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
