### PR TITLE
Fix Card height not filling wrapping ShadowBevel

### DIFF
--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -73,6 +73,7 @@ export const Card = ({
             padding={finalPadding}
             overflowX="hidden"
             overflowY="hidden"
+            minHeight="100%"
           >
             {children}
           </Box>


### PR DESCRIPTION
### WHY are these changes introduced?

| Before | After |
| --- | --- |
| <img width="1044" alt="before" src="https://github.com/Shopify/polaris/assets/11774595/ca1d9c5c-2ff5-4631-b256-3b68ebc540bc"> | <img width="1044" alt="after" src="https://github.com/Shopify/polaris/assets/11774595/bd55b07d-25f6-4e55-b358-53afab62a5c9"> |


### WHAT is this pull request doing?

Makes the Card height the full height of the ShadowBevel `<Box minHeight="100%">`

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card, HorizontalGrid, Text, VerticalStack} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <HorizontalGrid gap="4" columns={3}>
        <Card>
          <VerticalStack gap="5">
            <Text as="h3" variant="headingMd">
              Online store dashboard
            </Text>
            <p>View a summary of your online store’s performance.</p>
          </VerticalStack>
        </Card>
        <Card>
          <VerticalStack gap="5">
            <Text as="h3" variant="headingMd">
              Online store dashboard
            </Text>
            <p>
              View a summary of your online store’s performance. Aute mollit
              dolore qui eu cupidatat non. Dolore qui, eu cupidatat non.
              Cupidatat non, ipsum fugiat. Fugiat dolor exercitation laboris id.
              Exercitation laboris id cupidatat. Mollit dolore qui eu cupidatat
              non ipsum. Qui eu cupidatat non ipsum, fugiat dolor exercitation.
              Non ipsum, fugiat dolor exercitation laboris. Dolor exercitation
              laboris id cupidatat, magna enim. Id cupidatat magna enim ullamco
              sit laborum officia.
            </p>
          </VerticalStack>
        </Card>
        <Card>
          <VerticalStack gap="5">
            <Text as="h3" variant="headingMd">
              Online store dashboard
            </Text>
            <p>
              View a summary of your online store’s performance. Nulla excepteur
              elit ipsum est velit aliqua. Elit ipsum est velit aliqua qui. Est
              velit aliqua qui culpa. Aliqua qui culpa ex excepteur esse amet.
              Culpa ex excepteur esse amet minim. Excepteur esse, amet minim sed
              commodo laborum. Excepteur elit ipsum, est. Est velit aliqua qui
              culpa. Aliqua qui culpa ex excepteur esse amet. Culpa ex excepteur
              esse amet minim. Excepteur esse, amet minim sed commodo laborum.
              Minim, sed commodo laborum ipsum. Laborum ipsum quis aliquip, in
              quis nisi. Aliquip in, quis nisi. Nisi aliquip qui officia. Elit
              ipsum est velit aliqua qui. Est velit aliqua qui culpa. Aliqua qui
              culpa ex excepteur esse amet. Culpa ex excepteur esse amet minim.
              Excepteur esse, amet minim sed commodo laborum.
            </p>
          </VerticalStack>
        </Card>
      </HorizontalGrid>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
