### PR TITLE
[Tag] Remove inline padding for Tag with link

### DIFF
--- a/polaris-react/src/components/Tag/Tag.scss
+++ b/polaris-react/src/components/Tag/Tag.scss
@@ -269,7 +269,7 @@ $button-size: 20px;
     /* stylelint-disable-next-line polaris/border/polaris/at-rule-disallowed-list -- se23 */
     @include focus-ring('wide');
     border-radius: var(--p-border-radius-2);
-    padding: 0 calc(var(--p-space-1) + var(--p-space-05));
+    padding: 0;
 
     &:active {
       background: var(--p-color-bg-strong-active);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/771

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Before:
<img width="640" alt="Screenshot 2023-07-05 at 2 46 31 pm" src="https://github.com/Shopify/polaris/assets/12119389/e29d2462-2e67-4a4c-966c-f991ecbfdd9c">

After: 
<img width="636" alt="Screenshot 2023-07-05 at 2 46 47 pm" src="https://github.com/Shopify/polaris/assets/12119389/f9d63bc3-bbf2-4d40-b0de-e6e6c8589b42">

<!-- ℹ️ Delete the following for small / trivial changes -->

[Storybook](https://5d559397bae39100201eedc1-ugbxsyynvl.chromatic.com/?path=/story/all-components-tag--default&globals=polarisSummerEditions2023:true)