### PR TITLE
Add public primitive `line-height` token scale

### DIFF
--- a/.changeset/fuzzy-mails-judge.md
+++ b/.changeset/fuzzy-mails-judge.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Added public primitive `line-height` token scale

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -1,3 +1,4 @@
+import {size} from '../size';
 import type {MetadataProperties, Experimental} from '../types';
 
 type FontFamilyAlias = 'sans' | 'mono';
@@ -18,6 +19,14 @@ export type FontSizeScale =
 type FontLineHeightScaleExperimental = Experimental<'075'>;
 
 export type FontLineHeightScale =
+  | '300'
+  | '400'
+  | '500'
+  | '600'
+  | '700'
+  | '800'
+  | '1000'
+  | '1200'
   | '1'
   | '2'
   | '3'
@@ -91,6 +100,30 @@ export const font: {
   },
   'font-weight-bold': {
     value: '700',
+  },
+  'font-line-height-300': {
+    value: size[300],
+  },
+  'font-line-height-400': {
+    value: size[400],
+  },
+  'font-line-height-500': {
+    value: size[500],
+  },
+  'font-line-height-600': {
+    value: size[600],
+  },
+  'font-line-height-700': {
+    value: size[700],
+  },
+  'font-line-height-800': {
+    value: size[800],
+  },
+  'font-line-height-1000': {
+    value: size[1000],
+  },
+  'font-line-height-1200': {
+    value: size[1200],
   },
   'font-line-height-075-experimental': {
     value: '12px',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10441 

### WHAT is this pull request doing?

Adds the following values to new public primitive `line-height` token scale: 

| New Token          | Value        | Value (in px)
| ------------------------- | ------------------------ |  ------------------------ |
| `--p-font-line-height-300` | `size[300]`  | `12px`    |
| `--p-font-line-height-400` | `size[400]`  | `16px`    |
| `--p-font-line-height-500` | `size[500]`  | `20px`    |
| `--p-font-line-height-600` | `size[600]`  | `24px`    |
| `--p-font-line-height-700` | `size[700]`  | `28px`    |
| `--p-font-line-height-800` | `size[800]`  | `32px`    |
| `--p-font-line-height-1000` | `size[1000]`  | `40px`    |
| `--p-font-line-height-1200` | `size[1200]`  | `48px`    |