### PR TITLE
[Scrollable][Filters] Remove unwanted height in Scrollable Filters

### DIFF
--- a/.changeset/new-maps-own.md
+++ b/.changeset/new-maps-own.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[Scrollable] shadow overlays scrollable content correctly.

--- a/polaris-react/src/components/Popover/Popover.scss
+++ b/polaris-react/src/components/Popover/Popover.scss
@@ -62,8 +62,7 @@ $vertical-motion-offset: -5px;
 
 .ContentContainer {
   position: relative;
-  overflow-x: hidden;
-  overflow-y: hidden;
+  overflow: hidden;
   background: var(--p-color-bg);
   border-radius: var(--p-space-2);
 

--- a/polaris-react/src/components/Popover/Popover.scss
+++ b/polaris-react/src/components/Popover/Popover.scss
@@ -60,6 +60,23 @@ $vertical-motion-offset: -5px;
   }
 }
 
+.ContentContainer {
+  position: relative;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  background: var(--p-color-bg);
+  border-radius: var(--p-space-2);
+
+  /* Prevent Scrollable's box shadows overflowing the rounded corners of this
+   * element on Safari prior to tech preview version 156.
+   * See: https://bugs.webkit.org/show_bug.cgi?id=68196 */
+  isolation: isolate;
+
+  #{$se23} & {
+    border-radius: var(--p-space-3);
+  }
+}
+
 .Content {
   position: relative;
   display: flex;

--- a/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -19,8 +19,6 @@ import type {PaneProps} from '../Pane';
 import styles from '../../Popover.scss';
 import {PortalsManagerContext} from '../../../../utilities/portals';
 import type {PortalsContainerElement} from '../../../../utilities/portals';
-import {Box} from '../../../Box';
-import {UseFeatures} from '../../../../utilities/features';
 
 export enum PopoverCloseSource {
   Click,
@@ -232,18 +230,6 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       fluidContent && styles['Content-fluidContent'],
     );
 
-    const content = (
-      <div
-        id={id}
-        tabIndex={autofocusTarget === 'none' ? undefined : -1}
-        className={contentClassNames}
-        style={contentStyles}
-        ref={this.contentNode}
-      >
-        {renderPopoverContent(children, {captureOverscroll, sectioned})}
-      </div>
-    );
-
     return (
       <div className={className} {...overlay.props}>
         <EventListener event="click" handler={this.handleClick} />
@@ -255,19 +241,17 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
           tabIndex={0}
           onFocus={this.handleFocusFirstItem}
         />
-        <UseFeatures>
-          {(features) => (
-            <Box
-              position="relative"
-              overflowX="hidden"
-              overflowY="hidden"
-              background="bg"
-              borderRadius={features.polarisSummerEditions2023 ? '3' : '2'}
-            >
-              {content}
-            </Box>
-          )}
-        </UseFeatures>
+        <div className={styles.ContentContainer}>
+          <div
+            id={id}
+            tabIndex={autofocusTarget === 'none' ? undefined : -1}
+            className={contentClassNames}
+            style={contentStyles}
+            ref={this.contentNode}
+          >
+            {renderPopoverContent(children, {captureOverscroll, sectioned})}
+          </div>
+        </div>
         <div
           className={styles.FocusTracker}
           // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex

--- a/polaris-react/src/components/Scrollable/Scrollable.scss
+++ b/polaris-react/src/components/Scrollable/Scrollable.scss
@@ -2,12 +2,11 @@
   // stylelint-disable -- Polaris component custom properties
   --pc-scrollable-shadow-size: var(--p-space-5);
   --pc-scrollable-shadow-color: rgba(0, 0, 0, 0.15);
-  --pc-scrollable-shadow-bottom: inset 0
-    calc(-1 * var(--pc-scrollable-shadow-size)) var(--pc-scrollable-shadow-size)
-    calc(-1 * var(--pc-scrollable-shadow-size))
+  --pc-scrollable-shadow-bottom: 0 var(--pc-scrollable-shadow-size)
+    var(--pc-scrollable-shadow-size) var(--pc-scrollable-shadow-size)
     var(--pc-scrollable-shadow-color);
-  --pc-scrollable-shadow-top: inset 0 var(--pc-scrollable-shadow-size)
-    var(--pc-scrollable-shadow-size) calc(-1 * var(--pc-scrollable-shadow-size))
+  --pc-scrollable-shadow-top: 0 calc(-1 * var(--pc-scrollable-shadow-size))
+    var(--pc-scrollable-shadow-size) var(--pc-scrollable-shadow-size)
     var(--pc-scrollable-shadow-color);
   --pc-scrollable-max-height: none;
   // stylelint-enable
@@ -17,6 +16,11 @@
   max-height: var(--pc-scrollable-max-height);
   overflow-x: hidden;
   overflow-y: hidden;
+
+  /* Prevent Scrollable's box shadows overflowing the rounded corners of this
+   * element on Safari prior to tech preview version 156.
+   * See: https://bugs.webkit.org/show_bug.cgi?id=68196 */
+  isolation: isolate;
 
   &:focus {
     outline: var(--p-border-width-2) solid
@@ -33,24 +37,27 @@
     &::before,
     &::after {
       content: '';
-      pointer-events: none;
 
       /* Using CSS sticky to position the pseudo elements relative to the scroll
        * container insead of relative to the contents */
       position: sticky;
 
-      /* left/float/margin-right ensures it does not take up any static space,
-       * but still abides by position: sticky rules (ie; sorta position: fixed,
-       * but relative to the scroll container). */
+      // Stick it to the left
       left: 0;
-      float: left;
-      // stylelint-disable-next-line -- Can't use a token value here
-      margin-right: -100%;
 
-      /* Full width, but only as high as the shadow needs to be */
+      // Ensure we can give it an explicit height of 0 later
+      display: block;
+
+      // No one likes clicking on shadows!
+      pointer-events: none;
+
+      /* height: 0 ensures it does not take up any static space, but still
+       * abides by position: sticky rules (ie; sorta position: fixed, but
+       * relative to the scroll container). */
+      height: var(--p-space-0);
+
+      /* Full width to cover the entire scrollable container */
       width: 100%;
-      // stylelint-disable-next-line -- Using custom variable here for the height
-      height: var(--pc-scrollable-shadow-size);
 
       /* Arbitrarily picked this because it sorta sits above other elements most
       * of the time without obscuring modals that might be above, etc.
@@ -60,12 +67,12 @@
     }
 
     &::before {
-      // First element ticks to the top
+      // First element ticks to the top left
       top: 0;
     }
 
     &::after {
-      // Last element sticks to the bottom
+      // Last element sticks to the bottom left
       bottom: 0;
     }
   }

--- a/polaris-react/src/components/Scrollable/Scrollable.scss
+++ b/polaris-react/src/components/Scrollable/Scrollable.scss
@@ -42,7 +42,6 @@
        * container insead of relative to the contents */
       position: sticky;
 
-      // Stick it to the left
       left: 0;
 
       // Ensure we can give it an explicit height of 0 later


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/Shopify/polaris/pull/9752

- Before https://github.com/Shopify/polaris/pull/9752:
    - ![scrollable-bug-before](https://github.com/Shopify/polaris/assets/612020/222d975f-f37c-4d44-9876-caff262fbff9)
    - [Storybook](https://5d559397bae39100201eedc1-rxdryckmpi.chromatic.com/?path=/story/all-components-filters--with-a-resource-list&globals=polarisSummerEditions2023:true)
- After https://github.com/Shopify/polaris/pull/9752:
    - ![scrollable-bug-after](https://github.com/Shopify/polaris/assets/612020/4af71673-d5ed-46e8-bdcb-83e46553ae5f)
    - [Storybook](https://5d559397bae39100201eedc1-evnicxtjes.chromatic.com/?path=/story/all-components-filters--with-a-resource-list&globals=polarisSummerEditions2023:true)
- This PR:
    - ![scrollable-bug-fixed](https://github.com/Shopify/polaris/assets/612020/69ed976d-b4cb-42aa-aef5-5e1aadad81aa)
    - [Storybook](https://5d559397bae39100201eedc1-fpskayihlk.chromatic.com/?path=/story/all-components-filters--with-a-resource-list&globals=polarisSummerEditions2023:true)