### PR TITLE
[polaris.shopify.com] Fix example styling

### DIFF
--- a/.changeset/hungry-bobcats-drum.md
+++ b/.changeset/hungry-bobcats-drum.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Updated component example backgrounds

--- a/polaris.shopify.com/pages/examples/badge-attention.tsx
+++ b/polaris.shopify.com/pages/examples/badge-attention.tsx
@@ -1,9 +1,13 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
-  return <Badge status="attention">Open</Badge>;
+  return (
+    <Card>
+      <Badge status="attention">Open</Badge>
+    </Card>
+  );
 }
 
 export default withPolarisExample(BadgeExample);

--- a/polaris.shopify.com/pages/examples/badge-complete.tsx
+++ b/polaris.shopify.com/pages/examples/badge-complete.tsx
@@ -1,9 +1,13 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
-  return <Badge progress="complete">Fulfilled</Badge>;
+  return (
+    <Card>
+      <Badge progress="complete">Fulfilled</Badge>
+    </Card>
+  );
 }
 
 export default withPolarisExample(BadgeExample);

--- a/polaris.shopify.com/pages/examples/badge-critical.tsx
+++ b/polaris.shopify.com/pages/examples/badge-critical.tsx
@@ -1,9 +1,13 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
-  return <Badge status="critical">Action required</Badge>;
+  return (
+    <Card>
+      <Badge status="critical">Action required</Badge>
+    </Card>
+  );
 }
 
 export default withPolarisExample(BadgeExample);

--- a/polaris.shopify.com/pages/examples/badge-default.tsx
+++ b/polaris.shopify.com/pages/examples/badge-default.tsx
@@ -1,9 +1,13 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
-  return <Badge>Fulfilled</Badge>;
+  return (
+    <Card>
+      <Badge>Fulfilled</Badge>
+    </Card>
+  );
 }
 
 export default withPolarisExample(BadgeExample);

--- a/polaris.shopify.com/pages/examples/badge-incomplete.tsx
+++ b/polaris.shopify.com/pages/examples/badge-incomplete.tsx
@@ -1,12 +1,14 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
   return (
-    <Badge progress="incomplete" status="attention">
-      Unfulfilled
-    </Badge>
+    <Card>
+      <Badge progress="incomplete" status="attention">
+        Unfulfilled
+      </Badge>
+    </Card>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/badge-informational.tsx
+++ b/polaris.shopify.com/pages/examples/badge-informational.tsx
@@ -1,9 +1,13 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
-  return <Badge status="info">Draft</Badge>;
+  return (
+    <Card>
+      <Badge status="info">Draft</Badge>
+    </Card>
+  );
 }
 
 export default withPolarisExample(BadgeExample);

--- a/polaris.shopify.com/pages/examples/badge-partially-complete.tsx
+++ b/polaris.shopify.com/pages/examples/badge-partially-complete.tsx
@@ -1,12 +1,14 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
   return (
-    <Badge progress="partiallyComplete" status="warning">
-      Partially fulfilled
-    </Badge>
+    <Card>
+      <Badge progress="partiallyComplete" status="warning">
+        Partially fulfilled
+      </Badge>
+    </Card>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/badge-small.tsx
+++ b/polaris.shopify.com/pages/examples/badge-small.tsx
@@ -1,9 +1,13 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
-  return <Badge size="small">Fulfilled</Badge>;
+  return (
+    <Card>
+      <Badge size="small">Fulfilled</Badge>
+    </Card>
+  );
 }
 
 export default withPolarisExample(BadgeExample);

--- a/polaris.shopify.com/pages/examples/badge-success.tsx
+++ b/polaris.shopify.com/pages/examples/badge-success.tsx
@@ -1,9 +1,13 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
-  return <Badge status="success">Active</Badge>;
+  return (
+    <Card>
+      <Badge status="success">Active</Badge>
+    </Card>
+  );
 }
 
 export default withPolarisExample(BadgeExample);

--- a/polaris.shopify.com/pages/examples/badge-warning.tsx
+++ b/polaris.shopify.com/pages/examples/badge-warning.tsx
@@ -1,9 +1,13 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
-  return <Badge status="warning">On hold</Badge>;
+  return (
+    <Card>
+      <Badge status="warning">On hold</Badge>
+    </Card>
+  );
 }
 
 export default withPolarisExample(BadgeExample);

--- a/polaris.shopify.com/pages/examples/badge-with-status-and-progress-label-override.tsx
+++ b/polaris.shopify.com/pages/examples/badge-with-status-and-progress-label-override.tsx
@@ -1,16 +1,18 @@
-import {Badge} from '@shopify/polaris';
+import {Badge, Card} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BadgeExample() {
   return (
-    <Badge
-      status="success"
-      progress="complete"
-      statusAndProgressLabelOverride="Status: Published. Your online store is visible."
-    >
-      Published
-    </Badge>
+    <Card>
+      <Badge
+        status="success"
+        progress="complete"
+        toneAndProgressLabelOverride="Status: Published. Your online store is visible."
+      >
+        Published
+      </Badge>
+    </Card>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/badge-with-status-and-progress-label-override.tsx
+++ b/polaris.shopify.com/pages/examples/badge-with-status-and-progress-label-override.tsx
@@ -8,7 +8,7 @@ function BadgeExample() {
       <Badge
         status="success"
         progress="complete"
-        toneAndProgressLabelOverride="Status: Published. Your online store is visible."
+        statusAndProgressLabelOverride="Status: Published. Your online store is visible."
       >
         Published
       </Badge>

--- a/polaris.shopify.com/pages/examples/bleed-horizontal.tsx
+++ b/polaris.shopify.com/pages/examples/bleed-horizontal.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
-import {Bleed, Box, Text, HorizontalStack} from '@shopify/polaris';
+
+import {Bleed, Card, Text, HorizontalStack} from '@shopify/polaris';
 
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BleedHorizontalExample() {
   return (
-    <Box
-      background="bg"
-      borderWidth="1"
-      borderColor="border-subdued"
-      padding="8"
-    >
-      <Bleed marginInline="8">
+    <Card>
+      <Text as="h2" variant="bodyMd">
+        Content inside a card
+      </Text>
+      <Bleed marginInline="4">
         <Placeholder label="marginInline" />
       </Bleed>
-    </Box>
+    </Card>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/bleed-specific-direction.tsx
+++ b/polaris.shopify.com/pages/examples/bleed-specific-direction.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+
 import {
   VerticalStack,
   Bleed,
-  Box,
+  Card,
   Text,
   HorizontalStack,
 } from '@shopify/polaris';
@@ -12,46 +13,26 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function BleedSpecificDirectionExample() {
   return (
     <VerticalStack gap="6">
-      <Box
-        background="bg"
-        borderWidth="1"
-        borderColor="border-subdued"
-        padding="8"
-      >
+      <Card>
         <Bleed marginInlineStart="8">
           <Placeholder label="marginInlineStart" />
         </Bleed>
-      </Box>
-      <Box
-        background="bg"
-        borderWidth="1"
-        borderColor="border-subdued"
-        padding="8"
-      >
+      </Card>
+      <Card>
         <Bleed marginInlineEnd="8">
           <Placeholder label="marginInlineEnd" />
         </Bleed>
-      </Box>
-      <Box
-        background="bg"
-        borderWidth="1"
-        borderColor="border-subdued"
-        padding="8"
-      >
+      </Card>
+      <Card>
         <Bleed marginBlockStart="8">
           <Placeholder label="marginBlockStart" />
         </Bleed>
-      </Box>
-      <Box
-        background="bg"
-        borderWidth="1"
-        borderColor="border-subdued"
-        padding="8"
-      >
+      </Card>
+      <Card>
         <Bleed marginBlockEnd="8">
           <Placeholder label="marginBlockEnd" />
         </Bleed>
-      </Box>
+      </Card>
     </VerticalStack>
   );
 }

--- a/polaris.shopify.com/pages/examples/bleed-vertical.tsx
+++ b/polaris.shopify.com/pages/examples/bleed-vertical.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
-import {Bleed, Box, Text, HorizontalStack} from '@shopify/polaris';
+
+import {Bleed, Card, Text, HorizontalStack} from '@shopify/polaris';
 
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function BleedVerticalExample() {
   return (
-    <Box
-      background="bg"
-      borderColor="border-subdued"
-      borderWidth="1"
-      padding="8"
-    >
+    <Card>
       <Bleed marginBlock="8">
         <Placeholder label="marginBlock" />
       </Bleed>
-    </Box>
+    </Card>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/divider-with-border-color.tsx
+++ b/polaris.shopify.com/pages/examples/divider-with-border-color.tsx
@@ -1,28 +1,31 @@
 import React from 'react';
-import {Divider, Text, VerticalStack} from '@shopify/polaris';
+
+import {Card, Divider, Text, VerticalStack} from '@shopify/polaris';
 
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function DividerWithBorderColorExample() {
   return (
-    <VerticalStack gap="5">
-      <Text as="h1" variant="headingXs">
-        Default
-      </Text>
-      <Divider />
-      <Text as="h1" variant="headingXs">
-        Border
-      </Text>
-      <Divider borderColor="border" />
-      <Text as="h1" variant="headingXs">
-        Border inverse
-      </Text>
-      <Divider borderColor="border-inverse" />
-      <Text as="h1" variant="headingXs">
-        Transparent
-      </Text>
-      <Divider borderColor="transparent" />
-    </VerticalStack>
+    <Card>
+      <VerticalStack gap="5">
+        <Text as="h1" variant="headingXs">
+          Default
+        </Text>
+        <Divider />
+        <Text as="h1" variant="headingXs">
+          Border
+        </Text>
+        <Divider borderColor="border" />
+        <Text as="h1" variant="headingXs">
+          Border inverse
+        </Text>
+        <Divider borderColor="border-inverse" />
+        <Text as="h1" variant="headingXs">
+          Transparent
+        </Text>
+        <Divider borderColor="transparent" />
+      </VerticalStack>
+    </Card>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/keyboard-key-default.tsx
+++ b/polaris.shopify.com/pages/examples/keyboard-key-default.tsx
@@ -1,9 +1,13 @@
-import {KeyboardKey} from '@shopify/polaris';
+import {Card, KeyboardKey} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function Example() {
-  return <KeyboardKey>Ctrl</KeyboardKey>;
+  return (
+    <Card>
+      <KeyboardKey>Ctrl</KeyboardKey>
+    </Card>
+  );
 }
 
 export default withPolarisExample(Example);

--- a/polaris.shopify.com/pages/examples/tag-clickable.tsx
+++ b/polaris.shopify.com/pages/examples/tag-clickable.tsx
@@ -1,9 +1,13 @@
-import {Tag} from '@shopify/polaris';
+import {Card, Tag} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TagExample() {
-  return <Tag onClick={() => console.log('Clicked')}>Wholesale</Tag>;
+  return (
+    <Card>
+      <Tag onClick={() => console.log('Clicked')}>Wholesale</Tag>
+    </Card>
+  );
 }
 
 export default withPolarisExample(TagExample);

--- a/polaris.shopify.com/pages/examples/tag-default.tsx
+++ b/polaris.shopify.com/pages/examples/tag-default.tsx
@@ -1,9 +1,13 @@
-import {Tag} from '@shopify/polaris';
+import {Card, Tag} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TagExample() {
-  return <Tag>Wholesale</Tag>;
+  return (
+    <Card>
+      <Tag>Wholesale</Tag>
+    </Card>
+  );
 }
 
 export default withPolarisExample(TagExample);

--- a/polaris.shopify.com/pages/examples/tag-removable-with-link.tsx
+++ b/polaris.shopify.com/pages/examples/tag-removable-with-link.tsx
@@ -1,4 +1,4 @@
-import {Tag, LegacyStack} from '@shopify/polaris';
+import {Tag, LegacyStack, Card} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -20,9 +20,11 @@ function RemovableTagWithLinkExample() {
   );
 
   const tagMarkup = selectedTags.map((option) => (
-    <Tag key={option} onRemove={removeTag(option)} url="#">
-      {option}
-    </Tag>
+    <Card key={option}>
+      <Tag onRemove={removeTag(option)} url="#">
+        {option}
+      </Tag>
+    </Card>
   ));
 
   return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;

--- a/polaris.shopify.com/pages/examples/tag-removable.tsx
+++ b/polaris.shopify.com/pages/examples/tag-removable.tsx
@@ -1,4 +1,4 @@
-import {Tag, LegacyStack} from '@shopify/polaris';
+import {Tag, LegacyStack, Card} from '@shopify/polaris';
 import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
@@ -21,9 +21,9 @@ function RemovableTagExample() {
   );
 
   const tagMarkup = selectedTags.map((option) => (
-    <Tag key={option} onRemove={removeTag(option)}>
-      {option}
-    </Tag>
+    <Card key={option}>
+      <Tag onRemove={removeTag(option)}>{option}</Tag>
+    </Card>
   ));
 
   return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;

--- a/polaris.shopify.com/pages/examples/tag-with-custom-content.tsx
+++ b/polaris.shopify.com/pages/examples/tag-with-custom-content.tsx
@@ -1,16 +1,18 @@
-import {Tag, LegacyStack, Icon} from '@shopify/polaris';
+import {Tag, LegacyStack, Icon, Card} from '@shopify/polaris';
 import {WandMinor} from '@shopify/polaris-icons';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TagExample() {
   return (
-    <Tag url="#">
-      <LegacyStack spacing="extraTight">
-        <Icon source={WandMinor} />
-        <span>Wholesale</span>
-      </LegacyStack>
-    </Tag>
+    <Card>
+      <Tag url="#">
+        <LegacyStack spacing="extraTight">
+          <Icon source={WandMinor} />
+          <span>Wholesale</span>
+        </LegacyStack>
+      </Tag>
+    </Card>
   );
 }
 

--- a/polaris.shopify.com/pages/examples/tag-with-link.tsx
+++ b/polaris.shopify.com/pages/examples/tag-with-link.tsx
@@ -1,9 +1,13 @@
-import {Tag} from '@shopify/polaris';
+import {Card, Tag} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TagExample() {
-  return <Tag url="#">Wholesale</Tag>;
+  return (
+    <Card>
+      <Tag url="#">Wholesale</Tag>
+    </Card>
+  );
 }
 
 export default withPolarisExample(TagExample);

--- a/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.module.scss
+++ b/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.module.scss
@@ -5,6 +5,7 @@
   height: 100vh;
   padding-left: 32px;
   padding-right: 32px;
+  background-color: var(--p-color-bg-app);
 }
 
 .Example {


### PR DESCRIPTION
Some examples require the Polaris Frame: Modal, Toast, Nav etc... the frame adds a background color that doesn't match the current example background container. This leads to some visual weirdness: https://github.com/Shopify/polaris/issues/10586

This PR changes the example background color to match the Frame which fixes the above and also better represents most components:

Card
Layout
Page actions
Banner
Loading
Tables
Footer help
Toast
etc…

anything in a card, or related to Frame

Before | After
---|---
![image](https://github.com/Shopify/polaris/assets/6844391/4fc0ee5a-d61e-4f25-b2a3-96269a3456cb) | ![image](https://github.com/Shopify/polaris/assets/6844391/6a39b884-dc34-4c05-83ad-104553b76732)
