### PR TITLE
[ActionList][Item] Fix overflow on popover

### DIFF
--- a/.changeset/ninety-carrots-hammer.md
+++ b/.changeset/ninety-carrots-hammer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed ActionList item overflow and tooltip zIndex

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -175,6 +175,7 @@
     // stylelint-enable
     position: relative;
     margin-left: calc(var(--p-space-5) + var(--p-space-05));
+    max-width: 94%;
 
     &::before {
       content: '';

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -1,5 +1,8 @@
 @import '../../styles/common';
 
+$indented-item-margin: calc(var(--p-space-5) + var(--p-space-05));
+$indented-item-width: calc(100% - #{$indented-item-margin});
+
 .Item {
   // stylelint-disable -- Polaris component custom properties
   --pc-action-list-item-min-height: var(--p-space-10);
@@ -174,8 +177,8 @@
     --pc-action-list-image-size: 24px;
     // stylelint-enable
     position: relative;
-    margin-left: calc(var(--p-space-5) + var(--p-space-05));
-    max-width: 94%;
+    margin-left: $indented-item-margin;
+    max-width: $indented-item-width;
 
     &::before {
       content: '';

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -189,7 +189,7 @@ export const TruncateText = ({children}: {children: string}) => {
 
   return isOverflowing ? (
     <Tooltip
-      zIndexOverride={Number(zIndex['z-index-6'])}
+      zIndexOverride={Number(zIndex['z-index-11'])}
       preferredPosition="above"
       hoverDelay={1000}
       content={children}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/core-workflows/issues/1064

<!--
  Context about the problem that’s being addressed.
-->

- When the popover is expanded, indented items in the account menu are overflowing instead of truncating properly.

<details>
<summary> Expand for screenshot: </summary>

<img src="https://github.com/Shopify/core-workflows/assets/42528878/e19693b8-0071-44e7-b001-14978ef5699f" alt="bug screenshot" width="250px" height="auto" />

</details>

- When hovering over items, the tooltip does not show because it's behind the Popover.

<details>
<summary> Expand for screenshot: </summary>

<img src="https://github.com/Shopify/polaris/assets/42528878/47daa261-a73d-4a96-95ed-29d62d2444bb" alt="bug screenshot" width="250px" height="auto" />

</details>

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

- Applies a max-width to the indented items
- Applies a higher z-Index on tooltips

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

[Spin URL](https://admin.web.fx.zakaria-warsame.us.spin.dev/store/shop2/)
- Ensure the account menu items are truncating properly and not overflowing.
- Hover over the items ensure the tooltip shows up on top of the popover.


</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
~- [ ] Updated the component's `README.md` with documentation changes~
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
