### PR TITLE
[Page] Fix additionalMetadata spacing

### DIFF
--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -188,6 +188,22 @@ export function WithSubtitle() {
   );
 }
 
+export function WithSubtitleAndAdditionalMetadata() {
+  return (
+    <Page
+      backAction={{content: 'Products', url: '#'}}
+      title="Invoice"
+      subtitle="Statement period: May 3, 2019 to June 2, 2019"
+      additionalMetadata="Net payment due: Within 60 days of receipt"
+      secondaryActions={[{content: 'Download', icon: ArrowDownMinor}]}
+    >
+      <LegacyCard title="Credit card" sectioned>
+        <p>Credit card information</p>
+      </LegacyCard>
+    </Page>
+  );
+}
+
 export function WithExternalLink() {
   return (
     <Page

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -105,6 +105,10 @@ $action-menu-rollup-computed-width: 40px;
     margin-left: calc(
       var(--p-space-5) * 2 + var(--p-space-2) + var(--p-space-1)
     );
+
+    #{$se23} & {
+      margin-left: calc(var(--p-space-5) + var(--p-space-2) + var(--p-space-1));
+    }
   }
 
   .noBreadcrumbs & {

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -187,7 +187,11 @@ export function Header({
 
   const additionalMetadataMarkup = additionalMetadata ? (
     <div className={styles.AdditionalMetaData}>
-      <Text color="subdued" as="span">
+      <Text
+        color="subdued"
+        as="span"
+        variant={polarisSummerEditions2023 ? 'bodySm' : undefined}
+      >
         {additionalMetadata}
       </Text>
     </div>


### PR DESCRIPTION
### WHY are these changes introduced?

`Page.additionalMetadata` styles don't account for the reduced size of the `backAction` with experimental styles. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR ensures the left margin on `additionalMetadata` matches the `backAction` width and makes the experimental `additionalMetadata` font size the same as the experimental `subtitle` like it is in production.

| Before | After |
|--------|--------|
|<img width="756" alt="Screenshot 2023-07-09 at 5 31 52 PM" src="https://github.com/Shopify/polaris/assets/18447883/672199a9-7b2f-4c55-bb9d-3d19effcfffb"> | <img width="753" alt="Screenshot 2023-07-09 at 5 31 13 PM" src="https://github.com/Shopify/polaris/assets/18447883/e9a5e869-1898-4814-a2a6-74f78071c535"> |
| <img width="372" alt="Screenshot 2023-07-09 at 5 32 03 PM" src="https://github.com/Shopify/polaris/assets/18447883/87e63ba4-a834-470e-b054-d6f0e1ea9b7b">| <img width="373" alt="Screenshot 2023-07-09 at 5 38 13 PM" src="https://github.com/Shopify/polaris/assets/18447883/056d863d-6ff4-47cf-aee6-7c707dca66bb">| 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
