### PR TITLE
[TOC] Fix bug to render TOC on section content pages

### DIFF
--- a/polaris.shopify.com/content/tools/polaris-for-vscode.md
+++ b/polaris.shopify.com/content/tools/polaris-for-vscode.md
@@ -11,8 +11,15 @@ order: 1
 <Lede>{frontmatter.description}</Lede>
 
 <picture>
-  <source srcset="/images/tools/polaris-for-vscode/polaris-for-vscode-preview.png" media="(prefers-reduced-motion: reduce)"></source>
-  <img style={{maxWidth: "100%" }} srcset="/images/tools/polaris-for-vscode/polaris-for-vscode-preview.gif" alt="Demo of Polaris for VS Code tokens autocomplete" />
+  <source
+    srcSet="/images/tools/polaris-for-vscode/polaris-for-vscode-preview.png"
+    media="(prefers-reduced-motion: reduce)"
+  ></source>
+  <img
+    style={{maxWidth: '100%'}}
+    srcSet="/images/tools/polaris-for-vscode/polaris-for-vscode-preview.gif"
+    alt="Demo of Polaris for VS Code tokens autocomplete"
+  />
 </picture>
 
 ## Features

--- a/polaris.shopify.com/content/tools/polaris-migrator.md
+++ b/polaris.shopify.com/content/tools/polaris-migrator.md
@@ -6,6 +6,10 @@ icon: ReplaceMajor
 order: 3
 ---
 
+# {frontmatter.title}
+
+<Lede>{frontmatter.description}</Lede>
+
 [<img src="https://img.shields.io/npm/v/@shopify/polaris-migrator.svg?labelColor=f9f9f9&color=dcf5f0" alt="npm version" style={{width: "95px"}} />](https://www.npmjs.com/package/@shopify/polaris-migrator)
 
 <picture>

--- a/polaris.shopify.com/content/tools/polaris-migrator.md
+++ b/polaris.shopify.com/content/tools/polaris-migrator.md
@@ -9,8 +9,15 @@ order: 3
 [<img src="https://img.shields.io/npm/v/@shopify/polaris-migrator.svg?labelColor=f9f9f9&color=dcf5f0" alt="npm version" style={{width: "95px"}} />](https://www.npmjs.com/package/@shopify/polaris-migrator)
 
 <picture>
-  <source srcset="/images/tools/polaris-migrator/polaris-migrator-demo.png" media="(prefers-reduced-motion: reduce)"></source>
-  <img style={{maxWidth: "100%"}} srcset="/images/tools/polaris-migrator/polaris-migrator-demo.gif" alt="Demo of Polaris migrator" />
+  <source
+    srcSet="/images/tools/polaris-migrator/polaris-migrator-demo.png"
+    media="(prefers-reduced-motion: reduce)"
+  ></source>
+  <img
+    style={{maxWidth: '100%'}}
+    srcSet="/images/tools/polaris-migrator/polaris-migrator-demo.gif"
+    alt="Demo of Polaris migrator"
+  />
 </picture>
 
 ## Usage

--- a/polaris.shopify.com/content/tools/stylelint-polaris.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris.md
@@ -27,11 +27,11 @@ keywords:
 
 <picture>
   <source
-    srcset="/images/tools/stylelint-polaris/stylelint-demo.png"
+    srcSet="/images/tools/stylelint-polaris/stylelint-demo.png"
     media="(prefers-reduced-motion: reduce)"
   />
   <img
-    srcset="/images/tools/stylelint-polaris/stylelint-demo.gif"
+    srcSet="/images/tools/stylelint-polaris/stylelint-demo.gif"
     alt="Demo of Stylelint Polaris"
     style={{width: '100%'}}
   />

--- a/polaris.shopify.com/pages/[...slug].tsx
+++ b/polaris.shopify.com/pages/[...slug].tsx
@@ -96,7 +96,7 @@ const CatchAllTemplate = ({
     <Page
       editPageLinkPath={editPageLinkPath}
       isContentPage={isContentPage}
-      showTOC={showTOC}
+      showTOC={showTOC || isContentPage}
     >
       <PageMeta title={title} description={seoDescription} noIndex={noIndex} />
       <Markdown


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10472.
Fixes issue where Table of Contents was not rendering on content pages.

### WHAT is this pull request doing?

Updates conditional logic to render TOC on content pages.
Adds in missing title and description on Polaris-Migrator page.
Resolves console warning regarding source element `srcset` attribute.
    <details>
      <summary>Warning example</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/d68f9e91-5871-40bf-8f08-d40c9632bd76" alt="Warning example">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
