### PR TITLE
[polaris.shopify.com] Load correct Inter variable font weights

### DIFF
--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -6,6 +6,6 @@
 />
 <link
   id="inter-font-link"
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap"
   rel="stylesheet"
 />

--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -6,6 +6,6 @@
 />
 <link
   id="inter-font-link"
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;650;700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap"
   rel="stylesheet"
 />

--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -6,6 +6,6 @@
 />
 <link
   id="inter-font-link"
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;450;500;600;650;700;800;900&display=swap"
   rel="stylesheet"
 />

--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -6,6 +6,6 @@
 />
 <link
   id="inter-font-link"
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;450;500;600;650;700;800;900&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;650;700&display=swap"
   rel="stylesheet"
 />

--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -69,7 +69,7 @@ ReactDOM.render(
   crossorigin="anonymous"
 />
 <link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;650;700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap"
 />
 ```
 

--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -69,7 +69,7 @@ ReactDOM.render(
   crossorigin="anonymous"
 />
 <link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap"
 />
 ```
 

--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -69,7 +69,7 @@ ReactDOM.render(
   crossorigin="anonymous"
 />
 <link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;650;700&display=swap"
 />
 ```
 

--- a/polaris-tokens/src/themes/base/font.ts
+++ b/polaris-tokens/src/themes/base/font.ts
@@ -97,7 +97,7 @@ export const font: {
     value: '450',
   },
   'font-weight-medium': {
-    value: '500',
+    value: '550',
   },
   'font-weight-semibold': {
     value: '650',

--- a/polaris-tokens/src/themes/base/font.ts
+++ b/polaris-tokens/src/themes/base/font.ts
@@ -97,7 +97,7 @@ export const font: {
     value: '450',
   },
   'font-weight-medium': {
-    value: '550',
+    value: '500',
   },
   'font-weight-semibold': {
     value: '650',

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -1123,7 +1123,7 @@ Polaris references this font but doesn't load it. Apps will need to load the fon
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com/" />
 <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;650;700&display=swap" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap" />
 ```
 
 ### Icons

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -1123,7 +1123,7 @@ Polaris references this font but doesn't load it. Apps will need to load the fon
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com/" />
 <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;650;700&display=swap" />
 ```
 
 ### Icons

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -1123,7 +1123,7 @@ Polaris references this font but doesn't load it. Apps will need to load the fon
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com/" />
 <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap" />
 ```
 
 ### Icons

--- a/polaris.shopify.com/pages/_document.tsx
+++ b/polaris.shopify.com/pages/_document.tsx
@@ -5,7 +5,7 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@450;500;650;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap"
           rel="stylesheet"
         ></link>
       </Head>

--- a/polaris.shopify.com/pages/_document.tsx
+++ b/polaris.shopify.com/pages/_document.tsx
@@ -5,7 +5,7 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@450;500;650;700&display=swap"
           rel="stylesheet"
         ></link>
       </Head>

--- a/polaris.shopify.com/scripts/gen-og-images.mjs
+++ b/polaris.shopify.com/scripts/gen-og-images.mjs
@@ -81,7 +81,7 @@ const generateHTML = async (url, slug) => {
 
   const html = `
   <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@650');
 
   * {
     margin: 0;
@@ -102,7 +102,7 @@ const generateHTML = async (url, slug) => {
 
   h1 {
     font-size: 80px;
-    font-weight: 500;
+    font-weight: 650;
     letter-spacing: -0.01rem;
     max-width: 520px;
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10894


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Load the correct font weights for regular ~`400`~ `450` and semibold ~`600`~ `650` tokens.

Updates migration guide and any other documentation (like the readme) where the Inter font load string is present to include the correct weights, and removes unnecessary weights (`100`, `200`, `300` and `800`, `900`)

Before:
![image](https://github.com/Shopify/polaris/assets/67433661/9755c831-1a1b-4ca0-883b-c225ef4f1161)


After:
![image](https://github.com/Shopify/polaris/assets/67433661/045edf8b-cdbe-4c6c-97f7-f47b6182c705)


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
