### PR TITLE
[TrapFocus] Add focusFirstNode prop to TrapFocus

### DIFF
--- a/.changeset/lemon-frogs-deny.md
+++ b/.changeset/lemon-frogs-deny.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add focusFirstNode prop to TrapFocus component

--- a/polaris-react/src/components/TrapFocus/TrapFocus.tsx
+++ b/polaris-react/src/components/TrapFocus/TrapFocus.tsx
@@ -17,16 +17,22 @@ import {portal} from '../shared';
 
 export interface TrapFocusProps {
   trapping?: boolean;
+  focusFirstNode?: boolean;
   children?: React.ReactNode;
 }
 
-export function TrapFocus({trapping = true, children}: TrapFocusProps) {
+export function TrapFocus({
+  trapping = true,
+  focusFirstNode = true,
+  children,
+}: TrapFocusProps) {
   const {canSafelyFocus} = useFocusManager({trapping});
   const focusTrapWrapper = useRef<HTMLDivElement>(null);
   const [disableFocus, setDisableFocus] = useState(true);
 
   useEffect(() => {
     const disable =
+      focusFirstNode &&
       canSafelyFocus &&
       !(
         focusTrapWrapper.current &&
@@ -36,7 +42,7 @@ export function TrapFocus({trapping = true, children}: TrapFocusProps) {
         : true;
 
     setDisableFocus(disable);
-  }, [canSafelyFocus, trapping]);
+  }, [canSafelyFocus, trapping, focusFirstNode]);
 
   const handleFocusIn = (event: FocusEvent) => {
     const containerContentsHaveFocus =

--- a/polaris-react/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/polaris-react/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -141,6 +141,18 @@ describe('<TrapFocus />', () => {
     expect(document.activeElement).toBe(trapFocus.find('a')!.domNode);
   });
 
+  it('does not focus the first focused node when the focusFirstNode prop is false', () => {
+    const trapFocus = mountWithApp(
+      <TrapFocus focusFirstNode={false}>
+        <a href="/">
+          <TextField label="" value="" autoComplete="off" onChange={noop} />
+        </a>
+      </TrapFocus>,
+    );
+
+    expect(document.activeElement).not.toBe(trapFocus.find('a')!.domNode);
+  });
+
   it(`doesn't trade steal focus from another TrapFocus when multiple are rendered`, () => {
     const id = 'input';
     const trapFocus = mountWithApp(

--- a/polaris-react/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/polaris-react/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -141,7 +141,7 @@ describe('<TrapFocus />', () => {
     expect(document.activeElement).toBe(trapFocus.find('a')!.domNode);
   });
 
-  it('does not focus the first focused node when the focusFirstNode prop is false', () => {
+  it('does not focus the first focusable node when the focusFirstNode prop is false', () => {
     const trapFocus = mountWithApp(
       <TrapFocus focusFirstNode={false}>
         <a href="/">


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When using `TrapFocus`, the default behaviour is to focus the first focusable node. This may be undesirable if you still want to trap focus, but don't want the first focusable node to be focused.

This PR adds a `focusFirstNode` prop to `TrapFocus`, which can prevent the the first focusable node from being focused.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Best way to tophat is to run Polaris locally with this branch and the following change in <code>playground/Playground.tsx</code>:

```jsx
import React from 'react';

import {Page, TextField, TrapFocus} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <TrapFocus focusFirstNode={false}>
        <a href="/">
          <TextField label="" value="" autoComplete="off" onChange={() => {}} />
        </a>
      </TrapFocus>
    </Page>
  );
}
```

After running the following:

```sh
yarn && yarn build
yarn turbo run dev --filter=@shopify/polaris
```

You should be able to navigate to the `Playground` component and verify the following:
- You should notice that the TextField is not focused on load. 
- If you remove the `focusFirstNode` prop, it should focus on load.

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
