### PR TITLE
Add `Button` migration instructions

### DIFF
--- a/documentation/guides/migrating-from-v11-to-v12.md
+++ b/documentation/guides/migrating-from-v11-to-v12.md
@@ -58,7 +58,7 @@ Polaris v12.0.0 ([full release notes](https://github.com/Shopify/polaris/release
 
 - Boolean props to `variant` and `tone`
 
-`npx @shopify/polaris-migrator v12-react-update-button-components <path>`
+`npx @shopify/polaris-migrator v12-react-update-button-component <path>`
 
 **ButtonGroup**
 

--- a/documentation/guides/migrating-from-v11-to-v12.md
+++ b/documentation/guides/migrating-from-v11-to-v12.md
@@ -56,7 +56,9 @@ Polaris v12.0.0 ([full release notes](https://github.com/Shopify/polaris/release
 
 - connectedDisclosure: [See the updated split example](https://polaris.shopify.com/components/actions/button)
 
-// TODO - Boolean prop to tone, variant migration
+- Boolean props to `variant` and `tone`
+
+`npx @shopify/polaris-migrator v12-react-update-button-components <path>`
 
 **ButtonGroup**
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris/issues/10161

### WHAT is this pull request doing?

Adds instructions to run the `Button` migration