### PR TITLE
Layout tokens page - Fix heading spacing

### DIFF
--- a/polaris.shopify.com/content/design/layout/layout-tokens.md
+++ b/polaris.shopify.com/content/design/layout/layout-tokens.md
@@ -24,11 +24,8 @@ description: Apply consistent and harmonious space within and between ui element
 <Lede>{frontmatter.description}</Lede>
 
 <Subnav />
-
-<Stack gap="800">
-
 ## Overview
-
+<Stack gap="800">
     <Card>
         <Grid gap="400">
             <Grid.Cell columnSpan={{xs: 6, lg: 4}}>
@@ -91,8 +88,11 @@ description: Apply consistent and harmonious space within and between ui element
         </Grid>
     </Card>
 
+</Stack>
+
     ## How to apply them
 
+<Stack gap="800">
     <Card>
         <Grid gap="400">
             <Grid.Cell columnSpan={{xs: 6, lg: 4}}>


### PR DESCRIPTION
Before|After
:----:|:----:
<img width="1604" alt="Screenshot 2023-10-05 at 10 21 32 AM" src="https://github.com/Shopify/polaris/assets/3474483/97c32468-cd93-40a3-b8d8-5228f9d43ed9">|<img width="1604" alt="Screenshot 2023-10-05 at 10 21 35 AM" src="https://github.com/Shopify/polaris/assets/3474483/03d91191-e8d5-47f4-941d-f7271c9c7c1b">
<img width="1604" alt="Screenshot 2023-10-05 at 10 22 11 AM" src="https://github.com/Shopify/polaris/assets/3474483/9aa96221-7ffa-475d-9124-8dcf8e1eabd5">|<img width="1604" alt="Screenshot 2023-10-05 at 10 22 14 AM" src="https://github.com/Shopify/polaris/assets/3474483/b8a41d10-5f4a-48a8-ab79-4fe8468e40d5">
