### PR TITLE
[IndexFilters] Update cancel/save button spacing

### DIFF
--- a/polaris-react/src/components/Filters/Filters.scss
+++ b/polaris-react/src/components/Filters/Filters.scss
@@ -248,12 +248,32 @@
 
 .ClearAll {
   margin-left: var(--p-space-1);
+
+  #{$se23} & {
+    margin-left: var(--p-space-2);
+
+    // stylelint-disable-next-line -- se23 overrides
+    span {
+      font-size: var(--p-font-size-75);
+      font-weight: var(--p-font-weight-medium);
+    }
+  }
 }
 
 @media #{$p-breakpoints-md-down} {
   .ClearAll {
     margin-left: var(--p-space-2);
     padding-right: var(--p-space-4);
+
+    #{$se23} & {
+      margin-left: 0;
+
+      // stylelint-disable-next-line -- se23 overrides
+      span {
+        font-size: var(--p-font-size-100);
+        font-weight: var(--p-font-weight-medium);
+      }
+    }
   }
 
   .MultiplePinnedFilterClearAll {

--- a/polaris-react/src/components/Filters/Filters.tsx
+++ b/polaris-react/src/components/Filters/Filters.tsx
@@ -411,6 +411,7 @@ export function Filters({
           plain
           onClick={handleClearAllFilters}
           removeUnderline
+          monochrome={se23}
         >
           {i18n.translate('Polaris.Filters.clearFilters')}
         </Button>

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -13,6 +13,7 @@ import type {FiltersProps} from '../Filters';
 import {Tabs} from '../Tabs';
 import type {TabsProps} from '../Tabs';
 import {useBreakpoints} from '../../utilities/breakpoints';
+import {useFeatures} from '../../utilities/features';
 
 import {useIsSticky} from './hooks';
 import {
@@ -138,6 +139,7 @@ export function IndexFilters({
     setFalse: setFiltersUnFocused,
     setTrue: setFiltersFocused,
   } = useToggle(false);
+  const {polarisSummerEditions2023} = useFeatures();
 
   useOnValueChange(mode, (newMode) => {
     if (newMode === IndexFiltersMode.Filtering) {
@@ -421,7 +423,11 @@ export function IndexFilters({
                   mountedState={mdDown ? undefined : state}
                   borderlessQueryField
                 >
-                  <HorizontalStack gap="3" align="start" blockAlign="center">
+                  <HorizontalStack
+                    gap={polarisSummerEditions2023 ? '2' : '3'}
+                    align="start"
+                    blockAlign="center"
+                  >
                     <div
                       style={{
                         ...defaultStyle,

--- a/polaris-react/src/components/IndexFilters/components/UpdateButtons/UpdateButtons.tsx
+++ b/polaris-react/src/components/IndexFilters/components/UpdateButtons/UpdateButtons.tsx
@@ -123,7 +123,7 @@ export function UpdateButtons({
   }
 
   return (
-    <HorizontalStack align="start" blockAlign="center" gap="2">
+    <HorizontalStack align="start" blockAlign="center" gap={se23 ? '1' : '2'}>
       {cancelButtonMarkup}
       {primaryAction.type === 'save-as' ? (
         <Modal


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [this issue](https://github.com/Shopify/polaris-summer-editions/issues/961)

From issue:

- [x] Update save + cancel to use `button` `slim` 
- [x] Reduce spacing between cancel and save as from `8px` to `4px`
- [x] Update Clear all to use `bodyMD`

<details>
<summary>Before/after</summary>

|Before|After|
|-|-|
|<img width="820" alt="Screenshot 2023-07-24 at 3 18 14 PM" src="https://github.com/Shopify/polaris/assets/20652326/0e87f18a-791a-4601-abaf-73c5dc84b174">|<img width="771" alt="Screenshot 2023-07-24 at 3 16 44 PM" src="https://github.com/Shopify/polaris/assets/20652326/3bfd0b17-c4ac-4239-8973-8b7b018adac9">|

**Small screens**

|Before|After|
|-|-|
|<img width="720" alt="Screenshot 2023-07-24 at 3 18 22 PM" src="https://github.com/Shopify/polaris/assets/20652326/5ee77e7d-1c3b-4340-96cd-3bdd88165a90">|<img width="739" alt="Screenshot 2023-07-24 at 3 16 55 PM" src="https://github.com/Shopify/polaris/assets/20652326/83c3e901-d28d-4a7e-9b73-64e1aef71015">|

</details>

### How to 🎩

[Storybook in CI](https://5d559397bae39100201eedc1-zhxnxluwwd.chromatic.com/?path=/story/all-components-indexfilters--with-pinned-filters&globals=polarisSummerEditions2023:true)
IndexFilters > With pinned filters > Press search icon
