### PR TITLE
[IndexFilters] Fix layout shift when going from between default and filtering modes

### DIFF
--- a/.changeset/forty-dolphins-love.md
+++ b/.changeset/forty-dolphins-love.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[IndexFilters] Fixes layout shift when going beteen default and filtering modes

--- a/.changeset/forty-dolphins-love.md
+++ b/.changeset/forty-dolphins-love.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-[IndexFilters] Fixes layout shift when going beteen default and filtering modes
+Fixed layout shift in `IndexFilters` when switching modes

--- a/polaris-react/src/components/Filters/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/Filters/components/SearchField/SearchField.scss
@@ -3,7 +3,7 @@
 .SearchField {
   position: relative;
   display: flex;
-  padding-block: calc(var(--p-space-1_5-experimental) * 0.5);
+  padding-block: calc(var(--p-space-1) * 0.25);
   margin-left: var(--p-space-05);
 }
 

--- a/polaris-react/src/components/Filters/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/Filters/components/SearchField/SearchField.scss
@@ -3,7 +3,7 @@
 .SearchField {
   position: relative;
   display: flex;
-  padding-block: calc(var(--p-space-1) * 0.25);
+  padding-block: var(--p-space-025);
   margin-left: var(--p-space-05);
 }
 

--- a/polaris-react/src/components/IndexFilters/IndexFilters.scss
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.scss
@@ -5,10 +5,6 @@ $spinner-size: 20px;
 
 .IndexFiltersWrapper {
   width: 100%;
-
-  [class*='Button-Button'] {
-    display: flex;
-  }
 }
 
 @media #{$p-breakpoints-sm-up} {
@@ -139,5 +135,12 @@ $spinner-size: 20px;
 
   svg {
     display: block;
+  }
+}
+
+.ButtonWrap,
+.ActionWrap {
+  button {
+    display: flex;
   }
 }

--- a/polaris-react/src/components/IndexFilters/IndexFilters.scss
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.scss
@@ -5,6 +5,10 @@ $spinner-size: 20px;
 
 .IndexFiltersWrapper {
   width: 100%;
+
+  [class*='Button-Button'] {
+    display: flex;
+  }
 }
 
 @media #{$p-breakpoints-sm-up} {

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -437,7 +437,7 @@ export function IndexFilters({
                   borderlessQueryField
                   closeOnChildOverlayClick={closeOnChildOverlayClick}
                 >
-                  <div className={styles.SortWrapper}>
+                  <div className={styles.ButtonWrap}>
                     <HorizontalStack
                       gap={polarisSummerEditions2023 ? '2' : '3'}
                       align="start"

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -437,21 +437,23 @@ export function IndexFilters({
                   borderlessQueryField
                   closeOnChildOverlayClick={closeOnChildOverlayClick}
                 >
-                  <HorizontalStack
-                    gap={polarisSummerEditions2023 ? '2' : '3'}
-                    align="start"
-                    blockAlign="center"
-                  >
-                    <div
-                      style={{
-                        ...defaultStyle,
-                        ...transitionStyles[state],
-                      }}
+                  <div className={styles.SortWrapper}>
+                    <HorizontalStack
+                      gap={polarisSummerEditions2023 ? '2' : '3'}
+                      align="start"
+                      blockAlign="center"
                     >
-                      {updateButtonsMarkup}
-                    </div>
-                    {sortMarkup}
-                  </HorizontalStack>
+                      <div
+                        style={{
+                          ...defaultStyle,
+                          ...transitionStyles[state],
+                        }}
+                      >
+                        {updateButtonsMarkup}
+                      </div>
+                      {sortMarkup}
+                    </HorizontalStack>
+                  </div>
                 </Filters>
               ) : null}
             </div>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue in the IndexFilters where it caused a layout shift when toggling between default and filtering modes. This PR fixes that little layout shift.

### Before


https://github.com/Shopify/polaris/assets/2562596/85c96dcd-3854-455a-9ccb-cfecaf86b293

### After


https://github.com/Shopify/polaris/assets/2562596/24b55cfc-2ec8-47d7-9d27-be6088c4e2f1

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
