### PR TITLE
Rename `ThemeVariant` to `Theme`

### DIFF
--- a/.changeset/short-schools-run.md
+++ b/.changeset/short-schools-run.md
@@ -1,5 +1,4 @@
 ---
-'@shopify/polaris': minor
 '@shopify/polaris-tokens': minor
 ---
 

--- a/.changeset/short-schools-run.md
+++ b/.changeset/short-schools-run.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'@shopify/polaris-tokens': minor
+---
+
+Renamed `ThemeVariant` to `Theme` and exposed `Theme` type

--- a/polaris-react/src/utilities/use-theme.ts
+++ b/polaris-react/src/utilities/use-theme.ts
@@ -1,8 +1,6 @@
 import {createContext, useContext} from 'react';
-import type {ThemeName} from '@shopify/polaris-tokens';
+import type {ThemeName, Theme} from '@shopify/polaris-tokens';
 import {themes} from '@shopify/polaris-tokens';
-
-export type Theme = typeof themes[ThemeName];
 
 export function getTheme(themeName: ThemeName): Theme {
   return themes[themeName];

--- a/polaris-tokens/scripts/toStyleSheet.ts
+++ b/polaris-tokens/scripts/toStyleSheet.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import type {MetaThemeShape, MetaTokenGroupShape} from '../src/themes/types';
-import {metaThemeVariantPartials, metaThemeDefault} from '../src/themes';
+import {metaThemePartials, metaThemeDefault} from '../src/themes';
 import {themeNameDefault} from '../src/themes/constants';
 import {createThemeSelector} from '../src/themes/utils';
 import {createVar} from '../src/utilities';
@@ -52,18 +52,16 @@ export async function toStyleSheet() {
     }
   });
 
-  const metaThemeVariantPartialsEntries = Object.entries(
-    metaThemeVariantPartials,
-  ).filter(([themeName]) => themeName !== themeNameDefault) as Entries<
-    Omit<typeof metaThemeVariantPartials, typeof themeNameDefault>
-  >;
+  const metaThemePartialsEntries = Object.entries(metaThemePartials).filter(
+    ([themeName]) => themeName !== themeNameDefault,
+  ) as Entries<Omit<typeof metaThemePartials, typeof themeNameDefault>>;
 
   const styles = [
     `:root{color-scheme:light;${getMetaThemeDecls(metaThemeDefault)}}`,
-    metaThemeVariantPartialsEntries.map(
-      ([themeName, metaThemeVariantPartial]) =>
+    metaThemePartialsEntries.map(
+      ([themeName, metaThemePartial]) =>
         `${createThemeSelector(themeName)}{${getMetaThemeDecls(
-          metaThemeVariantPartial,
+          metaThemePartial,
         )}}`,
     ),
     getKeyframes(metaThemeDefault.motion),

--- a/polaris-tokens/scripts/toValues.ts
+++ b/polaris-tokens/scripts/toValues.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import {metaThemeVariants, metaThemeDefault} from '../src/themes';
+import {metaThemes, metaThemeDefault} from '../src/themes';
 import {extractMetaThemeValues} from '../src/themes/utils';
 
 const outputDir = path.join(__dirname, '../build');
@@ -24,12 +24,10 @@ export async function toValues() {
       createExport([
         'themes',
         Object.fromEntries(
-          Object.entries(metaThemeVariants).map(
-            ([themeName, metaThemeVariant]) => [
-              themeName,
-              extractMetaThemeValues(metaThemeVariant),
-            ],
-          ),
+          Object.entries(metaThemes).map(([themeName, metaTheme]) => [
+            themeName,
+            extractMetaThemeValues(metaTheme),
+          ]),
         ),
       ]),
     ]

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -8,7 +8,7 @@ export type {
   MetadataGroup,
 } from './types';
 
-export type {ThemeName} from './themes/types';
+export type {ThemeName, Theme} from './themes/types';
 
 export {themeNameDefault} from './themes/constants';
 

--- a/polaris-tokens/src/themes/index.ts
+++ b/polaris-tokens/src/themes/index.ts
@@ -1,5 +1,5 @@
-import type {MetaThemeVariantPartials, MetaThemeVariants} from './types';
-import {createMetaThemeVariant} from './utils';
+import type {MetaThemePartials, MetaThemes} from './types';
+import {createMetaTheme} from './utils';
 import {themeNameDefault} from './constants';
 import {metaThemeLight, metaThemeLightPartial} from './light';
 import {
@@ -7,19 +7,18 @@ import {
   metaThemeLightUpliftPartial,
 } from './light-uplift';
 
-export {createMetaThemeVariant} from './utils';
+export {createMetaTheme} from './utils';
 
-export const metaThemeVariants: MetaThemeVariants = {
+export const metaThemes: MetaThemes = {
   light: metaThemeLight,
   'Polaris-Summer-Editions-2023': metaThemeLightUplift,
 };
 
-export const metaThemeVariantPartials: MetaThemeVariantPartials = {
+export const metaThemePartials: MetaThemePartials = {
   light: metaThemeLightPartial,
   'Polaris-Summer-Editions-2023': metaThemeLightUpliftPartial,
 };
 
-export const metaThemeDefaultPartial =
-  metaThemeVariantPartials[themeNameDefault];
+export const metaThemeDefaultPartial = metaThemePartials[themeNameDefault];
 
-export const metaThemeDefault = createMetaThemeVariant(metaThemeDefaultPartial);
+export const metaThemeDefault = createMetaTheme(metaThemeDefaultPartial);

--- a/polaris-tokens/src/themes/light-uplift.ts
+++ b/polaris-tokens/src/themes/light-uplift.ts
@@ -1,8 +1,8 @@
 import * as colors from '../colors-experimental';
 
-import {createMetaThemeVariant, createMetaThemeVariantPartial} from './utils';
+import {createMetaTheme, createMetaThemePartial} from './utils';
 
-export const metaThemeLightUpliftPartial = createMetaThemeVariantPartial({
+export const metaThemeLightUpliftPartial = createMetaThemePartial({
   motion: {
     'motion-ease-out': {value: 'cubic-bezier(0.19, 0.91, 0.38, 1)'},
   },
@@ -172,6 +172,6 @@ export const metaThemeLightUpliftPartial = createMetaThemeVariantPartial({
   },
 });
 
-export const metaThemeLightUplift = createMetaThemeVariant(
+export const metaThemeLightUplift = createMetaTheme(
   metaThemeLightUpliftPartial,
 );

--- a/polaris-tokens/src/themes/light.ts
+++ b/polaris-tokens/src/themes/light.ts
@@ -1,5 +1,5 @@
-import {createMetaThemeVariant, createMetaThemeVariantPartial} from './utils';
+import {createMetaTheme, createMetaThemePartial} from './utils';
 
-export const metaThemeLightPartial = createMetaThemeVariantPartial({});
+export const metaThemeLightPartial = createMetaThemePartial({});
 
-export const metaThemeLight = createMetaThemeVariant(metaThemeLightPartial);
+export const metaThemeLight = createMetaTheme(metaThemeLightPartial);

--- a/polaris-tokens/src/themes/types.ts
+++ b/polaris-tokens/src/themes/types.ts
@@ -2,11 +2,11 @@ import type {metaThemeBase} from './base';
 import type {themeNames} from './constants';
 
 export type MetaThemeBase = typeof metaThemeBase;
-export type MetaThemeVariant = MetaThemeBase;
+export type MetaTheme = MetaThemeBase;
 
 export type ThemeName = typeof themeNames[number];
 export type ThemeBase = ExtractMetaThemeValues<MetaThemeBase>;
-export type ThemeVariant = ExtractMetaThemeValues<MetaThemeVariant>;
+export type Theme = ExtractMetaThemeValues<MetaTheme>;
 
 export interface MetaTokenProperties {
   value: string;
@@ -21,22 +21,22 @@ export interface MetaThemeShape {
   [tokenGroupName: string]: MetaTokenGroupShape;
 }
 
-export type MetaThemeVariants = {
-  [T in ThemeName]: MetaThemeVariant;
+export type MetaThemes = {
+  [T in ThemeName]: MetaTheme;
 };
 
 type ExcludeMotionKeyframes<T> = T extends `motion-keyframes-${string}`
   ? never
   : T;
 
-export type MetaThemeVariantPartialShape = {
+export type MetaThemePartialShape = {
   [TokenGroupName in keyof Omit<MetaThemeBase, 'breakpoints'>]?: {
     [TokenName in keyof MetaThemeBase[TokenGroupName] as ExcludeMotionKeyframes<TokenName>]?: MetaTokenProperties;
   };
 };
 
-export type MetaThemeVariantPartials = {
-  [T in ThemeName]: MetaThemeVariantPartialShape;
+export type MetaThemePartials = {
+  [T in ThemeName]: MetaThemePartialShape;
 };
 
 export type ExtractMetaTokenGroupValues<T extends MetaTokenGroupShape> = {

--- a/polaris-tokens/src/themes/utils.ts
+++ b/polaris-tokens/src/themes/utils.ts
@@ -7,21 +7,20 @@ import type {
   ExtractMetaThemeValues,
   ExtractMetaTokenGroupValues,
   MetaThemeShape,
-  MetaThemeVariant,
-  MetaThemeVariantPartialShape,
+  MetaTheme,
+  MetaThemePartialShape,
   MetaTokenGroupShape,
   ThemeName,
 } from './types';
 import {themeNameLightUplift} from './constants';
 import {metaThemeBase} from './base';
 
-export const createMetaThemeVariantPartial =
-  createExact<MetaThemeVariantPartialShape>();
+export const createMetaThemePartial = createExact<MetaThemePartialShape>();
 
-export function createMetaThemeVariant<
-  T extends Exact<MetaThemeVariantPartialShape, T>,
->(metaThemeVariantPartial: T): MetaThemeVariant {
-  return deepmerge(metaThemeBase, metaThemeVariantPartial);
+export function createMetaTheme<T extends Exact<MetaThemePartialShape, T>>(
+  metaThemePartial: T,
+): MetaTheme {
+  return deepmerge(metaThemeBase, metaThemePartial);
 }
 
 export function createThemeClassName(themeName: ThemeName) {


### PR DESCRIPTION
This PR renames `ThemeVariant` to `Theme` to simplify the internal structure of Polaris tokens and improve readability. The introduction of the base/variant theme architecture used explicit names to help communicate each themes intent (e.g. the base theme is internal, variant themes are derived from the base theme and the only themes exposed to consumers). However, we now think it can become an inferred concept that is articulated in the v12 documentation.

Additionally, we exposed the `Theme` type from Polaris tokens to avoid requiring consumers to infer the `Theme` shape from the `themes` export:

#### Before:

```ts
import type {ThemeName} from '@shopify/polaris-tokens';
import {themes} from '@shopify/polaris-tokens';

export type Theme = typeof themes[ThemeName];
```

#### After:

```ts
import type {Theme} from '@shopify/polaris-tokens';
```