### PR TITLE
[Tabs][Uplift]: Match hover and active colour

### DIFF
--- a/polaris-react/src/components/Tabs/Tabs.scss
+++ b/polaris-react/src/components/Tabs/Tabs.scss
@@ -133,12 +133,8 @@
     }
 
     &:not([aria-disabled='true']):hover {
-      background-color: var(--p-color-bg-subdued);
+      background-color: var(--p-color-bg-secondary-experimental);
       color: var(--p-color-text-primary);
-
-      #{$se23} & {
-        background-color: var(--p-color-bg-secondary-experimental);
-      }
     }
 
     &:not([aria-disabled='true']):focus-visible {
@@ -149,13 +145,9 @@
     }
 
     &:not([aria-disabled='true']):active {
-      background-color: var(--p-color-bg-subdued);
+      background-color: var(--p-color-bg-secondary-experimental);
       color: var(--p-color-text-primary);
       z-index: var(--p-z-index-1);
-
-      #{$se23} & {
-        background-color: var(--p-color-bg-secondary-experimental);
-      }
     }
 
     @media #{$p-breakpoints-md-up} {
@@ -187,12 +179,9 @@
   }
 
   #{$se23} & {
-    background: var(--p-color-bg-subdued);
+    background: var(--p-color-bg-secondary-experimental);
     color: var(--p-color-text);
-
-    #{$se23} & {
-      background: var(--p-color-bg-secondary-experimental);
-    }
+    border-radius: var(--p-border-radius-2);
 
     &[aria-disabled='true'] {
       background: var(--p-color-bg-disabled);
@@ -201,20 +190,12 @@
 
     &:not([aria-disabled='true']):hover,
     &:not([aria-disabled='true']):focus {
-      background-color: var(--p-color-bg-subdued);
+      background-color: var(--p-color-bg-secondary-experimental);
       color: var(--p-color-text-primary);
-
-      #{$se23} & {
-        background-color: var(--p-color-bg-secondary-experimental);
-      }
     }
 
     &:not([aria-disabled='true']):active {
-      background-color: var(--p-color-bg-subdued);
-
-      #{$se23} & {
-        background-color: var(--p-color-bg-secondary-experimental);
-      }
+      background-color: var(--p-color-bg-secondary-experimental);
     }
   }
 }
@@ -374,7 +355,7 @@
     }
 
     &:not([aria-disabled='true']):hover {
-      background-color: var(--p-color-bg-interactive-subdued-active);
+      background-color: var(--p-color-bg-secondary-experimental);
       color: var(--p-color-text-primary);
     }
 
@@ -384,7 +365,7 @@
     }
 
     &:not([aria-disabled='true']):active {
-      background-color: var(--p-color-bg-interactive-subdued-active);
+      background-color: var(--p-color-bg-secondary-experimental);
     }
   }
 }


### PR DESCRIPTION
## 📣 ❤️ Hey hey reviewers! 🥳 Would you mind looking at the `Questions` portion below? 🙏🏽 THANK YOU IN ADVANCE. 

### WHY are these changes introduced?

Following the **[Uplift Figma Link for `Tabs`](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Uplift-Components-%5Bgen3%E2%80%93alpha%5D?node-id=84001%3A38964&mode=dev)** 🖌️ , the background colour on `hover` and `active` should be 

```CSS
background: var(--background-bg-secondary, #F3F3F3);
```
Related https://github.com/Shopify/polaris/pull/9543 
Discovered through https://github.com/Shopify/web/issues/96536 

### WHAT is this pull request doing?

(with uplift) 
| Before | After |
|--------|--------|
| <img width="566" alt="Screenshot 2023-07-05 at 1 31 29 PM" src="https://github.com/Shopify/polaris/assets/43223543/41da1a18-6f19-4ece-af4d-bba8d5434316"> | <img width="566" alt="Screenshot 2023-07-05 at 1 32 34 PM" src="https://github.com/Shopify/polaris/assets/43223543/96c1239c-d63a-4cb1-a43e-6ddb2ae9cc9d"> |



### ❓ Questions 🙏🏽 
1. I'm noticing that the `More views` font is slightly more bolded - is this what we want? I can't find any thing in the Figma 😄
<img width="250" alt="Screenshot 2023-07-05 at 1 59 53 PM" src="https://github.com/Shopify/polaris/assets/43223543/084499b4-aeff-4280-982b-e3d4780c234d">

2. At a certain breakpoint, `More views` disappears, the tabs get slightly larger, and then a scroll appears. Is this the desired behaviour? I find it a little jarring. 

Here's a video: 

https://github.com/Shopify/polaris/assets/43223543/392582e0-6f59-4449-89b3-cde4a9a42429


### How to 🎩

🎩 🌀 [SPIN on web with these changes 😄 - takes you to Orders ❤️ ](https://admin.web.more-views.gina-bak.us.spin.dev/store/shop1/orders?inContextTimeframe=none) 🌀

Ensure that you have a smaller window frame to ensure that the `More views` is triggered 😄 


🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
