### PR TITLE
[ContextualSaveBar] Scroll to content if scroll top is less than top bar height

### DIFF
--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -548,7 +548,6 @@ export function DetailsPage() {
   // ---- Page markup ----
   const actualPageMarkup = (
     <Page
-      fullWidth
       backAction={{content: 'Products', url: '/products/31'}}
       title={title}
       titleMetadata={<Badge status="success">Success badge</Badge>}

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -624,6 +624,93 @@ export function DetailsPage() {
               {fileUpload}
             </DropZone>
           </LegacyCard>
+          <LegacyCard title="Media" sectioned>
+            <DropZone onDrop={handleDropZoneDrop}>
+              {uploadedFiles}
+              {fileUpload}
+            </DropZone>
+          </LegacyCard>
+          <LegacyCard title="Media" sectioned>
+            <DropZone onDrop={handleDropZoneDrop}>
+              {uploadedFiles}
+              {fileUpload}
+            </DropZone>
+          </LegacyCard>
+          <LegacyCard title="Media" sectioned>
+            <DropZone onDrop={handleDropZoneDrop}>
+              {uploadedFiles}
+              {fileUpload}
+            </DropZone>
+          </LegacyCard>
+          <LegacyCard title="Media" sectioned>
+            <DropZone onDrop={handleDropZoneDrop}>
+              {uploadedFiles}
+              {fileUpload}
+            </DropZone>
+          </LegacyCard>
+        </Layout.Section>
+        <Layout.Section secondary>
+          <LegacyCard title="Organization">
+            <LegacyCard.Section>
+              <Select
+                label="Product type"
+                options={options}
+                onChange={setSelected}
+                value={selected}
+              />
+              <br />
+              <Select
+                label="Vendor"
+                options={options}
+                onChange={setSelected}
+                value={selected}
+              />
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Collections" />
+            <LegacyCard.Section title="Tags" />
+          </LegacyCard>
+        </Layout.Section>
+        <Layout.Section secondary>
+          <LegacyCard title="Organization">
+            <LegacyCard.Section>
+              <Select
+                label="Product type"
+                options={options}
+                onChange={setSelected}
+                value={selected}
+              />
+              <br />
+              <Select
+                label="Vendor"
+                options={options}
+                onChange={setSelected}
+                value={selected}
+              />
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Collections" />
+            <LegacyCard.Section title="Tags" />
+          </LegacyCard>
+        </Layout.Section>
+        <Layout.Section secondary>
+          <LegacyCard title="Organization">
+            <LegacyCard.Section>
+              <Select
+                label="Product type"
+                options={options}
+                onChange={setSelected}
+                value={selected}
+              />
+              <br />
+              <Select
+                label="Vendor"
+                options={options}
+                onChange={setSelected}
+                value={selected}
+              />
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Collections" />
+            <LegacyCard.Section title="Tags" />
+          </LegacyCard>
         </Layout.Section>
         <Layout.Section secondary>
           <LegacyCard title="Organization">

--- a/polaris-react/src/components/Frame/Frame.tsx
+++ b/polaris-react/src/components/Frame/Frame.tsx
@@ -31,6 +31,7 @@ import {
 } from './components';
 import styles from './Frame.scss';
 
+const PAGE_PADDING_TOP = 12;
 const CONTEXTUAL_SAVE_SCROLL_HEIGHT_FROM_TOP = 56;
 
 export interface FrameProps {
@@ -116,12 +117,17 @@ class FrameInner extends PureComponent<CombinedProps, State> {
       ) {
         const saveDisabled =
           this.contextualSaveBar?.saveAction?.disabled ?? false;
+
         const currentScrollPosition =
           window.scrollY || document.documentElement.scrollTop;
 
-        if (!saveDisabled || currentScrollPosition !== 0) {
+        if (!saveDisabled) {
           window.scrollTo({
-            top: currentScrollPosition,
+            top:
+              currentScrollPosition <= CONTEXTUAL_SAVE_SCROLL_HEIGHT_FROM_TOP
+                ? currentScrollPosition + PAGE_PADDING_TOP
+                : currentScrollPosition +
+                  CONTEXTUAL_SAVE_SCROLL_HEIGHT_FROM_TOP,
             behavior: 'auto',
           });
         }

--- a/polaris-react/src/components/Frame/Frame.tsx
+++ b/polaris-react/src/components/Frame/Frame.tsx
@@ -31,7 +31,7 @@ import {
 } from './components';
 import styles from './Frame.scss';
 
-const PAGE_PADDING_TOP = 12;
+const OFFSET_PADDING_TOP = 12;
 const CONTEXTUAL_SAVE_SCROLL_HEIGHT_FROM_TOP = 56;
 
 export interface FrameProps {
@@ -125,7 +125,7 @@ class FrameInner extends PureComponent<CombinedProps, State> {
           window.scrollTo({
             top:
               currentScrollPosition <= CONTEXTUAL_SAVE_SCROLL_HEIGHT_FROM_TOP
-                ? currentScrollPosition + PAGE_PADDING_TOP
+                ? currentScrollPosition + OFFSET_PADDING_TOP
                 : currentScrollPosition +
                   CONTEXTUAL_SAVE_SCROLL_HEIGHT_FROM_TOP,
             behavior: 'auto',

--- a/polaris-react/src/components/Frame/Frame.tsx
+++ b/polaris-react/src/components/Frame/Frame.tsx
@@ -121,7 +121,7 @@ class FrameInner extends PureComponent<CombinedProps, State> {
 
         if (!saveDisabled || currentScrollPosition !== 0) {
           window.scrollTo({
-            top: currentScrollPosition + CONTEXTUAL_SAVE_SCROLL_HEIGHT_FROM_TOP,
+            top: currentScrollPosition,
             behavior: 'auto',
           });
         }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/959

When a merchant is scrolled to the top of the page and makes a change, the contextual save bar covers primary and secondary page actions, giving the illusion that these are no longer accessible. 

### WHAT is this pull request doing?

This PR scrolls to the content when the merchant is near the top of the page (hasn't scrolled beyond the top bar height)

If the merchant has scrolled beyond that threshold, no content jump will occur when the save bar is active

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

[Spin](https://admin.web.web-dm8y.kyle-durand.us.spin.dev/store/shop1/shipping_labels)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
