### PR TITLE
Resolve token name references in the `theme`

### DIFF
--- a/.changeset/wild-bulldogs-whisper.md
+++ b/.changeset/wild-bulldogs-whisper.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-tokens': patch
 ---
 
-Resolved token name references in the `theme`
+Updated the `toValues` token utility to resolve token name references in the `theme` to their unit values

--- a/.changeset/wild-bulldogs-whisper.md
+++ b/.changeset/wild-bulldogs-whisper.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': patch
+---
+
+Resolved token named references in the `theme`

--- a/.changeset/wild-bulldogs-whisper.md
+++ b/.changeset/wild-bulldogs-whisper.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-tokens': patch
 ---
 
-Resolved token named references in the `theme`
+Resolved token name references in the `theme`

--- a/polaris-tokens/scripts/toValues.ts
+++ b/polaris-tokens/scripts/toValues.ts
@@ -2,7 +2,10 @@ import fs from 'fs';
 import path from 'path';
 
 import {metaThemes, metaThemeDefault} from '../src/themes';
-import {extractMetaThemeValues} from '../src/themes/utils';
+import {
+  extractMetaThemeValues,
+  resolveMetaThemeRefs,
+} from '../src/themes/utils';
 
 const outputDir = path.join(__dirname, '../build');
 
@@ -13,7 +16,9 @@ export async function toValues() {
     }
   });
 
-  const themeDefault = extractMetaThemeValues(metaThemeDefault);
+  const themeDefault = extractMetaThemeValues(
+    resolveMetaThemeRefs(metaThemeDefault),
+  );
 
   await fs.promises.writeFile(
     path.join(outputDir, 'index.ts'),
@@ -26,7 +31,7 @@ export async function toValues() {
         Object.fromEntries(
           Object.entries(metaThemes).map(([themeName, metaTheme]) => [
             themeName,
-            extractMetaThemeValues(metaTheme),
+            extractMetaThemeValues(resolveMetaThemeRefs(metaTheme)),
           ]),
         ),
       ]),

--- a/polaris-tokens/src/themes/utils.ts
+++ b/polaris-tokens/src/themes/utils.ts
@@ -54,3 +54,27 @@ export function extractMetaThemeValues<T extends MetaThemeShape>(metaTheme: T) {
     ),
   ) as ExtractMetaThemeValues<T>;
 }
+
+export function resolveMetaThemeRefs<T extends MetaThemeShape>(
+  metaTheme: T,
+): T {
+  return Object.fromEntries(
+    Object.entries(metaTheme).map(([tokenGroupName, metaTokenGroup]) => [
+      tokenGroupName,
+      Object.fromEntries(
+        Object.entries(metaTokenGroup).map(([tokenName, tokenProperties]) => {
+          let tokenValue = tokenProperties.value;
+
+          if (tokenValue.startsWith('var(--p-')) {
+            const tokenNameRef = tokenValue.slice(8, -1);
+            const tokenGroupNameRef = tokenNameRef.split('-')[0];
+
+            tokenValue = metaTheme[tokenGroupNameRef][tokenNameRef].value;
+          }
+
+          return [tokenName, {...tokenProperties, value: tokenValue}];
+        }),
+      ),
+    ]),
+  ) as T;
+}

--- a/polaris-tokens/src/themes/utils.ts
+++ b/polaris-tokens/src/themes/utils.ts
@@ -62,18 +62,20 @@ export function resolveMetaThemeRefs<T extends MetaThemeShape>(
     Object.entries(metaTheme).map(([tokenGroupName, metaTokenGroup]) => [
       tokenGroupName,
       Object.fromEntries(
-        Object.entries(metaTokenGroup).map(([tokenName, tokenProperties]) => {
-          let tokenValue = tokenProperties.value;
+        Object.entries(metaTokenGroup).map(
+          ([tokenName, metaTokenProperties]) => {
+            let tokenValue = metaTokenProperties.value;
 
-          if (tokenValue.startsWith('var(--p-')) {
-            const tokenNameRef = tokenValue.slice(8, -1);
-            const tokenGroupNameRef = tokenNameRef.split('-')[0];
+            if (tokenValue.startsWith('var(--p-')) {
+              const tokenNameRef = tokenValue.slice(8, -1);
+              const tokenGroupNameRef = tokenNameRef.split('-')[0];
 
-            tokenValue = metaTheme[tokenGroupNameRef][tokenNameRef].value;
-          }
+              tokenValue = metaTheme[tokenGroupNameRef][tokenNameRef].value;
+            }
 
-          return [tokenName, {...tokenProperties, value: tokenValue}];
-        }),
+            return [tokenName, {...metaTokenProperties, value: tokenValue}];
+          },
+        ),
       ),
     ]),
   ) as T;

--- a/polaris-tokens/src/themes/utils.ts
+++ b/polaris-tokens/src/themes/utils.ts
@@ -79,7 +79,7 @@ export function resolveMetaThemeRefs<T extends MetaThemeShape>(
           ([tokenName, metaTokenProperties]) => {
             let tokenValue = metaTokenProperties.value;
 
-            if (tokenValue.startsWith('var(--p-')) {
+            while (tokenValue.startsWith('var(--p-')) {
               const tokenNameRef = tokenValue.slice(8, -1);
 
               tokenValue = flattenedMetaTheme[tokenNameRef].value;

--- a/polaris-tokens/src/themes/utils.ts
+++ b/polaris-tokens/src/themes/utils.ts
@@ -55,9 +55,22 @@ export function extractMetaThemeValues<T extends MetaThemeShape>(metaTheme: T) {
   ) as ExtractMetaThemeValues<T>;
 }
 
+export function flattenMetaTheme(metaTheme: MetaThemeShape) {
+  return Object.fromEntries(
+    Object.values(metaTheme).flatMap((metaTokenGroup) =>
+      Object.entries(metaTokenGroup).map(([tokenName, metaTokenProperties]) => [
+        tokenName,
+        metaTokenProperties,
+      ]),
+    ),
+  );
+}
+
 export function resolveMetaThemeRefs<T extends MetaThemeShape>(
   metaTheme: T,
 ): T {
+  const flattenedMetaTheme = flattenMetaTheme(metaTheme);
+
   return Object.fromEntries(
     Object.entries(metaTheme).map(([tokenGroupName, metaTokenGroup]) => [
       tokenGroupName,
@@ -68,9 +81,8 @@ export function resolveMetaThemeRefs<T extends MetaThemeShape>(
 
             if (tokenValue.startsWith('var(--p-')) {
               const tokenNameRef = tokenValue.slice(8, -1);
-              const tokenGroupNameRef = tokenNameRef.split('-')[0];
 
-              tokenValue = metaTheme[tokenGroupNameRef][tokenNameRef].value;
+              tokenValue = flattenedMetaTheme[tokenNameRef].value;
             }
 
             return [tokenName, {...metaTokenProperties, value: tokenValue}];

--- a/polaris-tokens/tests/utilities.test.js
+++ b/polaris-tokens/tests/utilities.test.js
@@ -237,4 +237,24 @@ describe('resolveMetaThemeRefs', () => {
 
     expect(resolveMetaThemeRefs(metaTheme)).toStrictEqual(expectedMetaTheme);
   });
+
+  it('resolves nested token references', () => {
+    const metaTheme = {
+      space: {
+        'space-1': {value: '1px'},
+        'space-2': {value: 'var(--p-space-1)'},
+        'space-gap': {value: 'var(--p-space-2)'},
+      },
+    };
+
+    const expectedMetaTheme = {
+      space: {
+        'space-1': {value: '1px'},
+        'space-2': {value: '1px'},
+        'space-gap': {value: '1px'},
+      },
+    };
+
+    expect(resolveMetaThemeRefs(metaTheme)).toStrictEqual(expectedMetaTheme);
+  });
 });

--- a/polaris-tokens/tests/utilities.test.js
+++ b/polaris-tokens/tests/utilities.test.js
@@ -9,6 +9,7 @@ import {
   getUnit,
   getMediaConditions,
 } from '../src/utilities';
+import {resolveMetaThemeRefs} from '../src/themes/utils';
 
 const mockTokenGroup = {
   'design-token-1': {
@@ -175,5 +176,47 @@ describe('getMediaConditions', () => {
         only: '(min-width: 2em)',
       },
     });
+  });
+});
+
+describe('resolveMetaThemeRefs', () => {
+  it('resolves token references inside the current token group', () => {
+    const metaTheme = {
+      space: {
+        'space-1': {value: '1px'},
+        'space-gap': {value: 'var(--p-space-1)'},
+      },
+    };
+
+    const expectedMetaTheme = {
+      space: {
+        'space-1': {value: '1px'},
+        'space-gap': {value: '1px'},
+      },
+    };
+
+    expect(resolveMetaThemeRefs(metaTheme)).toStrictEqual(expectedMetaTheme);
+  });
+
+  it('resolves token references outside the current token group', () => {
+    const metaTheme = {
+      font: {
+        'font-size-1': {value: '1px'},
+      },
+      text: {
+        'text-body-md-font-size': {value: 'var(--p-font-size-1)'},
+      },
+    };
+
+    const expectedMetaTheme = {
+      font: {
+        'font-size-1': {value: '1px'},
+      },
+      text: {
+        'text-body-md-font-size': {value: '1px'},
+      },
+    };
+
+    expect(resolveMetaThemeRefs(metaTheme)).toStrictEqual(expectedMetaTheme);
   });
 });

--- a/polaris-tokens/tests/utilities.test.js
+++ b/polaris-tokens/tests/utilities.test.js
@@ -219,4 +219,22 @@ describe('resolveMetaThemeRefs', () => {
 
     expect(resolveMetaThemeRefs(metaTheme)).toStrictEqual(expectedMetaTheme);
   });
+
+  it('resolves token references with multi-dash token group names', () => {
+    const metaTheme = {
+      zIndex: {
+        'z-index-1': {value: '1'},
+        'z-modal': {value: 'var(--p-z-index-1)'},
+      },
+    };
+
+    const expectedMetaTheme = {
+      zIndex: {
+        'z-index-1': {value: '1'},
+        'z-modal': {value: '1'},
+      },
+    };
+
+    expect(resolveMetaThemeRefs(metaTheme)).toStrictEqual(expectedMetaTheme);
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Alternative approach to https://github.com/Shopify/polaris/pull/10650

The new theme architecture in Polaris tokens intends to make extensive use of semantic tokens referencing primitives. Over the past month we've revamped and introduced a collection of new token scales that we'll use to incrementally create semantics to adopt in Polaris and the Admin. The process of referencing primitives in semantic tokens has already begun by using the associated CSS custom property e.g. `'semantic-token': 'var(--p-primitive-scale-1)'`. However, we did not consider the impact on non Web platform consumers. This PR aims to update our JS build artifact to resolve references to be platform agnostic.

### WHAT is this pull request doing?

This PR introduces a `resolveMetaThemeRefs` utility that resolves and replaces `var(--p-` references with hard coded values during the build.
