### PR TITLE
[polaris.shopify.com] Fix content styles

### DIFF
--- a/polaris.shopify.com/content/content/grammar-and-mechanics.md
+++ b/polaris.shopify.com/content/content/grammar-and-mechanics.md
@@ -880,9 +880,11 @@ Always use apostrophes, not vertical (straight) quotes.
 {/* prettier-ignore */}
 - <span
     style={{
-      fontSize: '5rem',
+      fontSize: '2rem',
       lineHeight: 0,
       verticalAlign: 'bottom',
+      display: 'inline-block',
+      height: 0,
     }}
   >’</span>
   <kbd>option</kbd> + <kbd>shift</kbd> + <kbd>]</kbd>
@@ -892,9 +894,11 @@ Always use apostrophes, not vertical (straight) quotes.
 {/* prettier-ignore */}
 - <span
     style={{
-      fontSize: '5rem',
+      fontSize: '2rem',
       lineHeight: 0,
       verticalAlign: 'bottom',
+      display: 'inline-block',
+      height: 0,
     }}
   >'</span>
 
@@ -1020,7 +1024,7 @@ Always use the ellipsis character, not three periods.
 {/* prettier-ignore */}
 <code
   style={{
-    fontSize: '5rem',
+    fontSize: '2rem',
     lineHeight: 0,
     backgroundColor: 'transparent',
   }}
@@ -1032,7 +1036,7 @@ Always use the ellipsis character, not three periods.
 {/* prettier-ignore */}
 <code
   style={{
-    fontSize: '5rem',
+    fontSize: '2rem',
     lineHeight: 0,
     backgroundColor: 'transparent',
   }}
@@ -1280,36 +1284,44 @@ Always use smart (curly) quotes, not vertical (straight) quotes.
 {/* prettier-ignore */}
 - <span
     style={{
-      fontSize: '5rem',
+      fontSize: '2rem',
       lineHeight: 0,
       verticalAlign: 'bottom',
+      display: 'inline-block',
+      height: 0,
     }}
   >‘</span>
   <kbd>option</kbd> + <kbd>]</kbd>
 {/* prettier-ignore */}
 - <span
     style={{
-      fontSize: '5rem',
+      fontSize: '2rem',
       lineHeight: 0,
       verticalAlign: 'bottom',
+      display: 'inline-block',
+      height: 0,
     }}
   >’</span>
   <kbd>option</kbd> + <kbd>shift</kbd> + <kbd>]</kbd>
 {/* prettier-ignore */}
 - <span
     style={{
-      fontSize: '5rem',
+      fontSize: '2rem',
       lineHeight: 0,
       verticalAlign: 'bottom',
+      display: 'inline-block',
+      height: 0,
     }}
   >“</span>
   <kbd>option</kbd> + <kbd>[</kbd>
 {/* prettier-ignore */}
 - <span
     style={{
-      fontSize: '5rem',
+      fontSize: '2rem',
       lineHeight: 0,
       verticalAlign: 'bottom',
+      display: 'inline-block',
+      height: 0,
     }}
   >”</span>
   <kbd>option</kbd> + <kbd>shift</kbd> + <kbd>[</kbd>
@@ -1319,17 +1331,21 @@ Always use smart (curly) quotes, not vertical (straight) quotes.
 {/* prettier-ignore */}
 - <span
     style={{
-      fontSize: '5rem',
+      fontSize: '2rem',
       lineHeight: 0,
       verticalAlign: 'bottom',
+      display: 'inline-block',
+      height: 0,
     }}
   >"</span>
   or
   <span
     style={{
-      fontSize: '5rem',
+      fontSize: '2rem',
       lineHeight: 0,
       verticalAlign: 'bottom',
+      display: 'inline-block',
+      height: 0,
     }}
   >'</span>
 

--- a/polaris.shopify.com/src/components/Box/index.tsx
+++ b/polaris.shopify.com/src/components/Box/index.tsx
@@ -26,7 +26,7 @@ export interface BoxProps {
 
 export type OwnProps<T> = Polymorphic.OwnProps<T>;
 
-type PolymorphicBox = Polymorphic.ForwardRefComponent<'div', BoxProps>;
+type PolymorphicBox = Polymorphic.ForwardRefComponent<any, BoxProps>;
 
 /**
  * Box is the most abstract component on top of which other components are

--- a/polaris.shopify.com/src/components/Grid/Grid.tsx
+++ b/polaris.shopify.com/src/components/Grid/Grid.tsx
@@ -42,7 +42,6 @@ export const Grid = forwardRef(
       as={as}
       ref={ref}
       style={{
-        // @ts-expect-error The types for `style` don't support css vars
         '--props-grid-gap':
           typeof gap !== 'undefined' ? `var(--p-space-${gap})` : undefined,
         '--props-grid-gap-x':

--- a/polaris.shopify.com/src/components/Stack/Stack.module.scss
+++ b/polaris.shopify.com/src/components/Stack/Stack.module.scss
@@ -8,3 +8,7 @@
   flex-direction: row;
   flex-wrap: var(--row-wrap-prop, nowrap);
 }
+
+.List {
+  margin: 0;
+}

--- a/polaris.shopify.com/src/components/Stack/index.tsx
+++ b/polaris.shopify.com/src/components/Stack/index.tsx
@@ -8,10 +8,16 @@ export interface StackProps {
 }
 
 export const Stack = forwardRef(
-  ({gap = '0', style, className, ...props}, ref) => (
+  ({gap = '0', style, className, as, ...props}, ref) => (
     <Box
+      as={as}
       ref={ref}
-      className={[styles.Stack, className]}
+      className={[
+        styles.Stack,
+        className,
+        // @ts-expect-error The types for `as` don't support `ul`?
+        as === 'ul' ? styles.List : undefined,
+      ]}
       style={{
         // @ts-expect-error The types for `style` don't support css vars for
         // some reason

--- a/polaris.shopify.com/src/components/Stack/index.tsx
+++ b/polaris.shopify.com/src/components/Stack/index.tsx
@@ -15,12 +15,9 @@ export const Stack = forwardRef(
       className={[
         styles.Stack,
         className,
-        // @ts-expect-error The types for `as` don't support `ul`?
         as === 'ul' ? styles.List : undefined,
       ]}
       style={{
-        // @ts-expect-error The types for `style` don't support css vars for
-        // some reason
         '--stack-gap-prop': `var(--p-space-${gap})`,
         ...style,
       }}


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris/issues/10626

Before:
![image](https://github.com/Shopify/polaris/assets/6844391/22e3f689-74eb-4b48-9088-91ba0f4b5ed3)

After:
![image](https://github.com/Shopify/polaris/assets/6844391/a14085a6-fdb3-4c4c-bacb-2e7d90794a65)
