### PR TITLE
fix(page-layout-and-docs): edit this page link reference

### DIFF
--- a/.changeset/afraid-cars-rescue.md
+++ b/.changeset/afraid-cars-rescue.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Fixed typos and `editOnGithubUrl` in docs

--- a/polaris-react/src/components/RadioButton/RadioButton.tsx
+++ b/polaris-react/src/components/RadioButton/RadioButton.tsx
@@ -8,7 +8,7 @@ import type {ChoiceBleedProps} from '../Choice';
 import styles from './RadioButton.scss';
 
 export interface RadioButtonProps extends ChoiceBleedProps {
-  /** Indicates the ID of the element that describes the the radio button */
+  /** Indicates the ID of the element that describes the radio button */
   ariaDescribedBy?: string;
   /** Label for the radio button */
   label: React.ReactNode;

--- a/polaris-react/src/utilities/tests/is-input-focused.test.tsx
+++ b/polaris-react/src/utilities/tests/is-input-focused.test.tsx
@@ -4,7 +4,7 @@ import {mount} from 'tests/utilities';
 import {isInputFocused} from '../is-input-focused';
 
 describe('isInputFocused', () => {
-  it('returns true when the the focused element is not input, textarea, select or has the attribute contenteditable', () => {
+  it('returns true when the focused element is not input, textarea, select or has the attribute contenteditable', () => {
     const markup = mount(<button />);
     markup.domNode!.focus();
     expect(isInputFocused()).toBe(false);

--- a/polaris.shopify.com/src/components/Page/Page.tsx
+++ b/polaris.shopify.com/src/components/Page/Page.tsx
@@ -37,7 +37,7 @@ function Layout({
     githubIssueSubject,
   )}&amp;labels=polaris.shopify.com`;
   const editOnGithubUrl = editPageLinkPath
-    ? `https://github.com/Shopify/polaris/tree/main${editPageLinkPath}`
+    ? `https://github.com/Shopify/polaris/tree/main/${editPageLinkPath}`
     : '';
 
   return (


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #8669 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

This change introduce following fixes:

- Fix the `Edit this page` reference link.
- Fix multiple usage of `the the` around the Polaris website, which is grammatically wrong.


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
