### PR TITLE
[Docs] fix pattern page spacing

### DIFF
--- a/polaris.shopify.com/src/components/Markdown/Markdown.tsx
+++ b/polaris.shopify.com/src/components/Markdown/Markdown.tsx
@@ -262,7 +262,7 @@ function Markdown<
 }
 
 export const HeadingWithCopyButton = forwardRef(
-  ({id, children, ...props}, ref) => {
+  ({id, children, className, ...props}, ref) => {
     const origin =
       typeof window !== 'undefined'
         ? window.location.origin
@@ -291,7 +291,11 @@ export const HeadingWithCopyButton = forwardRef(
         as="h1"
         id={id}
         {...props}
-        className={[styles.MarkdownHeading, styles[`Heading-${props.as}`]]}
+        className={[
+          styles.MarkdownHeading,
+          styles[`Heading-${props.as}`],
+          className,
+        ]}
         ref={ref}
       >
         {children}

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -262,3 +262,8 @@
     }
   }
 }
+// Additional class added to bust specificity in Markdown.module.scss
+.NoMargin.Heading-h2,
+.NoMargin.Heading-h3 {
+  margin: 0px;
+}

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -16,7 +16,10 @@ import {Lede} from '../Lede';
 import {Heading} from '../Heading';
 import Page from '../Page';
 import styles from './PatternPage.module.scss';
-import Markdown, {CodeVisibilityProvider} from '../Markdown';
+import Markdown, {
+  CodeVisibilityProvider,
+  HeadingWithCopyButton,
+} from '../Markdown';
 import {SideBySide} from '../Markdown/components/SideBySide';
 
 export type PatternMDX = SerializedMdx<
@@ -151,6 +154,23 @@ const defaultMdxComponents: React.ComponentProps<
   DefinitionTable: ({children}) => (
     <Box className={styles.DefinitionTable}>{children}</Box>
   ),
+  p: ({children}) => <Box as="p">{children}</Box>,
+  h2: ({children}) => (
+    <HeadingWithCopyButton
+      as="h2"
+      className={[styles.NoMargin, styles['Heading-h2']]}
+    >
+      {children}
+    </HeadingWithCopyButton>
+  ),
+  h3: ({children}) => (
+    <HeadingWithCopyButton
+      as="h3"
+      className={[styles.NoMargin, styles['Heading-h3']]}
+    >
+      {children}
+    </HeadingWithCopyButton>
+  ),
 };
 
 const PatternMarkdown = (props: ComponentProps<typeof Markdown>) => (
@@ -189,7 +209,7 @@ export default function PatternPage({pattern}: Props) {
             <Heading as="h1">
               <Box className={styles.Heading}>{pattern.frontmatter.title}</Box>
             </Heading>
-            <Lede>{pattern.frontmatter.lede}</Lede>
+            <Lede className={styles.NoMargin}>{pattern.frontmatter.lede}</Lede>
             {pattern.frontmatter.githubDiscussionsLink ? (
               <p className={styles.InfoLine}>
                 <Link


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #10198 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

* Overrides components specified in Markdown.tsx, with `NoMargin` classname applied in `PatternPage.tsx`. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
