### PR TITLE
Add private primitive `space` token

### DIFF
--- a/polaris-tokens/src/token-groups/space.ts
+++ b/polaris-tokens/src/token-groups/space.ts
@@ -20,6 +20,7 @@ export type SpaceScale =
   | '1600'
   | '2000'
   | '2400'
+  | '2800'
   | '3200'
   | '05'
   | '1'
@@ -94,6 +95,9 @@ export const space: {
   },
   'space-2400': {
     value: size[2400],
+  },
+  'space-2800': {
+    value: size[2800],
   },
   'space-3200': {
     value: size[3200],


### PR DESCRIPTION
### WHY are these changes introduced?

Related to #10435 and #10453

While working on the migration for this token scale an additional token was identified that should be added to the `space` scale.

### WHAT is this pull request doing?

Adds the following values to the `size` token scale: 

| New Token          | Value        | Value (in px) |
| ------------------------- | ------------------------ |  ------------------------ | 
| `--p-space-2800` | `size[2800]`  | `112px`    |