### PR TITLE
[Spinner] Consolidate se23 styles

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -335,11 +335,6 @@
     &::before {
       display: none;
     }
-
-    svg {
-      // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list, declaration-no-important -- override Spinner fill color
-      fill: var(--pc-button-text) !important;
-    }
   }
 
   &.destructive,
@@ -690,7 +685,12 @@
 }
 
 .loading.disabled svg {
-  fill: var(--p-color-icon-subdued);
+  fill: var(--p-color-bg-interactive);
+}
+
+.primary.disabled svg {
+  // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- override Spinner fill color
+  fill: var(--pc-button-text);
 }
 
 // The way the designs work, we need to do lots of reaching down to

--- a/polaris-react/src/components/Spinner/Spinner.scss
+++ b/polaris-react/src/components/Spinner/Spinner.scss
@@ -11,11 +11,7 @@ $large-size: 44px;
 .Spinner svg {
   animation: var(--p-motion-keyframes-spin) var(--p-motion-duration-500) linear
     infinite;
-  fill: var(--p-color-border-info);
-
-  #{$se23} & {
-    fill: var(--p-color-bg-interactive);
-  }
+  fill: var(--p-color-bg-interactive);
 }
 
 .sizeSmall svg {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #9968 .

### WHAT is this pull request doing?

Consolidates se23 beta styles for `Spinner`.
Updates loading styles where necessary in `Button.scss` to fix specificity issues.

### How to 🎩
[Storybook — Spinner](https://5d559397bae39100201eedc1-bxdwiiyynn.chromatic.com/?path=/story/all-components-spinner--all)
[Prod Storybook — Spinner](https://storybook.polaris.shopify.com/?path=/story/all-components-spinner--all&globals=polarisSummerEditions2023:true)

[Storybook — Button loading](https://5d559397bae39100201eedc1-bxdwiiyynn.chromatic.com/?path=/story/all-components-button--loading-state)
[Prod Storybook — Button loading](https://storybook.polaris.shopify.com/?path=/story/all-components-button--loading-state&globals=polarisSummerEditions2023:true)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
