### PR TITLE
[v12] Update changesets

### DIFF
--- a/.changeset/kind-phones-yell.md
+++ b/.changeset/kind-phones-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+Removed `divider` prop from `Page` component

--- a/.changeset/tall-chicken-repeat.md
+++ b/.changeset/tall-chicken-repeat.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': major
 ---
 
-Removed Summer Editions experimental styles and code for the following components: `Avatar`, `AccountConnection`, `ActionList`, `ActionMenu`, `Autocomplete`, `Breadcrumbs`, `Text`, `KeyboardKey`, `EmptyState`
+Removed Summer Editions experimental styles and code for the following components: `AppProvider`, `Avatar`, `AccountConnection`, `ActionList`, `ActionMenu`, `Autocomplete`, `Badge`, `Banner`, `Breadcrumbs`, `BulkActions`, `Button`, `ButtonGroup`, `CalloutCard`, `Card`, `CheckableButton`, `Checkbox`, `Choice`, `Connected`, `DataTable`, `DatePicker`, `DropZone`, `EmptyState`, `Filters`, `FormLayout`, `Frame`, `FullscreenBar`, `IndexFilters`, `IndexTable`, `InlineError`, `KeyboardKey`, `Labelled`, `Layout`, `LegacyCard`, `LegacyFilters`, `LegacyTabs`, `Link`, `List`, `Listbox`, `MediaCard`, `Modal`, `Navigation`, `OptionList`, `Page`, `PageActions`, `Pagination`, `Popover`, `ProgressBar`, `RadioButton`, `ResourceItem`, `ResourceList`, `Select`, `SettingAction`, `ShadowBevel`, `SkeletonPage`, `SkeletonThumbnail`, `Spinner`, `Tabs`, `Tag`, `Text`, `TextField`, `Thumbnail`, `TooltipOverlay`, `TopBar`, and `VideoThumbnail`

--- a/.changeset/wise-pianos-unite.md
+++ b/.changeset/wise-pianos-unite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+Removed `optionRole` prop from `OptionList` component


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #10035.

Updates existing `tall-chickens-repeat` changeset with all the component consolidation work (included any in progress/ready for review/up next/backlog PRs as well).

Adds changesets for [OptionList](https://github.com/Shopify/polaris/pull/10177) `optionRole` and [Page](https://github.com/Shopify/polaris/pull/10187) `divider` prop removal.