### PR TITLE
[Page] Add predictable ID for page title h1 element

### DIFF
--- a/.changeset/chatty-ravens-study.md
+++ b/.changeset/chatty-ravens-study.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Adds an ID to the h1 of the Page title

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
@@ -6,6 +6,8 @@ import {useFeatures} from '../../../../../../utilities/features';
 
 import styles from './Title.scss';
 
+export const PAGE_TITLE_IDENTIFIER = 'PolarisPageTitle';
+
 export interface TitleProps {
   /** Page title, in large type */
   title?: string;
@@ -29,7 +31,11 @@ export function Title({
     subtitle && styles.TitleWithSubtitle,
   );
 
-  const titleMarkup = title ? <h1 className={className}>{title}</h1> : null;
+  const titleMarkup = title ? (
+    <h1 className={className} id={PAGE_TITLE_IDENTIFIER}>
+      {title}
+    </h1>
+  ) : null;
 
   const titleMetadataMarkup = titleMetadata ? (
     <div className={styles.TitleMetadata}>{titleMetadata}</div>

--- a/polaris-react/src/components/Page/index.ts
+++ b/polaris-react/src/components/Page/index.ts
@@ -1,1 +1,2 @@
 export * from './Page';
+export {PAGE_TITLE_IDENTIFIER} from './components/Header/components/Title';

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -272,7 +272,7 @@ export type {
 export {OptionList} from './components/OptionList';
 export type {OptionListProps} from './components/OptionList';
 
-export {Page} from './components/Page';
+export {Page, PAGE_TITLE_IDENTIFIER} from './components/Page';
 export type {PageProps} from './components/Page';
 
 export {PageActions} from './components/PageActions';


### PR DESCRIPTION
### WHY are these changes introduced?

We want to use the contents of the `title` prop on the `Page` component to help announce to our merchants that the page has changed. In order to do this, we want to add an identifier to the `h1` element that we can target as part of a `MutationObserver` invocation to get the contents of the `h1` which will get injected into an aria-live region.


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
