### PR TITLE
Apply shadow-bevel to Card

### DIFF
--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import {useBreakpoints} from '../../utilities/breakpoints';
 import type {ResponsiveProp} from '../../utilities/css';
 import {Box} from '../Box';
+import {ShadowBevel} from '../ShadowBevel';
 import {useFeatures} from '../../utilities/features';
 import {WithinContentContext} from '../../utilities/within-content-context';
 
@@ -62,16 +63,32 @@ export const Card = ({
 
   return (
     <WithinContentContext.Provider value>
-      <Box
-        background={background}
-        padding={finalPadding}
-        shadow={polarisSummerEditions2023 ? 'card-sm-experimental' : 'md'}
-        borderRadius={hasBorderRadius ? defaultBorderRadius : undefined}
-        overflowX="hidden"
-        overflowY="hidden"
-      >
-        {children}
-      </Box>
+      {polarisSummerEditions2023 ? (
+        <ShadowBevel
+          boxShadow="xs"
+          borderRadius={hasBorderRadius ? '3' : '0-experimental'}
+        >
+          <Box
+            background={background}
+            padding={finalPadding}
+            overflowX="hidden"
+            overflowY="hidden"
+          >
+            {children}
+          </Box>
+        </ShadowBevel>
+      ) : (
+        <Box
+          background={background}
+          padding={finalPadding}
+          shadow="md"
+          borderRadius={hasBorderRadius ? defaultBorderRadius : undefined}
+          overflowX="hidden"
+          overflowY="hidden"
+        >
+          {children}
+        </Box>
+      )}
     </WithinContentContext.Provider>
   );
 };


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-summer-editions/issues/711

## Card

<img width="690" alt="card" src="https://github.com/Shopify/polaris/assets/11774595/a00bd538-8473-4201-97f1-f022b55b39e1">

## Account Connection

<img width="690" alt="account-connection" src="https://github.com/Shopify/polaris/assets/11774595/fa3f6153-5f57-424e-a5fc-beb880e62a1d">