### PR TITLE
Dynamic Fontsize for apple devices - target mobile only

### DIFF
--- a/.changeset/fresh-crews-try.md
+++ b/.changeset/fresh-crews-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Only apply apple dynamic text to mobile breakpoint

--- a/polaris-react/src/components/AppProvider/AppProvider.scss
+++ b/polaris-react/src/components/AppProvider/AppProvider.scss
@@ -61,8 +61,10 @@ html {
   font-sizes on descendant elements:
 */
 @supports (font: -apple-system-body) {
-  html {
-    font: -apple-system-body;
+  @media #{$p-breakpoints-sm-down} {
+    html {
+      font: -apple-system-body;
+    }
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where Desktop Safari has a font scale which is too small.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

We are wrapping the use of `font: -apple-system-body` within the mobile breakpoint to address the issue.
<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

**Desktop**
1. Visit [storybook](https://5d559397bae39100201eedc1-jcrahhpmju.chromatic.com/?path=/story/all-components-text--variants) in Desktop Safari
2. Open the Text Story
3. Ensure that the text size is normal
4. Double check with inspector and ensure `font:-apple-system-body` is not being applied

**Mobile**
1. Visit [storybook](https://5d559397bae39100201eedc1-jcrahhpmju.chromatic.com/?path=/story/all-components-text--variants) in iOS Simulator
2. Open the Text Story
3. Within the inspector verify that `font: -apple-system-body` is being applied
4. Change the accessibility font size and verify text size updates correctly


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
