### PR TITLE
[IndexFiltersManager] Deprecate IndexFiltersManager

### DIFF
--- a/.changeset/large-hats-vanish.md
+++ b/.changeset/large-hats-vanish.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Deprecated the IndexFiltersManager component

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -12,6 +12,7 @@ import {
   ScrollLockManager,
   ScrollLockManagerContext,
 } from '../../utilities/scroll-lock-manager';
+// eslint-disable-next-line import/no-deprecated
 import {IndexFiltersManager} from '../../utilities/index-filters';
 import {
   StickyManager,

--- a/polaris-react/src/utilities/index-filters/IndexFiltersManager.tsx
+++ b/polaris-react/src/utilities/index-filters/IndexFiltersManager.tsx
@@ -10,6 +10,7 @@ export interface IndexFiltersManagerProps {
 
 type Context = NonNullable<ContextType<typeof IndexFiltersModeContext>>;
 
+/** @deprecated No longer needed, will be removing in v12 */
 export function IndexFiltersManager({children}: IndexFiltersManagerProps) {
   const [mode, setMode] = useState<Context['mode']>(IndexFiltersMode.Default);
 

--- a/polaris-react/src/utilities/index-filters/tests/IndexFiltersManager.test.tsx
+++ b/polaris-react/src/utilities/index-filters/tests/IndexFiltersManager.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {IndexFiltersMode} from '../types';
+// eslint-disable-next-line import/no-deprecated
 import {IndexFiltersManager} from '../IndexFiltersManager';
 import {useSetIndexFiltersMode} from '../hooks';
 


### PR DESCRIPTION
### WHY are these changes introduced?

Deprecates IndexFiltersManager as it will be removed from v12.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
