### PR TITLE
Fix icon optimize config

### DIFF
--- a/polaris-icons/svgo.config.js
+++ b/polaris-icons/svgo.config.js
@@ -1,6 +1,13 @@
 module.exports = {
   plugins: [
-    'removeDimensions',
+    {
+      /**
+       * removeDimensions is set to true to remove width and height attributes from SVGs.
+       * This allows the SVG to scale to the size of its container, making it more responsive.
+       */
+      name: 'removeDimensions',
+      active: true,
+    },
     {
       name: 'preset-default',
       params: {
@@ -10,12 +17,6 @@ module.exports = {
            * with smaller (minor) icons inside.
            */
           removeViewBox: false,
-
-          /**
-           * removeDimensions is set to true to remove width and height attributes from SVGs.
-           * This allows the SVG to scale to the size of its container, making it more responsive.
-           */
-          removeDimensions: true,
 
           /**
            * The following 2 settings are disabled to reduce rendering inconsistency


### PR DESCRIPTION
This was causing quite a bit of output in build scripts. Adding a width and height to an icon then running yarn optimize confirms that this still works