### PR TITLE
Update `snapit` workflow to use the GitHub CLI

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -63,7 +63,7 @@ jobs:
       # issue_comment requires us to checkout the branch
       # https://github.com/actions/checkout/issues/331#issuecomment-1120113003
       - name: Checkout pull request branch
-        run: hub pr checkout ${{ github.event.issue.number }}
+        run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes `hub: command not found issue`

![image](https://github.com/Shopify/polaris/assets/32409546/f869720f-e5f9-4c07-9c00-579014b79058)

We no longer need to use the `hub` command as the GitHub CLI now exposes the same behavior via [gh pr checkout <number>](https://cli.github.com/manual/gh_pr_checkout).