### PR TITLE
[Storybook] Revert inter preload

### DIFF
--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -5,7 +5,6 @@
   crossorigin="anonymous"
 />
 <link
-  rel="preload"
   href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
   rel="stylesheet"
 />


### PR DESCRIPTION
### WHY are these changes introduced?

reverts the preload changes in https://github.com/Shopify/polaris/pull/10048 since storybook is now loading the system font instead of inter