### PR TITLE
[Banner Experimental] Bump dismiss button icon override specificity

### DIFF
--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.scss
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.scss
@@ -5,7 +5,8 @@
     // stylelint-disable-next-line -- se23
     svg,
     path {
-      fill: $fill-color;
+      // stylelint-disable-next-line -- se23 to override button
+      fill: $fill-color !important;
     }
   }
 }

--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.scss
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.scss
@@ -5,40 +5,42 @@
     // stylelint-disable-next-line -- se23
     svg,
     path {
-      // stylelint-disable-next-line -- se23 to override button
-      fill: $fill-color !important;
+      fill: $fill-color;
     }
   }
 }
 
-.icon-on-color {
+// duplicate selectors to bump specificity
+// https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#increasing_specificity_by_duplicating_selector
+
+.icon-on-color.icon-on-color {
   @include recolor-icon-se23(var(--p-color-icon-on-color));
 }
 
-.icon-success-strong-experimental {
+.icon-success-strong-experimental.icon-success-strong-experimental {
   @include recolor-icon-se23(var(--p-color-icon-success-strong-experimental));
 }
 
-.text-warning-strong {
+.text-warning-strong.text-warning-strong {
   @include recolor-icon-se23(var(--p-color-text-warning-strong));
 }
 
-.icon-warning-strong-experimental {
+.icon-warning-strong-experimental.icon-warning-strong-experimental {
   @include recolor-icon-se23(var(--p-color-icon-warning-strong-experimental));
 }
 
-.icon-critical-strong-experimental {
+.icon-critical-strong-experimental.icon-critical-strong-experimental {
   @include recolor-icon-se23(var(--p-color-icon-critical-strong-experimental));
 }
 
-.text-info-strong {
+.text-info-strong.text-info-strong {
   @include recolor-icon-se23(var(--p-color-text-info-strong));
 }
 
-.icon-info-strong-experimental {
+.icon-info-strong-experimental.icon-info-strong-experimental {
   @include recolor-icon-se23(var(--p-color-icon-info-strong-experimental));
 }
 
-.icon-subdued {
+.icon-subdued.icon-subdued {
   @include recolor-icon-se23(var(--p-color-icon-subdued));
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [this issue](https://github.com/Shopify/polaris-summer-editions/issues/887)

### WHAT is this pull request doing?
Use duplicate selectors to bump `primary iconOnly plain` override specificity


