### PR TITLE
[Modal] Disallow scroll if modal prop noScroll is true

### DIFF
--- a/.changeset/two-phones-move.md
+++ b/.changeset/two-phones-move.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[Modal] Disallow vertical scroll with use of noScroll

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -165,7 +165,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
     );
 
     const scrollContainerMarkup = noScroll ? (
-      <Box width="100%" overflowX="hidden">
+      <Box width="100%" overflowX="hidden" overflowY="hidden">
         {body}
       </Box>
     ) : (


### PR DESCRIPTION
### WHY are these changes introduced?

The noScroll prop on our modal should stop the scroll effect. This would be useful in cases where scrolls are already in the children components.

https://github.com/Shopify/polaris/assets/113911518/ba755e78-851a-4809-b3a3-5e31a8d7a7db

We are using this throughout Shopify on our resource pickers where noScroll is set to true. The issue is right now Banner is scrolling and causing a double scroll

https://github.com/Shopify/polaris/assets/113911518/ddaf01b6-1592-4a34-a36d-6e4e0e9b6f2c


### WHAT is this pull request doing?

We are simply adding the `overflow-y: hidden`.

`overflow-x: hidden` is already present but that only stops horizontal scroll

### How to 🎩

Add and remove the onScroll props to see scroll ability disappear. (You might need to shorten your window to get the scroll if your text isn't long enough)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Page, Modal, Button} from '../src';

export function Playground() {
  const [active, setActive] = useState(true);

  const handleChange = useCallback(() => setActive(!active), [active]);

  const activator = <Button onClick={handleChange}>Open</Button>;

  return (
    <Page title="Playground">
      {activator}
      <Modal
        activator={activator}
        title="Reach more shoppers with Instagram product tags"
        open={active}
        onClose={handleChange}
        noScroll
      >
        <p>
          Use Instagram posts to share your products with millions of people.
          Let shoppers buy from your store without leaving Instagram.
        </p>
        <p>
          Use Instagram posts to share your products with millions of people.
          Let shoppers buy from your store without leaving Instagram.
        </p>
        <p>
          Use Instagram posts to share your products with millions of people.
          Let shoppers buy from your store without leaving Instagram.
        </p>
        <p>
          Use Instagram posts to share your products with millions of people.
          Let shoppers buy from your store without leaving Instagram.
        </p>
        <p>
          Use Instagram posts to share your products with millions of people.
          Let shoppers buy from your store without leaving Instagram.
        </p>
        <p>
          Use Instagram posts to share your products with millions of people.
          Let shoppers buy from your store without leaving Instagram.
        </p>
        <p>
          Use Instagram posts to share your products with millions of people.
          Let shoppers buy from your store without leaving Instagram.
        </p>
        <p>
          Use Instagram posts to share your products with millions of people.
          Let shoppers buy from your store without leaving Instagram.
        </p>
      </Modal>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
