### PR TITLE
[Navigation] Fix background colour for items without url

### DIFF
--- a/polaris-react/src/components/Navigation/Navigation.stories.tsx
+++ b/polaris-react/src/components/Navigation/Navigation.stories.tsx
@@ -1375,3 +1375,65 @@ export function ItemWithMatchedIcon() {
     </Frame>
   );
 }
+
+export function ItemsWithoutUrl() {
+  const [selected, setSelected] = React.useState('all');
+
+  return (
+    <Frame>
+      <Navigation location="/">
+        <Navigation.Section
+          title="Templates"
+          items={[
+            {
+              label: 'All',
+              selected: selected === 'all',
+              onClick: () => setSelected('all'),
+            },
+            {
+              label: 'Announcements',
+              selected: selected === 'announcements',
+              onClick: () => setSelected('announcements'),
+            },
+            {
+              label: 'Holidays and occasions',
+              selected: selected === 'holidays',
+              onClick: () => setSelected('holidays'),
+            },
+            {
+              label: 'Newsletters',
+              selected: selected === 'newsletters',
+              onClick: () => setSelected('newsletters'),
+            },
+            {
+              label: 'Product highlights',
+              selected: selected === 'productHighlights',
+              onClick: () => setSelected('productHighlights'),
+            },
+            {
+              label: 'Promotions',
+              selected: selected === 'promotions',
+              onClick: () => setSelected('promotions'),
+              disabled: true,
+            },
+          ]}
+        />
+        <Navigation.Section
+          title="Custom"
+          items={[
+            {
+              label: 'Your templates',
+              selected: selected === 'yourTemplates',
+              onClick: () => setSelected('yourTemplates'),
+            },
+            {
+              label: 'Recent emails',
+              selected: selected === 'recentEmails',
+              onClick: () => setSelected('recentEmails'),
+            },
+          ]}
+        />
+      </Navigation>
+    </Frame>
+  );
+}

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -168,6 +168,9 @@ export function Item({
             className={classNames(
               styles.ItemInnerWrapper,
               disabled && styles.ItemInnerDisabled,
+              polarisSummerEditions2023
+                ? selectedOverride && styles['ItemInnerWrapper-selected']
+                : undefined,
             )}
           >
             <button


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris-summer-editions/issues/593

### WHY are these changes introduced?

The `ItemInnerWrapper-selected` wasn't being applied to Items without the `url` prop passed in. There's a conditional block dedicated for this case that wasn't updated. 

### WHAT is this pull request doing?

Fixing the background colour of selected items. 

[Spin](https://admin.web.email-bese.mateus-ferreira.us.spin.dev/store/shop1/apps/shopify-email/templates?activityType=CAMPAIGN_ACTIVITY&categories=HOLIDAY_AND_OCCASIONS&page=presets)

Storybook:

https://github.com/Shopify/polaris/assets/2091116/f06e4523-70aa-47a0-9098-2656c71a6f77


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
