### PR TITLE
[Pagination] Prefer tooltip position below the buttons

### DIFF
--- a/.changeset/five-toes-hammer.md
+++ b/.changeset/five-toes-hammer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Set the preferred position of `Pagination` button tooltips to `below`

--- a/.changeset/five-toes-hammer.md
+++ b/.changeset/five-toes-hammer.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Set the preferred position of `Pagination` button tooltips to `below`
+Set the preferred position of `Pagination` and `Page` `secondaryActions` button tooltips to `below`

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -36,7 +36,9 @@ export function SecondaryAction({
   );
 
   const actionMarkup = helpText ? (
-    <Tooltip content={helpText}>{buttonMarkup}</Tooltip>
+    <Tooltip preferredPosition="below" content={helpText}>
+      {buttonMarkup}
+    </Tooltip>
   ) : (
     buttonMarkup
   );

--- a/polaris-react/src/components/Pagination/Pagination.tsx
+++ b/polaris-react/src/components/Pagination/Pagination.tsx
@@ -91,7 +91,11 @@ export function Pagination({
   );
   const constructedPrevious =
     previousTooltip && hasPrevious ? (
-      <Tooltip activatorWrapper="span" content={previousTooltip}>
+      <Tooltip
+        activatorWrapper="span"
+        content={previousTooltip}
+        preferredPosition="below"
+      >
         {prev}
       </Tooltip>
     ) : (
@@ -111,7 +115,11 @@ export function Pagination({
   );
   const constructedNext =
     nextTooltip && hasNext ? (
-      <Tooltip activatorWrapper="span" content={nextTooltip}>
+      <Tooltip
+        activatorWrapper="span"
+        content={nextTooltip}
+        preferredPosition="below"
+      >
         {next}
       </Tooltip>
     ) : (


### PR DESCRIPTION
### WHY are these changes introduced?

When tooltips are provided to the the Page secondary or pagination actions, they default to rendering above the buttons because there's no preferred position set. This is a problem in embedded apps because the AppBridge TitleBar renders over the top of them.

<img width="965" alt="Screenshot 2023-08-04 at 1 54 38 PM" src="https://github.com/Shopify/polaris/assets/18447883/0b3f7da1-fbd4-465e-b0e8-5a1d9af2a18f">

### WHAT is this pull request doing?

This PR sets the preferred position of tooltipable actions in `Page` and `Pagination` to "below".

### How to 🎩

🌀 [Spinstance](https://admin.web.page-action-tooltip-alignment.chloe-rice.us.spin.dev/store/shop1/articles/2)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
