### PR TITLE
Apply `shadow-bevel` to `Popover`

### DIFF
--- a/polaris-react/src/components/Popover/Popover.scss
+++ b/polaris-react/src/components/Popover/Popover.scss
@@ -14,8 +14,11 @@ $vertical-motion-offset: -5px;
   will-change: left, top;
 
   #{$se23} & {
-    box-shadow: var(--p-shadow-card-lg-experimental);
-    border-radius: var(--p-border-radius-3);
+    @include shadow-bevel(
+      $boxShadow: var(--p-shadow-md),
+      $borderRadius: var(--p-border-radius-3),
+      $zIndex: 1
+    );
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-summer-editions/issues/711

<img width="619" alt="image" src="https://github.com/Shopify/polaris/assets/32409546/26a1e48e-105f-49a9-96ae-85c4778ffa41">