### PR TITLE
Create migration for replacing v11 `border` custom properties

### DIFF
--- a/.changeset/shiny-feet-marry.md
+++ b/.changeset/shiny-feet-marry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Created migration to replace deprecated `border` custom properties in polaris-react v12.0.0

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/transform.test.ts
@@ -1,0 +1,12 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v12-styles-replace-custom-property-border';
+const fixtures = ['v12-styles-replace-custom-property-border'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+    extension: 'scss',
+  });
+}

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.input.scss
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.input.scss
@@ -1,0 +1,18 @@
+.border {
+  border-radius: var(--p-border-radius-0-experimental);
+  border-radius: var(--p-border-radius-05);
+  border-radius: var(--p-border-radius-1);
+  border-radius: var(--p-border-radius-1_5-experimental);
+  border-radius: var(--p-border-radius-2);
+  border-radius: var(--p-border-radius-3);
+  border-radius: var(--p-border-radius-4);
+  border-radius: var(--p-border-radius-5);
+  border-radius: var(--p-border-radius-6);
+  border-width: var(--p-border-width-1);
+  border-width: var(--p-border-width-1-experimental);
+  border-width: var(--p-border-width-2);
+  border-width: var(--p-border-width-2-experimental);
+  border-width: var(--p-border-width-3);
+  border-width: var(--p-border-width-4);
+  border-width: var(--p-border-width-5);
+}

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.input.scss
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.input.scss
@@ -12,7 +12,7 @@
   border-width: var(--p-border-width-1-experimental);
   border-width: var(--p-border-width-2);
   border-width: var(--p-border-width-2-experimental);
-  border-width: var(--p-border-width-3);
+  // border-width: var(--p-border-width-3) / var(--p-border-width-050);
   border-width: var(--p-border-width-4);
-  border-width: var(--p-border-width-5);
+  // border-width: var(--p-border-width-5) / var(--p-border-width-100);
 }

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.input.scss
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.input.scss
@@ -12,7 +12,7 @@
   border-width: var(--p-border-width-1-experimental);
   border-width: var(--p-border-width-2);
   border-width: var(--p-border-width-2-experimental);
-  // border-width: var(--p-border-width-3) / var(--p-border-width-050);
+  border-width: var(--p-border-width-3);
   border-width: var(--p-border-width-4);
-  // border-width: var(--p-border-width-5) / var(--p-border-width-100);
+  border-width: var(--p-border-width-5);
 }

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.output.scss
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.output.scss
@@ -1,0 +1,18 @@
+.border {
+  border-radius: var(--p-border-radius-0);
+  border-radius: var(--p-border-radius-050);
+  border-radius: var(--p-border-radius-100);
+  border-radius: var(--p-border-radius-150);
+  border-radius: var(--p-border-radius-200);
+  border-radius: var(--p-border-radius-300);
+  border-radius: var(--p-border-radius-400);
+  border-radius: var(--p-border-radius-500);
+  border-radius: var(--p-border-radius-750);
+  border-width: var(--p-border-width-025);
+  border-width: var(--p-border-width-0165);
+  border-width: var(--p-border-width-050);
+  border-width: var(--p-border-width-025);
+  border-width: var(--p-border-width-050);
+  border-width: var(--p-border-width-100);
+  border-width: var(--p-border-width-100);
+}

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.output.scss
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.output.scss
@@ -12,7 +12,7 @@
   border-width: var(--p-border-width-0165);
   border-width: var(--p-border-width-050);
   border-width: var(--p-border-width-025);
-  border-width: var(--p-border-width-050);
+  // border-width: var(--p-border-width-3) / var(--p-border-width-050);
   border-width: var(--p-border-width-100);
-  border-width: var(--p-border-width-100);
+  // border-width: var(--p-border-width-5) / var(--p-border-width-100);
 }

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.output.scss
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/tests/v12-styles-replace-custom-property-border.output.scss
@@ -12,7 +12,7 @@
   border-width: var(--p-border-width-0165);
   border-width: var(--p-border-width-050);
   border-width: var(--p-border-width-025);
-  // border-width: var(--p-border-width-3) / var(--p-border-width-050);
+  border-width: var(--p-border-width-050);
   border-width: var(--p-border-width-100);
-  // border-width: var(--p-border-width-5) / var(--p-border-width-100);
+  border-width: var(--p-border-width-100);
 }

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/transform.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/transform.ts
@@ -1,0 +1,28 @@
+import type {FileInfo, API} from 'jscodeshift';
+
+import stylesReplaceCustomProperty from '../styles-replace-custom-property/transform';
+
+export default function transformer(fileInfo: FileInfo, _: API) {
+  return stylesReplaceCustomProperty(fileInfo, _, {replacementMaps});
+}
+
+const replacementMaps = {
+  '/.+/': {
+    '--p-border-radius-0-experimental': '--p-border-radius-0',
+    '--p-border-radius-05': '--p-border-radius-050',
+    '--p-border-radius-1': '--p-border-radius-100',
+    '--p-border-radius-1_5-experimental': '--p-border-radius-150',
+    '--p-border-radius-2': '--p-border-radius-200',
+    '--p-border-radius-3': '--p-border-radius-300',
+    '--p-border-radius-4': '--p-border-radius-400',
+    '--p-border-radius-5': '--p-border-radius-500',
+    '--p-border-radius-6': '--p-border-radius-750',
+    '--p-border-width-1': '--p-border-width-025',
+    '--p-border-width-1-experimental': '--p-border-width-0165',
+    '--p-border-width-2': '--p-border-width-050',
+    '--p-border-width-2-experimental': '--p-border-width-025',
+    '--p-border-width-3': '--p-border-width-050',
+    '--p-border-width-4': '--p-border-width-100',
+    '--p-border-width-5': '--p-border-width-100',
+  },
+};

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/transform.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/transform.ts
@@ -21,10 +21,8 @@ const replacementMaps = {
     '--p-border-width-1-experimental': '--p-border-width-0165',
     '--p-border-width-2': '--p-border-width-050',
     '--p-border-width-2-experimental': '--p-border-width-025',
-    // The following migration needs to be run on the next branch with the v12 launch
-    // '--p-border-width-3': '--p-border-width-050',
+    '--p-border-width-3': '--p-border-width-050',
     '--p-border-width-4': '--p-border-width-100',
-    // The following migration needs to be run on the next branch with the v12 launch
-    // '--p-border-width-5': '--p-border-width-100',
+    '--p-border-width-5': '--p-border-width-100',
   },
 };

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/transform.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/transform.ts
@@ -21,8 +21,10 @@ const replacementMaps = {
     '--p-border-width-1-experimental': '--p-border-width-0165',
     '--p-border-width-2': '--p-border-width-050',
     '--p-border-width-2-experimental': '--p-border-width-025',
-    '--p-border-width-3': '--p-border-width-050',
+    // The following migration needs to be run on the next branch with the v12 launch
+    // '--p-border-width-3': '--p-border-width-050',
     '--p-border-width-4': '--p-border-width-100',
-    '--p-border-width-5': '--p-border-width-100',
+    // The following migration needs to be run on the next branch with the v12 launch
+    // '--p-border-width-5': '--p-border-width-100',
   },
 };


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10443 
Fixes #10444 

### WHAT is this pull request doing?
This PR creates a migration for deprecated `border` custom properties in v12 using the generic codemod [`styles-replace-custom-property`](https://github.com/Shopify/polaris/pull/8265).

#### v12-styles-replace-custom-property-space
| Deprecated CSS Custom Property            | Replacement Value                  |
| ----------------------------------------- | ---------------------------------- |
| `--p-border-radius-0-experimental` | `--p-border-radius-0` | 
| `--p-border-radius-05` | `--p-border-radius-050` | 
| `--p-border-radius-1` | `--p-border-radius-100` | 
| `--p-border-radius-1_5-experimental` | `--p-border-radius-150` | 
| `--p-border-radius-2` | `--p-border-radius-200` | 
| `--p-border-radius-3` | `--p-border-radius-300` | 
| `--p-border-radius-4` | `--p-border-radius-400` | 
| `--p-border-radius-5` | `--p-border-radius-500` | 
| `--p-border-radius-6` | `--p-border-radius-750` | 
| `--p-border-width-1` | `--p-border-width-025` | 
| `--p-border-width-1-experimental` | `--p-border-width-0165` | 
| `--p-border-width-2` | `--p-border-width-050` | 
| `--p-border-width-2-experimental` | `--p-border-width-025` | 
| `--p-border-width-3` | `--p-border-width-050` | 
| `--p-border-width-4` | `--p-border-width-100` | 
| `--p-border-width-5` | `--p-border-width-100` | 

> [!NOTE]  
> The following values cannot be safely migrated pre-v12 while maintaining existing feature flag functionality. These tokens will need to be migrated in the next major version v12:

| New Token          | Value        | Value (in px)
| ------------------------- | ------------------------ |  ------------------------ |
| `--p-border-width-3` | `--p-border-width-050` | 
| `--p-border-width-5` | `--p-border-width-100` | 