### PR TITLE
Update `Button` `pressed` hover and active states

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -57,13 +57,13 @@
       // stylelint-enable selector-max-combinators
     }
 
-    &:focus:not(.primary):not(.plain):not(.pressed),
-    &:focus-visible:not(.primary):not(.plain):not(.pressed) {
+    &:focus:not(.primary):not(.plain),
+    &:focus-visible:not(.primary):not(.plain) {
       // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       box-shadow: var(--pc-button-shadow);
     }
 
-    &:hover:not(.pressed) {
+    &:hover {
       // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       box-shadow: var(--pc-button-shadow-hover);
     }

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -57,13 +57,13 @@
       // stylelint-enable selector-max-combinators
     }
 
-    &:focus:not(.primary):not(.plain),
-    &:focus-visible:not(.primary):not(.plain) {
+    &:focus:not(.primary):not(.plain):not(.pressed),
+    &:focus-visible:not(.primary):not(.plain):not(.pressed) {
       // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       box-shadow: var(--pc-button-shadow);
     }
 
-    &:hover {
+    &:hover:not(.pressed) {
       // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
       box-shadow: var(--pc-button-shadow-hover);
     }

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
@@ -45,6 +45,10 @@
     margin-left: 0;
     line-height: normal;
 
+    #{$se23} & {
+      z-index: unset;
+    }
+
     &:not(:first-child) {
       margin-left: calc(-1 * var(--p-space-025));
     }

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
@@ -46,6 +46,7 @@
     line-height: normal;
 
     #{$se23} & {
+      // stylelint-disable-next-line polaris/z-index/declaration-property-value-allowed-list -- se23 temporary styles
       z-index: unset;
     }
 

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -19,7 +19,7 @@ export function WithSegmentedButtons() {
   return (
     <ButtonGroup segmented>
       <Button>Bold</Button>
-      <Button>Italic</Button>
+      <Button pressed>Italic</Button>
       <Button>Underline</Button>
     </ButtonGroup>
   );

--- a/polaris-react/src/styles/shared/_buttons.scss
+++ b/polaris-react/src/styles/shared/_buttons.scss
@@ -81,10 +81,12 @@
 
       &:hover {
         background: var(--p-color-bg-strong-hover);
+        box-shadow: var(--p-shadow-inset-md);
       }
 
       &:active {
         background: var(--p-color-bg-strong-active);
+        box-shadow: var(--p-shadow-inset-md);
       }
     }
   }

--- a/polaris-react/src/styles/shared/_buttons.scss
+++ b/polaris-react/src/styles/shared/_buttons.scss
@@ -78,6 +78,14 @@
       background: var(--p-color-bg-strong-active);
       box-shadow: var(--p-shadow-inset-md);
       color: var(--p-color-text);
+
+      &:hover {
+        background: var(--p-color-bg-strong-hover);
+      }
+
+      &:active {
+        background: var(--p-color-bg-strong-active);
+      }
     }
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/863

### WHAT is this pull request doing?

Fixes the hover and active states for `pressed` buttons

<img width="205" alt="Screenshot 2023-07-06 at 2 32 42 PM" src="https://github.com/Shopify/polaris/assets/3474483/1dce6b88-e7c7-4f2d-be60-d54fe5111c27">


### How to 🎩
- Review the `ButtonGroup` with segmented buttons on Storybook