### PR TITLE
[IndexTable] Fix selected TableRow hover state when status/tone is applied [WIP]

### DIFF
--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -342,7 +342,7 @@ $loading-panel-height: 53px;
       }
 
       // stylelint-disable max-nesting-depth -- se23 status hover styles
-      &.statusCritical {
+      &.statusCritical:not(.TableRow-selected) {
         &,
         .TableCell-first,
         .TableCell-first + .TableCell {
@@ -350,7 +350,7 @@ $loading-panel-height: 53px;
         }
       }
 
-      &.statusWarning {
+      &.statusWarning:not(.TableRow-selected) {
         &,
         .TableCell-first,
         .TableCell-first + .TableCell {
@@ -358,7 +358,7 @@ $loading-panel-height: 53px;
         }
       }
 
-      &.statusSubdued {
+      &.statusSubdued:not(.TableRow-selected) {
         &,
         .TableCell-first,
         .TableCell-first + .TableCell {
@@ -366,7 +366,7 @@ $loading-panel-height: 53px;
         }
       }
 
-      &.statusSuccess {
+      &.statusSuccess:not(.TableRow-selected) {
         &,
         .TableCell-first,
         .TableCell-first + .TableCell {


### PR DESCRIPTION
### WHY are these changes introduced?

Identified an issue with the `TableRow` hover state when a tone or status has been applied and the row is selected. Pre `se23` the rows would use the selected row hover state, but post `se23` the row uses the status hover state, resulting in behaviour like below:

https://github.com/Shopify/polaris/assets/7304281/7525189e-71f0-47c2-ab81-43c34ad28649

### WHAT is this pull request doing?

This is simply ensuring that the row status hover effect is not applied when the row is selected by appending `:not(.TableRow-selected)` to the rule.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
