### PR TITLE
Revert "Revert "Executing `useBreakpoints` isormophically no longer t…

### DIFF
--- a/.changeset/fair-walls-sparkle.md
+++ b/.changeset/fair-walls-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Executing `useBreakpoints` isormophically no longer triggers a Hydration mismatch error or rendering bugs.

--- a/polaris-react/src/utilities/breakpoints.ts
+++ b/polaris-react/src/utilities/breakpoints.ts
@@ -60,8 +60,15 @@ const breakpointsQueryEntries = getBreakpointsQueryEntries(
   themeDefault.breakpoints,
 );
 
-function getMatches(defaults?: UseBreakpointsOptions['defaults']) {
-  if (!isServer) {
+function getMatches(
+  defaults?: UseBreakpointsOptions['defaults'],
+  /**
+   * Used to force defaults on initial client side render so they match SSR
+   * values and hence avoid a Hydration error.
+   */
+  forceDefaults?: boolean,
+) {
+  if (!isServer && !forceDefaults) {
     return Object.fromEntries(
       breakpointsQueryEntries.map(([directionAlias, query]) => [
         directionAlias,
@@ -117,7 +124,13 @@ export interface UseBreakpointsOptions {
  * breakpoints //=> All values will be `true` during SSR
  */
 export function useBreakpoints(options?: UseBreakpointsOptions) {
-  const [breakpoints, setBreakpoints] = useState(getMatches(options?.defaults));
+  // On SSR, and initial CSR, we force usage of the defaults to avoid a
+  // hydration mismatch error.
+  // Later, in the effect, we will call this again on the client side without
+  // any defaults to trigger a more accurate client side evaluation.
+  const [breakpoints, setBreakpoints] = useState(
+    getMatches(options?.defaults, true),
+  );
 
   useIsomorphicLayoutEffect(() => {
     const mediaQueryLists = breakpointsQueryEntries.map(([_, query]) =>
@@ -133,6 +146,10 @@ export function useBreakpoints(options?: UseBreakpointsOptions) {
         mql.addEventListener('change', handler);
       }
     });
+
+    // Trigger the breakpoint recalculation at least once client-side to ensure
+    // we don't have stale default values from SSR.
+    handler();
 
     return () => {
       mediaQueryLists.forEach((mql) => {

--- a/polaris-react/src/utilities/tests/use-breakpoints.test.tsx
+++ b/polaris-react/src/utilities/tests/use-breakpoints.test.tsx
@@ -18,89 +18,138 @@ describe('useBreakpoints', () => {
     matchMedia.restore();
   });
 
-  it('breakpoints-xs', () => {
+  it('initial render uses defaults', () => {
     setMediaWidth('breakpoints-xs');
+    let breakpoints;
+    let renders = 0;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        xsDown: true,
-        xsOnly: true,
-        xsUp: true,
+      renders++;
+      breakpoints = useBreakpoints({
+        defaults: {
+          mdDown: true,
+          mdOnly: true,
+          mdUp: true,
+        },
       });
+
+      expect(breakpoints).toMatchObject(
+        renders === 1
+          ? {
+              xsDown: false,
+              xsOnly: false,
+              xsUp: false,
+              mdDown: true,
+              mdOnly: true,
+              mdUp: true,
+            }
+          : {
+              xsDown: true,
+              xsOnly: true,
+              xsUp: true,
+              mdDown: false,
+              mdOnly: false,
+              mdUp: false,
+            },
+      );
 
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      xsDown: true,
+      xsOnly: true,
+      xsUp: true,
+      mdDown: false,
+      mdOnly: false,
+      mdUp: false,
+    });
+  });
+
+  it('breakpoints-xs', () => {
+    setMediaWidth('breakpoints-xs');
+    let breakpoints;
+    mount(<MockComponent />);
+
+    function MockComponent() {
+      breakpoints = useBreakpoints();
+      return null;
+    }
+
+    expect(breakpoints).toMatchObject({
+      xsDown: true,
+      xsOnly: true,
+      xsUp: true,
+    });
   });
 
   it('breakpoints-sm', () => {
     setMediaWidth('breakpoints-sm');
+    let breakpoints;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        smDown: true,
-        smOnly: true,
-        smUp: true,
-      });
-
+      breakpoints = useBreakpoints();
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      smDown: true,
+      smOnly: true,
+      smUp: true,
+    });
   });
 
   it('breakpoints-md', () => {
     setMediaWidth('breakpoints-md');
+    let breakpoints;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        mdDown: true,
-        mdOnly: true,
-        mdUp: true,
-      });
-
+      breakpoints = useBreakpoints();
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      mdDown: true,
+      mdOnly: true,
+      mdUp: true,
+    });
   });
 
   it('breakpoints-lg', () => {
     setMediaWidth('breakpoints-lg');
+    let breakpoints;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        lgDown: true,
-        lgOnly: true,
-        lgUp: true,
-      });
-
+      breakpoints = useBreakpoints();
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      lgDown: true,
+      lgOnly: true,
+      lgUp: true,
+    });
   });
 
   it('breakpoints-xl', () => {
     setMediaWidth('breakpoints-xl');
+    let breakpoints;
     mount(<MockComponent />);
 
     function MockComponent() {
-      const breakpoints = useBreakpoints();
-
-      expect(breakpoints).toMatchObject({
-        xlDown: true,
-        xlOnly: true,
-        xlUp: true,
-      });
-
+      breakpoints = useBreakpoints();
       return null;
     }
+
+    expect(breakpoints).toMatchObject({
+      xlDown: true,
+      xlOnly: true,
+      xlUp: true,
+    });
   });
 });
 


### PR DESCRIPTION
…riggers a Hydration mismatch error or rendering bugs." (#10916)"

This reverts https://github.com/Shopify/polaris/pull/10916 to reapply https://github.com/Shopify/polaris/pull/10886

cc @jesstelford