### PR TITLE
[Frame] Fix --pc-sidebar-width to 356px

### DIFF
--- a/.changeset/yellow-fishes-wave.md
+++ b/.changeset/yellow-fishes-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[Frame] Fix --pc-sidebar-width to 356px

--- a/polaris-react/src/components/Frame/Frame.scss
+++ b/polaris-react/src/components/Frame/Frame.scss
@@ -7,7 +7,7 @@ $sidebar-breakpoint: 1200px;
   --pc-frame-button-size: var(--p-space-8);
   --pc-nav-width: 240px;
   --pc-topbar-height: 56px;
-  --pc-sidebar-width: 376px;
+  --pc-sidebar-width: 356px;
   /* stylelint-enable */
   width: 100%;
   min-height: 100vh;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes Frame sidebar width to the correct value.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
