### PR TITLE
[TextField] Improve/Fix TextField's onKeyDown capture logic for arrow keys

### DIFF
--- a/.changeset/pretty-boats-pretend.md
+++ b/.changeset/pretty-boats-pretend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updating TextField to support ArrowUp and ArrowDown keypresses for "integer" type

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -683,11 +683,14 @@ export function TextField({
 
     const {key, which} = event;
 
-    if (type === 'integer' && key === 'ArrowUp') {
+    if (type === 'integer' && (key === 'ArrowUp' || which === Key.UpArrow)) {
       handleNumberChange(1);
       event.preventDefault();
     }
-    if (type === 'integer' && key === 'ArrowDown') {
+    if (
+      type === 'integer' &&
+      (key === 'ArrowDown' || which === Key.DownArrow)
+    ) {
       handleNumberChange(-1);
       event.preventDefault();
     }

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -682,6 +682,16 @@ export function TextField({
     }
 
     const {key, which} = event;
+
+    if (type === 'integer' && key === 'ArrowUp') {
+      handleNumberChange(1);
+      event.preventDefault();
+    }
+    if (type === 'integer' && key === 'ArrowDown') {
+      handleNumberChange(-1);
+      event.preventDefault();
+    }
+
     if ((which === Key.Home || key === 'Home') && min !== undefined) {
       if (onSpinnerChange != null) {
         onSpinnerChange(String(min), id);

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -1743,6 +1743,51 @@ describe('<TextField />', () => {
         jest.runOnlyPendingTimers();
         expect(spy).not.toHaveBeenCalled();
       });
+
+      describe('keydown events', () => {
+        it('decrements by 1 multiple of step when type is integer and ArrowDown is pressed', () => {
+          const spy = jest.fn();
+          const textField = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="integer"
+              value="10"
+              step={1}
+              onChange={spy}
+              autoComplete="off"
+            />,
+          );
+          textField.find('input')!.trigger('onKeyDown', {
+            key: 'ArrowDown',
+            which: Key.DownArrow,
+            preventDefault: noop,
+          });
+          expect(spy).toHaveBeenCalledWith('9', 'MyTextField');
+        });
+
+        it('increments by 1 multiple of step when type is integer and ArrowUp is pressed', () => {
+          const spy = jest.fn();
+          const textField = mountWithApp(
+            <TextField
+              id="MyTextField"
+              label="TextField"
+              type="integer"
+              value="10"
+              step={1}
+              largeStep={4}
+              onChange={spy}
+              autoComplete="off"
+            />,
+          );
+          textField.find('input')!.trigger('onKeyDown', {
+            key: 'ArrowUp',
+            which: Key.UpArrow,
+            preventDefault: noop,
+          });
+          expect(spy).toHaveBeenCalledWith('11', 'MyTextField');
+        });
+      });
     });
   });
 

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -1747,13 +1747,15 @@ describe('<TextField />', () => {
       describe('keydown events', () => {
         it('decrements by 1 multiple of step when type is integer and ArrowDown is pressed', () => {
           const spy = jest.fn();
+          const initialValue = 10;
+          const step = 1;
           const textField = mountWithApp(
             <TextField
               id="MyTextField"
               label="TextField"
               type="integer"
-              value="10"
-              step={1}
+              value={initialValue.toString()}
+              step={step}
               onChange={spy}
               autoComplete="off"
             />,
@@ -1763,18 +1765,23 @@ describe('<TextField />', () => {
             which: Key.DownArrow,
             preventDefault: noop,
           });
-          expect(spy).toHaveBeenCalledWith('9', 'MyTextField');
+          expect(spy).toHaveBeenCalledWith(
+            (initialValue - step).toString(),
+            'MyTextField',
+          );
         });
 
         it('increments by 1 multiple of step when type is integer and ArrowUp is pressed', () => {
           const spy = jest.fn();
+          const initialValue = 10;
+          const step = 9;
           const textField = mountWithApp(
             <TextField
               id="MyTextField"
               label="TextField"
               type="integer"
-              value="10"
-              step={1}
+              value={initialValue.toString()}
+              step={step}
               largeStep={4}
               onChange={spy}
               autoComplete="off"
@@ -1785,7 +1792,10 @@ describe('<TextField />', () => {
             which: Key.UpArrow,
             preventDefault: noop,
           });
-          expect(spy).toHaveBeenCalledWith('11', 'MyTextField');
+          expect(spy).toHaveBeenCalledWith(
+            (initialValue + step).toString(),
+            'MyTextField',
+          );
         });
       });
     });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where TextFields that have the prop `type="integer"` do not properly handle `onKeyDown` events for `ArrowUp` and `ArrowDown`. Ideally, we increment these values by 1 multiple of the `step` value.

Context: While working on the **Admin -> Products -> Catalogs** surface, we have a need for the `TextField` component to be able to handle `integer` inputs while also providing the ability to increment upward and downward with keypresses of `ArrowUp` and `ArrowDown`.

Demo after the fix is applied:
https://screenshot.click/20-27-irbo7-6glak.mp4
### WHAT is this pull request doing?
Resolves https://github.com/Shopify/polaris/issues/9779
The integer input type is not a standard input type in HTML5. HTML5 does not provide a specific input type specifically for integers. 

[the web](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) also doesn’t think that HTML5 inputs should take integer. if that’s the case, then it defaults to "text" . However, polaris textFields allow for an “integer” type when they [create input elements](https://github.com/Shopify/polaris/blob/d0477410d90946916e9dadcaf5cef2461be1909d/polaris-react/src/components/TextField/TextField.tsx#L540C1-L540C1). [this pr](https://github.com/Shopify/polaris/pull/9051) has some context on why “integer” was introduced. here is some TextFields.tsx code that i pseudo-coded to shorten:
```
type Type =
  | 'number'
  | 'integer'
  | ...
...
interface TextFieldProps {
  inputType?: Type;
  ...
}
...
const input = createElement('input', {
  type: inputType,
  ...
}
...
```

Since `<TextField type="integer" />` is essentially `<input type="text" />`, TextField.tsx will need to be responsible for handling some of the behavior that comes for free with `"number"` inputs. Some logic already exists but I noticed that "ArrowUp" and "ArrowDown" are specifically not being captured.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
