### PR TITLE
[OptionList] Remove section dividers

### DIFF
--- a/polaris-react/src/components/OptionList/OptionList.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.tsx
@@ -140,7 +140,9 @@ export function OptionList({
               polarisSummerEditions2023 ? '1_5-experimental' : '2'
             }
             borderColor="border-subdued"
-            borderBlockStartWidth={!isFirstOption ? '1' : undefined}
+            borderBlockStartWidth={
+              !isFirstOption && !polarisSummerEditions2023 ? '1' : undefined
+            }
           >
             <Text
               as={polarisSummerEditions2023 ? titleLevel : 'p'}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [this issue](https://github.com/Shopify/polaris-summer-editions/issues/291)

### How to 🎩

<details>
<summary>Before/after</summary>

|Before|After|
|-|-|
|<img width="551" alt="Screenshot 2023-07-24 at 3 23 20 PM" src="https://github.com/Shopify/polaris/assets/20652326/324cf021-135f-4930-ba42-13892aca4c3a">|<img width="535" alt="Screenshot 2023-07-24 at 3 23 41 PM" src="https://github.com/Shopify/polaris/assets/20652326/9014a57c-a4da-4014-8f57-43d171e96750">|

Pre-experimental remains unchanged
<img width="200" alt="Screenshot 2023-07-24 at 3 24 22 PM" src="https://github.com/Shopify/polaris/assets/20652326/f7144218-edc0-4afb-af1f-cedda832602d">


</details>

[Storybook in CI](https://5d559397bae39100201eedc1-fmmffkfclw.chromatic.com/?path=/story/all-components-optionlist--with-sections&globals=polarisSummerEditions2023:true) go to `OptionList > With sections`