### PR TITLE
[CSS] Generate contiguous responsive CSS vars

### DIFF
--- a/.changeset/red-dolls-shake.md
+++ b/.changeset/red-dolls-shake.md
@@ -1,0 +1,24 @@
+---
+'@shopify/polaris': patch
+---
+
+- [Internal]: Generate contiguous responsive CSS variables.
+
+  Ensures the CSS vars set via `style` props will override the responsive-props
+  SASS mixin which forces them to have a value of `initial`.
+
+  Forcing to `initial` is required when components are nested to avoid an outer
+  component accidentally setting a value for a nested component by specifying a
+  CSS variable (CSS vars are globally scoped and later-in-DOM has more
+  specificity).
+
+  However, `initial` is [not usable within a
+  `calc()`](https://polaris.shopify.com/sandbox?code=N4Igxg9gJgpiBcIA8UCWA3ABAZwC4E8AbGAXmGEwAcBDKNAOwHN5MAdcawsAClXtVypOmANSYAzACcYAWwCU7TAF8lAPlb1MmAMLV6AclyYArthiYkkWKr4ChhJAHorMVZj46Ayp4svVYTh45Jz8NJzR0dXoQABoQXAALWRhsBABtEEIIAOJ4GGiAXTiAd1QoRNT4NIKlIA),
+  so any unset values will not [fallback as they would when the browser
+  encounters a `var(--some-var-equals-initial, fallback)`](https://polaris.shopify.com/sandbox?code=N4Igxg9gJgpiBcIA8UCWA3ABAZwC4E8AbGAXmGEwHIBaagBzGuwgFsZr0BDAJ0vitQA7VLlSdClADSY6nKGkEBzfgB0QXbgApaDJq3YbpAZm4wWASjWYAvtYB8KwZkxJIsOxs3mkAejcw7TC5CAFcYbEwIADMXfzshETFCXzjMEOwYTFwAC0yo8UIAI04wAGsg8TDHXzR0OxBJEByzcIQAbRBCCDBxGHgYQRAAXUaAd1QoHOx2oesgA).
+
+  Adding this `forceContiguous` flag means we can be sure we're setting exactly
+  what the user asked for when passing in their prop, and not `initial`,
+  therefore retaining the existing behaviour while forward supporting the usage
+  of `calc()`. We still need the `initial` values to ensure any lower
+  breakpoints that are unset do not inherit parent values accidentally.

--- a/.changeset/stupid-planes-fold.md
+++ b/.changeset/stupid-planes-fold.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Export `breakpointAliases` to JS, facilitating easy breakpoint size iterations.

--- a/polaris-react/src/components/Bleed/tests/Bleed.test.tsx
+++ b/polaris-react/src/components/Bleed/tests/Bleed.test.tsx
@@ -26,6 +26,10 @@ describe('<Bleed />', () => {
     expect(bleed).toContainReactComponent('div', {
       style: {
         '--pc-bleed-margin-inline-start-xs': 'var(--p-space-2)',
+        '--pc-bleed-margin-inline-start-sm': 'var(--p-space-2)',
+        '--pc-bleed-margin-inline-start-md': 'var(--p-space-2)',
+        '--pc-bleed-margin-inline-start-lg': 'var(--p-space-2)',
+        '--pc-bleed-margin-inline-start-xl': 'var(--p-space-2)',
       } as React.CSSProperties,
     });
   });
@@ -40,9 +44,25 @@ describe('<Bleed />', () => {
     expect(bleed).toContainReactComponent('div', {
       style: {
         '--pc-bleed-margin-block-start-xs': 'var(--p-space-1)',
+        '--pc-bleed-margin-block-start-sm': 'var(--p-space-1)',
+        '--pc-bleed-margin-block-start-md': 'var(--p-space-1)',
+        '--pc-bleed-margin-block-start-lg': 'var(--p-space-1)',
+        '--pc-bleed-margin-block-start-xl': 'var(--p-space-1)',
         '--pc-bleed-margin-block-end-xs': 'var(--p-space-1)',
+        '--pc-bleed-margin-block-end-sm': 'var(--p-space-1)',
+        '--pc-bleed-margin-block-end-md': 'var(--p-space-1)',
+        '--pc-bleed-margin-block-end-lg': 'var(--p-space-1)',
+        '--pc-bleed-margin-block-end-xl': 'var(--p-space-1)',
         '--pc-bleed-margin-inline-start-xs': 'var(--p-space-2)',
+        '--pc-bleed-margin-inline-start-sm': 'var(--p-space-2)',
+        '--pc-bleed-margin-inline-start-md': 'var(--p-space-2)',
+        '--pc-bleed-margin-inline-start-lg': 'var(--p-space-2)',
+        '--pc-bleed-margin-inline-start-xl': 'var(--p-space-2)',
         '--pc-bleed-margin-inline-end-xs': 'var(--p-space-3)',
+        '--pc-bleed-margin-inline-end-sm': 'var(--p-space-3)',
+        '--pc-bleed-margin-inline-end-md': 'var(--p-space-3)',
+        '--pc-bleed-margin-inline-end-lg': 'var(--p-space-3)',
+        '--pc-bleed-margin-inline-end-xl': 'var(--p-space-3)',
       } as React.CSSProperties,
     });
   });

--- a/polaris-react/src/components/Box/tests/Box.test.tsx
+++ b/polaris-react/src/components/Box/tests/Box.test.tsx
@@ -25,6 +25,10 @@ describe('Box', () => {
     expect(box).toContainReactComponent('div', {
       style: {
         '--pc-box-padding-inline-start-xs': 'var(--p-space-2)',
+        '--pc-box-padding-inline-start-sm': 'var(--p-space-2)',
+        '--pc-box-padding-inline-start-md': 'var(--p-space-2)',
+        '--pc-box-padding-inline-start-lg': 'var(--p-space-2)',
+        '--pc-box-padding-inline-start-xl': 'var(--p-space-2)',
       } as React.CSSProperties,
     });
   });
@@ -39,9 +43,25 @@ describe('Box', () => {
     expect(box).toContainReactComponent('div', {
       style: {
         '--pc-box-padding-block-end-xs': 'var(--p-space-1)',
+        '--pc-box-padding-block-end-sm': 'var(--p-space-1)',
+        '--pc-box-padding-block-end-md': 'var(--p-space-1)',
+        '--pc-box-padding-block-end-lg': 'var(--p-space-1)',
+        '--pc-box-padding-block-end-xl': 'var(--p-space-1)',
         '--pc-box-padding-block-start-xs': 'var(--p-space-1)',
+        '--pc-box-padding-block-start-sm': 'var(--p-space-1)',
+        '--pc-box-padding-block-start-md': 'var(--p-space-1)',
+        '--pc-box-padding-block-start-lg': 'var(--p-space-1)',
+        '--pc-box-padding-block-start-xl': 'var(--p-space-1)',
         '--pc-box-padding-inline-end-xs': 'var(--p-space-1)',
+        '--pc-box-padding-inline-end-sm': 'var(--p-space-1)',
+        '--pc-box-padding-inline-end-md': 'var(--p-space-1)',
+        '--pc-box-padding-inline-end-lg': 'var(--p-space-1)',
+        '--pc-box-padding-inline-end-xl': 'var(--p-space-1)',
         '--pc-box-padding-inline-start-xs': 'var(--p-space-2)',
+        '--pc-box-padding-inline-start-sm': 'var(--p-space-2)',
+        '--pc-box-padding-inline-start-md': 'var(--p-space-2)',
+        '--pc-box-padding-inline-start-lg': 'var(--p-space-2)',
+        '--pc-box-padding-inline-start-xl': 'var(--p-space-2)',
       } as React.CSSProperties,
     });
   });

--- a/polaris-react/src/components/HorizontalGrid/tests/HorizontalGrid.test.tsx
+++ b/polaris-react/src/components/HorizontalGrid/tests/HorizontalGrid.test.tsx
@@ -12,6 +12,8 @@ describe('HorizontalGrid', () => {
     expect(horizontalGrid).toContainReactComponent('div', {
       style: {
         '--pc-horizontal-grid-gap-md': 'var(--p-space-1)',
+        '--pc-horizontal-grid-gap-lg': 'var(--p-space-1)',
+        '--pc-horizontal-grid-gap-xl': 'var(--p-space-1)',
         '--pc-horizontal-grid-align-items': 'start',
       } as React.CSSProperties,
     });

--- a/polaris-react/src/utilities/tests/css.test.ts
+++ b/polaris-react/src/utilities/tests/css.test.ts
@@ -29,6 +29,10 @@ describe('getResponsiveProps', () => {
   it('takes a string and returns the custom property', () => {
     expect(getResponsiveProps('stack', 'space', 'space', '4')).toMatchObject({
       '--pc-stack-space-xs': 'var(--p-space-4)',
+      '--pc-stack-space-sm': 'var(--p-space-4)',
+      '--pc-stack-space-md': 'var(--p-space-4)',
+      '--pc-stack-space-lg': 'var(--p-space-4)',
+      '--pc-stack-space-xl': 'var(--p-space-4)',
     });
   });
 
@@ -37,7 +41,82 @@ describe('getResponsiveProps', () => {
       getResponsiveProps('stack', 'space', 'space', {xs: '2', md: '8'}),
     ).toMatchObject({
       '--pc-stack-space-xs': 'var(--p-space-2)',
+      '--pc-stack-space-sm': 'var(--p-space-2)',
       '--pc-stack-space-md': 'var(--p-space-8)',
+      '--pc-stack-space-lg': 'var(--p-space-8)',
+      '--pc-stack-space-xl': 'var(--p-space-8)',
+    });
+  });
+
+  it('handles a full responsive object', () => {
+    expect(
+      getResponsiveProps('stack', 'space', 'space', {
+        xs: '2',
+        sm: '4',
+        md: '8',
+        lg: '8',
+        xl: '10',
+      }),
+    ).toMatchObject({
+      '--pc-stack-space-xs': 'var(--p-space-2)',
+      '--pc-stack-space-sm': 'var(--p-space-4)',
+      '--pc-stack-space-md': 'var(--p-space-8)',
+      '--pc-stack-space-lg': 'var(--p-space-8)',
+      '--pc-stack-space-xl': 'var(--p-space-10)',
+    });
+  });
+
+  it('fills in the blanks', () => {
+    expect(
+      getResponsiveProps('stack', 'space', 'space', {
+        xs: '2',
+        sm: '4',
+        xl: '10',
+      }),
+    ).toMatchObject({
+      '--pc-stack-space-xs': 'var(--p-space-2)',
+      '--pc-stack-space-sm': 'var(--p-space-4)',
+      '--pc-stack-space-md': 'var(--p-space-4)',
+      '--pc-stack-space-lg': 'var(--p-space-4)',
+      '--pc-stack-space-xl': 'var(--p-space-10)',
+    });
+  });
+
+  it('does not fill in leading undefined values', () => {
+    expect(
+      getResponsiveProps('stack', 'space', 'space', {
+        md: '4',
+        xl: '10',
+      }),
+    ).toMatchObject({
+      '--pc-stack-space-md': 'var(--p-space-4)',
+      '--pc-stack-space-lg': 'var(--p-space-4)',
+      '--pc-stack-space-xl': 'var(--p-space-10)',
+    });
+  });
+
+  it('treats falsey as a value', () => {
+    expect(
+      getResponsiveProps('stack', 'space', 'space', {
+        md: 0,
+        xl: '10',
+      }),
+    ).toMatchObject({
+      '--pc-stack-space-md': 'var(--p-space-0)',
+      '--pc-stack-space-lg': 'var(--p-space-0)',
+      '--pc-stack-space-xl': 'var(--p-space-10)',
+    });
+  });
+
+  it('ignores explicit "undefined" values', () => {
+    expect(
+      getResponsiveProps('stack', 'space', 'space', {
+        md: undefined,
+        lg: '10',
+      }),
+    ).toMatchObject({
+      '--pc-stack-space-lg': 'var(--p-space-10)',
+      '--pc-stack-space-xl': 'var(--p-space-10)',
     });
   });
 });

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -1,5 +1,6 @@
 export * from './metadata';
 export * from './utilities';
+export {breakpointsAliases} from './token-groups/breakpoints';
 export type {
   TokenGroup,
   Tokens,

--- a/polaris-tokens/src/token-groups/breakpoints.ts
+++ b/polaris-tokens/src/token-groups/breakpoints.ts
@@ -1,6 +1,11 @@
 import type {MetadataProperties} from '../types';
 
-export type BreakpointsAlias = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+// NOTE: Order is important here: smallest -> largest
+// Exporting as const means it will be typed as a Tuple instead of string[]
+export const breakpointsAliases = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+
+// Convert the Tuple to a union
+export type BreakpointsAlias = typeof breakpointsAliases[number];
 
 export type BreakpointsTokenName = `breakpoints-${BreakpointsAlias}`;
 


### PR DESCRIPTION
_See https://github.com/Shopify/polaris/pull/9593 for context and intended usage with `calc()`._

Ensures the CSS vars set via `style` props will override the responsive-props SASS mixin which forces them to have a value of `initial`.

Forcing to `initial` is required when components are nested to avoid an outer component accidentally setting a value for a nested component by specifying a CSS variable (CSS vars are globally scoped and later-in-DOM has more specificity).

However, `initial` is [not usable within a `calc()`](https://polaris.shopify.com/sandbox?code=N4Igxg9gJgpiBcIA8UCWA3ABAZwC4E8AbGAXmGEwAcBDKNAOwHN5MAdcawsAClXtVypOmANSYAzACcYAWwCU7TAF8lAPlb1MmAMLV6AclyYArthiYkkWKr4ChhJAHorMVZj46Ayp4svVYTh45Jz8NJzR0dXoQABoQXAALWRhsBABtEEIIAOJ4GGiAXTiAd1QoRNT4NIKlIA), so any unset values will not [fallback as they would when the browser encounters a `var(--some-var-equals-initial, fallback)`](https://polaris.shopify.com/sandbox?code=N4Igxg9gJgpiBcIA8UCWA3ABAZwC4E8AbGAXmGEwHIBaagBzGuwgFsZr0BDAJ0vitQA7VLlSdClADSY6nKGkEBzfgB0QXbgApaDJq3YbpAZm4wWASjWYAvtYB8KwZkxJIsOxs3mkAejcw7TC5CAFcYbEwIADMXfzshETFCXzjMEOwYTFwAC0yo8UIAI04wAGsg8TDHXzR0OxBJEByzcIQAbRBCCDBxGHgYQRAAXUaAd1QoHOx2oesgA).


Adding this ~`forceContiguous` flag~ _(made `forceContiguous: true` the default)_  means we can be sure we're setting exactly what the user asked for when passing in their prop, and not `initial`, therefore retaining the existing behaviour while forward supporting the usage of `calc()`. We still need the `initial` values to ensure any lower breakpoints that are unset do not inherit parent values accidentally.