### PR TITLE
[SkeletonBodyText] Add wrapper to SkeletonBodyText

### DIFF
--- a/.changeset/sixty-ties-lick.md
+++ b/.changeset/sixty-ties-lick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Wrap SkeletonBodyText lines in a div (width 100%)

--- a/polaris-react/src/components/SkeletonBodyText/SkeletonBodyText.scss
+++ b/polaris-react/src/components/SkeletonBodyText/SkeletonBodyText.scss
@@ -2,6 +2,10 @@
 
 $body-text-last-line-width: 80%;
 
+.SkeletonBodyTextContainer {
+  width: 100%;
+}
+
 .SkeletonBodyText {
   height: var(--p-space-2);
   display: flex;

--- a/polaris-react/src/components/SkeletonBodyText/SkeletonBodyText.tsx
+++ b/polaris-react/src/components/SkeletonBodyText/SkeletonBodyText.tsx
@@ -17,5 +17,7 @@ export function SkeletonBodyText({lines = 3}: SkeletonBodyTextProps) {
     bodyTextLines.push(<div className={styles.SkeletonBodyText} key={i} />);
   }
 
-  return <>{bodyTextLines}</>;
+  return (
+    <div className={styles.SkeletonBodyTextContainer}>{bodyTextLines}</div>
+  );
 }

--- a/polaris-react/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
+++ b/polaris-react/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
@@ -6,11 +6,15 @@ import {SkeletonBodyText} from '../SkeletonBodyText';
 describe('<SkeletonBodyText />', () => {
   it('renders the amount of lines provided', () => {
     const skeletonBodyText = mountWithApp(<SkeletonBodyText lines={2} />);
-    expect(skeletonBodyText.findAll('div')).toHaveLength(2);
+    expect(
+      skeletonBodyText.findAll('div', {className: 'SkeletonBodyText'}),
+    ).toHaveLength(2);
   });
 
   it('renders 3 lines if none are provided', () => {
     const skeletonBodyText = mountWithApp(<SkeletonBodyText />);
-    expect(skeletonBodyText.findAll('div')).toHaveLength(3);
+    expect(
+      skeletonBodyText.findAll('div', {className: 'SkeletonBodyText'}),
+    ).toHaveLength(3);
   });
 });


### PR DESCRIPTION
Wrap individual lines of SkeletonBodyText in a div with width 100% This allows the lines to fill available space in cases when width isn't specified, as an item in a HorizontalStack for example.

### WHY are these changes introduced?

Fixes #9703 

### WHAT is this pull request doing?

Adds a `<div width=100%>` wrapper around `<SkeletonBodyText>` lines, so that they'll fill available horizontal space.

Before:
![image](https://github.com/Shopify/polaris/assets/107708248/b82da79b-0015-477d-b012-fe25ddc2828b)

After:
![image](https://github.com/Shopify/polaris/assets/107708248/2dcfd6b5-7d7c-4486-94cf-9f626c1b4fac)

As a note, in the example `<SkeletonThumbnail>` has a tendency to get squished in `<HorizontalStack>`s. Is this something we want to address? The most straightforward workaround I've found is to just wrap it in a `<div>`, no other styling required.

### How to 🎩

With the changes pulled down, run `yarn dev` and take a look at the examples under `SkeletonBodyText` and `SkeletonPage` - There shouldn't be any changes, with the exception of `SkeletonBodyText - Default` - The last line shows with a width of 80% now. I think this is closer to the intended behaviour, looking at the difference between the example in the [doc](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) and how it looks in the code sandbox 😮 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {
  Card,
  Text,
  HorizontalStack,
  Layout,
  LegacyStack,
  Page,
  SkeletonBodyText,
  SkeletonThumbnail,
} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Card>
        <Text variant="headingMd" as="h2">
          3 Lines, LegacyStack with LegacyStack.Item fill :D
        </Text>
        <Layout.Section />
        <LegacyStack wrap={false}>
          <SkeletonThumbnail size="small" />
          <LegacyStack.Item fill>
            <SkeletonBodyText lines={3} />
          </LegacyStack.Item>
        </LegacyStack>
      </Card>
      <Layout.Section />
      <Card>
        <Text variant="headingMd" as="h2">
          3 lines, in a HorizontalStack
        </Text>
        <Layout.Section />
        <HorizontalStack wrap={false} blockAlign="start" gap="4">
          <SkeletonThumbnail size="small" />
          <SkeletonBodyText lines={3} />
        </HorizontalStack>
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
