### PR TITLE
[OptionList] Remove bg styles for multiselect options

### DIFF
--- a/polaris-react/src/components/OptionList/OptionList.stories.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.stories.tsx
@@ -65,6 +65,30 @@ export function Multiple() {
   );
 }
 
+export function MultipleWithDisabledOption() {
+  const [selected, setSelected] = useState([]);
+
+  const handleChange = useCallback((value) => setSelected(value), []);
+
+  return (
+    <LegacyCard>
+      <OptionList
+        title="Manage sales channels availability"
+        onChange={handleChange}
+        options={[
+          {value: 'online_store', label: 'Online Store'},
+          {value: 'messenger', label: 'Messenger', disabled: true},
+          {value: 'facebook', label: 'Facebook'},
+          {value: 'wholesale', label: 'Wholesale'},
+          {value: 'buzzfeed', label: 'BuzzFeed'},
+        ]}
+        selected={selected}
+        allowMultiple
+      />
+    </LegacyCard>
+  );
+}
+
 export function WithSections() {
   const [selected, setSelected] = useState([]);
 

--- a/polaris-react/src/components/OptionList/components/Option/Option.scss
+++ b/polaris-react/src/components/OptionList/components/Option/Option.scss
@@ -91,7 +91,8 @@ $control-vertical-adjustment: 2px;
 }
 
 .Label,
-.SingleSelectOption {
+.SingleSelectOption,
+.MultiSelectOption {
   display: flex;
   align-items: flex-start;
   width: 100%;
@@ -146,6 +147,17 @@ $control-vertical-adjustment: 2px;
     background: transparent;
     cursor: default;
     color: var(--p-color-text-disabled);
+  }
+}
+
+.MultiSelectOption {
+  #{$se23} & {
+    &:active:not(.disabled),
+    &.select,
+    &.select:hover:not(.disabled),
+    &:hover:not(.disabled) {
+      background-color: transparent;
+    }
   }
 }
 

--- a/polaris-react/src/components/OptionList/components/Option/Option.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/Option.tsx
@@ -100,6 +100,7 @@ export function Option({
     select && styles.select,
     verticalAlign && styles[variationName('verticalAlign', verticalAlign)],
     polarisSummerEditions2023 && allowMultiple && styles.CheckboxLabel,
+    polarisSummerEditions2023 && allowMultiple && styles.MultiSelectOption,
   );
 
   const checkBoxRole = role === 'option' ? 'presentation' : undefined;


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [9883](https://github.com/Shopify/polaris/issues/9883).
Updates styling on Option for multi select.

### WHAT is this pull request doing?

Removes background color on Option in OptionList if `allowMultiple` is true.
Adds new "Multiple With Disabled Option".

### How to 🎩

[OptionList Storybook](https://5d559397bae39100201eedc1-twmrpdlzge.chromatic.com/?path=/story/all-components-optionlist--default)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
