### PR TITLE
[Tabs] Update hover and active experimental colors

### DIFF
--- a/polaris-react/src/components/Tabs/Tabs.scss
+++ b/polaris-react/src/components/Tabs/Tabs.scss
@@ -133,7 +133,7 @@
     }
 
     &:not([aria-disabled='true']):hover {
-      background-color: var(--p-color-bg-secondary-experimental);
+      background-color: var(--p-color-bg-transparent-subdued-experimental);
       color: var(--p-color-text-primary);
     }
 
@@ -179,7 +179,7 @@
   }
 
   #{$se23} & {
-    background: var(--p-color-bg-secondary-experimental);
+    background: var(--p-color-bg-transparent-subdued-experimental);
     color: var(--p-color-text);
     border-radius: var(--p-border-radius-2);
 
@@ -190,12 +190,12 @@
 
     &:not([aria-disabled='true']):hover,
     &:not([aria-disabled='true']):focus {
-      background-color: var(--p-color-bg-secondary-experimental);
+      background-color: var(--p-color-bg-transparent-hover-experimental);
       color: var(--p-color-text-primary);
     }
 
     &:not([aria-disabled='true']):active {
-      background-color: var(--p-color-bg-secondary-experimental);
+      background-color: var(--p-color-bg-transparent-hover-experimental);
     }
   }
 }

--- a/polaris-react/src/components/Tabs/Tabs.scss
+++ b/polaris-react/src/components/Tabs/Tabs.scss
@@ -195,7 +195,7 @@
     }
 
     &:not([aria-disabled='true']):active {
-      background-color: var(--p-color-bg-transparent-hover-experimental);
+      background-color: var(--p-color-bg-transparent-active-experimental);
     }
   }
 }

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -469,7 +469,7 @@ export const Tabs = ({
 
   const disclosureButtonContent = (
     <>
-      <Text as="span" variant="bodySm" fontWeight="semibold">
+      <Text as="span" variant="bodySm" fontWeight="medium">
         {disclosureText ?? i18n.translate('Polaris.Tabs.toggleTabsLabel')}
       </Text>
       <div
@@ -584,6 +584,7 @@ export const Tabs = ({
                 <li className={disclosureTabClassName} role="presentation">
                   <Popover
                     preferredPosition="below"
+                    preferredAlignment="left"
                     activator={activator}
                     active={disclosureActivatorVisible && showDisclosure}
                     onClose={handleClose}


### PR DESCRIPTION
[Storybook link](https://5d559397bae39100201eedc1-ibcjcfthgb.chromatic.com/?path=/story/all-components-tabs--all&globals=polarisSummerEditions2023:true)

https://github.com/Shopify/polaris/assets/18447883/d7acd05f-ffcc-4604-ab6a-943368023acc

|Tabs| [Before](https://storybook.polaris.shopify.com/?path=/story/all-components-tabs--all&globals=polarisSummerEditions2023:true) | [After](https://5d559397bae39100201eedc1-ibcjcfthgb.chromatic.com/?path=/story/all-components-tabs--all&globals=polarisSummerEditions2023:true) |
|--------|--------|--------|
|<div>Active</div>| <img width="502" alt="tabs-before-active" src="https://github.com/Shopify/polaris/assets/18447883/0a0732ce-873e-4795-8d0f-b924d43042ce"> | <img width="474" alt="tabs-after-selected" src="https://github.com/Shopify/polaris/assets/18447883/7559cb85-5cf4-44f4-a538-56df882a6d27"> | 
|Hover| <img width="504" alt="tabs-before-hover" src="https://github.com/Shopify/polaris/assets/18447883/d9402151-28d7-48d2-b139-8537c1a71f54"> | <img width="475" alt="tabs-after-hover" src="https://github.com/Shopify/polaris/assets/18447883/737b9eae-a82a-4cc3-9861-0f9dbf22c8f3">| 

Also fixes the More views font weight mismatching with Tab item font weight.

| Before | After|
|--------|--------|
| <img width="593" alt="Screenshot 2023-07-07 at 2 00 00 PM" src="https://github.com/Shopify/polaris/assets/18447883/5b5fc45b-3ee3-4f16-9855-cd05ad320a48"> | <img width="670" alt="Screenshot 2023-07-07 at 2 00 11 PM" src="https://github.com/Shopify/polaris/assets/18447883/fb5b2cdf-f206-468c-99a9-4a2d90668d41"> | 



### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
