### PR TITLE
Update `Page` disabled secondary action styles

### DIFF
--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -80,8 +80,11 @@
           var(--p-color-border-interactive-focus);
         outline-offset: var(--p-space-05);
       }
-      &[aria-disabled="true"] {
-        background-color: var(--p-color-bg-transparent-disabled-experimental) !important;
+      // stylelint-disable-next-line selector-max-combinators -- se23
+      &[aria-disabled='true'] {
+        background-color: var(
+          --p-color-bg-transparent-disabled-experimental
+        ) !important;
       }
     }
 

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -80,6 +80,9 @@
           var(--p-color-border-interactive-focus);
         outline-offset: var(--p-space-05);
       }
+      &[aria-disabled="true"] {
+        background-color: var(--p-color-bg-transparent-disabled-experimental) !important;
+      }
     }
 
     &.destructive {


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-summer-editions/issues/99

### WHAT is this pull request doing?

- Update disabled secondary action styles for `Page` component
- Pagination styles also updated
- Primary actions disabled styles rendering as expected

<img width="845" alt="Screenshot 2023-07-18 at 10 09 34 AM" src="https://github.com/Shopify/polaris/assets/3474483/45e5dda1-8fd2-42fd-9f6b-f7f2af7ab6f1">
<img width="352" alt="Screenshot 2023-07-18 at 10 10 53 AM" src="https://github.com/Shopify/polaris/assets/3474483/d33f7467-35d4-4649-9506-b214bbd9da92">
<img width="326" alt="Screenshot 2023-07-18 at 10 11 16 AM" src="https://github.com/Shopify/polaris/assets/3474483/8037ba17-49ce-4e6a-a674-abc3fa6505bb">


### How to 🎩

Review in Storybook with beta flag turned on