### PR TITLE
[ResourceList] Remove layout jank when bulk actions enabled and item selected

### DIFF
--- a/.changeset/hip-cameras-greet.md
+++ b/.changeset/hip-cameras-greet.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[ResourceList] Remove layout jank when bulk actions enabled and item selected

--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -48,7 +48,12 @@ $item-wrapper-loading-height: 64px;
   border-top-left-radius: var(--p-border-radius-2);
   border-top-right-radius: var(--p-border-radius-2);
 
-  + .ResourceList {
+  // stylelint-disable-next-line selector-max-class, selector-max-combinators -- Ssshhhhh
+  + .ResourceList,
+  // Bulk actions get injected into the DOM between the wrapper and resource
+  // list dynamically when an item is checked, so we have to handle that case
+  // here.
+  + .BulkActionsWrapper + .ResourceList {
     border-top: var(--p-border-width-1) solid var(--p-color-border-subdued);
 
     #{$se23} & {


### PR DESCRIPTION
_Depends on https://github.com/Shopify/polaris/pull/10055_

[Storybook](https://5d559397bae39100201eedc1-kvcsqifnas.chromatic.com/?path=/story/all-components-resourcelist--with-bulk-actions)

**Before this PR** (1px vertical layout shift):

![resource-list-jank](https://github.com/Shopify/polaris/assets/612020/fc01fba4-953e-4cd7-b654-e184dc1b29a5)


**This PR**:

![resource-list-no-jank](https://github.com/Shopify/polaris/assets/612020/03983808-d6ea-4abb-beef-8da3378e8261)

Caused by a missing `border-top` on the top item when any item is selected & bulk actions are enabled.