### PR TITLE
[TextField] Allow TextField to disable 1Password integration

### DIFF
--- a/.changeset/brave-dancers-appear.md
+++ b/.changeset/brave-dancers-appear.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[TextField] Allow TextField to disable 1Password integration

--- a/.changeset/brave-dancers-appear.md
+++ b/.changeset/brave-dancers-appear.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-[TextField] Allow TextField to disable 1Password integration
+Added support for disabling 1Password integration in `TextField`

--- a/polaris-react/src/components/Tabs/components/CreateViewModal/CreateViewModal.tsx
+++ b/polaris-react/src/components/Tabs/components/CreateViewModal/CreateViewModal.tsx
@@ -111,6 +111,7 @@ export function CreateViewModal({
                       )
                     : undefined
                 }
+                disable1Password
               />
             </div>
           </FormLayout>

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -866,3 +866,19 @@ export function WithFormSubmit() {
     </VerticalStack>
   );
 }
+
+export function With1PasswordDisabled() {
+  const [value, setValue] = useState('Jaded Pixel');
+
+  const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+  return (
+    <TextField
+      label="Store name"
+      value={value}
+      onChange={handleChange}
+      autoComplete="off"
+      disable1Password
+    />
+  );
+}

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -173,6 +173,8 @@ interface NonMutuallyExclusiveProps {
   onBlur?(event?: React.FocusEvent): void;
   /** Removes the border around the input. Used in the IndexFilters component. */
   borderless?: boolean;
+  /** Disables the 1password extension on the text field */
+  disable1Password?: boolean;
 }
 
 export type MutuallyExclusiveSelectionProps =
@@ -239,6 +241,7 @@ export function TextField({
   onFocus,
   onBlur,
   borderless,
+  disable1Password,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -556,6 +559,7 @@ export function TextField({
     onKeyDown: handleKeyDown,
     onChange: !suggestion ? handleChange : undefined,
     onInput: suggestion ? handleChange : undefined,
+    'data-1p-ignore': disable1Password || undefined,
   });
 
   const inputWithVerticalContentMarkup = verticalContent ? (

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -85,6 +85,21 @@ describe('<TextField />', () => {
     });
   });
 
+  it('adds the data-1p-ignore prop if disable1Password is set', () => {
+    const textField = mountWithApp(
+      <TextField
+        label="TextField"
+        onChange={noop}
+        autoComplete="off"
+        disable1Password
+      />,
+    );
+
+    expect(textField).toContainReactComponent('input', {
+      'data-1p-ignore': true,
+    } as any);
+  });
+
   describe('click events', () => {
     it('bubbles up to the parent element when it occurs in the input', () => {
       const onClick = jest.fn();


### PR DESCRIPTION
### WHY are these changes introduced?

We have some text fields across the admin that we want to disable the 1Password integration on, namely the Create new View modal within the IndexFilters component, [as seen on this ticket](https://github.com/Shopify/web/issues/103483).


### WHAT is this pull request doing?

This PR introduces a new prop to the TextField, named `disable1Password` which will add the `data-1p-ignore` data attribute to the input, which is the [recommended way](https://developer.1password.com/docs/web/compatible-website-design/) of disabling this functionality.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
