### PR TITLE
`Docs` fix Box implementation to use more specific padding values first before defaulting to the overarching padding value

### DIFF
--- a/polaris.shopify.com/src/components/Box/index.tsx
+++ b/polaris.shopify.com/src/components/Box/index.tsx
@@ -41,15 +41,39 @@ export const Box = forwardRef(
       minWidth,
       maxWidth,
       padding = '0',
+      paddingBlockStart,
+      paddingBlockEnd,
+      paddingInlineStart,
+      paddingInlineEnd,
       ...props
     },
     forwardedRef,
   ) => {
     const style = {
-      ...getResponsiveProps('box', 'padding-block-start', 'space', padding),
-      ...getResponsiveProps('box', 'padding-block-end', 'space', padding),
-      ...getResponsiveProps('box', 'padding-inline-start', 'space', padding),
-      ...getResponsiveProps('box', 'padding-inline-end', 'space', padding),
+      ...getResponsiveProps(
+        'box',
+        'padding-block-start',
+        'space',
+        paddingBlockStart || padding,
+      ),
+      ...getResponsiveProps(
+        'box',
+        'padding-block-end',
+        'space',
+        paddingBlockEnd || padding,
+      ),
+      ...getResponsiveProps(
+        'box',
+        'padding-inline-start',
+        'space',
+        paddingInlineStart || padding,
+      ),
+      ...getResponsiveProps(
+        'box',
+        'padding-inline-end',
+        'space',
+        paddingInlineEnd || padding,
+      ),
       '--pc-box-min-height': minHeight,
       '--px-box-min-width': minWidth,
       '--px-box-max-width': maxWidth,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Previously the Box component in polaris.shopify.com wasn't properly respecting `padding-block-x` and `padding-inline-x` prop values. 

### WHAT is this pull request doing?

* Change `getResponsiveProps` invocation for `padding-block-x` and `padding-inline-x` to use the corresponding prop values before defaulting to the `padding` prop value. 
* 
### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
