### PR TITLE
Updated bg-transparent-subdued value

### DIFF
--- a/.changeset/silly-snakes-grow.md
+++ b/.changeset/silly-snakes-grow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': patch
+---
+
+Updated bg-transparent-subdued token value

--- a/.changeset/silly-snakes-grow.md
+++ b/.changeset/silly-snakes-grow.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris-tokens': patch
----
-
-Updated bg-transparent-subdued token value

--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -938,7 +938,7 @@ export const color: {
     description: '',
   },
   'color-bg-transparent-subdued-experimental': {
-    value: colorsExperimental.gray[16]('0.05'),
+    value: colorsExperimental.gray[16]('0.07'),
     description: '',
   },
   'color-bg-transparent-hover-experimental': {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/997

### WHAT is this pull request doing?

This PR updates bg-transparent-subdued value to increase contrast of default badges

<img width="841" alt="image" src="https://github.com/Shopify/polaris/assets/8629173/3ae74bea-b493-45b4-bf0f-d92656c523a4">

