### PR TITLE
Update default and active `Tab` background-color

### DIFF
--- a/polaris-react/src/components/Tabs/Tabs.scss
+++ b/polaris-react/src/components/Tabs/Tabs.scss
@@ -124,6 +124,7 @@
     // stylelint-disable-next-line -- no way to set focus ring without mixin currently
     @include focus-ring($size: 'wide');
     color: var(--p-color-text-primary);
+    background-color: transparent;
     border-radius: var(--p-border-radius-2);
     padding: var(--p-space-1_5-experimental) var(--p-space-3);
     height: 2rem;

--- a/polaris-react/src/components/Tabs/Tabs.scss
+++ b/polaris-react/src/components/Tabs/Tabs.scss
@@ -180,7 +180,7 @@
   }
 
   #{$se23} & {
-    background: var(--p-color-bg-transparent-subdued-experimental);
+    background: var(--p-color-bg-transparent-active-experimental);
     color: var(--p-color-text);
     border-radius: var(--p-border-radius-2);
 


### PR DESCRIPTION
Closes https://github.com/Shopify/polaris-summer-editions/issues/948

Before:

![Screenshot 2023-07-18 at 11 03 32 AM](https://github.com/Shopify/polaris/assets/32409546/ddd26365-33bf-4a5d-af6c-167f12ce12eb)

After:

![Screenshot 2023-07-18 at 11 07 04 AM](https://github.com/Shopify/polaris/assets/32409546/dadb6658-bc6d-468f-b98f-aa4271df74d9)
