### PR TITLE
Allow value changes in prop migration

### DIFF
--- a/.changeset/breezy-badgers-bow.md
+++ b/.changeset/breezy-badgers-bow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Added the ability to migrate prop values

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-specific-value.input.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-specific-value.input.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+declare function MyComponent(props: any): JSX.Element;
+
+export function App() {
+  return (
+    <>
+      <MyComponent foo="bar" prop="non-targetted-value">
+        Hello world
+      </MyComponent>
+      <MyComponent foo="bar" prop="targetted-value">
+        Hello world
+      </MyComponent>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-specific-value.output.tsx
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/react-rename-component-prop-with-specific-value.output.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+declare function MyComponent(props: any): JSX.Element;
+
+export function App() {
+  return (
+    <>
+      <MyComponent foo="bar" variant="non-targetted-value">
+        Hello world
+      </MyComponent>
+      <MyComponent foo="bar" variant="new-targetted-value">
+        Hello world
+      </MyComponent>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/react-rename-component-prop/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/tests/transform.test.ts
@@ -16,7 +16,7 @@ const fixtures = [
       componentName: 'MyComponent',
       from: 'prop',
       to: 'newProp',
-      newValue: 'new-value',
+      toValue: 'new-value',
     },
   },
   {
@@ -25,7 +25,7 @@ const fixtures = [
       componentName: 'MyComponent.CompoundComponent',
       from: 'prop',
       to: 'newProp',
-      newValue: 'new-value',
+      toValue: 'new-value',
     },
   },
   {
@@ -34,7 +34,17 @@ const fixtures = [
       componentName: 'MyComponent',
       from: 'booleanProp',
       to: 'variant',
-      newValue: 'boolean-prop-value',
+      toValue: 'boolean-prop-value',
+    },
+  },
+  {
+    name: 'react-rename-component-prop-with-specific-value',
+    options: {
+      componentName: 'MyComponent',
+      from: 'prop',
+      to: 'variant',
+      fromValue: 'targetted-value',
+      toValue: 'new-targetted-value',
     },
   },
 ];

--- a/polaris-migrator/src/migrations/react-rename-component-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-rename-component-prop/transform.ts
@@ -8,22 +8,17 @@ export default function transformer(
   options: Options,
 ) {
   const componentParts = options.componentName?.split('.');
-  if (
-    !options.componentName ||
-    !options.from ||
-    !options.to ||
-    componentParts?.length > 2
-  ) {
+  const {componentName, from, to, fromValue, toValue} = options;
+  if (!componentName || !from || !to || componentParts?.length > 2) {
     throw new Error(
       'Missing required options: componentName, from, to, or your compound component exceeds 2 levels',
     );
   }
 
   const source = j(file.source);
-  const componentName = options.componentName;
-  const props = {[options.from]: options.to};
+  const props = {[from]: to};
 
-  renameProps(j, source, componentName, props, options.newValue);
+  renameProps(j, source, componentName, props, fromValue, toValue);
 
   return source.toSource();
 }

--- a/polaris-migrator/src/utilities/jsx.ts
+++ b/polaris-migrator/src/utilities/jsx.ts
@@ -127,7 +127,8 @@ export function renameProps(
   source: Collection<any>,
   componentName: string,
   props: {[from: string]: string},
-  newValue?: string,
+  fromValue?: string,
+  toValue?: string,
 ) {
   const [component, subcomponent] = componentName.split('.');
 
@@ -141,7 +142,7 @@ export function renameProps(
         element.node.openingElement.name.property.name === subcomponent
       ) {
         element.node.openingElement.attributes?.forEach((node) =>
-          updateNode(node, props, newValue),
+          updateNode(node, props, fromValue, toValue),
         );
       }
     });
@@ -151,7 +152,7 @@ export function renameProps(
   // Handle basic components
   source.findJSXElements(componentName)?.forEach((element) => {
     element.node.openingElement.attributes?.forEach((node) =>
-      updateNode(node, props, newValue),
+      updateNode(node, props, fromValue, toValue),
     );
   });
 
@@ -160,7 +161,8 @@ export function renameProps(
   function updateNode(
     node: any,
     props: {[from: string]: string},
-    newValue?: string,
+    fromValue?: string,
+    toValue?: string,
   ) {
     const isFromProp = (prop: unknown): prop is keyof typeof props =>
       Object.keys(props).includes(prop as string);
@@ -170,7 +172,8 @@ export function renameProps(
     }
 
     node.name.name = props[node.name.name];
-    node.value = j.stringLiteral(newValue ?? node.value.value);
+    if (fromValue && node.value.value !== fromValue) return node;
+    node.value = j.stringLiteral(toValue ?? node.value.value);
     return node;
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10233

### WHAT is this pull request doing?

Necessary for Icon changes where we're changing `color` to `tone`, and also mapping `highlight` to `info`, `warning` to `caution`.
