### PR TITLE
[FilterPill] Remove filter pill on Popover close if empty

### DIFF
--- a/.changeset/weak-tips-agree.md
+++ b/.changeset/weak-tips-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[FilterPill] Remove FilterPill from Filters bar when Popover closes with an empty filter

--- a/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef} from 'react';
+import React, {useState, useEffect, useRef, useCallback} from 'react';
 import {
   CancelSmallMinor,
   CaretDownMinor,
@@ -80,7 +80,7 @@ export function FilterPill({
     });
   }, [elementRef, popoverActive]);
 
-  const togglePopoverActive = () => {
+  const togglePopoverActive = useCallback(() => {
     if (filter) {
       setPopoverActive((popoverActive) => !popoverActive);
     }
@@ -88,7 +88,14 @@ export function FilterPill({
     if (onClick) {
       onClick(filterKey);
     }
-  };
+  }, [filter, filterKey, onClick]);
+
+  const handlePopoverClose = useCallback(() => {
+    togglePopoverActive();
+    if (!selected) {
+      onRemove?.(filterKey);
+    }
+  }, [onRemove, selected, filterKey, togglePopoverActive]);
 
   const handleClear = () => {
     if (onRemove) onRemove(filterKey);
@@ -200,7 +207,7 @@ export function FilterPill({
         active={popoverActive && !disabled}
         activator={activator}
         key={filterKey}
-        onClose={togglePopoverActive}
+        onClose={handlePopoverClose}
         preferredAlignment="left"
         preventCloseOnChildOverlayClick={!closeOnChildOverlayClick}
       >

--- a/polaris-react/src/components/Filters/components/FilterPill/tests/FilterPill.test.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/tests/FilterPill.test.tsx
@@ -173,6 +173,28 @@ describe('<Filters />', () => {
       expect(spy).toHaveBeenCalledWith(defaultProps.filterKey);
     });
 
+    it('invokes the onRemove callback when closing the Popover when not selected', () => {
+      const spy = jest.fn();
+      const wrapper = mountWithApp(
+        <FilterPill {...defaultProps} onRemove={spy} />,
+      );
+      const activator = wrapper.find(UnstyledButton);
+      activator?.trigger('onClick');
+      wrapper.find(Popover)?.trigger('onClose');
+      expect(spy).toHaveBeenCalledWith(defaultProps.filterKey);
+    });
+
+    it('does not invoke the onRemove callback when closing the Popover when selected', () => {
+      const spy = jest.fn();
+      const wrapper = mountWithApp(
+        <FilterPill {...defaultProps} onRemove={spy} selected />,
+      );
+      const activator = wrapper.find(UnstyledButton);
+      activator?.trigger('onClick');
+      wrapper.find(Popover)?.trigger('onClose');
+      expect(spy).not.toHaveBeenCalledWith(defaultProps.filterKey);
+    });
+
     it('renders the popover initially open if initialActive is true', () => {
       const wrapper = mountWithApp(
         <FilterPill {...defaultProps} initialActive />,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/98322

A frustration that multiple people have reported is that when using the IndexFilters component and selecting a filter, if you close the popover without choosing a filter option within the Popover, the FilterPill for the filter remains in the filter bar, even though it is empty, and the only way to clear it is to press the "Clear all" button.

### WHAT is this pull request doing?

This PR introduces logic to remove the FilterPill from the Filter bar if a user closes the Popover containing the filter and no choice is selected.

Spinstance: https://admin.web.remove-unused-filters.marc-thomas.eu.spin.dev/store/shop1/orders?inContextTimeframe=none

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
