### PR TITLE
[ButtonGroup] Fix segmented buttons styling for gen3

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -1416,6 +1416,13 @@
     }
   }
 
+  .Button.pressed {
+    #{$se23} & {
+      // stylelint-disable-next-line -- se23 required for styling specificicty
+      clip-path: none !important;
+    }
+  }
+
   > :first-child .Button,
   > :first-child .Button::after {
     border-radius: 0;

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
@@ -53,6 +53,11 @@
     &:not(:first-child) {
       margin-left: calc(-1 * var(--p-space-025));
     }
+
+    // stylelint-disable-next-line -- se23 specific styling
+    + .Item:not(.selected) > button {
+      clip-path: inset(0 0 0 var(--p-space-025));
+    }
   }
 
   .Item-focused {

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
@@ -56,7 +56,9 @@
 
     // stylelint-disable-next-line -- se23 specific styling
     + .Item:not(.selected) > button {
-      clip-path: inset(0 0 0 var(--p-space-025));
+      #{$se23} & {
+        clip-path: inset(0 0 0 var(--p-space-025));
+      }
     }
   }
 

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {Button, ButtonGroup} from '@shopify/polaris';
 
@@ -16,12 +16,74 @@ export function Default() {
 }
 
 export function WithSegmentedButtons() {
+  const [activeButtonIndex, setActiveButtonIndex] = useState(0);
+
+  const handleButtonClick = useCallback(
+    (index: number) => {
+      if (activeButtonIndex === index) return;
+      setActiveButtonIndex(index);
+    },
+    [activeButtonIndex],
+  );
   return (
-    <ButtonGroup segmented>
-      <Button>Bold</Button>
-      <Button pressed>Italic</Button>
-      <Button>Underline</Button>
-    </ButtonGroup>
+    <div>
+      <ButtonGroup segmented>
+        <Button>Bold</Button>
+        <Button pressed>Italic</Button>
+        <Button>Underline</Button>
+      </ButtonGroup>
+      <br />
+      <ButtonGroup segmented>
+        <Button
+          pressed={activeButtonIndex === 0}
+          onClick={() => handleButtonClick(0)}
+        >
+          Mercury
+        </Button>
+        <Button
+          pressed={activeButtonIndex === 1}
+          onClick={() => handleButtonClick(1)}
+        >
+          Venus
+        </Button>
+        <Button
+          pressed={activeButtonIndex === 2}
+          onClick={() => handleButtonClick(2)}
+        >
+          Earth
+        </Button>
+        <Button
+          pressed={activeButtonIndex === 3}
+          onClick={() => handleButtonClick(3)}
+        >
+          Mars
+        </Button>
+        <Button
+          pressed={activeButtonIndex === 4}
+          onClick={() => handleButtonClick(4)}
+        >
+          Jupiter
+        </Button>
+        <Button
+          pressed={activeButtonIndex === 5}
+          onClick={() => handleButtonClick(5)}
+        >
+          Saturn
+        </Button>
+        <Button
+          pressed={activeButtonIndex === 6}
+          onClick={() => handleButtonClick(6)}
+        >
+          Uranus
+        </Button>
+        <Button
+          pressed={activeButtonIndex === 7}
+          onClick={() => handleButtonClick(7)}
+        >
+          Neptune
+        </Button>
+      </ButtonGroup>
+    </div>
   );
 }
 
@@ -48,6 +110,7 @@ export function NoWrapButtons() {
         }}
       >
         <ButtonGroup>
+          <Button>Fifth</Button>
           <Button>Fourth</Button>
           <Button>Third</Button>
           <Button>Second</Button>
@@ -65,6 +128,7 @@ export function NoWrapButtons() {
         }}
       >
         <ButtonGroup noWrap>
+          <Button>Fifth</Button>
           <Button>Fourth</Button>
           <Button>Third</Button>
           <Button>Second</Button>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/970

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds a `clip-path` to buttons in `segmented-buttons` to achieve a cleaner look.

Bonus: Adds a longer segmented button example story, and adds a fifth button for proper testing of wrapping buttons for gen3.

![image](https://github.com/Shopify/polaris/assets/67433661/b60684b9-d130-4e23-a09b-b9a3da65cade)
