### PR TITLE
Textfield add variant prop

### DIFF
--- a/.changeset/rotten-comics-think.md
+++ b/.changeset/rotten-comics-think.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added variant prop to TextField

--- a/.changeset/rotten-comics-think.md
+++ b/.changeset/rotten-comics-think.md
@@ -1,5 +1,7 @@
 ---
-'@shopify/polaris': minor
+'@shopify/polaris': major
 ---
 
-Added variant prop to TextField
+Replaced `borderless` prop with `variant` on TextField
+
+Migration: `npx @shopify/polaris-migrator react-rename-component-prop <path> --componentName="TextField" --from="borderless" --to="variant" --newValue="borderless"`

--- a/polaris-react/src/components/Filters/components/SearchField/SearchField.tsx
+++ b/polaris-react/src/components/Filters/components/SearchField/SearchField.tsx
@@ -105,7 +105,7 @@ export function SearchField({
       clearButton
       onClearButtonClick={handleClear}
       disabled={disabled}
-      borderless={borderlessQueryField}
+      variant={borderlessQueryField ? 'borderless' : undefined}
     />
   );
 }

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -738,7 +738,7 @@ export function All() {
           label="Borderless"
           value="Value"
           onChange={() => {}}
-          borderless
+          variant="borderless"
           autoComplete="off"
         />
       </FormLayout.Group>

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -292,7 +292,7 @@ export function TextField({
     error && styles.error,
     multiline && styles.multiline,
     focus && !disabled && styles.focus,
-    styles[variant],
+    variant !== 'inherit' && styles[variant],
   );
 
   const inputType = type === 'currency' ? 'text' : type;

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -161,10 +161,7 @@ interface NonMutuallyExclusiveProps {
   requiredIndicator?: boolean;
   /** Indicates whether or not a monospaced font should be used */
   monospaced?: boolean;
-  /** Removes the border around the input. Used in the IndexFilters component. */
-  /** @deprecated Use variant="borderless" instead */
-  borderless?: boolean;
-  /** Styling options for the TextField
+  /** Visual styling options for the TextField
    * @default 'inherit'
    */
   variant?: 'inherit' | 'borderless';
@@ -238,7 +235,6 @@ export function TextField({
   monospaced,
   selectTextOnFocus,
   suggestion,
-  borderless,
   variant = 'inherit',
   onClearButtonClick,
   onChange,
@@ -296,7 +292,7 @@ export function TextField({
     error && styles.error,
     multiline && styles.multiline,
     focus && !disabled && styles.focus,
-    (borderless || variant === 'borderless') && styles.borderless,
+    styles[variant],
   );
 
   const inputType = type === 'currency' ? 'text' : type;

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -161,6 +161,13 @@ interface NonMutuallyExclusiveProps {
   requiredIndicator?: boolean;
   /** Indicates whether or not a monospaced font should be used */
   monospaced?: boolean;
+  /** Removes the border around the input. Used in the IndexFilters component. */
+  /** @deprecated Use variant="borderless" instead */
+  borderless?: boolean;
+  /** Styling options for the TextField
+   * @default 'inherit'
+   */
+  variant?: 'inherit' | 'borderless';
   /** Callback fired when clear button is clicked */
   onClearButtonClick?(id: string): void;
   /** Callback fired when value is changed */
@@ -171,8 +178,6 @@ interface NonMutuallyExclusiveProps {
   onFocus?: (event?: React.FocusEvent) => void;
   /** Callback fired when input is blurred */
   onBlur?(event?: React.FocusEvent): void;
-  /** Removes the border around the input. Used in the IndexFilters component. */
-  borderless?: boolean;
 }
 
 export type MutuallyExclusiveSelectionProps =
@@ -233,12 +238,13 @@ export function TextField({
   monospaced,
   selectTextOnFocus,
   suggestion,
+  borderless,
+  variant = 'inherit',
   onClearButtonClick,
   onChange,
   onSpinnerChange,
   onFocus,
   onBlur,
-  borderless,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -290,7 +296,7 @@ export function TextField({
     error && styles.error,
     multiline && styles.multiline,
     focus && !disabled && styles.focus,
-    borderless && styles.borderless,
+    (borderless || variant === 'borderless') && styles.borderless,
   );
 
   const inputType = type === 'currency' ? 'text' : type;

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -2277,6 +2277,36 @@ describe('<TextField />', () => {
       expect(currentSelection).toStrictEqual(expectedSelection);
     });
   });
+
+  it('adds a borderless className when borderless prop is passed', () => {
+    const textField = mountWithApp(
+      <TextField
+        label="TextField"
+        onChange={noop}
+        autoComplete="off"
+        borderless
+      />,
+    );
+
+    expect(textField).toContainReactComponent('div', {
+      className: expect.stringContaining(styles.borderless),
+    });
+  });
+
+  it('adds a borderless className when variant=`borderless` prop is passed', () => {
+    const textField = mountWithApp(
+      <TextField
+        label="TextField"
+        onChange={noop}
+        autoComplete="off"
+        variant="borderless"
+      />,
+    );
+
+    expect(textField).toContainReactComponent('div', {
+      className: expect.stringContaining(styles.borderless),
+    });
+  });
 });
 
 function noop() {}

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -2284,7 +2284,7 @@ describe('<TextField />', () => {
         label="TextField"
         onChange={noop}
         autoComplete="off"
-        borderless
+        variant="borderless"
       />,
     );
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10033

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Deprecates `borderless` prop in favor of `variant='borderless'`