### PR TITLE
[Button] Add vertical align middle to plain buttons

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -574,6 +574,7 @@
     --pc-button-color-active: var(--p-color-bg-transparent-active-experimental);
     // stylelint-enable polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
     box-shadow: none;
+    vertical-align: middle;
 
     // stylelint-disable-next-line selector-max-combinators -- se23 temporary styles
     path {
@@ -804,6 +805,7 @@
 
   #{$se23} & {
     box-shadow: none;
+    vertical-align: middle;
     // stylelint-disable-next-line -- polaris/conventions/polaris/custom-property-allowed-list
     margin: calc(-1 * var(--pc-button-vertical-padding))
       calc(-1 * var(--p-space-3));


### PR DESCRIPTION
### WHY are these changes introduced?

Closes [this issue](https://github.com/Shopify/polaris-summer-editions/issues/926)

> See issue for codebox demonstrating the bug

### WHAT is this pull request doing?

Since buttons are `display: inline-flex`, icon svgs are causing the button elements to gain unnecessary height when wrapped with a block or inline div. (See issue for more details). This problem is very similar to the [icon badge height issue](https://github.com/Shopify/polaris/pull/9521) and was able to be resolved by adding `vertical-align: middle` to both `plain` and `primaryPlain` buttons. 

<details>

<summary>Note: I added the <code>vertical-align: middle</code> onto the the whole button instead of just the svg (like badge) so that the text and icon would always be aligned</summary>

|`vertical-align` just on svg element|`vertical-align` on button element|
|-|-|
|<img width="102" alt="Screenshot 2023-07-18 at 5 19 53 PM" src="https://github.com/Shopify/polaris/assets/20652326/519ae9d6-e4de-4c27-b0d0-9cfa7951cd05">|<img width="98" alt="Screenshot 2023-07-18 at 5 20 24 PM" src="https://github.com/Shopify/polaris/assets/20652326/cae52d72-4162-4ab2-bcb9-7c5426c84f38">|

</details>

## 🎩 Tophat

<details>
<summary>Screenshots use this code</summary>

Text field wraps connected items in a block div which reproduces the bug

```
    <TextField
      label="hi"
      type="number"
      value={''}
      onChange={() => {}}
      connectedRight={<Button icon={CancelMinor} plain primary />}
    />
```

</details>

|Button type|Before|After|
|-|-|-|
|`icon` + `plain` + `children`|<img width="98" alt="Screenshot 2023-07-18 at 5 26 41 PM" src="https://github.com/Shopify/polaris/assets/20652326/105314dc-902d-40bf-8182-e0af6fc7f54b">|<img width="88" alt="Screenshot 2023-07-18 at 5 26 47 PM" src="https://github.com/Shopify/polaris/assets/20652326/c83dcc9e-4a68-4a66-8473-278c15d536a2">|
|`icon` + `primary` + `plain` + `children`|<img width="105" alt="Screenshot 2023-07-18 at 5 28 49 PM" src="https://github.com/Shopify/polaris/assets/20652326/cd307aa5-3983-4dff-9f4c-174ff056d09d">|<img width="107" alt="Screenshot 2023-07-18 at 5 29 03 PM" src="https://github.com/Shopify/polaris/assets/20652326/25a46d6d-eb83-4468-9b23-5207181e63d5">|
|`icon` + `plain`|<img width="46" alt="Screenshot 2023-07-18 at 5 30 39 PM" src="https://github.com/Shopify/polaris/assets/20652326/02bcff4e-64de-41fe-9f8a-d1e9fc5fb1f3">|<img width="46" alt="Screenshot 2023-07-18 at 5 30 45 PM" src="https://github.com/Shopify/polaris/assets/20652326/fcfc72b0-6b97-452f-bc36-e95496b5ca53">|
|`icon` + `primary` + `plain`|<img width="45" alt="Screenshot 2023-07-18 at 5 31 59 PM" src="https://github.com/Shopify/polaris/assets/20652326/3263bf2b-fc5c-442b-a30b-d54e1ac21a45">|<img width="54" alt="Screenshot 2023-07-18 at 5 31 41 PM" src="https://github.com/Shopify/polaris/assets/20652326/4f294bf2-00b2-41e2-8379-41ba033eed66">|

