### PR TITLE
Update `ActionMenu` secondary action popover position

### DIFF
--- a/.changeset/thirty-bags-brake.md
+++ b/.changeset/thirty-bags-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Adjust popover positioning for `ActionMenu` secondary actions

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -21,7 +21,7 @@ export function SecondaryAction({
   getOffsetWidth,
   ...rest
 }: SecondaryAction) {
-  const secondaryActionsRef = useRef<HTMLSpanElement>(null);
+  const secondaryActionsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!getOffsetWidth || !secondaryActionsRef.current) return;
@@ -42,7 +42,7 @@ export function SecondaryAction({
   );
 
   return (
-    <span
+    <div
       className={classNames(
         styles.SecondaryAction,
         destructive && styles.destructive,
@@ -50,6 +50,6 @@ export function SecondaryAction({
       ref={secondaryActionsRef}
     >
       {actionMarkup}
-    </span>
+    </div>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/430

### WHAT is this pull request doing?

Adjust position of popover relative to the activator button. This spacing issue already existed but was not as noticeable due to the button style. This PR applies the fix without the beta flag.

<img width="219" alt="Screenshot 2023-07-12 at 9 45 22 AM" src="https://github.com/Shopify/polaris/assets/3474483/386e0b80-bbcb-4fd9-89b8-62983a88d414">|<img width="265" alt="Screenshot 2023-07-12 at 9 45 05 AM" src="https://github.com/Shopify/polaris/assets/3474483/301bf1c6-1645-49a7-b6ce-9f721ca949a1">
:----:|:----:
<img width="235" alt="Screenshot 2023-07-12 at 9 45 37 AM" src="https://github.com/Shopify/polaris/assets/3474483/82ca7daf-a642-4a5f-aa5b-4a3f02adc1e3">|<img width="246" alt="Screenshot 2023-07-12 at 9 45 50 AM" src="https://github.com/Shopify/polaris/assets/3474483/d87ca6a4-3e7c-4816-8883-6c32b347e05c">
Before|After

### How to 🎩

Review in Storybook, with and without beta flag