### PR TITLE
[Avatar] Override SE23 background override with imageHasLoaded

### DIFF
--- a/.changeset/popular-pumas-sin.md
+++ b/.changeset/popular-pumas-sin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Ensure Avatar has no background color if an source prop is passed in to allow for transparent images

--- a/polaris-react/src/components/Avatar/Avatar.scss
+++ b/polaris-react/src/components/Avatar/Avatar.scss
@@ -28,6 +28,10 @@
     // stylelint-enable
     background: var(--p-color-avatar-background-experimental);
     color: var(--p-color-avatar-color-experimental);
+
+    &.imageHasLoaded {
+      background: transparent;
+    }
   }
 
   @media (forced-colors: active) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10203


### WHAT is this pull request doing?

Changing Avatar background to transparent if there is an image passed in

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
