### PR TITLE
[Filters] Fix bug where changes to `appliedFilters` prop don't get respected

### DIFF
--- a/.changeset/three-trains-tie.md
+++ b/.changeset/three-trains-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated the Filters component to fix a bug where `appliedFilters` changes via prop were not being handled

--- a/.changeset/three-trains-tie.md
+++ b/.changeset/three-trains-tie.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Updated the Filters component to fix a bug where `appliedFilters` changes via prop were not being handled
+Fixed a bug in `Filters` where changes to the `appliedFilters` prop were not being handled

--- a/polaris-react/src/components/Filters/Filters.tsx
+++ b/polaris-react/src/components/Filters/Filters.tsx
@@ -141,6 +141,7 @@ export function Filters({
   const {mdDown} = useBreakpoints();
   const {polarisSummerEditions2023: se23} = useFeatures();
   const [popoverActive, setPopoverActive] = useState(false);
+  const [localPinnedFilters, setLocalPinnedFilters] = useState<string[]>([]);
   const hasMounted = useRef(false);
 
   useEffect(() => {
@@ -157,22 +158,43 @@ export function Filters({
   const appliedFilterKeys = appliedFilters?.map(({key}) => key);
 
   const pinnedFiltersFromPropsAndAppliedFilters = filters.filter(
-    ({pinned, key}) => {
-      const isPinnedOrApplied =
-        Boolean(pinned) || appliedFilterKeys?.includes(key);
-      return isPinnedOrApplied;
-    },
-  );
-  const [localPinnedFilters, setLocalPinnedFilters] = useState<string[]>(
-    pinnedFiltersFromPropsAndAppliedFilters.map(({key}) => key),
+    ({pinned, key}) =>
+      (Boolean(pinned) || appliedFilterKeys?.includes(key)) &&
+      // Filters that are pinned in local state display at the end of our list
+      !localPinnedFilters.find((filterKey) => filterKey === key),
   );
 
-  const pinnedFilters = localPinnedFilters
+  useEffect(() => {
+    const allAppliedFilterKeysInLocalPinnedFilters = appliedFilterKeys?.every(
+      (value) => localPinnedFilters.includes(value),
+    );
+
+    if (!allAppliedFilterKeysInLocalPinnedFilters) {
+      setLocalPinnedFilters((currentLocalPinnedFilters: string[]): string[] => {
+        const newPinnedFilters =
+          appliedFilterKeys?.filter(
+            (filterKey) =>
+              !currentLocalPinnedFilters.find(
+                (currentFilterKey) => currentFilterKey === filterKey,
+              ),
+          ) || [];
+
+        return [...currentLocalPinnedFilters, ...newPinnedFilters];
+      });
+    }
+  }, [appliedFilterKeys, localPinnedFilters]);
+
+  const pinnedFiltersFromLocalState = localPinnedFilters
     .map((key) => filters.find((filter) => filter.key === key))
     .reduce<FilterInterface[]>(
       (acc, filter) => (filter ? [...acc, filter] : acc),
       [],
     );
+
+  const pinnedFilters = [
+    ...pinnedFiltersFromPropsAndAppliedFilters,
+    ...pinnedFiltersFromLocalState,
+  ];
 
   const onFilterClick =
     ({key, onAction}: FilterInterface) =>

--- a/polaris-react/src/components/Filters/tests/Filters.test.tsx
+++ b/polaris-react/src/components/Filters/tests/Filters.test.tsx
@@ -205,6 +205,33 @@ describe('<Filters />', () => {
     });
   });
 
+  it('correctly adds the applied filters when updated via props', () => {
+    const appliedFilters = [
+      {
+        ...defaultProps.filters[2],
+        label: 'Value is Baz',
+        value: ['Baz'],
+        onRemove: jest.fn(),
+      },
+    ];
+    const wrapper = mountWithApp(
+      <Filters {...defaultProps} appliedFilters={[]} />,
+    );
+
+    expect(wrapper).not.toContainReactComponent(FilterPill, {
+      selected: true,
+    });
+
+    wrapper.setProps({
+      appliedFilters,
+    });
+
+    expect(wrapper.findAll(FilterPill)[1]).toHaveReactProps({
+      label: 'Value is Baz',
+      selected: true,
+    });
+  });
+
   it('correctly invokes the onRemove callback when clicking on an applied filter', () => {
     const scrollSpy = jest.fn();
     HTMLElement.prototype.scroll = scrollSpy;

--- a/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
@@ -10,6 +10,7 @@ import {
   RangeSlider,
   TextField,
   Card,
+  IndexFiltersMode,
 } from '@shopify/polaris';
 
 import {useSetIndexFiltersMode} from './hooks';
@@ -575,6 +576,292 @@ export function WithPinnedFilters() {
         />
       ),
       shortcut: true,
+    },
+    {
+      key: 'moneySpent',
+      label: 'Money spent',
+      filter: (
+        <RangeSlider
+          label="Money spent is between"
+          labelHidden
+          value={moneySpent || [0, 500]}
+          prefix="$"
+          output
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleMoneySpentChange}
+        />
+      ),
+    },
+  ];
+
+  const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
+  if (!isEmpty(accountStatus)) {
+    const key = 'accountStatus';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountStatus),
+      onRemove: handleAccountStatusRemove,
+    });
+  }
+  if (!isEmpty(moneySpent)) {
+    const key = 'moneySpent';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, moneySpent),
+      onRemove: handleMoneySpentRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, taggedWith),
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+
+  return (
+    <Card padding="0">
+      <IndexFilters
+        sortOptions={sortOptions}
+        sortSelected={sortSelected}
+        queryValue={queryValue}
+        queryPlaceholder="Searching in all"
+        onQueryChange={handleFiltersQueryChange}
+        onQueryClear={() => {}}
+        onSort={setSortSelected}
+        primaryAction={primaryAction}
+        cancelAction={{
+          onAction: onHandleCancel,
+          disabled: false,
+          loading: false,
+        }}
+        tabs={tabs}
+        selected={selected}
+        onSelect={setSelected}
+        canCreateNewView
+        onCreateNewView={onCreateNewView}
+        filters={filters}
+        appliedFilters={appliedFilters}
+        onClearAll={handleFiltersClearAll}
+        mode={mode}
+        setMode={setMode}
+      />
+      <Table />
+    </Card>
+  );
+
+  function disambiguateLabel(key, value) {
+    switch (key) {
+      case 'moneySpent':
+        return `Money spent is between $${value[0]} and $${value[1]}`;
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'accountStatus':
+        return value.map((val) => `Customer ${val}`).join(', ');
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(value) {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+
+export function WithNoPinnedAndPrefilledFilters() {
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+  const [itemStrings, setItemStrings] = useState([
+    'All',
+    'Unpaid',
+    'Open',
+    'Closed',
+    'Local delivery',
+    'Local pickup',
+  ]);
+  const deleteView = (index: number) => {
+    const newItemStrings = [...itemStrings];
+    newItemStrings.splice(index, 1);
+    setItemStrings(newItemStrings);
+    setSelected(0);
+  };
+
+  const duplicateView = async (name: string) => {
+    setItemStrings([...itemStrings, name]);
+    setSelected(itemStrings.length);
+    await sleep(1);
+    return true;
+  };
+
+  const tabs: TabProps[] = itemStrings.map((item, index) => ({
+    content: item,
+    index,
+    onAction: () => {},
+    id: `${item}-${index}`,
+    isLocked: index === 0,
+    actions:
+      index === 0
+        ? []
+        : [
+            {
+              type: 'rename',
+              onAction: () => {},
+              onPrimaryAction: async (value: string) => {
+                const newItemsStrings = tabs.map((item, idx) => {
+                  if (idx === index) {
+                    return value;
+                  }
+                  return item.content;
+                });
+                await sleep(1);
+                setItemStrings(newItemsStrings);
+                return true;
+              },
+            },
+            {
+              type: 'duplicate',
+              onPrimaryAction: async (name) => {
+                await sleep(1);
+                duplicateView(name);
+                return true;
+              },
+            },
+            {
+              type: 'edit',
+            },
+            {
+              type: 'delete',
+              onPrimaryAction: async (id: string) => {
+                await sleep(1);
+                deleteView(index);
+                return true;
+              },
+            },
+          ],
+  }));
+  const [selected, setSelected] = useState(0);
+  const onCreateNewView = async (value: string) => {
+    await sleep(500);
+    setItemStrings([...itemStrings, value]);
+    setSelected(itemStrings.length);
+    return true;
+  };
+  const sortOptions: IndexFiltersProps['sortOptions'] = [
+    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+  ];
+  const [sortSelected, setSortSelected] = useState(['order asc']);
+  const {mode, setMode} = useSetIndexFiltersMode(IndexFiltersMode.Filtering);
+  const onHandleCancel = () => {};
+
+  const onHandleSave = async () => {
+    await sleep(1);
+    return true;
+  };
+
+  const primaryAction: IndexFiltersProps['primaryAction'] =
+    selected === 0
+      ? {
+          type: 'save-as',
+          onAction: onCreateNewView,
+          disabled: false,
+          loading: false,
+        }
+      : {
+          type: 'save',
+          onAction: onHandleSave,
+          disabled: false,
+          loading: false,
+        };
+  const [accountStatus, setAccountStatus] = useState<string[] | null>([
+    'enabled',
+  ]);
+  const [moneySpent, setMoneySpent] = useState(null);
+  const [taggedWith, setTaggedWith] = useState('Returning customer');
+  const [queryValue, setQueryValue] = useState('');
+
+  const handleAccountStatusChange = useCallback(
+    (value) => setAccountStatus(value),
+    [],
+  );
+  const handleMoneySpentChange = useCallback(
+    (value) => setMoneySpent(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value) => setQueryValue(value),
+    [],
+  );
+  const handleAccountStatusRemove = useCallback(
+    () => setAccountStatus(null),
+    [],
+  );
+  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+  const handleFiltersClearAll = useCallback(() => {
+    handleAccountStatusRemove();
+    handleMoneySpentRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAccountStatusRemove,
+    handleMoneySpentRemove,
+    handleQueryValueRemove,
+    handleTaggedWithRemove,
+  ]);
+
+  const filters = [
+    {
+      key: 'accountStatus',
+      label: 'Account status',
+      filter: (
+        <ChoiceList
+          title="Account status"
+          titleHidden
+          choices={[
+            {label: 'Enabled', value: 'enabled'},
+            {label: 'Not invited', value: 'not invited'},
+            {label: 'Invited', value: 'invited'},
+            {label: 'Declined', value: 'declined'},
+          ]}
+          selected={accountStatus || []}
+          onChange={handleAccountStatusChange}
+          allowMultiple
+        />
+      ),
+      pinned: false,
+    },
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+      pinned: false,
     },
     {
       key: 'moneySpent',


### PR DESCRIPTION
### WHY are these changes introduced?

Navigating through the admin this morning I noticed an issue on the Orders index, when refreshing the page with a set of filters that don't match any existing filter, that the active filters don't appear in the Filters component. See video below:


https://github.com/Shopify/polaris/assets/2562596/bb170b1f-0739-4778-8474-54c1ffe29f6e

It turns out that the Orders index async loads the filter data if it does not match a saved view, and returns an empty `appliedFilters` array initially, before updating it with the correct `appliedFilters`.

Due to [this recently introduced change](https://github.com/Shopify/polaris/pull/10429) (sorry folks 🤡) we no longer are able to react to changes to the `appliedFilters` prop because of [this line](https://github.com/Shopify/polaris/pull/10429/files#diff-f21b98ea8a1f295706a4342f1e9ce543562f6c47d6d0682367e90bb7c23961d8R167), which sets the `localPinnedFilters` state only when the component mounts. In the case of the Orders index with the parameters mentioned above, this would set 0 pinned filters, due to the `appliedFilters` being empty. Because we don't call `setLocalPinnedFilters` on changes to the `appliedFilters`, this gives us the bug outlined in the video above. The filters do get set, but the filter does not appear in the pinned list.


### WHAT is this pull request doing?

This PR effectively reverts that change, and instead uses a more robust approach to ensure that FilterPills being powered by `appliedFilters` rather than `localPinnedState` do not vanish when they become unapplied (when the filter values for the filter are removed).

What we want to do, is add any applied filters to the array of `localPinnedState` so that when any filter value gets removed, the FilterPill remains as an unselected FilterPill. The merchant can then click out of the Popover to fully remove the FilterPill from the Filters bar.

This is achieved by a `useEffect` hook, which listens for changes to the `appliedFilterKeys` and `localPinnedFilters` arrays, and checks if all values within `appliedFilterKeys` are not currently in the `localPinnedFilters` array. If that is the case, we know that we want to add these keys to the `localPinnedFilters` array, to ensure they are added as `FilterPill`s if the `appliedFilters` value changes post-mount.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Video of Snapshot in use on Spinstance:

https://github.com/Shopify/polaris/assets/2562596/23decb34-c423-412c-90f0-213d89834786

- Spinstance: https://admin.web.orders-pill-check.marc-thomas.eu.spin.dev/store/shop1/orders?inContextTimeframe=none
- Note that adding in filters that don't match a saved view, and then refreshing, the applied filters appear as FilterPills.

- Storybook: https://5d559397bae39100201eedc1-kqkexazlai.chromatic.com/?path=/story/all-components-indexfilters--with-no-pinned-and-prefilled-filters&globals=polarisSummerEditions2023:true
- Note that removing the values from the "Account status" filter keeps the filter pill visible, until the Popover is closed

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
