### PR TITLE
[Banner] Add safety check for status value

### DIFF
--- a/.changeset/brave-items-promise.md
+++ b/.changeset/brave-items-promise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix banner bug

--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
@@ -49,8 +49,11 @@ export function BannerExperimental({
   const i18n = useI18n();
   const withinContentContainer = useContext(WithinContentContext);
   const isInlineIconBanner = !title && !withinContentContainer;
+  const bannerStatus = Object.keys(bannerAttributes).includes(status)
+    ? status
+    : 'info';
   const bannerColors =
-    bannerAttributes[status][
+    bannerAttributes[bannerStatus][
       withinContentContainer ? 'withinContentContainer' : 'withinPage'
     ];
 
@@ -64,7 +67,7 @@ export function BannerExperimental({
     ) : null,
     bannerIcon: hideIcon ? null : (
       <span className={styles[bannerColors.icon]}>
-        <Icon source={icon ?? bannerAttributes[status].icon} />
+        <Icon source={icon ?? bannerAttributes[bannerStatus].icon} />
       </span>
     ),
     actionButtons:


### PR DESCRIPTION
For some reason, we are getting an undefined status value on some banners even though the default value is `info` and the value is typed. Added a safety check for object access to fix the bug before we can investigate further on why this is happening.