### PR TITLE
Apply `shadow-bevel` to `LegacyCard`

### DIFF
--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -7,11 +7,7 @@
   overflow: clip;
 
   #{$se23} & {
-    box-shadow: var(--p-shadow-card-sm-experimental);
-
-    @media print {
-      box-shadow: none;
-    }
+    box-shadow: var(--p-shadow-xs);
   }
 
   + .LegacyCard {
@@ -26,12 +22,23 @@
     border-radius: var(--p-border-radius-2);
 
     #{$se23} & {
-      border-radius: var(--p-border-radius-3);
+      @include shadow-bevel(
+        $boxShadow: var(--p-shadow-xs),
+        $borderRadius: var(--p-border-radius-3)
+      );
     }
   }
 
   @media print {
     box-shadow: none;
+
+    #{$se23} & {
+      @include shadow-bevel(
+        $boxShadow: none,
+        $borderRadius: none,
+        $content: none
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-summer-editions/issues/711

## Legacy Card

<img width="1460" alt="Screenshot 2023-07-06 at 7 39 26 PM" src="https://github.com/Shopify/polaris/assets/32409546/dfca47d0-79cf-4801-8240-c303e5008cb8">

## Media Card


https://github.com/Shopify/polaris/assets/11774595/e7e0ceb2-3e76-4882-bdbb-8f630522c312

