### PR TITLE
Update `polaris-tokens` tests

### DIFF
--- a/polaris-tokens/tests/toStyleSheet.test.js
+++ b/polaris-tokens/tests/toStyleSheet.test.js
@@ -5,57 +5,55 @@ import {
 } from '../scripts/toStyleSheet';
 
 const mockTokenGroup = {
-  'design-token-1': {
+  'token-name-1': {
     value: 'valueA',
   },
-  'design-token-2': {
+  'token-name-2': {
     value: 'valueB',
   },
 };
 
 const mockMotionTokenGroup = {
-  ...mockTokenGroup,
-  'motion-keyframes-token-1': {
+  'motion-token-1': {
     value: 'valueA',
   },
-  'motion-keyframes-token-2': {
+  'motion-token-2': {
     value: 'valueB',
   },
+  'motion-keyframes-token-1': {
+    value: 'valueC',
+  },
+  'motion-keyframes-token-2': {
+    value: 'valueD',
+  },
 };
-
 const mockTheme = {
-  border: {},
-  color: {},
-  font: {},
-  motion: {},
-  // Note: We don't need to assign mock values to the remaining static tokens.
-  shadow: mockTokenGroup,
-  space: {},
-  zIndex: {},
+  tokenGroupName: mockTokenGroup,
+  motion: mockMotionTokenGroup,
 };
 
-const expectedThemeDecls =
-  '--p-design-token-1:valueA;--p-design-token-2:valueB;';
+const expectedTokenGroupDecls =
+  '--p-token-name-1:valueA;--p-token-name-2:valueB;';
 
-const expectedKeyframes =
-  '@keyframes p-motion-keyframes-token-1valueA@keyframes p-motion-keyframes-token-2valueB';
+const expectedMotionTokenGroupDecls =
+  '--p-motion-token-1:valueA;--p-motion-token-2:valueB;--p-motion-keyframes-token-1:p-motion-keyframes-token-1;--p-motion-keyframes-token-2:p-motion-keyframes-token-2;';
 
-const expectedKeyframesCustomProperties =
-  '--p-motion-keyframes-token-1:p-motion-keyframes-token-1;--p-motion-keyframes-token-2:p-motion-keyframes-token-2;';
+const expectedThemeDecls = `${expectedTokenGroupDecls}${expectedMotionTokenGroupDecls}`;
+
+const expectedMotionKeyframes =
+  '@keyframes p-motion-keyframes-token-1valueC@keyframes p-motion-keyframes-token-2valueD';
 
 describe('getMetaTokenGroupDecls', () => {
   it('creates a string of CSS declarations', () => {
     const tokenGroupDecls = getMetaTokenGroupDecls(mockTokenGroup);
 
-    expect(tokenGroupDecls).toBe(expectedThemeDecls);
+    expect(tokenGroupDecls).toBe(expectedTokenGroupDecls);
   });
 
   it('creates a string of CSS declarations and keyframes at-rules from motion tokens', () => {
     const tokenGroupDecls = getMetaTokenGroupDecls(mockMotionTokenGroup);
 
-    expect(tokenGroupDecls).toBe(
-      `${expectedThemeDecls}${expectedKeyframesCustomProperties}`,
-    );
+    expect(tokenGroupDecls).toBe(expectedMotionTokenGroupDecls);
   });
 });
 
@@ -63,7 +61,7 @@ describe('getKeyframes', () => {
   it('creates a string of keyframes at-rules', () => {
     const keyframes = getKeyframes(mockMotionTokenGroup);
 
-    expect(keyframes).toBe(expectedKeyframes);
+    expect(keyframes).toBe(expectedMotionKeyframes);
   });
 });
 


### PR DESCRIPTION
Makes the mock token names and token group names more generic.