### PR TITLE
Use Inter as preferred sans font family

### DIFF
--- a/.changeset/rotten-planets-watch.md
+++ b/.changeset/rotten-planets-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Use Inter as preferred sans font family

--- a/.changeset/rotten-planets-watch.md
+++ b/.changeset/rotten-planets-watch.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-tokens': minor
 ---
 
-Use Inter as preferred sans font family
+Added Inter reference as preferred sans font family

--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -1,0 +1,10 @@
+<link rel="preconnect" href="https://fonts.googleapis.com/" />
+<link
+  rel="preconnect"
+  href="https://fonts.gstatic.com/"
+  crossorigin="anonymous"
+/>
+<link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
+  rel="stylesheet"
+/>

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -44,7 +44,7 @@ export const font: {
 } = {
   'font-family-sans': {
     value:
-      "-apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
+      "'Inter', -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
   },
   'font-family-mono': {
     value:


### PR DESCRIPTION
Updates the `--p-font-family-sans` token to use [Inter](https://fonts.google.com/specimen/Inter) as the preferred font.