### PR TITLE
Simpler addition of reviewers to PR in workflow

### DIFF
--- a/.github/workflows/merge-main-into-next.yml
+++ b/.github/workflows/merge-main-into-next.yml
@@ -25,6 +25,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add commit authors as reviewers to PR
-        run: gh pr edit `gh pr list --head=main --base=next --json number --jq '.[].number'` --add-reviewer=`gh pr list --head=main --base=next --json commits --jq='.[].commits.[].authors.[].login' | sort -u  | grep -v '\[bot\]' | sed 's/^.*$/"&"/g' | sed -z '$ s/\n$//' | tr '\n' ','`
+        run: gh pr edit `gh pr list --head=main --base=next --json number --jq '.[].number'` --add-reviewer=${{ github.triggering_actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Getting a [permissions error with the more robust way](https://github.com/Shopify/polaris/actions/runs/6232461382/job/16915687407), pressumably because of the request for "commits" also pulls in info about each author's "organisations" which I don't actually care about. 🤷 