### PR TITLE
Introduce pagination prop to tables and lists

### DIFF
--- a/.changeset/silver-wasps-greet.md
+++ b/.changeset/silver-wasps-greet.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Updated IndexTable, ResourceList, and DataTable to have built-in pagination props

--- a/.changeset/silver-wasps-greet.md
+++ b/.changeset/silver-wasps-greet.md
@@ -1,6 +1,5 @@
 ---
 '@shopify/polaris': minor
-'polaris.shopify.com': minor
 ---
 
 Updated IndexTable, ResourceList, and DataTable to have built-in pagination props

--- a/polaris-react/src/components/DataTable/DataTable.stories.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.stories.tsx
@@ -874,3 +874,46 @@ export function WithStickyHeaderEnabled() {
     </Page>
   );
 }
+
+export function WithPagination() {
+  const rows = [
+    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+    [
+      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
+
+  return (
+    <Page title="Sales by product">
+      <LegacyCard>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={rows}
+          totals={['', '', '', 255, '$155,830.00']}
+          pagination={{
+            hasNext: true,
+            onNext: () => {},
+          }}
+        />
+      </LegacyCard>
+    </Page>
+  );
+}

--- a/polaris-react/src/components/DataTable/DataTable.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.tsx
@@ -10,6 +10,8 @@ import {headerCell} from '../shared';
 import {EventListener} from '../EventListener';
 import {AfterInitialMount} from '../AfterInitialMount';
 import {Sticky} from '../Sticky';
+import {Pagination} from '../Pagination';
+import type {PaginationProps} from '../Pagination';
 
 import {Cell, Navigation} from './components';
 import type {CellProps} from './components';
@@ -27,6 +29,8 @@ export type TableRow =
 export type TableData = string | number | React.ReactNode;
 
 export type ColumnContentType = 'text' | 'numeric';
+
+export type DataTablePaginationProps = Omit<PaginationProps, 'type'>;
 
 const getRowClientHeights = (rows: NodeList | undefined) => {
   const heights: number[] = [];
@@ -97,6 +101,8 @@ export interface DataTableProps {
   fixedFirstColumns?: number;
   /** Specify a min width for the first column if neccessary */
   firstColumnMinWidth?: string;
+  /** Properties to enable pagination at the bottom of the table. */
+  pagination?: DataTablePaginationProps;
 }
 
 type CombinedProps = DataTableProps & {
@@ -177,6 +183,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
       hasZebraStripingOnData = false,
       stickyHeader = false,
       hasFixedFirstColumn: fixedFirstColumn = false,
+      pagination,
     } = this.props;
     const {
       condensed,
@@ -300,6 +307,10 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
       <div className={styles.Footer}>{footerContent}</div>
     ) : null;
 
+    const paginationMarkup = pagination ? (
+      <Pagination type="table" {...pagination} />
+    ) : null;
+
     const headerTotalsMarkup = !showTotalsInFooter ? totalsMarkup : null;
     const footerTotalsMarkup = showTotalsInFooter ? (
       <tfoot>{totalsMarkup}</tfoot>
@@ -398,6 +409,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
               {footerTotalsMarkup}
             </table>
           </div>
+          {paginationMarkup}
           {footerMarkup}
         </div>
       </div>

--- a/polaris-react/src/components/DataTable/tests/DataTable.test.tsx
+++ b/polaris-react/src/components/DataTable/tests/DataTable.test.tsx
@@ -3,6 +3,7 @@ import {timer} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
 
 import {Checkbox} from '../../Checkbox';
+import {Pagination} from '../../Pagination';
 import {Cell, Navigation} from '../components';
 import {DataTable} from '../DataTable';
 import type {DataTableProps} from '../DataTable';
@@ -637,6 +638,29 @@ describe('<DataTable />', () => {
       const tables = dataTable.findAll('table');
 
       expect(tables).toHaveLength(1);
+    });
+  });
+
+  describe('pagination', () => {
+    it('does not render Pagination when pagination props are not provided', () => {
+      const dataTable = mountWithApp(<DataTable {...defaultProps} />);
+
+      expect(dataTable).not.toContainReactComponent(Pagination);
+    });
+
+    it('renders Pagination with table type when pagination props are provided', () => {
+      const paginationProps = {
+        hasNext: true,
+      };
+
+      const dataTable = mountWithApp(
+        <DataTable {...defaultProps} pagination={paginationProps} />,
+      );
+
+      expect(dataTable).toContainReactComponent(Pagination, {
+        type: 'table',
+        ...paginationProps,
+      });
     });
   });
 });

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -3929,3 +3929,116 @@ export function WithSubHeaders() {
     </LegacyCard>
   );
 }
+
+export function WithPagination() {
+  const customers = [
+    {
+      id: '3410',
+      url: '#',
+      name: 'Mae Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$2,400',
+    },
+    {
+      id: '3411',
+      url: '#',
+      name: 'Joe Jemison',
+      location: 'Sydney, AU',
+      orders: 20,
+      amountSpent: '$1,400',
+    },
+    {
+      id: '3412',
+      url: '#',
+      name: 'Sam Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$400',
+    },
+    {
+      id: '3413',
+      url: '#',
+      name: 'Mae Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$4,300',
+    },
+    {
+      id: '2563',
+      url: '#',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+  ];
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(customers);
+
+  const rowMarkup = customers.map(
+    ({id, name, location, orders, amountSpent}, index) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <Text fontWeight="bold" as="span">
+            {name}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{location}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {orders}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {amountSpent}
+          </Text>
+        </IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <LegacyCard>
+      <IndexTable
+        resourceName={resourceName}
+        itemCount={customers.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {title: 'Name'},
+          {title: 'Location'},
+          {
+            alignment: 'end',
+            id: 'order-count',
+            title: 'Order count',
+          },
+          {
+            alignment: 'end',
+            id: 'amount-spent',
+            title: 'Amount spent',
+          },
+        ]}
+        pagination={{
+          hasNext: true,
+          onNext: () => {},
+        }}
+      >
+        {rowMarkup}
+      </IndexTable>
+    </LegacyCard>
+  );
+}

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -15,6 +15,8 @@ import {EventListener} from '../EventListener';
 import {SelectAllActions} from '../SelectAllActions';
 // eslint-disable-next-line import/no-deprecated
 import {LegacyStack} from '../LegacyStack';
+import {Pagination} from '../Pagination';
+import type {PaginationProps} from '../Pagination';
 import {Sticky} from '../Sticky';
 import {Spinner} from '../Spinner';
 import {Text} from '../Text';
@@ -88,6 +90,8 @@ interface IndexTableSortToggleLabels {
   [key: number]: IndexTableSortToggleLabel;
 }
 
+export type IndexTablePaginationProps = Omit<PaginationProps, 'type'>;
+
 export interface IndexTableBaseProps {
   headings: NonEmptyArray<IndexTableHeading>;
   promotedBulkActions?: BulkActionsProps['promotedActions'];
@@ -118,6 +122,8 @@ export interface IndexTableBaseProps {
   sortToggleLabels?: IndexTableSortToggleLabels;
   /** Add zebra striping to table rows */
   hasZebraStriping?: boolean;
+  /** Properties to enable pagination at the bottom of the table. */
+  pagination?: IndexTablePaginationProps;
 }
 
 export interface TableHeadingRect {
@@ -1162,21 +1168,29 @@ export function IndexTable({
   hasMoreItems,
   condensed,
   onSelectionChange,
+  pagination,
   ...indexTableBaseProps
 }: IndexTableProps) {
+  const paginationMarkup = pagination ? (
+    <Pagination type="table" {...pagination} />
+  ) : null;
+
   return (
-    <IndexProvider
-      selectable={selectable && !condensed}
-      itemCount={itemCount}
-      selectedItemsCount={selectedItemsCount}
-      resourceName={passedResourceName}
-      loading={loading}
-      hasMoreItems={hasMoreItems}
-      condensed={condensed}
-      onSelectionChange={onSelectionChange}
-    >
-      <IndexTableBase {...indexTableBaseProps}>{children}</IndexTableBase>
-    </IndexProvider>
+    <>
+      <IndexProvider
+        selectable={selectable && !condensed}
+        itemCount={itemCount}
+        selectedItemsCount={selectedItemsCount}
+        resourceName={passedResourceName}
+        loading={loading}
+        hasMoreItems={hasMoreItems}
+        condensed={condensed}
+        onSelectionChange={onSelectionChange}
+      >
+        <IndexTableBase {...indexTableBaseProps}>{children}</IndexTableBase>
+      </IndexProvider>
+      {paginationMarkup}
+    </>
   );
 }
 

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -22,6 +22,7 @@ import {AfterInitialMount} from '../../AfterInitialMount';
 import {UnstyledButton} from '../../UnstyledButton';
 import {Tooltip} from '../../Tooltip';
 import {IndexProvider} from '../../IndexProvider';
+import {Pagination} from '../../Pagination';
 
 jest.mock('../utilities', () => ({
   ...jest.requireActual('../utilities'),
@@ -800,6 +801,35 @@ describe('<IndexTable>', () => {
       index.setProps({itemCount: 60});
 
       expect(computeTableDimensions).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('pagination', () => {
+    it('does not render Pagination when pagination props are not provided', () => {
+      const index = mountWithApp(
+        <IndexTable {...defaultProps} pagination={undefined}>
+          {mockTableItems.map(mockRenderRow)}
+        </IndexTable>,
+      );
+
+      expect(index).not.toContainReactComponent(Pagination);
+    });
+
+    it('renders Pagination with table type when pagination props are provided', () => {
+      const paginationProps = {
+        hasNext: true,
+      };
+
+      const index = mountWithApp(
+        <IndexTable {...defaultProps} pagination={paginationProps}>
+          {mockTableItems.map(mockRenderRow)}
+        </IndexTable>,
+      );
+
+      expect(index).toContainReactComponent(Pagination, {
+        type: 'table',
+        ...paginationProps,
+      });
     });
   });
 });

--- a/polaris-react/src/components/Pagination/Pagination.scss
+++ b/polaris-react/src/components/Pagination/Pagination.scss
@@ -24,8 +24,10 @@
   }
 
   &.table {
+    border-top: 1px solid var(--p-color-border);
+
     button {
-      --button-min-height: var(--p-space-600);
+      --button-min-height: 28px;
       background-color: var(--p-color-bg-subdued);
       min-height: var(--button-min-height);
       min-width: var(--button-min-height);

--- a/polaris-react/src/components/Pagination/Pagination.stories.tsx
+++ b/polaris-react/src/components/Pagination/Pagination.stories.tsx
@@ -64,7 +64,6 @@ export function WithTableType() {
       style={{
         maxWidth: 'calc(700px + (2 * var(--p-space-400)))',
         margin: '0 auto',
-        border: '1px solid var(--p-color-border)',
       }}
     >
       <Pagination

--- a/polaris-react/src/components/ResourceList/ResourceList.stories.tsx
+++ b/polaris-react/src/components/ResourceList/ResourceList.stories.tsx
@@ -1248,3 +1248,51 @@ export function WithAllOfItsElements() {
     }
   }
 }
+
+export function WithPagination() {
+  return (
+    <Card padding="0">
+      <ResourceList
+        resourceName={{singular: 'customer', plural: 'customers'}}
+        items={[
+          {
+            id: 100,
+            url: '#',
+            name: 'Mae Jemison',
+            location: 'Decatur, USA',
+          },
+          {
+            id: 200,
+            url: '#',
+            name: 'Ellen Ochoa',
+            location: 'Los Angeles, USA',
+          },
+        ]}
+        pagination={{
+          hasNext: true,
+          onNext: () => {},
+        }}
+        renderItem={(item) => {
+          const {id, url, name, location} = item;
+          const media = <Avatar customer size="medium" name={name} />;
+
+          return (
+            <ResourceItem
+              id={id}
+              url={url}
+              media={media}
+              accessibilityLabel={`View details for ${name}`}
+            >
+              <h3>
+                <Text fontWeight="bold" as="span">
+                  {name}
+                </Text>
+              </h3>
+              <div>{location}</div>
+            </ResourceItem>
+          );
+        }}
+      />
+    </Card>
+  );
+}

--- a/polaris-react/src/components/ResourceList/ResourceList.tsx
+++ b/polaris-react/src/components/ResourceList/ResourceList.tsx
@@ -31,6 +31,8 @@ import {BulkActions, useIsBulkActionsSticky} from '../BulkActions';
 import type {BulkActionsProps} from '../BulkActions';
 import {SelectAllActions} from '../SelectAllActions';
 import {CheckableButton} from '../CheckableButton';
+import {Pagination} from '../Pagination';
+import type {PaginationProps} from '../Pagination';
 
 import styles from './ResourceList.scss';
 
@@ -65,6 +67,8 @@ function defaultIdForItem<TItemType extends ResourceListItemData>(
     ? item.id
     : index.toString();
 }
+
+export type ResourceListPaginationProps = Omit<PaginationProps, 'type'>;
 
 export interface ResourceListProps<
   TItemType extends ResourceListItemData = ResourceListItemData,
@@ -121,6 +125,8 @@ export interface ResourceListProps<
   idForItem?(item: TItemType, index: number): string;
   /** Function to resolve the ids of items */
   resolveItemId?(item: TItemType): string;
+  /** Properties to enable pagination at the bottom of the list. */
+  pagination?: ResourceListPaginationProps;
 }
 
 export function ResourceList<TItemType extends ResourceListItemData>({
@@ -148,6 +154,7 @@ export function ResourceList<TItemType extends ResourceListItemData>({
   renderItem,
   idForItem = defaultIdForItem,
   resolveItemId,
+  pagination,
 }: ResourceListProps<TItemType>) {
   const i18n = useI18n();
   const [selectMode, setSelectMode] = useState(
@@ -737,6 +744,10 @@ export function ResourceList<TItemType extends ResourceListItemData>({
     </ul>
   ) : null;
 
+  const paginationMarkup = pagination ? (
+    <Pagination type="table" {...pagination} />
+  ) : null;
+
   // This is probably a legit error but I don't have the time to refactor this
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const context = {
@@ -767,6 +778,7 @@ export function ResourceList<TItemType extends ResourceListItemData>({
         {emptySearchStateMarkup}
         {emptyStateMarkup}
         {loadingWithoutItemsMarkup}
+        {paginationMarkup}
       </div>
       <div ref={bulkActionsIntersectionRef} />
     </ResourceListContext.Provider>

--- a/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -13,6 +13,7 @@ import {EmptyState} from '../../EmptyState';
 import {Select} from '../../Select';
 import {Spinner} from '../../Spinner';
 import {ResourceItem} from '../../ResourceItem';
+import {Pagination} from '../../Pagination';
 import {SELECT_ALL_ITEMS} from '../../../utilities/resource-list';
 import {ResourceList} from '../ResourceList';
 import styles from '../ResourceList.scss';
@@ -1357,6 +1358,35 @@ describe('<ResourceList />', () => {
       resourceList.setProps({items: newItems});
 
       expect(computeTableDimensions).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('pagination', () => {
+    it('does not render Pagination when pagination props are not provided', () => {
+      const resourceList = mountWithApp(
+        <ResourceList items={itemsWithID} renderItem={renderItem} />,
+      );
+
+      expect(resourceList).not.toContainReactComponent(Pagination);
+    });
+
+    it('renders Pagination with table type when pagination props are provided', () => {
+      const paginationProps = {
+        hasNext: true,
+      };
+
+      const resourceList = mountWithApp(
+        <ResourceList
+          items={itemsWithID}
+          renderItem={renderItem}
+          pagination={paginationProps}
+        />,
+      );
+
+      expect(resourceList).toContainReactComponent(Pagination, {
+        type: 'table',
+        ...paginationProps,
+      });
     });
   });
 });

--- a/polaris.shopify.com/content/components/lists/resource-list.md
+++ b/polaris.shopify.com/content/components/lists/resource-list.md
@@ -66,6 +66,9 @@ examples:
   - fileName: resource-list-with-all-of-its-elements.tsx
     title: With all of its elements
     description: Use as a broad example that includes most props available to resource list.
+  - fileName: resource-list-with-pagination.tsx
+    title: With pagination
+    description: Use when the list contains many rows and they need paginating.
 previewImg: /images/components/lists/resource-list.png
 ---
 

--- a/polaris.shopify.com/content/components/tables/data-table.md
+++ b/polaris.shopify.com/content/components/tables/data-table.md
@@ -42,6 +42,9 @@ examples:
   - fileName: data-table-with-sticky-header-enabled.tsx
     title: With sticky header enabled
     description: Use as a broad example that includes most props available to data table.
+  - fileName: data-table-with-pagination.tsx
+    title: With pagination
+    description: Use when the table contains many rows and they need paginating.
 previewImg: /images/components/tables/data-table.png
 ---
 

--- a/polaris.shopify.com/content/components/tables/index-table.md
+++ b/polaris.shopify.com/content/components/tables/index-table.md
@@ -72,6 +72,9 @@ examples:
   - fileName: index-table-with-subheaders.tsx
     title: With subheaders
     description: An index table with multiple table headers. Use to present merchants with resources grouped by a relevant data value to enable faster bulk selection.
+  - fileName: index-table-with-pagination.tsx
+    title: With pagination
+    description: Use when the table contains many rows and they need paginating.
 previewImg: /images/components/tables/index-table.png
 ---
 

--- a/polaris.shopify.com/pages/examples/data-table-with-pagination.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-pagination.tsx
@@ -1,0 +1,48 @@
+import {Page, LegacyCard, DataTable} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function DataTableWithPaginationExample() {
+  const rows = [
+    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+    [
+      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
+
+  return (
+    <Page title="Sales by product">
+      <LegacyCard>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={rows}
+          totals={['', '', '', 255, '$155,830.00']}
+          pagination={{
+            hasNext: true,
+            onNext: () => {},
+          }}
+        />
+      </LegacyCard>
+    </Page>
+  );
+}
+
+export default withPolarisExample(DataTableWithPaginationExample);

--- a/polaris.shopify.com/pages/examples/index-table-with-pagination.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-pagination.tsx
@@ -1,0 +1,102 @@
+import {
+  IndexTable,
+  LegacyCard,
+  useIndexResourceState,
+  Text,
+  Badge,
+} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function IndexTableWithPaginationExample() {
+  const orders = [
+    {
+      id: '1020',
+      order: '#1020',
+      date: 'Jul 20 at 4:34pm',
+      customer: 'Jaydon Stanton',
+      total: '$969.44',
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+    {
+      id: '1019',
+      order: '#1019',
+      date: 'Jul 20 at 3:46pm',
+      customer: 'Ruben Westerfelt',
+      total: '$701.19',
+      paymentStatus: <Badge progress="partiallyComplete">Partially paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+    {
+      id: '1018',
+      order: '#1018',
+      date: 'Jul 20 at 3.44pm',
+      customer: 'Leo Carder',
+      total: '$798.24',
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+  ];
+  const resourceName = {
+    singular: 'order',
+    plural: 'orders',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(orders);
+
+  const rowMarkup = orders.map(
+    (
+      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+      index,
+    ) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {order}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{date}</IndexTable.Cell>
+        <IndexTable.Cell>{customer}</IndexTable.Cell>
+        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <LegacyCard>
+      <IndexTable
+        resourceName={resourceName}
+        itemCount={orders.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {title: 'Order'},
+          {title: 'Date'},
+          {title: 'Customer'},
+          {title: 'Total', alignment: 'end'},
+          {title: 'Payment status'},
+          {title: 'Fulfillment status'},
+        ]}
+        pagination={{
+          hasNext: true,
+          onNext: () => {},
+        }}
+      >
+        {rowMarkup}
+      </IndexTable>
+    </LegacyCard>
+  );
+}
+
+export default withPolarisExample(IndexTableWithPaginationExample);

--- a/polaris.shopify.com/pages/examples/resource-list-with-pagination.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-pagination.tsx
@@ -1,0 +1,57 @@
+import {
+  LegacyCard,
+  ResourceList,
+  Avatar,
+  ResourceItem,
+  Text,
+} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function ResourceListWithPaginationExample() {
+  return (
+    <LegacyCard>
+      <ResourceList
+        resourceName={{singular: 'customer', plural: 'customers'}}
+        items={[
+          {
+            id: '100',
+            url: '#',
+            name: 'Mae Jemison',
+            location: 'Decatur, USA',
+          },
+          {
+            id: '200',
+            url: '#',
+            name: 'Ellen Ochoa',
+            location: 'Los Angeles, USA',
+          },
+        ]}
+        pagination={{
+          hasNext: true,
+          onNext: () => {},
+        }}
+        renderItem={(item) => {
+          const {id, url, name, location} = item;
+          const media = <Avatar customer size="medium" name={name} />;
+
+          return (
+            <ResourceItem
+              id={id}
+              url={url}
+              media={media}
+              accessibilityLabel={`View details for ${name}`}
+            >
+              <Text variant="bodyMd" fontWeight="bold" as="h3">
+                {name}
+              </Text>
+              <div>{location}</div>
+            </ResourceItem>
+          );
+        }}
+      />
+    </LegacyCard>
+  );
+}
+
+export default withPolarisExample(ResourceListWithPaginationExample);

--- a/polaris.shopify.com/pages/examples/resource-list-with-pagination.tsx
+++ b/polaris.shopify.com/pages/examples/resource-list-with-pagination.tsx
@@ -33,7 +33,7 @@ function ResourceListWithPaginationExample() {
         }}
         renderItem={(item) => {
           const {id, url, name, location} = item;
-          const media = <Avatar customer size="medium" name={name} />;
+          const media = <Avatar customer size="md" name={name} />;
 
           return (
             <ResourceItem


### PR DESCRIPTION
### WHY are these changes introduced?

Supports https://github.com/Shopify/web/issues/102860

`Pagination` is added as an auxiliary component to `DataTable`, `IndexTable`, and `ResourceList`. This has resulted in inconsistent usage and UX across Admin along with differing implementations. Baking this concern into the resources will provide a consistent aesthetic and ease our maintainability of pagination concerns with regards to these components.

At the moment, `web` (i.e. Admin) has the following instance counts with `Pagination`:
- DataTable - 8
- IndexTable - 34
- ResourceList - 25

There also includes 11 `ResourceListWithHeader` instances, but that is a custom component within Admin. So, maintaining a consistent Pagination experience across each of these instances becomes challenging if they each need independent instantiation of `Pagination` as a child component.

❓ For `IndexTable` should I key of [hasMoreItems](https://github.com/Shopify/polaris/blob/557134c75c8f5b6dee0d925561e9a2b4ba900b2b/polaris-react/src/components/IndexTable/IndexTable.tsx#L1184) to determine whether to render `Pagination` or should the consumer manage it? Need to better understand what this attribute is used for and whether that's reasonable. Edit: This does not seem to be consistently used, so I don't think this would be reliable.

🚨 **REMINDER for myself:** Update documentation with regards to `Pagination` and `IndexTable`

### WHAT is this pull request doing?

Introduces an optional `pagination` prop to `DataTable`, `IndexTable`, and `ResourceList`. If the `pagination` prop is provided, which contains the `Pagination` props, then it will render a table type `Pagination` component at the bottom of the of the table/list. If no `pagination` prop is provided, then it will not render a `Pagination` component.

The table type `Pagination` component will also have a border top by default. We do not have a use case at the moment where a table type `Pagination` component does not need this aesthetic, so it is always present.

Increases table type `Pagination` buttons to a larger click area (i.e. `28px`).

### How to 🎩

- [Pagination](https://storybook.web.polaris-table-component-pagination.matt-kubej.us.spin.dev/?path=/story/all-components-pagination--with-table-type&globals=polarisSummerEditions2023:true;polarisSummerEditions2023ShadowBevelOptOut:true)
- [DataTable](https://storybook.web.polaris-table-component-pagination.matt-kubej.us.spin.dev/?path=/story/all-components-datatable--with-pagination&globals=polarisSummerEditions2023:true;polarisSummerEditions2023ShadowBevelOptOut:true)
- [IndexTable](https://storybook.web.polaris-table-component-pagination.matt-kubej.us.spin.dev/?path=/story/all-components-indextable--with-pagination&globals=polarisSummerEditions2023:true;polarisSummerEditions2023ShadowBevelOptOut:true)
- [ResourceList](https://storybook.web.polaris-table-component-pagination.matt-kubej.us.spin.dev/?path=/story/all-components-resourcelist--with-pagination&globals=polarisSummerEditions2023:true;polarisSummerEditions2023ShadowBevelOptOut:true)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
