### PR TITLE
Remove mix blend mode on primary button

### DIFF
--- a/.changeset/young-dragons-switch.md
+++ b/.changeset/young-dragons-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed primary Button styles for Chrome on Android devices

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -326,8 +326,6 @@
       box-shadow: var(--p-shadow-button-primary-strong-experimental);
       border-radius: 9px;
       transition: opacity 75ms cubic-bezier(0.19, 0.91, 0.38, 1);
-      mix-blend-mode: luminosity;
-      // stylelint-enable
     }
 
     &:hover {

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -326,6 +326,7 @@
       box-shadow: var(--p-shadow-button-primary-strong-experimental);
       border-radius: 9px;
       transition: opacity 75ms cubic-bezier(0.19, 0.91, 0.38, 1);
+      // stylelint-enable
     }
 
     &:hover {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1035

### WHAT is this pull request doing?

The `mix-blend-mode` was causing a visual regression on Android Chrome.

This was tested on a Google Pixel 6 Pro on Chrome

| Before | After |
| --- | --- |
| <img width="516" alt="before" src="https://github.com/Shopify/polaris/assets/11774595/3387fee2-7b53-4dec-89b4-4cdd1ee7465a"> | <img width="516" alt="after" src="https://github.com/Shopify/polaris/assets/11774595/358f61ea-c31a-4d95-bf73-c1b9e7c5db30"> |
