### PR TITLE
Bulk actions style updates

### DIFF
--- a/polaris-react/src/components/BulkActions/BulkActions.scss
+++ b/polaris-react/src/components/BulkActions/BulkActions.scss
@@ -60,9 +60,10 @@ $bulk-actions-button-stacking-order: (
   pointer-events: auto;
 
   #{$se23} & {
+    padding: var(--p-space-3);
     @include shadow-bevel(
       $boxShadow: var(--p-shadow-md),
-      $borderRadius: var(--p-border-radius-2)
+      $borderRadius: var(--p-border-radius-3)
     );
   }
 

--- a/polaris-react/src/components/BulkActions/BulkActions.scss
+++ b/polaris-react/src/components/BulkActions/BulkActions.scss
@@ -95,10 +95,11 @@ $bulk-actions-button-stacking-order: (
 
     #{$se23} & {
       background-color: var(--p-color-bg-strong);
-      // box-shadow: none;
+      box-shadow: none;
       /* stylelint-disable-next-line selector-max-combinators -- se23 */
       &:hover {
         background-color: var(--p-color-bg-strong-hover);
+        box-shadow: none;
       }
       /* stylelint-disable-next-line selector-max-combinators -- se23 */
       &:focus-visible,

--- a/polaris-react/src/components/BulkActions/BulkActions.scss
+++ b/polaris-react/src/components/BulkActions/BulkActions.scss
@@ -92,6 +92,44 @@ $bulk-actions-button-stacking-order: (
 
   button {
     display: flex;
+
+    #{$se23} & {
+      background-color: var(--p-color-bg-strong);
+      // box-shadow: none;
+      /* stylelint-disable-next-line selector-max-combinators -- se23 */
+      &:hover {
+        background-color: var(--p-color-bg-strong-hover);
+      }
+      /* stylelint-disable-next-line selector-max-combinators -- se23 */
+      &:focus-visible,
+      &:active {
+        background-color: var(--p-color-bg-strong-active);
+      }
+      /* stylelint-disable-next-line selector-max-combinators -- se23 */
+      &:focus-visible:not(:active) {
+        /* stylelint-disable-next-line polaris/border/polaris/at-rule-disallowed-list -- se23 */
+        @include no-focus-ring;
+        outline: var(--p-border-width-2) solid
+          var(--p-color-border-interactive-focus);
+        outline-offset: var(--p-space-05);
+      }
+      // stylelint-disable-next-line selector-max-combinators -- se23
+      &[aria-disabled='true'] {
+        background-color: var(--p-color-bg-transparent-disabled-experimental);
+      }
+    }
+  }
+
+  // Extra specificity
+  // stylelint-disable-next-line selector-max-class, selector-max-specificity -- se23
+  &.BulkActionButton.BulkActionButton button {
+    #{$se23} & {
+      // stylelint-disable-next-line selector-max-class, selector-max-combinators -- se23
+      &:focus-visible,
+      &:active {
+        box-shadow: var(--p-shadow-inset-md);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/973

### WHAT is this pull request doing?

Updates padding, border radius, and add custom button style overrides to Bulk Actions. Adding the custom button style overrides is not a scalable pattern and this should be revisited.

Before
<img width="496" alt="Screenshot 2023-07-25 at 10 21 28 AM" src="https://github.com/Shopify/polaris/assets/3474483/8885d171-ee58-4b05-b076-3b114788cec5">

After
<img width="486" alt="Screenshot 2023-07-25 at 10 20 48 AM" src="https://github.com/Shopify/polaris/assets/3474483/58bcd593-c693-4a1c-8dc0-da42bc4f7d9a">

### How to 🎩
Review in Storybook with the beta flag turned on