### PR TITLE
[EmptyState] Consolidate se23 logic and styles 

### DIFF
--- a/.changeset/tall-chicken-repeat.md
+++ b/.changeset/tall-chicken-repeat.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': major
 ---
 
-Removed Summer Editions experimental styles and code for the following components: `Avatar`, `AccountConnection`, `ActionList`, `ActionMenu`, `Autocomplete`, `Breadcrumbs`, `Text`, `KeyboardKey`
+Removed Summer Editions experimental styles and code for the following components: `Avatar`, `AccountConnection`, `ActionList`, `ActionMenu`, `Autocomplete`, `Breadcrumbs`, `Text`, `KeyboardKey`, `EmptyState`

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -1,7 +1,6 @@
-import React, {useContext} from 'react';
+import React from 'react';
 
 import {classNames} from '../../utilities/css';
-import {WithinContentContext} from '../../utilities/within-content-context';
 import type {ComplexAction} from '../../types';
 import {Box} from '../Box';
 import {buttonFrom} from '../Button';
@@ -9,7 +8,6 @@ import {Image} from '../Image';
 import {Text} from '../Text';
 import {VerticalStack} from '../VerticalStack';
 import {HorizontalStack} from '../HorizontalStack';
-import {useFeatures} from '../../utilities/features';
 
 import styles from './EmptyState.scss';
 
@@ -48,8 +46,6 @@ export function EmptyState({
   secondaryAction,
   footerContent,
 }: EmptyStateProps) {
-  const {polarisSummerEditions2023} = useFeatures();
-  const withinContentContainer = useContext(WithinContentContext);
   const imageContainedClass = classNames(
     imageContained && styles.imageContained,
   );
@@ -81,49 +77,33 @@ export function EmptyState({
 
   const footerContentMarkup = footerContent ? (
     <Box paddingBlockStart="4">
-      <Text
-        as="span"
-        color={polarisSummerEditions2023 ? undefined : 'subdued'}
-        alignment="center"
-        variant={polarisSummerEditions2023 ? 'bodySm' : 'bodyMd'}
-      >
+      <Text as="span" alignment="center" variant="bodySm">
         {footerContent}
       </Text>
     </Box>
   ) : null;
-
-  const headingSize = withinContentContainer ? 'headingLg' : 'headingXl';
 
   const primaryActionMarkup = action
     ? buttonFrom(action, {primary: true, size: 'medium'})
     : null;
 
   const headingMarkup = heading ? (
-    <Box paddingBlockEnd={polarisSummerEditions2023 ? '1_5-experimental' : '4'}>
-      <Text
-        variant={polarisSummerEditions2023 ? 'headingMd' : headingSize}
-        as="p"
-        alignment="center"
-      >
+    <Box paddingBlockEnd="1_5-experimental">
+      <Text variant="headingMd" as="p" alignment="center">
         {heading}
       </Text>
     </Box>
   ) : null;
 
   const childrenMarkup = children ? (
-    <Text
-      as="span"
-      color={polarisSummerEditions2023 ? undefined : 'subdued'}
-      alignment="center"
-      variant={polarisSummerEditions2023 ? 'bodySm' : 'bodyMd'}
-    >
+    <Text as="span" alignment="center" variant="bodySm">
       {children}
     </Text>
   ) : null;
 
   const textContentMarkup =
     headingMarkup || children ? (
-      <Box paddingBlockEnd={polarisSummerEditions2023 ? '4' : '6'}>
+      <Box paddingBlockEnd="4">
         {headingMarkup}
         {childrenMarkup}
       </Box>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/9933

### WHAT is this pull request doing?

Consolidates se23 beta styles for `EmptyState`.

### How to 🎩

Compare and make sure they are the same:

* This PR's [Storybook](https://5d559397bae39100201eedc1-xyztablchw.chromatic.com/?path=/story/all-components-emptystate--default)
* [Production Storybook](https://storybook.polaris.shopify.com/?path=/story/all-components-emptystate--default&globals=polarisSummerEditions2023:true)