### PR TITLE
Add semantic `space` token scale

### DIFF
--- a/.changeset/sweet-toes-divide.md
+++ b/.changeset/sweet-toes-divide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Added semantic `space` token scale

--- a/polaris-tokens/src/themes/base/space.ts
+++ b/polaris-tokens/src/themes/base/space.ts
@@ -41,7 +41,15 @@ export type SpaceScale =
   | '32'
   | SpaceScaleExperimental;
 
-export type SpaceTokenName = `space-${SpaceScale}`;
+export type SpaceAlias =
+  | 'button-group-gap'
+  | 'card-gap'
+  | 'card-padding'
+  | 'table-cell-padding';
+
+export type SpaceAliasOrScale = SpaceAlias | SpaceScale;
+
+export type SpaceTokenName = `space-${SpaceAliasOrScale}`;
 
 export type SpaceTokenGroup = {
   [TokenName in SpaceTokenName]: string;
@@ -103,6 +111,18 @@ export const space: {
   },
   'space-3200': {
     value: createVar('space-32'),
+  },
+  'space-button-group-gap': {
+    value: createVar('space-200'),
+  },
+  'space-card-gap': {
+    value: createVar('space-400'),
+  },
+  'space-card-padding': {
+    value: createVar('space-400'),
+  },
+  'space-table-cell-padding': {
+    value: createVar('space-150'),
   },
   'space-05': {
     value: '2px',

--- a/polaris-tokens/src/themes/base/space.ts
+++ b/polaris-tokens/src/themes/base/space.ts
@@ -42,10 +42,8 @@ export type SpaceScale =
   | SpaceScaleExperimental;
 
 export type SpaceAlias =
-  | 'button-group-gap'
-  | 'card-gap'
-  | 'card-padding'
-  | 'table-cell-padding';
+  /** Specialty and component spacing. */
+  'button-group-gap' | 'card-gap' | 'card-padding' | 'table-cell-padding';
 
 export type SpaceAliasOrScale = SpaceAlias | SpaceScale;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10436

### WHAT is this pull request doing?

Adds the following values to new semantic `space` token scale: 

| New Token          | Value        |
| ------------------------- | ------------------------ |  
| `--p-space-button-group-gap` | `--p-space-200`    |
| `--p-space-card-gap` | `--p-space-400`    |
| `--p-space-card-padding` | `--p-space-400`    |
| `--p-space-table-cell-padding` | `--p-space-150`    |


