### PR TITLE
Remove bottom padding from LegacyCard heading and top padding from LegacyCard action footer

### DIFF
--- a/.changeset/weak-glasses-relate.md
+++ b/.changeset/weak-glasses-relate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Legacy card update experimental padding

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -233,11 +233,15 @@
   justify-content: flex-end;
   padding: var(--p-space-2) var(--p-space-4) var(--p-space-4);
 
+  #{$se23} & {
+    padding: 0 var(--p-space-4) var(--p-space-4);
+  }
+
   @media #{$p-breakpoints-sm-up} {
     padding: 0 var(--p-space-5) var(--p-space-5);
 
     #{$se23} & {
-      padding: var(--p-space-2) var(--p-space-4) var(--p-space-4);
+      padding: 0 var(--p-space-4) var(--p-space-4);
     }
   }
 

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -58,7 +58,7 @@
     padding: var(--p-space-5) var(--p-space-5) 0;
 
     #{$se23} & {
-      padding: var(--p-space-2) var(--p-space-4);
+      padding: var(--p-space-2) var(--p-space-4) 0;
     }
   }
 


### PR DESCRIPTION
[Before Story](https://storybook.polaris.shopify.com/?path=/story/all-components-legacycard--all&globals=polarisSummerEditions2023:true) with `LegacyCard.Heading` `padding-bottom: 8px` (treats headings the same as sections)
[After Story](https://5d559397bae39100201eedc1-ivllhrhcbc.chromatic.com/?path=/story/all-components-legacycard--all&globals=polarisSummerEditions2023:true) with `LegacyCard.Heading` `padding-bottom: 0px`