### PR TITLE
Executing `useBreakpoints` isormophically no longer triggers a Hydration mismatch error or rendering bugs.

### DIFF
--- a/.changeset/fair-walls-sparkle.md
+++ b/.changeset/fair-walls-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Executing `useBreakpoints` isormophically no longer triggers a Hydration mismatch error or rendering bugs.

--- a/polaris-react/src/utilities/breakpoints.ts
+++ b/polaris-react/src/utilities/breakpoints.ts
@@ -58,8 +58,15 @@ type BreakpointsMatches = {
 
 const breakpointsQueryEntries = getBreakpointsQueryEntries(breakpoints);
 
-function getMatches(defaults?: UseBreakpointsOptions['defaults']) {
-  if (!isServer) {
+function getMatches(
+  defaults?: UseBreakpointsOptions['defaults'],
+  /**
+   * Used to force defaults on initial client side render so they match SSR
+   * values and hence avoid a Hydration error.
+   */
+  forceDefaults?: boolean,
+) {
+  if (!isServer && !forceDefaults) {
     return Object.fromEntries(
       breakpointsQueryEntries.map(([directionAlias, query]) => [
         directionAlias,
@@ -115,7 +122,13 @@ export interface UseBreakpointsOptions {
  * breakpoints //=> All values will be `true` during SSR
  */
 export function useBreakpoints(options?: UseBreakpointsOptions) {
-  const [breakpoints, setBreakpoints] = useState(getMatches(options?.defaults));
+  // On SSR, and initial CSR, we force usage of the defaults to avoid a
+  // hydration mismatch error.
+  // Later, in the effect, we will call this again on the client side without
+  // any defaults to trigger a more accurate client side evaluation.
+  const [breakpoints, setBreakpoints] = useState(
+    getMatches(options?.defaults, true),
+  );
 
   useIsomorphicLayoutEffect(() => {
     const mediaQueryLists = breakpointsQueryEntries.map(([_, query]) =>
@@ -131,6 +144,10 @@ export function useBreakpoints(options?: UseBreakpointsOptions) {
         mql.addEventListener('change', handler);
       }
     });
+
+    // Trigger the breakpoint recalculation at least once client-side to ensure
+    // we don't have stale default values from SSR.
+    handler();
 
     return () => {
       mediaQueryLists.forEach((mql) => {

--- a/polaris-react/src/utilities/tests/use-breakpoints.test.tsx
+++ b/polaris-react/src/utilities/tests/use-breakpoints.test.tsx
@@ -18,89 +18,138 @@ describe('useBreakpoints', () => {
     matchMedia.restore();
   });
 
-  it('breakpoints-xs', () => {
+  it('initial render uses defaults', () => {
     setMediaWidth('breakpoints-xs');
+    let breakpoints;
+    let renders = 0;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        xsDown: true,
-        xsOnly: true,
-        xsUp: true,
+      renders++;
+      breakpoints = useBreakpoints({
+        defaults: {
+          mdDown: true,
+          mdOnly: true,
+          mdUp: true,
+        },
       });
+
+      expect(breakpoints).toMatchObject(
+        renders === 1
+          ? {
+              xsDown: false,
+              xsOnly: false,
+              xsUp: false,
+              mdDown: true,
+              mdOnly: true,
+              mdUp: true,
+            }
+          : {
+              xsDown: true,
+              xsOnly: true,
+              xsUp: true,
+              mdDown: false,
+              mdOnly: false,
+              mdUp: false,
+            },
+      );
 
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      xsDown: true,
+      xsOnly: true,
+      xsUp: true,
+      mdDown: false,
+      mdOnly: false,
+      mdUp: false,
+    });
+  });
+
+  it('breakpoints-xs', () => {
+    setMediaWidth('breakpoints-xs');
+    let breakpoints;
+    mount(<MockComponent />);
+
+    function MockComponent() {
+      breakpoints = useBreakpoints();
+      return null;
+    }
+
+    expect(breakpoints).toMatchObject({
+      xsDown: true,
+      xsOnly: true,
+      xsUp: true,
+    });
   });
 
   it('breakpoints-sm', () => {
     setMediaWidth('breakpoints-sm');
+    let breakpoints;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        smDown: true,
-        smOnly: true,
-        smUp: true,
-      });
-
+      breakpoints = useBreakpoints();
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      smDown: true,
+      smOnly: true,
+      smUp: true,
+    });
   });
 
   it('breakpoints-md', () => {
     setMediaWidth('breakpoints-md');
+    let breakpoints;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        mdDown: true,
-        mdOnly: true,
-        mdUp: true,
-      });
-
+      breakpoints = useBreakpoints();
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      mdDown: true,
+      mdOnly: true,
+      mdUp: true,
+    });
   });
 
   it('breakpoints-lg', () => {
     setMediaWidth('breakpoints-lg');
+    let breakpoints;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        lgDown: true,
-        lgOnly: true,
-        lgUp: true,
-      });
-
+      breakpoints = useBreakpoints();
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      lgDown: true,
+      lgOnly: true,
+      lgUp: true,
+    });
   });
 
   it('breakpoints-xl', () => {
     setMediaWidth('breakpoints-xl');
+    let breakpoints;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        xlDown: true,
-        xlOnly: true,
-        xlUp: true,
-      });
-
+      breakpoints = useBreakpoints();
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      xlDown: true,
+      xlOnly: true,
+      xlUp: true,
+    });
   });
 });
 


### PR DESCRIPTION
To reproduce:

1. Visit https://polaris.shopify.com/examples/card-with-rounded-corners which should show rounded corners from 768px viewport width and above.
2. Set your viewport width to 768px or more (ie; so it matches `md` breakpoint or more)
3. Refresh the page
4. Notice there are no rounded corners
5. Resize your viewport to be 767px or less.
6. Resize your viewport to be 768px or more.
7. Notice the rounded corners now appear.

**Before**
![no-rounded-corners](https://github.com/Shopify/polaris/assets/612020/2db60308-b8d2-40c9-8460-c8bdadc19b2d)

**This PR**
![no-rounded-corners-fixed](https://github.com/Shopify/polaris/assets/612020/22944249-8c4a-4418-9bca-be6251598512)

---

### More details

This is an issue anywhere `useBreakpoints()` is used with SSR.

For example, with `<Banner>`;

1. Style props are being set based on a variable `smUp`: https://github.com/Shopify/polaris/blob/next/polaris-react/src/components/Banner/Banner.tsx#L202-L205
2. `smUp` is [defined above](https://github.com/Shopify/polaris/blob/next/polaris-react/src/components/Banner/Banner.tsx#L193) as `const {smUp} = useBreakpoints();`
3. In SSR, `useBreakpionts` [initially returns](https://github.com/Shopify/polaris/blob/1c60bf060768ece6219de851b456048592051b10/polaris-react/src/utilities/breakpoints.ts#L118C55-L118C55) a call to `getMatches()`, forwarding any "default" parameters (none are passed in by `<Banner>`)
4. In SSR, `getMatches()` returns `false` [for all breakpoints unless a default is set](https://github.com/Shopify/polaris/blob/1c60bf060768ece6219de851b456048592051b10/polaris-react/src/utilities/breakpoints.ts#L80-L85)
5. Back in `useBreakpoints()`, an effect is used to setup media query match event listeners. These trigger each time the matchy-ness of a media query changes, _but not in between_.
    - For example, between `sm` (>490px) to `md` (<768px), the matchy-ness of the media queries are not changing, so none of the event listeners will be called. But once the window hits 768px, `md` will now match, and so the event listener is triggered which updates state and re-renders the component.
    - Note also that when doing SSR, the initial values of the `getMatches()` calls will differ client-side than server-side, resulting in a "Hydration error", but critically _will not re-render with the client-side values_.
7. So the end result; `smUp === false` in SSR, then is immediately `smUp === true` in CSR causing a client side "Hydration error", but continues to render with the SSR values until the window is resized past a breakpoint triggering a state update to reflect the new breakpoint.