### PR TITLE
Tweak main->next PR creation workflow to use existing PR and merge directly from main

### DIFF
--- a/.github/workflows/merge-main-into-next.yml
+++ b/.github/workflows/merge-main-into-next.yml
@@ -10,16 +10,18 @@ jobs:
   updateNext:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout next branch
-        uses: actions/checkout@v4
-        with:
-          ref: next
-      - name: Merge main into next branch
-        run: |
-          git checkout -b update-next
-          git fetch origin main:main
-          git merge main
-      - name: Create PR with for review by last commit author
-        run: gh pr create -B next -H update-next --title 'Merge latest main into next' --body 'This PR was opened by a GitHub Action on behalf of ${{ github.event.push.pusher.username }} following their recent push to main in order to keep the `next` branch up to date. ${{ github.event.push.pusher.username }} -- resolve any merge conflicts and ensure that your recent changes to main work as expected.' --reviewer ${{ github.event.push.pusher.username }}
+      - name: Check for existing PR
+        id: existing_pr
+        run: echo "pr-num=`gh pr list --head=main --base=next --json number --jq '.[].number'`"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create PR for review by last commit author
+        if: ${{ !steps.existing_pr.outputs.pr-num }}
+        run: gh pr create -B next -H main --title 'Merge latest main into next' --body 'This PR was opened by a GitHub Action on behalf of ${{ github.event.push.pusher.username }} following their recent push to main in order to keep the `next` branch up to date. ${{ github.event.push.pusher.username }} -- resolve any merge conflicts and ensure that your recent changes to main work as expected.' --reviewer ${{ github.event.push.pusher.username }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add last commit author as reviewer to existing PR
+        if: ${{ steps.existing_pr.outputs.pr-num }}
+        run: gh pr edit ${{ steps.existing_pr.outputs.pr-num }} --add-reviewer ${{ github.event.push.pusher.username }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
1. The `merge` step [was failing the whole workflow when there's conflicts](https://github.com/Shopify/polaris/actions/runs/6231366245/job/16912817651). I've opted to have GitHub handle the merge for us by asking it to merge `main` (head) into `next` (base).
2. The existing logic would attempt to recreate a PR for every workflow run. I've added logic which will simply add the pusher as a reviewer to an existing (open) PR if there is one.