### PR TITLE
[CSS] Remove unnecessary contiguousness of responsive props

### DIFF
--- a/.changeset/metal-pigs-share.md
+++ b/.changeset/metal-pigs-share.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+- Revert "[Internal]: Generate contiguous responsive CSS variables."

--- a/polaris-react/src/components/Bleed/tests/Bleed.test.tsx
+++ b/polaris-react/src/components/Bleed/tests/Bleed.test.tsx
@@ -26,10 +26,6 @@ describe('<Bleed />', () => {
     expect(bleed).toContainReactComponent('div', {
       style: {
         '--pc-bleed-margin-inline-start-xs': 'var(--p-space-2)',
-        '--pc-bleed-margin-inline-start-sm': 'var(--p-space-2)',
-        '--pc-bleed-margin-inline-start-md': 'var(--p-space-2)',
-        '--pc-bleed-margin-inline-start-lg': 'var(--p-space-2)',
-        '--pc-bleed-margin-inline-start-xl': 'var(--p-space-2)',
       } as React.CSSProperties,
     });
   });
@@ -44,25 +40,9 @@ describe('<Bleed />', () => {
     expect(bleed).toContainReactComponent('div', {
       style: {
         '--pc-bleed-margin-block-start-xs': 'var(--p-space-1)',
-        '--pc-bleed-margin-block-start-sm': 'var(--p-space-1)',
-        '--pc-bleed-margin-block-start-md': 'var(--p-space-1)',
-        '--pc-bleed-margin-block-start-lg': 'var(--p-space-1)',
-        '--pc-bleed-margin-block-start-xl': 'var(--p-space-1)',
         '--pc-bleed-margin-block-end-xs': 'var(--p-space-1)',
-        '--pc-bleed-margin-block-end-sm': 'var(--p-space-1)',
-        '--pc-bleed-margin-block-end-md': 'var(--p-space-1)',
-        '--pc-bleed-margin-block-end-lg': 'var(--p-space-1)',
-        '--pc-bleed-margin-block-end-xl': 'var(--p-space-1)',
         '--pc-bleed-margin-inline-start-xs': 'var(--p-space-2)',
-        '--pc-bleed-margin-inline-start-sm': 'var(--p-space-2)',
-        '--pc-bleed-margin-inline-start-md': 'var(--p-space-2)',
-        '--pc-bleed-margin-inline-start-lg': 'var(--p-space-2)',
-        '--pc-bleed-margin-inline-start-xl': 'var(--p-space-2)',
         '--pc-bleed-margin-inline-end-xs': 'var(--p-space-3)',
-        '--pc-bleed-margin-inline-end-sm': 'var(--p-space-3)',
-        '--pc-bleed-margin-inline-end-md': 'var(--p-space-3)',
-        '--pc-bleed-margin-inline-end-lg': 'var(--p-space-3)',
-        '--pc-bleed-margin-inline-end-xl': 'var(--p-space-3)',
       } as React.CSSProperties,
     });
   });

--- a/polaris-react/src/components/Box/tests/Box.test.tsx
+++ b/polaris-react/src/components/Box/tests/Box.test.tsx
@@ -25,10 +25,6 @@ describe('Box', () => {
     expect(box).toContainReactComponent('div', {
       style: {
         '--pc-box-padding-inline-start-xs': 'var(--p-space-2)',
-        '--pc-box-padding-inline-start-sm': 'var(--p-space-2)',
-        '--pc-box-padding-inline-start-md': 'var(--p-space-2)',
-        '--pc-box-padding-inline-start-lg': 'var(--p-space-2)',
-        '--pc-box-padding-inline-start-xl': 'var(--p-space-2)',
       } as React.CSSProperties,
     });
   });
@@ -43,25 +39,9 @@ describe('Box', () => {
     expect(box).toContainReactComponent('div', {
       style: {
         '--pc-box-padding-block-end-xs': 'var(--p-space-1)',
-        '--pc-box-padding-block-end-sm': 'var(--p-space-1)',
-        '--pc-box-padding-block-end-md': 'var(--p-space-1)',
-        '--pc-box-padding-block-end-lg': 'var(--p-space-1)',
-        '--pc-box-padding-block-end-xl': 'var(--p-space-1)',
         '--pc-box-padding-block-start-xs': 'var(--p-space-1)',
-        '--pc-box-padding-block-start-sm': 'var(--p-space-1)',
-        '--pc-box-padding-block-start-md': 'var(--p-space-1)',
-        '--pc-box-padding-block-start-lg': 'var(--p-space-1)',
-        '--pc-box-padding-block-start-xl': 'var(--p-space-1)',
         '--pc-box-padding-inline-end-xs': 'var(--p-space-1)',
-        '--pc-box-padding-inline-end-sm': 'var(--p-space-1)',
-        '--pc-box-padding-inline-end-md': 'var(--p-space-1)',
-        '--pc-box-padding-inline-end-lg': 'var(--p-space-1)',
-        '--pc-box-padding-inline-end-xl': 'var(--p-space-1)',
         '--pc-box-padding-inline-start-xs': 'var(--p-space-2)',
-        '--pc-box-padding-inline-start-sm': 'var(--p-space-2)',
-        '--pc-box-padding-inline-start-md': 'var(--p-space-2)',
-        '--pc-box-padding-inline-start-lg': 'var(--p-space-2)',
-        '--pc-box-padding-inline-start-xl': 'var(--p-space-2)',
       } as React.CSSProperties,
     });
   });

--- a/polaris-react/src/components/HorizontalGrid/tests/HorizontalGrid.test.tsx
+++ b/polaris-react/src/components/HorizontalGrid/tests/HorizontalGrid.test.tsx
@@ -12,8 +12,6 @@ describe('HorizontalGrid', () => {
     expect(horizontalGrid).toContainReactComponent('div', {
       style: {
         '--pc-horizontal-grid-gap-md': 'var(--p-space-1)',
-        '--pc-horizontal-grid-gap-lg': 'var(--p-space-1)',
-        '--pc-horizontal-grid-gap-xl': 'var(--p-space-1)',
         '--pc-horizontal-grid-align-items': 'start',
       } as React.CSSProperties,
     });

--- a/polaris-react/src/utilities/css.ts
+++ b/polaris-react/src/utilities/css.ts
@@ -36,39 +36,23 @@ export function sanitizeCustomProperties(
 }
 
 /**
- * Given an object like so:
+ * Given params like so:
+ * (
+ *   'button',
+ *   'padding',
+ *   'spacing',
+ *   {
+ *     sm: "4",
+ *     lg: "6"
+ *   }
+ * )
+ * Converts it to an object like so:
  * {
- *   sm: 4,
- *   lg: 6
- * }
- * Fill in the blanks starting at >= sm (because it's the first one set):
- * {
- *   sm: 4,
- *   md: 4,
- *   lg: 6
- *   xl: 6
+ *   '--pc-button-padding-sm': 'var(--p-spacing-4)',
+ *   '--pc-button-padding-lg': 'var(--p-spacing-6)'
  * }
  *
  */
-function makeResponsivePropsContiguous<T>(
-  responsiveProp: ResponsivePropConfig<T>,
-): ResponsivePropConfig<T> {
-  const result: ResponsivePropConfig<T> = {};
-
-  let prev: T | undefined;
-
-  breakpointsAliases.forEach((breakpointAlias) => {
-    if (typeof responsiveProp[breakpointAlias] !== 'undefined') {
-      result[breakpointAlias] = responsiveProp[breakpointAlias];
-      prev = responsiveProp[breakpointAlias];
-    } else if (prev) {
-      result[breakpointAlias] = prev;
-    }
-  });
-
-  return result;
-}
-
 export function getResponsiveProps<T = string>(
   componentName: string,
   componentProp: string,
@@ -91,8 +75,6 @@ export function getResponsiveProps<T = string>(
       ]),
     );
   }
-
-  result = makeResponsivePropsContiguous(result);
 
   // Prefix each responsive key with the correct token name
   return Object.fromEntries(

--- a/polaris-react/src/utilities/tests/css.test.ts
+++ b/polaris-react/src/utilities/tests/css.test.ts
@@ -29,10 +29,6 @@ describe('getResponsiveProps', () => {
   it('takes a string and returns the custom property', () => {
     expect(getResponsiveProps('stack', 'space', 'space', '4')).toMatchObject({
       '--pc-stack-space-xs': 'var(--p-space-4)',
-      '--pc-stack-space-sm': 'var(--p-space-4)',
-      '--pc-stack-space-md': 'var(--p-space-4)',
-      '--pc-stack-space-lg': 'var(--p-space-4)',
-      '--pc-stack-space-xl': 'var(--p-space-4)',
     });
   });
 
@@ -41,10 +37,7 @@ describe('getResponsiveProps', () => {
       getResponsiveProps('stack', 'space', 'space', {xs: '2', md: '8'}),
     ).toMatchObject({
       '--pc-stack-space-xs': 'var(--p-space-2)',
-      '--pc-stack-space-sm': 'var(--p-space-2)',
       '--pc-stack-space-md': 'var(--p-space-8)',
-      '--pc-stack-space-lg': 'var(--p-space-8)',
-      '--pc-stack-space-xl': 'var(--p-space-8)',
     });
   });
 
@@ -66,22 +59,6 @@ describe('getResponsiveProps', () => {
     });
   });
 
-  it('fills in the blanks', () => {
-    expect(
-      getResponsiveProps('stack', 'space', 'space', {
-        xs: '2',
-        sm: '4',
-        xl: '10',
-      }),
-    ).toMatchObject({
-      '--pc-stack-space-xs': 'var(--p-space-2)',
-      '--pc-stack-space-sm': 'var(--p-space-4)',
-      '--pc-stack-space-md': 'var(--p-space-4)',
-      '--pc-stack-space-lg': 'var(--p-space-4)',
-      '--pc-stack-space-xl': 'var(--p-space-10)',
-    });
-  });
-
   it('does not fill in leading undefined values', () => {
     expect(
       getResponsiveProps('stack', 'space', 'space', {
@@ -90,7 +67,6 @@ describe('getResponsiveProps', () => {
       }),
     ).toMatchObject({
       '--pc-stack-space-md': 'var(--p-space-4)',
-      '--pc-stack-space-lg': 'var(--p-space-4)',
       '--pc-stack-space-xl': 'var(--p-space-10)',
     });
   });
@@ -103,7 +79,6 @@ describe('getResponsiveProps', () => {
       }),
     ).toMatchObject({
       '--pc-stack-space-md': 'var(--p-space-0)',
-      '--pc-stack-space-lg': 'var(--p-space-0)',
       '--pc-stack-space-xl': 'var(--p-space-10)',
     });
   });
@@ -116,7 +91,6 @@ describe('getResponsiveProps', () => {
       }),
     ).toMatchObject({
       '--pc-stack-space-lg': 'var(--p-space-10)',
-      '--pc-stack-space-xl': 'var(--p-space-10)',
     });
   });
 });


### PR DESCRIPTION
Initially, this was introduced in 3536e3aa0 to work around the following being invalid (`calc()` can't handle `initial`):

```css
--foo: initial;
calc(10px + var(--foo));
```

However, the only usage so far is in 0f97293b0 where a different work around was used (falling back to a "0" value):

```css
--foo: initial;
calc(10px + var(--foo, 0rem));
```

The other side-effect of introducing contiguous responsive props was excessive inline styles being added to some components. For example;

```tsx
<Box padding="4" paddingInlineStart="6" paddingBlockEnd="8" />
```

would result in:

```css
--pc-box-padding-xs: var(--p-spacing-4);
--pc-box-padding-sm: var(--p-spacing-4);
--pc-box-padding-md: var(--p-spacing-4);
--pc-box-padding-lg: var(--p-spacing-4);
--pc-box-padding-xl: var(--p-spacing-4);
--pc-box-padding-inline-start-xs: var(--p-spacing-6);
--pc-box-padding-inline-start-sm: var(--p-spacing-6);
--pc-box-padding-inline-start-md: var(--p-spacing-6);
--pc-box-padding-inline-start-lg: var(--p-spacing-6);
--pc-box-padding-inline-start-xl: var(--p-spacing-6);
--pc-box-padding-block-end-xs: var(--p-spacing-8);
--pc-box-padding-block-end-sm: var(--p-spacing-8);
--pc-box-padding-block-end-md: var(--p-spacing-8);
--pc-box-padding-block-end-lg: var(--p-spacing-8);
--pc-box-padding-block-end-xl: var(--p-spacing-8);
```

Reverting the `makeContiguous` calculation results in simpler inline styles which correctly fall back thanks to `var()`'s handling of `initial`. The same example above becomes:

```css
--pc-box-padding-xs: var(--p-spacing-4);
--pc-box-padding-inline-start-xs: var(--p-spacing-6);
--pc-box-padding-block-end-xs: var(--p-spacing-8);
```