### PR TITLE
Chromatic font test solution B

### DIFF
--- a/polaris-react/.storybook/preview.js
+++ b/polaris-react/.storybook/preview.js
@@ -6,6 +6,17 @@ import {GridOverlay} from './GridOverlay';
 import {RenderPerformanceProfiler} from './RenderPerformanceProfiler';
 import {gridOptions, featureFlagOptions} from './manager';
 import {breakpoints} from '@shopify/polaris-tokens';
+import isChromatic from 'chromatic/isChromatic';
+
+// Use the document.fonts API to ensure fonts have fully loaded before rendering a story. Important for consistency when doing visual diffing in Chromatic.
+// See: https://developer.mozilla.org/en-US/docs/Web/API/Document/fonts
+const fontLoader = async () => ({
+  fonts: await document.fonts.ready,
+});
+
+// Exporting as a loader from `preview.js` forces the promise to be resolved before EVERY story
+// See: https://storybook.js.org/docs/react/writing-stories/loaders
+export const loaders = isChromatic() && document.fonts ? [fontLoader] : [];
 
 function StrictModeDecorator(Story, context) {
   const {strictMode} = context.globals;

--- a/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -137,6 +137,11 @@ export class PositionedOverlay extends PureComponent<
       zIndexOverride,
     } = this.props;
 
+    if (!document.fonts.check('12px Inter')) {
+      // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
+      return <p>Inter not loaded</p>;
+    }
+
     const style = {
       top: top == null || isNaN(top) ? undefined : top,
       left: left == null || isNaN(left) ? undefined : left,
@@ -315,10 +320,7 @@ export class PositionedOverlay extends PureComponent<
           preferredAlignment,
         );
 
-        const chevronOffset =
-          activatorRect.center.x -
-          horizontalPosition +
-          overlayMargins.horizontal * 2;
+        const chevronOffset = activatorRect.center.x - horizontalPosition;
 
         this.setState(
           {


### PR DESCRIPTION
Snapshot is from when inter is not loaded yet

<img width="298" alt="Screenshot 2023-08-16 at 5 00 42 PM" src="https://github.com/Shopify/polaris/assets/20652326/f7f7a033-d671-4357-a168-f2e7c9a6feb1">

https://shopify.chromatic.com/build?appId=5d559397bae39100201eedc1&number=19446