### PR TITLE
Update `AccountConnection` `Avatar` to be top aligned

### DIFF
--- a/polaris-react/src/components/AccountConnection/AccountConnection.tsx
+++ b/polaris-react/src/components/AccountConnection/AccountConnection.tsx
@@ -49,12 +49,14 @@ export function AccountConnection({
     : undefined;
 
   const avatarMarkup = connected ? (
-    <Avatar
-      accessibilityLabel=""
-      name={accountName}
-      initials={initials}
-      source={avatarUrl}
-    />
+    <span>
+      <Avatar
+        accessibilityLabel=""
+        name={accountName}
+        initials={initials}
+        source={avatarUrl}
+      />
+    </span>
   ) : null;
 
   const titleContent = title ? title : accountName;


### PR DESCRIPTION
Closes https://github.com/Shopify/polaris-summer-editions/issues/764

Note: These updates are intentionally not beta-flagged as the issue occurs regardless (see below)

Before: The `Avatar` itself is stretched from the parent flex container.

https://github.com/Shopify/polaris/assets/32409546/8f370e61-43a7-4ed0-8efc-7a3ec75dae04

After: Stretching is now applied to the wrapping span

https://github.com/Shopify/polaris/assets/32409546/b3d5944b-69c4-4fa6-ae9b-568e02b24cfd


