### PR TITLE
[EmptyState] Update EmptyState Text size and color for children and footer

### DIFF
--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -81,7 +81,12 @@ export function EmptyState({
 
   const footerContentMarkup = footerContent ? (
     <Box paddingBlockStart="4">
-      <Text as="span" color="subdued" alignment="center">
+      <Text
+        as="span"
+        color={polarisSummerEditions2023 ? undefined : 'subdued'}
+        alignment="center"
+        variant={polarisSummerEditions2023 ? 'bodySm' : 'bodyMd'}
+      >
         {footerContent}
       </Text>
     </Box>
@@ -108,7 +113,7 @@ export function EmptyState({
   const childrenMarkup = children ? (
     <Text
       as="span"
-      color="subdued"
+      color={polarisSummerEditions2023 ? undefined : 'subdued'}
       alignment="center"
       variant={polarisSummerEditions2023 ? 'bodySm' : 'bodyMd'}
     >

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -106,7 +106,12 @@ export function EmptyState({
   ) : null;
 
   const childrenMarkup = children ? (
-    <Text as="span" color="subdued" alignment="center">
+    <Text
+      as="span"
+      color="subdued"
+      alignment="center"
+      variant={polarisSummerEditions2023 ? 'bodySm' : 'bodyMd'}
+    >
       {children}
     </Text>
   ) : null;


### PR DESCRIPTION
According to the [figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Uplift-Components-%5Bgen3%E2%80%93alpha%5D?type=design&node-id=27579-4461&t=DZZMNbChkoDd7k3o-0), body and footer Text of the `EmptyState` should be bodySm (12px) and color #303030 for the experimental design.

### WHY are these changes introduced?

Part of [this issue](https://github.com/Shopify/polaris-summer-editions/issues/212)

### WHAT is this pull request doing?

Without the `polarisSummerEditions2023` beta flag enabled, body text remains 14px and color is `subdued`:

<img width="914" alt="Screenshot 2023-07-24 at 9 02 50 AM" src="https://github.com/Shopify/polaris/assets/112722302/c7c237ea-5ece-4fb1-b476-076b70188be3">

<img width="914" alt="Screenshot 2023-07-24 at 9 02 59 AM" src="https://github.com/Shopify/polaris/assets/112722302/6f8f82e1-a9c9-47a5-b485-eba9281b7e8d">

With the `polarisSummerEditions2023` beta flag enabled, body text and footer text is 12px and color is #303030:

<img width="910" alt="Screenshot 2023-07-24 at 10 22 53 AM" src="https://github.com/Shopify/polaris/assets/112722302/f891dd8e-ab19-4a66-b842-e149615131d6">

<img width="921" alt="Screenshot 2023-07-24 at 10 23 19 AM" src="https://github.com/Shopify/polaris/assets/112722302/924c8df6-7232-4262-97b7-803b071c4887">

### How to 🎩

With the changes pulled down, run `yarn dev` and take a look at the examples under `EmptyState` - there shouldn't be any changes with polarisSummerEditions2023 turned off. When you do enable the beta flag, the body text should be 12px and color is #303030. 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, EmptyState} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <EmptyState
        heading="Manage your inventory transfers"
        action={{content: 'Add transfer'}}
        secondaryAction={{
          content: 'Learn more',
          url: 'https://help.shopify.com/',
        }}
        image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
      >
        <p>Track and receive your incoming inventory from suppliers.</p>
      </EmptyState>
    </Page>
  );
}
```

</details>


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
