### PR TITLE
Add public primitive `space` token scale

### DIFF
--- a/.changeset/hot-houses-pretend.md
+++ b/.changeset/hot-houses-pretend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Added public primitive `space` token scales

--- a/.changeset/hot-houses-pretend.md
+++ b/.changeset/hot-houses-pretend.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-tokens': minor
 ---
 
-Added public primitive `space` token scales
+Added public primitive `space` token scale

--- a/polaris-tokens/src/token-groups/space.ts
+++ b/polaris-tokens/src/token-groups/space.ts
@@ -1,3 +1,4 @@
+import {size} from '../size';
 import type {MetadataProperties, Experimental} from '../types';
 
 type SpaceScaleExperimental = Experimental<'1_5'>;
@@ -5,6 +6,21 @@ type SpaceScaleExperimental = Experimental<'1_5'>;
 export type SpaceScale =
   | '0'
   | '025'
+  | '050'
+  | '100'
+  | '150'
+  | '200'
+  | '300'
+  | '400'
+  | '500'
+  | '600'
+  | '800'
+  | '1000'
+  | '1200'
+  | '1600'
+  | '2000'
+  | '2400'
+  | '3200'
   | '05'
   | '1'
   | '2'
@@ -32,10 +48,55 @@ export const space: {
   [TokenName in SpaceTokenName]: MetadataProperties;
 } = {
   'space-0': {
-    value: '0px',
+    value: size[0],
   },
   'space-025': {
-    value: '1px',
+    value: size['025'],
+  },
+  'space-050': {
+    value: size['050'],
+  },
+  'space-100': {
+    value: size[100],
+  },
+  'space-150': {
+    value: size[150],
+  },
+  'space-200': {
+    value: size[200],
+  },
+  'space-300': {
+    value: size[300],
+  },
+  'space-400': {
+    value: size[400],
+  },
+  'space-500': {
+    value: size[500],
+  },
+  'space-600': {
+    value: size[600],
+  },
+  'space-800': {
+    value: size[800],
+  },
+  'space-1000': {
+    value: size[1000],
+  },
+  'space-1200': {
+    value: size[1200],
+  },
+  'space-1600': {
+    value: size[1600],
+  },
+  'space-2000': {
+    value: size[2000],
+  },
+  'space-2400': {
+    value: size[2400],
+  },
+  'space-3200': {
+    value: size[3200],
   },
   'space-05': {
     value: '2px',


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes #10435

### WHAT is this pull request doing?

Adds the following values to new public primitive `space` token scales: 

| New Token          | Value        | Value (in px)
| ------------------------- | ------------------------ |  ------------------------ |
| `--p-space-050` | `size['050']`  | `2px`    |
| `--p-space-100` | `size[100]`  | `4px`    |
| `--p-space-150` | `size[150]`  | `6px`    |
| `--p-space-200` | `size[200]`  | `8px`    |
| `--p-space-300` | `size[300]`  | `12px`    |
| `--p-space-400` | `size[400]`  | `16px`    |
| `--p-space-500` | `size[500]`  | `20px`    |
| `--p-space-600` | `size[600]`  | `24px`    |
| `--p-space-800` | `size[800]`  | `32px`    |
| `--p-space-1000` | `size[1000]`  | `40px`    |
| `--p-space-1200` | `size[1200]`  | `48px`    |
| `--p-space-1600` | `size[1600]`  | `64px`    |
| `--p-space-2000` | `size[2000]`  | `80px`    |
| `--p-space-2400` | `size[2400]`  | `96px`    |
| `--p-space-3200` | `size[3200]`  | `128px`    |