### PR TITLE
[Page] Fix additionalMeta alignment with no BackAction

### DIFF
--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -204,6 +204,21 @@ export function WithSubtitleAndAdditionalMetadata() {
   );
 }
 
+export function WithSubtitleAndAdditionalMetadataAndNoBackAction() {
+  return (
+    <Page
+      title="Invoice"
+      subtitle="Statement period: May 3, 2019 to June 2, 2019"
+      additionalMetadata="Net payment due: Within 60 days of receipt"
+      secondaryActions={[{content: 'Download', icon: ArrowDownMinor}]}
+    >
+      <LegacyCard title="Credit card" sectioned>
+        <p>Credit card information</p>
+      </LegacyCard>
+    </Page>
+  );
+}
+
 export function WithExternalLink() {
   return (
     <Page

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -128,7 +128,7 @@ $action-menu-rollup-computed-width: 40px;
     margin-left: calc(
       var(--p-space-5) * 2 + var(--p-space-2) + var(--p-space-1)
     );
-
+    // Because of this line, we need an additional #{$se23} & specificity buster for .noBreadcrumbs below.
     #{$se23} & {
       margin-left: calc(var(--p-space-5) + var(--p-space-2) + var(--p-space-1));
     }
@@ -136,6 +136,11 @@ $action-menu-rollup-computed-width: 40px;
 
   .noBreadcrumbs & {
     margin-left: 0;
+    // se23 override -- specificity buster for the above margin-left calculation
+    // see https://github.com/Shopify/polaris-summer-editions/issues/918
+    #{$se23} & {
+      margin-left: 0;
+    }
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
 
Fixes https://github.com/Shopify/polaris-summer-editions/issues/918

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Before: 
![Screenshot 2023-07-24 at 4 06 02 pm](https://github.com/Shopify/polaris/assets/12119389/d9fb7720-13f7-4f34-8601-3c4a1d820795)

After: 
![Screenshot 2023-07-24 at 4 06 47 pm](https://github.com/Shopify/polaris/assets/12119389/ad79f94e-c2d7-4dd2-985c-f66e43b43b42)

### How to 🎩

[Storybook](https://5d559397bae39100201eedc1-vjgllrsdyh.chromatic.com/?path=/story/all-components-page--with-subtitle-and-additional-metadata-and-no-back-action&globals=polarisSummerEditions2023:true)
