### PR TITLE
[polaris-migrator] Add a migration to change inline for block comments

### DIFF
--- a/.changeset/fluffy-peas-dress.md
+++ b/.changeset/fluffy-peas-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Adds new styles-replace-inline-comments general migration

--- a/polaris-migrator/codeshift.config.js
+++ b/polaris-migrator/codeshift.config.js
@@ -11,6 +11,7 @@ module.exports = {
       'styles-insert-stylelint-disable',
     ),
     'styles-replace-custom-property': resolve('styles-replace-custom-property'),
+    'styles-replace-inline-comments': resolve('styles-replace-inline-comments'),
     'v11-react-update-page-breadcrumbs': resolve(
       'v11-react-update-page-breadcrumbs',
     ),

--- a/polaris-migrator/src/migrations/styles-replace-inline-comments/tests/styles-replace-inline-comments.input.scss
+++ b/polaris-migrator/src/migrations/styles-replace-inline-comments/tests/styles-replace-inline-comments.input.scss
@@ -1,0 +1,12 @@
+// single-inline-comment
+$single-inline-comment: 1rem;
+
+// multiline
+// comment
+$multiline-comment: 1rem;
+
+.comment {
+  $top-nested-comment: 1rem;
+  // nested-sandwidched-comment
+  $bottom-nested-comment: 1rem;
+}

--- a/polaris-migrator/src/migrations/styles-replace-inline-comments/tests/styles-replace-inline-comments.output.scss
+++ b/polaris-migrator/src/migrations/styles-replace-inline-comments/tests/styles-replace-inline-comments.output.scss
@@ -1,0 +1,12 @@
+/* single-inline-comment */
+$single-inline-comment: 1rem;
+
+/* multiline */
+/* comment */
+$multiline-comment: 1rem;
+
+.comment {
+  $top-nested-comment: 1rem;
+  /* nested-sandwidched-comment */
+  $bottom-nested-comment: 1rem;
+}

--- a/polaris-migrator/src/migrations/styles-replace-inline-comments/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/styles-replace-inline-comments/tests/transform.test.ts
@@ -1,0 +1,17 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'styles-replace-inline-comments';
+const fixtures = ['styles-replace-inline-comments'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+    extension: 'scss',
+    options: {
+      customSyntax: 'postcss-scss',
+      reportDescriptionlessDisables: true,
+      rules: {},
+    },
+  });
+}

--- a/polaris-migrator/src/migrations/styles-replace-inline-comments/transform.ts
+++ b/polaris-migrator/src/migrations/styles-replace-inline-comments/transform.ts
@@ -1,0 +1,37 @@
+import type {API, FileInfo, Options} from 'jscodeshift';
+import type {Plugin} from 'postcss';
+import postcss from 'postcss';
+import stylelint from 'stylelint';
+
+const plugin = (): Plugin => {
+  return {
+    postcssPlugin: 'styles-replace-inline-comments',
+    Comment(comment) {
+      comment.raws.inline = false;
+      comment.raws.right = ' ';
+      comment.raws.left = ' ';
+    },
+  };
+};
+
+export default async function transformer(
+  file: FileInfo,
+  _: API,
+  options: Options,
+) {
+  return postcss([
+    stylelint({
+      config: {
+        extends: [options.config ?? '@shopify/stylelint-polaris'],
+      },
+    }) as Plugin,
+    plugin(),
+  ])
+    .process(file.source, {
+      from: file.path,
+      syntax: require('postcss-scss'),
+    })
+    .then((result) => {
+      return result.css;
+    });
+}


### PR DESCRIPTION
### WHY are these changes introduced?

In the context of `shopify/web`'s code yellow, we are looking to drop sass. The overall topic here is substraction, so we want to rewrite all comments to the CSS native block style by default

### WHAT is this pull request doing?

Creates a new migration `styles-replace-inline-comments` that replaces inline by block comments

### How to 🎩

I think tests should be enough, but you can look at https://github.com/Shopify/web/pull/105280/commits/12c19b7f3be5f9689406ad690e368bcd55a3f894 as a reference of the output of running the codemod over a fraction of the `shopify/web` codebase

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
