### PR TITLE
[ActionList] Forces block content to do vertical alignment

### DIFF
--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -227,4 +227,12 @@
   min-width: 0;
   max-width: 100%;
   flex: 1 1 auto;
+  display: block;
+  vertical-align: middle;
+
+  // stylelint-disable -- forces content to be block so vertical-align can do its thing
+  * {
+    display: block;
+  }
+  // stylelint-disable
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Despite the fact that `ActionList.Item` only takes `content` as `string`, it works very well with a `React.ReactNode` too. On Shopify Email, we are using this very component to render some SVG and the only problem is it is not well aligned.

Modifying this component to take in `content?: string | React.ReactNode` has proven to be more difficult as `Action`, from which is derives `content` is used in many places and maybe we don't want to allow everything that uses `Action` to accept a node as `content`.

### WHAT is this pull request doing?

By adding `display: block` to `.Text` and forcing its children to also be, we achieve the desired effect:

| Before | After |
| --- | --- |
| <img width="281" alt="Screenshot 2023-08-02 at 3 01 53 PM" src="https://github.com/Shopify/polaris/assets/642737/27e42a12-0f41-43fc-af2c-a5ee7d7e133e"> | <img width="285" alt="Screenshot 2023-08-02 at 3 01 24 PM" src="https://github.com/Shopify/polaris/assets/642737/84aa47f7-5575-4cae-b5cf-71180b433309"> |

### How to 🎩

This is a copy of what we have on the docs sandbox for `ActionList`, modded only for the typing to be "compliant" and also use an SVG as node example.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  const [active, setActive] = useState(true);

  const toggleActive = useCallback(() => setActive((active) => !active), []);

  const handleImportedAction = useCallback(
    () => console.log("Imported action"),
    []
  );

  const handleExportedAction = useCallback(
    () => console.log("Exported action"),
    []
  );

  const activator = (
    <Button onClick={toggleActive} disclosure>
      More actions
    </Button>
  );

  const someNode = <svg fill="none" height="2" viewBox="0 0 140 2" width="140" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="M0 1C0 0.447715 0.447715 0 1 0H1.00507C1.55735 0 2.00507 0.447715 2.00507 1C2.00507 1.55228 1.55735 2 1.00507 2H1C0.447715 2 0 1.55228 0 1ZM8.11258 1C8.11258 0.447715 8.56029 0 9.11258 0H9.12271C9.675 0 10.1227 0.447715 10.1227 1C10.1227 1.55228 9.675 2 9.12271 2H9.11258C8.56029 2 8.11258 1.55228 8.11258 1ZM16.2302 1C16.2302 0.447715 16.6779 0 17.2302 0H17.2404C17.7926 0 18.2404 0.447715 18.2404 1C18.2404 1.55228 17.7926 2 17.2404 2H17.2302C16.6779 2 16.2302 1.55228 16.2302 1ZM24.3479 1C24.3479 0.447715 24.7956 0 25.3479 0H25.358C25.9103 0 26.358 0.447715 26.358 1C26.358 1.55228 25.9103 2 25.358 2H25.3479C24.7956 2 24.3479 1.55228 24.3479 1ZM32.4655 1C32.4655 0.447715 32.9132 0 33.4655 0H33.4757C34.0279 0 34.4757 0.447715 34.4757 1C34.4757 1.55228 34.0279 2 33.4757 2H33.4655C32.9132 2 32.4655 1.55228 32.4655 1ZM40.5832 1C40.5832 0.447715 41.0309 0 41.5832 0H41.5933C42.1456 0 42.5933 0.447715 42.5933 1C42.5933 1.55228 42.1456 2 41.5933 2H41.5832C41.0309 2 40.5832 1.55228 40.5832 1ZM48.7008 1C48.7008 0.447715 49.1485 0 49.7008 0H49.711C50.2632 0 50.711 0.447715 50.711 1C50.711 1.55228 50.2632 2 49.711 2H49.7008C49.1485 2 48.7008 1.55228 48.7008 1ZM56.8185 1C56.8185 0.447715 57.2662 0 57.8185 0H57.8286C58.3809 0 58.8286 0.447715 58.8286 1C58.8286 1.55228 58.3809 2 57.8286 2H57.8185C57.2662 2 56.8185 1.55228 56.8185 1ZM64.9361 1C64.9361 0.447715 65.3838 0 65.9361 0H65.9462C66.4985 0 66.9462 0.447715 66.9462 1C66.9462 1.55228 66.4985 2 65.9462 2H65.9361C65.3838 2 64.9361 1.55228 64.9361 1ZM73.0538 1C73.0538 0.447715 73.5015 0 74.0538 0H74.0639C74.6162 0 75.0639 0.447715 75.0639 1C75.0639 1.55228 74.6162 2 74.0639 2H74.0538C73.5015 2 73.0538 1.55228 73.0538 1ZM81.1714 1C81.1714 0.447715 81.6191 0 82.1714 0H82.1815C82.7338 0 83.1815 0.447715 83.1815 1C83.1815 1.55228 82.7338 2 82.1815 2H82.1714C81.6191 2 81.1714 1.55228 81.1714 1ZM89.289 1C89.289 0.447715 89.7368 0 90.289 0H90.2992C90.8515 0 91.2992 0.447715 91.2992 1C91.2992 1.55228 90.8515 2 90.2992 2H90.289C89.7368 2 89.289 1.55228 89.289 1ZM97.4067 1C97.4067 0.447715 97.8544 0 98.4067 0H98.4168C98.9691 0 99.4168 0.447715 99.4168 1C99.4168 1.55228 98.9691 2 98.4168 2H98.4067C97.8544 2 97.4067 1.55228 97.4067 1ZM105.524 1C105.524 0.447715 105.972 0 106.524 0H106.534C107.087 0 107.534 0.447715 107.534 1C107.534 1.55228 107.087 2 106.534 2H106.524C105.972 2 105.524 1.55228 105.524 1ZM113.642 1C113.642 0.447715 114.09 0 114.642 0H114.652C115.204 0 115.652 0.447715 115.652 1C115.652 1.55228 115.204 2 114.652 2H114.642C114.09 2 113.642 1.55228 113.642 1ZM121.76 1C121.76 0.447715 122.207 0 122.76 0H122.77C123.322 0 123.77 0.447715 123.77 1C123.77 1.55228 123.322 2 122.77 2H122.76C122.207 2 121.76 1.55228 121.76 1ZM129.877 1C129.877 0.447715 130.325 0 130.877 0H130.887C131.44 0 131.887 0.447715 131.887 1C131.887 1.55228 131.44 2 130.887 2H130.877C130.325 2 129.877 1.55228 129.877 1ZM137.995 1C137.995 0.447715 138.443 0 138.995 0H139C139.552 0 140 0.447715 140 1C140 1.55228 139.552 2 139 2H138.995C138.443 2 137.995 1.55228 137.995 1Z" fill="#5C5F62" fill-rule="evenodd"></path></svg>

  return (
    <div style={{ height: "250px" }}>
      <Popover
        active={active}
        activator={activator}
        autofocusTarget="first-node"
        onClose={toggleActive}
      >
        <ActionList
          actionRole="menuitem"
          items={[
            {
              content: someNode as unknown as string,
              onAction: handleImportedAction
            },
            {
              content: someNode as unknown as string,
              onAction: handleExportedAction
            }
          ]}
        />
      </Popover>
    </div>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
