### PR TITLE
[Avatar] Remove `shape`

### DIFF
--- a/.changeset/chilly-grapes-enjoy.md
+++ b/.changeset/chilly-grapes-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+Removed `shape` prop on `Avatar` component

--- a/polaris-react/src/components/Avatar/Avatar.scss
+++ b/polaris-react/src/components/Avatar/Avatar.scss
@@ -18,6 +18,7 @@
   background: var(--p-color-avatar-background-experimental);
   color: var(--p-color-avatar-color-experimental);
   user-select: none;
+  border-radius: var(--p-border-radius-05);
 
   @media (forced-colors: active) {
     border: var(--p-border-width-1) solid transparent;
@@ -36,23 +37,6 @@
   font-weight: var(--p-font-weight-regular);
 
   &.long {
-    font-size: var(--p-font-size-75);
-  }
-}
-
-.shapeRound {
-  border-radius: var(--p-border-radius-05);
-}
-
-.shapeSquare {
-  border-radius: var(--p-border-radius-05);
-
-  .Text {
-    font-size: var(--p-font-size-200);
-    font-weight: var(--p-font-weight-regular);
-  }
-
-  .long {
     font-size: var(--p-font-size-75);
   }
 }

--- a/polaris-react/src/components/Avatar/Avatar.stories.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.stories.tsx
@@ -20,15 +20,6 @@ export default {
   component: Avatar,
 } as ComponentMeta<typeof Avatar>;
 
-const shapes: {
-  [S in NonNullable<AvatarProps['shape']>]: string;
-} = {
-  round: 'Round',
-  square: 'Square',
-};
-
-const shapeEntries = Object.entries(shapes) as Entries<typeof shapes>;
-
 const sizes: {
   [S in NonNullable<AvatarProps['size']>]: string;
 } = {
@@ -75,124 +66,68 @@ const styleInitialsLongEntries = Object.entries(styleInitialsLong) as Entries<
 export function All() {
   return (
     <BlockStack gap="4">
-      {shapeEntries.map(([shape, shapeLabel]) => (
-        <Box key={shape} paddingBlockEnd="2">
-          <BlockStack gap="3">
-            <Text as="h2" variant="headingXl">
-              Shape: {shapeLabel}
+      <Box paddingBlockEnd="2">
+        <BlockStack gap="3">
+          <BlockStack gap="2">
+            <Text as="h2" variant="headingXs">
+              Default
+            </Text>
+            <InlineStack gap="2" blockAlign="center">
+              {sizeEntries.map(([size]) => (
+                <Avatar key={size} size={size} />
+              ))}
+            </InlineStack>
+          </BlockStack>
+          <BlockStack gap="2">
+            <Text as="h2" variant="headingXs">
+              With customer
+            </Text>
+            <InlineStack gap="2" blockAlign="center">
+              {sizeEntries.map(([size]) => (
+                <Avatar key={size} size={size} customer />
+              ))}
+            </InlineStack>
+          </BlockStack>
+          <BlockStack gap="2">
+            <Text as="h2" variant="headingXs">
+              With image
+            </Text>
+            <InlineStack gap="2" blockAlign="center">
+              <Image />
+            </InlineStack>
+          </BlockStack>
+          <BlockStack gap="2">
+            <Text as="h2" variant="headingXs">
+              With icon (all styles)
+            </Text>
+            <IconColorsSizes />
+          </BlockStack>
+          <BlockStack gap="2">
+            <Text as="h2" variant="headingXs">
+              With default initials (all styles)
+            </Text>
+            <InitialsColorsSizes />
+          </BlockStack>
+          <BlockStack gap="2">
+            <Text as="h2" variant="headingXs">
+              With long initials (all styles)
+            </Text>
+            <InitialsLong />
+          </BlockStack>
+          <BlockStack gap="2">
+            <Text as="h2" variant="headingXs">
+              With long and wide initials
             </Text>
             <BlockStack gap="2">
-              <Text as="h2" variant="headingXs">
-                Default
-              </Text>
               <InlineStack gap="2" blockAlign="center">
                 {sizeEntries.map(([size]) => (
-                  <Avatar key={size} shape={shape} size={size} />
+                  <Avatar key={size} size={size} initials="WWW" />
                 ))}
               </InlineStack>
-            </BlockStack>
-            <BlockStack gap="2">
-              <Text as="h2" variant="headingXs">
-                With customer
-              </Text>
-              <InlineStack gap="2" blockAlign="center">
-                {sizeEntries.map(([size]) => (
-                  <Avatar key={size} shape={shape} size={size} customer />
-                ))}
-              </InlineStack>
-            </BlockStack>
-            <BlockStack gap="2">
-              <Text as="h2" variant="headingXs">
-                With image
-              </Text>
-              <InlineStack gap="2" blockAlign="center">
-                {sizeEntries.map(([size]) => (
-                  <Avatar
-                    key={size}
-                    shape={shape}
-                    size={size}
-                    source="https://burst.shopifycdn.com/photos/woman-dressed-in-pale-colors.jpg"
-                  />
-                ))}
-              </InlineStack>
-            </BlockStack>
-            <BlockStack gap="2">
-              <Text as="h2" variant="headingXs">
-                With name (all styles)
-              </Text>
-              <BlockStack gap="2">
-                {styleInitialsDefaultEntries.map(([style, initials]) => (
-                  <InlineStack key={style} gap="2" blockAlign="center">
-                    {sizeEntries.map(([size]) => (
-                      <Avatar
-                        key={size}
-                        shape={shape}
-                        name={initials}
-                        size={size}
-                      />
-                    ))}
-                  </InlineStack>
-                ))}
-              </BlockStack>
-            </BlockStack>
-            <BlockStack gap="2">
-              <Text as="h2" variant="headingXs">
-                With default initials (all styles)
-              </Text>
-              <BlockStack gap="2">
-                {styleInitialsDefaultEntries.map(([style, initials]) => (
-                  <InlineStack key={style} gap="2" blockAlign="center">
-                    {sizeEntries.map(([size]) => (
-                      <Avatar
-                        key={size}
-                        shape={shape}
-                        initials={initials}
-                        size={size}
-                      />
-                    ))}
-                  </InlineStack>
-                ))}
-              </BlockStack>
-            </BlockStack>
-            <BlockStack gap="2">
-              <Text as="h2" variant="headingXs">
-                With long initials (all styles)
-              </Text>
-              <BlockStack gap="2">
-                {styleInitialsLongEntries.map(([style, initialsLong]) => (
-                  <InlineStack key={style} gap="2" blockAlign="center">
-                    {sizeEntries.map(([size]) => (
-                      <Avatar
-                        key={size}
-                        shape={shape}
-                        initials={initialsLong}
-                        size={size}
-                      />
-                    ))}
-                  </InlineStack>
-                ))}
-              </BlockStack>
-            </BlockStack>
-            <BlockStack gap="2">
-              <Text as="h2" variant="headingXs">
-                With long and wide initials
-              </Text>
-              <BlockStack gap="2">
-                <InlineStack gap="2" blockAlign="center">
-                  {sizeEntries.map(([size]) => (
-                    <Avatar
-                      key={size}
-                      shape={shape}
-                      size={size}
-                      initials="WWW"
-                    />
-                  ))}
-                </InlineStack>
-              </BlockStack>
             </BlockStack>
           </BlockStack>
-        </Box>
-      ))}
+        </BlockStack>
+      </Box>
     </BlockStack>
   );
 }
@@ -201,89 +136,49 @@ export function Default() {
   return <Avatar />;
 }
 
-export function CircleIconColorsSizes() {
+export function IconColorsSizes() {
   return (
-    <BlockStack gap="4">
-      <InlineStack gap="4">
-        <Avatar customer size="extraSmall" />
-        <Avatar name="AG" size="extraSmall" />
-        <Avatar name="AA" size="extraSmall" />
-        <Avatar name="AC" size="extraSmall" />
-        <Avatar name="AB" size="extraSmall" />
-        <Avatar name="AE" size="extraSmall" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar customer size="small" />
-        <Avatar name="AG" size="small" />
-        <Avatar name="AA" size="small" />
-        <Avatar name="AC" size="small" />
-        <Avatar name="AB" size="small" />
-        <Avatar name="AE" size="small" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar customer size="medium" />
-        <Avatar name="AG" size="medium" />
-        <Avatar name="AA" size="medium" />
-        <Avatar name="AC" size="medium" />
-        <Avatar name="AB" size="medium" />
-        <Avatar name="AE" size="medium" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar customer size="large" />
-        <Avatar name="AG" size="large" />
-        <Avatar name="AA" size="large" />
-        <Avatar name="AC" size="large" />
-        <Avatar name="AB" size="large" />
-        <Avatar name="AE" size="large" />
-      </InlineStack>
+    <BlockStack gap="2">
+      {styleInitialsDefaultEntries.map(([style, initials]) => (
+        <InlineStack key={style} gap="2" blockAlign="center">
+          {sizeEntries.map(([size]) => (
+            <Avatar key={size} name={initials} size={size} />
+          ))}
+        </InlineStack>
+      ))}
     </BlockStack>
   );
 }
 
-export function CircleInitialsColorsSizes() {
+export function InitialsColorsSizes() {
   return (
-    <BlockStack gap="4">
-      <InlineStack gap="4">
-        <Avatar initials="AG" size="extraSmall" />
-        <Avatar initials="AA" size="extraSmall" />
-        <Avatar initials="AC" size="extraSmall" />
-        <Avatar initials="AB" size="extraSmall" />
-        <Avatar initials="AE" size="extraSmall" />
-        <Avatar initials="WW" size="extraSmall" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar initials="AG" size="small" />
-        <Avatar initials="AA" size="small" />
-        <Avatar initials="AC" size="small" />
-        <Avatar initials="AB" size="small" />
-        <Avatar initials="AE" size="small" />
-        <Avatar initials="WW" size="small" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar initials="AG" size="medium" />
-        <Avatar initials="AA" size="medium" />
-        <Avatar initials="AC" size="medium" />
-        <Avatar initials="AB" size="medium" />
-        <Avatar initials="AE" size="medium" />
-        <Avatar initials="WW" size="medium" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar initials="AG" size="large" />
-        <Avatar initials="AA" size="large" />
-        <Avatar initials="AC" size="large" />
-        <Avatar initials="AB" size="large" />
-        <Avatar initials="AE" size="large" />
-        <Avatar initials="WW" size="large" />
-      </InlineStack>
+    <BlockStack gap="2">
+      {styleInitialsDefaultEntries.map(([style, initials]) => (
+        <InlineStack key={style} gap="2" blockAlign="center">
+          {sizeEntries.map(([size]) => (
+            <Avatar key={size} initials={initials} size={size} />
+          ))}
+        </InlineStack>
+      ))}
     </BlockStack>
   );
 }
 
-export function CircleInitialsLong() {
-  return <Avatar initials="WWW" name="Woluwayemisi Wolu Weun-Jung" />;
+export function InitialsLong() {
+  return (
+    <BlockStack gap="2">
+      {styleInitialsLongEntries.map(([style, initialsLong]) => (
+        <InlineStack key={style} gap="2" blockAlign="center">
+          {sizeEntries.map(([size]) => (
+            <Avatar key={size} initials={initialsLong} size={size} />
+          ))}
+        </InlineStack>
+      ))}
+    </BlockStack>
+  );
 }
 
-export function CircleExtraSmallInContext() {
+export function ExtraSmallInContext() {
   const [active, setActive] = useState(true);
   const toggleActive = useCallback(() => setActive((active) => !active), []);
   const activator = (
@@ -314,89 +209,18 @@ export function CircleExtraSmallInContext() {
   );
 }
 
-export function CircleImage() {
+export function Image() {
   return (
-    <Avatar
-      name="Image"
-      source="https://burst.shopifycdn.com/photos/woman-dressed-in-pale-colors.jpg"
-    />
-  );
-}
-
-export function SquareIconColorsSizes() {
-  return (
-    <BlockStack gap="4">
-      <InlineStack gap="4">
-        <Avatar customer size="extraSmall" shape="square" />
-        <Avatar name="AG" size="extraSmall" shape="square" />
-        <Avatar name="AA" size="extraSmall" shape="square" />
-        <Avatar name="AC" size="extraSmall" shape="square" />
-        <Avatar name="AB" size="extraSmall" shape="square" />
-        <Avatar name="AE" size="extraSmall" shape="square" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar customer size="small" shape="square" />
-        <Avatar name="AG" size="small" shape="square" />
-        <Avatar name="AA" size="small" shape="square" />
-        <Avatar name="AC" size="small" shape="square" />
-        <Avatar name="AB" size="small" shape="square" />
-        <Avatar name="AE" size="small" shape="square" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar customer size="medium" shape="square" />
-        <Avatar name="AG" size="medium" shape="square" />
-        <Avatar name="AA" size="medium" shape="square" />
-        <Avatar name="AC" size="medium" shape="square" />
-        <Avatar name="AB" size="medium" shape="square" />
-        <Avatar name="AE" size="medium" shape="square" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar customer size="large" shape="square" />
-        <Avatar name="AG" size="large" shape="square" />
-        <Avatar name="AA" size="large" shape="square" />
-        <Avatar name="AC" size="large" shape="square" />
-        <Avatar name="AB" size="large" shape="square" />
-        <Avatar name="AE" size="large" shape="square" />
-      </InlineStack>
-    </BlockStack>
-  );
-}
-
-export function SquareInitialsColorsSizes() {
-  return (
-    <BlockStack gap="4">
-      <InlineStack gap="4">
-        <Avatar initials="AG" size="extraSmall" shape="square" />
-        <Avatar initials="AA" size="extraSmall" shape="square" />
-        <Avatar initials="AC" size="extraSmall" shape="square" />
-        <Avatar initials="AB" size="extraSmall" shape="square" />
-        <Avatar initials="AE" size="extraSmall" shape="square" />
-        <Avatar initials="WW" size="extraSmall" shape="square" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar initials="AG" size="small" shape="square" />
-        <Avatar initials="AA" size="small" shape="square" />
-        <Avatar initials="AC" size="small" shape="square" />
-        <Avatar initials="AB" size="small" shape="square" />
-        <Avatar initials="AE" size="small" shape="square" />
-        <Avatar initials="WW" size="small" shape="square" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar initials="AG" size="medium" shape="square" />
-        <Avatar initials="AA" size="medium" shape="square" />
-        <Avatar initials="AC" size="medium" shape="square" />
-        <Avatar initials="AB" size="medium" shape="square" />
-        <Avatar initials="AE" size="medium" shape="square" />
-        <Avatar initials="WW" size="medium" shape="square" />
-      </InlineStack>
-      <InlineStack gap="4">
-        <Avatar initials="AG" size="large" shape="square" />
-        <Avatar initials="AA" size="large" shape="square" />
-        <Avatar initials="AC" size="large" shape="square" />
-        <Avatar initials="AB" size="large" shape="square" />
-        <Avatar initials="AE" size="large" shape="square" />
-        <Avatar initials="WW" size="large" shape="square" />
-      </InlineStack>
-    </BlockStack>
+    <InlineStack gap="2" blockAlign="center">
+      {sizeEntries.map(([size]) => (
+        <Avatar
+          key={size}
+          size={size}
+          initials="WWW"
+          name="Image"
+          source="https://burst.shopifycdn.com/photos/woman-dressed-in-pale-colors.jpg"
+        />
+      ))}
+    </InlineStack>
   );
 }

--- a/polaris-react/src/components/Avatar/Avatar.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.tsx
@@ -15,8 +15,6 @@ type Size =
   | 'large'
   | Experimental<'xl' | '2xl'>;
 
-type Shape = 'square' | 'round';
-
 enum Status {
   Pending = 'PENDING',
   Loaded = 'LOADED',
@@ -60,11 +58,6 @@ export interface AvatarProps {
    * @default 'medium'
    */
   size?: Size;
-  /**
-   * Shape of avatar
-   * @default 'round'
-   */
-  shape?: Shape;
   /** The name of the person */
   name?: string;
   /** Initials of person to display */
@@ -86,7 +79,6 @@ export function Avatar({
   initials,
   customer,
   size = 'medium',
-  shape = 'round',
   accessibilityLabel,
 }: AvatarProps) {
   const i18n = useI18n();
@@ -130,7 +122,6 @@ export function Avatar({
     styles.Avatar,
     size && styles[variationName('size', size)],
     hasImage && status === Status.Loaded && styles.imageHasLoaded,
-    shape && styles[variationName('shape', shape)],
     !customer &&
       !source &&
       styles[variationName('style', styleClass(nameString))],

--- a/polaris-react/src/components/Avatar/tests/Avatar.test.tsx
+++ b/polaris-react/src/components/Avatar/tests/Avatar.test.tsx
@@ -36,7 +36,7 @@ describe('<Avatar />', () => {
       const src = 'image/path/';
       const avatar = mountWithApp(<Avatar source={src} />);
       expect(avatar).toContainReactComponent('span', {
-        className: 'Avatar sizeMedium shapeRound',
+        className: 'Avatar sizeMedium',
       });
       expect(avatar).toContainReactComponent('span', {
         className: expect.not.stringContaining('styleOne'),
@@ -60,7 +60,7 @@ describe('<Avatar />', () => {
       const src = 'image/path/';
       const avatar = mountWithApp(<Avatar customer source={src} />);
       expect(avatar).toContainReactComponent('span', {
-        className: 'Avatar sizeMedium shapeRound',
+        className: 'Avatar sizeMedium',
       });
       expect(avatar).toContainReactComponent('span', {
         className: expect.not.stringContaining('styleOne'),
@@ -148,24 +148,6 @@ describe('<Avatar />', () => {
       const avatar = mountWithApp(<Avatar name="Hello World" />);
       expect(avatar).toContainReactComponent('span', {
         'aria-label': 'Hello World',
-      });
-    });
-  });
-
-  describe('shape', () => {
-    it('renders a square background when square is passed to shape', () => {
-      const avatar = mountWithApp(<Avatar initials="DL" shape="square" />);
-
-      expect(avatar).toContainReactComponent('span', {
-        className: expect.stringContaining('shapeSquare'),
-      });
-    });
-
-    it('renders a round background when square is not passed to shape', () => {
-      const avatar = mountWithApp(<Avatar initials="DL" />);
-
-      expect(avatar).toContainReactComponent('span', {
-        className: expect.stringContaining('shapeRound'),
       });
     });
   });

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -74,7 +74,6 @@ export function UserMenu({
       </span>
       <MessageIndicator active={showIndicator}>
         <Avatar
-          shape="square"
           size={polarisSummerEditions2023 ? 'medium' : 'small'}
           initials={initials && initials.replace(' ', '')}
           source={avatar}

--- a/polaris.shopify.com/content/components/images-and-icons/avatar.md
+++ b/polaris.shopify.com/content/components/images-and-icons/avatar.md
@@ -28,9 +28,6 @@ examples:
   - fileName: avatar-extra-small.tsx
     title: Extra small
     description: Use to present an avatar in a condensed layout, such as a data table cell or an action list item.
-  - fileName: avatar-square.tsx
-    title: Square
-    description: Use a `square` shape when the avatar represents a non-person entity like an app, channel, or store.
 ---
 
 ## Best practices

--- a/polaris.shopify.com/pages/examples/avatar-square.tsx
+++ b/polaris.shopify.com/pages/examples/avatar-square.tsx
@@ -1,9 +1,0 @@
-import {Avatar} from '@shopify/polaris';
-import React from 'react';
-import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
-
-function AvatarExample() {
-  return <Avatar name="Shop One" shape="square" />;
-}
-
-export default withPolarisExample(AvatarExample);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/9977

### WHAT is this pull request doing?

- Removes the `shape` prop from `Avatar` as now there is only the squircle shape
- Cleaned up the `Avatar` stories