### PR TITLE
[Icon] Add caution color variant; fix warning color

### DIFF
--- a/polaris-react/src/components/Icon/Icon.scss
+++ b/polaris-react/src/components/Icon/Icon.scss
@@ -58,9 +58,19 @@
   fill: var(--p-color-icon-interactive);
 }
 
-.colorWarning {
+.colorCaution {
   svg {
     fill: var(--p-color-icon-caution);
+  }
+
+  &::before {
+    background-color: var(--p-color-bg-caution);
+  }
+}
+
+.colorWarning {
+  svg {
+    fill: var(--p-color-icon-warning);
   }
 
   &::before {

--- a/polaris-react/src/components/Icon/Icon.stories.tsx
+++ b/polaris-react/src/components/Icon/Icon.stories.tsx
@@ -20,6 +20,7 @@ export function Colored() {
       <Icon source={CirclePlusMinor} color="primary" />
       <Icon source={CirclePlusMinor} color="highlight" />
       <Icon source={CirclePlusMinor} color="success" />
+      <Icon source={CirclePlusMinor} color="caution" />
       <Icon source={CirclePlusMinor} color="warning" />
       <Icon source={CirclePlusMinor} color="critical" />
       <Icon source={CirclePlusMinor} color="magic" />
@@ -49,6 +50,8 @@ export function WithBackdrop() {
       <BackdropIcon iconColor="base" boxBackground="bg-strong" />
       <BackdropIcon iconColor="highlight" boxBackground="bg-info" />
       <BackdropIcon iconColor="success" boxBackground="bg-success" />
+      <BackdropIcon iconColor="caution" boxBackground="bg-caution" />
+
       <BackdropIcon iconColor="warning" boxBackground="bg-warning" />
       <BackdropIcon iconColor="critical" boxBackground="bg-critical" />
     </VerticalStack>

--- a/polaris-react/src/components/Icon/Icon.tsx
+++ b/polaris-react/src/components/Icon/Icon.tsx
@@ -12,6 +12,7 @@ type Color =
   | 'critical'
   | 'interactive'
   | 'warning'
+  | 'caution'
   | 'highlight'
   | 'success'
   | 'primary'
@@ -23,6 +24,7 @@ const COLORS_WITH_BACKDROPS = [
   'highlight',
   'success',
   'warning',
+  'caution',
 ];
 
 export interface IconProps {


### PR DESCRIPTION
### WHY are these changes introduced?

The `Icon` currently doesn't support a caution variant, needed by Online Store UI, and instead maps the caution icon color to the warning variant.  

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR maps the `--p-color-icon-warning` to the warning `color` variant and adds a caution color variant.

| Before | After|
|--------|--------|
|  | <img width="44" alt="Screenshot 2023-07-09 at 6 19 15 PM" src="https://github.com/Shopify/polaris/assets/18447883/784add3c-f8d2-428d-990c-88c015aec052">|
| Cell | <img width="59" alt="Screenshot 2023-07-09 at 6 16 37 PM" src="https://github.com/Shopify/polaris/assets/18447883/b565f0ad-861e-4c9e-ae1c-423f4f5bd3f8"> |
| Cell | Cell |
| Cell | Cell | 

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
