### PR TITLE
[IndexFilters] Update mobile view when in uplift mood

### DIFF
--- a/.changeset/poor-donkeys-fail.md
+++ b/.changeset/poor-donkeys-fail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed UI inconsistencies in the mobile view of the IndexFilters

--- a/polaris-react/src/components/Filters/Filters.scss
+++ b/polaris-react/src/components/Filters/Filters.scss
@@ -9,11 +9,19 @@
   background: var(--p-color-bg);
 }
 
+.ContainerUplift {
+  background: none;
+}
+
 @media #{$p-breakpoints-sm-down} {
   .Container {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     height: 57px;
+
+    &.ContainerUplift {
+      height: unset;
+    }
   }
 }
 

--- a/polaris-react/src/components/Filters/Filters.tsx
+++ b/polaris-react/src/components/Filters/Filters.tsx
@@ -284,8 +284,8 @@ export function Filters({
     ? {
         paddingInlineStart: '2',
         paddingInlineEnd: '2',
-        paddingBlockStart: '1_5-experimental',
-        paddingBlockEnd: '1_5-experimental',
+        paddingBlockStart: '2',
+        paddingBlockEnd: '2',
       }
     : {
         paddingBlockStart: {
@@ -304,7 +304,9 @@ export function Filters({
       };
 
   const queryFieldMarkup = hideQueryField ? null : (
-    <div className={styles.Container}>
+    <div
+      className={classNames(styles.Container, se23 && styles.ContainerUplift)}
+    >
       <Box {...containerSpacing}>
         <HorizontalStack
           align="start"

--- a/polaris-react/src/components/Filters/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/Filters/components/SearchField/SearchField.scss
@@ -20,6 +20,7 @@
   border-radius: var(--p-border-radius-1);
   border-color: var(--p-color-border-input);
   padding-inline: var(--p-space-1_5-experimental);
+  width: 100%;
 
   &:hover {
     border-color: var(--p-color-border-input-hover);

--- a/polaris-react/src/components/IndexFilters/components/Container/Container.scss
+++ b/polaris-react/src/components/IndexFilters/components/Container/Container.scss
@@ -16,5 +16,9 @@
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     height: 57px;
+
+    #{$se23} & {
+      height: unset;
+    }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10256

Due to the uplift initiative, the mobile views of the IndexFilters component looks a little wonky. As well as the CTAs overlapping the filters by being pushed to another row, we have some height differentials going between the two states that are less than ideal.

Spinstance: https://admin.web.if-fix.marc-thomas.eu.spin.dev/store/shop1/products?selectedView=all

### WHAT is this pull request doing?

<img width="2088" alt="Screenshot 2023-09-06 at 12 40 24" src="https://github.com/Shopify/polaris/assets/2562596/c4a04202-65ab-4639-95cc-0aa03d7b3a86">
<img width="2088" alt="Screenshot 2023-09-06 at 12 40 27" src="https://github.com/Shopify/polaris/assets/2562596/90ff7b91-db07-4cfd-917a-7047716f6837">

- Fixes the overlapping CTA issue by applying a `width: 100%` to the input within the Filters bar.
- Fixes height discrepancies within the mobile interface of the IndexFilters on both the filtering and default modes.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
