### PR TITLE
[polaris.shopify.com] Fix gen-colors script

### DIFF
--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -6,9 +6,9 @@
     "node": "^16.17.0 || >=18.12.0"
   },
   "scripts": {
-    "build": "yarn gen-assets && yarn gen-colors && playroom build && next build && cp -r public ./.next/standalone/polaris.shopify.com/ && mkdirp ./.next/standalone/polaris.shopify.com/.next && cp -r .next/static ./.next/standalone/polaris.shopify.com/.next/",
+    "build": "yarn gen-colors && yarn gen-assets && playroom build && next build && cp -r public ./.next/standalone/polaris.shopify.com/ && mkdirp ./.next/standalone/polaris.shopify.com/.next && cp -r .next/static ./.next/standalone/polaris.shopify.com/.next/",
     "start": "cd ./.next/standalone/polaris.shopify.com && node ./server.js",
-    "dev": "yarn get-props && run-p dev:*",
+    "dev": "yarn gen-colors && yarn get-props && run-p dev:*",
     "dev:server": "open http://localhost:3000 && next dev",
     "dev:playroom": "rm -rf ./public/playroom && playroom start",
     "dev:watch-md": "node scripts/watch-md.mjs",

--- a/polaris.shopify.com/scripts/gen-colors.ts
+++ b/polaris.shopify.com/scripts/gen-colors.ts
@@ -6,4 +6,5 @@ import * as colors from '../../polaris-tokens/src/colors';
 const cacheDir = path.join(process.cwd(), '.cache');
 const colorJsonFile = path.join(cacheDir, 'colors.json');
 
+fs.mkdirSync(cacheDir, {recursive: true});
 fs.writeFileSync(colorJsonFile, JSON.stringify(colors, null, 2));


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes gen-colors script causing build failures on `next` 
Previously we were running `gen-assets` before `gen-colors`. This builds the website for a puppeteer process which would choke on the `Markdown/components/Colors.ts` file import of `.cache/colors.json`. This is due to the fact that `gen-colors` hadn't been run yet. 


### WHAT is this pull request doing?

- Flips the call order of `gen-assets` and `gen-color` such that `gen-color` is always called first. 
- Change `gen-colors` to create a `.cache` directory if one doesn't exist yet, (as previously this was created in the `gen-assets` procedure).