### PR TITLE
Hide Button text when loading for all style variants

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -775,7 +775,10 @@
 
   &,
   &:hover,
-  &.disabled {
+  &.disabled,
+  #{$se23} &,
+  #{$se23} &:hover,
+  #{$se23} &.disabled {
     color: transparent;
   }
 }
@@ -935,7 +938,8 @@
       background: none;
     }
 
-    &.loading {
+    &.loading,
+    #{$se23} &.loading {
       color: transparent;
     }
   }

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -737,5 +737,15 @@ export function DisabledState() {
 }
 
 export function LoadingState() {
-  return <Button loading>Save product</Button>;
+  return (
+    <HorizontalStack gap="5">
+      <Button loading>Save product</Button>
+      <Button primary loading>
+        Save product
+      </Button>
+      <Button plain loading>
+        Save product
+      </Button>
+    </HorizontalStack>
+  );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/791

#### Before

https://github.com/Shopify/polaris/assets/11774595/997be490-5ed6-4839-b2e0-6508786b15d3

#### After

https://github.com/Shopify/polaris/assets/11774595/71dd042e-041b-472d-9b66-9943d59dcaa4


### WHAT is this pull request doing?

Tophat using the LoadingState story in`Button.stories.tsx` and adding the `primary` prop:

```jsx
export function LoadingState() {
  return (
    <Button primary loading>
      Save product
    </Button>
  );
}
```