### PR TITLE
[Docs] Allow opting out of auto margin/padding with the .margin-considered-harmful class

### DIFF
--- a/polaris.shopify.com/src/components/Lede/Lede.module.scss
+++ b/polaris.shopify.com/src/components/Lede/Lede.module.scss
@@ -1,9 +1,14 @@
+@import '../../styles/variables.scss';
+
 .LedeParagraph {
   &,
   & p {
     font-size: var(--font-size-600);
     font-weight: var(--font-weight-500);
     letter-spacing: var(--letter-spacing-300);
-    margin-bottom: 1.5rem;
+
+    #{$notMarginConsideredHarmful} {
+      margin-bottom: 1.5rem;
+    }
   }
 }

--- a/polaris.shopify.com/src/components/Markdown/Markdown.module.scss
+++ b/polaris.shopify.com/src/components/Markdown/Markdown.module.scss
@@ -143,15 +143,21 @@
 
 /* The various gaps between adjacent elements */
 .Heading-h1 {
-  margin-block: 1.5rem;
+  #{$notMarginConsideredHarmful} {
+    margin-block: 1.5rem;
+  }
 }
 
 .Heading-h2 {
-  margin-block: 3rem 1rem;
+  #{$notMarginConsideredHarmful} {
+    margin-block: 3rem 1rem;
+  }
 }
 
 .Heading-h3 {
-  margin-block: 1.5rem 1rem;
+  #{$notMarginConsideredHarmful} {
+    margin-block: 1.5rem 1rem;
+  }
 }
 
 .Heading-h4,
@@ -160,7 +166,9 @@
 .List,
 .Paragraph,
 .HorizontalRule {
-  margin-block: 1rem;
+  #{$notMarginConsideredHarmful} {
+    margin-block: 1rem;
+  }
 }
 
 .Heading-h1,
@@ -172,7 +180,9 @@
 .Paragraph,
 .List {
   &:first-child {
-    margin-top: 0;
+    #{$notMarginConsideredHarmful} {
+      margin-top: 0;
+    }
   }
 }
 
@@ -180,17 +190,23 @@
 .Heading-h4 {
   + .Paragraph,
   + .List {
-    margin-top: -0.5rem;
+    #{$notMarginConsideredHarmful} {
+      margin-top: -0.5rem;
+    }
   }
 }
 
 .List {
   .List {
-    margin-block: 0;
+    #{$notMarginConsideredHarmful} {
+      margin-block: 0;
+    }
   }
 
   .Paragraph {
-    margin-block: 0;
+    #{$notMarginConsideredHarmful} {
+      margin-block: 0;
+    }
   }
 }
 

--- a/polaris.shopify.com/src/components/Markdown/Markdown.tsx
+++ b/polaris.shopify.com/src/components/Markdown/Markdown.tsx
@@ -89,19 +89,21 @@ const FencedCodeWithVisibilityToggle: ComponentType<
   const [showCode, setShowCode] = useCodeVisibility();
   if (type === 'livePreview') {
     return (
-      <PatternsExample
-        example={{
-          code: (children as string) ?? '',
-          previewContext,
-          sandboxContext,
-        }}
-        isCodeVisible={showCode}
-        isActionsVisible={isActionsVisible}
-        onCodeVisibilityToggle={() => {
-          setShowCode?.(!showCode);
-        }}
-        title={title ?? 'Pattern Name'}
-      />
+      <Box className="margin-considered-harmful">
+        <PatternsExample
+          example={{
+            code: (children as string) ?? '',
+            previewContext,
+            sandboxContext,
+          }}
+          isCodeVisible={showCode}
+          isActionsVisible={isActionsVisible}
+          onCodeVisibilityToggle={() => {
+            setShowCode?.(!showCode);
+          }}
+          title={title ?? 'Pattern Name'}
+        />
+      </Box>
     );
   }
 

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -262,8 +262,3 @@
     }
   }
 }
-// Additional class added to bust specificity in Markdown.module.scss
-.NoMargin.Heading-h2,
-.NoMargin.Heading-h3 {
-  margin: 0px;
-}

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -155,18 +155,12 @@ const defaultMdxComponents: React.ComponentProps<
   ),
   p: ({children}) => <Box as="p">{children}</Box>,
   h2: ({children}) => (
-    <HeadingWithCopyButton
-      as="h2"
-      className={[styles.NoMargin, styles['Heading-h2']]}
-    >
+    <HeadingWithCopyButton as="h2" className={[styles['Heading-h2']]}>
       {children}
     </HeadingWithCopyButton>
   ),
   h3: ({children}) => (
-    <HeadingWithCopyButton
-      as="h3"
-      className={[styles.NoMargin, styles['Heading-h3']]}
-    >
+    <HeadingWithCopyButton as="h3" className={styles['Heading-h3']}>
       {children}
     </HeadingWithCopyButton>
   ),
@@ -205,7 +199,7 @@ export default function PatternPage({pattern}: Props) {
       />
 
       <Page isContentPage>
-        <Stack gap="8">
+        <Stack gap="8" className="margin-considered-harmful">
           <Stack gap="4">
             <Heading as="h1">
               <Box className={styles.Heading}>{pattern.frontmatter.title}</Box>

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -319,18 +319,22 @@ button {
 .components-grid__title {
   font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-font-line-height-3);
-  margin: 0 !important;
-  margin-bottom: var(--p-space-1) !important;
+  #{$notMarginConsideredHarmful} {
+    margin: 0 !important;
+    margin-bottom: var(--p-space-1) !important;
+  }
   color: #4e52b8;
 }
 
 .tip-banner {
-  padding: var(--p-space-4) var(--p-space-6);
   background: var(--p-color-bg-info-subdued);
   border-radius: var(--p-border-radius-2);
   color: #00565e !important;
-  margin: var(--p-space-6) 0;
-  margin-bottom: var(--p-space-16);
+  #{$notMarginConsideredHarmful} {
+    padding: var(--p-space-4) var(--p-space-6);
+    margin: var(--p-space-6) 0;
+    margin-bottom: var(--p-space-16);
+  }
 }
 
 .tip-banner__header {
@@ -340,5 +344,7 @@ button {
 }
 
 .tip-banner__header h4 {
-  margin: 0 !important;
+  #{$notMarginConsideredHarmful} {
+    margin: 0 !important;
+  }
 }

--- a/polaris.shopify.com/src/styles/variables.scss
+++ b/polaris.shopify.com/src/styles/variables.scss
@@ -5,3 +5,26 @@ $breakpointTablet: 768px;
 $breakpointDesktopSmall: 1040px;
 $breakpointDesktop: 1400px;
 $breakpointDesktopLarge: 1600px;
+
+// NOTE: Prettier messes with the comments for some reason
+// prettier-ignore
+$notMarginConsideredHarmful:
+  // Extend the current selector
+  '&'
+  // Use :where() to not change the specificity of the selector
+  + ':where('
+  // Only match when the current selector is NOT a decendent of the
+  // .margin-considered-harmful class
+  + ':not('
+  // Using seemingly redundant :is() here for backwards compatability with older
+  // browsers that haven't yet enabled complex selectors within a `:not()`, but
+  // HAVE enabled them in a `:is()`. See:
+  // https://groups.google.com/a/chromium.org/g/blink-dev/c/0alTkXvDCL8/m/-ClOGvOJBAAJ
+  + ':is('
+  // :global() to stop CSS Modules munging this classname.
+  // The * means "all possible decenders", so when coupled with the :not(), it
+  // means "not an ancestor of". This is necessary due to the way :not() works
+  // when finding a matching selector. See:
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/:not?ref=serpapi#description
+  + ':global(.margin-considered-harmful) *)'
+  + '))';


### PR DESCRIPTION
This is a prototype of a holistic solution to the problem partially patched in #10425.

It's a bit of CSS wizardry which ensures margin (or external padding) is only applied to elements that are _not_ a descendant of an element with class `.margin-considered-harmful`.

My reasoning:

tl;dr: When writing english prose, content editors expect it to render nicely by default. But when using React components, we expect it to render predictably.

1. The docs site should be as simple as possible for content editors to make changes. One way of doing this is to apply default styles to all rendered markdown (including margin) to meet a minimum level of aesthetics.
2. Leaning into MDX means there will also now be interleaved React components. We expect those components to _not_ have any default styles they don't set themselves. For example; the Patterns page, or other complex layouts which specify their own styles.
3. [Margin is considered harmful](https://mxstbr.com/thoughts/margin/) (for non-longform content) because it breaks encapsulation and leads to unexpected results as components are re-used.
4. Therefore, we need two styling "modes":
    1. "Longform" content which is mostly just paragraphs - gets default styles including margin.
    2. "Components" which are self-contained and re-usable - gets no default margin.

I'm not strongly opinionated on this one, but I would like to solve it wholistically now so we don't end up with [more `!important`s](https://github.com/search?q=repo%3AShopify%2Fpolaris+important+language%3ASCSS+path%3A%2F%5Epolaris.shopify.com%5C%2Fsrc%5C%2F%2F&type=code) as we introduce more MDX components.