### PR TITLE
[Avatar] Add back `customer` prop

### DIFF
--- a/documentation/guides/migrating-from-v11-to-v12.md
+++ b/documentation/guides/migrating-from-v11-to-v12.md
@@ -12,7 +12,6 @@ Polaris v12.0.0 ([full release notes](https://github.com/Shopify/polaris/release
 
 `npx @shopify/polaris-migrator v12-react-avatar-component <path>`
 
-- Remove the `customer` prop
 - Replace the `size` prop with the new mapping below
 
 | Before                    | After       |

--- a/polaris-migrator/src/migrations/v12-react-avatar-component/tests/v12-react-avatar-component.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-avatar-component/tests/v12-react-avatar-component.output.tsx
@@ -4,11 +4,11 @@ import {Avatar} from '@shopify/polaris';
 export function App() {
   return (
     <>
-      <Avatar size="unknown" />
-      <Avatar size="xs" />
-      <Avatar size="sm" />
-      <Avatar size="md" />
-      <Avatar size="lg" />
+      <Avatar customer size="unknown" />
+      <Avatar customer size="xs" />
+      <Avatar customer size="sm" />
+      <Avatar customer size="md" />
+      <Avatar customer size="lg" />
       <Avatar size="xl" />
       <Avatar size="xl" />
     </>

--- a/polaris-migrator/src/migrations/v12-react-avatar-component/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-avatar-component/transform.ts
@@ -6,7 +6,7 @@ import {
   hasImportSpecifier,
   normalizeImportSourcePaths,
 } from '../../utilities/imports';
-import {removeJSXAttributes, replaceJSXAttributes} from '../../utilities/jsx';
+import {replaceJSXAttributes} from '../../utilities/jsx';
 
 export interface MigrationOptions extends Options {
   relative?: boolean;
@@ -45,8 +45,6 @@ export default function transformer(
 
   // Find all JSX elements with the name 'Avatar'
   source.findJSXElements(localElementName).forEach((element) => {
-    // Remove the 'customer' prop
-    removeJSXAttributes(j, element, 'customer');
     // Replace the 'size' prop value with the new size
     replaceJSXAttributes(j, element, 'size', 'size', sizeMapping);
   });

--- a/polaris-react/src/components/ActionList/ActionList.stories.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.stories.tsx
@@ -374,7 +374,7 @@ export function WithAPrefixAndASuffix() {
           },
           {
             content: 'Or there',
-            prefix: <Avatar name="Farrah" size="sm" />,
+            prefix: <Avatar customer name="Farrah" size="sm" />,
             suffix: <Icon source={ChevronRightMinor} />,
           },
         ]}

--- a/polaris-react/src/components/AppProvider/AppProvider.stories.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.stories.tsx
@@ -58,7 +58,7 @@ export function Default(_, context) {
             ]}
             renderItem={(item) => {
               const {id, url, name, location} = item;
-              const media = <Avatar size="md" name={name} />;
+              const media = <Avatar customer size="md" name={name} />;
 
               return (
                 <ResourceList.Item id={id} url={url} media={media}>
@@ -121,7 +121,7 @@ export function WithI18n(_, context) {
             ]}
             renderItem={(item) => {
               const {id, url, name, location} = item;
-              const media = <Avatar size="md" name={name} />;
+              const media = <Avatar customer size="md" name={name} />;
 
               return (
                 <ResourceList.Item id={id} url={url} media={media}>

--- a/polaris-react/src/components/Avatar/Avatar.stories.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.stories.tsx
@@ -79,7 +79,7 @@ export function All() {
             </Text>
             <InlineStack gap="2" blockAlign="center">
               {sizes.map((size) => (
-                <Avatar key={size} size={size} />
+                <Avatar customer key={size} size={size} />
               ))}
             </InlineStack>
           </BlockStack>
@@ -189,11 +189,11 @@ export function ExtraSmallInContext() {
           items={[
             {
               content: 'Chet Baker',
-              prefix: <Avatar size="xs" name="Chet Baker" />,
+              prefix: <Avatar customer size="xs" name="Chet Baker" />,
             },
             {
               content: 'Farrah Fawcett',
-              prefix: <Avatar size="xs" name="Farrah Fawcett" />,
+              prefix: <Avatar customer size="xs" name="Farrah Fawcett" />,
             },
           ]}
         />

--- a/polaris-react/src/components/Avatar/Avatar.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.tsx
@@ -55,6 +55,8 @@ export interface AvatarProps {
   name?: string;
   /** Initials of person to display */
   initials?: string;
+  /** Whether the avatar is for a customer */
+  customer?: boolean;
   /** URL of the avatar image which falls back to initials if the image fails to load */
   source?: string;
   /** Callback fired when the image fails to load  */
@@ -68,6 +70,7 @@ export function Avatar({
   source,
   onError,
   initials,
+  customer,
   size = 'md',
   accessibilityLabel,
 }: AvatarProps) {
@@ -112,7 +115,9 @@ export function Avatar({
     styles.Avatar,
     size && styles[variationName('size', size)],
     hasImage && status === Status.Loaded && styles.imageHasLoaded,
-    !source && styles[variationName('style', styleClass(nameString))],
+    !customer &&
+      !source &&
+      styles[variationName('style', styleClass(nameString))],
   );
 
   const textClassName = classNames(
@@ -158,20 +163,21 @@ export function Avatar({
     </>
   );
 
-  const avatarBody = !initials ? (
-    avatarPath
-  ) : (
-    <text
-      className={textClassName}
-      x="50%"
-      y="50%"
-      dy={verticalOffset}
-      fill="currentColor"
-      textAnchor="middle"
-    >
-      {initials}
-    </text>
-  );
+  const avatarBody =
+    customer || !initials ? (
+      avatarPath
+    ) : (
+      <text
+        className={textClassName}
+        x="50%"
+        y="50%"
+        dy={verticalOffset}
+        fill="currentColor"
+        textAnchor="middle"
+      >
+        {initials}
+      </text>
+    );
 
   const svgMarkup = hasImage ? null : (
     <span className={styles.Initials}>

--- a/polaris-react/src/components/Avatar/tests/Avatar.test.tsx
+++ b/polaris-react/src/components/Avatar/tests/Avatar.test.tsx
@@ -46,19 +46,19 @@ describe('<Avatar />', () => {
 
   describe('customer', () => {
     it('renders an inline svg', () => {
-      const avatar = mountWithApp(<Avatar />);
+      const avatar = mountWithApp(<Avatar customer />);
       expect(avatar).toContainReactComponentTimes('svg', 1);
     });
 
     it('does not render a customer Avatar if a source is provided', () => {
       const src = 'image/path/';
-      const avatar = mountWithApp(<Avatar source={src} />);
+      const avatar = mountWithApp(<Avatar customer source={src} />);
       expect(avatar).not.toContainReactComponent('svg');
     });
 
     it('does not apply a style class', () => {
       const src = 'image/path/';
-      const avatar = mountWithApp(<Avatar source={src} />);
+      const avatar = mountWithApp(<Avatar customer source={src} />);
       expect(avatar).toContainReactComponent('span', {
         className: 'Avatar sizeMd',
       });

--- a/polaris-react/src/components/Filters/Filters.stories.tsx
+++ b/polaris-react/src/components/Filters/Filters.stories.tsx
@@ -184,7 +184,7 @@ export function WithAResourceList() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -500,7 +500,7 @@ export function WithChildrenContent() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -631,7 +631,7 @@ export function Disabled() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -781,7 +781,7 @@ export function SomeDisabled() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -983,7 +983,7 @@ export function WithQueryFieldHidden() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -1181,7 +1181,7 @@ export function WithQueryFieldDisabled() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -1405,7 +1405,7 @@ export function WithAdditionalFilterSections() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris-react/src/components/LegacyFilters/LegacyFilters.stories.tsx
+++ b/polaris-react/src/components/LegacyFilters/LegacyFilters.stories.tsx
@@ -179,7 +179,7 @@ export function WithAResourceList() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -493,7 +493,7 @@ export function WithChildrenContent() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -621,7 +621,7 @@ export function Disabled() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -768,7 +768,7 @@ export function SomeDisabled() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -897,7 +897,7 @@ export function WithoutClearButton() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -1090,7 +1090,7 @@ export function WithHelpText() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -1286,7 +1286,7 @@ export function WithQueryFieldHidden() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item
@@ -1482,7 +1482,7 @@ export function WithQueryFieldDisabled() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris-react/src/components/OptionList/OptionList.stories.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.stories.tsx
@@ -334,7 +334,7 @@ export function All() {
                 {
                   value: 'avatar_extra_small',
                   label: 'Avatar extra small',
-                  media: <Avatar name="Hello World" size="sm" />,
+                  media: <Avatar name="Hello World" size="xs" />,
                 },
                 {
                   value: 'avatar_small',

--- a/polaris-react/src/components/ResourceItem/ResourceItem.stories.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.stories.tsx
@@ -102,7 +102,9 @@ export function SelectableWithMedia() {
             <ResourceItem
               id={id}
               url={url}
-              media={<Avatar size="md" name={name} source={avatarSource} />}
+              media={
+                <Avatar customer size="md" name={name} source={avatarSource} />
+              }
               accessibilityLabel={`View details for ${name}`}
               name={name}
             >
@@ -142,7 +144,9 @@ export function WithMedia() {
             <ResourceItem
               id={id}
               url={url}
-              media={<Avatar size="md" name={name} source={avatarSource} />}
+              media={
+                <Avatar customer size="md" name={name} source={avatarSource} />
+              }
               accessibilityLabel={`View details for ${name}`}
               name={name}
             >
@@ -183,7 +187,9 @@ export function WithShortcutActions() {
             <ResourceItem
               id={id}
               url={url}
-              media={<Avatar size="md" name={name} source={avatarSource} />}
+              media={
+                <Avatar customer size="md" name={name} source={avatarSource} />
+              }
               shortcutActions={[
                 {content: 'View latest order', url: latestOrderUrl},
               ]}
@@ -230,7 +236,9 @@ export function WithPersistedShortcutActions() {
             <ResourceItem
               id={id}
               url={url}
-              media={<Avatar size="md" name={name} source={avatarSource} />}
+              media={
+                <Avatar customer size="md" name={name} source={avatarSource} />
+              }
               persistActions
               shortcutActions={shortcutActions}
               accessibilityLabel={`View details for ${name}`}
@@ -273,7 +281,9 @@ export function WithVerticalAlignment() {
               verticalAlignment="center"
               id={id}
               url={url}
-              media={<Avatar size="md" name={name} source={avatarSource} />}
+              media={
+                <Avatar customer size="md" name={name} source={avatarSource} />
+              }
               accessibilityLabel={`View details for ${name}`}
               name={name}
             >

--- a/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -559,7 +559,7 @@ describe('<ResourceItem />', () => {
     it('includes an <Avatar /> if one is provided', () => {
       const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
-          <ResourceItem id={itemId} url={url} media={<Avatar />} />
+          <ResourceItem id={itemId} url={url} media={<Avatar customer />} />
         </ResourceListContext.Provider>,
       );
       expect(wrapper).toContainReactComponent(Avatar);

--- a/polaris-react/src/components/ResourceList/ResourceList.stories.tsx
+++ b/polaris-react/src/components/ResourceList/ResourceList.stories.tsx
@@ -39,7 +39,7 @@ export function Default() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
 
           return (
             <ResourceItem
@@ -147,7 +147,7 @@ export function WithSelectionAndNoBulkActions() {
 
   function renderItem(item) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem
@@ -228,7 +228,7 @@ export function WithBulkActions() {
 
   function renderItem(item) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem
@@ -305,7 +305,7 @@ export function WithBulkActionsAndManyItems() {
 
   function renderItem(item) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem
@@ -387,7 +387,7 @@ export function WithLoadingState() {
 
   function renderItem(item) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem
@@ -428,7 +428,7 @@ export function WithTotalCount() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
 
           return (
             <ResourceItem
@@ -474,7 +474,7 @@ export function WithHeaderContent() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
 
           return (
             <ResourceItem
@@ -542,7 +542,7 @@ export function WithSorting() {
 
   function renderItem(item) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem
@@ -596,7 +596,7 @@ export function WithAlternateTool() {
 
   function renderItem(item) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem
@@ -706,7 +706,7 @@ export function WithFiltering() {
 
   function renderItem(item) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem id={id} url={url} media={media}>
@@ -819,7 +819,7 @@ export function WithACustomEmptySearchResultState() {
 
   function renderItem(item) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem id={id} url={url} media={media}>
@@ -874,7 +874,7 @@ export function WithItemShortcutActions() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location, latestOrderUrl} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
           const shortcutActions = latestOrderUrl
             ? [
                 {
@@ -930,7 +930,7 @@ export function WithPersistentItemShortcutActions() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location, latestOrderUrl} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
           const shortcutActions = latestOrderUrl
             ? [
                 {
@@ -1050,7 +1050,7 @@ export function WithMultiselect() {
 
   function renderItem(item, _, index) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem
@@ -1208,7 +1208,7 @@ export function WithAllOfItsElements() {
 
   function renderItem(item) {
     const {id, url, name, location, latestOrderUrl} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
     const shortcutActions = latestOrderUrl
       ? [{content: 'View latest order', url: latestOrderUrl}]
       : null;

--- a/polaris.shopify.com/content/components/images-and-icons/avatar.md
+++ b/polaris.shopify.com/content/components/images-and-icons/avatar.md
@@ -44,7 +44,7 @@ Avatars are used to show a thumbnail representation of an individual or business
 
 ## Best practices
 
-Avatars should be one of 6 sizes:
+Avatars should be one of 5 sizes:
 
 - Extra small (20 x 20 px): use in tightly condensed layouts
 - Small (24 × 24 px): use when the medium size is too big for the layout, or when the avatar has less importance

--- a/polaris.shopify.com/pages/examples/action-list-with-a-prefix-and-a-suffix.tsx
+++ b/polaris.shopify.com/pages/examples/action-list-with-a-prefix-and-a-suffix.tsx
@@ -22,7 +22,7 @@ function ActionListWithPrefixSuffixExample() {
           },
           {
             content: 'Or there',
-            prefix: <Avatar name="Farrah" size="sm" />,
+            prefix: <Avatar customer name="Farrah" size="sm" />,
             suffix: <Icon source={ChevronRightMinor} />,
           },
         ]}

--- a/polaris.shopify.com/pages/examples/app-provider-default.tsx
+++ b/polaris.shopify.com/pages/examples/app-provider-default.tsx
@@ -49,7 +49,7 @@ function AppProviderExample() {
             ]}
             renderItem={(item) => {
               const {id, url, name, location} = item;
-              const media = <Avatar size="md" name={name} />;
+              const media = <Avatar customer size="md" name={name} />;
 
               return (
                 <ResourceList.Item id={id} url={url} media={media}>

--- a/polaris.shopify.com/pages/examples/app-provider-with-i18n.tsx
+++ b/polaris.shopify.com/pages/examples/app-provider-with-i18n.tsx
@@ -49,7 +49,7 @@ function AppProviderI18NExample() {
             ]}
             renderItem={(item) => {
               const {id, url, name, location} = item;
-              const media = <Avatar size="md" name={name} />;
+              const media = <Avatar customer size="md" name={name} />;
 
               return (
                 <ResourceList.Item id={id} url={url} media={media}>

--- a/polaris.shopify.com/pages/examples/avatar-default.tsx
+++ b/polaris.shopify.com/pages/examples/avatar-default.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function AvatarExample() {
-  return <Avatar name="Farrah" />;
+  return <Avatar customer name="Farrah" />;
 }
 
 export default withPolarisExample(AvatarExample);

--- a/polaris.shopify.com/pages/examples/avatar-extra-small.tsx
+++ b/polaris.shopify.com/pages/examples/avatar-extra-small.tsx
@@ -18,11 +18,11 @@ function ExtraSmallAvatarExample() {
           items={[
             {
               content: 'Chet Baker',
-              prefix: <Avatar size="xs" name="Chet Baker" />,
+              prefix: <Avatar customer size="xs" name="Chet Baker" />,
             },
             {
               content: 'Farrah Fawcett',
-              prefix: <Avatar size="xs" name="Farrah Fawcett" />,
+              prefix: <Avatar customer size="xs" name="Farrah Fawcett" />,
             },
           ]}
         />

--- a/polaris.shopify.com/pages/examples/filters-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-disabled.tsx
@@ -101,7 +101,7 @@ function FiltersDisabledExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/filters-with-a-resource-list.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-a-resource-list.tsx
@@ -177,7 +177,7 @@ function FiltersWithAResourceListExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/filters-with-children-content.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-children-content.tsx
@@ -105,7 +105,7 @@ function FiltersWithChildrenContentExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/filters-with-query-field-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-query-field-disabled.tsx
@@ -178,7 +178,7 @@ function FiltersWithQueryFieldDisabledExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/filters-with-query-field-hidden.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-query-field-hidden.tsx
@@ -187,7 +187,7 @@ function ResourceListFiltersExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/filters-with-some-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/filters-with-some-disabled.tsx
@@ -124,7 +124,7 @@ function FiltersWithSomeDisabledExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/legacy-filters-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-filters-disabled.tsx
@@ -98,7 +98,7 @@ function DisableAllFiltersExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/legacy-filters-some-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-filters-some-disabled.tsx
@@ -127,7 +127,7 @@ function DisableSomeFiltersExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/legacy-filters-with-a-resource-list.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-filters-with-a-resource-list.tsx
@@ -173,7 +173,7 @@ function ResourceListFiltersExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/legacy-filters-with-children-content.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-filters-with-children-content.tsx
@@ -101,7 +101,7 @@ function FiltersExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/legacy-filters-with-help-text.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-filters-with-help-text.tsx
@@ -175,7 +175,7 @@ function ResourceListFiltersExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/legacy-filters-with-query-field-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-filters-with-query-field-disabled.tsx
@@ -174,7 +174,7 @@ function ResourceListFiltersExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/legacy-filters-with-query-field-hidden.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-filters-with-query-field-hidden.tsx
@@ -174,7 +174,7 @@ function ResourceListFiltersExample() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/legacy-filters-without-clear-button.tsx
+++ b/polaris.shopify.com/pages/examples/legacy-filters-without-clear-button.tsx
@@ -106,7 +106,7 @@ function Playground() {
           ]}
           renderItem={(item) => {
             const {id, url, name, location} = item;
-            const media = <Avatar size="md" name={name} />;
+            const media = <Avatar customer size="md" name={name} />;
 
             return (
               <ResourceList.Item

--- a/polaris.shopify.com/pages/examples/resource-item-with-media.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-media.tsx
@@ -30,7 +30,9 @@ function ResourceItemExample() {
             <ResourceItem
               id={id}
               url={url}
-              media={<Avatar size="md" name={name} source={avatarSource} />}
+              media={
+                <Avatar customer size="md" name={name} source={avatarSource} />
+              }
               accessibilityLabel={`View details for ${name}`}
               name={name}
             >

--- a/polaris.shopify.com/pages/examples/resource-item-with-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-shortcut-actions.tsx
@@ -34,7 +34,9 @@ function ResourceItemExample() {
             <ResourceItem
               id={id}
               url={url}
-              media={<Avatar size="md" name={name} source={avatarSource} />}
+              media={
+                <Avatar customer size="md" name={name} source={avatarSource} />
+              }
               shortcutActions={shortcutActions}
               accessibilityLabel={`View details for ${name}`}
               name={name}

--- a/polaris.shopify.com/pages/examples/resource-item-with-vertical-alignment.tsx
+++ b/polaris.shopify.com/pages/examples/resource-item-with-vertical-alignment.tsx
@@ -31,7 +31,9 @@ function ResourceItemExample() {
               verticalAlignment="center"
               id={id}
               url={url}
-              media={<Avatar size="md" name={name} source={avatarSource} />}
+              media={
+                <Avatar customer size="md" name={name} source={avatarSource} />
+              }
               accessibilityLabel={`View details for ${name}`}
               name={name}
             >

--- a/polaris.shopify.com/pages/examples/resource-list-default.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-default.tsx
@@ -29,7 +29,7 @@ function ResourceListExample() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
 
           return (
             <ResourceItem

--- a/polaris.shopify.com/pages/examples/resource-list-with-a-custom-empty-search-result-state.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-a-custom-empty-search-result-state.tsx
@@ -104,7 +104,7 @@ function ResourceListWithFilteringExample() {
     location: string;
   }) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem id={id} url={url} media={media}>

--- a/polaris.shopify.com/pages/examples/resource-list-with-all-of-its-elements.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-all-of-its-elements.tsx
@@ -154,7 +154,7 @@ function ResourceListExample() {
 
   function renderItem(item: typeof items[number]) {
     const {id, url, name, location, latestOrderUrl} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
     const shortcutActions = latestOrderUrl
       ? [{content: 'View latest order', url: latestOrderUrl}]
       : undefined;

--- a/polaris.shopify.com/pages/examples/resource-list-with-alternate-tool.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-alternate-tool.tsx
@@ -43,7 +43,7 @@ function ResourceListWithAlternateToolExample() {
 
   function renderItem(item: typeof items[number]) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem

--- a/polaris.shopify.com/pages/examples/resource-list-with-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-bulk-actions.tsx
@@ -72,7 +72,7 @@ function ResourceListWithBulkActionsExample() {
 
   function renderItem(item: typeof items[number]) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem

--- a/polaris.shopify.com/pages/examples/resource-list-with-filtering.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-filtering.tsx
@@ -108,7 +108,7 @@ function ResourceListWithFilteringExample() {
 
   function renderItem(item: typeof items[number]) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem id={id} url={url} media={media}>

--- a/polaris.shopify.com/pages/examples/resource-list-with-item-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-item-shortcut-actions.tsx
@@ -31,7 +31,7 @@ function ResourceListExample() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location, latestOrderUrl} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
           const shortcutActions = latestOrderUrl
             ? [
                 {

--- a/polaris.shopify.com/pages/examples/resource-list-with-loading-state.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-loading-state.tsx
@@ -78,7 +78,7 @@ function ResourceListWithLoadingExample() {
     location: string;
   }) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem

--- a/polaris.shopify.com/pages/examples/resource-list-with-multiselect.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-multiselect.tsx
@@ -97,7 +97,7 @@ function ResourceListExample() {
 
   function renderItem(item: typeof items[number], _: string, index: number) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem

--- a/polaris.shopify.com/pages/examples/resource-list-with-persistent-item-shortcut-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-persistent-item-shortcut-actions.tsx
@@ -31,7 +31,7 @@ function ResourceListExample() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location, latestOrderUrl} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
           const shortcutActions = latestOrderUrl
             ? [
                 {

--- a/polaris.shopify.com/pages/examples/resource-list-with-selection-and-no-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-selection-and-no-bulk-actions.tsx
@@ -49,7 +49,7 @@ function ResourceListWithSelectionExample() {
 
   function renderItem(item: typeof items[number]) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem

--- a/polaris.shopify.com/pages/examples/resource-list-with-sorting.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-sorting.tsx
@@ -52,7 +52,7 @@ function ResourceListWithSortingExample() {
 
   function renderItem(item: typeof items[number]) {
     const {id, url, name, location} = item;
-    const media = <Avatar size="md" name={name} />;
+    const media = <Avatar customer size="md" name={name} />;
 
     return (
       <ResourceItem

--- a/polaris.shopify.com/pages/examples/resource-list-with-total-count.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-total-count.tsx
@@ -29,7 +29,7 @@ function ResourceListWithTotalItemsCount() {
         ]}
         renderItem={(item) => {
           const {id, url, name, location} = item;
-          const media = <Avatar size="md" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
 
           return (
             <ResourceItem


### PR DESCRIPTION
We need to add back the `customer` prop to support the gray + customer icon combination.