### PR TITLE
Allow `rel` on Links

### DIFF
--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -20,6 +20,8 @@ export interface LinkProps {
   external?: boolean;
   /** Where to display the url */
   target?: Target;
+  /** Defines the relationship between a linked resource and the current document */
+  rel?: Target;
   /** Makes the link color the same as the current text color and adds an underline */
   monochrome?: boolean;
   /** Removes text decoration underline to the link */
@@ -38,6 +40,7 @@ export function Link({
   onClick,
   external,
   target,
+  rel,
   id,
   monochrome,
   removeUnderline,
@@ -62,6 +65,7 @@ export function Link({
             url={url}
             external={external}
             target={target}
+            rel={rel}
             id={id}
             aria-label={accessibilityLabel}
             data-primary-link={dataPrimaryLink}

--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -21,7 +21,7 @@ export interface LinkProps {
   /** Where to display the url */
   target?: Target;
   /** Defines the relationship between a linked resource and the current document */
-  rel?: Target;
+  rel?: string;
   /** Makes the link color the same as the current text color and adds an underline */
   monochrome?: boolean;
   /** Removes text decoration underline to the link */

--- a/polaris-react/src/utilities/link/types.ts
+++ b/polaris-react/src/utilities/link/types.ts
@@ -10,6 +10,8 @@ export interface LinkLikeComponentProps
   external?: boolean;
   /** Where to display the url */
   target?: Target;
+  /** Defines the relationship between a linked resource and the current document */
+  rel?: string;
   /** Makes the browser download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value. */
   download?: string | boolean;
   [key: string]: any;


### PR DESCRIPTION
### WHY are these changes introduced?

The `rel` attribute defines the relationship between a linked document and the current document. Polaris should allow passing it through to underlying `<a>` elements.

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel