### PR TITLE
Fix rename prop migration

### DIFF
--- a/.changeset/odd-owls-know.md
+++ b/.changeset/odd-owls-know.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Fixed a bug in the rename prop migration

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-boolean.input.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-boolean.input.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
 declare function MyComponent(props: any): JSX.Element;
-declare function Child(props: any): JSX.Element;
 
 export function App() {
   return (
-    <MyComponent newProp="new-value">
-      Hello
-      <Child prop="value" />
+    <MyComponent foo="bar" booleanProp>
+      Hello world
     </MyComponent>
   );
 }

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-boolean.output.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-boolean.output.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
 declare function MyComponent(props: any): JSX.Element;
-declare function Child(props: any): JSX.Element;
 
 export function App() {
   return (
-    <MyComponent newProp="new-value">
-      Hello
-      <Child prop="value" />
+    <MyComponent foo="bar" variant="boolean-prop-value">
+      Hello world
     </MyComponent>
   );
 }

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-new-value.input.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-new-value.input.tsx
@@ -1,17 +1,7 @@
 import React from 'react';
 
-interface MyComponentProps {
-  prop?: string;
-  newProp?: string;
-  children?: React.ReactNode;
-}
-
-const Child = (props: {prop: string}) => <>{props.prop}</>;
-
-function MyComponent(props: MyComponentProps) {
-  const value = props.newProp ?? props.prop;
-  return <div data-prop={value}>{props.children}</div>;
-}
+declare function MyComponent(props: any): JSX.Element;
+declare function Child(props: any): JSX.Element;
 
 export function App() {
   return (

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop.input.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop.input.tsx
@@ -1,21 +1,11 @@
 import React from 'react';
 
-interface MyComponentProps {
-  prop?: string;
-  newProp?: string;
-  children?: React.ReactNode;
-}
-
-const Child = (props: {prop: string}) => <>{props.prop}</>;
-
-function MyComponent(props: MyComponentProps) {
-  const value = props.newProp || props.prop;
-  return <div data-prop={value}>{props.children}</div>;
-}
+declare function MyComponent(props: any): JSX.Element;
+declare function Child(props: any): JSX.Element;
 
 export function App() {
   return (
-    <MyComponent prop="value">
+    <MyComponent prop="value" foo="bar">
       Hello
       <Child prop="value" />
     </MyComponent>

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop.output.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop.output.tsx
@@ -1,21 +1,11 @@
 import React from 'react';
 
-interface MyComponentProps {
-  prop?: string;
-  newProp?: string;
-  children?: React.ReactNode;
-}
-
-const Child = (props: {prop: string}) => <>{props.prop}</>;
-
-function MyComponent(props: MyComponentProps) {
-  const value = props.newProp || props.prop;
-  return <div data-prop={value}>{props.children}</div>;
-}
+declare function MyComponent(props: any): JSX.Element;
+declare function Child(props: any): JSX.Element;
 
 export function App() {
   return (
-    <MyComponent newProp="value">
+    <MyComponent newProp="value" foo="bar">
       Hello
       <Child prop="value" />
     </MyComponent>

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-compound-component-prop-with-new-value.input.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-compound-component-prop-with-new-value.input.tsx
@@ -1,21 +1,10 @@
 import React from 'react';
 
-interface MyComponentProps {
-  prop?: string;
-  newProp?: string;
-  children?: React.ReactNode;
-}
+declare function MyComponent(props: any): JSX.Element;
+declare function SubComponent(props: any): JSX.Element;
+declare function Child(props: any): JSX.Element;
 
-const Child = (props: {prop: string}) => <>{props.prop}</>;
-
-function MyComponent(props: MyComponentProps) {
-  const value = props.newProp ?? props.prop;
-  return <div data-prop={value}>{props.children}</div>;
-}
-
-function SubComponent({...props}: any) {
-  return <div {...props} />;
-}
+MyComponent.SubComponent = SubComponent;
 
 export function App() {
   return (
@@ -26,5 +15,3 @@ export function App() {
     </MyComponent>
   );
 }
-
-MyComponent.SubComponent = SubComponent;

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-compound-component-prop-with-new-value.input.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-compound-component-prop-with-new-value.input.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 
 declare function MyComponent(props: any): JSX.Element;
-declare function SubComponent(props: any): JSX.Element;
+declare function CompoundComponent(props: any): JSX.Element;
 declare function Child(props: any): JSX.Element;
 
-MyComponent.SubComponent = SubComponent;
+MyComponent.CompoundComponent = CompoundComponent;
 
 export function App() {
   return (
     <MyComponent>
-      <MyComponent.SubComponent prop="value" />
+      <MyComponent.CompoundComponent prop="value" />
       Hello
       <Child prop="value" />
     </MyComponent>

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-compound-component-prop-with-new-value.output.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-compound-component-prop-with-new-value.output.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 
 declare function MyComponent(props: any): JSX.Element;
-declare function SubComponent(props: any): JSX.Element;
+declare function CompoundComponent(props: any): JSX.Element;
 declare function Child(props: any): JSX.Element;
 
-MyComponent.SubComponent = SubComponent;
+MyComponent.CompoundComponent = CompoundComponent;
 
 export function App() {
   return (
     <MyComponent>
-      <MyComponent.SubComponent newProp="new-value" />
+      <MyComponent.CompoundComponent newProp="new-value" />
       Hello
       <Child prop="value" />
     </MyComponent>

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-compound-component-prop-with-new-value.output.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-compound-component-prop-with-new-value.output.tsx
@@ -1,30 +1,17 @@
 import React from 'react';
 
-interface MyComponentProps {
-  prop?: string;
-  newProp?: string;
-  children?: React.ReactNode;
-}
+declare function MyComponent(props: any): JSX.Element;
+declare function SubComponent(props: any): JSX.Element;
+declare function Child(props: any): JSX.Element;
 
-const Child = (props: {prop: string}) => <>{props.prop}</>;
-
-function MyComponent(props: MyComponentProps) {
-  const value = props.newProp ?? props.prop;
-  return <div data-prop={value}>{props.children}</div>;
-}
-
-function SubComponent({...props}: any) {
-  return <div {...props} />;
-}
+MyComponent.SubComponent = SubComponent;
 
 export function App() {
   return (
     <MyComponent>
-      <MyComponent.SubComponent newProp="new value" />
+      <MyComponent.SubComponent newProp="new-value" />
       Hello
       <Child prop="value" />
     </MyComponent>
   );
 }
-
-MyComponent.SubComponent = SubComponent;

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/transform.test.ts
@@ -22,7 +22,7 @@ const fixtures = [
   {
     name: 'react-rename-compound-component-prop-with-new-value',
     options: {
-      componentName: 'MyComponent.SubComponent',
+      componentName: 'MyComponent.CompoundComponent',
       from: 'prop',
       to: 'newProp',
       newValue: 'new-value',

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/transform.test.ts
@@ -16,7 +16,7 @@ const fixtures = [
       componentName: 'MyComponent',
       from: 'prop',
       to: 'newProp',
-      newValue: 'new value',
+      newValue: 'new-value',
     },
   },
   {
@@ -25,7 +25,16 @@ const fixtures = [
       componentName: 'MyComponent.SubComponent',
       from: 'prop',
       to: 'newProp',
-      newValue: 'new value',
+      newValue: 'new-value',
+    },
+  },
+  {
+    name: 'react-rename-component-prop-with-boolean',
+    options: {
+      componentName: 'MyComponent',
+      from: 'booleanProp',
+      to: 'variant',
+      newValue: 'boolean-prop-value',
     },
   },
 ];

--- a/polaris-migrator/src/utilities/jsx.ts
+++ b/polaris-migrator/src/utilities/jsx.ts
@@ -165,7 +165,7 @@ export function renameProps(
     const isFromProp = (prop: unknown): prop is keyof typeof props =>
       Object.keys(props).includes(prop as string);
 
-    if (node.type !== 'JSXAttribute' && !isFromProp(node.name.name)) {
+    if (!(node.type === 'JSXAttribute' && isFromProp(node.name.name))) {
       return node;
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

`react-rename-component-prop` migration was not working as expected when there were multiple props on a component

<img width="552" alt="Screenshot 2023-08-24 at 10 12 10 AM" src="https://github.com/Shopify/polaris/assets/3474483/5ca5de71-f587-49cf-87ea-5fc73d298864">

### WHAT is this pull request doing?

- Adds more test cases
- Fixes migration

<img width="590" alt="Screenshot 2023-08-24 at 10 12 35 AM" src="https://github.com/Shopify/polaris/assets/3474483/8dc1ee41-1900-4383-81e0-7635b2d2fa0b">
