### PR TITLE
Remove shadow-bevel opt out logic

### DIFF
--- a/polaris-react/src/components/AppProvider/AppProvider.scss
+++ b/polaris-react/src/components/AppProvider/AppProvider.scss
@@ -5,21 +5,6 @@
   --polaris-version-number: '{{POLARIS_VERSION}}';
 }
 
-#{$se23} {
-  // stylelint-disable -- Shadow bevel opt out custom properties
-  --pc-app-provider-shadow-bevel-content: '';
-  --pc-app-provider-shadow-bevel-border: none;
-  // stylelint-enable
-}
-
-#{$se23ShadowBevelOptOut} {
-  // stylelint-disable -- Shadow bevel opt out custom properties
-  --pc-app-provider-shadow-bevel-content: none;
-  --pc-app-provider-shadow-bevel-border: var(--p-border-width-1) solid
-    var(--p-color-border);
-  // stylelint-enable
-}
-
 html,
 body {
   font-size: var(--p-font-size-100);

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -18,7 +18,6 @@ import type {LinkLikeComponent} from '../../utilities/link';
 import {
   FeaturesContext,
   classNamePolarisSummerEditions2023,
-  classNamePolarisSummerEditions2023ShadowBevelOptOut,
 } from '../../utilities/features';
 import type {FeaturesConfig} from '../../utilities/features';
 
@@ -97,11 +96,6 @@ export class AppProvider extends Component<AppProviderProps, State> {
       classNamePolarisSummerEditions2023,
       features.polarisSummerEditions2023,
     );
-
-    document.documentElement.classList.toggle(
-      classNamePolarisSummerEditions2023ShadowBevelOptOut,
-      features.polarisSummerEditions2023ShadowBevelOptOut,
-    );
   };
 
   getFeatures = () => {
@@ -110,8 +104,6 @@ export class AppProvider extends Component<AppProviderProps, State> {
     return {
       ...features,
       polarisSummerEditions2023: features?.polarisSummerEditions2023 ?? true,
-      polarisSummerEditions2023ShadowBevelOptOut:
-        features?.polarisSummerEditions2023ShadowBevelOptOut ?? false,
     };
   };
 

--- a/polaris-react/src/components/Banner/Banner.scss
+++ b/polaris-react/src/components/Banner/Banner.scss
@@ -26,19 +26,13 @@
 .withinPage {
   @include shadow-bevel(
     $boxShadow: var(--p-shadow-sm),
-    $borderRadius: var(--p-border-radius-0-experimental),
-    // The following arguments explicitly ignore the shadow-bevel opt out
-    $border: none,
-    $content: ''
+    $borderRadius: var(--p-border-radius-0-experimental)
   );
 
   @media #{$p-breakpoints-sm-up} {
     @include shadow-bevel(
       $boxShadow: var(--p-shadow-sm),
-      $borderRadius: var(--p-border-radius-3),
-      // The following arguments explicitly ignore the shadow-bevel opt out
-      $border: none,
-      $content: ''
+      $borderRadius: var(--p-border-radius-3)
     );
   }
 

--- a/polaris-react/src/styles/_common.scss
+++ b/polaris-react/src/styles/_common.scss
@@ -24,4 +24,3 @@
 // However, we're still supporting iOS 12 for embedded web views in some apps, which
 // unfortunately doesn't support :where https://caniuse.com/?search=%3Awhere
 $se23: 'html[class~="Polaris-Summer-Editions-2023"]';
-$se23ShadowBevelOptOut: 'html[class~="Polaris-SE23-Shadow-Bevel-Opt-Out"]';

--- a/polaris-react/src/styles/foundation/_shadow-bevel.scss
+++ b/polaris-react/src/styles/foundation/_shadow-bevel.scss
@@ -7,8 +7,8 @@
 @mixin shadow-bevel(
   $boxShadow: null,
   $borderRadius: null,
-  $border: var(--pc-app-provider-shadow-bevel-border),
-  $content: var(--pc-app-provider-shadow-bevel-content),
+  $border: null,
+  $content: '',
   $zIndex: 0
 ) {
   position: relative;

--- a/polaris-react/src/utilities/features/context.ts
+++ b/polaris-react/src/utilities/features/context.ts
@@ -4,8 +4,6 @@ import type {FeaturesConfig} from './types';
 
 export const classNamePolarisSummerEditions2023 =
   'Polaris-Summer-Editions-2023';
-export const classNamePolarisSummerEditions2023ShadowBevelOptOut =
-  'Polaris-SE23-Shadow-Bevel-Opt-Out';
 
 export const FeaturesContext = createContext<FeaturesConfig | undefined>(
   undefined,

--- a/polaris-react/src/utilities/features/types.ts
+++ b/polaris-react/src/utilities/features/types.ts
@@ -1,6 +1,5 @@
 export interface FeaturesConfig {
   polarisSummerEditions2023?: boolean;
-  polarisSummerEditions2023ShadowBevelOptOut?: boolean;
   [key: string]: boolean | undefined;
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #10194.
Removes shadow bevel opt out logic (except for storybook as that's a separate issue).

### How to 🎩

[Banner Storybook](https://5d559397bae39100201eedc1-tnqlfybcue.chromatic.com/?path=/story/all-components-banner--all)
[Banner Prod Storybook](https://storybook.polaris.shopify.com/?path=/story/all-components-banner--all&globals=polarisSummerEditions2023:true)

[AppProvider Storybook](https://5d559397bae39100201eedc1-tnqlfybcue.chromatic.com/?path=/story/all-components-appprovider--default)
[AppProvider Prod Storybook](https://storybook.polaris.shopify.com/?path=/story/all-components-appprovider--default&globals=polarisSummerEditions2023:true)

> Note: small spacing diff in Banner all story is expected because it was updated in `next`. Story matches what's in `next`.

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
