### PR TITLE
[Docs] Add shortDescription for all components

### DIFF
--- a/polaris.shopify.com/content/components/actions/account-connection.md
+++ b/polaris.shopify.com/content/components/actions/account-connection.md
@@ -1,5 +1,6 @@
 ---
 title: Account connection
+shortDescription: Used for connecting or disconnecting a store to various accounts, like Facebook for the sales channel.
 category: Actions
 keywords:
   - AccountConnection

--- a/polaris.shopify.com/content/components/actions/button-group.md
+++ b/polaris.shopify.com/content/components/actions/button-group.md
@@ -1,5 +1,6 @@
 ---
 title: Button group
+shortDescription: Displays multiple related actions stacked or in a horizontal row for arrangement and spacing.
 category: Actions
 keywords:
   - ButtonGroup

--- a/polaris.shopify.com/content/components/actions/button.md
+++ b/polaris.shopify.com/content/components/actions/button.md
@@ -1,5 +1,6 @@
 ---
 title: Button
+shortDescription: Used primarily for actions like 'Add', 'Close', 'Cancel', or 'Save'. Plain buttons are used for less important actions.
 category: Actions
 keywords:
   - CTA

--- a/polaris.shopify.com/content/components/actions/index.md
+++ b/polaris.shopify.com/content/components/actions/index.md
@@ -1,5 +1,6 @@
 ---
 title: Actions
+shortDescription: Perform tasks or take actions within the Shopify admin.
 expanded: true
 order: 1
 previewImg: /images/components/actions.png

--- a/polaris.shopify.com/content/components/actions/page-actions.md
+++ b/polaris.shopify.com/content/components/actions/page-actions.md
@@ -1,5 +1,6 @@
 ---
 title: Page actions
+shortDescription: Allows merchants to take key actions at the bottom of specific pages in the interface.
 category: Actions
 keywords:
   - PageActions

--- a/polaris.shopify.com/content/components/deprecated/caption.md
+++ b/polaris.shopify.com/content/components/deprecated/caption.md
@@ -1,5 +1,6 @@
 ---
 title: Caption
+shortDescription: Caption text is smaller than the recommended size for general reading. Used in graphs, timestamps, or as secondary text.
 category: Deprecated
 keywords:
   - labels

--- a/polaris.shopify.com/content/components/deprecated/display-text.md
+++ b/polaris.shopify.com/content/components/deprecated/display-text.md
@@ -1,5 +1,6 @@
 ---
 title: Display text
+shortDescription: Display styles make a bold visual statement. Used for visual storytelling, marketing content, or capturing attention.
 category: Deprecated
 keywords:
   - DisplayText

--- a/polaris.shopify.com/content/components/deprecated/heading.md
+++ b/polaris.shopify.com/content/components/deprecated/heading.md
@@ -1,5 +1,6 @@
 ---
 title: Heading
+shortDescription: Used as the titles of each major section of a page in the interface, like in card components.
 category: Deprecated
 keywords:
   - titles

--- a/polaris.shopify.com/content/components/deprecated/index.md
+++ b/polaris.shopify.com/content/components/deprecated/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deprecated
+shortDescription: Deprecated components will be removed in future major versions of Polaris. They should be avoided and will show warnings.
 expanded: true
 order: 12
 previewImg: /images/components/deprecated.png

--- a/polaris.shopify.com/content/components/deprecated/legacy-card.md
+++ b/polaris.shopify.com/content/components/deprecated/legacy-card.md
@@ -1,5 +1,6 @@
 ---
 title: Legacy card
+shortDescription: Legacy version of the Card component. Used to group similar concepts and tasks together for easier scanning and reading.
 category: Deprecated
 keywords:
   - layout

--- a/polaris.shopify.com/content/components/deprecated/legacy-filters.md
+++ b/polaris.shopify.com/content/components/deprecated/legacy-filters.md
@@ -1,5 +1,6 @@
 ---
 title: Legacy filters
+shortDescription: Legacy version of the Filters component. Used to filter the items of a list or table.
 category: Selection and input
 keywords:
   - filters

--- a/polaris.shopify.com/content/components/deprecated/legacy-stack.md
+++ b/polaris.shopify.com/content/components/deprecated/legacy-stack.md
@@ -1,5 +1,6 @@
 ---
 title: Legacy stack
+shortDescription: Legacy version of the Stack component. Used for layout of a horizontal row of components or vertical centering.
 category: Deprecated
 keywords:
   - rows

--- a/polaris.shopify.com/content/components/deprecated/legacy-tabs.md
+++ b/polaris.shopify.com/content/components/deprecated/legacy-tabs.md
@@ -1,5 +1,6 @@
 ---
 title: Legacy tabs
+shortDescription: Used to alternate among related views within the same context.
 category: Deprecated
 keywords:
   - layout

--- a/polaris.shopify.com/content/components/deprecated/setting-toggle.md
+++ b/polaris.shopify.com/content/components/deprecated/setting-toggle.md
@@ -1,5 +1,6 @@
 ---
 title: Setting toggle
+shortDescription: Used to control a feature or option that can be turned on or off.
 category: Deprecated
 keywords:
   - SettingToggle

--- a/polaris.shopify.com/content/components/deprecated/sheet.md
+++ b/polaris.shopify.com/content/components/deprecated/sheet.md
@@ -1,5 +1,6 @@
 ---
 title: Sheet
+shortDescription: A large container providing actions and information contextual to the page without interrupting flow like a modal.
 category: Deprecated
 keywords:
   - sheet

--- a/polaris.shopify.com/content/components/deprecated/subheading.md
+++ b/polaris.shopify.com/content/components/deprecated/subheading.md
@@ -1,5 +1,6 @@
 ---
 title: Subheading
+shortDescription: Used for the title of any sub-sections in top-level page sections.
 category: Deprecated
 keywords:
   - title bar

--- a/polaris.shopify.com/content/components/deprecated/text-container.md
+++ b/polaris.shopify.com/content/components/deprecated/text-container.md
@@ -1,5 +1,6 @@
 ---
 title: Text container
+shortDescription: Used to wrap text elements like paragraphs, headings, and lists for vertical spacing.
 category: Deprecated
 releasedIn: 1.9.0
 keywords:

--- a/polaris.shopify.com/content/components/deprecated/text-style.md
+++ b/polaris.shopify.com/content/components/deprecated/text-style.md
@@ -1,5 +1,6 @@
 ---
 title: Text style
+shortDescription: Enhances text with additional visual meaning, like using subdued text to de-emphasize it.
 category: Deprecated
 keywords:
   - TextStyle

--- a/polaris.shopify.com/content/components/deprecated/visually-hidden.md
+++ b/polaris.shopify.com/content/components/deprecated/visually-hidden.md
@@ -1,5 +1,6 @@
 ---
 title: Visually hidden
+shortDescription: Used when an element needs to be available to assistive technology but otherwise hidden.
 category: Deprecated
 keywords:
   - VisuallyHidden

--- a/polaris.shopify.com/content/components/feedback-indicators/badge.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/badge.md
@@ -1,5 +1,6 @@
 ---
 title: Badge
+shortDescription: Used to inform merchants of the tone of an object or an action taken.
 category: Feedback indicators
 keywords:
   - pills

--- a/polaris.shopify.com/content/components/feedback-indicators/banner.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/banner.md
@@ -1,5 +1,6 @@
 ---
 title: Banner
+shortDescription: Informs merchants about important changes or persistent conditions in a prominent way.
 category: Feedback indicators
 keywords:
   - inform

--- a/polaris.shopify.com/content/components/feedback-indicators/exception-list.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/exception-list.md
@@ -1,5 +1,6 @@
 ---
 title: Exception list
+shortDescription: Helps merchants notice important, standout information that adds extra context to a task.
 category: Feedback indicators
 keywords:
   - exception list

--- a/polaris.shopify.com/content/components/feedback-indicators/index.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/index.md
@@ -1,5 +1,6 @@
 ---
 title: Feedback indicators
+shortDescription: Inform merchants about the status of a process, provide feedback, or indicate progress.
 expanded: true
 order: 5
 previewImg: /images/components/feedback-indicators.png

--- a/polaris.shopify.com/content/components/feedback-indicators/loading.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/loading.md
@@ -1,5 +1,6 @@
 ---
 title: Loading
+shortDescription: Used to indicate to merchants that a page is loading or an upload is processing.
 category: Feedback indicators
 keywords:
   - spinner

--- a/polaris.shopify.com/content/components/feedback-indicators/progress-bar.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/progress-bar.md
@@ -1,5 +1,6 @@
 ---
 title: Progress bar
+shortDescription: Used to visually represent the completion of a task or operation.
 category: Feedback indicators
 releasedIn: 1.8.0
 keywords:

--- a/polaris.shopify.com/content/components/feedback-indicators/skeleton-body-text.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/skeleton-body-text.md
@@ -1,5 +1,6 @@
 ---
 title: Skeleton body text
+shortDescription: Provides a low fidelity representation of content before it appears, improving perceived load times.
 category: Feedback indicators
 releasedIn: 1.7.0
 keywords:

--- a/polaris.shopify.com/content/components/feedback-indicators/skeleton-display-text.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/skeleton-display-text.md
@@ -1,5 +1,6 @@
 ---
 title: Skeleton display text
+shortDescription: Provides a low fidelity representation of content before it appears, improving perceived load times.
 category: Feedback indicators
 releasedIn: 1.7.0
 keywords:

--- a/polaris.shopify.com/content/components/feedback-indicators/skeleton-page.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/skeleton-page.md
@@ -1,5 +1,6 @@
 ---
 title: Skeleton page
+shortDescription: Used with other skeleton loading components to provide a low fidelity representation of the UI before content appears.
 category: Feedback indicators
 releasedIn: 1.7.0
 keywords:

--- a/polaris.shopify.com/content/components/feedback-indicators/skeleton-tabs.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/skeleton-tabs.md
@@ -1,5 +1,6 @@
 ---
 title: Skeleton tabs
+shortDescription: Provides a low fidelity representation of content before it appears, improving perceived load times.
 category: Feedback indicators
 releasedIn: 9.0
 keywords:

--- a/polaris.shopify.com/content/components/feedback-indicators/skeleton-thumbnail.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/skeleton-thumbnail.md
@@ -1,5 +1,6 @@
 ---
 title: Skeleton thumbnail
+shortDescription: Provides a low fidelity representation of an image before it appears, improving perceived load times.
 category: Feedback indicators
 releasedIn: 3.7.2
 keywords:

--- a/polaris.shopify.com/content/components/feedback-indicators/spinner.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/spinner.md
@@ -1,5 +1,6 @@
 ---
 title: Spinner
+shortDescription: Used to notify merchants that their action is being processed. Used for content that can’t be represented with skeleton loading components.
 category: Feedback indicators
 releasedIn: 1.7.0
 keywords:

--- a/polaris.shopify.com/content/components/feedback-indicators/toast.md
+++ b/polaris.shopify.com/content/components/feedback-indicators/toast.md
@@ -1,5 +1,6 @@
 ---
 title: Toast
+shortDescription: A non-disruptive message that provides quick feedback on the outcome of an action.
 category: Feedback indicators
 keywords:
   - toast

--- a/polaris.shopify.com/content/components/images-and-icons/avatar.md
+++ b/polaris.shopify.com/content/components/images-and-icons/avatar.md
@@ -1,5 +1,6 @@
 ---
 title: Avatar
+shortDescription: Used to show a thumbnail representation of an individual or business in the interface.
 category: Images and icons
 keywords:
   - photo

--- a/polaris.shopify.com/content/components/images-and-icons/icon.md
+++ b/polaris.shopify.com/content/components/images-and-icons/icon.md
@@ -1,5 +1,6 @@
 ---
 title: Icon
+shortDescription: Used to visually communicate core parts of the product and available actions, acting as wayfinding tools.
 category: Images and icons
 keywords:
   - iconography

--- a/polaris.shopify.com/content/components/images-and-icons/index.md
+++ b/polaris.shopify.com/content/components/images-and-icons/index.md
@@ -1,5 +1,6 @@
 ---
 title: Images and icons
+shortDescription: Represent visual content, such as avatars and thumbnails for images or video.
 expanded: true
 order: 4
 previewImg: /images/components/images-and-icons.png

--- a/polaris.shopify.com/content/components/images-and-icons/keyboard-key.md
+++ b/polaris.shopify.com/content/components/images-and-icons/keyboard-key.md
@@ -1,5 +1,6 @@
 ---
 title: Keyboard key
+shortDescription: Used to educate merchants about keyboard shortcuts.
 category: Images and icons
 keywords:
   - KeyboardKey

--- a/polaris.shopify.com/content/components/images-and-icons/thumbnail.md
+++ b/polaris.shopify.com/content/components/images-and-icons/thumbnail.md
@@ -1,5 +1,6 @@
 ---
 title: Thumbnail
+shortDescription: Used as a visual anchor and identifier for an object, along with text to provide context.
 category: Images and icons
 keywords:
   - photo

--- a/polaris.shopify.com/content/components/images-and-icons/video-thumbnail.md
+++ b/polaris.shopify.com/content/components/images-and-icons/video-thumbnail.md
@@ -1,5 +1,6 @@
 ---
 title: Video thumbnail
+shortDescription: A clickable placeholder image that opens a video player within a modal or full screen when clicked.
 category: Images and icons
 keywords:
   - video

--- a/polaris.shopify.com/content/components/layout-and-structure/bleed.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/bleed.md
@@ -1,5 +1,6 @@
 ---
 title: Bleed
+shortDescription: Applies negative margin to a layout, extending it to the edge of the screen on small screens.
 category: Layout and structure
 keywords:
   - layout

--- a/polaris.shopify.com/content/components/layout-and-structure/card.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/card.md
@@ -1,5 +1,6 @@
 ---
 title: Card
+shortDescription: Used to group similar concepts and tasks together for easier scanning and reading.
 category: Layout and structure
 keywords:
   - layout

--- a/polaris.shopify.com/content/components/layout-and-structure/form-layout.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/form-layout.md
@@ -1,5 +1,6 @@
 ---
 title: Form layout
+shortDescription: Manages the layout of all forms and fields within it. Used for the layout of new forms and managing the layout of all forms.
 category: Layout and structure
 keywords:
   - FormLayout

--- a/polaris.shopify.com/content/components/layout-and-structure/index.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/index.md
@@ -1,5 +1,6 @@
 ---
 title: Layout and structure
+shortDescription: The arrangement of elements on a page that helps merchants understand and find information to complete their goals.
 expanded: true
 order: 2
 primitives:

--- a/polaris.shopify.com/content/components/layout-and-structure/layout.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/layout.md
@@ -1,5 +1,6 @@
 ---
 title: Layout
+shortDescription: A structural component used to group other components. Creates consistent spacing and helps layout stack and scale responsively.
 category: Layout and structure
 keywords:
   - one column

--- a/polaris.shopify.com/content/components/layout-and-structure/media-card.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/media-card.md
@@ -1,5 +1,6 @@
 ---
 title: Media card
+shortDescription: Provides a container for introductory or highlight information. Often used in a grid to present related content.
 category: Layout and structure
 keywords:
   - MediaCard

--- a/polaris.shopify.com/content/components/layout-and-structure/page.md
+++ b/polaris.shopify.com/content/components/layout-and-structure/page.md
@@ -1,5 +1,6 @@
 ---
 title: Page
+shortDescription: Used to build the layout of a page in the Shopify admin. A flexible container for composing pages consistently.
 category: Layout and structure
 keywords:
   - page

--- a/polaris.shopify.com/content/components/lists/description-list.md
+++ b/polaris.shopify.com/content/components/lists/description-list.md
@@ -1,5 +1,6 @@
 ---
 title: Description list
+shortDescription: Used to present pairs of related information, like terms and definitions, or names and values, in a list format.
 category: Lists
 keywords:
   - DescriptionList

--- a/polaris.shopify.com/content/components/navigation/tabs.md
+++ b/polaris.shopify.com/content/components/navigation/tabs.md
@@ -1,5 +1,6 @@
 ---
 title: Tabs
+shortDescription: Used to alternate among related views within the same context.
 category: Navigation
 keywords:
   - layout

--- a/polaris.shopify.com/content/components/navigation/top-bar.md
+++ b/polaris.shopify.com/content/components/navigation/top-bar.md
@@ -1,5 +1,6 @@
 ---
 title: Top bar
+shortDescription: Appears at the top of the page and is used to brand and navigate major applications areas.
 category: Navigation
 keywords:
   - global chrome

--- a/polaris.shopify.com/content/components/overlays/modal.md
+++ b/polaris.shopify.com/content/components/overlays/modal.md
@@ -1,5 +1,6 @@
 ---
 title: Modal
+shortDescription: Used to interrupt merchants with urgent information, details, or actions.
 category: Overlays
 keywords:
   - modal

--- a/polaris.shopify.com/content/components/overlays/popover.md
+++ b/polaris.shopify.com/content/components/overlays/popover.md
@@ -1,5 +1,6 @@
 ---
 title: Popover
+shortDescription: Small overlays that open on demand and close when the merchant interacts with any other part of Shopify. Used to surface secondary information or actions.
 category: Overlays
 keywords:
   - interactive

--- a/polaris.shopify.com/content/components/selection-and-input/color-picker.md
+++ b/polaris.shopify.com/content/components/selection-and-input/color-picker.md
@@ -1,5 +1,6 @@
 ---
 title: Color picker
+shortDescription: Allows merchants to choose a color visually, or by entering a hex value.
 category: Selection and input
 keywords:
   - ColorPicker

--- a/polaris.shopify.com/content/components/selection-and-input/contextual-save-bar.md
+++ b/polaris.shopify.com/content/components/selection-and-input/contextual-save-bar.md
@@ -1,5 +1,6 @@
 ---
 title: Contextual save bar
+shortDescription: Informs merchants of their options once they have made changes to a form on the page or while creating a new object.
 category: Selection and input
 keywords:
   - form

--- a/polaris.shopify.com/content/components/selection-and-input/filters.md
+++ b/polaris.shopify.com/content/components/selection-and-input/filters.md
@@ -1,5 +1,6 @@
 ---
 title: Filters
+shortDescription: A composite component that filters the items of a list or table.
 category: Selection and input
 keywords:
   - filters

--- a/polaris.shopify.com/content/components/tables/data-table.md
+++ b/polaris.shopify.com/content/components/tables/data-table.md
@@ -1,5 +1,6 @@
 ---
 title: Data table
+shortDescription: Used to organize and display all information from a data set. Aimed to be as simple as possible for merchants.
 category: Tables
 keywords:
   - DataTable

--- a/polaris.shopify.com/content/components/utilities/collapsible.md
+++ b/polaris.shopify.com/content/components/utilities/collapsible.md
@@ -1,5 +1,6 @@
 ---
 title: Collapsible
+shortDescription: Hides content and allows merchants to expand it. Used to hide optional settings, information, and actions.
 category: Utilities
 keywords:
   - hide

--- a/polaris.shopify.com/content/components/utilities/frame.md
+++ b/polaris.shopify.com/content/components/utilities/frame.md
@@ -1,5 +1,6 @@
 ---
 title: Frame
+shortDescription: Creates the structure of the Shopify admin. All of the main sections of the admin are nested in the frame.
 category: Utilities
 keywords:
   - navigation

--- a/polaris.shopify.com/content/components/utilities/scrollable.md
+++ b/polaris.shopify.com/content/components/utilities/scrollable.md
@@ -1,5 +1,6 @@
 ---
 title: Scrollable
+shortDescription: Used in components with too much content for the available vertical space. Embeds long-form content in components like modals and popovers.
 category: Utilities
 keywords:
   - long form

--- a/polaris.shopify.com/src/components/RichCardGrid/RichCardGrid.tsx
+++ b/polaris.shopify.com/src/components/RichCardGrid/RichCardGrid.tsx
@@ -6,6 +6,7 @@ import type {Status, FoundationsCategory} from '../../types';
 export interface RichCardGridProps {
   title: string;
   description: string;
+  shortDescription?: string;
   /* url is usually derived from the file path, but can be overwritten here */
   url?: string;
   previewImg?: string;
@@ -26,27 +27,40 @@ function RichCardGrid({
     <Grid>
       {cards
         .filter(({draft}) => !draft)
-        .map(({title, description, url, previewImg, icon, status}, index) => (
-          <GridItem
-            key={index}
-            title={title}
-            description={description ?? ''}
-            url={url ?? ''}
-            renderPreview={() =>
-              previewImg ? (
-                <Preview alt={title} src={previewImg} />
-              ) : (
-                <FoundationsThumbnail
-                  icon={icon!}
-                  category={
-                    category ?? (title.toLowerCase() as FoundationsCategory)
-                  }
-                />
-              )
-            }
-            status={status}
-          />
-        ))}
+        .map(
+          (
+            {
+              title,
+              description,
+              shortDescription,
+              url,
+              previewImg,
+              icon,
+              status,
+            },
+            index,
+          ) => (
+            <GridItem
+              key={index}
+              title={title}
+              description={shortDescription ?? description ?? ''}
+              url={url ?? ''}
+              renderPreview={() =>
+                previewImg ? (
+                  <Preview alt={title} src={previewImg} />
+                ) : (
+                  <FoundationsThumbnail
+                    icon={icon!}
+                    category={
+                      category ?? (title.toLowerCase() as FoundationsCategory)
+                    }
+                  />
+                )
+              }
+              status={status}
+            />
+          ),
+        )}
     </Grid>
   );
 }

--- a/polaris.shopify.com/src/types.ts
+++ b/polaris.shopify.com/src/types.ts
@@ -61,6 +61,7 @@ export type FrontMatter = {
   category?: string;
   url?: string;
   description?: string;
+  shortDescription?: string;
   seoDescription?: string;
   examples?: Example[];
   icon?: string;


### PR DESCRIPTION
A solution to the problem raised in https://github.com/Shopify/polaris/issues/10364#issuecomment-1710890227

> I'm wondering if the long descriptions are the correct ones to show on the preview cards?
> 
> I've seen this in other places too; the long description doesn't show enough information before it's truncated, effectively making it useless 🤔  There's also the issue with markdown; the description can contain arbitrary markdown which is why it's been pushed into the content instead of the frontmatter, but I think it makese more sense to have plain text in the preview cards.
> 
> We've already got a mechanism/types for setting a specific `seoDescription` in the frontmatter which will override the `description` frontmatter or `firstParagraph` auto generated value. Should we perhaps add a `shortDescription` option also?

- [Docs] Support shortDescription on index pages when available
- [Docs] Add short descriptions to all components