### PR TITLE
[Pagination] introduce type prop and table type

### DIFF
--- a/.changeset/curvy-peas-flow.md
+++ b/.changeset/curvy-peas-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added a `type` prop to `Pagination` to support a table row layout 

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
@@ -43,22 +43,10 @@
     z-index: var(--pc-button-group-item);
     margin-top: 0;
     margin-left: 0;
-    line-height: normal;
-
-    #{$se23} & {
-      // stylelint-disable-next-line polaris/z-index/declaration-property-value-allowed-list -- se23 temporary styles
-      z-index: unset;
-    }
+    line-height: 1;
 
     &:not(:first-child) {
       margin-left: calc(-1 * var(--p-space-025));
-    }
-
-    // stylelint-disable-next-line -- se23 specific styling
-    + .Item:not(.selected) > button {
-      #{$se23} & {
-        clip-path: inset(0 0 0 var(--p-space-025));
-      }
     }
   }
 

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Button, ButtonGroup} from '@shopify/polaris';
+import {Button, ButtonGroup, Icon} from '@shopify/polaris';
+import {DeleteMinor} from '@shopify/polaris-icons';
 
 export default {
   component: ButtonGroup,
@@ -28,9 +29,16 @@ export function WithSegmentedButtons() {
   return (
     <div>
       <ButtonGroup segmented>
-        <Button>Bold</Button>
-        <Button pressed>Italic</Button>
-        <Button>Underline</Button>
+        <Button size="slim">Bold</Button>
+        <Button size="slim" pressed>
+          Italic
+        </Button>
+        <Button size="slim">Underline</Button>
+        <Button
+          size="slim"
+          icon={<Icon source={DeleteMinor} />}
+          accessibilityLabel="Delete"
+        />
       </ButtonGroup>
       <br />
       <ButtonGroup segmented>

--- a/polaris-react/src/components/Pagination/Pagination.scss
+++ b/polaris-react/src/components/Pagination/Pagination.scss
@@ -24,4 +24,43 @@
       }
     }
   }
+
+  &.table {
+    button {
+      #{$se23} & {
+        --button-min-height: var(--p-space-6);
+        background-color: var(--p-color-bg-subdued);
+        min-height: var(--button-min-height);
+        min-width: var(--button-min-height);
+        height: var(--button-min-height);
+        width: var(--button-min-height);
+        padding: unset;
+
+        /* stylelint-disable selector-max-combinators, selector-max-compound-selectors, max-nesting-depth -- cleaner until se23 clean up */
+        &:hover {
+          background-color: var(--p-color-bg-strong-hover);
+
+          svg {
+            fill: var(--p-color-icon-hover);
+          }
+        }
+
+        &:active,
+        &:focus {
+          background-color: var(--p-color-bg-strong-active);
+
+          svg {
+            fill: var(--p-color-icon-active);
+          }
+        }
+
+        &:disabled {
+          svg {
+            fill: var(--p-color-icon-disabled);
+          }
+        }
+        /* stylelint-enable */
+      }
+    }
+  }
 }

--- a/polaris-react/src/components/Pagination/Pagination.stories.tsx
+++ b/polaris-react/src/components/Pagination/Pagination.stories.tsx
@@ -57,3 +57,27 @@ export function WithLabel() {
     />
   );
 }
+
+export function WithTableType() {
+  return (
+    <div
+      style={{
+        maxWidth: 'calc(700px + (2 * var(--p-space-4)))',
+        margin: '0 auto',
+        border: '1px solid var(--p-color-border)',
+      }}
+    >
+      <Pagination
+        onPrevious={() => {
+          console.log('Previous');
+        }}
+        onNext={() => {
+          console.log('Next');
+        }}
+        type="table"
+        hasNext
+        label="1-50 of 8,450 orders"
+      />
+    </div>
+  );
+}

--- a/polaris-react/src/components/Pagination/Pagination.tsx
+++ b/polaris-react/src/components/Pagination/Pagination.tsx
@@ -11,6 +11,8 @@ import {Text} from '../Text';
 import {Tooltip} from '../Tooltip';
 import {Box} from '../Box';
 import {useFeatures} from '../../utilities/features';
+import {HorizontalStack} from '../HorizontalStack';
+import {classNames} from '../../utilities/css';
 
 import styles from './Pagination.scss';
 
@@ -46,6 +48,8 @@ export interface PaginationProps {
   onPrevious?(): void;
   /** Text to provide more context in between the arrow buttons */
   label?: React.ReactNode;
+  /** Layout structure of the component */
+  type?: 'page' | 'table';
 }
 
 export function Pagination({
@@ -62,6 +66,7 @@ export function Pagination({
   accessibilityLabel,
   accessibilityLabels,
   label,
+  type = 'page',
 }: PaginationProps) {
   const i18n = useI18n();
   const {polarisSummerEditions2023} = useFeatures();
@@ -159,6 +164,43 @@ export function Pagination({
         }
       />
     ));
+
+  if (type === 'table') {
+    const labelMarkup = label ? (
+      <Text as="span" variant="bodySm" fontWeight="medium">
+        {label}
+      </Text>
+    ) : null;
+
+    return (
+      <nav
+        aria-label={navLabel}
+        ref={node}
+        className={classNames(styles.Pagination, styles.table)}
+      >
+        {previousButtonEvents}
+        {nextButtonEvents}
+        <Box
+          background="bg-subdued"
+          paddingBlockStart="1_5-experimental"
+          paddingBlockEnd="1_5-experimental"
+          paddingInlineStart="3"
+          paddingInlineEnd="2"
+        >
+          <HorizontalStack
+            align={labelMarkup ? 'space-between' : 'end'}
+            blockAlign="center"
+          >
+            {labelMarkup}
+            <ButtonGroup segmented>
+              {constructedPrevious}
+              {constructedNext}
+            </ButtonGroup>
+          </HorizontalStack>
+        </Box>
+      </nav>
+    );
+  }
 
   const labelTextMarkup =
     hasNext && hasPrevious ? (

--- a/polaris-react/src/components/Pagination/tests/Pagination.test.tsx
+++ b/polaris-react/src/components/Pagination/tests/Pagination.test.tsx
@@ -9,6 +9,7 @@ import {ButtonGroup} from '../../ButtonGroup';
 import {TextField} from '../../TextField';
 import {Text} from '../../Text';
 import {Tooltip} from '../../Tooltip';
+import {HorizontalStack} from '../../HorizontalStack';
 import en from '../../../../locales/en.json';
 
 interface HandlerMap {
@@ -49,219 +50,301 @@ describe('<Pagination />', () => {
     removeEventListener.mockRestore();
   });
 
-  describe('tooltip', () => {
-    it('renders a tooltip if nextTooltip is provided and hasNext is true', () => {
-      const pagination = mountWithApp(<Pagination nextTooltip="k" hasNext />);
-      expect(pagination).toContainReactComponent(Tooltip, {
-        content: 'k',
-      });
-    });
+  describe.each(['page' as const, 'table' as const])(
+    `shared functionality - type: %s`,
+    (type) => {
+      describe('tooltip', () => {
+        it('renders a tooltip if nextTooltip is provided and hasNext is true', () => {
+          const pagination = mountWithApp(
+            <Pagination nextTooltip="k" hasNext type={type} />,
+          );
+          expect(pagination).toContainReactComponent(Tooltip, {
+            content: 'k',
+          });
+        });
 
-    it('does not render a tooltip if nextTooltip is provided and hasNext is false', () => {
-      const pagination = mountWithApp(
-        <Pagination nextTooltip="k" hasNext={false} />,
-      );
-      expect(pagination).not.toContainReactComponent(Tooltip);
-    });
+        it('does not render a tooltip if nextTooltip is provided and hasNext is false', () => {
+          const pagination = mountWithApp(
+            <Pagination nextTooltip="k" hasNext={false} type={type} />,
+          );
+          expect(pagination).not.toContainReactComponent(Tooltip);
+        });
 
-    it('renders a tooltip if previousToolTip is provided and hasPrevious is true', () => {
-      const pagination = mountWithApp(
-        <Pagination previousTooltip="j" hasPrevious />,
-      );
-      expect(pagination).toContainReactComponent(Tooltip, {
-        content: 'j',
-      });
-    });
+        it('renders a tooltip if previousToolTip is provided and hasPrevious is true', () => {
+          const pagination = mountWithApp(
+            <Pagination previousTooltip="j" hasPrevious />,
+          );
+          expect(pagination).toContainReactComponent(Tooltip, {
+            content: 'j',
+          });
+        });
 
-    it('does not render  tooltip if previousToolTip is provided and hasPrevious is false', () => {
-      const pagination = mountWithApp(
-        <Pagination previousTooltip="j" hasPrevious={false} />,
-      );
-      expect(pagination).not.toContainReactComponent(Tooltip);
-    });
+        it('does not render  tooltip if previousToolTip is provided and hasPrevious is false', () => {
+          const pagination = mountWithApp(
+            <Pagination previousTooltip="j" hasPrevious={false} type={type} />,
+          );
+          expect(pagination).not.toContainReactComponent(Tooltip);
+        });
 
-    it('renders a tooltip for nextToolTip and previousToolTip when they are provided and hasPrevious and hasNext are true', () => {
-      const pagination = mountWithApp(
-        <Pagination previousTooltip="j" nextTooltip="k" hasPrevious hasNext />,
-      );
+        it('renders a tooltip for nextToolTip and previousToolTip when they are provided and hasPrevious and hasNext are true', () => {
+          const pagination = mountWithApp(
+            <Pagination
+              previousTooltip="j"
+              nextTooltip="k"
+              hasPrevious
+              hasNext
+              type={type}
+            />,
+          );
 
-      expect(pagination).toContainReactComponentTimes(Tooltip, 2);
-    });
-  });
-
-  describe('accessibilityLabel', () => {
-    it('inserts prop as aria-label', () => {
-      const pagination = mountWithApp(<Pagination accessibilityLabel="test" />);
-      expect(pagination).toContainReactComponent('nav', {'aria-label': 'test'});
-    });
-
-    it('uses default value for aria-label', () => {
-      const pagination = mountWithApp(<Pagination />);
-
-      expect(pagination).toContainReactComponent('nav', {
-        'aria-label': 'Pagination',
-      });
-    });
-  });
-
-  describe('accessibilityLabels', () => {
-    const defaultProps = {
-      accessibilityLabels: {
-        previous: 'Previous orders page',
-        next: 'Next orders page',
-      },
-    };
-
-    it('passes accessibilityLabels to Button', () => {
-      const pagination = mountWithApp(
-        <Pagination {...defaultProps} previousURL="prev" nextURL="next" />,
-      );
-
-      expect(pagination).toContainReactComponent(Button, {
-        accessibilityLabel: defaultProps.accessibilityLabels.previous,
+          expect(pagination).toContainReactComponentTimes(Tooltip, 2);
+        });
       });
 
-      expect(pagination).toContainReactComponent(Button, {
-        accessibilityLabel: defaultProps.accessibilityLabels.next,
+      describe('accessibilityLabel', () => {
+        it('inserts prop as aria-label', () => {
+          const pagination = mountWithApp(
+            <Pagination accessibilityLabel="test" type={type} />,
+          );
+          expect(pagination).toContainReactComponent('nav', {
+            'aria-label': 'test',
+          });
+        });
+
+        it('uses default value for aria-label', () => {
+          const pagination = mountWithApp(<Pagination type={type} />);
+
+          expect(pagination).toContainReactComponent('nav', {
+            'aria-label': 'Pagination',
+          });
+        });
       });
-    });
 
-    it('renders default accessibilityLabels on Button', () => {
-      const pagination = mountWithApp(
-        <Pagination previousURL="prev" nextURL="next" />,
-      );
+      describe('accessibilityLabels', () => {
+        const defaultProps = {
+          accessibilityLabels: {
+            previous: 'Previous orders page',
+            next: 'Next orders page',
+          },
+        };
 
-      expect(pagination).toContainReactComponent(Button, {
-        accessibilityLabel: en.Polaris.Pagination.previous,
+        it('passes accessibilityLabels to Button', () => {
+          const pagination = mountWithApp(
+            <Pagination
+              {...defaultProps}
+              previousURL="prev"
+              nextURL="next"
+              type={type}
+            />,
+          );
+
+          expect(pagination).toContainReactComponent(Button, {
+            accessibilityLabel: defaultProps.accessibilityLabels.previous,
+          });
+
+          expect(pagination).toContainReactComponent(Button, {
+            accessibilityLabel: defaultProps.accessibilityLabels.next,
+          });
+        });
+
+        it('renders default accessibilityLabels on Button', () => {
+          const pagination = mountWithApp(
+            <Pagination previousURL="prev" nextURL="next" type={type} />,
+          );
+
+          expect(pagination).toContainReactComponent(Button, {
+            accessibilityLabel: en.Polaris.Pagination.previous,
+          });
+
+          expect(pagination).toContainReactComponent(Button, {
+            accessibilityLabel: en.Polaris.Pagination.next,
+          });
+        });
       });
 
-      expect(pagination).toContainReactComponent(Button, {
-        accessibilityLabel: en.Polaris.Pagination.next,
+      describe('label', () => {
+        it('renders as text', () => {
+          const pagination = mountWithApp(
+            <Pagination label="test" type={type} />,
+          );
+          expect(pagination.text()).toContain('test');
+        });
       });
-    });
-  });
 
-  describe('label', () => {
-    it('renders as text', () => {
-      const pagination = mountWithApp(<Pagination label="test" />);
-      expect(pagination.text()).toContain('test');
-    });
-
-    it('has subdued text without next and previous pages', () => {
-      const pagination = mountWithApp(<Pagination label="test" />);
-
-      expect(pagination).toContainReactComponent(Text, {
-        color: 'subdued',
-      });
-    });
-  });
-
-  it('adds a keypress event for nextKeys', () => {
-    const spy = jest.fn();
-    mountWithApp(
-      <Pagination hasNext nextKeys={[Key.KeyK]} onNext={spy} nextTooltip="k" />,
-    );
-
-    listenerMap.keyup({keyCode: Key.KeyK});
-
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  it('adds a keypress event for previousKeys', () => {
-    const spy = jest.fn();
-    mountWithApp(
-      <Pagination
-        hasPrevious
-        previousKeys={[Key.KeyJ]}
-        onPrevious={spy}
-        previousTooltip="j"
-      />,
-    );
-
-    listenerMap.keyup({keyCode: Key.KeyJ});
-
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  describe('input elements', () => {
-    it('will not call paginations callback on keypress if a input element is focused', () => {
-      const spy = jest.fn();
-      const wrapper = mountWithApp(
-        <div>
-          <TextField label="test" value="" onChange={noop} autoComplete="off" />
+      it('adds a keypress event for nextKeys', () => {
+        const spy = jest.fn();
+        mountWithApp(
           <Pagination
-            nextTooltip="j"
+            hasNext
+            nextKeys={[Key.KeyK]}
+            onNext={spy}
+            nextTooltip="k"
+            type={type}
+          />,
+        );
+
+        listenerMap.keyup({keyCode: Key.KeyK});
+
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('adds a keypress event for previousKeys', () => {
+        const spy = jest.fn();
+        mountWithApp(
+          <Pagination
+            hasPrevious
             previousKeys={[Key.KeyJ]}
             onPrevious={spy}
             previousTooltip="j"
-          />
-        </div>,
-      );
-      focusElement(wrapper, 'input');
-      listenerMap.keyup({keyCode: Key.KeyJ});
-      expect(spy).not.toHaveBeenCalled();
-    });
-  });
+            type={type}
+          />,
+        );
 
-  describe('nextURL/previousURL', () => {
-    let pagination: CustomRoot<any, any>;
+        listenerMap.keyup({keyCode: Key.KeyJ});
 
-    it('navigates the browser to the anchors target when the designated key is pressed', () => {
-      const spy = jest.fn();
-      pagination = mountWithApp(
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      describe('input elements', () => {
+        it('will not call paginations callback on keypress if a input element is focused', () => {
+          const spy = jest.fn();
+          const wrapper = mountWithApp(
+            <div>
+              <TextField
+                label="test"
+                value=""
+                onChange={noop}
+                autoComplete="off"
+              />
+              <Pagination
+                nextTooltip="j"
+                previousKeys={[Key.KeyJ]}
+                onPrevious={spy}
+                previousTooltip="j"
+                type={type}
+              />
+            </div>,
+          );
+          focusElement(wrapper, 'input');
+          listenerMap.keyup({keyCode: Key.KeyJ});
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('nextURL/previousURL', () => {
+        let pagination: CustomRoot<any, any>;
+
+        it('navigates the browser to the anchors target when the designated key is pressed', () => {
+          const spy = jest.fn();
+          pagination = mountWithApp(
+            <Pagination
+              hasPrevious
+              previousKeys={[Key.KeyJ]}
+              previousTooltip="j"
+              previousURL="https://www.google.com"
+              type={type}
+            />,
+          );
+          const anchor = pagination.find('a')!.domNode as HTMLAnchorElement;
+          anchor.click = spy;
+          listenerMap.keyup({keyCode: Key.KeyJ});
+
+          expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not navigate the browser when hasNext or hasPrevious is false', () => {
+          const anchorClickSpy = jest.fn();
+          pagination = mountWithApp(
+            <Pagination
+              hasPrevious={false}
+              previousKeys={[Key.KeyJ]}
+              previousTooltip="j"
+              previousURL="https://www.google.com"
+              type={type}
+            />,
+          );
+
+          const anchor = pagination.find('a')!.domNode as HTMLAnchorElement;
+          anchor.click = anchorClickSpy;
+          listenerMap.keyup({keyCode: Key.KeyJ});
+
+          expect(anchorClickSpy).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      it('uses Button and ButtonGroup as subcomponents', () => {
+        const pagination = mountWithApp(
+          <Pagination nextURL="/next" previousURL="/prev" type={type} />,
+        );
+
+        expect(pagination).toContainReactComponent(ButtonGroup, {
+          segmented: true,
+        });
+        expect(pagination).toContainReactComponent(Button, {url: '/prev'});
+        expect(pagination).toContainReactComponent(Button, {url: '/next'});
+      });
+    },
+  );
+
+  describe('type: page', () => {
+    it('the ButtonGroup is not segmented when there is a label', () => {
+      const pagination = mountWithApp(
         <Pagination
-          hasPrevious
-          previousKeys={[Key.KeyJ]}
-          previousTooltip="j"
-          previousURL="https://www.google.com"
+          nextURL="/next"
+          previousURL="/prev"
+          label="Hello, world!"
+          type="page"
         />,
+        {features: {polarisSummerEditions2023: false}},
       );
-      const anchor = pagination.find('a')!.domNode as HTMLAnchorElement;
-      anchor.click = spy;
-      listenerMap.keyup({keyCode: Key.KeyJ});
 
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(pagination).toContainReactComponent(ButtonGroup, {
+        segmented: false,
+      });
     });
 
-    it('does not navigate the browser when hasNext or hasPrevious is false', () => {
-      const anchorClickSpy = jest.fn();
-      pagination = mountWithApp(
-        <Pagination
-          hasPrevious={false}
-          previousKeys={[Key.KeyJ]}
-          previousTooltip="j"
-          previousURL="https://www.google.com"
-        />,
-      );
+    describe('label', () => {
+      it('has subdued text without next and previous pages', () => {
+        const pagination = mountWithApp(
+          <Pagination label="test" type="page" />,
+        );
 
-      const anchor = pagination.find('a')!.domNode as HTMLAnchorElement;
-      anchor.click = anchorClickSpy;
-      listenerMap.keyup({keyCode: Key.KeyJ});
-
-      expect(anchorClickSpy).toHaveBeenCalledTimes(0);
+        expect(pagination).toContainReactComponent(Text, {
+          color: 'subdued',
+        });
+      });
     });
   });
 
-  it('uses Button and ButtonGroup as subcomponents', () => {
-    const pagination = mountWithApp(
-      <Pagination nextURL="/next" previousURL="/prev" />,
-    );
+  describe('type: table', () => {
+    it('places the content at the end of the container', () => {
+      const pagination = mountWithApp(
+        <Pagination hasNext nextURL="/next" previousURL="/prev" type="table" />,
+      );
 
-    expect(pagination).toContainReactComponent(ButtonGroup, {
-      segmented: true,
+      expect(pagination).toContainReactComponent(HorizontalStack, {
+        align: 'end',
+        blockAlign: 'center',
+      });
     });
-    expect(pagination).toContainReactComponent(Button, {url: '/prev'});
-    expect(pagination).toContainReactComponent(Button, {url: '/next'});
-  });
 
-  it('the ButtonGroup is not segmented when there is a label', () => {
-    const pagination = mountWithApp(
-      <Pagination nextURL="/next" previousURL="/prev" label="Hello, world!" />,
-      {features: {polarisSummerEditions2023: false}},
-    );
+    describe('label', () => {
+      it('spaces the content apart within the container', () => {
+        const pagination = mountWithApp(
+          <Pagination
+            hasNext
+            nextURL="/next"
+            previousURL="/prev"
+            type="table"
+            label="test"
+          />,
+        );
 
-    expect(pagination).toContainReactComponent(ButtonGroup, {
-      segmented: false,
+        expect(pagination).toContainReactComponent(HorizontalStack, {
+          align: 'space-between',
+          blockAlign: 'center',
+        });
+      });
     });
   });
 });

--- a/polaris.shopify.com/content/components/navigation/pagination.md
+++ b/polaris.shopify.com/content/components/navigation/pagination.md
@@ -22,13 +22,16 @@ keywords:
 examples:
   - fileName: pagination-default.tsx
     title: Default
-    description: Use for pagination at the bottom of lists.
+    description: Use for pagination of resources.
   - fileName: pagination-with-keyboard-navigation.tsx
     title: With keyboard navigation
     description: Attach standard keyboard shortcuts to important pagination controls.
   - fileName: pagination-with-label.tsx
     title: With label
     description: Add a label between navigation buttons to provide more context of the content being viewed by the user.
+  - fileName: pagination-with-table-type.tsx
+    title: With table type
+    description: Use for pagination at the bottom of tables or lists.
 ---
 
 ## Best practices

--- a/polaris.shopify.com/pages/examples/pagination-with-table-type.tsx
+++ b/polaris.shopify.com/pages/examples/pagination-with-table-type.tsx
@@ -1,0 +1,29 @@
+import {Pagination} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function PaginationExample() {
+  return (
+    <div
+      style={{
+        maxWidth: '700px',
+        margin: 'auto',
+        border: '1px solid var(--p-color-border)'
+      }}
+    >
+      <Pagination
+        onPrevious={() => {
+          console.log('Previous');
+        }}
+        onNext={() => {
+          console.log('Next');
+        }}
+        type="table"
+        hasNext
+        label="1-50 of 8,450 orders"
+      />
+    </div>
+  );
+}
+
+export default withPolarisExample(PaginationExample);


### PR DESCRIPTION
### WHY are these changes introduced?

Introduces a table layout to the `Pagination` component, which would then be utilized by `IndexTable`

Design:
<img width="1128" alt="Screenshot 2023-09-11 at 9 56 40 PM" src="https://github.com/Shopify/polaris/assets/86790511/f0f3cb17-7dbf-47eb-9386-cf1fa1d83295">

[Figma](https://www.figma.com/file/w0Fv15A3zvWVyilpHxTxBn/Index-filters-and-search-post-release?node-id=975%3A142279&mode=dev)

### WHAT is this pull request doing?

Introduces `type` prop to `Pagination`. A value of `page` results in the existing aesthetic with no changes. A value of `table` results in the new table aesthetic, which is intended to be utilized by the `IndexTable`.

### How to 🎩

[Storybook](https://storybook.web.polaris-pagination-table-format.matt-kubej.us.spin.dev/?path=/story/all-components-pagination--with-table-type&globals=polarisSummerEditions2023:true;polarisSummerEditions2023ShadowBevelOptOut:true)

- Validate the Storybook matches the specifications
- Validate that there are no regressions to the existing `page` Pagination configurations.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
