### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Default
+* @Shopify/polaris-team
+
+# React, TypeScript, JavaScript
+*.tsx @Shopify/polaris-eng
+*.ts @Shopify/polaris-eng
+*.js @Shopify/polaris-eng
+
+# Config files
+*.yml @Shopify/polaris-eng
+*.json @Shopify/polaris-eng
+
+# Documentation
+*.mdx @Shopify/polaris-team
+*.md @Shopify/polaris-team
+
+/polaris.shopify.com/content/design @Shopify/polaris-ux
+/polaris.shopify.com/content/foundations @Shopify/polaris-ux
+/polaris.shopify.com/content/patterns @Shopify/polaris-ux
+


### PR DESCRIPTION
### WHY are these changes introduced?

Major version work is moving quickly. We need visibility into changes shipping to main to avoid reverts and conflicts  and divert changes to `next` when needed.

