### PR TITLE
[IndexTable] Select all overlay height adjustment

### DIFF
--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -18,12 +18,6 @@
     --pc-index-table-table-header-offset: 32px;
     border-radius: 0;
 
-    // This is to account for the changing Checkbox size at this breakpoint.
-    @media #{$p-breakpoints-md-up} {
-      // stylelint-disable-next-line -- Polaris component custom properties
-      --pc-index-table-table-header-offset: 30px;
-    }
-
     @media #{$p-breakpoints-sm-up} {
       border-radius: inherit;
       border-start-start-radius: 0;
@@ -908,7 +902,7 @@ $loading-panel-height: 53px;
     padding-left: var(--p-space-3);
     padding-top: var(--p-space-1_5-experimental);
     padding-bottom: var(--p-space-1_5-experimental);
-    line-height: var(--p-font-line-height-1);
+    line-height: var(--p-font-line-height-2);
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/776
Previously the SelectAllWrapper had a variable height based on the size of the checkbox (20px at mdDown and 18px at all breakpoints above). However this is not inline with how the table header row calculates its height, which is always a static `line-height` of `20px`. 

This discrepancy was resulting in a misalignment of the SelectAllWrapper (30px) and the table header row its meant to cover (32.5px). 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This pr resolves this misalignment by conforming the SelectAllWrapper to the same height heuristics as the table header row it overlays:
* Enforce a line-height of this element of `--p-font-line-height-2` 
* Remove the media query override of `--pc-index-table-table-header-offset`, such that that value is always `32px`. 

Before: 
![Screenshot 2023-07-07 at 4 36 26 pm](https://github.com/Shopify/polaris/assets/12119389/5f29a861-ff80-4fb2-9f33-e4b26204c464)

After: 
![Screenshot 2023-07-07 at 4 36 02 pm](https://github.com/Shopify/polaris/assets/12119389/cd7ac2b7-9199-4e33-b33d-7cfa8d526590)


[Storybook](https://5d559397bae39100201eedc1-uqaokdjdwl.chromatic.com/?path=/story/all-components-indextable--with-all-of-its-elements&globals=polarisSummerEditions2023:true)