### PR TITLE
Adjust spacing on `Page` breadcrumbs

### DIFF
--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -106,7 +106,11 @@ export function Header({
 
   const breadcrumbMarkup = backAction ? (
     <div className={styles.BreadcrumbWrapper}>
-      <Box maxWidth="100%" paddingInlineEnd="4" printHidden>
+      <Box
+        maxWidth="100%"
+        paddingInlineEnd={polarisSummerEditions2023 ? '1' : '4'}
+        printHidden
+      >
         <Breadcrumbs backAction={backAction} />
       </Box>
     </div>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/775

### WHAT is this pull request doing?

Reduces spacing on `Page` breadcrumbs

### How to 🎩

Review in Storybook