### PR TITLE
Add untriaged label to opened issues

### DIFF
--- a/.github/workflows/untriaged-labeler.yml
+++ b/.github/workflows/untriaged-labeler.yml
@@ -1,0 +1,18 @@
+name: Add untriaged label
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label issues
+        uses: andymckay/labeler@1.0.2
+        with:
+          add-labels: 'untriaged'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the `untriaged` label to newly opened GitHub issues. This will help prevent the Security Bot from adding unwanted security bug comments.

<img width="914" alt="Screenshot 2023-07-06 at 8 58 08 AM" src="https://github.com/Shopify/polaris/assets/11774595/52ce0e10-9c8d-4cb7-a0ca-486d345ccc45">
