### PR TITLE
Handle `buttonFrom` function in migration

### DIFF
--- a/.changeset/dull-dingos-collect.md
+++ b/.changeset/dull-dingos-collect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Handled `buttonFrom` and `buttonsFrom` functions in `Button` migration

--- a/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-from-function.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-from-function.input.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import {buttonFrom} from '@shopify/polaris';
+import {buttonFrom, buttonsFrom} from '@shopify/polaris';
 
 const myButtonFrom = buttonFrom;
 
@@ -12,6 +11,13 @@ export function App() {
   );
 
   const myButtonMarkup = myButtonFrom(
+    {content: 'Edit', onAction: () => {}},
+    {
+      primary: true,
+    },
+  );
+
+  const multipleButtonsMarkup = buttonsFrom(
     {content: 'Edit', onAction: () => {}},
     {
       primary: true,

--- a/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-from-function.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-from-function.input.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {buttonFrom} from '@shopify/polaris';
+
+const myButtonFrom = buttonFrom;
+
+export function App() {
+  const primaryFooterActionMarkup = buttonFrom(
+    {content: 'Edit', onAction: () => {}},
+    {
+      primary: true,
+    },
+  );
+
+  const myButtonMarkup = myButtonFrom(
+    {content: 'Edit', onAction: () => {}},
+    {
+      primary: true,
+    },
+  );
+
+  return primaryFooterActionMarkup;
+}

--- a/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-from-function.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-from-function.output.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {buttonFrom} from '@shopify/polaris';
 
 const myButtonFrom =
@@ -21,6 +20,15 @@ export function App() {
       primary: true,
     },
   );
+
+  const multipleButtonsMarkup =
+    /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+    buttonsFrom(
+      {content: 'Edit', onAction: () => {}},
+      {
+        primary: true,
+      },
+    );
 
   return primaryFooterActionMarkup;
 }

--- a/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-from-function.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-from-function.output.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {buttonFrom} from '@shopify/polaris';
+
+const myButtonFrom =
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+  buttonFrom;
+
+export function App() {
+  const primaryFooterActionMarkup =
+    /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+    buttonFrom(
+      {content: 'Edit', onAction: () => {}},
+      {
+        primary: true,
+      },
+    );
+
+  const myButtonMarkup = myButtonFrom(
+    {content: 'Edit', onAction: () => {}},
+    {
+      primary: true,
+    },
+  );
+
+  return primaryFooterActionMarkup;
+}

--- a/polaris-migrator/src/migrations/v12-react-update-button-component/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-button-component/transform.ts
@@ -28,7 +28,8 @@ export default function transformer(
       hasImportDeclaration(j, source, '@shopify/polaris') &&
       (hasImportSpecifier(j, source, 'Button', '@shopify/polaris') ||
         hasImportSpecifier(j, source, 'ButtonProps', '@shopify/polaris') ||
-        hasImportSpecifier(j, source, 'buttonFrom', '@shopify/polaris'))
+        hasImportSpecifier(j, source, 'buttonFrom', '@shopify/polaris') ||
+        hasImportSpecifier(j, source, 'buttonsFrom', '@shopify/polaris'))
     )
   ) {
     return fileInfo.source;
@@ -37,6 +38,10 @@ export default function transformer(
   const localFunctionName =
     getImportSpecifierName(j, source, 'buttonFrom', '@shopify/polaris') ||
     'buttonFrom';
+
+  const localFunctionPluralName =
+    getImportSpecifierName(j, source, 'buttonsFrom', '@shopify/polaris') ||
+    'buttonsFrom';
 
   const localElementName =
     getImportSpecifierName(j, source, 'Button', '@shopify/polaris') || 'Button';
@@ -314,7 +319,8 @@ export default function transformer(
       (path) =>
         path.node.name === localElementName ||
         path.node.name === localElementTypeName ||
-        path.node.name === localFunctionName,
+        path.node.name === localFunctionName ||
+        path.node.name === localFunctionPluralName,
     )
     .forEach((path) => {
       if (path.node.type !== 'Identifier') return;

--- a/polaris-migrator/src/migrations/v12-react-update-button-component/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-button-component/transform.ts
@@ -22,16 +22,21 @@ export default function transformer(
 ) {
   const source = j(fileInfo.source);
 
-  // If `Button` component name is not imported, exit
+  // If `Button` component name or `buttonFrom` function is not imported, exit
   if (
     !(
       hasImportDeclaration(j, source, '@shopify/polaris') &&
       (hasImportSpecifier(j, source, 'Button', '@shopify/polaris') ||
-        hasImportSpecifier(j, source, 'ButtonProps', '@shopify/polaris'))
+        hasImportSpecifier(j, source, 'ButtonProps', '@shopify/polaris') ||
+        hasImportSpecifier(j, source, 'buttonFrom', '@shopify/polaris'))
     )
   ) {
     return fileInfo.source;
   }
+
+  const localFunctionName =
+    getImportSpecifierName(j, source, 'buttonFrom', '@shopify/polaris') ||
+    'buttonFrom';
 
   const localElementName =
     getImportSpecifierName(j, source, 'Button', '@shopify/polaris') || 'Button';
@@ -308,7 +313,8 @@ export default function transformer(
     .filter(
       (path) =>
         path.node.name === localElementName ||
-        path.node.name === localElementTypeName,
+        path.node.name === localElementTypeName ||
+        path.node.name === localFunctionName,
     )
     .forEach((path) => {
       if (path.node.type !== 'Identifier') return;


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris/issues/10260

### WHAT is this pull request doing?

Adds a comment for manual migration of usages of the `buttonFrom` function. There are approximately 100 usages of it in `web` so handling these manually is quicker than trying to write a codemod for them.