### PR TITLE
[TextField] Remove disable1Password prop

### DIFF
--- a/.changeset/fifty-wombats-battle.md
+++ b/.changeset/fifty-wombats-battle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+Removed deprecated `disable1Password` prop from `TextField`.

--- a/polaris-react/src/components/Tabs/components/CreateViewModal/CreateViewModal.tsx
+++ b/polaris-react/src/components/Tabs/components/CreateViewModal/CreateViewModal.tsx
@@ -111,7 +111,6 @@ export function CreateViewModal({
                       )
                     : undefined
                 }
-                disable1Password
               />
             </div>
           </FormLayout>

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -882,7 +882,6 @@ export function With1PasswordDisabled() {
       value={value}
       onChange={handleChange}
       autoComplete="off"
-      disable1Password
     />
   );
 }

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -175,11 +175,6 @@ interface NonMutuallyExclusiveProps {
   onFocus?: (event?: React.FocusEvent) => void;
   /** Callback fired when input is blurred */
   onBlur?(event?: React.FocusEvent): void;
-  /**
-   * @deprecated Turning off 1Password and LastPass password manager autofill is done automatically when `autocomplete` is set to `off`.
-   * Disables the 1password extension on the text field.
-   */
-  disable1Password?: boolean;
 }
 
 export type MutuallyExclusiveSelectionProps =
@@ -246,7 +241,6 @@ export function TextField({
   onSpinnerChange,
   onFocus,
   onBlur,
-  disable1Password,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -565,7 +559,7 @@ export function TextField({
     onChange: !suggestion ? handleChange : undefined,
     onInput: suggestion ? handleChange : undefined,
     // 1Password disable data attribute
-    'data-1p-ignore': autoComplete === 'off' || disable1Password || undefined,
+    'data-1p-ignore': autoComplete === 'off' || undefined,
     // LastPass disable data attribute
     'data-lpignore': autoComplete === 'off' || undefined,
     // Dashlane disable data attribute

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -85,21 +85,6 @@ describe('<TextField />', () => {
     });
   });
 
-  it('adds the 1Password disable prop if disable1Password is set', () => {
-    const textField = mountWithApp(
-      <TextField
-        label="TextField"
-        onChange={noop}
-        autoComplete="off"
-        disable1Password
-      />,
-    );
-
-    expect(textField).toContainReactComponent('input', {
-      'data-1p-ignore': true,
-    } as any);
-  });
-
   it('adds the password manager disabled props if autoComplete="off" is set', () => {
     const textField = mountWithApp(
       <TextField label="TextField" onChange={noop} autoComplete="off" />,


### PR DESCRIPTION
Removes the deprecated `disable1Password` prop.


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
