### PR TITLE
Revert "[TextField] Automatically set password manager disable props if `autoComplete="off"`"

### DIFF
--- a/.changeset/quiet-grapes-end.md
+++ b/.changeset/quiet-grapes-end.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris': minor
----
-
-Updated the TextField to automatically set password manager disable data attributes based on the autoComplete prop

--- a/.changeset/quiet-grapes-end.md
+++ b/.changeset/quiet-grapes-end.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+---
+
+- Updated the `TextField` to automatically set password manager disable data attributes when `autoComplete` is set to "off"
+- Deprecated the `TextField` `disable1Password` prop

--- a/polaris-react/src/components/Tabs/components/CreateViewModal/CreateViewModal.tsx
+++ b/polaris-react/src/components/Tabs/components/CreateViewModal/CreateViewModal.tsx
@@ -111,6 +111,7 @@ export function CreateViewModal({
                       )
                     : undefined
                 }
+                disable1Password
               />
             </div>
           </FormLayout>

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -878,6 +878,7 @@ export function With1PasswordDisabled() {
       value={value}
       onChange={handleChange}
       autoComplete="off"
+      disable1Password
     />
   );
 }

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -173,6 +173,8 @@ interface NonMutuallyExclusiveProps {
   onBlur?(event?: React.FocusEvent): void;
   /** Removes the border around the input. Used in the IndexFilters component. */
   borderless?: boolean;
+  /** Disables the 1password extension on the text field */
+  disable1Password?: boolean;
 }
 
 export type MutuallyExclusiveSelectionProps =
@@ -239,6 +241,7 @@ export function TextField({
   onFocus,
   onBlur,
   borderless,
+  disable1Password,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -556,12 +559,7 @@ export function TextField({
     onKeyDown: handleKeyDown,
     onChange: !suggestion ? handleChange : undefined,
     onInput: suggestion ? handleChange : undefined,
-    // 1Password disable data attribute
-    'data-1p-ignore': autoComplete === 'off' || undefined,
-    // LastPass disable data attribute
-    'data-lpignore': autoComplete === 'off' || undefined,
-    // Dashlane disable data attribute
-    'data-form-type': autoComplete === 'off' ? 'other' : undefined,
+    'data-1p-ignore': disable1Password || undefined,
   });
 
   const inputWithVerticalContentMarkup = verticalContent ? (

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -173,7 +173,10 @@ interface NonMutuallyExclusiveProps {
   onBlur?(event?: React.FocusEvent): void;
   /** Removes the border around the input. Used in the IndexFilters component. */
   borderless?: boolean;
-  /** Disables the 1password extension on the text field */
+  /**
+   * @deprecated Turning off 1Password and LastPass password manager autofill is done automatically when `autocomplete` is set to `off`.
+   * Disables the 1password extension on the text field.
+   */
   disable1Password?: boolean;
 }
 
@@ -559,7 +562,12 @@ export function TextField({
     onKeyDown: handleKeyDown,
     onChange: !suggestion ? handleChange : undefined,
     onInput: suggestion ? handleChange : undefined,
-    'data-1p-ignore': disable1Password || undefined,
+    // 1Password disable data attribute
+    'data-1p-ignore': autoComplete === 'off' || disable1Password || undefined,
+    // LastPass disable data attribute
+    'data-lpignore': autoComplete === 'off' || undefined,
+    // Dashlane disable data attribute
+    'data-form-type': autoComplete === 'off' ? 'other' : undefined,
   });
 
   const inputWithVerticalContentMarkup = verticalContent ? (

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -85,7 +85,7 @@ describe('<TextField />', () => {
     });
   });
 
-  it('adds the data-1p-ignore prop if disable1Password is set', () => {
+  it('adds the 1Password disable prop if disable1Password is set', () => {
     const textField = mountWithApp(
       <TextField
         label="TextField"
@@ -97,6 +97,18 @@ describe('<TextField />', () => {
 
     expect(textField).toContainReactComponent('input', {
       'data-1p-ignore': true,
+    } as any);
+  });
+
+  it('adds the password manager disabled props if autoComplete="off" is set', () => {
+    const textField = mountWithApp(
+      <TextField label="TextField" onChange={noop} autoComplete="off" />,
+    );
+
+    expect(textField).toContainReactComponent('input', {
+      'data-1p-ignore': true,
+      'data-lpignore': true,
+      'data-form-type': 'other',
     } as any);
   });
 

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -85,15 +85,18 @@ describe('<TextField />', () => {
     });
   });
 
-  it('adds the password manager disabled props if autoComplete="off" is set', () => {
+  it('adds the data-1p-ignore prop if disable1Password is set', () => {
     const textField = mountWithApp(
-      <TextField label="TextField" onChange={noop} autoComplete="off" />,
+      <TextField
+        label="TextField"
+        onChange={noop}
+        autoComplete="off"
+        disable1Password
+      />,
     );
 
     expect(textField).toContainReactComponent('input', {
       'data-1p-ignore': true,
-      'data-lpignore': true,
-      'data-form-type': 'other',
     } as any);
   });
 


### PR DESCRIPTION
Reverts the removal of `TextField` prop `disable1Password` shipped in Shopify/polaris#10709 and deprecates it instead. 