### PR TITLE
[Polaris Sandbox] Support passing feature=X URL params to <AppProvider>

### DIFF
--- a/.changeset/silent-pigs-care.md
+++ b/.changeset/silent-pigs-care.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+[Polaris Sandbox] Support passing feature=X URL params to <AppProvider>

--- a/patches/playroom+0.28.0.patch
+++ b/patches/playroom+0.28.0.patch
@@ -80,9 +80,15 @@ index b175d74..ce3e7ef 100644
    const resolvedThemeName =
      themeName === '__PLAYROOM__NO_THEME__' ? null : themeName;
 diff --git a/node_modules/playroom/src/Playroom/Frames/Frames.tsx b/node_modules/playroom/src/Playroom/Frames/Frames.tsx
-index 5b4af43..3bb2615 100644
+index 5b4af43..4800827 100644
 --- a/node_modules/playroom/src/Playroom/Frames/Frames.tsx
 +++ b/node_modules/playroom/src/Playroom/Frames/Frames.tsx
+@@ -1,4 +1,4 @@
+-import React, { useRef } from 'react';
++import React, { useRef, useEffect, useState } from 'react';
+ import flatMap from 'lodash/flatMap';
+ import Iframe from './Iframe';
+ import { compileJsx } from '../../utils/compileJsx';
 @@ -6,7 +6,6 @@ import { PlayroomProps } from '../Playroom';
  import { Strong } from '../Strong/Strong';
  import { Text } from '../Text/Text';
@@ -91,7 +97,24 @@ index 5b4af43..3bb2615 100644
  
  import * as styles from './Frames.css';
  
-@@ -44,10 +43,9 @@ export default function Frames({ code, themes, widths }: FramesProps) {
+@@ -20,6 +19,16 @@ let renderCode = '<React.Fragment></React.Fragment>';
+ 
+ export default function Frames({ code, themes, widths }: FramesProps) {
+   const scrollingPanelRef = useRef<HTMLDivElement | null>(null);
++  const [params, setParams] = useState<string>('');
++
++  useEffect(() => {
++    const search = new URLSearchParams(window.location.search);
++    search.delete('code');
++    search.delete('theme');
++    if (search.size) {
++      setParams(`?${search.toString()}`)
++    }
++  }, []);
+ 
+   const frames = flatMap(widths, (width) =>
+     themes.map((theme) => ({
+@@ -44,10 +53,9 @@ export default function Frames({ code, themes, widths }: FramesProps) {
              <div className={styles.frameBorder} />
              <Iframe
                intersectionRootRef={scrollingPanelRef}
@@ -101,7 +124,7 @@ index 5b4af43..3bb2615 100644
 -              )}
 +              code={renderCode}
 +              themeName={frame.theme}
-+              src={`${playroomConfig.baseUrl}frame.html`}
++              src={`${playroomConfig.baseUrl}frame.html${params}`}
                className={styles.frame}
                style={{ width: frame.width }}
                data-testid="previewFrame"
@@ -245,3 +268,34 @@ index a1819bf..70ac15c 100644
  };
  
  export const formatForInsertion = ({
+diff --git a/node_modules/playroom/src/utils/usePreviewUrl.ts b/node_modules/playroom/src/utils/usePreviewUrl.ts
+index ec225dd..c1cce20 100644
+--- a/node_modules/playroom/src/utils/usePreviewUrl.ts
++++ b/node_modules/playroom/src/utils/usePreviewUrl.ts
+@@ -8,15 +8,24 @@ const baseUrl = window.location.href
+   .split(playroomConfig.paramType === 'hash' ? '#' : '?')[0]
+   .split('index.html')[0];
+ 
++const extraParams = new URLSearchParams(window.location.search);
++extraParams.delete('code');
++extraParams.delete('theme');
++
++let extraParamsStr = '';
++if (extraParams.size) {
++  extraParamsStr = `&${extraParams.toString()}`
++}
++
+ export default (theme: string) => {
+   const [{ code }] = useContext(StoreContext);
+ 
+   const isThemed = theme !== '__PLAYROOM__NO_THEME__';
+ 
+-  return createPreviewUrl({
++  return `${createPreviewUrl({
+     baseUrl,
+     code,
+     theme: isThemed ? theme : undefined,
+     paramType: playroomConfig.paramType,
+-  });
++  })}${extraParamsStr}`;
+ };

--- a/polaris.shopify.com/playroom/FrameComponent.tsx
+++ b/polaris.shopify.com/playroom/FrameComponent.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {AppProvider} from '@shopify/polaris';
 import '@shopify/polaris/build/esm/styles.css';
 import enTranslations from '@shopify/polaris/locales/en.json';
@@ -10,11 +10,25 @@ export default function FrameComponent({
   theme: any;
   children: React.ReactNode;
 }) {
+  const [features, setFeatures] =
+    useState<React.ComponentProps<typeof AppProvider>['features']>();
   useEffect(() => {
     updateGrowFrameHeight(`${document.body.scrollHeight}px`);
   });
+  useEffect(() => {
+    const urlFeatures = new URLSearchParams(window.location.search).get(
+      'features',
+    );
+    if (typeof urlFeatures === 'string') {
+      setFeatures(
+        Object.fromEntries(
+          urlFeatures.split(',').map((feature) => [feature.trim(), true]),
+        ),
+      );
+    }
+  }, []);
   return (
-    <AppProvider i18n={theme || enTranslations}>
+    <AppProvider i18n={theme || enTranslations} features={features}>
       <div id="polaris-sandbox-wrapper">{children}</div>
     </AppProvider>
   );


### PR DESCRIPTION
### WHY are these changes introduced?

Polaris `<AppProvider>` accepts a `features` prop which en(dis)ables functionality within the rendered components.

The Polaris Sandbox (aka Playroom) does an opinionated render of the `<AppProvider>` _without_ setting any `features`. 

### WHAT is this pull request doing?

This PR does two related things:

1. Sets up Polaris Sandbox to forward URL parameters through to the final rendered frame. This also includes the generated preview URL.
2. The opinionated render of `<AppProvider>` within each frame parses the URL params looking for `features=X,Y`, and uses that as the `features` prop.

### How to 🎩

Checkout this branch [locally](https://github.com/Shopify/polaris/blob/main/README.md#local-development), then run the following command to get the dev server up and running quickly:

```sh
yarn && yarn turbo run build --filter='!polaris.shopify.com' && yarn workspace polaris.shopify.com dev
```

Then visit http://localhost:3000/sandbox _(might have to refresh a few times until the error goes away - Playroom can take a bit to boot up)_.

Enter the following code into the Sandbox editor:

```tsx
<Box padding="4">
  <HorizontalStack gap="5" blockAlign="end">
    <Button primary>Label</Button>
    <Button primary disabled>
      Label
    </Button>
    <Button primary icon={CancelSmallMinor} />
  </HorizontalStack>
</Box>
```

You should see something similar to:

<img width="341" alt="Screenshot 2023-07-12 at 12 10 03 pm" src="https://github.com/Shopify/polaris/assets/612020/f2662306-b33c-4ec4-8e74-969e20abb402">

Add `&features=polarisSummerEditions2023` to the URL and load the page.

You should see something similar to:

<img width="339" alt="Screenshot 2023-07-12 at 12 11 02 pm" src="https://github.com/Shopify/polaris/assets/612020/57c2350f-b7c8-4aaa-98fd-9a303fe307a7">

Finally, click the <img width="25" alt="Screenshot 2023-07-12 at 12 11 36 pm" src="https://github.com/Shopify/polaris/assets/612020/9b963f5e-31f3-478f-889c-fe17fdaf1b5c">, then "Open <img width="25" alt="Screenshot 2023-07-12 at 12 11 36 pm" src="https://github.com/Shopify/polaris/assets/612020/9b963f5e-31f3-478f-889c-fe17fdaf1b5c">", and you should see:

<img width="220" alt="Screenshot 2023-07-12 at 12 12 23 pm" src="https://github.com/Shopify/polaris/assets/612020/089c07ee-3517-4e36-a227-81a7c83e8d96">