### PR TITLE
[polaris.shopify.com] Fix thumbnail images in safari

### DIFF
--- a/polaris.shopify.com/src/components/ThumbnailPreview/index.tsx
+++ b/polaris.shopify.com/src/components/ThumbnailPreview/index.tsx
@@ -41,8 +41,8 @@ const Preview = ({
           {...(aspectRatio && aspectRatios[aspectRatio])}
           style={{
             objectFit: aspectRatio ? 'contain' : 'cover',
-            maxHeight: '100%',
-            maxWidth: '100%',
+            width: '100%',
+            height: '100%',
           }}
         />
       ) : null}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10937


![image](https://github.com/Shopify/polaris/assets/6844391/9bc1faff-12de-4a55-86b3-3b0e628c0429)

