### PR TITLE
[Docs] Fix hydration errors

### DIFF
--- a/polaris.shopify.com/src/components/Lede/index.tsx
+++ b/polaris.shopify.com/src/components/Lede/index.tsx
@@ -2,13 +2,13 @@ import {forwardRef} from 'react';
 import styles from './Lede.module.scss';
 import {Box, type WithAsProp} from '../Box';
 
-export const Lede = forwardRef(({as = 'p', className, ...props}, ref) => (
+export const Lede = forwardRef(({as = 'div', className, ...props}, ref) => (
   <Box
     ref={ref}
     as={as}
     className={[styles.LedeParagraph, className]}
     {...props}
   />
-)) as WithAsProp<{}, typeof Box, 'p'>;
+)) as WithAsProp<{}, typeof Box, 'div'>;
 
 Lede.displayName = 'Lede';

--- a/polaris.shopify.com/src/components/PropsTable/PropsTable.tsx
+++ b/polaris.shopify.com/src/components/PropsTable/PropsTable.tsx
@@ -217,10 +217,10 @@ function TypeTable({
                           </p>
                         )}
                         {deprecationMessage && (
-                          <p className={styles.DeprecationNotice}>
+                          <div className={styles.DeprecationNotice}>
                             <StatusBadge status={StatusName.Deprecated} />{' '}
                             {endWithPeriod(deprecationMessage)}
-                          </p>
+                          </div>
                         )}
                       </div>
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #10629.
Fixes hydration error on component page refresh or navigation from another component page.

> [!NOTE]
> There may be ramifications in terms of accessibility for `/design`, `/foundations`, etc pages where the <Lede> renders its children as plain text but [we have a separate issue to look into that post v12](https://github.com/Shopify/polaris/issues/10645). 

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
