### PR TITLE
 Move level 3 nav items to page subnav

### DIFF
--- a/polaris.shopify.com/content/design/typography/font-and-typescale.md
+++ b/polaris.shopify.com/content/design/typography/font-and-typescale.md
@@ -1,0 +1,15 @@
+---
+title: Font and typescale
+order: 1
+keywords:
+  - type styles
+  - font sizes
+  - fonts
+icon: TypeMinor
+---
+
+# {frontmatter.title}
+
+<Lede>{frontmatter.description}</Lede>
+
+<Subnav />

--- a/polaris.shopify.com/content/design/typography/index.md
+++ b/polaris.shopify.com/content/design/typography/index.md
@@ -12,6 +12,8 @@ icon: TypeMajor
 
 <Lede>{frontmatter.description}</Lede>
 
+<Subnav />
+
 ![An illustration of letters constructed from lego blocks](/images/design/typography/text-featured@2x.png)
 
 ## Working with typography

--- a/polaris.shopify.com/content/design/typography/tokens.md
+++ b/polaris.shopify.com/content/design/typography/tokens.md
@@ -1,0 +1,14 @@
+---
+title: Tokens
+order: 3
+keywords:
+  - type styles
+  - font sizes
+  - fonts
+---
+
+# {frontmatter.title}
+
+<Lede>{frontmatter.description}</Lede>
+
+<Subnav />

--- a/polaris.shopify.com/content/design/typography/typesetting.md
+++ b/polaris.shopify.com/content/design/typography/typesetting.md
@@ -1,0 +1,15 @@
+---
+title: Typesetting
+order: 2
+keywords:
+  - type styles
+  - font sizes
+  - fonts
+icon: TextAlignmentLeftMajor
+---
+
+# {frontmatter.title}
+
+<Lede>{frontmatter.description}</Lede>
+
+<Subnav />

--- a/polaris.shopify.com/scripts/watch-md.mjs
+++ b/polaris.shopify.com/scripts/watch-md.mjs
@@ -5,7 +5,7 @@ import genCacheJson from './gen-cache-json.mjs';
 
 const mdPath = path.join(process.cwd(), 'content');
 
-// Run intially
+// Run initially
 await genCacheJson();
 
 // Run whenever there is a change to a .md file

--- a/polaris.shopify.com/src/components/Frame/Frame.tsx
+++ b/polaris.shopify.com/src/components/Frame/Frame.tsx
@@ -14,7 +14,8 @@ import {useRouter} from 'next/router';
 import StatusBadge from '../StatusBadge';
 
 const NAV_ID = 'nav';
-
+// Nav levels greater than this should be part of <Subnav />
+const MAX_NAV_LEVEL = 1;
 interface Props {
   darkMode: DarkMode;
   children: React.ReactNode;
@@ -215,7 +216,8 @@ function NavItem({
 
             if (!child.slug) return null;
 
-            const isExpandable = child.children && !child.hideChildren;
+            const isExpandable =
+              child.children && !child.hideChildren && level < MAX_NAV_LEVEL;
             const id = (child.slug || key).replace(/\//g, '');
             const navAriaId = `nav-${id}`;
             const segments = asPath.slice(1).split('/');

--- a/polaris.shopify.com/src/components/Markdown/Markdown.tsx
+++ b/polaris.shopify.com/src/components/Markdown/Markdown.tsx
@@ -18,6 +18,7 @@ import {Stack} from '../../components/Stack';
 import StatusBanner from '../../components/StatusBanner';
 import TipBanner from '../../components/TipBanner';
 import {Lede} from '../../components/Lede';
+import Subnav from '../../components/Subnav';
 import {SideBySide} from './components/SideBySide';
 import YoutubeVideo from '../YoutubeVideo';
 import {DoDont, Do, Dont} from './components/DoDont';
@@ -229,6 +230,7 @@ function Markdown<
         StatusBanner,
         TipBanner,
         Lede,
+        Subnav,
         RichCardGrid,
         Colors,
         Tip: ({children}) => (

--- a/polaris.shopify.com/src/components/Subnav/Subnav.module.scss
+++ b/polaris.shopify.com/src/components/Subnav/Subnav.module.scss
@@ -1,0 +1,31 @@
+.Items {
+  --text: #000;
+  --border: #000;
+
+  display: inline-flex;
+  gap: var(--p-space-1);
+  border-radius: var(--p-border-radius-3);
+  border: 1px solid var(--border);
+  padding: var(--p-space-1);
+}
+
+.Item {
+  display: flex;
+  align-items: center;
+  gap: var(--p-space-2);
+  padding: var(--p-space-1_5-experimental) var(--p-space-3);
+  border-radius: var(--p-border-radius-2);
+  background-color: var(--surface);
+  color: var(--text);
+  fill: var(--text);
+
+  &:hover {
+    background-color: var(--surface-subdued);
+  }
+}
+
+.Item--active {
+  --surface: #000;
+  --surface-subdued: #000;
+  --text: #fff;
+}

--- a/polaris.shopify.com/src/components/Subnav/Subnav.tsx
+++ b/polaris.shopify.com/src/components/Subnav/Subnav.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link';
+
+import navJSON from '../../../.cache/nav.json';
+import {NavJSON, NavItem} from '../../types';
+import {className} from '../../utils/various';
+
+import styles from './Subnav.module.scss';
+import {useRouter} from 'next/router';
+import {Icon} from '@shopify/polaris';
+import * as polarisIcons from '@shopify/polaris-icons';
+
+type PolarisIcon = keyof typeof polarisIcons;
+const nav = navJSON.children as NavJSON;
+
+function Subnav() {
+  const {asPath} = useRouter();
+  const navItems = getNavItems(asPath);
+
+  if (!navItems) {
+    console.warn('No subnav items found for path:', asPath);
+    return null;
+  }
+
+  const sortedNavItems = Object.entries(navItems).sort(([_a, a], [_b, b]) => {
+    if (a.order && b.order) return a.order > b.order ? 1 : -1;
+    return 0;
+  });
+
+  return (
+    <nav>
+      <ul className={styles.Items}>
+        {sortedNavItems.map(([key, navItem]) => (
+          <Link
+            className={className(
+              styles.Item,
+              asPath === navItem.slug && styles['Item--active'],
+            )}
+            key={key}
+            href={{pathname: navItem.slug || './'}}
+          >
+            {navItem.icon ? (
+              <Icon source={polarisIcons[navItem.icon as PolarisIcon]} />
+            ) : null}
+            {navItem.title}
+          </Link>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+function getNavItems(path: string): {[key: string]: NavItem} | undefined {
+  const paths = path.split('/').filter((segment) => segment);
+
+  const navItemPath = paths.join('.children.');
+  const currentNavItem = getObjectValue<NavItem>(nav, navItemPath);
+
+  const isOverviewPage = currentNavItem?.children !== undefined;
+
+  // Get the parent nav item if we're on a subpage
+  const parentItemPath = paths.slice(0, -1).join('.children.');
+  const parentNavItem = isOverviewPage
+    ? currentNavItem
+    : getObjectValue<NavItem>(nav, parentItemPath);
+
+  // Return if we're on a page that doesn't have a subnav
+  if (!parentNavItem) return;
+
+  return {
+    overview: {
+      title: 'Overview',
+      slug: parentNavItem?.slug,
+      order: 0,
+    },
+    ...parentNavItem.children,
+  };
+}
+
+function getObjectValue<T>(obj: any, path: string): T | undefined {
+  const keys = path.split('.');
+  let value = obj;
+
+  for (const key of keys) {
+    if (value && typeof value === 'object' && key in value) {
+      value = value[key];
+    } else {
+      return undefined;
+    }
+  }
+
+  return value;
+}
+
+export default Subnav;

--- a/polaris.shopify.com/src/components/Subnav/index.ts
+++ b/polaris.shopify.com/src/components/Subnav/index.ts
@@ -1,0 +1,3 @@
+import Subnav from './Subnav';
+
+export default Subnav;


### PR DESCRIPTION
Closes #10151

Creates a `Subnav` component that will inject subnav items into the MDX. We could also probably add this to the `Lede` component, but it is currently a standalone component.

> [!Note]
> The styles aren't updated, but are scaffolded to be quickly updated with the Uplift colors and Figma spec

```mdx

<Lede>{title}</Ledel>

<Subnav />

```

### Screenshot example using Typography

<img width="1471" alt="subnav-proto" src="https://github.com/Shopify/polaris/assets/11774595/270a00d8-15f9-484b-a5d5-de8fd162eb6f">
