### PR TITLE
Revert "Updated `Breadcrumb` back button styling (#9733)"

### DIFF
--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,8 +6,6 @@ import {UnstyledLink} from '../UnstyledLink';
 import type {CallbackAction, LinkAction} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {Text} from '../Text';
-import {Button} from '../Button';
-import {useFeatures} from '../../utilities/features';
 
 import styles from './Breadcrumbs.scss';
 
@@ -18,7 +16,6 @@ export interface BreadcrumbsProps {
 
 export function Breadcrumbs({backAction}: BreadcrumbsProps) {
   const {content} = backAction;
-  const {polarisSummerEditions2023} = useFeatures();
 
   const contentMarkup = (
     <>
@@ -55,22 +52,5 @@ export function Breadcrumbs({backAction}: BreadcrumbsProps) {
       </button>
     );
 
-  const summerEditionsBreadcrumbMarkup = (
-    <Button
-      key={content}
-      url={'url' in backAction ? backAction.url : undefined}
-      onPointerDown={handleMouseUpByBlurring}
-      aria-label={backAction.accessibilityLabel}
-      icon={ArrowLeftMinor}
-      accessibilityLabel={content}
-    />
-  );
-
-  return (
-    <nav role="navigation">
-      {polarisSummerEditions2023
-        ? summerEditionsBreadcrumbMarkup
-        : breadcrumbMarkup}
-    </nav>
-  );
+  return <nav role="navigation">{breadcrumbMarkup}</nav>;
 }

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -15,29 +15,6 @@ $action-menu-rollup-computed-width: 40px;
 
 .BreadcrumbWrapper {
   grid-area: breadcrumbs;
-
-  #{$se23} & {
-    /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
-    a,
-    button {
-      background-color: transparent;
-      border-radius: var(--p-border-radius-2);
-      box-shadow: none;
-
-      /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
-      &:hover {
-        box-shadow: none;
-        background-color: var(--p-color-bg-strong-hover);
-      }
-
-      /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
-      &:focus {
-        background-color: var(--p-color-bg-strong-active);
-        /* stylelint-disable-next-line declaration-no-important -- SE23 match button group */
-        box-shadow: var(--p-shadow-inset-md) !important;
-      }
-    }
-  }
 }
 
 .PaginationWrapper {

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -96,7 +96,7 @@ export interface BaseButton {
   /** Callback when element is touched */
   onTouchStart?(): void;
   /** Callback when pointerdown event is being triggered */
-  onPointerDown?(event: React.PointerEvent<HTMLButtonElement>): void;
+  onPointerDown?(): void;
 }
 
 export interface Action {


### PR DESCRIPTION
This reverts commit 79e604b340c4a80fcd45ab40a19c8210319bbea5.

Fixes https://github.com/Shopify/polaris-summer-editions/issues/1002

But opens https://github.com/Shopify/polaris-summer-editions/issues/947