### PR TITLE
fixed dark mode menu button on Safari

### DIFF
--- a/polaris.shopify.com/src/components/Frame/Frame.module.scss
+++ b/polaris.shopify.com/src/components/Frame/Frame.module.scss
@@ -255,7 +255,7 @@ $breakpointNav: $breakpointTablet;
     transform: scale(0.8);
 
     @include dark-mode {
-      filter: invert(1);
+      fill: white;
     }
   }
 
@@ -287,7 +287,7 @@ $breakpointNav: $breakpointTablet;
   }
 
   @include dark-mode {
-    filter: invert(1);
+    fill: white;
   }
 }
 


### PR DESCRIPTION
The Menu button on Safari in dark mode is broken
<img width="554" alt="image" src="https://github.com/Shopify/polaris/assets/1266923/01f797d4-3853-4a5c-be6d-83333a666588">

I noticed that we use `filter: invert(1)` on the SVG which is fine if we had any color actually specified on the menu SVG. Without it the menu button can't be inverted and the fact this works on chrome is a bug 🙃 

I replaced it with `fill: white`. We can replace `white` with the appropriate token here if there is one in the future but should make sure that the menu button color in light mode is also specified.