### PR TITLE
Icon button plain destructive `active` and `hover` styles

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -1080,7 +1080,7 @@
       fill: var(--p-color-bg-critical-strong-hover);
 
       #{$se23} & {
-        fill: var(--p-color-icon-critical-strong-experimental);
+        fill: var(--p-color-icon-critical-hover-experimental);
       }
     }
 
@@ -1093,7 +1093,7 @@
       fill: var(--p-color-bg-critical-strong-active);
 
       #{$se23} & {
-        fill: var(--p-color-icon-critical-strong-experimental);
+        fill: var(--p-color-icon-critical-active-experimental);
       }
     }
 

--- a/polaris-tokens/src/token-groups/color.ts
+++ b/polaris-tokens/src/token-groups/color.ts
@@ -179,12 +179,14 @@ type ColorTextAliasExperimental = Experimental<
 >;
 
 type ColorIconAliasExperimental = Experimental<
+  | 'icon-critical-active'
+  | 'icon-critical-hover'
+  | 'icon-critical-strong-active'
+  | 'icon-critical-strong-hover'
+  | 'icon-critical-strong'
   | 'icon-info-strong'
   | 'icon-success-strong'
   | 'icon-warning-strong'
-  | 'icon-critical-strong'
-  | 'icon-critical-strong-hover'
-  | 'icon-critical-strong-active'
 >;
 
 type ColorBorderAliasExperimental = Experimental<
@@ -1018,6 +1020,14 @@ export const color: {
     description: '',
   },
   'color-icon-critical-strong-active-experimental': {
+    value: colorsExperimental.red[16],
+    description: '',
+  },
+  'color-icon-critical-hover-experimental': {
+    value: colorsExperimental.red[15],
+    description: '',
+  },
+  'color-icon-critical-active-experimental': {
     value: colorsExperimental.red[16],
     description: '',
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/994

### WHAT is this pull request doing?

Updates the hover and active color for the `plain` `destructive` icon only buttons

<img width="128" alt="Screenshot 2023-07-20 at 2 31 21 PM" src="https://github.com/Shopify/polaris/assets/3474483/7c6f380b-b795-4f01-b161-4443522da92d">


### How to 🎩
Review in Storybook with the beta flag turned on