### PR TITLE
[InlineError] Manually migrate `color` custom properties for v11 to v12

### DIFF
--- a/polaris-react/src/components/InlineError/InlineError.scss
+++ b/polaris-react/src/components/InlineError/InlineError.scss
@@ -3,11 +3,11 @@
 .InlineError {
   display: flex;
   color: var(--p-color-text-critical);
-  fill: var(--p-color-icon-critical);
+  fill: var(--p-color-text-critical);
 }
 
 .Icon {
-  fill: var(--p-color-icon-critical);
+  fill: var(--p-color-text-critical);
   margin-left: calc(-1 * var(--p-space-050));
   margin-right: var(--p-space-200);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #10391.

### WHAT is this pull request doing?

Manually migrates `InlineError` component `color` custom properties.
    <details>
      <summary>InlineError — before</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/f9f2ea44-f058-4ef0-9c35-71017ca7f6fe" alt="InlineError — before">
    </details>
    <details>
      <summary>InlineError — after</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/4cb1f673-6c1a-4dc4-8c10-28c2b904339c" alt="InlineError — after">
    </details>

### How to 🎩

[Storybook](https://5d559397bae39100201eedc1-uoggaugpto.chromatic.com/?path=/story/all-components-inlineerror--default)
[Next branch storybook](https://5d559397bae39100201eedc1-iqlmktwkqx.chromatic.com/?path=/story/all-components-inlineerror--default)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
