### PR TITLE
`Docs` Directive Card should fill vertical space

### DIFF
--- a/polaris.shopify.com/src/components/Box/Box.module.scss
+++ b/polaris.shopify.com/src/components/Box/Box.module.scss
@@ -12,4 +12,11 @@
     'padding-inline-start'
   );
   @include responsive-props('box', 'padding-inline-end', 'padding-inline-end');
+
+  --pc-box-min-height: initial;
+  --pc-box-min-width: initial;
+  --pc-box-max-width: initial;
+  min-height: var(--pc-box-min-height);
+  min-width: var(--pc-box-min-width);
+  max-width: var(--pc-box-max-width);
 }

--- a/polaris.shopify.com/src/components/Box/index.tsx
+++ b/polaris.shopify.com/src/components/Box/index.tsx
@@ -16,6 +16,12 @@ export interface BoxProps {
   paddingInlineEnd?: ResponsiveProp<SpaceScale>;
   paddingBlockStart?: ResponsiveProp<SpaceScale>;
   paddingBlockEnd?: ResponsiveProp<SpaceScale>;
+  /** Minimum height of container */
+  minHeight?: string;
+  /** Minimum width of container */
+  minWidth?: string;
+  /** Maximum width of container */
+  maxWidth?: string;
 }
 
 export type OwnProps<T> = Polymorphic.OwnProps<T>;
@@ -27,13 +33,27 @@ type PolymorphicBox = Polymorphic.ForwardRefComponent<'div', BoxProps>;
  * built. It renders a `div` element by default, customisable via the `as` prop.
  */
 export const Box = forwardRef(
-  ({as: Tag = 'div', className, padding = '0', ...props}, forwardedRef) => {
+  (
+    {
+      as: Tag = 'div',
+      className,
+      minHeight,
+      minWidth,
+      maxWidth,
+      padding = '0',
+      ...props
+    },
+    forwardedRef,
+  ) => {
     const style = {
       ...getResponsiveProps('box', 'padding-block-start', 'space', padding),
       ...getResponsiveProps('box', 'padding-block-end', 'space', padding),
       ...getResponsiveProps('box', 'padding-inline-start', 'space', padding),
       ...getResponsiveProps('box', 'padding-inline-end', 'space', padding),
-    };
+      '--pc-box-min-height': minHeight,
+      '--px-box-min-width': minWidth,
+      '--px-box-max-width': maxWidth,
+    } as React.CSSProperties;
     return (
       <Tag
         style={style}

--- a/polaris.shopify.com/src/components/Card/index.tsx
+++ b/polaris.shopify.com/src/components/Card/index.tsx
@@ -1,19 +1,21 @@
 import styles from './Card.module.scss';
 import {ResponsiveProp} from '../../utils/various';
-import {Box} from '../Box';
+import {Box, BoxProps} from '../Box';
 import React from 'react';
 import {SpaceScale} from '@shopify/polaris-tokens';
 
+export interface CardProps extends BoxProps {
+  padding?: ResponsiveProp<SpaceScale>;
+  className?: string;
+}
 export function Card({
   children,
   className,
   padding = {xs: '4'},
-}: React.PropsWithChildren<{
-  padding?: ResponsiveProp<SpaceScale>;
-  className?: string;
-}>) {
+  ...props
+}: React.PropsWithChildren<CardProps>) {
   return (
-    <Box padding={padding} className={[styles.Card, className]}>
+    <Box padding={padding} className={[styles.Card, className]} {...props}>
       {children}
     </Box>
   );

--- a/polaris.shopify.com/src/components/Markdown/components/DirectiveCard/index.tsx
+++ b/polaris.shopify.com/src/components/Markdown/components/DirectiveCard/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@shopify/polaris-icons';
 
 import {Box} from '../../../Box';
-import {Card} from '../../../Card';
+import {Card, CardProps} from '../../../Card';
 import {Stack, Row} from '../../../Stack';
 import ImageThumbnail from '../../../ThumbnailPreview';
 import styles from './styles.module.scss';
@@ -21,10 +21,11 @@ export enum DirectiveStatusName {
 }
 
 export type DirectiveStatus = DirectiveStatusName;
-type DirectiveProps = React.PropsWithChildren<{
+interface DirectiveCardProps extends CardProps {
   status: DirectiveStatus;
-}>;
-export const DirectiveCard = ({children, status}: DirectiveProps) => {
+}
+type DirectiveProps = React.PropsWithChildren<DirectiveCardProps>;
+export const DirectiveCard = ({children, status, ...props}: DirectiveProps) => {
   const childrenArray = Children.toArray(children) as ReactElement[];
 
   let image: ReactElement | undefined;
@@ -38,7 +39,7 @@ export const DirectiveCard = ({children, status}: DirectiveProps) => {
   });
 
   return (
-    <Card>
+    <Card {...props}>
       {image?.props?.src ? (
         <Stack gap="4">
           <Bleed marginInline="4" marginBlockStart="4">

--- a/polaris.shopify.com/src/components/Markdown/components/DoDont/index.tsx
+++ b/polaris.shopify.com/src/components/Markdown/components/DoDont/index.tsx
@@ -75,12 +75,16 @@ export const DoDont = ({children}: PropsWithChildren) => {
 
 export const Do = ({children}: DoDontProps) => {
   return (
-    <DirectiveCard status={DirectiveStatusName.Do}>{children}</DirectiveCard>
+    <DirectiveCard minHeight="100%" status={DirectiveStatusName.Do}>
+      {children}
+    </DirectiveCard>
   );
 };
 
 export const Dont = ({children}: DoDontProps) => {
   return (
-    <DirectiveCard status={DirectiveStatusName.Dont}>{children}</DirectiveCard>
+    <DirectiveCard minHeight="100%" status={DirectiveStatusName.Dont}>
+      {children}
+    </DirectiveCard>
   );
 };


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #10634  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

* Add `min-height` `max-width` and `min-width` prop support to the `Box` component in docs 
* Allow props spreading from the `DirectiveCard` and `Card` components down to the respective `Box` component. 
* `Do` and `Dont` components both now have a minHeight value of `100%`. 

This seems like the best way to solve this within the context of the docs, the other alternative is to make adjustments to the Grid.Cell component such that its children always expand to fill its height. However that'd be an update to the Grid component which seems out of scope for this block of work. 

This resolves the issue as below. 
Before: 
![Screenshot 2023-09-25 at 4 25 34 pm](https://github.com/Shopify/polaris/assets/12119389/5969bff5-53d5-4ac2-9ebb-e362cc06fab8)

After: 
![Screenshot 2023-09-25 at 4 28 41 pm](https://github.com/Shopify/polaris/assets/12119389/4779556c-3143-4da9-a9cc-bb3316753780)

However also means that in certain layouts, due to how we're using Grid, these components will blow out to the size of the tallest Grid.Cell

Before: 
![Screenshot 2023-09-25 at 4 25 30 pm](https://github.com/Shopify/polaris/assets/12119389/3064992e-6904-420a-b54e-88791b406697)

After: 
![Screenshot 2023-09-25 at 4 28 37 pm](https://github.com/Shopify/polaris/assets/12119389/9f909bc3-bbff-445d-a13c-e0f9210f67d6)


<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
