### PR TITLE
adds mouse listeners to ResourceItem

### DIFF
--- a/.changeset/proud-dogs-visit.md
+++ b/.changeset/proud-dogs-visit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+adds onMouseOut & onMouseOver callbacks on ResourceItem component

--- a/.changeset/proud-dogs-visit.md
+++ b/.changeset/proud-dogs-visit.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-adds onMouseOut & onMouseOver callbacks on ResourceItem component
+Added support for setting `onMouseOut` and `onMouseOver` callbacks on `ResourceItem`

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -432,7 +432,6 @@ class BaseResourceItem extends Component<CombinedProps, State> {
   };
 
   private handleMouseOut = () => {
-    const {onMouseOut = () => {}} = this.props;
     this.state.focused && this.setState({focused: false, focusedInner: false});
     onMouseOut();
   };

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -160,7 +160,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
       verticalAlignment,
       dataHref,
       breakpoints,
-      onMouseOver = () => {},
+      onMouseOver,
     } = this.props;
 
     const {actionsMenuVisible, focused, focusedInner, selected} = this.state;

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -62,6 +62,10 @@ interface BaseProps {
   verticalAlignment?: Alignment;
   /** Prefetched url attribute to bind to the main element being returned */
   dataHref?: string;
+  /** Callback when mouse cursor is on item */
+  onMouseOver?: () => void;
+  /** Callback when mouse cursor leaves item */
+  onMouseOut?: () => void;
 }
 
 interface PropsWithUrl extends BaseProps {
@@ -156,6 +160,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
       verticalAlignment,
       dataHref,
       breakpoints,
+      onMouseOver = () => {},
     } = this.props;
 
     const {actionsMenuVisible, focused, focusedInner, selected} = this.state;
@@ -387,6 +392,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}
             onKeyUp={this.handleKeyUp}
+            onMouseOver={onMouseOver}
             onMouseOut={this.handleMouseOut}
             data-href={url}
           >
@@ -426,7 +432,9 @@ class BaseResourceItem extends Component<CombinedProps, State> {
   };
 
   private handleMouseOut = () => {
+    const {onMouseOut = () => {}} = this.props;
     this.state.focused && this.setState({focused: false, focusedInner: false});
+    onMouseOut();
   };
 
   private handleLargerSelectionArea = (event: React.MouseEvent<any>) => {

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -433,7 +433,9 @@ class BaseResourceItem extends Component<CombinedProps, State> {
 
   private handleMouseOut = () => {
     this.state.focused && this.setState({focused: false, focusedInner: false});
-    onMouseOut();
+    if (this.props.onMouseOut) {
+      this.props.onMouseOut();
+    }
   };
 
   private handleLargerSelectionArea = (event: React.MouseEvent<any>) => {

--- a/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -657,6 +657,44 @@ describe('<ResourceItem />', () => {
     });
   });
 
+  describe('mouse events', () => {
+    it('triggers onMouseOver callback when mouse over event is triggered on container', () => {
+      const onMouseOverSpy = jest.fn();
+      const resourceItem = mountWithApp(
+        <ResourceListContext.Provider value={mockSelectModeContext}>
+          <ResourceItem id={itemId} url={url} onMouseOver={onMouseOverSpy} />
+        </ResourceListContext.Provider>,
+      );
+
+      expect(onMouseOverSpy).not.toHaveBeenCalled();
+
+      const wrapperDiv = resourceItem.find('div', {'data-href': url} as any);
+
+      wrapperDiv!.trigger('onMouseOver');
+
+      expect(onMouseOverSpy).toHaveBeenCalled();
+      onMouseOverSpy.mockRestore();
+    });
+
+    it('triggers onMouseOut callback when mouse out event is triggered on container', () => {
+      const onMouseOutSpy = jest.fn();
+      const resourceItem = mountWithApp(
+        <ResourceListContext.Provider value={mockSelectModeContext}>
+          <ResourceItem id={itemId} url={url} onMouseOut={onMouseOutSpy} />
+        </ResourceListContext.Provider>,
+      );
+
+      expect(onMouseOutSpy).not.toHaveBeenCalled();
+
+      const wrapperDiv = resourceItem.find('div', {'data-href': url} as any);
+
+      wrapperDiv!.trigger('onMouseOut');
+
+      expect(onMouseOutSpy).toHaveBeenCalled();
+      onMouseOutSpy.mockRestore();
+    });
+  });
+
   describe('focused', () => {
     it('removes the focus state when mousing out a focused item', () => {
       const resourceItem = mountWithApp(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

For our use case of ResourceItem we need the ability to add a button to the item which shows on hover. With our current approach, we cannot account for the padding on the actual item container. By adding the listeners directly on the Polaris component, we can get the correct mouseOver/mouseOut based on the container.

A video showing the issue: https://videobin.shopify.io/v/qOQLd6 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
