### PR TITLE
[IndexTable] vertically align sort and tooltip column headers

### DIFF
--- a/.changeset/tall-lamps-behave.md
+++ b/.changeset/tall-lamps-behave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[IndexTable] vertically align sort and tooltip column headers 

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -514,6 +514,7 @@ $loading-panel-height: 53px;
   font-weight: var(--p-font-weight-medium);
   color: var(--p-color-text-subdued);
   font-size: var(--p-font-size-75);
+  line-height: var(--p-font-line-height-2);
 
   &:hover,
   &:focus {
@@ -585,7 +586,13 @@ $loading-panel-height: 53px;
   }
 }
 
-.TableHeadingUnderline {
+.TableHeadingUnderline::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: calc(-1 * var(--p-border-width-2));
+  width: 100%;
+  height: var(--p-border-width-2);
   border-bottom: var(--p-border-width-2) dotted var(--p-color-border-subdued);
 
   #{$se23} & {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes alignment of sort button headers with body line-height, so text headers and sort button headers are aligned. Additionally, the presence of a tooltip header results in a bottom border of 2px. This resulted in some headers being taller than other headers without a tooltip by 2px, which resulted in misalignment. This also led to the height of the IndexTable column row growing by 2px when a column header had tooltip styling.

Listed below are images of a sort button header with a text header with a line drawn across the center. These images are zoomed in as the alignment difference is very subtle. These images highlight the issue.

**Default header**
![image](https://github.com/Shopify/polaris/assets/86790511/74cea082-67a4-4d45-9065-55fc46851b0b)

**Sticky header**
![image](https://github.com/Shopify/polaris/assets/86790511/f56685a3-04dc-4a4b-a3b2-f340853ba2db)

**With tooltip**
![image](https://github.com/Shopify/polaris/assets/86790511/ec2f9aeb-18f4-4e87-a1c4-80fb799f343c)

### WHAT is this pull request doing?

`line-height` set on the `body` is not being inherited by `button`, so I set it explicitly on the sortable button class to align with the text headers that do inherit the `line-height` from the `body`.

For the tooltip underline, this PR switches to utilizing an absolutely positioned pseudo-element, so it does not impact the height of the column label and the height of the column header row.

### How to 🎩

Navigate to the following Storybooks
- [IndexTable - With Sortable Headings](https://storybook.web.orders-index-misaligned-headers.matt-kubej.us.spin.dev/?path=/story/all-components-indextable--with-sortable-headings&globals=polarisSummerEditions2023:true;polarisSummerEditions2023ShadowBevelOptOut:true)
- [IndexTable - WIth Custom Tooltips](https://storybook.web.orders-index-misaligned-headers.matt-kubej.us.spin.dev/?path=/story/all-components-indextable--with-custom-tooltips&globals=polarisSummerEditions2023:true;polarisSummerEditions2023ShadowBevelOptOut:true)

After focusing/inspecting the iframe containing the rendered IndexTable with Chrome DevTools, paste the following snippet into console in order to draw a centered line across the header row to inspect that the labels are center aligned with each other. I found it easiest to spot alignment by comparing labels with the letter "e".

```javascript
(function drawCenterGuide() {
  const style = document.createElement('style');

  style.innerHTML = `
    thead {
      position: relative;
    }

    thead::after {
      content: "";
      position: absolute;
      left: 0;
      top: 50%;
      transform: translateY(-50%);
      background: red;
      width: 100%;
      height: 1px;
      z-index: 9999;
    }
  `;

  document.head.appendChild(style);
})();
```

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
