### PR TITLE
Update snapit.yml trigger keywords

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -12,7 +12,7 @@ jobs:
     name: Snapshot Release
     if: |
       github.event.issue.pull_request &&
-      (github.event.comment.body == '/snapit' || github.event.comment.body == '/snapshot-release')
+      (startsWith(github.event.comment.body, '/snapit') || startsWith(github.event.comment.body, '/snapshot-release'))
     runs-on: ubuntu-latest
     steps:
       - name: Enforce permission requirement


### PR DESCRIPTION
As long as a PR comment `startsWith` the keywords `/snapit` or `/snapshot-release`, the workflow will trigger