### PR TITLE
Ignore appending to changelog for prereleases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
-  "changelog": ["@changesets/changelog-github", {"repo": "Shopify/polaris"}],
+  "changelog": false,
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
The additional content in the CHANGELOG.md was becoming tedious to rebase and not needed for the prerelease.

The official changesets will be applied to the CHANGELOG.md when `next` is ready to be merged into `main`.