### PR TITLE
Rename `shadow-bevel` opt out class name

### DIFF
--- a/polaris-react/src/styles/_common.scss
+++ b/polaris-react/src/styles/_common.scss
@@ -24,4 +24,4 @@
 // However, we're still supporting iOS 12 for embedded web views in some apps, which
 // unfortunately doesn't support :where https://caniuse.com/?search=%3Awhere
 $se23: 'html[class~="Polaris-Summer-Editions-2023"]';
-$se23ShadowBevelOptOut: 'html[class~="Polaris-Summer-Editions-2023-Shadow-Bevel-Opt-Out"]';
+$se23ShadowBevelOptOut: 'html[class~="Polaris-SE23-Shadow-Bevel-Opt-Out"]';

--- a/polaris-react/src/utilities/features/context.ts
+++ b/polaris-react/src/utilities/features/context.ts
@@ -5,7 +5,7 @@ import type {FeaturesConfig} from './types';
 export const classNamePolarisSummerEditions2023 =
   'Polaris-Summer-Editions-2023';
 export const classNamePolarisSummerEditions2023ShadowBevelOptOut =
-  'Polaris-Summer-Editions-2023-Shadow-Bevel-Opt-Out';
+  'Polaris-SE23-Shadow-Bevel-Opt-Out';
 
 export const FeaturesContext = createContext<FeaturesConfig | undefined>(
   undefined,


### PR DESCRIPTION
This PR renames the `shadow-bevel` opt out class name to prevent the override styles from being enabled when the se23 beta-flag is active. There are existing selectors (`html[class*="Polaris-Summer-Editions-2023"]`) used throughout the organization that partially match the `shadow-bevel` opt out class, causing both the `shadow-bevel` and `border` styles to be applied at the same time. @sophschneider and I decided that renaming the class name within Polaris would be quicker and safer than [updating existing beta-flag selectors](https://github.com/Shopify/polaris/pull/9713#discussion_r1261904192) across the organization.