### PR TITLE
Fix button disabled state on monochrome variant

### DIFF
--- a/.changeset/healthy-cameras-fry.md
+++ b/.changeset/healthy-cameras-fry.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fixes disabled state for `monochromePlain` variant in `Button`
+Fixed disabled state for `monochromePlain` variant in `Button`

--- a/.changeset/healthy-cameras-fry.md
+++ b/.changeset/healthy-cameras-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixes disabled state for `monochromePlain` variant in `Button`

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -956,8 +956,7 @@
     }
 
     &.disabled {
-      color: currentColor;
-      opacity: 0.4;
+      color: var(--p-color-text-disabled);
 
       svg {
         fill: currentColor;

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -706,11 +706,12 @@ export function DisabledState() {
       <Button variant="plain" tone="critical" disabled>
         Buy shipping label
       </Button>
-      <span style={{color: '#bf0711'}}>
+      {/* Visual check to ensure the button color is not inherited from the parent */}
+      <Box color="text-critical">
         <Button variant="monochromePlain" disabled>
           Buy shipping label
         </Button>
-      </span>
+      </Box>
     </ButtonGroup>
   );
 }

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -706,6 +706,11 @@ export function DisabledState() {
       <Button variant="plain" tone="critical" disabled>
         Buy shipping label
       </Button>
+      <span style={{color: '#bf0711'}}>
+        <Button variant="monochromePlain" disabled>
+          Buy shipping label
+        </Button>
+      </span>
     </ButtonGroup>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes point 3 in #10897

The `monochromePlain` variant, was using `currentColor` when `disabled`. 

### WHAT is this pull request doing?

This PR replaces the `currentColor` with the `text-disabled` token as outlined in #10897. In addition, storybook has been updated to include the `monochromePlain` variant in the disabled preview.

| Before      | After |
| ----------- | ----------- |
|  <img width="130" alt="Screenshot 2023-10-09 at 20 47 44" src="https://github.com/Shopify/polaris/assets/50641262/5c209557-ee3a-47cc-9195-0cb33e452fc4"> | <img width="136" alt="Screenshot 2023-10-09 at 20 45 00" src="https://github.com/Shopify/polaris/assets/50641262/ebb27d1d-0516-4c0d-988f-887b9e25ebdd">|

### 🎩 checklist

- [X] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [X] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
