### PR TITLE
Update `ShadowBevel` to explicitly create a local stacking context

### DIFF
--- a/polaris-react/src/components/ShadowBevel/ShadowBevel.scss
+++ b/polaris-react/src/components/ShadowBevel/ShadowBevel.scss
@@ -2,6 +2,8 @@
 
 .ShadowBevel {
   overflow: hidden;
+  // stylelint-disable-next-line -- Explicitly set `0` to create a local stacking context. While the initial `z-index: auto` has a stack level of `0` within the current stacking context, it does not create a new local stacking context.
+  z-index: 0;
 
   @include responsive-props(
     $componentName: 'shadow-bevel',


### PR DESCRIPTION
Closes https://github.com/Shopify/polaris-summer-editions/issues/957

Before:

https://github.com/Shopify/polaris/assets/32409546/67da521c-98cd-4e28-a0b3-7bf89eac1f64

After:

https://github.com/Shopify/polaris/assets/32409546/8fdd74e2-5526-4ff6-b385-bbbf9bed8a74

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Card, Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <div style={{position: 'relative'}}>
        <div
          style={{
            width: 'calc(100vw - 200px)',
            paddingLeft: 'calc(20px + 200px)',
            height: '50vh',
            overflowX: 'scroll',
          }}
        >
          <div style={{width: '75vw', display: 'grid', gap: 8}}>
            <Card>Card 1</Card>
            <Card>Card 2</Card>
          </div>
        </div>
        <div
          style={{
            position: 'absolute',
            top: 0,
            left: 0,
            width: '200px',
            height: '100%',
            background: 'white',
            border: '1px solid lightgray',
            borderRadius: 8,
          }}
        >
          Side navigation
        </div>
      </div>
    </Page>
  );
}
```

</details>
