### PR TITLE
[Page Actions] Remove shadow on focus states for buttons in Page Header

### DIFF
--- a/.changeset/purple-sheep-cough.md
+++ b/.changeset/purple-sheep-cough.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed the focus states of actions within the Page Header component

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -63,17 +63,16 @@
       background-color: var(--p-color-bg-strong) !important;
       border-radius: var(--p-border-radius-2) !important;
       /* stylelint-disable-next-line selector-max-combinators -- se23 */
-      &:hover {
+      &:is(:hover, :focus) {
         background-color: var(--p-color-bg-strong-hover) !important;
       }
       /* stylelint-disable-next-line selector-max-combinators -- se23 */
-      &:focus,
       &:active {
         background-color: var(--p-color-bg-strong-active) !important;
         box-shadow: var(--p-shadow-inset-md) !important;
       }
       /* stylelint-disable-next-line selector-max-combinators -- se23 */
-      &:focus:not(:active) {
+      &:focus-visible {
         /* stylelint-disable-next-line polaris/border/polaris/at-rule-disallowed-list -- se23 */
         @include no-focus-ring;
         outline: var(--p-border-width-2) solid
@@ -94,11 +93,10 @@
       button {
         color: var(--p-color-text-critical) !important;
         /* stylelint-disable-next-line selector-max-combinators, max-nesting-depth -- se23 */
-        &:hover {
+        &:is(:hover, :focus) {
           background-color: var(--p-color-bg-strong-hover) !important;
         }
         /* stylelint-disable-next-line selector-max-combinators, max-nesting-depth -- se23 */
-        &:focus,
         &:active {
           background-color: var(--p-color-bg-strong-active) !important;
         }

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -25,16 +25,31 @@ $action-menu-rollup-computed-width: 40px;
       box-shadow: none;
 
       /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
+      &:is(:hover, :focus, :focus-visible) {
+        /* stylelint-disable-next-line declaration-no-important -- SE23 match button group */
+        box-shadow: none !important;
+      }
+
+      /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
       &:hover {
-        box-shadow: none;
         background-color: var(--p-color-bg-strong-hover);
       }
 
       /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
       &:focus {
+        background-color: none;
+      }
+
+      /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
+      &:active {
         background-color: var(--p-color-bg-strong-active);
         /* stylelint-disable-next-line declaration-no-important -- SE23 match button group */
         box-shadow: var(--p-shadow-inset-md) !important;
+      }
+
+      /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
+      &:focus-visible {
+        background-color: var(--p-color-bg-strong-hover);
       }
     }
   }
@@ -54,6 +69,10 @@ $action-menu-rollup-computed-width: 40px;
     &:focus {
       border: var(--p-border-width-1) solid var(--p-color-border-strong) !important;
       // stylelint-enable declaration-no-important
+    }
+
+    &:focus {
+      background-color: var(--p-color-bg-strong);
     }
   }
 

--- a/polaris-react/src/components/Page/components/Header/Header.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.scss
@@ -31,13 +31,8 @@ $action-menu-rollup-computed-width: 40px;
       }
 
       /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
-      &:hover {
+      &:is(:hover, :focus-visible) {
         background-color: var(--p-color-bg-strong-hover);
-      }
-
-      /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
-      &:focus {
-        background-color: none;
       }
 
       /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
@@ -45,11 +40,6 @@ $action-menu-rollup-computed-width: 40px;
         background-color: var(--p-color-bg-strong-active);
         /* stylelint-disable-next-line declaration-no-important -- SE23 match button group */
         box-shadow: var(--p-shadow-inset-md) !important;
-      }
-
-      /* stylelint-disable-next-line selector-max-combinators -- SE23 match button group */
-      &:focus-visible {
-        background-color: var(--p-color-bg-strong-hover);
       }
     }
   }
@@ -69,10 +59,6 @@ $action-menu-rollup-computed-width: 40px;
     &:focus {
       border: var(--p-border-width-1) solid var(--p-color-border-strong) !important;
       // stylelint-enable declaration-no-important
-    }
-
-    &:focus {
-      background-color: var(--p-color-bg-strong);
     }
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Linked to https://github.com/Shopify/web/issues/104248

We have noticed that the focus states for the actions in the Page Header do not match the focus states for other buttons within Polaris. They have a darker background, and an inset shadow. This should be the `:active` state, not the `:focus-visible` state.

### WHAT is this pull request doing?

This PR is updating the visuals of the actions within the Page Header, namely the breadcrumbs and actions.

- We set the `:focus` style to match the `:hover` style, to bring this in line with other Button components.
- We include new `:focus-visible` style rules to remove the box shadow for the page actions
- We change the existing `:focus` styles to `:active`, as these styles should be applied when the page actions are pressed


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Storybook: https://5d559397bae39100201eedc1-kvktrdbvcr.chromatic.com/?path=/story/all-components-page--default&globals=polarisSummerEditions2023:true


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
