### PR TITLE
[Text] Allows Text to work as dt/dd

### DIFF
--- a/.changeset/four-numbers-impress.md
+++ b/.changeset/four-numbers-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[Text] Allows Text to work as dt/dd

--- a/polaris-react/src/components/Text/README.md
+++ b/polaris-react/src/components/Text/README.md
@@ -278,3 +278,18 @@ Use to de-emphasize a piece of text that is less important to merchants than oth
   No supplier listed
 </Text>
 ```
+
+### In a definition list
+
+Use as the `dt` and `dd` elements in a definition list
+
+```jsx
+<dl>
+  <Text as="dt" variant="bodyLg">
+    Definition Title
+  </Text>
+  <Text as="dd" variant="bodySm">
+    Definition Description
+  </Text>
+</dl>
+```

--- a/polaris-react/src/components/Text/Text.stories.tsx
+++ b/polaris-react/src/components/Text/Text.stories.tsx
@@ -135,3 +135,14 @@ export const ParentWithChild = () => (
     children
   </Text>
 );
+
+export const InADefinitionList = () => (
+  <dl>
+    <Text as="dt" variant="bodyLg">
+      Definition Title
+    </Text>
+    <Text as="dd" variant="bodySm">
+      Definition Description
+    </Text>
+  </dl>
+);

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -6,6 +6,8 @@ import {classNames} from '../../utilities/css';
 import styles from './Text.scss';
 
 type Element =
+  | 'dt'
+  | 'dd'
   | 'h1'
   | 'h2'
   | 'h3'


### PR DESCRIPTION
### WHY are these changes introduced?

When doing the a11y review for the ReportCard it was noted that a component should be a definition list, this PR ensure's we can use the Text component as `dd` or `dt` so we can have a terser and more semantic markup without having to wrap those with wrapper elements.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Included a story for Text component usage as part of a definition list.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
