### PR TITLE
Fix missing Inter font on existing `font-family-sans` usages

### DIFF
--- a/polaris-react/src/components/AppProvider/AppProvider.scss
+++ b/polaris-react/src/components/AppProvider/AppProvider.scss
@@ -40,10 +40,6 @@ html,
 body,
 button {
   font-family: var(--p-font-family-sans);
-
-  #{$se23} & {
-    font-family: var(--p-font-family-sans-experimental);
-  }
 }
 
 html {

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -45,7 +45,8 @@ export const font: {
   'font-family-sans': {
     value:
       "-apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
-      valueExperimental: "'Inter', -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
+    valueExperimental:
+      "'Inter', -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
   },
   'font-family-mono': {
     value:

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -1,8 +1,6 @@
 import type {MetadataProperties, Experimental} from '../types';
 
-type FontFamilyAliasExperimental = Experimental<'sans'>;
-
-type FontFamilyAlias = 'sans' | 'mono' | FontFamilyAliasExperimental;
+type FontFamilyAlias = 'sans' | 'mono';
 
 type FontSizeScaleExperimental = Experimental<'70' | '80'>;
 
@@ -47,10 +45,7 @@ export const font: {
   'font-family-sans': {
     value:
       "-apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
-  },
-  'font-family-sans-experimental': {
-    value:
-      "'Inter', -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
+      valueExperimental: "'Inter', -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
   },
   'font-family-mono': {
     value:


### PR DESCRIPTION
This PR fixes ~130 missing Inter fonts across the organization by moving the experimental font stack to `font['font-family-sans'].valueExperimental`.

Before:

![image](https://github.com/Shopify/polaris/assets/32409546/051bb666-f46f-4d5a-a064-03e75f86a159)

After:

![image](https://github.com/Shopify/polaris/assets/32409546/4acf2fbc-dccb-4d48-af03-d3684cbf07f9)

