### PR TITLE
[LegacyCard] Fix nested sections

### DIFF
--- a/.changeset/khaki-geese-cross.md
+++ b/.changeset/khaki-geese-cross.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+LegacyCard fixed xs screen section border radii

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -21,11 +21,33 @@
   @media #{$p-breakpoints-sm-up} {
     border-radius: var(--p-border-radius-2);
 
+    .Section:first-child {
+      border-top-left-radius: var(--p-border-radius-2);
+      border-top-right-radius: var(--p-border-radius-2);
+    }
+
+    .Section:last-child {
+      border-bottom-left-radius: var(--p-border-radius-2);
+      border-bottom-right-radius: var(--p-border-radius-2);
+    }
+
     #{$se23} & {
       @include shadow-bevel(
         $boxShadow: var(--p-shadow-xs),
         $borderRadius: var(--p-border-radius-3)
       );
+
+      border-radius: var(--p-border-radius-3);
+
+      .Section:first-child {
+        border-top-left-radius: var(--p-border-radius-3);
+        border-top-right-radius: var(--p-border-radius-3);
+      }
+
+      .Section:last-child {
+        border-bottom-left-radius: var(--p-border-radius-3);
+        border-bottom-right-radius: var(--p-border-radius-3);
+      }
     }
   }
 
@@ -100,34 +122,6 @@
   @media print {
     padding-top: var(--p-space-1);
     padding-bottom: var(--p-space-1);
-  }
-}
-
-.Section:first-child {
-  border-top-left-radius: var(--p-border-radius-2);
-  border-top-right-radius: var(--p-border-radius-2);
-
-  #{$se23} & {
-    border-radius: 0;
-
-    @media #{$p-breakpoints-sm-up} {
-      border-top-left-radius: var(--p-border-radius-3);
-      border-top-right-radius: var(--p-border-radius-3);
-    }
-  }
-}
-
-.Section:last-child {
-  border-bottom-left-radius: var(--p-border-radius-2);
-  border-bottom-right-radius: var(--p-border-radius-2);
-
-  #{$se23} & {
-    border-radius: 0;
-
-    @media #{$p-breakpoints-sm-up} {
-      border-bottom-left-radius: var(--p-border-radius-3);
-      border-bottom-right-radius: var(--p-border-radius-3);
-    }
   }
 }
 

--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -36,14 +36,15 @@
         $boxShadow: var(--p-shadow-xs),
         $borderRadius: var(--p-border-radius-3)
       );
-
       border-radius: var(--p-border-radius-3);
 
+      // stylelint-disable-next-line -- se23 override
       .Section:first-child {
         border-top-left-radius: var(--p-border-radius-3);
         border-top-right-radius: var(--p-border-radius-3);
       }
 
+      // stylelint-disable-next-line -- se23 override
       .Section:last-child {
         border-bottom-left-radius: var(--p-border-radius-3);
         border-bottom-right-radius: var(--p-border-radius-3);

--- a/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
@@ -1,3 +1,4 @@
+import type {PropsWithChildren} from 'react';
 import React, {useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
@@ -402,22 +403,6 @@ export function WithFlushedSections() {
   );
 }
 
-const DynamicChildren = () => {
-  const [showChildren, setShowChildren] = useState(false);
-  return (
-    <div>
-      <LegacyCard.Section>
-        <Button onClick={() => setShowChildren(!showChildren)}>
-          {showChildren ? 'Hide ' : 'Show '}children
-        </Button>
-      </LegacyCard.Section>
-      {showChildren ? (
-        <LegacyCard.Section>Child section content</LegacyCard.Section>
-      ) : null}
-    </div>
-  );
-};
-
 export function All() {
   return (
     <VerticalStack gap="2">
@@ -431,13 +416,9 @@ export function All() {
       </LegacyCard>
       <LegacyCard title="Non-text first item">
         <LegacyCard.Section>
-          <Box
-            minHeight="50px"
-            borderRadius="2"
-            borderStyle="solid"
-            borderWidth="1"
-            borderColor="border"
-          />
+          <Box>
+            <LegacyCard.Section subdued>Section 1 content</LegacyCard.Section>
+          </Box>
         </LegacyCard.Section>
         <LegacyCard.Section title="Section 2 heading">
           Section 2 content
@@ -468,18 +449,6 @@ export function All() {
           </LegacyCard.Section>
         </div>
       </LegacyCard>
-      <LegacyCard title="Non section last child">
-        <LegacyCard.Section>Section 1 content</LegacyCard.Section>
-        <LegacyCard.Section>
-          Section 2 content, there is an empty div under this
-        </LegacyCard.Section>
-        <div />
-      </LegacyCard>
-      <LegacyCard>
-        Direct child text
-        <LegacyCard.Section>Section 1 content</LegacyCard.Section>
-        <LegacyCard.Section>Section 2 content</LegacyCard.Section>
-      </LegacyCard>
       <LegacyCard>
         <div>
           <h2>Custom header in an h2</h2>
@@ -504,34 +473,6 @@ export function All() {
       </LegacyCard>
       <LegacyCard>
         <div>Card content in div not in section</div>
-      </LegacyCard>
-      <LegacyCard title="Card headings with top subdued">
-        <LegacyCard.Section title="Section 1 heading" subdued>
-          Subdued Section 1 content
-        </LegacyCard.Section>
-        <LegacyCard.Section title="Section 2 heading">
-          Section 2 content
-        </LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard title="Card headings with bottom subdued">
-        <LegacyCard.Section title="Section 1 heading">
-          Section 1 content
-        </LegacyCard.Section>
-        <LegacyCard.Section title="Section 2 heading" subdued>
-          <p>Subdued section 2 content</p>
-        </LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard title="No section headings with top subdued">
-        <LegacyCard.Section subdued>
-          Subdued Section 1 content
-        </LegacyCard.Section>
-        <LegacyCard.Section>Section 2 content</LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard title="No section headings with bottom subdued">
-        <LegacyCard.Section>Section 1 content</LegacyCard.Section>
-        <LegacyCard.Section subdued>
-          Subdued section 2 content
-        </LegacyCard.Section>
       </LegacyCard>
       <LegacyCard>
         <LegacyCard.Section subdued>
@@ -565,73 +506,53 @@ export function All() {
         <DynamicChildren />
       </LegacyCard>
       <LegacyCard title="Only one header section" />
-      <LegacyCard
-        secondaryFooterActions={[{content: 'Dismiss'}]}
-        primaryFooterAction={{content: 'Export Report'}}
-      >
-        <LegacyCard.Header
-          actions={[
-            {
-              content: 'Total Sales',
-            },
-          ]}
-          title="Sales"
-        >
-          <Popover
-            active={false}
-            activator={
-              <Button disclosure plain>
-                View Sales
-              </Button>
-            }
-            onClose={() => {}}
-          >
-            <ActionList
-              items={[{content: 'Gross Sales'}, {content: 'Net Sales'}]}
-            />
-          </Popover>
-        </LegacyCard.Header>
-        <LegacyCard.Section title="Total Sales Breakdown">
-          <ResourceList
-            resourceName={{singular: 'sale', plural: 'sales'}}
-            items={[
-              {
-                sales: 'Orders',
-                amount: 'USD$0.00',
-                url: '#',
-              },
-              {
-                sales: 'Returns',
-                amount: '-USD$250.00',
-                url: '#',
-              },
-            ]}
-            renderItem={(item) => {
-              const {sales, amount, url} = item;
-              return (
-                <ResourceList.Item
-                  url={url}
-                  accessibilityLabel={`View Sales for ${sales}`}
-                >
-                  <LegacyStack>
-                    <LegacyStack.Item fill>{sales}</LegacyStack.Item>
-                    <LegacyStack.Item>{amount}</LegacyStack.Item>
-                  </LegacyStack>
-                </ResourceList.Item>
-              );
-            }}
-          />
+      <LegacyCard>
+        <LegacyCard.Section title="First outside section">
+          <VerticalStack gap="2">
+            <Box>
+              <LegacyCard.Section subdued>
+                First nested section
+              </LegacyCard.Section>
+            </Box>
+            <Box>
+              <LegacyCard.Section subdued>
+                Second nested section
+              </LegacyCard.Section>
+            </Box>
+          </VerticalStack>
         </LegacyCard.Section>
-        <LegacyCard.Section title="Deactivated reports" subdued>
-          Outside of subsection
-          <LegacyCard.Subsection>Inside of subsection</LegacyCard.Subsection>
-          Outside of subsection
-        </LegacyCard.Section>
-        <LegacyCard.Section>
-          The sales reports are available only if your store is on the Shopify
-          plan or higher.
+        <LegacyCard.Section title="Second outside section">
+          <VerticalStack gap="2">
+            <Box>
+              <LegacyCard.Section subdued>
+                First nested section
+              </LegacyCard.Section>
+            </Box>
+            <Box>
+              <LegacyCard.Section subdued>
+                Second nested section
+              </LegacyCard.Section>
+            </Box>
+          </VerticalStack>
         </LegacyCard.Section>
       </LegacyCard>
+      <WithAllElements />
     </VerticalStack>
+  );
+}
+
+function DynamicChildren() {
+  const [showChildren, setShowChildren] = useState(false);
+  return (
+    <div>
+      <LegacyCard.Section>
+        <Button onClick={() => setShowChildren(!showChildren)}>
+          {showChildren ? 'Hide ' : 'Show '}children
+        </Button>
+      </LegacyCard.Section>
+      {showChildren ? (
+        <LegacyCard.Section>Child section content</LegacyCard.Section>
+      ) : null}
+    </div>
   );
 }

--- a/polaris-react/src/components/LegacyCard/LegacyCard.tsx
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.tsx
@@ -187,10 +187,12 @@ function useLegacyCardPaddingObserverRef() {
           updatePadding(firstSection, 'top', true);
         }
 
-        // Update padding for last section no matter what child it is a
-        // descendant of
-        lastSection = lastElement;
-        updatePadding(lastSection, 'bottom', true);
+        // Update padding for last element if it is the last child or
+        // a descendant of the last child
+        if (legacyCardNode.lastChild?.contains(lastElement)) {
+          lastSection = lastElement;
+          updatePadding(lastSection, 'bottom', true);
+        }
       };
 
       // First initial render

--- a/polaris-react/src/components/LegacyCard/LegacyCard.tsx
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.tsx
@@ -178,7 +178,7 @@ function useLegacyCardPaddingObserverRef() {
         if (!currentElements?.length) return;
 
         const firstElement = currentElements[0];
-        const lastElement = currentElements[currentElements.length - 1];
+        const lastElement = getMostSeniorLastElement(currentElements);
 
         // Update padding for first element if it is the first child or
         // a descendant of the first child
@@ -234,4 +234,21 @@ function updatePadding(
     case 'bottom':
       (element as HTMLElement).classList.toggle(styles.LastSectionPadding, add);
   }
+}
+
+/*
+ * Get the senior most last element in a node list ordered by
+ * a depth first traversal.
+ * https://www.w3.org/TR/selectors-api/#document-order
+ */
+function getMostSeniorLastElement(elements: NodeListOf<Element>) {
+  let lastElement = elements[0];
+
+  elements.forEach((element) => {
+    if (!lastElement.contains(element)) {
+      lastElement = element;
+    }
+  });
+
+  return lastElement;
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [this issue](https://github.com/Shopify/polaris-summer-editions/issues/865)

### WHAT is this pull request doing?

* Sections were not getting the proper border radii on xs screens since pre experimental changes. This fixes that by moving the border radius changes under `.LegacyCard`. The previous fix was causing weird behaviour for nested sections. (See issue screenshot)

(pink background to better see the diff)
|Before|After|
|-|-|
|<img width="310" alt="Screenshot 2023-07-07 at 10 51 45 AM" src="https://github.com/Shopify/polaris/assets/20652326/cd730287-f8dc-477a-b5d2-c056409b8dc1">|<img width="305" alt="Screenshot 2023-07-07 at 10 51 57 AM" src="https://github.com/Shopify/polaris/assets/20652326/f6d2f45c-c4af-46f2-95e3-9a62b8d18e58">|

* Nested sections were not getting extra padding correctly applied. This PR gets the senior most last element to apply the extra padding to

### How to 🎩

* [Storybook all story](https://5d559397bae39100201eedc1-ftchoclche.chromatic.com/?path=/story/all-components-legacycard--all&globals=polarisSummerEditions2023:true) (scroll down to see nested section example)
* [Spin in payments](https://admin.web.web-n1jm.sophie-schneider.us.spin.dev/store/shop1/settings/payments) showing the page from the issue screenshot

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
