### PR TITLE
[ContextualSaveBar] Fixes ContextualSaveBar and Frame styles to respect page layout

### DIFF
--- a/.changeset/great-trees-smile.md
+++ b/.changeset/great-trees-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixes ContextualSaveBar and Frame styles to respect page layout

--- a/polaris-react/src/components/Frame/Frame.scss
+++ b/polaris-react/src/components/Frame/Frame.scss
@@ -178,6 +178,11 @@ $sidebar-breakpoint: 1200px;
     /* stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- Only needed here */
     top: var(--pc-topbar-height);
 
+    /* stylelint-disable-next-line polaris/media-queries/polaris/at-rule-disallowed-list -- Need to respect the page margins */
+    @include page-layout;
+    // But don't want to respect the max-width
+    max-width: none;
+
     @media #{$p-breakpoints-md-up} {
       /* stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- Only needed here */
       left: var(--pc-nav-width);

--- a/polaris-react/src/components/Frame/Frame.stories.tsx
+++ b/polaris-react/src/components/Frame/Frame.stories.tsx
@@ -1098,6 +1098,19 @@ function WithSidebarEnabled({
           {pageMarkup}
           {toastMarkup}
           {modalMarkup}
+          <div
+            style={{
+              position: 'fixed',
+              right: 0,
+              top: 'var(--pc-topbar-height)',
+              width: 'var(--pc-sidebar-width)',
+              height: '100vh',
+              background: 'var(--p-color-bg)',
+              padding: 'var(--p-space-2)',
+            }}
+          >
+            This is a sidebar
+          </div>
         </Frame>
       </AppProvider>
     </div>

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -29,7 +29,7 @@ $contextual-save-height: 44px;
     color: var(--p-color-bg-inverse);
     box-shadow: var(--p-shadow-md);
 
-    @media #{$p-breakpoints-md-up} {
+    @media #{$p-breakpoints-sm-up} {
       border-radius: var(--p-border-radius-3);
       margin-top: var(--p-space-2);
       margin-bottom: var(--p-space-2);

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -23,7 +23,8 @@ $contextual-save-height: 44px;
     --p-color-bg-subdued-active: var(--p-color-bg-subdued-active);
     /* stylelint-enable */
     border-radius: var(--p-border-radius-3);
-    margin: var(--p-space-2);
+    margin-top: var(--p-space-2);
+    margin-bottom: var(--p-space-2);
     height: $contextual-save-height;
     background-color: var(--p-color-bg-input);
     color: var(--p-color-bg-inverse);

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -22,13 +22,18 @@ $contextual-save-height: 44px;
     --p-color-bg-hover: var(--p-color-bg-hover);
     --p-color-bg-subdued-active: var(--p-color-bg-subdued-active);
     /* stylelint-enable */
-    border-radius: var(--p-border-radius-3);
-    margin-top: var(--p-space-2);
-    margin-bottom: var(--p-space-2);
+    margin-top: 0;
+    margin-bottom: 0;
     height: $contextual-save-height;
     background-color: var(--p-color-bg-input);
     color: var(--p-color-bg-inverse);
     box-shadow: var(--p-shadow-md);
+
+    @media #{$p-breakpoints-md-up} {
+      border-radius: var(--p-border-radius-3);
+      margin-top: var(--p-space-2);
+      margin-bottom: var(--p-space-2);
+    }
   }
 
   .LogoContainer {


### PR DESCRIPTION
### WHY are these changes introduced?

With the changes to the ContextualSaveBar to be inside the content frame we noticed that the margins were wrong.


Before:
![image](https://github.com/Shopify/polaris/assets/167921/e2c13b79-c667-4b8d-84c5-66b60a45846d)

After:
<img width="1304" alt="image" src="https://github.com/Shopify/polaris/assets/167921/a2fc06f9-dd2e-4910-8fa4-1edae1d5e159">

### WHAT is this pull request doing?

This PR ensure's we're using the `page-layout` mixin so that the ContextualSaveBar is aligned with pages. It then removes the horizontal margin from the inner ContextualSaveBar component.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Use storybook and check the Frame > With sidebar story, with the summer edition beta flag enabled.

https://5d559397bae39100201eedc1-rozpmntrce.chromatic.com/?path=/story/all-components-frame--with-sidebar&globals=polarisSummerEditions2023:true

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
