### PR TITLE
[IndexFilters] Support index filters with filtering only

### DIFF
--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,11 +1,47 @@
-import React from 'react';
+import React, {useState} from 'react';
 
-import {Page} from '../src';
+import {IndexFilters, IndexFiltersMode, Page, VerticalStack} from '../src';
 
 export function Playground() {
+  const [queryOne, setQueryOne] = useState('');
+  const [queryTwo, setQueryTwo] = useState('');
   return (
     <Page title="Playground">
-      {/* Add the code you want to test in here */}
+      <VerticalStack gap="2">
+        <IndexFilters
+          mode={IndexFiltersMode.Filtering}
+          queryPlaceholder="Search"
+          queryValue={queryOne}
+          onQueryChange={(value) => setQueryOne(value)}
+          onQueryClear={() => setQueryOne('')}
+          onClearAll={() => console.log('clear all')}
+          sortOptions={[
+            {label: 'sort asc', value: 'value asc', directionLabel: 'asc'},
+            {label: 'sort desc', value: 'value desc', directionLabel: 'desc'},
+          ]}
+          onSort={() => {
+            console.log('sort');
+          }}
+          sortSelected={['sort asc']}
+        />
+        <IndexFilters
+          mode={IndexFiltersMode.Filtering}
+          queryPlaceholder="Search"
+          queryValue={queryTwo}
+          onQueryChange={(value) => setQueryTwo(value)}
+          onQueryClear={() => setQueryTwo('')}
+          onClearAll={() => console.log('clear all')}
+          sortOptions={[
+            {label: 'sort asc', value: 'value asc', directionLabel: 'asc'},
+            {label: 'sort desc', value: 'value desc', directionLabel: 'desc'},
+          ]}
+          onSort={() => {
+            console.log('sort');
+          }}
+          sortSelected={['sort asc']}
+          loading
+        />
+      </VerticalStack>
     </Page>
   );
 }

--- a/polaris-react/src/components/IndexFilters/components/UpdateButtons/UpdateButtons.tsx
+++ b/polaris-react/src/components/IndexFilters/components/UpdateButtons/UpdateButtons.tsx
@@ -22,7 +22,7 @@ interface UpdateIndexFiltersPrimaryAction
 
 export interface UpdateButtonsProps {
   primaryAction?: UpdateIndexFiltersPrimaryAction;
-  cancelAction: IndexFiltersCancelAction;
+  cancelAction?: IndexFiltersCancelAction;
   viewNames: string[];
   disabled?: boolean;
 }
@@ -111,12 +111,16 @@ export function UpdateButtons({
       plain
       primary={se23 ? true : undefined}
       size="micro"
-      onClick={cancelAction.onAction}
+      onClick={cancelAction?.onAction}
       disabled={disabled}
     >
       {i18n.translate('Polaris.IndexFilters.UpdateButtons.cancel')}
     </Button>
   );
+
+  if (!primaryAction && !cancelAction) {
+    return null;
+  }
 
   if (!primaryAction) {
     return cancelButtonMarkup;


### PR DESCRIPTION
### WHY are these changes introduced?

This is a draft PR to open the discussion on `IndexFilters` being able to support the filtering mode only.

We would like to use the `IndexFilters` component in the Customers section, in the: 
- customer index 
- segment index 
- companies index 

![image](https://github.com/Shopify/polaris/assets/33726710/3f0182a6-ec8d-4f29-b7a6-2751cf0aa519)

### WHAT is this pull request doing?

- Makes the `tabs` and `filters` props optional 
- Makes the `cancelAction` prop optional as well

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

**I left the playground code in as this is a draft PR**

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
