### PR TITLE
[Sandbox] Mock Frame functions in the Sandbox to avoid hard failures

### DIFF
--- a/polaris.shopify.com/playroom/FrameComponent.tsx
+++ b/polaris.shopify.com/playroom/FrameComponent.tsx
@@ -1,8 +1,43 @@
 import React, {useEffect, useState} from 'react';
-import {AppProvider} from '@shopify/polaris';
+import {AppProvider, FrameContext} from '@shopify/polaris';
 import '@shopify/polaris/build/esm/styles.css';
 import enTranslations from '@shopify/polaris/locales/en.json';
 import {updateGrowFrameHeight} from '../src/components/GrowFrame';
+
+const mockFrameContext = {
+  toastMessages: [],
+  showToast: () => {
+    console.info(
+      '[Polaris] Frame#showToast() is not available in Sandbox mode.',
+    );
+  },
+  hideToast: () => {
+    console.info(
+      '[Polaris] Frame#hideToast() is not available in Sandbox mode.',
+    );
+  },
+  setContextualSaveBar: () => {
+    console.info(
+      '[Polaris] Frame#setContextualSaveBar() is not available in Sandbox mode.',
+    );
+  },
+  removeContextualSaveBar: () => {
+    console.info(
+      '[Polaris] Frame#removeContextualSaveBar() is not available in Sandbox mode.',
+    );
+  },
+  startLoading: () => {
+    console.info(
+      '[Polaris] Frame#startLoading() is not available in Sandbox mode.',
+    );
+  },
+  stopLoading: () => {
+    console.info(
+      '[Polaris] Frame#stopLoading() is not available in Sandbox mode.',
+    );
+  },
+};
+
 export default function FrameComponent({
   theme = enTranslations,
   children,
@@ -29,7 +64,9 @@ export default function FrameComponent({
   }, []);
   return (
     <AppProvider i18n={theme || enTranslations} features={features}>
-      <div id="polaris-sandbox-wrapper">{children}</div>
+      <FrameContext.Provider value={mockFrameContext}>
+        <div id="polaris-sandbox-wrapper">{children}</div>
+      </FrameContext.Provider>
     </AppProvider>
   );
 }


### PR DESCRIPTION
Doing the same fix as #10492, but for the Sandbox.

**Before**

<img width="367" alt="Screenshot 2023-09-18 at 2 53 23 pm" src="https://github.com/Shopify/polaris/assets/612020/fcc435ff-27f8-4e45-94e6-69c4ad09efc7">

**This PR**

<img width="513" alt="Screenshot 2023-09-18 at 3 18 01 pm" src="https://github.com/Shopify/polaris/assets/612020/ccdfcec5-2b04-4863-b3cf-014f5759f641">
