### PR TITLE
[polaris-migrator] Add admin migration to replace breakpoint-after and breakpoint-before legacy usage

### DIFF
--- a/.changeset/shy-lies-build.md
+++ b/.changeset/shy-lies-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Added replace-breakpoint-after and replace-breakpoint-before admin migrations

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/admin-replace-breakpoint-after.input.scss
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/admin-replace-breakpoint-after.input.scss
@@ -1,0 +1,29 @@
+.Foo {
+  @include legacy-polaris-v8.breakpoint-after(360px) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-after($single-column-breakpoint) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-after(
+    $single-column-breakpoint
+  ) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-after(variables.$full-content-width) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-after(variables.resource-list(breakpoint-small)) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-after(variables.$home-condensed + 1) {
+    display: flex;
+  }
+}
+
+

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/admin-replace-breakpoint-after.output.scss
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/admin-replace-breakpoint-after.output.scss
@@ -1,0 +1,25 @@
+.Foo {
+  @media (min-width: #{legacy-polaris-v8.em(360px)}) {
+    display: flex;
+  }
+
+  @media (min-width: #{legacy-polaris-v8.em($single-column-breakpoint)}) {
+    display: flex;
+  }
+
+  @media (min-width: #{legacy-polaris-v8.em($single-column-breakpoint)}) {
+    display: flex;
+  }
+
+  @media (min-width: #{legacy-polaris-v8.em(variables.$full-content-width)}) {
+    display: flex;
+  }
+
+  @media (min-width: #{legacy-polaris-v8.em(variables.resource-list(breakpoint-small))}) {
+    display: flex;
+  }
+
+  @media (min-width: #{legacy-polaris-v8.em(variables.$home-condensed + 1)}) {
+    display: flex;
+  }
+}

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/transform.test.ts
@@ -1,0 +1,17 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'admin-replace-breakpoint-after';
+const fixtures = ['admin-replace-breakpoint-after', 'with-inclusive'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+    extension: 'scss',
+    options: {
+      customSyntax: 'postcss-scss',
+      reportDescriptionlessDisables: true,
+      rules: {},
+    },
+  });
+}

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/with-inclusive.input.scss
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/with-inclusive.input.scss
@@ -1,0 +1,12 @@
+.Foo {
+  @include legacy-polaris-v8.breakpoint-after(360px, false) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-after(
+    variables.$home-sidebar-visible,
+    false
+  ) {
+    display: flex;
+  }
+}

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/with-inclusive.output.scss
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-after/tests/with-inclusive.output.scss
@@ -1,0 +1,9 @@
+.Foo {
+  @media (width > #{legacy-polaris-v8.em(360px)}) {
+    display: flex;
+  }
+
+  @media (width > #{legacy-polaris-v8.em(variables.$home-sidebar-visible)}) {
+    display: flex;
+  }
+}

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-after/transform.ts
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-after/transform.ts
@@ -1,0 +1,40 @@
+import type {API, FileInfo} from 'jscodeshift';
+import type {Plugin} from 'postcss';
+import postcss from 'postcss';
+
+export default async function transformer(file: FileInfo, _: API) {
+  return postcss(plugin()).process(file.source, {
+    syntax: require('postcss-scss'),
+  }).css;
+}
+
+const plugin = (): Plugin => {
+  return {
+    postcssPlugin: 'admin-replace-breakpoint-after',
+    AtRule(atRule) {
+      if (atRule.name === 'include') {
+        const normalizedParams = atRule.params
+          .split('\n')
+          .map((line) => line.trim())
+          .join('');
+
+        const match =
+          /legacy-polaris-v8.breakpoint-after\((?<params>.*)\)/.exec(
+            normalizedParams,
+          );
+
+        if (match && match.groups) {
+          const [breakpoint, inclusive] = postcss.list.comma(
+            match.groups.params,
+          );
+
+          const breakpointValue = `#{legacy-polaris-v8.em(${breakpoint})}`;
+          const condition = inclusive ? `width >` : `max-width:`;
+
+          atRule.name = 'media';
+          atRule.params = `(${condition} ${breakpointValue})`;
+        }
+      }
+    },
+  };
+};

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/admin-replace-breakpoint-before.input.scss
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/admin-replace-breakpoint-before.input.scss
@@ -1,0 +1,29 @@
+.Foo {
+  @include legacy-polaris-v8.breakpoint-before(360px) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-before($single-column-breakpoint) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-before(
+    $single-column-breakpoint
+  ) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-before(variables.$full-content-width) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-before(variables.resource-list(breakpoint-small)) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-before(variables.$home-condensed + 1) {
+    display: flex;
+  }
+}
+
+

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/admin-replace-breakpoint-before.output.scss
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/admin-replace-breakpoint-before.output.scss
@@ -1,0 +1,25 @@
+.Foo {
+  @media (max-width: #{legacy-polaris-v8.em(360px)}) {
+    display: flex;
+  }
+
+  @media (max-width: #{legacy-polaris-v8.em($single-column-breakpoint)}) {
+    display: flex;
+  }
+
+  @media (max-width: #{legacy-polaris-v8.em($single-column-breakpoint)}) {
+    display: flex;
+  }
+
+  @media (max-width: #{legacy-polaris-v8.em(variables.$full-content-width)}) {
+    display: flex;
+  }
+
+  @media (max-width: #{legacy-polaris-v8.em(variables.resource-list(breakpoint-small))}) {
+    display: flex;
+  }
+
+  @media (max-width: #{legacy-polaris-v8.em(variables.$home-condensed + 1)}) {
+    display: flex;
+  }
+}

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/transform.test.ts
@@ -1,0 +1,17 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'admin-replace-breakpoint-before';
+const fixtures = ['admin-replace-breakpoint-before', 'with-inclusive'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+    extension: 'scss',
+    options: {
+      customSyntax: 'postcss-scss',
+      reportDescriptionlessDisables: true,
+      rules: {},
+    },
+  });
+}

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/with-inclusive.input.scss
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/with-inclusive.input.scss
@@ -1,0 +1,12 @@
+.Foo {
+  @include legacy-polaris-v8.breakpoint-before(360px, false) {
+    display: flex;
+  }
+
+  @include legacy-polaris-v8.breakpoint-before(
+    variables.$home-sidebar-visible,
+    false
+  ) {
+    display: flex;
+  }
+}

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/with-inclusive.output.scss
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-before/tests/with-inclusive.output.scss
@@ -1,0 +1,9 @@
+.Foo {
+  @media (width < #{legacy-polaris-v8.em(360px)}) {
+    display: flex;
+  }
+
+  @media (width < #{legacy-polaris-v8.em(variables.$home-sidebar-visible)}) {
+    display: flex;
+  }
+}

--- a/polaris-migrator/src/migrations/admin-replace-breakpoint-before/transform.ts
+++ b/polaris-migrator/src/migrations/admin-replace-breakpoint-before/transform.ts
@@ -1,0 +1,40 @@
+import type {API, FileInfo} from 'jscodeshift';
+import type {Plugin} from 'postcss';
+import postcss from 'postcss';
+
+export default async function transformer(file: FileInfo, _: API) {
+  return postcss(plugin()).process(file.source, {
+    syntax: require('postcss-scss'),
+  }).css;
+}
+
+const plugin = (): Plugin => {
+  return {
+    postcssPlugin: 'admin-replace-breakpoint-before',
+    AtRule(atRule) {
+      if (atRule.name === 'include') {
+        const normalizedParams = atRule.params
+          .split('\n')
+          .map((line) => line.trim())
+          .join('');
+
+        const match =
+          /legacy-polaris-v8.breakpoint-before\((?<params>.*)\)/.exec(
+            normalizedParams,
+          );
+
+        if (match && match.groups) {
+          const [breakpoint, inclusive] = postcss.list.comma(
+            match.groups.params,
+          );
+
+          const breakpointValue = `#{legacy-polaris-v8.em(${breakpoint})}`;
+          const condition = inclusive ? `width <` : `max-width:`;
+
+          atRule.name = 'media';
+          atRule.params = `(${condition} ${breakpointValue})`;
+        }
+      }
+    },
+  };
+};


### PR DESCRIPTION
### WHY are these changes introduced?


### WHAT is this pull request doing?

Adds a couple of additional migrations in the context of shopify/web's code yellow to:
- Replace usages of `breakpoint-after` by `@media (min-width: ...)`
- Replace usages of `breakpoint-before` by `@media (max-width: ...)`

### How to 🎩

Tests should be good enough here. Some things to note:
- We still require the `em()` function... not sure if we already have a plan in place for that 🤔 
- The original mixin added or substracted `0.01em` in case `inclusive` was set to false. For simplicity here we simply turn to range queries instead of that

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
