### PR TITLE
Fix `untriaged-labeler` workflow

### DIFF
--- a/.github/workflows/untriaged-labeler.yml
+++ b/.github/workflows/untriaged-labeler.yml
@@ -12,18 +12,17 @@ jobs:
     permissions:
       issues: write
     steps:
-
-    - name: Check labels
-      id: check_labels
-      uses: actions/github-script@v5
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const labels = context.payload.issue.labels.map(label => label.name);
-          const hasBugLabel = labels.includes('Bug');
-          const hasUntriagedLabel = labels.includes('untriaged');
-          core.setOutput('hasBugLabel', hasBugLabel);
-          core.setOutput('hasUntriagedLabel', hasUntriagedLabel);
+      - name: Check labels
+        id: check_labels
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labels = context.payload.issue.labels.map(label => label.name);
+            const hasBugLabel = labels.includes('Bug');
+            const hasUntriagedLabel = labels.includes('untriaged');
+            core.setOutput('hasBugLabel', hasBugLabel);
+            core.setOutput('hasUntriagedLabel', hasUntriagedLabel);
 
       - name: Label issues
         uses: andymckay/labeler@1.0.2


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes error for `untriaged-labeler` workflow.
I noticed it's been [failing](https://github.com/Shopify/polaris/actions/workflows/untriaged-labeler.yml) consistently for the past couple weeks.
    <details>
      <summary>Error example</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/f5236b99-86d9-4f63-9307-2d8348b0fc9a" alt="Error example">
    </details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
