### PR TITLE
Add public primitive `font-size` token scale

### DIFF
--- a/.changeset/healthy-scissors-hope.md
+++ b/.changeset/healthy-scissors-hope.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Added public primitive `font-size` token scale

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -1,3 +1,4 @@
+import {size} from '../size';
 import type {MetadataProperties, Experimental} from '../types';
 
 type FontFamilyAlias = 'sans' | 'mono';
@@ -5,6 +6,12 @@ type FontFamilyAlias = 'sans' | 'mono';
 type FontSizeScaleExperimental = Experimental<'70' | '80'>;
 
 export type FontSizeScale =
+  | '275'
+  | '325'
+  | '350'
+  | '750'
+  | '900'
+  | '1000'
   | '75'
   | '100'
   | '200'
@@ -49,6 +56,24 @@ export const font: {
   'font-family-mono': {
     value:
       "ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace",
+  },
+  'font-size-275': {
+    value: size[275],
+  },
+  'font-size-325': {
+    value: size[325],
+  },
+  'font-size-350': {
+    value: size[350],
+  },
+  'font-size-750': {
+    value: size[750],
+  },
+  'font-size-900': {
+    value: size[900],
+  },
+  'font-size-1000': {
+    value: size[1000],
   },
   'font-size-70-experimental': {
     value: '11px',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10475
Part of #10439

### WHAT is this pull request doing?

Adds the following values to new public primitive `font-size` token scale: 

| New Token          | Value        | Value (in px)
| ------------------------- | ------------------------ |  ------------------------ |
| `--p-font-size-275` | `size[275]`  | `11px`    |
| ~`--p-font-size-300`~ | ~`size[300]`~  | ~`12px`~   |
| `--p-font-size-325` | `size[325]`  | `13px`    |
| `--p-font-size-350` | `size[350]`  | `14px`    |
| ~`--p-font-size-400`~ | ~`size[400]`~  | ~`16px`~    |
| ~`--p-font-size-500`~ | ~`size[500]`~  | ~`20px`~    |
| ~`--p-font-size-600`~ | ~`size[600]`~  | ~`24px`~    |
| `--p-font-size-750` | `size[750]`  | `30px`    |
| `--p-font-size-900` | `size[900]`  | `36px`    |
| `--p-font-size-1000` | `size[1000]`  | `40px`    |

> [!NOTE]  
> The following values were not added since they conflict with existing tokens with the same name. These tokens will have their values updated in the next major version v12:

| New Token          | Value        | Value (in px)
| ------------------------- | ------------------------ |  ------------------------ |
| `--p-font-size-300` | `size[300]`  | `12px`  |
| `--p-font-size-400` | `size[400]`  | `16px`    |
| `--p-font-size-500` | `size[500]`  | `20px`    |
| `--p-font-size-600` | `size[600]`  | `24px`    |