### PR TITLE
Apply shadow-bevel mixin to Tooltip

### DIFF
--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -16,7 +16,10 @@
   transition: none;
 
   #{$se23} & {
-    box-shadow: var(--p-shadow-xl);
+    @include shadow-bevel(
+      $boxShadow: var(--p-shadow-xl),
+      $borderRadius: var(--pc-tooltip-border-radius)
+    );
   }
 
   @media screen and (-ms-high-contrast: active) {


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-summer-editions/issues/711

## Tooltip

| Before | After |
| --- | --- |
| <img width="231" alt="before" src="https://github.com/Shopify/polaris/assets/11774595/c6a3b3a7-f532-4b79-a03f-0d95d99e64dd"> | <img width="231" alt="after" src="https://github.com/Shopify/polaris/assets/11774595/a980a8a4-7893-4298-af47-358f8a0dac25"> |