### PR TITLE
[Docs] Update StatusBadge

### DIFF
--- a/polaris.shopify.com/src/components/StatusBadge/StatusBadge.module.scss
+++ b/polaris.shopify.com/src/components/StatusBadge/StatusBadge.module.scss
@@ -1,24 +1,37 @@
 .StatusBadge {
-  font-size: var(--font-size-100);
+  font-size: var(--p-font-size-75);
   letter-spacing: 0;
-  font-weight: var(--font-weight-400);
-  border-radius: var(--border-radius-round);
-  padding: 0.05rem 0.25rem;
-  color: var(--text);
+  font-weight: var(--p-font-weight-medium);
+  padding: var(--p-space-05) var(--p-space-2);
+  color: var(--p-color-text-subdued);
+  border-radius: var(--p-border-radius-2);
+}
 
-  &[data-value='alpha'] {
-    background: var(--surface-attention);
-  }
+.toneSuccess {
+  background-color: var(--p-color-bg-success);
+  color: var(--p-color-text-success);
+}
 
-  &[data-value='warning'],
-  &[data-value='deprecated'],
-  &[data-value='legacy'] {
-    background: var(--surface-warning);
-  }
+.toneInfo {
+  background-color: var(--p-color-bg-info);
+  color: var(--p-color-text-info);
+}
 
-  &[data-value='beta'],
-  &[data-value='information'],
-  &[data-value='new'] {
-    background: var(--surface-information);
-  }
+.toneAttention {
+  background-color: var(--p-color-bg-caution);
+  color: var(--p-color-text-caution);
+}
+
+.toneWarning {
+  background-color: var(--p-color-bg-warning);
+  color: var(--p-color-text-warning-experimental);
+}
+
+.toneCritical {
+  background-color: var(--p-color-bg-critical);
+  color: var(--p-color-text-critical);
+}
+
+.toneNew {
+  background-color: var(--p-color-bg-transparent-subdued-experimental);
 }

--- a/polaris.shopify.com/src/components/StatusBadge/StatusBadge.tsx
+++ b/polaris.shopify.com/src/components/StatusBadge/StatusBadge.tsx
@@ -1,15 +1,30 @@
 import {Status} from '../../types';
+import {className as classNames, variationName} from '../../utils/various';
 import styles from './StatusBadge.module.scss';
 
 interface Props {
   status: Status;
 }
+
+type Tone = 'info' | 'success' | 'warning' | 'critical' | 'attention' | 'new';
+
+const StatusToneMapping: {[S in Status]: Tone} = {
+  Alpha: 'info',
+  Beta: 'success',
+  Deprecated: 'critical',
+  Information: 'info',
+  Legacy: 'warning',
+  New: 'new',
+  Warning: 'warning',
+};
+
 function StatusBadge({status}: Props) {
-  return (
-    <div className={styles.StatusBadge} data-value={status.toLowerCase()}>
-      {status}
-    </div>
+  const className = classNames(
+    styles.StatusBadge,
+    styles[variationName('tone', StatusToneMapping[status])],
   );
+
+  return <div className={className}>{status}</div>;
 }
 
 export default StatusBadge;

--- a/polaris.shopify.com/src/utils/various.ts
+++ b/polaris.shopify.com/src/utils/various.ts
@@ -62,6 +62,10 @@ export const className = (...classNames: ClassName[]): string => {
     .join(' ');
 };
 
+export const variationName = (name: string, value: string) => {
+  return `${name}${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+};
+
 export const toPascalCase = (str: string): string =>
   (str.match(/[a-zA-Z0-9]+/g) || [])
     .map((w) => `${w.charAt(0).toUpperCase()}${w.slice(1)}`)


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #10457.
Updates StatusBadge component to align with uplifted Polaris Badge component.

### WHAT is this pull request doing?

Updated the existing StatusBadge component. The original intent was to replace it with the Polaris Badge component, but it requires wrapping StatusBadge in an AppProvider so I've updated the StatusBadge to align with the Polaris Badge component instead.

StatusBadge was also updated to use polaris-tokens wherever applicable instead of style guide tokens.
    <details>
      <summary>Example of all status badges for testing purposes</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/3859176c-01ef-4339-938c-e69ca7d64c9e" alt="Example of all status badges">
    </details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
