### PR TITLE
[Storybook] Preload Inter stylesheet and font in Storybook

### DIFF
--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -1,8 +1,18 @@
 <link rel="preconnect" href="https://fonts.googleapis.com/" />
+<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
 <link
-  rel="preconnect"
-  href="https://fonts.gstatic.com/"
-  crossorigin="anonymous"
+  rel="preload"
+  as="style"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
+/>
+<!-- preload latin font face from Inter stylesheet https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=block -->
+<!-- learn more at https://dev.to/pilcrowonpaper/preloading-google-fonts-37h1 -->
+<link
+  rel="preload"
+  as="font"
+  href="https://fonts.gstatic.com/s/inter/v12/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7W0Q5nw.woff2"
+  type="font/woff2"
+  crossorigin
 />
 <link
   href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10038 

> Note: I'm hypothesising that properly preloading inter will fix the flakey tests based on the popover/tooltip position investigation I did (see issue), but we will have to see after this is merged. Regardless, its probably best to preload the font

Async loading of the Inter font is causing a discrepancy in chromatic snapshots because of layout shifts caused by the font flashing.

* My previous [attempt](https://github.com/Shopify/polaris/pull/10048) to preload the Inter font didn't work (it was just falling back to the SF font)
* I found [this article](https://dev.to/pilcrowonpaper/preloading-google-fonts-37h1) that suggests to not only preload the stylesheet but to preload the font itself

### WHAT is this pull request doing?

Adds Storybook font and stylesheet preloads as per the suggestions from [this article](https://dev.to/pilcrowonpaper/preloading-google-fonts-37h1)

### How to 🎩

You can see the font flash visually when doing an `Empty cache and hard reload`

<details>
<summary>To replicate the layout shift in storybook:</summary>

1. go to a flakey story [LegacyCard with separate header](https://storybook.polaris.shopify.com/?path=/story/all-components-legacycard--with-separate-header&globals=polarisSummerEditions2023:true)
2. Empty cache and hard reload
3. remount component on story to see popover overlay layout shift
4. compare to [fixed story on this PR](https://5d559397bae39100201eedc1-lrzewbgaqz.chromatic.com/?path=/story/all-components-legacycard--with-separate-header)

https://github.com/Shopify/polaris/assets/20652326/5ddb8ddd-f9ed-4a24-a3a8-451369aab19f

</details>

<details>
<summary>To replicate the font loading bug more explicitly:</summary>

1. put a `debugger` statement [here](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx#L146) 
2. go to the `LegacyCard with separate header` story
3. Open dev tools
5. Empty cache and hard reload
6. Inspect text element
7. Check the "Rendered fonts" in the computed styles tab

</details>

|Before on first render|After on first render|
|-|-|
|<img width="1272" alt="Screenshot 2023-08-15 at 5 07 15 PM" src="https://github.com/Shopify/polaris/assets/20652326/9f6f5ec4-743d-44c2-be38-7b03784dc1a6">|<img width="1272" alt="Screenshot 2023-08-15 at 5 08 40 PM" src="https://github.com/Shopify/polaris/assets/20652326/0bc3cdde-b188-4c1e-b235-78fda52bd928">|

