### PR TITLE
[IndexFiltering] Set focus default to true

### DIFF
--- a/.changeset/chilled-otters-sing.md
+++ b/.changeset/chilled-otters-sing.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+- Initialized filters focus based on mode state

--- a/.changeset/chilled-otters-sing.md
+++ b/.changeset/chilled-otters-sing.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-- Initialized filters focus based on mode state
+- Updated `Filters` query field to initialize with focus based on `mode` state

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -144,16 +144,18 @@ export function IndexFilters({
     value: filtersFocused,
     setFalse: setFiltersUnFocused,
     setTrue: setFiltersFocused,
-  } = useToggle(false);
+  } = useToggle(mode === IndexFiltersMode.Filtering);
   const {polarisSummerEditions2023} = useFeatures();
 
-  useOnValueChange(mode, (newMode) => {
+  const handleModeChange = (newMode: IndexFiltersMode) => {
     if (newMode === IndexFiltersMode.Filtering) {
       setFiltersFocused();
     } else {
       setFiltersUnFocused();
     }
-  });
+  };
+
+  useOnValueChange(mode, handleModeChange);
 
   useEventListener('keydown', (event) => {
     if (disableKeyboardShortcuts) return;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/core-workflows/issues/1020

<!--
  Context about the problem that’s being addressed.
-->

- Currently when navigating to a given index table with the  query included in the URL, the input field will contain the value but will not be focused
- Since only indexes containing queries have the state of `mode` as Filtering, we dynamically initialize with it. This way when the URL includes a query, the input field is focused without accessibility trade-offs.

<details>
<summary> Specifications </summary>

![image](https://github.com/Shopify/polaris/assets/42528878/a576e9a7-7016-48be-a146-1a8b4d40cfb2)
</details>

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

- This PR sets the initial focus of the input fields to true when `IndexFiltersMode` is `Filtering`.


### How to 🎩

- [Spin URL containing query](https://admin.web.hadf.zakaria-warsame.us.spin.dev/store/shop1/products?query=aero)
  - Ensure the input is focused when you go to the page or refresh with the query included



### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
~- [ ] Updated the component's `README.md` with documentation changes~ 
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

