### PR TITLE
Revert "[Filters] Fix hitting max call depth when appliedFilters is undefined"

### DIFF
--- a/.changeset/seven-apricots-provide.md
+++ b/.changeset/seven-apricots-provide.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris': patch
----
-
-Fixed issue with setting local pinned filters in `Filters` when no `appliedFilters` were provided.

--- a/polaris-react/src/components/Filters/Filters.tsx
+++ b/polaris-react/src/components/Filters/Filters.tsx
@@ -165,9 +165,9 @@ export function Filters({
   );
 
   useEffect(() => {
-    const allAppliedFilterKeysInLocalPinnedFilters =
-      !appliedFilterKeys ||
-      appliedFilterKeys.every((value) => localPinnedFilters.includes(value));
+    const allAppliedFilterKeysInLocalPinnedFilters = appliedFilterKeys?.every(
+      (value) => localPinnedFilters.includes(value),
+    );
 
     if (!allAppliedFilterKeysInLocalPinnedFilters) {
       setLocalPinnedFilters((currentLocalPinnedFilters: string[]): string[] => {


### PR DESCRIPTION
Reverts Shopify/polaris#10711

Temporarily reverting this PR so the [color migration](https://github.com/Shopify/polaris/pull/10576) can be on a dedicated release.