### PR TITLE
[Navigation] Add ariaDescribedBy prop for drag and drop accessibility

### DIFF
--- a/.changeset/lovely-hotels-teach.md
+++ b/.changeset/lovely-hotels-teach.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added `ariaDescribedBy` prop to navigation for accessibility

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -50,6 +50,7 @@ export function Item({
   showVerticalHoverPointer,
   onMouseEnter,
   onMouseLeave,
+  ariaDescribedBy,
 }: ItemProps) {
   const i18n = useI18n();
   const {isNavigationCollapsed} = useMediaQuery();
@@ -290,6 +291,7 @@ export function Item({
         aria-disabled={disabled}
         aria-label={accessibilityLabel}
         onClick={getClickHandler(onClick)}
+        aria-describedby={ariaDescribedBy}
         {...normalizeAriaAttributes(
           secondaryNavigationId,
           subNavigationItems.length > 0,

--- a/polaris-react/src/components/Navigation/types.ts
+++ b/polaris-react/src/components/Navigation/types.ts
@@ -36,6 +36,7 @@ export interface ItemProps extends ItemURLDetails {
   expanded?: boolean;
   shouldResizeIcon?: boolean;
   truncateText?: boolean;
+  ariaDescribedBy?: string;
 }
 
 export interface SubNavigationItem extends ItemURLDetails {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#101292](https://github.com/Shopify/web/issues/101292)

Needed for https://github.com/Shopify/web/pull/103898

The drag and drop functionality available to mouse users is not available to keyboard-only and screen reader users. This PR addresses that.

### WHAT is this pull request doing?

Adds the ariaDescribedBy to navigation.

### How to 🎩

Spin: https://admin.web.web-polaris-9fh6.dustin-malik.us.spin.dev/store/shop1

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
