### PR TITLE
Inter font experimental

### DIFF
--- a/.changeset/wicked-pillows-burn.md
+++ b/.changeset/wicked-pillows-burn.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'@shopify/polaris-tokens': patch
+---
+
+Only use Inter for experimental styles

--- a/polaris-react/src/components/AppProvider/AppProvider.scss
+++ b/polaris-react/src/components/AppProvider/AppProvider.scss
@@ -25,6 +25,10 @@ html,
 body,
 button {
   font-family: var(--p-font-family-sans);
+
+  #{$se23} & {
+    font-family: var(--p-font-family-sans-experimental);
+  }
 }
 
 html {

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -1,6 +1,8 @@
 import type {MetadataProperties, Experimental} from '../types';
 
-type FontFamilyAlias = 'sans' | 'mono';
+type FontFamilyAliasExperimental = Experimental<'sans'>;
+
+type FontFamilyAlias = 'sans' | 'mono' | FontFamilyAliasExperimental;
 
 type FontSizeScaleExperimental = Experimental<'70' | '80'>;
 
@@ -43,6 +45,10 @@ export const font: {
   [TokenName in FontTokenName]: MetadataProperties;
 } = {
   'font-family-sans': {
+    value:
+      "-apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
+  },
+  'font-family-sans-experimental': {
     value:
       "'Inter', -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
   },


### PR DESCRIPTION
The current `--p-font-family-sans` will use Inter. This will display if the use has the font locally. In order to prevent this, we should move this value to an experimental token and apply the font style using the experimental feature flag.