### PR TITLE
Add AppProvider instructions to migration guide

### DIFF
--- a/documentation/guides/migrating-from-v11-to-v12.md
+++ b/documentation/guides/migrating-from-v11-to-v12.md
@@ -136,3 +136,7 @@ Polaris v12.0.0 ([full release notes](https://github.com/Shopify/polaris/release
 **DescriptionList**
 
 `npx @shopify/polaris-migrator react-rename-component-prop <path> --componentName="DescriptionList" --from="spacing" --to="gap"`
+
+**AppProvider**
+
+The `AppProvider`'s `features` prop no longer accepts the keys `polarisSummerEditions2023` and `polarisSummerEditions2023ShadowBevelOptOut`. You should be able to remove the `features` prop completely from your Polaris `AppProvider` since there aren't any feature flags in Polaris for v12.


### PR DESCRIPTION
Resolves https://github.com/Shopify/polaris/issues/10451

I could make a migration to remove the `features` attribute from `AppProvider` but since consumers should only have a few app providers at most, a migration may be overkill. Just added a note to the migration guide instead.