### PR TITLE
[Tabs] Change icon for Rename View action

### DIFF
--- a/.changeset/old-points-give.md
+++ b/.changeset/old-points-give.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Update icon from infoMinor to EditMinor for rename view action.

--- a/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
@@ -213,7 +213,7 @@ export const Tab = forwardRef(
 
     const actionContent = {
       rename: {
-        icon: InfoMinor,
+        icon: EditMinor,
         content: i18n.translate('Polaris.Tabs.Tab.rename'),
       },
       duplicate: {


### PR DESCRIPTION
This PR simply changes the icon used for the 'Rename View' action within `Tabs` from `InfoMinor` to `EditMinor` as it makes more sense in supporting the label.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
