### PR TITLE
Link to GitHub from within Storybooks built on CI

### DIFF
--- a/.github/workflows/ci-a11y-vrt.yml
+++ b/.github/workflows/ci-a11y-vrt.yml
@@ -97,6 +97,10 @@ jobs:
 
       - name: Build Storybook
         run: yarn workspace @shopify/polaris run storybook:build --quiet
+        env:
+          STORYBOOK_GITHUB_SHA: ${{ github.sha }}
+          STORYBOOK_GITHUB_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          STORYBOOK_GITHUB_PR: ${{ github.event.number }}
 
       - name: Run Chromatic tests
         uses: chromaui/action@v1
@@ -109,3 +113,5 @@ jobs:
           exitOnceUploaded: true
         env:
           STORYBOOK_GITHUB_SHA: ${{ github.sha }}
+          STORYBOOK_GITHUB_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          STORYBOOK_GITHUB_PR: ${{ github.event.number }}

--- a/polaris-react/.storybook/manager.js
+++ b/polaris-react/.storybook/manager.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import {AddonPanel, ArgsTable} from '@storybook/components';
+import {AddonPanel, ArgsTable, Icons, IconButton} from '@storybook/components';
 import {addons, types} from '@storybook/addons';
 import {useGlobals} from '@storybook/api';
-import {create} from '@storybook/theming';
+import {styled, create} from '@storybook/theming';
 
 const colors = {
   primary: '#008060',
@@ -63,6 +63,12 @@ addons.register('polaris/global-controls', () => {
     match: ({viewMode}) => viewMode === 'story',
     render: ({active, key}) => <FeatureFlagPanel active={active} key={key} />,
   });
+  addons.add('github/link', {
+    type: types.TOOLEXTRA,
+    title: 'GitHub',
+    match: ({viewMode}) => viewMode === 'story' || viewMode === 'docs',
+    render: GitHubToolbar,
+  });
 });
 
 export const featureFlagOptions = {
@@ -102,6 +108,38 @@ export const gridOptions = {
     options: ['above', 'below'],
   },
 };
+
+const IconButtonLink = styled(IconButton)({
+  textDecoration: 'none',
+});
+
+function GitHubToolbar() {
+  let link;
+  let title;
+  let buttonText;
+
+  if (process.env.STORYBOOK_GITHUB_REPO_URL) {
+    link = `${process.env.STORYBOOK_GITHUB_REPO_URL}`;
+    title = 'View source on GitHub';
+    buttonText = 'GitHub';
+    if (process.env.STORYBOOK_GITHUB_PR) {
+      link = `${link}/pull/${process.env.STORYBOOK_GITHUB_PR}`;
+      title = `Built from PR #${process.env.STORYBOOK_GITHUB_PR}`;
+      buttonText = `PR #${process.env.STORYBOOK_GITHUB_PR}`;
+    } else if (process.env.STORYBOOK_GITHUB_SHA) {
+      link = `${link}/commit/${process.env.STORYBOOK_GITHUB_SHA}`;
+      title = `Built from commit ${process.env.STORYBOOK_GITHUB_SHA}`;
+      buttonText = <code>{process.env.STORYBOOK_GITHUB_SHA.slice(0, 7)}</code>;
+    }
+  }
+
+  return link ? (
+    <IconButtonLink as="a" href={link} title={title} target="_blank">
+      <Icons icon="github" />
+      &nbsp;{buttonText}
+    </IconButtonLink>
+  ) : null;
+}
 
 function FeatureFlagPanel(props) {
   const [globals, updateGlobals] = useGlobals();


### PR DESCRIPTION
![storybook-github-link-demo](https://github.com/Shopify/polaris/assets/612020/c05d5af8-85c6-43bb-bef9-a631518d4e38)

👉 **Live example: [Storybook of this PR!](https://5d559397bae39100201eedc1-uiywkjoufu.chromatic.com/?path=/story/playground--details-page)**

---

I often find myself sharing the Storybook links generated by Chromatic as part of GitHub CI. But those links don't contain any information on where that build came from (the format is `https://<rnd-id>.chromatic.com`). This is bad for me, because I lose track of which tabs were for which Pull Requests, but also bad for folks I share it to as there's no easy way for them to comment on the PR with issues they discover.

This is a quality of life addition which inserts a link into the Storybook toolbar linking back to either; 1) The PR which triggered the build, or 2) If unable to determine the PR, the commit the build is from, or 3) If unable to determine the commit, the Polaris repo, or 4) `null` (for localhost):

### Localhost (no change)
![storybook-github-link-localhost](https://github.com/Shopify/polaris/assets/612020/4cd3d549-c7ab-4d2b-8683-f0c4688564cc)

### The Polaris repo (unable to detect commit or PR)
![storybook-github-link-github](https://github.com/Shopify/polaris/assets/612020/7eb6d680-d933-486f-9542-22da280606f7)

### A commit (unable to detect PR)
![storybook-github-link-commit](https://github.com/Shopify/polaris/assets/612020/64c59aed-2291-4775-be5d-d4d807359c42)

### A PR
![storybook-github-link-pr](https://github.com/Shopify/polaris/assets/612020/c8008d84-2352-41a3-adb3-4aec4cc9290d)