### PR TITLE
Revert "[Button] Add vertical align middle to plain buttons"

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -574,7 +574,6 @@
     --pc-button-color-active: var(--p-color-bg-transparent-active-experimental);
     // stylelint-enable polaris/conventions/polaris/custom-property-allowed-list -- se23 temporary styles
     box-shadow: none;
-    vertical-align: middle;
 
     // stylelint-disable-next-line selector-max-combinators -- se23 temporary styles
     path {
@@ -805,7 +804,6 @@
 
   #{$se23} & {
     box-shadow: none;
-    vertical-align: middle;
     // stylelint-disable-next-line -- polaris/conventions/polaris/custom-property-allowed-list
     margin: calc(-1 * var(--pc-button-vertical-padding))
       calc(-1 * var(--p-space-3));


### PR DESCRIPTION
Reverts Shopify/polaris#9743

This was causing regressions with buttons inline with text. We will consider alternative fixes for the original issue https://github.com/Shopify/polaris-summer-editions/issues/926

![image](https://github.com/Shopify/polaris/assets/11774595/427d0369-18be-4e25-8a47-ac519dd78b9c)
