### PR TITLE
[polaris.shopify.com] Fix preview for color tokens

### DIFF
--- a/.changeset/silly-years-search.md
+++ b/.changeset/silly-years-search.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Updated logic for rendering `color` custom property previews in `TokenList`

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -232,7 +232,7 @@ function TokenPreview({name, value}: TokenPreviewProps) {
   };
 
   // Colors
-  if (value.startsWith('rgba')) {
+  if (value.startsWith('rgba') || value.includes('color-')) {
     return (
       <div
         {...previewDivAttributes}


### PR DESCRIPTION
### WHY are these changes introduced?

Updates conditional logic to render token preview in TokenList for tokens that don't use `rgba()` as the value.

### WHAT is this pull request doing?

Update logic to render token preview for color tokens with `rgba()` or `--p-color` as the value.
    <details>
      <summary>Color tokens — before</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/a2442fa0-87e9-44a5-afe7-b6962089d879" alt="Color tokens — before">
    </details>
    <details>
      <summary>Color tokens — after</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/98827dc6-1340-4c35-938e-16a671a0bad2" alt="Color tokens — after">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
