### PR TITLE
Add public primitive `width` token scale

### DIFF
--- a/.changeset/twelve-radios-stare.md
+++ b/.changeset/twelve-radios-stare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Added public primitive `width` token scale

--- a/polaris-for-vscode/src/server.ts
+++ b/polaris-for-vscode/src/server.ts
@@ -83,6 +83,7 @@ const tokenGroupPatterns: TokenGroupPatterns = {
   motion: /animation/,
   shadow: /shadow/,
   space: /margin|padding|gap|top|left|right|bottom/,
+  width: /width|min-width|max-width/,
   zIndex: /z-index/,
 };
 

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -62,6 +62,12 @@ export type {
 } from './token-groups/space';
 
 export type {
+  WidthTokenGroup,
+  WidthTokenName,
+  WidthScale,
+} from './token-groups/width';
+
+export type {
   ZIndexTokenGroup,
   ZIndexTokenName,
   ZIndexZScale,

--- a/polaris-tokens/src/themes/base.ts
+++ b/polaris-tokens/src/themes/base.ts
@@ -6,6 +6,7 @@ import {font} from '../token-groups/font';
 import {motion} from '../token-groups/motion';
 import {shadow} from '../token-groups/shadow';
 import {space} from '../token-groups/space';
+import {width} from '../token-groups/width';
 import {zIndex} from '../token-groups/zIndex';
 
 import type {MetaThemeShape} from './types';
@@ -20,5 +21,6 @@ export const metaThemeBase = createMetaThemeBase({
   motion,
   shadow: tokensToRems(shadow),
   space: tokensToRems(space),
+  width: tokensToRems(width),
   zIndex,
 });

--- a/polaris-tokens/src/token-groups/width.ts
+++ b/polaris-tokens/src/token-groups/width.ts
@@ -1,0 +1,95 @@
+import {size} from '../size';
+import type {MetadataProperties} from '../types';
+
+export type WidthScale =
+  | '0'
+  | '025'
+  | '050'
+  | '100'
+  | '150'
+  | '200'
+  | '300'
+  | '400'
+  | '500'
+  | '600'
+  | '700'
+  | '800'
+  | '900'
+  | '1000'
+  | '1200'
+  | '1600'
+  | '2000'
+  | '2400'
+  | '2800'
+  | '3200';
+
+export type WidthTokenName = `width-${WidthScale}`;
+
+export type WidthTokenGroup = {
+  [TokenName in WidthTokenName]: string;
+};
+
+export const width: {
+  [TokenName in WidthTokenName]: MetadataProperties;
+} = {
+  'width-0': {
+    value: size[0],
+  },
+  'width-025': {
+    value: size['025'],
+  },
+  'width-050': {
+    value: size['050'],
+  },
+  'width-100': {
+    value: size[100],
+  },
+  'width-150': {
+    value: size[150],
+  },
+  'width-200': {
+    value: size[200],
+  },
+  'width-300': {
+    value: size[300],
+  },
+  'width-400': {
+    value: size[400],
+  },
+  'width-500': {
+    value: size[500],
+  },
+  'width-600': {
+    value: size[600],
+  },
+  'width-700': {
+    value: size[700],
+  },
+  'width-800': {
+    value: size[800],
+  },
+  'width-900': {
+    value: size[900],
+  },
+  'width-1000': {
+    value: size[1000],
+  },
+  'width-1200': {
+    value: size[1200],
+  },
+  'width-1600': {
+    value: size[1600],
+  },
+  'width-2000': {
+    value: size[2000],
+  },
+  'width-2400': {
+    value: size[2400],
+  },
+  'width-2800': {
+    value: size[2800],
+  },
+  'width-3200': {
+    value: size[3200],
+  },
+};


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10438 

### WHAT is this pull request doing?

Adds the following values to new public primitive `width` token scale: 

| New Token          | Value        | Value (in px)
| ------------------------- | ------------------------ |  ------------------------ |
| `--p-width-0` | `size['0']`  | `0px`    |
| `--p-width-025` | `size['025']`  | `1px`    |
| `--p-width-050` | `size['050']`  | `2px`    |
| `--p-width-100` | `size[100]`  | `4px`    |
| `--p-width-150` | `size[150]`  | `6px`    |
| `--p-width-200` | `size[200]`  | `8px`    |
| `--p-width-300` | `size[300]`  | `12px`    |
| `--p-width-400` | `size[400]`  | `16px`    |
| `--p-width-500` | `size[500]`  | `20px`    |
| `--p-width-600` | `size[600]`  | `24px`    |
| `--p-width-700` | `size[700]`  | `28px`    |
| `--p-width-800` | `size[800]`  | `32px`    |
| `--p-width-900` | `size[900]`  | `36px`    |
| `--p-width-1000` | `size[1000]`  | `40px`    |
| `--p-width-1200` | `size[1200]`  | `48px`    |
| `--p-width-1600` | `size[1600]`  | `64px`    |
| `--p-width-2000` | `size[2000]`  | `80px`    |
| `--p-width-2400` | `size[2400]`  | `96px`    |
| `--p-width-2800` | `size[2800]`  | `112px`    |
| `--p-width-3200` | `size[3200]`  | `128px`    |