### PR TITLE
Add CI tests for experimental code

### DIFF
--- a/.changeset/poor-forks-switch.md
+++ b/.changeset/poor-forks-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Run CI tests for both polarisSummerEditions2023 states

--- a/.changeset/poor-forks-switch.md
+++ b/.changeset/poor-forks-switch.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Run CI tests for both polarisSummerEditions2023 states
+Updated CI tests to account for both polarisSummerEditions2023 beta flag states

--- a/.github/workflows/ci-a11y-vrt-experimental.yml
+++ b/.github/workflows/ci-a11y-vrt-experimental.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - next
-      - beta
     paths:
       - 'polaris-react/src/**'
       - 'polaris-react/playground/**'

--- a/.github/workflows/ci-a11y-vrt.yml
+++ b/.github/workflows/ci-a11y-vrt.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - next
-      - beta
     paths:
       - 'polaris-react/src/**'
       - 'polaris-react/playground/**'

--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - next
-      - beta
   pull_request:
 
 jobs:

--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI experimental
 
 on:
   push:
@@ -44,9 +44,9 @@ jobs:
             **/.turbo
             node_modules/.cache/turbo
             polaris.shopify.com/.next/cache
-          key: ${{ runner.os }}-node${{ matrix.node-version }}-test-v2-${{ github.sha }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-test-experimental-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-node${{ matrix.node-version }}-test-v2-
+            ${{ runner.os }}-node${{ matrix.node-version }}-test-experimental-
 
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -61,4 +61,6 @@ jobs:
         run: yarn type-check
 
       - name: Test
+        env:
+          SE23: 'on'
         run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - next
-      - beta
   pull_request:
 
 jobs:

--- a/polaris-react/jest.config.js
+++ b/polaris-react/jest.config.js
@@ -14,4 +14,6 @@ module.exports = {
     '\\.svg$': '<rootDir>/config/jest-transform-image.js',
   },
   watchPathIgnorePatterns: ['<rootDir>/build', '<rootDir>/node_modules'],
+  testPathIgnorePatterns:
+    process.env.SE23 === 'on' ? ['\\.preexperimental.test.tsx$'] : [],
 };

--- a/polaris-react/jest.config.js
+++ b/polaris-react/jest.config.js
@@ -14,6 +14,4 @@ module.exports = {
     '\\.svg$': '<rootDir>/config/jest-transform-image.js',
   },
   watchPathIgnorePatterns: ['<rootDir>/build', '<rootDir>/node_modules'],
-  testPathIgnorePatterns:
-    process.env.SE23 === 'on' ? ['\\.preexperimental.test.tsx$'] : [],
 };

--- a/polaris-react/src/components/Badge/tests/Badge.test.tsx
+++ b/polaris-react/src/components/Badge/tests/Badge.test.tsx
@@ -34,19 +34,18 @@ describe('<Badge />', () => {
   });
 
   it('does not add pip styles when progress is not provided', () => {
-    const badge = mountWithApp(<Badge status="attention" />);
-
-    expect(badge).not.toContainReactComponent('span', {
-      className: 'Pip',
+    const badge = mountWithApp(<Badge status="attention" />, {
+      features: {polarisSummerEditions2023: true},
     });
+    expect(badge).not.toContainReactComponent(Icon);
   });
 
   it('renders with pip styles when progress is provided', () => {
-    const badge = mountWithApp(<Badge progress="incomplete" />);
-
-    expect(badge).toContainReactComponent('span', {
-      className: 'Pip progressIncomplete',
+    const badge = mountWithApp(<Badge progress="incomplete" />, {
+      features: {polarisSummerEditions2023: true},
     });
+
+    expect(badge).toContainReactComponent(Icon);
   });
 
   it('does not render an icon when icon is not provided', () => {
@@ -170,6 +169,29 @@ describe('<Badge.Pip />', () => {
     expect(badge).toContainReactComponent(Text, {
       children: 'Complete',
       visuallyHidden: true,
+    });
+  });
+
+  // se23 -- css pip replaced with icon pip
+  describe('polarisSummerEditions2023 false', () => {
+    it('does not add pip styles when progress is not provided', () => {
+      const badge = mountWithApp(<Badge status="attention" />, {
+        features: {polarisSummerEditions2023: false},
+      });
+
+      expect(badge).not.toContainReactComponent('span', {
+        className: 'Pip',
+      });
+    });
+
+    it('renders with pip styles when progress is provided', () => {
+      const badge = mountWithApp(<Badge progress="incomplete" />, {
+        features: {polarisSummerEditions2023: false},
+      });
+
+      expect(badge).toContainReactComponent('span', {
+        className: 'Pip progressIncomplete',
+      });
     });
   });
 });

--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
@@ -121,7 +121,7 @@ export function BannerExperimental({
   return <DefaultBanner {...sharedBannerProps}>{children}</DefaultBanner>;
 }
 
-function DefaultBanner({
+export function DefaultBanner({
   backgroundColor,
   textColor,
   bannerTitle,
@@ -171,7 +171,7 @@ function DefaultBanner({
   );
 }
 
-function InlineIconBanner({
+export function InlineIconBanner({
   backgroundColor,
   bannerIcon,
   actionButtons,
@@ -225,7 +225,7 @@ function InlineIconBanner({
   );
 }
 
-function WithinContentContainerBanner({
+export function WithinContentContainerBanner({
   backgroundColor,
   textColor,
   bannerTitle,

--- a/polaris-react/src/components/Banner/tests/Banner.test.tsx
+++ b/polaris-react/src/components/Banner/tests/Banner.test.tsx
@@ -766,14 +766,14 @@ describe('<BannerExperimental />', () => {
       expect(banner).toContainReactComponent(DefaultBanner);
     });
 
-    it('shows the InlineIconBanner variant by when there is no title and it is not in a content container', () => {
+    it('shows the InlineIconBanner variant by default when there is no title and it is not in a content container', () => {
       const banner = mountWithApp(<Banner />, {
         features: {polarisSummerEditions2023: true},
       });
       expect(banner).toContainReactComponent(InlineIconBanner);
     });
 
-    it('shows the WithinContentContainerBanner variant by when there is no title and it is in a content container', () => {
+    it('shows the WithinContentContainerBanner variant by default when there is no title and it is in a content container', () => {
       const card = mountWithApp(
         <Card>
           <Banner />

--- a/polaris-react/src/components/Banner/tests/Banner.test.tsx
+++ b/polaris-react/src/components/Banner/tests/Banner.test.tsx
@@ -5,10 +5,16 @@ import {
   CircleInformationMajor,
   CircleAlertMajor,
   DiamondAlertMajor,
+  TickMinor,
+  RiskMinor,
+  InfoMinor,
+  DiamondAlertMinor,
 } from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
 
 import {Button} from '../../Button';
+import {Card} from '../../Card';
+import {Modal} from '../../Modal';
 import {Text} from '../../Text';
 import {Icon} from '../../Icon';
 import {Spinner} from '../../Spinner';
@@ -17,28 +23,42 @@ import {UnstyledLink} from '../../UnstyledLink';
 import {BannerContext} from '../../../utilities/banner-context';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {Banner} from '../Banner';
-import type {BannerHandles} from '../Banner';
+import type {BannerHandles, BannerStatus} from '../Banner';
+// eslint-disable-next-line @shopify/strict-component-boundaries -- se23 test will eventaully be beside component
+import {
+  DefaultBanner,
+  InlineIconBanner,
+  WithinContentContainerBanner,
+} from '../components/BannerExperimental/BannerExperimental';
 
 describe('<Banner />', () => {
   it('renders a title', () => {
-    const banner = mountWithApp(<Banner title="Banner title" />);
+    const banner = mountWithApp(<Banner title="Banner title" />, {
+      features: {polarisSummerEditions2023: false},
+    });
     expect(
       banner.find(Text, {as: 'h2', variant: 'headingMd'}),
     ).toContainReactText('Banner title');
   });
 
   it('passes an h2 element to Heading', () => {
-    const banner = mountWithApp(<Banner title="Banner title" />);
+    const banner = mountWithApp(<Banner title="Banner title" />, {
+      features: {polarisSummerEditions2023: false},
+    });
     expect(banner).toContainReactComponent(Text, {as: 'h2'});
   });
 
   it('passes the provided icon source to Icon', () => {
-    const banner = mountWithApp(<Banner icon={CirclePlusMinor} />);
+    const banner = mountWithApp(<Banner icon={CirclePlusMinor} />, {
+      features: {polarisSummerEditions2023: false},
+    });
     expect(banner).toContainReactComponent(Icon, {source: CirclePlusMinor});
   });
 
   it('uses a success circleCheckMark if status is success and sets a status aria role', () => {
-    const banner = mountWithApp(<Banner status="success" />);
+    const banner = mountWithApp(<Banner status="success" />, {
+      features: {polarisSummerEditions2023: false},
+    });
 
     expect(banner).toContainReactComponent(Icon, {
       source: CircleTickMajor,
@@ -48,7 +68,9 @@ describe('<Banner />', () => {
   });
 
   it('uses a highlight circleInformation if status is info and sets a status aria role', () => {
-    const banner = mountWithApp(<Banner status="info" />);
+    const banner = mountWithApp(<Banner status="info" />, {
+      features: {polarisSummerEditions2023: false},
+    });
 
     expect(banner).toContainReactComponent(Icon, {
       source: CircleInformationMajor,
@@ -58,7 +80,9 @@ describe('<Banner />', () => {
   });
 
   it('uses a warning circleAlert if status is warning and sets an alert aria role', () => {
-    const banner = mountWithApp(<Banner status="warning" />);
+    const banner = mountWithApp(<Banner status="warning" />, {
+      features: {polarisSummerEditions2023: false},
+    });
     expect(banner).toContainReactComponent(Icon, {
       source: CircleAlertMajor,
       color: 'warning',
@@ -67,7 +91,9 @@ describe('<Banner />', () => {
   });
 
   it('uses a critical circleBarred if status is critical and sets an alert aria role', () => {
-    const banner = mountWithApp(<Banner status="critical" />);
+    const banner = mountWithApp(<Banner status="critical" />, {
+      features: {polarisSummerEditions2023: false},
+    });
     expect(banner).toContainReactComponent(Icon, {
       source: DiamondAlertMajor,
       color: 'critical',
@@ -76,7 +102,9 @@ describe('<Banner />', () => {
   });
 
   it('uses a default icon and aria role', () => {
-    const banner = mountWithApp(<Banner />);
+    const banner = mountWithApp(<Banner />, {
+      features: {polarisSummerEditions2023: false},
+    });
     expect(banner).toContainReactComponent(Icon, {
       source: CircleInformationMajor,
       color: 'base',
@@ -85,8 +113,12 @@ describe('<Banner />', () => {
   });
 
   it('disables aria-live when stopAnnouncements is enabled', () => {
-    const politeBanner = mountWithApp(<Banner />);
-    const quietBanner = mountWithApp(<Banner stopAnnouncements />);
+    const politeBanner = mountWithApp(<Banner />, {
+      features: {polarisSummerEditions2023: false},
+    });
+    const quietBanner = mountWithApp(<Banner stopAnnouncements />, {
+      features: {polarisSummerEditions2023: false},
+    });
 
     expect(politeBanner.find('div')).toHaveReactProps({'aria-live': 'polite'});
     expect(quietBanner.find('div')).toHaveReactProps({'aria-live': 'off'});
@@ -103,6 +135,7 @@ describe('<Banner />', () => {
         >
           Hello World
         </Banner>,
+        {features: {polarisSummerEditions2023: false}},
       );
 
       expect(bannerWithAction.find(UnstyledButton)).toContainReactText(
@@ -121,6 +154,7 @@ describe('<Banner />', () => {
         >
           Hello World
         </Banner>,
+        {features: {polarisSummerEditions2023: false}},
       );
 
       expect(bannerWithAction).toContainReactComponent(Spinner);
@@ -137,6 +171,7 @@ describe('<Banner />', () => {
         >
           Hello World
         </Banner>,
+        {features: {polarisSummerEditions2023: false}},
       );
 
       expect(bannerWithAction).toContainReactComponent('button', {
@@ -162,6 +197,7 @@ describe('<Banner />', () => {
         >
           Hello World
         </Banner>,
+        {features: {polarisSummerEditions2023: false}},
       );
 
       expect(bannerWithActions.find(UnstyledLink)).toContainReactText(
@@ -181,6 +217,7 @@ describe('<Banner />', () => {
         >
           Hello World
         </Banner>,
+        {features: {polarisSummerEditions2023: false}},
       );
 
       expect(bannerWithActions.find(UnstyledLink)).toContainReactText(
@@ -192,7 +229,9 @@ describe('<Banner />', () => {
   describe('onDismiss()', () => {
     it('is called when the dismiss button is clicked', () => {
       const spy = jest.fn();
-      const banner = mountWithApp(<Banner onDismiss={spy} />);
+      const banner = mountWithApp(<Banner onDismiss={spy} />, {
+        features: {polarisSummerEditions2023: false},
+      });
       banner.find(Button)!.trigger('onClick');
 
       expect(spy).toHaveBeenCalled();
@@ -214,6 +253,7 @@ describe('<Banner />', () => {
       >
         Hello World
       </Banner>,
+      {features: {polarisSummerEditions2023: false}},
     );
 
     const unstyledLink = bannerWithSecondaryAction
@@ -241,6 +281,7 @@ describe('<Banner />', () => {
       >
         Hello World
       </Banner>,
+      {features: {polarisSummerEditions2023: false}},
     );
 
     const unstyledLink = bannerWithSecondaryAction
@@ -264,6 +305,7 @@ describe('<Banner />', () => {
           Some content
         </Banner>
       </WithinContentContext.Provider>,
+      {features: {polarisSummerEditions2023: false}},
     );
 
     expect(bannerWithContentContext).toContainReactComponent(UnstyledButton);
@@ -281,7 +323,9 @@ describe('<Banner />', () => {
         return <Banner ref={banner} status="critical" />;
       }
 
-      const testComponent = mountWithApp(<Test />);
+      const testComponent = mountWithApp(<Test />, {
+        features: {polarisSummerEditions2023: false},
+      });
 
       expect(document.activeElement).toBe(
         testComponent.find('div', {tabIndex: 0})!.domNode,
@@ -290,7 +334,9 @@ describe('<Banner />', () => {
 
     describe('Focus className', () => {
       it('adds a keyFocused class to the banner on keyUp', () => {
-        const banner = mountWithApp(<Banner />);
+        const banner = mountWithApp(<Banner />, {
+          features: {polarisSummerEditions2023: false},
+        });
 
         const bannerDiv = banner.find('div', {
           className: 'Banner withinPage',
@@ -306,7 +352,9 @@ describe('<Banner />', () => {
       });
 
       it('does not add a keyFocused class onMouseUp', () => {
-        const banner = mountWithApp(<Banner />);
+        const banner = mountWithApp(<Banner />, {
+          features: {polarisSummerEditions2023: false},
+        });
 
         const bannerDiv = banner.find('div', {
           className: 'Banner withinPage',
@@ -339,6 +387,7 @@ describe('<Banner />', () => {
         <Banner>
           <Child />
         </Banner>,
+        {features: {polarisSummerEditions2023: false}},
       );
 
       expect(banner.find(Child)).toContainReactComponent('div');
@@ -365,7 +414,9 @@ describe('<Banner />', () => {
     ])(
       'sets Icon props when: %s',
       (_: any, status: any, color: any, iconSource: any) => {
-        const banner = mountWithApp(<Banner status={status} />);
+        const banner = mountWithApp(<Banner status={status} />, {
+          features: {polarisSummerEditions2023: false},
+        });
 
         expect(banner).toContainReactComponent(Icon, {
           color,
@@ -373,5 +424,400 @@ describe('<Banner />', () => {
         });
       },
     );
+  });
+});
+
+window.matchMedia =
+  window.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      addListener() {},
+      removeListener() {},
+    };
+  };
+
+describe('<BannerExperimental />', () => {
+  it('renders a title', () => {
+    const banner = mountWithApp(<Banner title="Banner title" />, {
+      features: {polarisSummerEditions2023: true},
+    });
+    expect(
+      banner.find(Text, {as: 'h2', variant: 'headingSm'}),
+    ).toContainReactText('Banner title');
+  });
+
+  it('passes the provided icon source to Icon', () => {
+    const banner = mountWithApp(<Banner icon={CirclePlusMinor} />, {
+      features: {polarisSummerEditions2023: true},
+    });
+    expect(banner).toContainReactComponent(Icon, {source: CirclePlusMinor});
+  });
+
+  it('disables aria-live when stopAnnouncements is enabled', () => {
+    const politeBanner = mountWithApp(<Banner />, {
+      features: {polarisSummerEditions2023: true},
+    });
+    const quietBanner = mountWithApp(<Banner stopAnnouncements />, {
+      features: {polarisSummerEditions2023: true},
+    });
+
+    expect(politeBanner.find('div')).toHaveReactProps({'aria-live': 'polite'});
+    expect(quietBanner.find('div')).toHaveReactProps({'aria-live': 'off'});
+  });
+
+  describe('action', () => {
+    it('renders an unstyled button', () => {
+      const bannerWithAction = mountWithApp(
+        <Banner
+          title="Test"
+          action={{
+            content: 'Primary action',
+          }}
+        >
+          Hello World
+        </Banner>,
+        {features: {polarisSummerEditions2023: true}},
+      );
+
+      expect(bannerWithAction.find(UnstyledButton)).toContainReactText(
+        'Primary action',
+      );
+    });
+
+    it('renders a Spinner when loading', () => {
+      const bannerWithAction = mountWithApp(
+        <Banner
+          title="Test"
+          action={{
+            content: 'Primary action',
+            loading: true,
+          }}
+        >
+          Hello World
+        </Banner>,
+        {features: {polarisSummerEditions2023: true}},
+      );
+
+      expect(bannerWithAction).toContainReactComponent(Spinner);
+    });
+
+    it('renders a disabled button when loading', () => {
+      const bannerWithAction = mountWithApp(
+        <Banner
+          title="Test"
+          action={{
+            content: 'Primary action',
+            loading: true,
+          }}
+        >
+          Hello World
+        </Banner>,
+        {features: {polarisSummerEditions2023: true}},
+      );
+
+      expect(bannerWithAction).toContainReactComponent('button', {
+        'aria-disabled': true,
+        'aria-busy': true,
+      });
+    });
+  });
+
+  describe('secondaryAction', () => {
+    it('renders when a primary action is provided', () => {
+      const bannerWithActions = mountWithApp(
+        <Banner
+          title="Test"
+          action={{
+            content: 'Primary action',
+          }}
+          secondaryAction={{
+            content: 'Secondary external link',
+            url: 'https://test.com',
+            external: true,
+          }}
+        >
+          Hello World
+        </Banner>,
+        {features: {polarisSummerEditions2023: true}},
+      );
+
+      expect(bannerWithActions.find(UnstyledLink)).toContainReactText(
+        'Secondary external link',
+      );
+    });
+
+    it('renders when a primary action is not provided', () => {
+      const bannerWithActions = mountWithApp(
+        <Banner
+          title="Test"
+          secondaryAction={{
+            content: 'Secondary external link',
+            url: 'https://test.com',
+            external: true,
+          }}
+        >
+          Hello World
+        </Banner>,
+        {features: {polarisSummerEditions2023: true}},
+      );
+
+      expect(bannerWithActions.find(UnstyledLink)).toContainReactText(
+        'Secondary external link',
+      );
+    });
+  });
+
+  describe('onDismiss()', () => {
+    it('is called when the dismiss button is clicked', () => {
+      const spy = jest.fn();
+      const banner = mountWithApp(<Banner onDismiss={spy} />, {
+        features: {polarisSummerEditions2023: true},
+      });
+      banner.find(Button)!.trigger('onClick');
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  it('creates an external link and adds the noopener and noreferrer accessibility attributes to external link in secondaryAction', () => {
+    const bannerWithSecondaryAction = mountWithApp(
+      <Banner
+        title="Test"
+        action={{
+          content: 'Primary action',
+        }}
+        secondaryAction={{
+          content: 'Secondary external link',
+          url: 'https://test.com',
+          external: true,
+        }}
+      >
+        Hello World
+      </Banner>,
+      {features: {polarisSummerEditions2023: true}},
+    );
+
+    const unstyledLink = bannerWithSecondaryAction
+      .find(UnstyledLink)!
+      .find('a');
+
+    expect(unstyledLink).toHaveReactProps({
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    });
+  });
+
+  it('creates a link with custom target in secondaryAction', () => {
+    const bannerWithSecondaryAction = mountWithApp(
+      <Banner
+        title="Test"
+        action={{
+          content: 'Primary action',
+        }}
+        secondaryAction={{
+          content: 'Secondary external link',
+          url: 'https://test.com',
+          target: '_top',
+        }}
+      >
+        Hello World
+      </Banner>,
+      {features: {polarisSummerEditions2023: true}},
+    );
+
+    const unstyledLink = bannerWithSecondaryAction
+      .find(UnstyledLink)!
+      .find('a');
+
+    expect(unstyledLink).toHaveReactProps({
+      target: '_top',
+      rel: undefined,
+    });
+  });
+
+  it('renders an unstyled button with contentContext', () => {
+    const bannerWithContentContext = mountWithApp(
+      <WithinContentContext.Provider value>
+        <Banner
+          action={{
+            content: 'Primary action',
+          }}
+        >
+          Some content
+        </Banner>
+      </WithinContentContext.Provider>,
+      {features: {polarisSummerEditions2023: true}},
+    );
+
+    expect(bannerWithContentContext).toContainReactComponent(UnstyledButton);
+  });
+
+  describe('focus', () => {
+    it('exposes a function that allows the banner to be programmatically focused', () => {
+      function Test() {
+        const banner = useRef<BannerHandles>(null);
+
+        useEffect(() => {
+          banner.current && banner.current.focus();
+        }, []);
+
+        return <Banner ref={banner} status="critical" />;
+      }
+
+      const testComponent = mountWithApp(<Test />, {
+        features: {polarisSummerEditions2023: true},
+      });
+
+      expect(document.activeElement).toBe(
+        testComponent.find('div', {tabIndex: 0})!.domNode,
+      );
+    });
+
+    describe('Focus className', () => {
+      it('adds a keyFocused class to the banner on keyUp', () => {
+        const banner = mountWithApp(<Banner />, {
+          features: {polarisSummerEditions2023: true},
+        });
+
+        const bannerDiv = banner.find('div', {
+          className: 'Banner withinPage',
+        });
+
+        bannerDiv!.trigger('onKeyUp', {
+          target: bannerDiv!.domNode as HTMLDivElement,
+        });
+
+        expect(banner).toContainReactComponent('div', {
+          className: 'Banner keyFocused withinPage',
+        });
+      });
+
+      it('does not add a keyFocused class onMouseUp', () => {
+        const banner = mountWithApp(<Banner />, {
+          features: {polarisSummerEditions2023: true},
+        });
+
+        const bannerDiv = banner.find('div', {
+          className: 'Banner withinPage',
+        });
+
+        bannerDiv!.trigger('onMouseUp', {
+          currentTarget: bannerDiv!.domNode as HTMLDivElement,
+        });
+
+        expect(banner).toContainReactComponent('div', {
+          className: 'Banner withinPage',
+        });
+      });
+    });
+  });
+
+  describe('context and variants', () => {
+    it('passes the within banner context', () => {
+      const Child: React.FunctionComponent = (_props) => {
+        return (
+          <BannerContext.Consumer>
+            {(BannerContext) => {
+              return BannerContext ? <div /> : null;
+            }}
+          </BannerContext.Consumer>
+        );
+      };
+
+      const banner = mountWithApp(
+        <Banner>
+          <Child />
+        </Banner>,
+        {features: {polarisSummerEditions2023: true}},
+      );
+
+      expect(banner.find(Child)).toContainReactComponent('div');
+    });
+
+    it('shows the WithinContentContainerBanner variant inside a Card', () => {
+      const card = mountWithApp(
+        <Card>
+          <Banner title="Banner title" />
+        </Card>,
+        {
+          features: {polarisSummerEditions2023: true},
+        },
+      );
+      expect(card).toContainReactComponent(WithinContentContainerBanner);
+    });
+
+    it('shows the WithinContentContainerBanner variant inside a Modal', () => {
+      const modal = mountWithApp(
+        <Modal open title="" onClose={() => {}}>
+          <Banner title="Banner title" />
+        </Modal>,
+        {
+          features: {polarisSummerEditions2023: true},
+        },
+      );
+      expect(modal).toContainReactComponent(WithinContentContainerBanner);
+    });
+
+    it('shows the DefaultBanner variant by default', () => {
+      const banner = mountWithApp(<Banner title="Banner title" />, {
+        features: {polarisSummerEditions2023: true},
+      });
+      expect(banner).toContainReactComponent(DefaultBanner);
+    });
+
+    it('shows the InlineIconBanner variant by when there is no title and it is not in a content container', () => {
+      const banner = mountWithApp(<Banner />, {
+        features: {polarisSummerEditions2023: true},
+      });
+      expect(banner).toContainReactComponent(InlineIconBanner);
+    });
+
+    it('shows the WithinContentContainerBanner variant by when there is no title and it is in a content container', () => {
+      const card = mountWithApp(
+        <Card>
+          <Banner />
+        </Card>,
+        {
+          features: {polarisSummerEditions2023: true},
+        },
+      );
+      expect(card).toContainReactComponent(WithinContentContainerBanner);
+    });
+  });
+
+  describe('aria role', () => {
+    it.each([
+      ['success', 'status'],
+      ['info', 'status'],
+      ['warning', 'alert'],
+      ['critical', 'alert'],
+    ])(
+      'aria role when status is %s',
+      (status: BannerStatus, role: 'string') => {
+        const banner = mountWithApp(<Banner status={status} />, {
+          features: {polarisSummerEditions2023: true},
+        });
+
+        expect(banner).toContainReactComponent('div', {role});
+      },
+    );
+  });
+
+  describe('icon', () => {
+    it.each([
+      ['success', TickMinor],
+      ['info', InfoMinor],
+      ['warning', RiskMinor],
+      ['critical', DiamondAlertMinor],
+    ])('icon when status is %s', (status: BannerStatus, icon: any) => {
+      const banner = mountWithApp(<Banner status={status} />, {
+        features: {polarisSummerEditions2023: true},
+      });
+
+      expect(banner).toContainReactComponent(Icon, {
+        source: icon,
+      });
+    });
   });
 });

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -61,9 +61,8 @@ export function Breadcrumbs({backAction}: BreadcrumbsProps) {
       url={'url' in backAction ? backAction.url : undefined}
       onClick={'onAction' in backAction ? backAction.onAction : undefined}
       onPointerDown={handleMouseUpByBlurring}
-      aria-label={backAction.accessibilityLabel}
       icon={ArrowLeftMinor}
-      accessibilityLabel={content}
+      accessibilityLabel={backAction.accessibilityLabel ?? content}
     />
   );
 

--- a/polaris-react/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/polaris-react/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -78,7 +78,7 @@ describe('<Breadcrumbs />', () => {
     });
   });
 
-  it('renders breadcrumb content as a visually hidden label when the new design language is enabled', () => {
+  it('renders breadcrumb content as a visually hidden label', () => {
     const linkBackAction: LinkAction = {
       content: 'Products',
       url: 'https://www.shopify.com',
@@ -86,7 +86,6 @@ describe('<Breadcrumbs />', () => {
     const wrapper = mountWithApp(<Breadcrumbs backAction={linkBackAction} />);
 
     expect(wrapper).toContainReactComponent(Text, {
-      children: 'Products',
       visuallyHidden: true,
     });
   });

--- a/polaris-react/src/components/Button/tests/Button.test.tsx
+++ b/polaris-react/src/components/Button/tests/Button.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {
   CaretDownMinor,
   CaretUpMinor,
+  ChevronDownMinor,
+  ChevronUpMinor,
   PlusMinor,
   SelectMinor,
 } from '@shopify/polaris-icons';
@@ -220,12 +222,14 @@ describe('<Button />', () => {
         ],
       };
 
-      const button = mountWithApp(<Button connectedDisclosure={disclosure} />);
+      const button = mountWithApp(<Button connectedDisclosure={disclosure} />, {
+        features: {polarisSummerEditions2023: true},
+      });
       expect(button).toContainReactComponentTimes('button', 2);
 
       const disclosureButton = button.findAll('button')[1];
       expect(disclosureButton).toContainReactComponent(Icon, {
-        source: CaretDownMinor,
+        source: ChevronDownMinor,
       });
     });
 
@@ -456,27 +460,33 @@ describe('<Button />', () => {
 
   describe('disclosure', () => {
     it('assumes "down" if set to true', () => {
-      const button = mountWithApp(<Button disclosure />);
+      const button = mountWithApp(<Button disclosure />, {
+        features: {polarisSummerEditions2023: true},
+      });
       const disclosureIcon = button
         .find('div', {className: styles.DisclosureIcon})!
         .find(Icon);
-      expect(disclosureIcon).toHaveReactProps({source: CaretDownMinor});
+      expect(disclosureIcon).toHaveReactProps({source: ChevronDownMinor});
     });
 
     it('is facing down if set to "down"', () => {
-      const button = mountWithApp(<Button disclosure="down" />);
+      const button = mountWithApp(<Button disclosure="down" />, {
+        features: {polarisSummerEditions2023: true},
+      });
       const disclosureIcon = button
         .find('div', {className: styles.DisclosureIcon})!
         .find(Icon);
-      expect(disclosureIcon).toHaveReactProps({source: CaretDownMinor});
+      expect(disclosureIcon).toHaveReactProps({source: ChevronDownMinor});
     });
 
     it('is facing up if set to "up"', () => {
-      const button = mountWithApp(<Button disclosure="up" />);
+      const button = mountWithApp(<Button disclosure="up" />, {
+        features: {polarisSummerEditions2023: true},
+      });
       const disclosureIcon = button
         .find('div', {className: styles.DisclosureIcon})!
         .find(Icon);
-      expect(disclosureIcon).toHaveReactProps({source: CaretUpMinor});
+      expect(disclosureIcon).toHaveReactProps({source: ChevronUpMinor});
     });
 
     it('is double-arrow if set to "select"', () => {
@@ -532,5 +542,58 @@ describe('<Button />', () => {
       };
       expect(link).toContainReactComponent('button', selector);
     });
+  });
+});
+
+// se23 -- CaretDownMinor replaced with ChevronDownMinor
+describe('polarisSummerEditions2023 false', () => {
+  it('connects a disclosure icon button to the button', () => {
+    const disclosure = {
+      actions: [
+        {
+          content: 'Save and mark as ordered',
+        },
+      ],
+    };
+
+    const button = mountWithApp(<Button connectedDisclosure={disclosure} />, {
+      features: {polarisSummerEditions2023: false},
+    });
+    expect(button).toContainReactComponentTimes('button', 2);
+
+    const disclosureButton = button.findAll('button')[1];
+    expect(disclosureButton).toContainReactComponent(Icon, {
+      source: CaretDownMinor,
+    });
+  });
+
+  it('assumes "down" if set to true', () => {
+    const button = mountWithApp(<Button disclosure />, {
+      features: {polarisSummerEditions2023: false},
+    });
+    const disclosureIcon = button
+      .find('div', {className: styles.DisclosureIcon})!
+      .find(Icon);
+    expect(disclosureIcon).toHaveReactProps({source: CaretDownMinor});
+  });
+
+  it('is facing down if set to "down"', () => {
+    const button = mountWithApp(<Button disclosure="down" />, {
+      features: {polarisSummerEditions2023: false},
+    });
+    const disclosureIcon = button
+      .find('div', {className: styles.DisclosureIcon})!
+      .find(Icon);
+    expect(disclosureIcon).toHaveReactProps({source: CaretDownMinor});
+  });
+
+  it('is facing up if set to "up"', () => {
+    const button = mountWithApp(<Button disclosure="up" />, {
+      features: {polarisSummerEditions2023: false},
+    });
+    const disclosureIcon = button
+      .find('div', {className: styles.DisclosureIcon})!
+      .find(Icon);
+    expect(disclosureIcon).toHaveReactProps({source: CaretUpMinor});
   });
 });

--- a/polaris-react/src/components/Card/tests/Card.test.tsx
+++ b/polaris-react/src/components/Card/tests/Card.test.tsx
@@ -5,6 +5,7 @@ import {setMediaWidth} from 'tests/utilities/breakpoints';
 
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {Card} from '..';
+import {ShadowBevel} from '../../ShadowBevel';
 
 const heading = <p>Online store dashboard</p>;
 const subheading = <p>View a summary of your online store performance</p>;
@@ -57,12 +58,31 @@ describe('Card', () => {
         {heading}
         {subheading}
       </Card>,
+      {features: {polarisSummerEditions2023: true}},
     );
 
-    expect(card).toContainReactComponent('div', {
-      style: expect.objectContaining({
-        '--pc-box-border-radius': 'var(--p-border-radius-2)',
-      }),
+    expect(card).toContainReactComponent(ShadowBevel, {
+      borderRadius: '3',
+    });
+  });
+
+  // se23 -- default borderRadius changed from '2' to '3', border radius on ShadowBevel instead of Box
+  describe('polarisSummerEditions2023 false', () => {
+    it('sets default border radius when roundedAbove breakpoint passed in', () => {
+      setMediaWidth('breakpoints-sm');
+      const card = mountWithApp(
+        <Card roundedAbove="sm">
+          {heading}
+          {subheading}
+        </Card>,
+        {features: {polarisSummerEditions2023: false}},
+      );
+
+      expect(card).toContainReactComponent('div', {
+        style: expect.objectContaining({
+          '--pc-box-border-radius': 'var(--p-border-radius-2)',
+        }),
+      });
     });
   });
 });

--- a/polaris-react/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/polaris-react/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
+import {UploadMajor} from '@shopify/polaris-icons';
 
 import {Text} from '../../../../Text';
 import {DropZoneContext} from '../../../context';
 import {FileUpload} from '../FileUpload';
 import {uploadArrow as uploadArrowImage} from '../../../images';
+import {Icon} from '../../../../Icon';
 
 describe('<FileUpload />', () => {
   const defaultStates = {
@@ -83,11 +85,10 @@ describe('<FileUpload />', () => {
       >
         <FileUpload />
       </DropZoneContext.Provider>,
+      {features: {polarisSummerEditions2023: true}},
     );
 
-    expect(fileUpload).not.toContainReactComponent(Text);
-
-    expect(fileUpload).toContainReactComponentTimes('img', 1);
+    expect(fileUpload).toContainReactComponent(Icon, {source: UploadMajor});
   });
 
   it('sets a default actionTitle if the prop is provided then removed', () => {
@@ -138,4 +139,22 @@ describe('<FileUpload />', () => {
       });
     },
   );
+
+  // se23 - img replaced with Icon
+  describe('polarisSummerEditions2023 false', () => {
+    it('renders small view', () => {
+      const fileUpload = mountWithApp(
+        <DropZoneContext.Provider
+          value={{size: 'small', type: 'file', ...defaultStates}}
+        >
+          <FileUpload />
+        </DropZoneContext.Provider>,
+        {features: {polarisSummerEditions2023: false}},
+      );
+
+      expect(fileUpload).not.toContainReactComponent(Text);
+
+      expect(fileUpload).toContainReactComponentTimes('img', 1);
+    });
+  });
 });

--- a/polaris-react/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/polaris-react/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -150,11 +150,13 @@ describe('<EmptyState />', () => {
       );
       const text = emptyState.find(Text)!;
 
-      expect(text).toHaveReactProps({variant: 'headingXl'});
+      expect(text).toHaveReactProps({
+        variant: expect.stringContaining('heading'),
+      });
       expect(text).toContainReactText(expectedHeading);
     });
 
-    it('renders a headingLg Text when in a content context', () => {
+    it('renders a heading Text when in a content context', () => {
       const emptyStateInContentContext = mountWithApp(
         <WithinContentContext.Provider value>
           <EmptyState heading="Heading" image={imgSrc} />
@@ -162,7 +164,7 @@ describe('<EmptyState />', () => {
       );
 
       expect(emptyStateInContentContext).toContainReactComponent(Text, {
-        variant: 'headingLg',
+        variant: expect.stringContaining('heading'),
       });
     });
   });

--- a/polaris-react/src/components/Filters/components/FilterPill/tests/FilterPill.test.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/tests/FilterPill.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
-import {CaretDownMinor} from '@shopify/polaris-icons';
+import {CaretDownMinor, ChevronDownMinor} from '@shopify/polaris-icons';
 
 import {FilterPill} from '../FilterPill';
 import type {FilterPillProps} from '../FilterPill';
@@ -51,11 +51,13 @@ describe('<Filters />', () => {
       expect(wrapper).toContainReactText(defaultProps.label);
     });
 
-    it('renders with bodyMd variant when on a small screen', () => {
+    it('renders with bodyLg variant when on a small screen', () => {
       mockUseBreakpoints(true);
-      const wrapper = mountWithApp(<FilterPill {...defaultProps} />);
+      const wrapper = mountWithApp(<FilterPill {...defaultProps} />, {
+        features: {polarisSummerEditions2023: true},
+      });
       expect(wrapper).toContainReactComponent(Text, {
-        variant: 'bodyMd',
+        variant: 'bodyLg',
         children: defaultProps.label,
       });
     });
@@ -83,18 +85,22 @@ describe('<Filters />', () => {
     });
 
     it('when not selected, renders a caret icon', () => {
-      const wrapper = mountWithApp(<FilterPill {...defaultProps} />);
+      const wrapper = mountWithApp(<FilterPill {...defaultProps} />, {
+        features: {polarisSummerEditions2023: true},
+      });
       expect(wrapper.findAll(UnstyledButton)[0]).toContainReactComponent(Icon, {
-        source: CaretDownMinor,
+        source: ChevronDownMinor,
       });
     });
 
     it('when selected, does not render a caret icon', () => {
-      const wrapper = mountWithApp(<FilterPill {...defaultProps} selected />);
+      const wrapper = mountWithApp(<FilterPill {...defaultProps} selected />, {
+        features: {polarisSummerEditions2023: true},
+      });
       expect(wrapper.findAll(UnstyledButton)[0]).not.toContainReactComponent(
         Icon,
         {
-          source: CaretDownMinor,
+          source: ChevronDownMinor,
         },
       );
     });
@@ -192,6 +198,42 @@ describe('<Filters />', () => {
       expect(scrollSpy).toHaveBeenCalledWith({
         left: 0,
       });
+    });
+  });
+
+  // se23 - small screen bodyMd text replaced with bodyLg
+  // CaretDownMinor replaced with ChevronDownMinor
+  describe('polarisSummerEditions2023 false', () => {
+    it('renders with bodyMd variant when on a small screen', () => {
+      mockUseBreakpoints(true);
+      const wrapper = mountWithApp(<FilterPill {...defaultProps} />, {
+        features: {polarisSummerEditions2023: false},
+      });
+      expect(wrapper).toContainReactComponent(Text, {
+        variant: 'bodyMd',
+        children: defaultProps.label,
+      });
+    });
+
+    it('when not selected, renders a caret icon', () => {
+      const wrapper = mountWithApp(<FilterPill {...defaultProps} />, {
+        features: {polarisSummerEditions2023: false},
+      });
+      expect(wrapper.findAll(UnstyledButton)[0]).toContainReactComponent(Icon, {
+        source: CaretDownMinor,
+      });
+    });
+
+    it('when selected, does not render a caret icon', () => {
+      const wrapper = mountWithApp(<FilterPill {...defaultProps} selected />, {
+        features: {polarisSummerEditions2023: false},
+      });
+      expect(wrapper.findAll(UnstyledButton)[0]).not.toContainReactComponent(
+        Icon,
+        {
+          source: CaretDownMinor,
+        },
+      );
     });
   });
 });

--- a/polaris-react/src/components/Filters/components/FilterPill/tests/FilterPill.test.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/tests/FilterPill.test.tsx
@@ -84,7 +84,7 @@ describe('<Filters />', () => {
       expect(spy).toHaveBeenCalledWith(defaultProps.filterKey);
     });
 
-    it('when not selected, renders a caret icon', () => {
+    it('when not selected, renders a chevron icon', () => {
       const wrapper = mountWithApp(<FilterPill {...defaultProps} />, {
         features: {polarisSummerEditions2023: true},
       });
@@ -93,7 +93,7 @@ describe('<Filters />', () => {
       });
     });
 
-    it('when selected, does not render a caret icon', () => {
+    it('when selected, does not render a chevron icon', () => {
       const wrapper = mountWithApp(<FilterPill {...defaultProps} selected />, {
         features: {polarisSummerEditions2023: true},
       });

--- a/polaris-react/src/components/IndexFilters/components/SortButton/components/DirectionButton/tests/DirectionButton.test.tsx
+++ b/polaris-react/src/components/IndexFilters/components/SortButton/components/DirectionButton/tests/DirectionButton.test.tsx
@@ -20,7 +20,6 @@ describe('DirectionButton', () => {
 
     expect(wrapper).toContainReactComponent(Icon, {
       source: ArrowUpMinor,
-      color: 'base',
     });
   });
 
@@ -36,7 +35,6 @@ describe('DirectionButton', () => {
 
     expect(wrapper).toContainReactComponent(Icon, {
       source: ArrowDownMinor,
-      color: 'base',
     });
   });
 
@@ -52,7 +50,6 @@ describe('DirectionButton', () => {
 
     expect(wrapper).toContainReactComponent(Icon, {
       source: ArrowUpMinor,
-      color: 'interactive',
     });
   });
 

--- a/polaris-react/src/components/LegacyCard/components/Header/tests/Header.test.tsx
+++ b/polaris-react/src/components/LegacyCard/components/Header/tests/Header.test.tsx
@@ -17,13 +17,17 @@ describe('<Header />', () => {
   describe('title', () => {
     it('renders a heading when defined', () => {
       const header = mountWithApp(<Header title="Staff accounts" />);
-      expect(header).toContainReactComponent(Text, {variant: 'headingMd'});
+      expect(header).toContainReactComponent(Text, {
+        as: 'h2',
+      });
     });
 
     it('renders the title directly if its a valid React element', () => {
       const title = <div>Staff accounts</div>;
       const header = mountWithApp(<Header title={title} />);
-      expect(header).not.toContainReactComponent(Text, {variant: 'headingLg'});
+      expect(header).not.toContainReactComponent(Text, {
+        as: 'h2',
+      });
       expect(header).toContainReactComponent('div', {
         children: 'Staff accounts',
       });
@@ -32,9 +36,7 @@ describe('<Header />', () => {
     it('is used as the content for the heading', () => {
       const title = 'Staff accounts';
       const header = mountWithApp(<Header title={title} />);
-      expect(header.find(Text, {variant: 'headingMd'})).toContainReactText(
-        title,
-      );
+      expect(header.find(Text, {as: 'h2'})).toContainReactText(title);
     });
   });
 

--- a/polaris-react/src/components/Modal/tests/Modal.test.tsx
+++ b/polaris-react/src/components/Modal/tests/Modal.test.tsx
@@ -314,9 +314,7 @@ describe('<Modal>', () => {
 
       expect(modal.find(Header)).toContainReactComponent('div', {
         style: expect.objectContaining({
-          '--pc-box-inset-inline-end': 'var(--p-space-0)',
           position: 'absolute',
-          zIndex: '1',
         }) as React.CSSProperties,
       });
       expect(modal.find(Header)).not.toContainReactComponent(Text, {

--- a/polaris-react/src/components/OptionList/components/Option/tests/Option.test.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/tests/Option.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {Checkbox} from '../../Checkbox';
+import {Checkbox as PolarisCheckbox} from '../../../../Checkbox';
 import {Scrollable} from '../../../../Scrollable';
 import {Option} from '../Option';
 import type {OptionProps} from '../Option';
@@ -19,8 +20,10 @@ describe('<Option />', () => {
   };
 
   it('renders a checkbox if allowMultiple is true', () => {
-    const checkbox = mountWithApp(<Option {...defaultProps} allowMultiple />);
-    expect(checkbox).toContainReactComponent(Checkbox);
+    const checkbox = mountWithApp(<Option {...defaultProps} allowMultiple />, {
+      features: {polarisSummerEditions2023: true},
+    });
+    expect(checkbox).toContainReactComponent(PolarisCheckbox);
   });
 
   it('renders a button if allowMultiple is false or undefined', () => {
@@ -58,8 +61,9 @@ describe('<Option />', () => {
 
     const input = mountWithApp(
       <Option {...defaultProps} onClick={spy} allowMultiple />,
+      {features: {polarisSummerEditions2023: true}},
     ).find('input')!;
-    input.trigger('onChange');
+    input.trigger('onClick');
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(section, index);
@@ -119,9 +123,9 @@ describe('<Option />', () => {
 
   it('sets the pass through props for Checkbox if multiple items are allowed', () => {
     const {id, value, select, disabled} = defaultProps;
-    const checkbox = mountWithApp(
-      <Option {...defaultProps} allowMultiple />,
-    ).find(Checkbox)!;
+    const checkbox = mountWithApp(<Option {...defaultProps} allowMultiple />, {
+      features: {polarisSummerEditions2023: true},
+    }).find(PolarisCheckbox)!;
 
     expect(checkbox.prop('id')).toBe(id);
     expect(checkbox.prop('value')).toBe(value);
@@ -144,7 +148,7 @@ describe('<Option />', () => {
     );
 
     expect(option).toContainReactComponent('label', {
-      className: 'Label select',
+      className: expect.stringContaining('Label select'),
     });
   });
 
@@ -155,7 +159,7 @@ describe('<Option />', () => {
 
     expect(option).toContainReactComponent(Scrollable.ScrollTo);
     expect(option).toContainReactComponent('label', {
-      className: 'Label active',
+      className: expect.stringContaining('Label active'),
     });
   });
 
@@ -164,7 +168,7 @@ describe('<Option />', () => {
       const option = mountWithApp(<Option {...defaultProps} allowMultiple />);
 
       expect(option).toContainReactComponent('label', {
-        className: 'Label',
+        className: expect.stringContaining('Label'),
       });
     });
 
@@ -174,7 +178,7 @@ describe('<Option />', () => {
       );
 
       expect(option).toContainReactComponent('label', {
-        className: 'Label verticalAlignTop',
+        className: expect.stringContaining('Label verticalAlignTop'),
       });
     });
 
@@ -184,7 +188,7 @@ describe('<Option />', () => {
       );
 
       expect(option).toContainReactComponent('label', {
-        className: 'Label verticalAlignCenter',
+        className: expect.stringContaining('Label verticalAlignCenter'),
       });
     });
 
@@ -194,8 +198,51 @@ describe('<Option />', () => {
       );
 
       expect(option).toContainReactComponent('label', {
-        className: 'Label verticalAlignBottom',
+        className: expect.stringContaining('Label verticalAlignBottom'),
       });
+    });
+  });
+
+  // se23 - Custom checbox replaced with PolarisCheckbox
+  // 'onChange' event replaced with 'onClick'
+  describe('polarisSummerEditions2023 false', () => {
+    it('renders a checkbox if allowMultiple is true', () => {
+      const checkbox = mountWithApp(
+        <Option {...defaultProps} allowMultiple />,
+        {
+          features: {polarisSummerEditions2023: false},
+        },
+      );
+      expect(checkbox).toContainReactComponent(Checkbox);
+    });
+
+    it('calls onClick with section and index if option is not disabled and multiple options are allowed', () => {
+      const spy = jest.fn();
+      const {section, index} = defaultProps;
+
+      const input = mountWithApp(
+        <Option {...defaultProps} onClick={spy} allowMultiple />,
+        {features: {polarisSummerEditions2023: false}},
+      ).find('input')!;
+      input.trigger('onChange');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(section, index);
+    });
+
+    it('sets the pass through props for Checkbox if multiple items are allowed', () => {
+      const {id, value, select, disabled} = defaultProps;
+      const checkbox = mountWithApp(
+        <Option {...defaultProps} allowMultiple />,
+        {
+          features: {polarisSummerEditions2023: false},
+        },
+      ).find(Checkbox)!;
+
+      expect(checkbox.prop('id')).toBe(id);
+      expect(checkbox.prop('value')).toBe(value);
+      expect(checkbox.prop('checked')).toBe(select);
+      expect(checkbox.prop('disabled')).toBe(disabled);
     });
   });
 });

--- a/polaris-react/src/components/OptionList/tests/OptionList.test.tsx
+++ b/polaris-react/src/components/OptionList/tests/OptionList.test.tsx
@@ -483,9 +483,10 @@ describe('<OptionList />', () => {
 
         const inputWrapper = mountWithApp(
           <OptionList {...defaultProps} onChange={spy} allowMultiple />,
+          {features: {polarisSummerEditions2023: true}},
         ).find('input');
 
-        inputWrapper!.trigger('onChange');
+        inputWrapper!.trigger('onClick');
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy).toHaveBeenCalledWith([firstOption(options, sections)]);
@@ -503,9 +504,10 @@ describe('<OptionList />', () => {
             selected={selected}
             allowMultiple
           />,
+          {features: {polarisSummerEditions2023: true}},
         ).find('input');
 
-        inputWrapper!.trigger('onChange');
+        inputWrapper!.trigger('onClick');
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy).toHaveBeenCalledWith([
@@ -526,9 +528,10 @@ describe('<OptionList />', () => {
             selected={selected}
             allowMultiple
           />,
+          {features: {polarisSummerEditions2023: true}},
         ).find('input');
 
-        inputWrapper!.trigger('onChange');
+        inputWrapper!.trigger('onClick');
 
         const valueToCheck = firstOption(options, sections);
         const newSelected = selected.filter((value) => value !== valueToCheck);
@@ -579,6 +582,72 @@ describe('<OptionList />', () => {
       optionWrappers.forEach((option) => {
         expect(option.props.verticalAlign).toBeUndefined();
       });
+    });
+  });
+
+  // se23 - 'onChange' event replaced with 'onClick'
+  describe('polarisSummerEditions2023 false', () => {
+    it('selects an item when nothing was selected', () => {
+      const spy = jest.fn();
+      const {options, sections} = defaultProps;
+
+      const inputWrapper = mountWithApp(
+        <OptionList {...defaultProps} onChange={spy} allowMultiple />,
+        {features: {polarisSummerEditions2023: false}},
+      ).find('input');
+
+      inputWrapper!.trigger('onChange');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith([firstOption(options, sections)]);
+    });
+
+    it('selects an item when multiple items are selected', () => {
+      const spy = jest.fn();
+      const {options, sections} = defaultProps;
+      const selected = ['11', '8'];
+
+      const inputWrapper = mountWithApp(
+        <OptionList
+          {...defaultProps}
+          onChange={spy}
+          selected={selected}
+          allowMultiple
+        />,
+        {features: {polarisSummerEditions2023: false}},
+      ).find('input');
+
+      inputWrapper!.trigger('onChange');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith([
+        firstOption(options, sections),
+        ...selected,
+      ]);
+    });
+
+    it('deselects an item when it is already selected', () => {
+      const spy = jest.fn();
+      const {options, sections} = defaultProps;
+      const selected = ['10', '8', '5'];
+
+      const inputWrapper = mountWithApp(
+        <OptionList
+          {...defaultProps}
+          onChange={spy}
+          selected={selected}
+          allowMultiple
+        />,
+        {features: {polarisSummerEditions2023: false}},
+      ).find('input');
+
+      inputWrapper!.trigger('onChange');
+
+      const valueToCheck = firstOption(options, sections);
+      const newSelected = selected.filter((value) => value !== valueToCheck);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(newSelected);
     });
   });
 });

--- a/polaris-react/src/components/Pagination/tests/Pagination.test.tsx
+++ b/polaris-react/src/components/Pagination/tests/Pagination.test.tsx
@@ -257,6 +257,7 @@ describe('<Pagination />', () => {
   it('the ButtonGroup is not segmented when there is a label', () => {
     const pagination = mountWithApp(
       <Pagination nextURL="/next" previousURL="/prev" label="Hello, world!" />,
+      {features: {polarisSummerEditions2023: false}},
     );
 
     expect(pagination).toContainReactComponent(ButtonGroup, {

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -359,13 +359,14 @@ describe('<Tooltip />', () => {
         <Tooltip content="Inner content">
           <Link>link content</Link>
         </Tooltip>,
+        {features: {polarisSummerEditions2023: true}},
       );
 
       findWrapperComponent(tooltip)!.trigger('onMouseOver');
 
       expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div', {
         style: expect.objectContaining({
-          '--pc-tooltip-border-radius': 'var(--p-border-radius-1)',
+          '--pc-tooltip-border-radius': 'var(--p-border-radius-2)',
         }) as React.CSSProperties,
       });
     });
@@ -506,6 +507,26 @@ describe('<Tooltip />', () => {
       findWrapperComponent(tooltip)!.trigger('onMouseOver');
       expect(tooltip).toContainReactComponent(TooltipOverlay, {
         instant: true,
+      });
+    });
+  });
+
+  // se23 - default border radius 1 replaced with 2
+  describe('polarisSummerEditions2023 false', () => {
+    it('renders content with the default border radius', () => {
+      const tooltip = mountWithApp(
+        <Tooltip content="Inner content">
+          <Link>link content</Link>
+        </Tooltip>,
+        {features: {polarisSummerEditions2023: false}},
+      );
+
+      findWrapperComponent(tooltip)!.trigger('onMouseOver');
+
+      expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div', {
+        style: expect.objectContaining({
+          '--pc-tooltip-border-radius': 'var(--p-border-radius-1)',
+        }) as React.CSSProperties,
       });
     });
   });

--- a/polaris-react/tests/utilities/react-testing.tsx
+++ b/polaris-react/tests/utilities/react-testing.tsx
@@ -27,7 +27,7 @@ export const mountWithApp = createMount<
       <PolarisTestProvider
         i18n={translations}
         features={{
-          polarisSummerEditions2023: false,
+          polarisSummerEditions2023: process.env.SE23 === 'on',
           ...features,
         }}
         {...rest}


### PR DESCRIPTION
### 🤨 WHAT is this pull request doing?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/1029
Duplicates CI checks for `{features: {polarisSummerEditions2023: true}}`
<details>
<summary>How to run tests in the CLI</summary>
<br />
I implemented this using a <code>SE23</code> environment variable that can be set to <code>on</code> or <code>off</code>. (I don't use true/false to avoid confusion with strings vs booleans).

To run tests with `{features: {polarisSummerEditions2023: true}}`:

```
SE23='on' yarn test
```

To run tests with  `{features: {polarisSummerEditions2023: false}}`

```
yarn test
// or
SE23='off' yarn test
```
</details>

<img width="400" alt="Screenshot 2023-08-01 at 1 51 24 PM" src="https://github.com/Shopify/polaris/assets/20652326/d760c8e1-7cf8-44e2-ba41-c3ba6c7fcf4d">


### 🔨 How tests are fixed

To add these checks, I had to fix all failing tests when `polarisSummerEditions2023: true`. To do this, I investigated the failing tests and followed these steps:

1. See if test can be fixed to pass on both without compromising the purpose of the test
2. If not, duplicate the test
3. Create a `polarisSummerEditions2023 false` describe block at the end of the file
4. Move the duplicated test there and pass `polarisSummerEditions2023: false` to `mountWithApp` to force the feature flag on every test run
5. In the original failing test, force `polarisSummerEditions2023: true` and fix the test

#### Example for <code>CaretDownMinor</code> -> <code>ChevronDownMinor</code> changes</summary>

```diff
it('is a test that will only pass post se23', () => {
-  const component = mountWithApp(<MyComponent />);
-  expect(component).toContainReactComponent(Icon, {source: CaretDownMinor});
+  const component = mountWithApp(<MyComponent />, {features: {polarisSummerEditions2023: true}});
+  expect(component).toContainReactComponent(Icon, {source: ChevronDownMinor});
});

+ describe('polarisSummerEditions2023 false', () => {
+  it('is a test that will only pass pre se23', () => {
+    const component = mountWithApp(<MyComponent />, {features: {polarisSummerEditions2023: false}});
+      expect(component).toContainReactComponent(Icon, {source: CaretDownMinor});
+  });
```

### 🧽 How these should be cleaned up

When we remove the `polarisSummerEditions2023` feature, we will need simply: 

1. delete all the `polarisSummerEditions2023 false` describe blocks
2. remove the  {features: {polarisSummerEditions2023: true} from `mountWithApp`s

#### Clean up for example above</summary>

```diff
it('is a test that will only pass post se23', () => {
-  const component = mountWithApp(<MyComponent />, {features: {polarisSummerEditions2023: true}});
+. const component = mountWithApp(<MyComponent />);
  expect(component).toContainReactComponent(Icon, {source: ChevronDownMinor});
});

- describe('polarisSummerEditions2023 false', () => {
-   it('is a test that will only pass pre se23', () => {
-     const component = mountWithApp(<MyComponent />, {features: {polarisSummerEditions2023: false}});
-     expect(component).toBeNull();
-   });
```

### How to 🎩

Make sure all CI checks pass 😎