### PR TITLE
[LegacyCard.Section] Remove extra padding when flush is true

### DIFF
--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -117,7 +117,10 @@
   #{$se23} & {
     border-bottom-left-radius: var(--p-border-radius-3);
     border-bottom-right-radius: var(--p-border-radius-3);
-    padding-bottom: var(--p-space-4);
+
+    &:not(.Section-flush) {
+      padding-bottom: var(--p-space-4);
+    }
   }
 }
 
@@ -165,7 +168,9 @@
 
 .Section-subdued:last-child {
   #{$se23} & {
-    padding: var(--p-space-4);
+    &:not(.Section-flush) {
+      padding: var(--p-space-4);
+    }
 
     @media print {
       padding-top: var(--p-space-2);

--- a/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
@@ -399,3 +399,22 @@ export function WithFlushedSections() {
     </LegacyCard>
   );
 }
+
+export function WithStackedFlushSections() {
+  return (
+    <LegacyCard>
+      <LegacyCard.Header title="Online store dashboard" />
+      <LegacyCard.Section flush>
+        <TextContainer>
+          View a summary of your online store’s performance.
+        </TextContainer>
+      </LegacyCard.Section>
+      <LegacyCard.Section flush subdued>
+        <TextContainer>
+          View a summary of your online store’s performance, including sales,
+          visitors, top products, and referrals.
+        </TextContainer>
+      </LegacyCard.Section>
+    </LegacyCard>
+  );
+}


### PR DESCRIPTION
Resolves Shopify/polaris-summer-editions#376, Shopify/polaris-summer-editions#727

When the `$se23` variable is set to true a more specific CSS selector causes the `LegacyCard.Section` component to have unnecessary padding. Since this is a flush component its padding should be `0`.

|                           | Before | After |
|----------------|--------|------|
| **With $se23**       | ![Screenshot 2023-07-04 at 10 06 36](https://github.com/Shopify/polaris/assets/10282220/04e5ae2b-3b84-469f-b50d-2ef9d1bc7645) | ![Screenshot 2023-07-04 at 10 05 50](https://github.com/Shopify/polaris/assets/10282220/b65b912f-ac76-406d-adf4-0d13208d068f) | 
| **Without $se23** | ![Screenshot 2023-07-04 at 10 06 31](https://github.com/Shopify/polaris/assets/10282220/09a1f68e-36e6-4048-b5e8-33bff973012b) | ![Screenshot 2023-07-04 at 10 05 43](https://github.com/Shopify/polaris/assets/10282220/d7e7330b-a81e-4d1c-8ed1-135a41b0a390)  |

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

We now wrap the se23 specific padding in a `&:not(.Section-flush) {` to ensure we don't add the padding to flush components.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
