### PR TITLE
[ButtonGroup] Update variant plain prop name

### DIFF
--- a/polaris-react/src/components/ButtonGroup/components/Item/Item.tsx
+++ b/polaris-react/src/components/ButtonGroup/components/Item/Item.tsx
@@ -18,7 +18,7 @@ export function Item({button}: ItemProps) {
   const className = classNames(
     styles.Item,
     focused && styles['Item-focused'],
-    button.props.plain && styles['Item-plain'],
+    button.props.variant === 'plain' && styles['Item-plain'],
   );
 
   return (


### PR DESCRIPTION
### WHAT is this pull request doing?

Update `ButtonGroup` variant styles to match the changes from https://github.com/Shopify/polaris/pull/10090

### How to 🎩

Check that this story is getting the plain button group item variant

|Next branch|This PR|Production|
|-|-|-|
|<img width="321" alt="Screenshot 2023-08-24 at 2 36 27 PM" src="https://github.com/Shopify/polaris/assets/20652326/54bff50b-f4b1-4540-a891-7f3c4a7afaf7">|<img width="306" alt="Screenshot 2023-08-24 at 2 37 27 PM" src="https://github.com/Shopify/polaris/assets/20652326/3dd5578e-51ad-4469-82fe-61db3440b936">|<img width="303" alt="Screenshot 2023-08-24 at 2 37 12 PM" src="https://github.com/Shopify/polaris/assets/20652326/7141b6a8-9589-4746-a7d7-eb9229a6c61d">|

