### PR TITLE
[TopBar] Manually migrate `color` custom properties for v11 to v12

### DIFF
--- a/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
@@ -98,12 +98,13 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-300));
     color var(--p-motion-duration-200) var(--p-motion-ease);
 
   &:hover {
-    border-color: var(--p-color-border-hover);
+    border-color: var(--p-color-border-inverse-hover);
   }
 
   &:active,
   &:focus {
-    box-shadow: inset 0 0 0 var(--p-border-width-1) var(--p-color-border);
+    box-shadow: inset 0 0 0 var(--p-border-width-1)
+      var(--p-color-border-inverse-active);
   }
 
   &::placeholder {
@@ -185,6 +186,6 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-300));
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(--p-color-bg-inset-strong);
+  background-color: var(--p-color-bg-surface-inverse);
   border-radius: var(--p-border-radius-2);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #10388.

### WHAT is this pull request doing?

Manually migrates `TopBar` component `color` custom properties.

### How to 🎩

[Storybook](https://5d559397bae39100201eedc1-prihtemvap.chromatic.com/?path=/story/all-components-topbar--default)
[Next branch storybook](https://5d559397bae39100201eedc1-iqlmktwkqx.chromatic.com/?path=/story/all-components-topbar--default)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
