### PR TITLE
[FilterPill] Fix Button Padding

### DIFF
--- a/.changeset/great-cycles-heal.md
+++ b/.changeset/great-cycles-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed padding on FilterPill Buttons

--- a/polaris-react/src/components/Filters/components/FilterPill/FilterPill.scss
+++ b/polaris-react/src/components/Filters/components/FilterPill/FilterPill.scss
@@ -157,7 +157,9 @@
 .PopoverWrapper {
   min-width: 185px;
   max-width: 300px;
+}
 
+.ClearButtonWrapper {
   #{$se23} & button {
     min-height: 0;
     padding: 0;

--- a/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
@@ -183,7 +183,7 @@ export function FilterPill({
   );
 
   const clearButtonMarkup = !hideClearButton && (
-    <div>
+    <div className={styles.ClearButtonWrapper}>
       <Button onClick={handleClear} plain disabled={!selected} textAlign="left">
         {i18n.translate('Polaris.FilterPill.clear')}
       </Button>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Buttons rendered in Filters in the IndexTable have no padding:

<img width="288" alt="image" src="https://github.com/Shopify/polaris/assets/40364429/ba4aa42a-3d15-426f-83e4-34417c22cb12">


This looks like it was introduced in https://github.com/Shopify/polaris/pull/9775 in order to fix another issue. However any buttons passed down as part of the filter prop markup no longer have any padding.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Adds a class to the div wrapping the clear button and targets this button specifically with 0 padding, allowing other buttons passed down to this component to render as expected.

| Before | After |
|--------|--------|
| <img width="336" alt="image" src="https://github.com/Shopify/polaris/assets/40364429/8f4ca151-309b-4c70-bd9f-cd0d56bcec7b"> | <img width="271" alt="image" src="https://github.com/Shopify/polaris/assets/40364429/18b20f78-b120-4f49-9377-ced33731f41a"> |



