### PR TITLE
Fix segmented `ButtonGroup` spacing

### DIFF
--- a/.changeset/proud-cougars-turn.md
+++ b/.changeset/proud-cougars-turn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed negative margin of `segmented` `ButtonGroup.Item` when child `Button` is `primary`

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -632,57 +632,61 @@ export function SelectDisclosure() {
 }
 
 export function Split() {
-  const [active, setActive] = React.useState(false);
+  const [active, setActive] = React.useState<string | null>(null);
+
+  const toggleActive = (id: string) => () => {
+    setActive((activeId) => (activeId !== id ? id : null));
+  };
   return (
     <div style={{height: '100px'}}>
-      <ButtonGroup variant="segmented">
-        <Button variant="primary">Save</Button>
+      <InlineStack gap="500">
+        <ButtonGroup variant="segmented">
+          <Button variant="primary">Save</Button>
 
-        <div style={{width: '3px'}} />
-
-        <Popover
-          active={active}
-          preferredAlignment="right"
-          activator={
-            <Button
-              variant="primary"
-              onClick={() => setActive(true)}
-              icon={ChevronDownMinor}
-              accessibilityLabel="Other save actions"
+          <Popover
+            active={active === 'popover1'}
+            preferredAlignment="right"
+            activator={
+              <Button
+                variant="primary"
+                onClick={toggleActive('popover1')}
+                icon={ChevronDownMinor}
+                accessibilityLabel="Other save actions"
+              />
+            }
+            autofocusTarget="first-node"
+            onClose={toggleActive('popover1')}
+          >
+            <ActionList
+              actionRole="menuitem"
+              items={[{content: 'Save as draft'}]}
             />
-          }
-          autofocusTarget="first-node"
-          onClose={() => setActive(false)}
-        >
-          <ActionList
-            actionRole="menuitem"
-            items={[{content: 'Save as draft'}]}
-          />
-        </Popover>
-      </ButtonGroup>
+          </Popover>
+        </ButtonGroup>
 
-      <ButtonGroup variant="segmented">
-        <Button>Save</Button>
+        <ButtonGroup variant="segmented">
+          <Button>Save</Button>
 
-        <Popover
-          active={active}
-          preferredAlignment="right"
-          activator={
-            <Button
-              onClick={() => setActive(true)}
-              icon={ChevronDownMinor}
-              accessibilityLabel="Other save actions"
+          <Popover
+            active={active === 'popover2'}
+            preferredAlignment="right"
+            activator={
+              <Button
+                onClick={toggleActive('popover2')}
+                icon={ChevronDownMinor}
+                accessibilityLabel="Other save actions"
+              />
+            }
+            autofocusTarget="first-node"
+            onClose={toggleActive('popover2')}
+          >
+            <ActionList
+              actionRole="menuitem"
+              items={[{content: 'Save as draft'}]}
             />
-          }
-          autofocusTarget="first-node"
-          onClose={() => setActive(false)}
-        >
-          <ActionList
-            actionRole="menuitem"
-            items={[{content: 'Save as draft'}]}
-          />
-        </Popover>
-      </ButtonGroup>
+          </Popover>
+        </ButtonGroup>
+      </InlineStack>
     </div>
   );
 }

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
@@ -41,6 +41,11 @@
 
     &:not(:first-child) {
       margin-left: calc(-1 * var(--p-space-025));
+
+      /* stylelint-disable-next-line selector-max-specificity, selector-no-qualifying-type, selector-max-combinators -- Primary buttons segment groups need the negative margin-left applied directly on the button element. They have inset shine via shadow bevels that cause the appearance of double borders when composed in a segmented ButtonGroup, which flattens the joint between them and ruins the illusion of dimension. */
+      button[class*='Button-primary'] {
+        margin-left: calc(-1 * var(--p-space-025));
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes # 2 in https://github.com/Shopify/polaris/issues/10897

This PR splits out the bug fix commit from https://github.com/Shopify/polaris/pull/10893 as that PR was too far behind changes to the migration guide to merge. The spacing between segmented button group items is 1px greater than it should be now that the shadow tokens have been changed. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR places the negative margin of the `segmented` `variant`  of `ButtonGroup.Item` directly on the child `Button` when it's `primary`. This prevents the dimension between items from being visually flattened by the appearance of double borders from the shine shadows.

| [Before](https://storybook.polaris.shopify.com/?path=/story/all-components-button--split&globals=polarisSummerEditions2023:true)| [After](https://shopify.chromatic.com/test?appId=5d559397bae39100201eedc1&id=651fbd16a1674be8917c922c&k=651fbd16a1674be8917c922c-1200px-interactive-true) |
|--------|--------|
|  <img width="481" alt="Screenshot 2023-10-06 at 3 10 10 AM" src="https://github.com/Shopify/polaris/assets/18447883/708f0028-2b78-46eb-bda2-82b4f40a5690">| <img width="498" alt="Screenshot 2023-10-06 at 3 09 59 AM" src="https://github.com/Shopify/polaris/assets/18447883/60976f80-71ae-435b-a7a9-34bcddf8ce1a"> | 

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
