### PR TITLE
[LegacyTabs] Fix markup of Tab content for LegacyTabs using URL prop

### DIFF
--- a/polaris-react/src/components/LegacyTabs/LegacyTabs.stories.tsx
+++ b/polaris-react/src/components/LegacyTabs/LegacyTabs.stories.tsx
@@ -24,6 +24,13 @@ export function All() {
 
       <VerticalStack gap="4">
         <Text as="h2" variant="headingXl">
+          With URL tabs
+        </Text>
+        <WithUrlTabs />
+      </VerticalStack>
+
+      <VerticalStack gap="4">
+        <Text as="h2" variant="headingXl">
           Fitted
         </Text>
         <Fitted />
@@ -87,6 +94,51 @@ export function Default() {
   );
 }
 
+export function WithUrlTabs() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = useCallback(
+    (selectedTabIndex) => setSelected(selectedTabIndex),
+    [],
+  );
+
+  const tabs = [
+    {
+      id: 'all-customers-2',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-content-2',
+      url: '#',
+    },
+    {
+      id: 'accepts-marketing-2',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-content-2',
+      url: '#',
+    },
+    {
+      id: 'repeat-customers-2',
+      content: 'Repeat customers',
+      panelID: 'repeat-customers-content-2',
+      url: '#',
+    },
+    {
+      id: 'prospects-2',
+      content: 'Prospects',
+      panelID: 'prospects-content-2',
+      url: '#',
+    },
+  ];
+
+  return (
+    <LegacyTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
+      <LegacyCard.Section title={tabs[selected].content}>
+        <p>Tab {selected} selected</p>
+      </LegacyCard.Section>
+    </LegacyTabs>
+  );
+}
+
 export function Fitted() {
   const [selected, setSelected] = useState(0);
 
@@ -97,15 +149,15 @@ export function Fitted() {
 
   const tabs = [
     {
-      id: 'all-customers-fitted-2',
+      id: 'all-customers-fitted-3',
       content: 'All',
       accessibilityLabel: 'All customers',
-      panelID: 'all-customers-fitted-content-2',
+      panelID: 'all-customers-fitted-content-3',
     },
     {
-      id: 'accepts-marketing-fitted-2',
+      id: 'accepts-marketing-fitted-3',
       content: 'Accepts marketing',
-      panelID: 'accepts-marketing-fitted-Ccontent-2',
+      panelID: 'accepts-marketing-fitted-Ccontent-3',
     },
   ];
 
@@ -135,23 +187,23 @@ export function WithBadgeContent() {
 
   const tabs = [
     {
-      id: 'all-customers-fitted-3',
+      id: 'all-customers-fitted-4',
       content: (
         <span>
           All <Badge status="new">10+</Badge>
         </span>
       ),
       accessibilityLabel: 'All customers',
-      panelID: 'all-customers-fitted-content-3',
+      panelID: 'all-customers-fitted-content-4',
     },
     {
-      id: 'accepts-marketing-fitted-3',
+      id: 'accepts-marketing-fitted-4',
       content: (
         <span>
           Accepts marketing <Badge status="new">4</Badge>
         </span>
       ),
-      panelID: 'accepts-marketing-fitted-content-3',
+      panelID: 'accepts-marketing-fitted-content-4',
     },
   ];
 
@@ -181,25 +233,25 @@ export function WithCustomDisclosure() {
 
   const tabs = [
     {
-      id: 'all-customers-4',
+      id: 'all-customers-5',
       content: 'All',
       accessibilityLabel: 'All customers',
-      panelID: 'all-customers-content-4',
+      panelID: 'all-customers-content-5',
     },
     {
-      id: 'accepts-marketing-4',
+      id: 'accepts-marketing-5',
       content: 'Accepts marketing',
-      panelID: 'accepts-marketing-content-4',
+      panelID: 'accepts-marketing-content-5',
     },
     {
-      id: 'repeat-customers-4',
+      id: 'repeat-customers-5',
       content: 'Repeat customers',
-      panelID: 'repeat-customers-content-4',
+      panelID: 'repeat-customers-content-5',
     },
     {
-      id: 'prospects-4',
+      id: 'prospects-5',
       content: 'Prospects',
-      panelID: 'prospects-content-4',
+      panelID: 'prospects-content-5',
     },
   ];
 

--- a/polaris-react/src/components/LegacyTabs/components/Tab/Tab.tsx
+++ b/polaris-react/src/components/LegacyTabs/components/Tab/Tab.tsx
@@ -1,13 +1,11 @@
 import React, {useEffect, useRef} from 'react';
 
 import {UnstyledLink} from '../../../UnstyledLink';
-import {Text} from '../../../Text';
 import {classNames} from '../../../../utilities/css';
 import {
   focusFirstFocusableNode,
   handleMouseUpByBlurring,
 } from '../../../../utilities/focus';
-import {useFeatures} from '../../../../utilities/features';
 import styles from '../../LegacyTabs.scss';
 
 export interface TabProps {
@@ -38,7 +36,6 @@ export function Tab({
   const wasSelected = useRef(selected);
   const panelFocused = useRef(false);
   const node = useRef<HTMLLIElement | null>(null);
-  const {polarisSummerEditions2023} = useFeatures();
 
   // A tab can start selected when it is moved from the disclosure dropdown
   // into the main list, so we need to send focus from the tab to the panel
@@ -89,14 +86,6 @@ export function Tab({
     selected && styles.Underline,
   );
 
-  const titleMarkup = polarisSummerEditions2023 ? (
-    <Text as="p" variant="bodySm">
-      {children}
-    </Text>
-  ) : (
-    <span className={styles.Title}>{children}</span>
-  );
-
   const markup = url ? (
     <UnstyledLink
       id={id}
@@ -110,7 +99,7 @@ export function Tab({
       aria-label={accessibilityLabel}
       onMouseUp={handleMouseUpByBlurring}
     >
-      {titleMarkup}
+      <span className={styles.Title}>{children}</span>
     </UnstyledLink>
   ) : (
     <button


### PR DESCRIPTION
### WHY are these changes introduced?

Text markup for LegacyTabs that are using url prop looks broken. When using `url` prop Text markup is different and no longer has Tab styling. No indication of either tab is active, spacing and text styling is off too.
This PR aims to fix it by removing bits of code and this way unifying markup.

**Before**
![image](https://github.com/Shopify/polaris/assets/8435507/3f3e101e-ab7c-4650-91f2-ae0be40d278d)

**After**
![image](https://github.com/Shopify/polaris/assets/8435507/9d2ccbd4-8d22-46bc-a104-73985202fc8a)

### WHAT is this pull request doing?

Removes branching logic: 

```jsx
  const titleMarkup = polarisSummerEditions2023 ? (
    <Text as="p" variant="bodySm">
      {children}
    </Text>
  ) : (
    <span className={styles.Title}>{children}</span>
  );
```

And uses same markup as for Tabs without URLs:
```jsx
<span className={styles.Title}>{children}</span>
```


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
