### PR TITLE
[LegacyCard] Center LegacyCard.Heading content 

### DIFF
--- a/polaris-react/src/components/LegacyCard/LegacyCard.scss
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.scss
@@ -12,6 +12,12 @@
       $borderRadius: var(--p-border-radius-0-experimental),
       $zIndex: 101
     );
+
+    // stylelint-disable-next-line -- se23 override custom heading font sizes
+    h2,
+    h3 {
+      font-size: var(--p-font-size-80-experimental);
+    }
   }
 
   + .LegacyCard {

--- a/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
@@ -17,7 +17,7 @@ import {
   VerticalStack,
   Box,
 } from '@shopify/polaris';
-import {ProductsMajor} from '@shopify/polaris-icons';
+import {ProductsMajor, CancelMajor} from '@shopify/polaris-icons';
 
 export default {
   component: LegacyCard,
@@ -535,6 +535,16 @@ export function All() {
             </Box>
           </VerticalStack>
         </LegacyCard.Section>
+      </LegacyCard>
+      <LegacyCard>
+        <LegacyCard.Header title="Header with icon button child">
+          <Button
+            icon={CancelMajor}
+            primary
+            plain
+            accessibilityLabel="Cancel button"
+          />
+        </LegacyCard.Header>
       </LegacyCard>
       <WithAllElements />
     </VerticalStack>

--- a/polaris-react/src/components/LegacyCard/components/Header/Header.tsx
+++ b/polaris-react/src/components/LegacyCard/components/Header/Header.tsx
@@ -7,6 +7,7 @@ import {LegacyStack} from '../../../LegacyStack';
 import {Text} from '../../../Text';
 import styles from '../../LegacyCard.scss';
 import {useFeatures} from '../../../../utilities/features';
+import {HorizontalStack} from '../../../HorizontalStack';
 
 export interface LegacyCardHeaderProps {
   title?: React.ReactNode;
@@ -32,12 +33,28 @@ export function Header({children, title, actions}: LegacyCardHeaderProps) {
   );
 
   const headingMarkup =
+    // eslint-disable-next-line no-nested-ternary
     actionMarkup || children ? (
-      <LegacyStack alignment="baseline">
-        <LegacyStack.Item fill>{titleMarkup}</LegacyStack.Item>
-        {actionMarkup}
-        {children}
-      </LegacyStack>
+      polarisSummerEditions2023 ? (
+        <HorizontalStack
+          wrap={false}
+          gap="2"
+          align="space-between"
+          blockAlign="center"
+        >
+          {titleMarkup}
+          <HorizontalStack wrap={false} gap="4" blockAlign="center">
+            {actionMarkup}
+            {children}
+          </HorizontalStack>
+        </HorizontalStack>
+      ) : (
+        <LegacyStack alignment="baseline">
+          <LegacyStack.Item fill>{titleMarkup}</LegacyStack.Item>
+          {actionMarkup}
+          {children}
+        </LegacyStack>
+      )
     ) : (
       titleMarkup
     );


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [this issue](https://github.com/Shopify/polaris-summer-editions/issues/881)
Resolves [this issue](https://github.com/Shopify/web/issues/97516)

1. There are lots of instances in the Admin where the children of a `LegacyCard.Header` isn't aligned with the header title. This is because `LegacyCard.Header` is a `<LegacyStack alignment="baseline">`.

<img width="291" alt="Screenshot 2023-07-11 at 11 07 07 PM" src="https://github.com/Shopify/polaris/assets/20652326/54ec48d0-5ae2-4ab4-bbd2-b7d52a68b5fa">

2. There are lots of instances in the Admin where `LegacyCard` contains h2 `headingMd` (`14px`) when they are supposed to be `headingSm`(`13px`). This is when builders are not passing a string to the `title` prop and are creating headings with their own text elements.

### WHAT is this pull request doing?

<details>
<summary>Use `HorizontalStack` with center alignment instead of `LegacyStack baseline` for header content</summary>

|Before|After|
|-|-|
| <img width="475" alt="Screenshot 2023-07-11 at 11 16 53 PM" src="https://github.com/Shopify/polaris/assets/20652326/a1201725-470c-4030-a662-852828acbe14"> | <img width="472" alt="Screenshot 2023-07-11 at 11 18 32 PM" src="https://github.com/Shopify/polaris/assets/20652326/cb2bcbe4-cfd1-4eca-bfb8-8245bad46416">|

</details>

<details>
<summary>Override all `h2` in `LegacyCard` to be `13px` no matter what the `Text` variant is to enforce consistency</summary>

|Before|After|
|-|-|
| <img width="264" alt="Screenshot 2023-07-11 at 11 28 10 PM" src="https://github.com/Shopify/polaris/assets/20652326/857dd4b8-0660-4deb-b1f9-419f67c2995f"> | <img width="267" alt="Screenshot 2023-07-11 at 11 27 19 PM" src="https://github.com/Shopify/polaris/assets/20652326/4843c5e4-3606-420b-b8f6-473a778f51c7"> |

</details>

### Tophat

Check NoteCard heading icon is aligned
https://admin.web.tag-card.sophie-schneider.us.spin.dev/store/shop1/orders/10

Check all headings are `13px`
https://admin.web.tag-card.sophie-schneider.us.spin.dev/store/shop1/products/5
