### PR TITLE
Update `font-weight` and `letter-spacing` for Inter font

### DIFF
--- a/.changeset/early-coats-trade.md
+++ b/.changeset/early-coats-trade.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'@shopify/polaris-tokens': patch
+---
+
+Updated experimental `font-weight` and `letter-spacing` for Inter font

--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -5,6 +5,6 @@
   crossorigin="anonymous"
 />
 <link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
   rel="stylesheet"
 />

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -56,52 +56,46 @@
   color: var(--p-color-text-inverse);
 }
 
-@mixin se23-headingSm {
-  font-size: var(--p-font-size-80-experimental);
-  line-height: var(--p-font-line-height-2);
-}
-
-.headingXs {
+@mixin text-heading-xs {
   font-size: var(--p-font-size-75);
+  font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-font-line-height-1);
-  font-weight: var(--p-font-weight-semibold);
-
-  #{$se23} & {
-    @include se23-headingSm;
-  }
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
 }
 
-.headingSm {
+@mixin text-heading-sm {
   font-size: var(--p-font-size-100);
-  line-height: var(--p-font-line-height-2);
   font-weight: var(--p-font-weight-semibold);
-
-  #{$se23} & {
-    @include se23-headingSm;
-  }
+  line-height: var(--p-font-line-height-2);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
 }
 
-.headingMd {
+@mixin text-heading-sm-experimental {
+  font-size: var(--p-font-size-80-experimental);
+  font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-font-line-height-2);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+}
+
+@mixin text-heading-md {
   font-size: var(--p-font-size-200);
+  font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-font-line-height-3);
-  font-weight: var(--p-font-weight-semibold);
-
-  #{$se23} & {
-    font-size: var(--p-font-size-100);
-    line-height: var(--p-font-line-height-2);
-  }
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
 }
 
-.headingLg {
-  font-size: var(--p-font-size-200);
-  line-height: var(--p-font-line-height-2);
+@mixin text-heading-md-experimental {
+  font-size: var(--p-font-size-100);
   font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-font-line-height-2);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+}
 
-  #{$se23} & {
-    font-size: var(--p-font-size-300);
-    line-height: var(--p-font-line-height-3);
-    font-weight: var(--p-font-weight-bold);
-  }
+@mixin text-heading-lg {
+  font-size: var(--p-font-size-200);
+  font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-font-line-height-2);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
 
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-300);
@@ -109,109 +103,224 @@
   }
 }
 
-.headingXl {
+@mixin text-heading-lg-experimental {
   font-size: var(--p-font-size-300);
+  font-weight: var(--p-font-weight-extra-semibold-experimental);
   line-height: var(--p-font-line-height-3);
-  font-weight: var(--p-font-weight-semibold);
+  letter-spacing: var(--p-font-letter-spacing-tight-experimental);
+}
 
-  #{$se23} & {
-    font-weight: var(--p-font-weight-bold);
-  }
+@mixin text-heading-xl {
+  font-size: var(--p-font-size-300);
+  font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-font-line-height-3);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
 
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-400);
     line-height: var(--p-font-line-height-4);
-
-    #{$se23} & {
-      line-height: var(--p-font-line-height-5);
-    }
   }
 }
 
-.heading2xl {
+@mixin text-heading-xl-experimental {
   font-size: var(--p-font-size-300);
+  font-weight: var(--p-font-weight-extra-semibold-experimental);
   line-height: var(--p-font-line-height-3);
-  font-weight: var(--p-font-weight-semibold);
+  letter-spacing: var(--p-font-letter-spacing-tight-experimental);
 
-  #{$se23} & {
+  @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-400);
-    line-height: var(--p-font-line-height-5);
     font-weight: var(--p-font-weight-bold);
+    line-height: var(--p-font-line-height-5);
+    letter-spacing: var(--p-font-letter-spacing-tight-experimental);
   }
+}
+
+@mixin text-heading-2xl {
+  font-size: var(--p-font-size-300);
+  font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-font-line-height-3);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
 
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-500);
     line-height: var(--p-font-line-height-5);
-
-    #{$se23} & {
-      // Specificity bump
-      font-size: var(--p-font-size-500);
-      line-height: var(--p-font-line-height-6);
-    }
   }
 }
 
-@mixin se23-heading3xl {
-  font-size: var(--p-font-size-500);
-  line-height: var(--p-font-line-height-6);
+@mixin text-heading-2xl-experimental {
+  font-size: var(--p-font-size-400);
   font-weight: var(--p-font-weight-bold);
+  line-height: var(--p-font-line-height-5);
+  letter-spacing: var(--p-font-letter-spacing-tight-experimental);
 
   @media #{$p-breakpoints-md-up} {
-    font-size: var(--p-font-size-600);
-    line-height: var(--p-font-line-height-7);
+    font-size: var(--p-font-size-500);
+    line-height: var(--p-font-line-height-6);
+    letter-spacing: var(--p-font-letter-spacing-tighter-experimental);
   }
 }
 
-.heading3xl {
+@mixin text-heading-3xl {
   font-size: var(--p-font-size-400);
-  line-height: var(--p-font-line-height-4);
   font-weight: var(--p-font-weight-semibold);
+  line-height: var(--p-font-line-height-4);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
 
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-600);
     line-height: var(--p-font-line-height-6);
   }
+}
 
-  #{$se23} & {
-    @include se23-heading3xl;
+@mixin text-heading-3xl-experimental {
+  font-size: var(--p-font-size-500);
+  font-weight: var(--p-font-weight-bold);
+  line-height: var(--p-font-line-height-6);
+  letter-spacing: var(--p-font-letter-spacing-tighter-experimental);
+
+  @media #{$p-breakpoints-md-up} {
+    font-size: var(--p-font-size-600);
+    line-height: var(--p-font-line-height-7);
+    letter-spacing: var(--p-font-letter-spacing-tightest-experimental);
   }
 }
 
-.heading4xl {
+@mixin text-heading-4xl {
   font-size: var(--p-font-size-600);
-  line-height: var(--p-font-line-height-6);
   font-weight: var(--p-font-weight-bold);
+  line-height: var(--p-font-line-height-6);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
 
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-700);
     line-height: var(--p-font-line-height-7);
   }
+}
+
+@mixin text-body-xs-experimental {
+  font-size: var(--p-font-size-70-experimental);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-font-line-height-075-experimental);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+}
+
+@mixin text-body-sm {
+  font-size: var(--p-font-size-75);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-font-line-height-1);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+}
+
+@mixin text-body-md {
+  font-size: var(--p-font-size-100);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-font-line-height-2);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+}
+
+@mixin text-body-md-experimental {
+  font-size: var(--p-font-size-80-experimental);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-font-line-height-2);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+}
+
+@mixin text-body-lg {
+  font-size: var(--p-font-size-200);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-font-line-height-2);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+}
+
+@mixin text-body-lg-experimental {
+  font-size: var(--p-font-size-100);
+  font-weight: var(--p-font-weight-regular);
+  line-height: var(--p-font-line-height-2);
+  letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+}
+
+.headingXs {
+  @include text-heading-xs;
 
   #{$se23} & {
-    @include se23-heading3xl;
+    @include text-heading-sm-experimental;
+  }
+}
+
+.headingSm {
+  @include text-heading-sm;
+
+  #{$se23} & {
+    @include text-heading-sm-experimental;
+  }
+}
+
+.headingMd {
+  @include text-heading-md;
+
+  #{$se23} & {
+    @include text-heading-md-experimental;
+  }
+}
+
+.headingLg {
+  @include text-heading-lg;
+
+  #{$se23} & {
+    @include text-heading-lg-experimental;
+  }
+}
+
+.headingXl {
+  @include text-heading-xl;
+
+  #{$se23} & {
+    @include text-heading-xl-experimental;
+  }
+}
+
+.heading2xl {
+  @include text-heading-2xl;
+
+  #{$se23} & {
+    @include text-heading-2xl-experimental;
+  }
+}
+
+.heading3xl {
+  @include text-heading-3xl;
+
+  #{$se23} & {
+    @include text-heading-3xl-experimental;
+  }
+}
+
+.heading4xl {
+  @include text-heading-4xl;
+
+  #{$se23} & {
+    @include text-heading-3xl-experimental;
   }
 }
 
 .bodySm {
-  font-size: var(--p-font-size-75);
-  line-height: var(--p-font-line-height-1);
+  @include text-body-sm;
 }
 
 .bodyMd {
-  font-size: var(--p-font-size-100);
-  line-height: var(--p-font-line-height-2);
+  @include text-body-md;
 
   #{$se23} & {
-    font-size: var(--p-font-size-80-experimental);
+    @include text-body-md-experimental;
   }
 }
 
 .bodyLg {
-  font-size: var(--p-font-size-200);
-  line-height: var(--p-font-line-height-2);
+  @include text-body-lg;
 
   #{$se23} & {
-    font-size: var(--p-font-size-100);
+    @include text-body-lg-experimental;
   }
 }
 

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -61,6 +61,10 @@
   font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-font-line-height-1);
   letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+
+  #{$se23} & {
+    @include text-heading-sm-experimental;
+  }
 }
 
 @mixin text-heading-sm {
@@ -68,6 +72,10 @@
   font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-font-line-height-2);
   letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+
+  #{$se23} & {
+    @include text-heading-sm-experimental;
+  }
 }
 
 @mixin text-heading-sm-experimental {
@@ -82,6 +90,10 @@
   font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-font-line-height-3);
   letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+
+  #{$se23} & {
+    @include text-heading-md-experimental;
+  }
 }
 
 @mixin text-heading-md-experimental {
@@ -101,6 +113,10 @@
     font-size: var(--p-font-size-300);
     line-height: var(--p-font-line-height-3);
   }
+
+  #{$se23} & {
+    @include text-heading-lg-experimental;
+  }
 }
 
 @mixin text-heading-lg-experimental {
@@ -119,6 +135,10 @@
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-400);
     line-height: var(--p-font-line-height-4);
+  }
+
+  #{$se23} & {
+    @include text-heading-xl-experimental;
   }
 }
 
@@ -146,6 +166,10 @@
     font-size: var(--p-font-size-500);
     line-height: var(--p-font-line-height-5);
   }
+
+  #{$se23} & {
+    @include text-heading-2xl-experimental;
+  }
 }
 
 @mixin text-heading-2xl-experimental {
@@ -170,6 +194,10 @@
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-600);
     line-height: var(--p-font-line-height-6);
+  }
+
+  #{$se23} & {
+    @include text-heading-3xl-experimental;
   }
 }
 
@@ -196,6 +224,10 @@
     font-size: var(--p-font-size-700);
     line-height: var(--p-font-line-height-7);
   }
+
+  #{$se23} & {
+    @include text-heading-3xl-experimental;
+  }
 }
 
 @mixin text-body-xs-experimental {
@@ -217,6 +249,10 @@
   font-weight: var(--p-font-weight-regular);
   line-height: var(--p-font-line-height-2);
   letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+
+  #{$se23} & {
+    @include text-body-md-experimental;
+  }
 }
 
 @mixin text-body-md-experimental {
@@ -231,6 +267,10 @@
   font-weight: var(--p-font-weight-regular);
   line-height: var(--p-font-line-height-2);
   letter-spacing: var(--p-font-letter-spacing-normal-experimental);
+
+  #{$se23} & {
+    @include text-body-lg-experimental;
+  }
 }
 
 @mixin text-body-lg-experimental {
@@ -242,66 +282,34 @@
 
 .headingXs {
   @include text-heading-xs;
-
-  #{$se23} & {
-    @include text-heading-sm-experimental;
-  }
 }
 
 .headingSm {
   @include text-heading-sm;
-
-  #{$se23} & {
-    @include text-heading-sm-experimental;
-  }
 }
 
 .headingMd {
   @include text-heading-md;
-
-  #{$se23} & {
-    @include text-heading-md-experimental;
-  }
 }
 
 .headingLg {
   @include text-heading-lg;
-
-  #{$se23} & {
-    @include text-heading-lg-experimental;
-  }
 }
 
 .headingXl {
   @include text-heading-xl;
-
-  #{$se23} & {
-    @include text-heading-xl-experimental;
-  }
 }
 
 .heading2xl {
   @include text-heading-2xl;
-
-  #{$se23} & {
-    @include text-heading-2xl-experimental;
-  }
 }
 
 .heading3xl {
   @include text-heading-3xl;
-
-  #{$se23} & {
-    @include text-heading-3xl-experimental;
-  }
 }
 
 .heading4xl {
   @include text-heading-4xl;
-
-  #{$se23} & {
-    @include text-heading-3xl-experimental;
-  }
 }
 
 .bodySm {
@@ -310,18 +318,10 @@
 
 .bodyMd {
   @include text-body-md;
-
-  #{$se23} & {
-    @include text-body-md-experimental;
-  }
 }
 
 .bodyLg {
   @include text-body-lg;
-
-  #{$se23} & {
-    @include text-body-lg-experimental;
-  }
 }
 
 // font-weight must be below variant styles so

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -40,11 +40,18 @@ export type FontWeightAlias =
   | 'bold'
   | FontWeightAliasExperimental;
 
+type FontLetterSpacingAliasExperimental = Experimental<
+  'tightest' | 'tighter' | 'tight' | 'normal'
+>;
+
+export type FontLetterSpacingAlias = FontLetterSpacingAliasExperimental;
+
 export type FontTokenName =
   | `font-family-${FontFamilyAlias}`
   | `font-size-${FontSizeScale}`
   | `font-weight-${FontWeightAlias}`
-  | `font-line-height-${FontLineHeightScale}`;
+  | `font-line-height-${FontLineHeightScale}`
+  | `font-letter-spacing-${FontLetterSpacingAlias}`;
 
 export type FontTokenGroup = {
   [TokenName in FontTokenName]: string;
@@ -139,5 +146,17 @@ export const font: {
   },
   'font-line-height-7': {
     value: '48px',
+  },
+  'font-letter-spacing-tightest-experimental': {
+    value: '-0.24px',
+  },
+  'font-letter-spacing-tighter-experimental': {
+    value: '-0.16px',
+  },
+  'font-letter-spacing-tight-experimental': {
+    value: '-0.08px',
+  },
+  'font-letter-spacing-normal-experimental': {
+    value: '0px',
   },
 };

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -148,13 +148,13 @@ export const font: {
     value: '48px',
   },
   'font-letter-spacing-tightest-experimental': {
-    value: '-0.24px',
+    value: '-0.54px',
   },
   'font-letter-spacing-tighter-experimental': {
-    value: '-0.16px',
+    value: '-0.3px',
   },
   'font-letter-spacing-tight-experimental': {
-    value: '-0.08px',
+    value: '-0.2px',
   },
   'font-letter-spacing-normal-experimental': {
     value: '0px',

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -29,9 +29,7 @@ export type FontLineHeightScale =
   | '7'
   | FontLineHeightScaleExperimental;
 
-type FontWeightAliasExperimental = Experimental<
-  'extra-medium' | 'extra-semibold'
->;
+type FontWeightAliasExperimental = Experimental<'extra-semibold'>;
 
 export type FontWeightAlias =
   | 'regular'
@@ -106,13 +104,9 @@ export const font: {
   },
   'font-weight-regular': {
     value: '400',
-    valueExperimental: '450',
   },
   'font-weight-medium': {
     value: '500',
-  },
-  'font-weight-extra-medium-experimental': {
-    value: '550',
   },
   'font-weight-semibold': {
     value: '600',

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -29,7 +29,16 @@ export type FontLineHeightScale =
   | '7'
   | FontLineHeightScaleExperimental;
 
-export type FontWeightAlias = 'regular' | 'medium' | 'semibold' | 'bold';
+type FontWeightAliasExperimental = Experimental<
+  'extra-medium' | 'extra-semibold'
+>;
+
+export type FontWeightAlias =
+  | 'regular'
+  | 'medium'
+  | 'semibold'
+  | 'bold'
+  | FontWeightAliasExperimental;
 
 export type FontTokenName =
   | `font-family-${FontFamilyAlias}`
@@ -90,12 +99,19 @@ export const font: {
   },
   'font-weight-regular': {
     value: '400',
+    valueExperimental: '450',
   },
   'font-weight-medium': {
     value: '500',
   },
+  'font-weight-extra-medium-experimental': {
+    value: '550',
+  },
   'font-weight-semibold': {
     value: '600',
+  },
+  'font-weight-extra-semibold-experimental': {
+    value: '650',
   },
   'font-weight-bold': {
     value: '700',


### PR DESCRIPTION
WIP

Closes https://github.com/Shopify/polaris-summer-editions/issues/972

This PR applies a collection of typography changes following the recent introduction of the `Inter` font:
- Updated and added `font-weight` tokens
- Added `letter-spacing` tokens
- Reorganized `Text` composite token variants into Sass mixins
  - These are consumed by the `Text` variant classes. However, we will now have access to these composite styles in stylesheets that haven't or can't upgrade to use `Text`
  - TODO: Replace hard coded `font` tokens with `text-*` mixins in all components (quickly counted +200 instances)
- Updated the Storybook Google Fonts URL to use [the weight range syntax](https://fonts.google.com/knowledge/using_type/loading_variable_fonts_on_the_web)
  - TODO: Add documentation containing a brief snippet for consumers

![Screenshot 2023-07-20 at 11 01 29 AM](https://github.com/Shopify/polaris/assets/32409546/0ee3a820-9ff4-463f-a8a2-7debdb1c9ae3)
