### PR TITLE
Update button migration examples

### DIFF
--- a/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-plain-monochrome-component.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-plain-monochrome-component.input.tsx
@@ -12,6 +12,9 @@ export function App() {
       <Button monochrome plain>
         Edit
       </Button>
+      <Button monochrome plain primary>
+        Edit
+      </Button>
       <Button plain monochrome={isPolarisUplift}>
         Edit
       </Button>

--- a/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-plain-monochrome-component.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-button-component/tests/v12-react-update-button-plain-monochrome-component.output.tsx
@@ -9,6 +9,10 @@ export function App() {
       <Button variant="monochromePlain">Edit</Button>
       <Button variant="monochromePlain">Edit</Button>
       {/* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */}
+      <Button monochrome plain primary>
+        Edit
+      </Button>
+      {/* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */}
       <Button plain monochrome={isPolarisUplift}>
         Edit
       </Button>


### PR DESCRIPTION
### WHY are these changes introduced?

Adds an example of what's to be expected when migrating a `<Button primary plain monochrome />` element. I don't think we don't want to default to a new style, like `plain monochrome` which might be the safest, because consumers may want to opt for the `plain` variant.

So we just insert a comment and defer to the team / section responsible