### PR TITLE
Update Polaris Stylelint version matchups chart

### DIFF
--- a/.changeset/swift-radios-count.md
+++ b/.changeset/swift-radios-count.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Updated Polaris Stylelint version matchups chart

--- a/polaris.shopify.com/content/tools/stylelint-polaris/index.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/index.md
@@ -108,6 +108,9 @@ There are over 40 rules configured in Stylelint Polaris to help you avoid errors
 | 8.0.0                      | 10.32.0          |
 | 9.0.0                      | 10.36.0          |
 | 10.0.0                     | 10.44.0          |
+| 11.0.0                     | 10.48.0          |
+| 12.0.0                     | 10.49.0          |
+| 13.0.0                     | 11.0.0           |
 
 _\*@shopify/stylelint-polaris v5.0.0 was the first stable release_
 


### PR DESCRIPTION
### WHY are these changes introduced?

Updates the Polaris Stylelint version matchups chart with our latest releases. 

### WHAT is this pull request doing?

Adds entries to the chart for Polaris Stylelint v11.0.0, v12.0.0, and v13.0.0.

| Before | After |
| -- | -- |
| <img width="975" alt="Screenshot 2023-08-07 at 11 57 33 AM" src="https://github.com/Shopify/polaris/assets/21976492/6a0c4361-6cb3-4c30-9fb6-97dd3176e5ff">|<img width="975" alt="Screenshot 2023-08-07 at 11 57 03 AM" src="https://github.com/Shopify/polaris/assets/21976492/60ff645c-201d-496b-bebb-0cb6ffe931ed">|
