### PR TITLE
[Stylelint v15] Add changelog to stylelint polaris major release

### DIFF
--- a/.changeset/little-ears-call.md
+++ b/.changeset/little-ears-call.md
@@ -1,0 +1,6 @@
+---
+'@shopify/stylelint-polaris': major
+---
+
+- Updated dependencies \[[`2a467249f`](https://github.com/Shopify/polaris/commit/2a467249f3a198dc252eba53df9fecc7bf6572dd), [`2cdc59f88`](https://github.com/Shopify/polaris/commit/2cdc59f8823a6529ebb6150c316934633f86b28c), [`794d1f5e4`](https://github.com/Shopify/polaris/commit/794d1f5e4b79a2721594979d31972cd7534d6174), [`86d4040c05`](https://github.com/Shopify/polaris/commit/86d4040c052a0dba0cb6f0d6e0f6fb8faf14c532), [`08aaf11ec`](https://github.com/Shopify/polaris/commit/08aaf11ec59680155476a20036a672795c2bad47), [`a2aefd0`](https://github.com/Shopify/polaris/commit/a2aefd0608b854b376c1f8de8bd33195074dc7e3), [`2ce6c37`](https://github.com/Shopify/polaris/commit/2ce6c375d9a180609c087764d963bb20868e03bf)]:
+  - @shopify/polaris-tokens@8.0.0


### PR DESCRIPTION
Add changelog so we can release stylelint breaking changes as a major release

We [marked `v14.1.2` as unsafe](https://github.com/Shopify/polaris/releases/tag/%40shopify%2Fstylelint-polaris%4014.1.2) since it had the breaking changes from polaris v12 and polaris-tokens v8

