### PR TITLE
Add APIs for runtime Polaris tokens access

### DIFF
--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -1,10 +1,13 @@
 import React, {Component} from 'react';
+import type {ThemeName} from '@shopify/polaris-tokens';
+import {themeNameDefault} from '@shopify/polaris-tokens';
 
 import {EphemeralPresenceManager} from '../EphemeralPresenceManager';
 import {MediaQueryProvider} from '../MediaQueryProvider';
 import {FocusManager} from '../FocusManager';
 import {PortalsManager} from '../PortalsManager';
 import {I18n, I18nContext} from '../../utilities/i18n';
+import {ThemeNameContext} from '../../utilities/use-theme-name';
 import {
   ScrollLockManager,
   ScrollLockManagerContext,
@@ -115,32 +118,40 @@ export class AppProvider extends Component<AppProviderProps, State> {
     };
   };
 
+  getThemeName = (): ThemeName =>
+    this.getFeatures().polarisSummerEditions2023
+      ? 'Polaris-Summer-Editions-2023'
+      : themeNameDefault;
+
   render() {
     const {children} = this.props;
     const features = this.getFeatures();
+    const themeName = this.getThemeName();
 
     const {intl, link} = this.state;
 
     return (
-      <FeaturesContext.Provider value={features}>
-        <I18nContext.Provider value={intl}>
-          <ScrollLockManagerContext.Provider value={this.scrollLockManager}>
-            <StickyManagerContext.Provider value={this.stickyManager}>
-              <LinkContext.Provider value={link}>
-                <MediaQueryProvider>
-                  <PortalsManager>
-                    <FocusManager>
-                      <EphemeralPresenceManager>
-                        {children}
-                      </EphemeralPresenceManager>
-                    </FocusManager>
-                  </PortalsManager>
-                </MediaQueryProvider>
-              </LinkContext.Provider>
-            </StickyManagerContext.Provider>
-          </ScrollLockManagerContext.Provider>
-        </I18nContext.Provider>
-      </FeaturesContext.Provider>
+      <ThemeNameContext.Provider value={themeName}>
+        <FeaturesContext.Provider value={features}>
+          <I18nContext.Provider value={intl}>
+            <ScrollLockManagerContext.Provider value={this.scrollLockManager}>
+              <StickyManagerContext.Provider value={this.stickyManager}>
+                <LinkContext.Provider value={link}>
+                  <MediaQueryProvider>
+                    <PortalsManager>
+                      <FocusManager>
+                        <EphemeralPresenceManager>
+                          {children}
+                        </EphemeralPresenceManager>
+                      </FocusManager>
+                    </PortalsManager>
+                  </MediaQueryProvider>
+                </LinkContext.Provider>
+              </StickyManagerContext.Provider>
+            </ScrollLockManagerContext.Provider>
+          </I18nContext.Provider>
+        </FeaturesContext.Provider>
+      </ThemeNameContext.Provider>
     );
   }
 }

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -425,6 +425,7 @@ export {
 export {ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT} from './utilities/scroll-lock-manager';
 export {WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT} from './utilities/within-content-context';
 export {useEventListener} from './utilities/use-event-listener';
+export {useThemeVarDecl} from './utilities/use-theme-var-decl';
 export {useIndexResourceState} from './utilities/use-index-resource-state';
 export {
   useRowHovered as useIndexTableRowHovered,

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -1,5 +1,7 @@
 import './configure';
 
+export {themeVars} from '@shopify/polaris-tokens';
+
 // Key is an enum, not a type. It probably shouldn't live in a file called types
 export {Key} from './types';
 

--- a/polaris-react/src/utilities/use-css-decl.ts
+++ b/polaris-react/src/utilities/use-css-decl.ts
@@ -1,0 +1,92 @@
+import {useEffect, useReducer} from 'react';
+
+export type CSSDeclAction =
+  | {
+      type: 'updated';
+      declValue: string;
+      element: Element;
+    }
+  | {
+      type: 'errored';
+      error: string;
+    };
+
+export interface CSSDeclState {
+  prop: string;
+  value: string;
+  element: Element | null;
+  status: 'init' | 'success' | 'error';
+  error: string | undefined;
+}
+
+function cssDeclReducer(
+  state: CSSDeclState,
+  action: CSSDeclAction,
+): CSSDeclState {
+  switch (action.type) {
+    case 'updated':
+      return {
+        ...state,
+        status: 'success',
+        value: action.declValue.trim(),
+        element: action.element,
+        error: undefined,
+      };
+    case 'errored':
+      return {
+        ...state,
+        status: 'error',
+        value: '',
+        element: null,
+        error: action.error,
+      };
+    default:
+      return state;
+  }
+}
+
+// Derived from https://github.com/JCofman/react-use-css-custom-property/blob/73e89aac1260ec9e120c8b259975cb95735c1171/src/index.tsx#L74
+export function useCSSDecl(
+  declProp: string,
+  selectors = ':root',
+): CSSDeclState {
+  const [state, dispatch] = useReducer(cssDeclReducer, {
+    status: 'init',
+    prop: declProp,
+    value: '',
+    element: null,
+    error: undefined,
+  });
+
+  useEffect(() => {
+    const element = document.querySelector(selectors);
+
+    if (!element) {
+      dispatch({
+        type: 'errored',
+        error: `No element matching ${selectors}`,
+      });
+      return;
+    }
+
+    const declValue = window
+      .getComputedStyle(element)
+      .getPropertyValue(declProp);
+
+    if (!declValue) {
+      dispatch({
+        type: 'errored',
+        error: `No CSS declaration value for ${declProp} on ${selectors}`,
+      });
+      return;
+    }
+
+    dispatch({
+      type: 'updated',
+      declValue,
+      element,
+    });
+  }, [declProp, selectors]);
+
+  return state;
+}

--- a/polaris-react/src/utilities/use-theme-name.ts
+++ b/polaris-react/src/utilities/use-theme-name.ts
@@ -1,0 +1,17 @@
+import type {ThemeName} from '@shopify/polaris-tokens';
+import {themeNameDefault} from '@shopify/polaris-tokens';
+import {createContext, useContext} from 'react';
+
+export const ThemeNameContext = createContext<ThemeName>(themeNameDefault);
+
+export function useThemeName() {
+  const themeName = useContext(ThemeNameContext);
+
+  if (!themeName) {
+    throw new Error(
+      'No themeName was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/app-provider for implementation instructions.',
+    );
+  }
+
+  return themeName;
+}

--- a/polaris-react/src/utilities/use-theme-var-decl.ts
+++ b/polaris-react/src/utilities/use-theme-var-decl.ts
@@ -1,0 +1,14 @@
+import type {ThemeVarName} from '@shopify/polaris-tokens';
+import {createThemeSelector, themeNameDefault} from '@shopify/polaris-tokens';
+
+import {useCSSDecl} from './use-css-decl';
+import {useThemeName} from './use-theme-name';
+
+export function useThemeVarDecl(themeVarName: ThemeVarName) {
+  const themeName = useThemeName();
+
+  return useCSSDecl(
+    themeVarName,
+    themeName === themeNameDefault ? ':root' : createThemeSelector(themeName),
+  );
+}

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -8,6 +8,9 @@ export type {
   MetadataGroup,
 } from './types';
 
+export type {ThemeVars} from './themes';
+export {themeVars} from './themes';
+
 export type {
   BorderTokenGroup,
   BorderTokenName,

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -8,8 +8,13 @@ export type {
   MetadataGroup,
 } from './types';
 
-export type {ThemeVars} from './themes';
 export {themeVars} from './themes';
+
+export type {ThemeName, ThemeVarName, ThemeVars} from './themes/types';
+
+export {themeNameDefault} from './themes/constants';
+
+export {createThemeSelector} from './themes/utils';
 
 export type {
   BorderTokenGroup,

--- a/polaris-tokens/src/themes/index.ts
+++ b/polaris-tokens/src/themes/index.ts
@@ -1,9 +1,8 @@
 import {createVar} from '../utilities';
 
-import type {Themes, ThemesPartials} from './types';
+import type {Themes, ThemesPartials, ThemeVars} from './types';
 import {themeLight} from './light';
 import {themeLightUplift, themeLightUpliftPartial} from './light-uplift';
-import type {ThemeBase} from './base';
 import {themeBase} from './base';
 
 export {themeDefault} from './constants';
@@ -15,12 +14,6 @@ export const themes: Themes = {
 
 export const themesPartials: ThemesPartials = {
   'Polaris-Summer-Editions-2023': themeLightUpliftPartial,
-};
-
-export type ThemeVars = {
-  [TokenGroupName in keyof ThemeBase]: {
-    [TokenName in keyof ThemeBase[TokenGroupName]]: string;
-  };
 };
 
 /**

--- a/polaris-tokens/src/themes/index.ts
+++ b/polaris-tokens/src/themes/index.ts
@@ -1,6 +1,10 @@
+import {createVar} from '../utilities';
+
 import type {Themes, ThemesPartials} from './types';
 import {themeLight} from './light';
 import {themeLightUplift, themeLightUpliftPartial} from './light-uplift';
+import type {ThemeBase} from './base';
+import {themeBase} from './base';
 
 export {themeDefault} from './constants';
 
@@ -12,3 +16,45 @@ export const themes: Themes = {
 export const themesPartials: ThemesPartials = {
   'Polaris-Summer-Editions-2023': themeLightUpliftPartial,
 };
+
+export type ThemeVars = {
+  [TokenGroupName in keyof ThemeBase]: {
+    [TokenName in keyof ThemeBase[TokenGroupName]]: string;
+  };
+};
+
+/**
+ * Theme object where values represent token names as CSS variables.
+ *
+ * Useful for applying theme-agnostic tokens in JavaScript.
+ *
+ * @example
+ * const themeVars = {
+ *   color: { 'color-bg': 'var(--p-color-bg)' }
+ *   font: { 'font-family': 'var(--p-font-family)' }
+ *   // etc.
+ * }
+ *
+ * @example
+ * // ✅ Do
+ * import {themeVars} from '@shopify/polaris-tokens';
+ *
+ * themeVars.color['color-bg']; // var(--p-color-bg)
+ *
+ * // ❌ Don't
+ * import * as themes from '@shopify/polaris-tokens/themes';
+ *
+ * themes.light.color['color-bg']; // #123
+ * themes.dark.color['color-bg']; // #456
+ */
+export const themeVars = Object.fromEntries(
+  Object.entries(themeBase).map(([tokenGroupName, tokenGroup]) => [
+    tokenGroupName,
+    Object.fromEntries(
+      Object.keys(tokenGroup).map((tokenName) => [
+        tokenName,
+        `var(${createVar(tokenName)})`,
+      ]),
+    ),
+  ]),
+) as ThemeVars;

--- a/polaris-tokens/src/themes/light-uplift.ts
+++ b/polaris-tokens/src/themes/light-uplift.ts
@@ -173,3 +173,5 @@ export const themeLightUpliftPartial = createThemeVariantPartial({
 });
 
 export const themeLightUplift = createThemeVariant(themeLightUpliftPartial);
+
+export type ThemeLightUplift = typeof themeLightUplift;

--- a/polaris-tokens/src/themes/light.ts
+++ b/polaris-tokens/src/themes/light.ts
@@ -1,3 +1,5 @@
 import {themeBase} from './base';
 
 export const themeLight = themeBase;
+
+export type ThemeLight = typeof themeLight;

--- a/polaris-tokens/src/themes/types.ts
+++ b/polaris-tokens/src/themes/types.ts
@@ -1,3 +1,5 @@
+import type {CreateVarName} from '../types';
+
 import type {ThemeBase} from './base';
 import type {themeNames, themeNameDefault} from './constants';
 
@@ -35,3 +37,28 @@ export type Themes = {
 export type ThemesPartials = {
   [T in Exclude<ThemeName, typeof themeNameDefault>]: ThemeVariantPartialShape;
 };
+
+export type ThemeVars = {
+  [TokenGroupName in keyof ThemeBase]: {
+    [TokenName in keyof ThemeBase[TokenGroupName]]: string;
+  };
+};
+
+/**
+ * `ThemeVars` tokens represented as CSS variable names.
+ *
+ * @example
+ * type ThemeVars = {
+ *   color: { 'color-bg': 'var(--p-color-bg)' }
+ *   font: { 'font-family': 'var(--p-font-family)' }
+ * }
+ *
+ * type ThemeVarName = '--p-color-bg' | '--p-font-family' | ...
+ */
+export type ThemeVarName = {
+  [TokenGroupName in keyof ThemeVars]: {
+    [TokenName in keyof ThemeVars[TokenGroupName]]: TokenName extends string
+      ? CreateVarName<TokenName>
+      : never;
+  }[keyof ThemeVars[TokenGroupName]];
+}[keyof ThemeVars];

--- a/polaris-tokens/src/types.ts
+++ b/polaris-tokens/src/types.ts
@@ -3,6 +3,7 @@ import type {Metadata} from './metadata';
 export type Entry<T> = [keyof T, T[keyof T]];
 export type Entries<T> = Entry<T>[];
 export type Experimental<T extends string> = `${T}-experimental`;
+export type CreateVarName<T extends string> = `--p-${T}`;
 
 export interface MetadataProperties {
   description?: string;


### PR DESCRIPTION
This PR introduces two APIs for accessing theme tokens at runtime. 

### `themeVars`

Although CSS custom properties and component props are the recommended pattern for consumers to access tokens, there are certain scenarios where JavaScript access is necessary. After evaluating usage of `tokens` in JavaScript across the organization we determined that a majority of the existing use cases did not require the underlying computed value. For these cases we're introducing a `themeVars` object from `@shopify/polaris`.

The `themeVars` API allows consumers to reference theme-agnostic tokens in JavaScript by remapping the token values to CSS variables. It's important to clarify that accessing `themeVars.color['color-bg']`, for example, returns `var(--p-color-bg)` instead of an RGBA value like the original `tokens.color['color-bg']` object. This design choice ensures type safety and independence from the active global theme.

```ts
import {themeVars} from '@shopify/polaris';

themeVars.color['color-bg'] // 'var(--p-color-bg)'
```

### `useThemeVarDecl`

In addition to theme-agnostic vars, we've introduced a `useThemeVarDecl` hook to dynamically resolve theme variables and retrieve their computed values at runtime. While we anticipate limited usage of this utility, our audit revealed valid scenarios where the underlying computed values was needed (for example with animation timeouts).

To enable the `useThemeVarDecl` hook, we updated the `AppProvider` to incorporate a new `ThemeNameContext`. This context is used by `useThemeVarDecl` to determine what global selector to target when retrieving computed theme variable values.

```ts
import {useThemeVarDecl} from '@shopify/polaris';

function App() {
  const colorBgDecl = useThemeVarDecl('--p-color-bg');

  colorBgDecl // { status: 'success', value: '#123', ... }
}
```

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, useThemeVarDecl} from '../src';

export function Playground() {
  const themeVarDecl = useThemeVarDecl('--p-color-bg-primary');

  return (
    <Page title="Playground">
      <div style={{width: 100, height: 100, background: themeVarDecl.value}} />
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>