### PR TITLE
[v12 Migration guide] Update component migration commands

### DIFF
--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -1042,7 +1042,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 **🔔 Stepped migration**: You must run the `color` -> `tone` migration after running the tone rename migrations.
 
-#### Step 1: Replace `warning` tone with `caution`
+#### Step 1: Replace `color="warning"` with `tone="caution"`
 
 <Code
   code={{

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -785,9 +785,9 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 ```diff
 - <Button
--   connectedDisclosure={
--     <Popover activator={<Button icon={ChevronDownMinor} />} />
--   }
+-   connectedDisclosure={{
+-     icon: ChevronDownMinor,
+-   }}
 - >
 -   Save
 - </Button>

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -1357,10 +1357,8 @@ Page dividers are no longer a pattern in the new Polaris design language. If you
 <CollapsibleDetails summary="💡 Migration example">
 
 ```diff
-- <Icon source={CirclePlusMinor} color={iconColor} backdrop />
-+ <Box background={boxBackground} padding="100" width="28px" borderRadius="full">
-+  <Icon source={CirclePlusMinor} color={iconColor} />
-+ </Box>
+- <Page divider />
++ <Page />
 ```
 
 </CollapsibleDetails>

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -940,7 +940,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 </CollapsibleDetails>
 
-#### Step 2: Replace `highlight` tone with `info`
+#### Step 2: Replace `color="highlight"` with `tone="info"`
 
 <Code
   code={{

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -50,7 +50,7 @@ When running token and component migrations, we recommend the following workflow
 The [polaris-migrator](/tools/polaris-migrator) CLI commands are scaffolded for you to paste into your terminal:
 
 - Tailor the directories in the command glob paths to those relevant to your app's file structure. For example, this generic monorepo glob `**/*.{css,scss}` might need to be changed to explicitly target stylesheets in `{src}/**/*.{css,scss}` in your app.
-- Adjust the file extensions for the migrations you are running. For example, React component migrations in a TypeScript app should target `*.{,ts,tsx}` files, while token migrations should target `*.{css,scss}` files.
+- Adjust the file extensions for the migrations you are running. For example, React component migrations in a TypeScript app should target `*.{ts,tsx}` files, while token migrations should target `*.{css,scss}` files.
 
 ```bash
 # Example migration

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -52,8 +52,14 @@ Follow the migration guide sections below where we have the [@shopify/polaris-mi
 ```bash
 # Example migration
 npx @shopify/polaris-migrator ...
-# Stash files with "polaris-migrator:" comments
-git stash push $(grep -r -l "polaris-migrator:" $(git ls-files -m))
+# Find modified files containing "polaris-migrator:" manual migration comments
+matching_files=$(grep -r -l "polaris-migrator:" $(git ls-files -m))
+# Stash the files needing manual migration if there are any
+if [[ -n "$matching_files" ]]; then
+    git stash push $matching_files
+else
+    echo "No modified files contain 'polaris-migrator:'"
+fi
 # Stage all migrated files without "polaris-migrator:" comments
 git add .
 # Format staged files only
@@ -90,7 +96,7 @@ git add .
 # Format staged files only
 git diff --staged --name-only | xargs npx prettier --write
 # Optional: run stylelint if using stylelint-polaris and running migrations on stylesheets
-npx stylelint "./**/*.{css,scss}"
+npx stylelint "**/*.{css,scss}"
 #  Commit manual migrations
 git commit -m "[Manual] Migrate X from Polaris v11 to v12"
 ```
@@ -120,7 +126,7 @@ git commit -m "[Manual] Migrate X from Polaris v11 to v12"
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-react-avatar-component "./**/*.{ts,tsx}"`,
+    code: String.raw`npx @shopify/polaris-migrator v12-react-avatar-component "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -233,9 +239,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 ### IndexTable.Row
 
-**🔔 Stepped migration**: You must run the `color` -> `tone` migration before running the tone rename migrations.
-
-#### Step 1: Replace `status` prop with `tone`
+#### Replace `status` prop with `tone`
 
 <Code
   code={{
@@ -265,7 +269,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 </CollapsibleDetails>
 
-#### Step 2: Replace `subdued` prop with `tone`
+#### Replace `subdued` prop with `tone`
 
 <Code
   code={{
@@ -640,7 +644,7 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-react-update-button-component "./**/*.{ts,tsx}"`,
+    code: String.raw`npx @shopify/polaris-migrator v12-react-update-button-component "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -994,7 +998,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 ### Text
 
-**🔔 Stepped migration**: You must run the `color` -> `tone` migration before running the tone rename migrations.
+**🔔 Stepped migration**: You must run the `color` -> `tone` migration after running the tone rename migrations.
 
 #### Step 1: Replace `warning` tone with `caution`
 
@@ -1358,7 +1362,7 @@ To replace deprecated `border` custom properties, you can run the [v12-styles-re
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-border "./**/*..{css,scss}"`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-border "**/*.{css,scss}"`,
   }}
 />
 
@@ -1504,7 +1508,7 @@ To replace deprecated `color` custom properties, you can run the [v12-styles-rep
   code={{
     title: 'Polaris Migrator codemod for step 1',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-color "./**/*..{css,scss}" --step=1`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-color "**/*.{css,scss}" --step=1`,
   }}
 />
 
@@ -1713,7 +1717,7 @@ To replace deprecated `color` custom properties, you can run the [v12-styles-rep
   code={{
     title: 'Polaris Migrator codemod for step 2',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-color "./**/*..{css,scss}" --step=2`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-color "**/*.{css,scss}" --step=2`,
   }}
 />
 
@@ -1968,7 +1972,7 @@ To replace deprecated `font` custom properties, you can run the [v12-styles-repl
   code={{
     title: 'Polaris Migrator codemod for step 1',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-font "./**/*..{css,scss}" --step=1`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-font "**/*.{css,scss}" --step=1`,
   }}
 />
 
@@ -2009,7 +2013,7 @@ To replace deprecated `font` custom properties, you can run the [v12-styles-repl
   code={{
     title: 'Polaris Migrator codemod for step 2',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-font "./**/*..{css,scss}" --step=2`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-font "**/*.{css,scss}" --step=2`,
   }}
 />
 
@@ -2040,7 +2044,7 @@ To replace deprecated `font` custom properties, you can run the [v12-styles-repl
   code={{
     title: 'Polaris Migrator codemod for step 3',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-font "./**/*..{css,scss}" --step=3`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-font "**/*.{css,scss}" --step=3`,
   }}
 />
 
@@ -2071,7 +2075,7 @@ To replace deprecated `font` custom properties, you can run the [v12-styles-repl
   code={{
     title: 'Polaris Migrator codemod for step 4',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-font "./**/*..{css,scss}" --step=4`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-font "**/*.{css,scss}" --step=4`,
   }}
 />
 
@@ -2109,7 +2113,7 @@ To replace deprecated `shadow` custom properties, you can run the [v12-styles-re
 
 </CollapsibleDetails>
 
-**🔔 Stepped migration**: The font migration needs to be run in **2** sequential steps due to context dependent manual migrations.
+**🔔 Stepped migration**: The shadow migration needs to be run in **2** sequential steps due to context dependent manual migrations.
 
 #### Shadow migration step 1
 
@@ -2117,7 +2121,7 @@ To replace deprecated `shadow` custom properties, you can run the [v12-styles-re
   code={{
     title: 'Polaris Migrator codemod for step 1',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-shadow "./**/*..{css,scss}"`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-shadow "**/*.{css,scss}"`,
   }}
 />
 
@@ -2139,12 +2143,6 @@ To replace deprecated `shadow` custom properties, you can run the [v12-styles-re
     code={{
       title: `Check RegExp for outdated <Box shadow="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?shadow`,
-    }}
-  />
-  <Code
-    code={{
-      title: `Check RegExp for outdated <ShadowBevel boxShadow="..." /> prop`,
-      code: String.raw`<ShadowBevel[^>\w](?:[^>]|\n)*?boxShadow`,
     }}
   />
 </CollapsibleDetails>
@@ -2232,7 +2230,7 @@ To replace deprecated `space` custom properties, you can run the [v12-styles-rep
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-space "./**/*..{css,scss}"`,
+    code: String.raw`npx @shopify/polaris-migrator v12-styles-replace-custom-property-space "**/*.{css,scss}"`,
   }}
 />
 

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -900,7 +900,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 **🔔 Stepped migration**: You must run the `color` -> `tone` migration after running the tone rename migrations.
 
-#### Step 1: Replace `warning` tone with `caution`
+#### Step 1: Replace `color="warning"` with `tone="caution"`
 
 <Code
   code={{

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -15,7 +15,7 @@ order: 1
 
 Upgrading to Polaris v12 from v11 requires several automated and manual migrations of token, component, and component prop names that have been removed, replaced, or renamed. The bulk of migrations are automated using the [@shopify/polaris-migrator](/tools/polaris-migrator) CLI tool, with the edge cases handled by find and replace in your code editor using provided RegExp searches. You can reference the [recommended migration workflow](#migration-workflow) or [glossary](#glossary) sections for additional migration support.
 
-Not on v11 yet either? Check out our other [migration guides](https://github.com/Shopify/polaris/tree/main/documentation/guides) to get up to date.
+Not on v11 yet? You'll need to follow the [migration guides](https://github.com/Shopify/polaris/tree/main/documentation/guides) for previous major versions before upgrading to v12.
 
 <Code
   code={{
@@ -25,7 +25,7 @@ Not on v11 yet either? Check out our other [migration guides](https://github.com
   }}
 />
 
-<CollapsibleDetails summary="Note: If you've installed other Polaris packages independently, you will also need to upgrade those to the versions we released along with v12.">
+<CollapsibleDetails summary="Note: If you've installed other Polaris packages independently, you will also need to upgrade those to the major versions we released along with v12.">
 
 | Package                      | Version          |
 | ---------------------------- | ---------------- |
@@ -45,16 +45,19 @@ Not on v11 yet either? Check out our other [migration guides](https://github.com
 
 When running token and component migrations, we recommend the following workflow:
 
-### 1️⃣ Automated migrations using Polaris Migrator
+### 1️⃣ Automate migrations using Polaris Migrator
 
-Follow the migration guide sections below where we have the [@shopify/polaris-migrator](/tools/polaris-migrator) commands scaffolded for you to paste into your terminal. We've defaulted the glob path in the commands to run on all `ts`/`tsx`/`scss`/`css` files, but feel free to update them to your own app's relevant path, e.g., `{app,packages}/**/*.{css,scss}`. The file extensions can be adjusted depending on what migrations you are running. For example, component migrations can be run on `*.{ts,tsx}` files while token migrations can be run on `*.{css,scss}` files.
+The [polaris-migrator](/tools/polaris-migrator) CLI commands are scaffolded for you to paste into your terminal:
+
+- Tailor the directories in the command glob paths to those relevant to your app's file structure. For example, this generic monorepo glob `**/*.{css,scss}` might need to be changed to explicitly target stylesheets in `{src}/**/*.{css,scss}` in your app.
+- Adjust the file extensions for the migrations you are running. For example, React component migrations in a TypeScript app should target `*.{,ts,tsx}` files, while token migrations should target `*.{css,scss}` files.
 
 ```bash
 # Example migration
 npx @shopify/polaris-migrator ...
 # Find modified files containing "polaris-migrator:" manual migration comments
 matching_files=$(grep -r -l "polaris-migrator:" $(git ls-files -m))
-# Stash the files needing manual migration if there are any
+# Stash the files needing manual migrations if there are any
 if [[ -n "$matching_files" ]]; then
     git stash push $matching_files
 else
@@ -70,9 +73,9 @@ git add .
 git commit -m "[Automated] Migrate X from Polaris v11 to v12"
 ```
 
-The polaris migrator could insert comments or skip instances that are unsafe to automatically migrate. You will need to resolve those issues in the next manual migration step.
+The `polaris-migrator` could insert comments or skip instances that are unsafe to automatically migrate. You will need to resolve those issues in the next manual migration step.
 
-### 2️⃣ Manual migrations using migrator comments and RegExp code search
+### 2️⃣ Manually migrate using migrator comments and RegExp code search
 
 Now, you need to validate the automatic migration and manually update any outstanding issues. The migration guide sections may have additional resources to help you resolve the migrations manually, such as `💡 Migration example`, `➡️ Replacement mappings` tables, and descriptions of what the automated migrations are doing.
 
@@ -134,6 +137,7 @@ git commit -m "[Manual] Migrate X from Polaris v11 to v12"
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Avatar size="..." /> prop`,
     code: String.raw`<Avatar[^>\w](?:[^>]|\n)*?size`,
   }}
@@ -191,6 +195,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Badge status="..." /> prop`,
     code: String.raw`<Badge[^>\w](?:[^>]|\n)*?status`,
   }}
@@ -221,6 +226,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Badge statusAndProgressLabelOverride="..." /> prop`,
     code: String.raw`<Badge[^>\w](?:[^>]|\n)*?statusAndProgressLabelOverride`,
   }}
@@ -253,6 +259,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <IndexTable.Row status="..." /> prop`,
     code: String.raw`<IndexTable\.Row[^>\w](?:[^>]|\n)*?status`,
   }}
@@ -283,6 +290,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <IndexTable.Row subdued="..." /> prop`,
     code: String.raw`<IndexTable\.Row[^>\w](?:[^>]|\n)*?subdued`,
   }}
@@ -315,6 +323,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Layout.Section oneThird /> prop`,
     code: String.raw`<Layout\.Section[^>\w](?:[^>]|\n)*?oneThird`,
   }}
@@ -345,6 +354,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Layout.Section oneHalf /> prop`,
     code: String.raw`<Layout\.Section[^>\w](?:[^>]|\n)*?oneHalf`,
   }}
@@ -375,6 +385,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Layout.Section fullWidth /> prop`,
     code: String.raw`<Layout\.Section[^>\w](?:[^>]|\n)*?fullWidth`,
   }}
@@ -405,6 +416,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Layout.Section secondary /> prop`,
     code: String.raw`<Layout\.Section[^>\w](?:[^>]|\n)*?secondary`,
   }}
@@ -437,6 +449,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <TextField borderless /> prop`,
     code: String.raw`<TextField[^>\w](?:[^>]|\n)*?borderless`,
   }}
@@ -495,6 +508,7 @@ This border radius property rename aligns with [CSS border radius constituent pr
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Box borderRadiusEndStart="..." /> prop`,
     code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderRadiusEndStart`,
   }}
@@ -502,6 +516,7 @@ This border radius property rename aligns with [CSS border radius constituent pr
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Box borderRadiusEndEnd="..." /> prop`,
     code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderRadiusEndEnd`,
   }}
@@ -509,6 +524,7 @@ This border radius property rename aligns with [CSS border radius constituent pr
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Box borderRadiusStartStart="..." /> prop`,
     code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderRadiusStartStart`,
   }}
@@ -516,6 +532,7 @@ This border radius property rename aligns with [CSS border radius constituent pr
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Box borderRadiusStartEnd="..." /> prop`,
     code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderRadiusStartEnd`,
   }}
@@ -550,6 +567,7 @@ Directional components now use `Inline` and `Block` naming conventions which are
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <HorizontalStack /> component`,
     code: String.raw`HorizontalStack`,
   }}
@@ -584,6 +602,7 @@ Directional components now use `Inline` and `Block` naming conventions which are
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <VerticalStack /> component`,
     code: String.raw`VerticalStack`,
   }}
@@ -618,6 +637,7 @@ Directional components now use `Inline` and `Block` naming conventions which are
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <HorizontalGrid /> component`,
     code: String.raw`HorizontalGrid`,
   }}
@@ -652,6 +672,7 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Button connectedDisclosure /> prop`,
     code: String.raw`<Button[^>\w](?:[^>]|\n)*?connectedDisclosure`,
   }}
@@ -659,6 +680,7 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Button destructive /> prop`,
     code: String.raw`<Button[^>\w](?:[^>]|\n)*?destructive`,
   }}
@@ -666,6 +688,7 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Button outline /> prop`,
     code: String.raw`<Button[^>\w](?:[^>]|\n)*?outline`,
   }}
@@ -673,6 +696,7 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Button monochrome /> prop`,
     code: String.raw`<Button[^>\w](?:[^>]|\n)*?monochrome`,
   }}
@@ -680,6 +704,7 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Button plain /> prop`,
     code: String.raw`<Button[^>\w](?:[^>]|\n)*?plain`,
   }}
@@ -687,6 +712,7 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Button primary /> prop`,
     code: String.raw`<Button[^>\w](?:[^>]|\n)*?primary`,
   }}
@@ -694,6 +720,7 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Button primarySuccess /> prop`,
     code: String.raw`<Button[^>\w](?:[^>]|\n)*?primarySuccess`,
   }}
@@ -757,10 +784,16 @@ The `Button` component has been updated to replace deprecated `connectedDisclosu
 The [updated split example](/components/actions/button) can also be referenced as an example for this manual migration.
 
 ```diff
-- <Button connectedDisclosure />
+- <Button
+-   connectedDisclosure={
+-     <Popover activator={<Button icon={ChevronDownMinor} />} />
+-   }
+- >
+-   Save
+- </Button>
 + <ButtonGroup variant="segmented">
-+   <Button />
-+   <Button icon={ChevronDownMinor} />
++   <Button>Save</Button>
++   <Popover activator={<Button icon={ChevronDownMinor} />}/>
 + </ButtonGroup>
 ```
 
@@ -782,6 +815,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <ButtonGroup spacing="..." /> prop`,
     code: String.raw`<ButtonGroup[^>\w](?:[^>]|\n)*?spacing`,
   }}
@@ -812,6 +846,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <ButtonGroup segmented /> prop`,
     code: String.raw`<ButtonGroup[^>\w](?:[^>]|\n)*?segmented`,
   }}
@@ -844,6 +879,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Banner status="..." /> prop`,
     code: String.raw`<Banner[^>\w](?:[^>]|\n)*?status`,
   }}
@@ -878,6 +914,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Icon color="warning" /> prop`,
     code: String.raw`<Icon[^>\w](?:[^>]|\n)*?color="warning"`,
   }}
@@ -885,6 +922,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Icon color="warning" /> prop`,
     code: String.raw`<Icon[^>\w](?:[^>]|\n)*?tone="warning"`,
   }}
@@ -916,6 +954,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Icon color="highlight" /> prop`,
     code: String.raw`<Icon[^>\w](?:[^>]|\n)*?color="highlight"`,
   }}
@@ -923,6 +962,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Icon color="highlight" /> prop`,
     code: String.raw`<Icon[^>\w](?:[^>]|\n)*?tone="highlight"`,
   }}
@@ -954,6 +994,7 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Icon color="..." /> prop`,
     code: String.raw`<Icon[^>\w](?:[^>]|\n)*?color`,
   }}
@@ -978,6 +1019,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Icon backdrop /> prop`,
     code: String.raw`<Icon[^>\w](?:[^>]|\n)*?backdrop`,
   }}
@@ -1014,6 +1056,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Text color="warning" /> prop`,
     code: String.raw`<Text[^>\w](?:[^>]|\n)*?color="warning"`,
   }}
@@ -1021,6 +1064,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Text color="warning" /> prop`,
     code: String.raw`<Text[^>\w](?:[^>]|\n)*?tone="warning"`,
   }}
@@ -1052,6 +1096,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Text color="..." /> prop`,
     code: String.raw`<Text[^>\w](?:[^>]|\n)*?color`,
   }}
@@ -1082,6 +1127,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Text variant="headingXs" /> prop`,
     code: String.raw`<Text[^>\w](?:[^>]|\n)*?variant="headingXs"`,
   }}
@@ -1112,6 +1158,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Text variant="heading4xl" /> prop`,
     code: String.raw`<Text[^>\w](?:[^>]|\n)*?variant="heading4xl"`,
   }}
@@ -1144,6 +1191,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Modal small /> prop`,
     code: String.raw`<Modal[^>\w](?:[^>]|\n)*?small`,
   }}
@@ -1174,6 +1222,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Modal large /> prop`,
     code: String.raw`<Modal[^>\w](?:[^>]|\n)*?large`,
   }}
@@ -1204,6 +1253,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Modal fullScreen /> prop`,
     code: String.raw`<Modal[^>\w](?:[^>]|\n)*?fullScreen`,
   }}
@@ -1236,6 +1286,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <List spacing="..." /> prop`,
     code: String.raw`<List[^>\w](?:[^>]|\n)*?spacing`,
   }}
@@ -1268,6 +1319,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <DescriptionList spacing="..." /> prop`,
     code: String.raw`<DescriptionList[^>\w](?:[^>]|\n)*?spacing`,
   }}
@@ -1294,6 +1346,7 @@ Page dividers are no longer a pattern in the new Polaris design language. If you
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <Page divider /> prop`,
     code: String.raw`<Page[^>\w](?:[^>]|\n)*?divider`,
   }}
@@ -1320,6 +1373,7 @@ The `AppProvider` `features` prop no longer accepts the keys `polarisSummerEditi
 
 <Code
   code={{
+    className: 'language-regex',
     title: `Check RegExp for outdated <AppProvider features={...} /> prop`,
     code: String.raw`<AppProvider[^>\w](?:[^>]|\n)*?features`,
   }}
@@ -1380,84 +1434,98 @@ To replace deprecated `border` custom properties, you can run the [v12-styles-re
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Tooltip borderRadius="..." /> prop`,
       code: String.raw`<Tooltip[^>\w](?:[^>]|\n)*?borderRadius`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderRadius="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderRadius`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderEndStartRadius="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderEndStartRadius`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderEndEndRadius="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderEndEndRadius`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderStartStartRadius="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderStartStartRadius`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderStartEndRadius="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderStartEndRadius`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderWidth="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderWidth`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderBlockStartWidth="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderBlockStartWidth`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderBlockEndWidth="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderBlockEndWidth`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderInlineStartWidth="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderInlineStartWidth`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderInlineEndWidth="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderInlineEndWidth`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box outlineWidth="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?outlineWidth`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <ShadowBevel borderRadius="..." /> prop`,
       code: String.raw`<ShadowBevel[^>\w](?:[^>]|\n)*?borderRadius`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Divider borderWidth="..." /> prop`,
       code: String.raw`<Divider[^>\w](?:[^>]|\n)*?borderWidth`,
     }}
@@ -1530,42 +1598,49 @@ To replace deprecated `color` custom properties, you can run the [v12-styles-rep
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box background="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?background`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Card background="..." /> prop`,
       code: String.raw`<Card[^>\w](?:[^>]|\n)*?background`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box outlineColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?outlineColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Divider borderColor="..." /> prop`,
       code: String.raw`<Divider[^>\w](?:[^>]|\n)*?borderColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Banner textColor="..." /> prop`,
       code: String.raw`<Banner[^>\w](?:[^>]|\n)*?textColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box color="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?color`,
     }}
@@ -1728,6 +1803,7 @@ To replace deprecated `color` custom properties, you can run the [v12-styles-rep
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box outlineColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?outlineColor`,
     }}
@@ -1744,42 +1820,49 @@ To replace deprecated `color` custom properties, you can run the [v12-styles-rep
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box background="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?background`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Card background="..." /> prop`,
       code: String.raw`<Card[^>\w](?:[^>]|\n)*?background`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box outlineColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?outlineColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Divider borderColor="..." /> prop`,
       code: String.raw`<Divider[^>\w](?:[^>]|\n)*?borderColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Banner textColor="..." /> prop`,
       code: String.raw`<Banner[^>\w](?:[^>]|\n)*?textColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box color="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?color`,
     }}
@@ -1819,42 +1902,49 @@ Manually migrate the following tokens to their hardcoded values:
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box background="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?background`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Card background="..." /> prop`,
       code: String.raw`<Card[^>\w](?:[^>]|\n)*?background`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box outlineColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?outlineColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Divider borderColor="..." /> prop`,
       code: String.raw`<Divider[^>\w](?:[^>]|\n)*?borderColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Banner textColor="..." /> prop`,
       code: String.raw`<Banner[^>\w](?:[^>]|\n)*?textColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box color="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?color`,
     }}
@@ -1888,42 +1978,49 @@ If you want to unblock your migration quickly you can manually hardcode the valu
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box background="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?background`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Card background="..." /> prop`,
       code: String.raw`<Card[^>\w](?:[^>]|\n)*?background`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box borderColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?borderColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box outlineColor="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?outlineColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Divider borderColor="..." /> prop`,
       code: String.raw`<Divider[^>\w](?:[^>]|\n)*?borderColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Banner textColor="..." /> prop`,
       code: String.raw`<Banner[^>\w](?:[^>]|\n)*?textColor`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box color="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?color`,
     }}
@@ -2141,6 +2238,7 @@ To replace deprecated `shadow` custom properties, you can run the [v12-styles-re
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box shadow="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?shadow`,
     }}
@@ -2201,12 +2299,14 @@ The following tokens need to be manually migrated because their values are conte
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box shadow="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?shadow`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <ShadowBevel boxShadow="..." /> prop`,
       code: String.raw`<ShadowBevel[^>\w](?:[^>]|\n)*?boxShadow`,
     }}
@@ -2246,6 +2346,7 @@ To replace deprecated `space` custom properties, you can run the [v12-styles-rep
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Tooltip padding="..." /> prop`,
       code: String.raw`<Tooltip[^>\w](?:[^>]|\n)*?padding`,
     }}
@@ -2257,66 +2358,77 @@ To replace deprecated `space` custom properties, you can run the [v12-styles-rep
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <HorizontalGrid gap="..." /> prop`,
       code: String.raw`<HorizontalGrid[^>\w](?:[^>]|\n)*?gap`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <InlineGrid gap="..." /> prop`,
       code: String.raw`<InlineGrid[^>\w](?:[^>]|\n)*?gap`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box padding="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?padding`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box paddingBlockStart="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?paddingBlockStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box paddingBlockEnd="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?paddingBlockEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box paddingInlineStart="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?paddingInlineStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box paddingInlineEnd="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?paddingInlineEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box insetBlockStart="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?insetBlockStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box insetBlockEnd="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?insetBlockEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box insetInlineStart="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?insetInlineStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Box insetInlineEnd="..." /> prop`,
       code: String.raw`<Box[^>\w](?:[^>]|\n)*?insetInlineEnd`,
     }}
@@ -2328,12 +2440,14 @@ To replace deprecated `space` custom properties, you can run the [v12-styles-rep
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <VerticalStack gap="..." /> prop`,
       code: String.raw`<VerticalStack[^>\w](?:[^>]|\n)*?gap`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <BlockStack gap="..." /> prop`,
       code: String.raw`<BlockStack[^>\w](?:[^>]|\n)*?gap`,
     }}
@@ -2345,168 +2459,196 @@ To replace deprecated `space` custom properties, you can run the [v12-styles-rep
   </p>
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <HorizontalStack gap="..." /> prop`,
       code: String.raw`<HorizontalStack[^>\w](?:[^>]|\n)*?gap`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <InlineStack gap="..." /> prop`,
       code: String.raw`<InlineStack[^>\w](?:[^>]|\n)*?gap`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Choice bleed="..." /> prop`,
       code: String.raw`<Choice[^>\w](?:[^>]|\n)*?bleed`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Choice bleedBlockStart="..." /> prop`,
       code: String.raw`<Choice[^>\w](?:[^>]|\n)*?bleedBlockStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Choice bleedBlockEnd="..." /> prop`,
       code: String.raw`<Choice[^>\w](?:[^>]|\n)*?bleedBlockEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Choice bleedInlineStart="..." /> prop`,
       code: String.raw`<Choice[^>\w](?:[^>]|\n)*?bleedInlineStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Choice bleedInlineEnd="..." /> prop`,
       code: String.raw`<Choice[^>\w](?:[^>]|\n)*?bleedInlineEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <RadioButton bleed="..." /> prop`,
       code: String.raw`<RadioButton[^>\w](?:[^>]|\n)*?bleed`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <RadioButton bleedBlockStart="..." /> prop`,
       code: String.raw`<RadioButton[^>\w](?:[^>]|\n)*?bleedBlockStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <RadioButton bleedBlockEnd="..." /> prop`,
       code: String.raw`<RadioButton[^>\w](?:[^>]|\n)*?bleedBlockEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <RadioButton bleedInlineStart="..." /> prop`,
       code: String.raw`<RadioButton[^>\w](?:[^>]|\n)*?bleedInlineStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <RadioButton bleedInlineEnd="..." /> prop`,
       code: String.raw`<RadioButton[^>\w](?:[^>]|\n)*?bleedInlineEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Checkbox bleed="..." /> prop`,
       code: String.raw`<Checkbox[^>\w](?:[^>]|\n)*?bleed`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Checkbox bleedBlockStart="..." /> prop`,
       code: String.raw`<Checkbox[^>\w](?:[^>]|\n)*?bleedBlockStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Checkbox bleedBlockEnd="..." /> prop`,
       code: String.raw`<Checkbox[^>\w](?:[^>]|\n)*?bleedBlockEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Checkbox bleedInlineStart="..." /> prop`,
       code: String.raw`<Checkbox[^>\w](?:[^>]|\n)*?bleedInlineStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Checkbox bleedInlineEnd="..." /> prop`,
       code: String.raw`<Checkbox[^>\w](?:[^>]|\n)*?bleedInlineEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Stack gap="..." /> prop`,
       code: String.raw`<Stack[^>\w](?:[^>]|\n)*?gap`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Grid gap="..." /> prop`,
       code: String.raw`<Grid[^>\w](?:[^>]|\n)*?gap`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Grid gapX="..." /> prop`,
       code: String.raw`<Grid[^>\w](?:[^>]|\n)*?gapX`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Grid gapY="..." /> prop`,
       code: String.raw`<Grid[^>\w](?:[^>]|\n)*?gapY`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Card padding="..." /> prop`,
       code: String.raw`<Card[^>\w](?:[^>]|\n)*?padding`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Bleed marginInline="..." /> prop`,
       code: String.raw`<Bleed[^>\w](?:[^>]|\n)*?marginInline`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Bleed marginBlock="..." /> prop`,
       code: String.raw`<Bleed[^>\w](?:[^>]|\n)*?marginBlock`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Bleed marginBlockStart="..." /> prop`,
       code: String.raw`<Bleed[^>\w](?:[^>]|\n)*?marginBlockStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Bleed marginBlockEnd="..." /> prop`,
       code: String.raw`<Bleed[^>\w](?:[^>]|\n)*?marginBlockEnd`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Bleed marginInlineStart="..." /> prop`,
       code: String.raw`<Bleed[^>\w](?:[^>]|\n)*?marginInlineStart`,
     }}
   />
   <Code
     code={{
+      className: 'language-regex',
       title: `Check RegExp for outdated <Bleed marginInlineEnd="..." /> prop`,
       code: String.raw`<Bleed[^>\w](?:[^>]|\n)*?marginInlineEnd`,
     }}

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -90,7 +90,7 @@ git add .
 # Format staged files only
 git diff --staged --name-only | xargs npx prettier --write
 # Optional: run stylelint if using stylelint-polaris and running migrations on stylesheets
-npx stylelint "./**/*..{css,scss}"
+npx stylelint "./**/*.{css,scss}"
 #  Commit manual migrations
 git commit -m "[Manual] Migrate X from Polaris v11 to v12"
 ```
@@ -175,7 +175,7 @@ git commit -m "[Manual] Migrate X from Polaris v11 to v12"
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Badge" --from="status" --to="tone"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Badge --fromProp status --toProp tone "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -207,7 +207,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Badge" --from="statusAndProgressLabelOverride" --to="toneAndProgressLabelOverride"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Badge --fromProp statusAndProgressLabelOverride --toProp toneAndProgressLabelOverride "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -241,7 +241,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="IndexTable.Row" --from="status" --to="tone"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName IndexTable.Row --fromProp status --toProp tone "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -271,7 +271,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="IndexTable.Row" --from="subdued" --to="tone" --toValue="subdued"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName IndexTable.Row --fromPropType boolean --fromProp subdued --toProp tone --toValue subdued "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -303,7 +303,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Layout.Section" --from="oneThird" --to="variant" --toValue="oneThird"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Layout.Section --fromPropType boolean --fromProp oneThird --toProp variant --toValue oneThird "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -333,7 +333,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Layout.Section" --from="oneHalf" --to="variant" --toValue="oneHalf"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Layout.Section --fromPropType boolean --fromProp oneHalf --toProp variant --toValue oneHalf "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -363,7 +363,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Layout.Section" --from="fullWidth" --to="variant" --toValue="fullWidth"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Layout.Section --fromPropType boolean --fromProp fullWidth --toProp variant --toValue fullWidth "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -393,7 +393,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Layout.Section" --from="secondary" --to="variant" --toValue="oneThird"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Layout.Section --fromPropType boolean --fromProp secondary --toProp variant --toValue oneThird "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -425,7 +425,7 @@ You will also need to update `Badge.pip` `status` -> `tone`
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="TextField" --from="borderless" --to="variant" --toValue="borderless"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName TextField --fromPropType boolean --fromProp borderless --toProp variant --toValue borderless "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -459,7 +459,7 @@ This border radius property rename aligns with [CSS border radius constituent pr
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Box" --from="borderRadiusEndStart" --to="borderEndStartRadius"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Box --fromProp borderRadiusEndStart --toProp borderEndStartRadius "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -467,7 +467,7 @@ This border radius property rename aligns with [CSS border radius constituent pr
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Box" --from="borderRadiusEndEnd" --to="borderEndEndRadius"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Box --fromProp borderRadiusEndEnd --toProp borderEndEndRadius "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -475,7 +475,7 @@ This border radius property rename aligns with [CSS border radius constituent pr
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Box" --from="borderRadiusStartStart" --to="borderStartStartRadius"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Box --fromProp borderRadiusStartStart --toProp borderStartStartRadius "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -483,7 +483,7 @@ This border radius property rename aligns with [CSS border radius constituent pr
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Box" --from="borderRadiusStartEnd" --to="borderStartEndRadius"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Box --fromProp borderRadiusStartEnd --toProp borderStartEndRadius "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -538,7 +538,7 @@ Directional components now use `Inline` and `Block` naming conventions which are
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component "./**/*.{ts,tsx}" --renameFrom="HorizontalStack" --renameTo="InlineStack" --renamePropsFrom="HorizontalStackProps" --renamePropsTo="InlineStackProps"`,
+    code: String.raw`npx @shopify/polaris-migrator react-rename-component --renameFrom HorizontalStack --renameTo InlineStack --renamePropsFrom HorizontalStackProps --renamePropsTo InlineStackProps "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -572,7 +572,7 @@ Directional components now use `Inline` and `Block` naming conventions which are
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component "./**/*.{ts,tsx}" --renameFrom="VerticalStack" --renameTo="BlockStack" --renamePropsFrom="VerticalStackProps" --renamePropsTo="BlockStackProps"`,
+    code: String.raw`npx @shopify/polaris-migrator react-rename-component --renameFrom VerticalStack --renameTo BlockStack --renamePropsFrom VerticalStackProps --renamePropsTo BlockStackProps "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -606,7 +606,7 @@ Directional components now use `Inline` and `Block` naming conventions which are
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component "./**/*.{ts,tsx}" --renameFrom="HorizontalGrid" --renameTo="InlineGrid" --renamePropsFrom="HorizontalGridProps" --renamePropsTo="InlineGridProps"`,
+    code: String.raw`npx @shopify/polaris-migrator react-rename-component --renameFrom HorizontalGrid --renameTo InlineGrid --renamePropsFrom HorizontalGridProps --renamePropsTo InlineGridProps "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -770,7 +770,7 @@ The [updated split example](/components/actions/button) can also be referenced a
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="ButtonGroup" --from="spacing" --to="gap"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName ButtonGroup --fromProp spacing --toProp gap "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -800,7 +800,7 @@ The [updated split example](/components/actions/button) can also be referenced a
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="ButtonGroup" --from="segmented" --to="variant" --toValue="segmented"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName ButtonGroup --fromPropType boolean --fromProp segmented --toProp variant --toValue segmented "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -832,7 +832,7 @@ The [updated split example](/components/actions/button) can also be referenced a
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Banner" --from="status" --to="tone"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Banner --fromProp status --toProp tone "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -858,45 +858,15 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 ### Icon
 
-**🔔 Stepped migration**: You must run the `color` -> `tone` migration before running the tone rename migrations.
+**🔔 Stepped migration**: You must run the `color` -> `tone` migration after running the tone rename migrations.
 
-#### Step 1: Replace `color` prop with `tone`
-
-<Code
-  code={{
-    title: 'polaris-migrator codemod',
-    className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Icon" --from="color" --to="tone"`,
-  }}
-/>
-
-<CollapsibleDetails summary="✅ Post-migration RegExp validation">
-
-<Code
-  code={{
-    title: `Check RegExp for outdated <Icon color="..." /> prop`,
-    code: String.raw`<Icon[^>\w](?:[^>]|\n)*?color`,
-  }}
-/>
-
-</CollapsibleDetails>
-
-<CollapsibleDetails summary="💡 Migration example">
-
-```diff
-- <Icon color="success" />
-+ <Icon tone="success" />
-```
-
-</CollapsibleDetails>
-
-#### Step 2: Replace `warning` tone with `caution`
+#### Step 1: Replace `warning` tone with `caution`
 
 <Code
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Icon" --from="tone" --to="tone" --fromValue="warning" --toValue="caution"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Icon --fromProp color --toProp tone --fromValue warning --toValue caution "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -928,13 +898,13 @@ The [updated split example](/components/actions/button) can also be referenced a
 
 </CollapsibleDetails>
 
-#### Step 3: Replace `highlight` tone with `info`
+#### Step 2: Replace `highlight` tone with `info`
 
 <Code
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Icon" --from="tone" --to="tone" --fromValue="highlight" --toValue="info"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Icon --fromProp color --toProp tone --fromValue highlight --toValue info "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -962,6 +932,36 @@ The [updated split example](/components/actions/button) can also be referenced a
 - <Icon color="highlight" />
 - <Icon tone="highlight" />
 + <Icon tone="info" />
+```
+
+</CollapsibleDetails>
+
+#### Step 3: Replace `color` prop with `tone`
+
+<Code
+  code={{
+    title: 'polaris-migrator codemod',
+    className: 'language-bash',
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Icon --fromProp color --toProp tone "**/*.{ts,tsx}"`,
+  }}
+/>
+
+<CollapsibleDetails summary="✅ Post-migration RegExp validation">
+
+<Code
+  code={{
+    title: `Check RegExp for outdated <Icon color="..." /> prop`,
+    code: String.raw`<Icon[^>\w](?:[^>]|\n)*?color`,
+  }}
+/>
+
+</CollapsibleDetails>
+
+<CollapsibleDetails summary="💡 Migration example">
+
+```diff
+- <Icon color="success" />
++ <Icon tone="success" />
 ```
 
 </CollapsibleDetails>
@@ -996,43 +996,13 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 **🔔 Stepped migration**: You must run the `color` -> `tone` migration before running the tone rename migrations.
 
-#### Step 1: Replace `color` prop with `tone`
+#### Step 1: Replace `warning` tone with `caution`
 
 <Code
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Text" --from="color" --to="tone"`,
-  }}
-/>
-
-<CollapsibleDetails summary="✅ Post-migration RegExp validation">
-
-<Code
-  code={{
-    title: `Check RegExp for outdated <Text color="..." /> prop`,
-    code: String.raw`<Text[^>\w](?:[^>]|\n)*?color`,
-  }}
-/>
-
-</CollapsibleDetails>
-
-<CollapsibleDetails summary="💡 Migration example">
-
-```diff
-- <Text color="success" />
-+ <Text tone="success" />
-```
-
-</CollapsibleDetails>
-
-#### Step 2: Replace `warning` tone with `caution`
-
-<Code
-  code={{
-    title: 'polaris-migrator codemod',
-    className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Text" --from="tone" --to="tone" --fromValue="warning" --toValue="caution"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Text --fromProp color --toProp tone --fromValue warning --toValue caution "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -1064,13 +1034,43 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
 
 </CollapsibleDetails>
 
+#### Step 2: Replace `color` prop with `tone`
+
+<Code
+  code={{
+    title: 'polaris-migrator codemod',
+    className: 'language-bash',
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Text --fromProp color --toProp tone "**/*.{ts,tsx}"`,
+  }}
+/>
+
+<CollapsibleDetails summary="✅ Post-migration RegExp validation">
+
+<Code
+  code={{
+    title: `Check RegExp for outdated <Text color="..." /> prop`,
+    code: String.raw`<Text[^>\w](?:[^>]|\n)*?color`,
+  }}
+/>
+
+</CollapsibleDetails>
+
+<CollapsibleDetails summary="💡 Migration example">
+
+```diff
+- <Text color="success" />
++ <Text tone="success" />
+```
+
+</CollapsibleDetails>
+
 #### Replace `headingXs` prop with `headingSm`
 
 <Code
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Text" --from="variant" --to="variant" --fromValue="headingXs" --toValue="headingSm"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Text --fromProp variant --fromValue headingXs --toValue headingSm "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -1100,7 +1100,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Text" --from="variant" --to="variant" --fromValue="heading4xl" --toValue="heading3xl"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Text --fromProp variant --fromValue heading4xl --toValue heading3xl "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -1132,7 +1132,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Modal" --from="small" --to="size" --toValue="small"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Modal --fromPropType boolean --fromProp small --toProp size --toValue small "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -1162,7 +1162,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Modal" --from="large" --to="size" --toValue="large"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Modal --fromPropType boolean --fromProp large --toProp size --toValue large "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -1192,7 +1192,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="Modal" --from="fullScreen" --to="size" --toValue="fullScreen"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Modal --fromPropType boolean --fromProp fullScreen --toProp size --toValue fullScreen "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -1224,7 +1224,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="List" --from="spacing" --to="gap"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName List --fromProp spacing --toProp gap "**/*.{ts,tsx}"`,
   }}
 />
 
@@ -1256,7 +1256,7 @@ Backdrop is not a pattern in the new Polaris design language. If you must use a 
   code={{
     title: 'polaris-migrator codemod',
     className: 'language-bash',
-    code: String.raw`npx @shopify/polaris-migrator react-rename-component-prop "./**/*.{ts,tsx}" --componentName="DescriptionList" --from="spacing" --to="gap"`,
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName DescriptionList --fromProp spacing --toProp gap "**/*.{ts,tsx}"`,
   }}
 />
 

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -137,6 +137,8 @@ html {
 
   code,
   pre {
+    .token {
+    }
     .keyword {
       color: var(--code-keyword);
     }
@@ -177,6 +179,32 @@ html {
     }
     .prefix {
       font-weight: 900;
+    }
+
+    .quantifier {
+      color: var(--code-quantifier);
+    }
+    .escape,
+    .special-escape {
+      color: var(--code-escape);
+    }
+    .char-class,
+    .charset-punctuation {
+      color: var(--code-charset-punctuation);
+    }
+    .anchor {
+      color: var(--code-anchor);
+    }
+    .group {
+      color: var(--code-group);
+    }
+    .backreference,
+    .alternation {
+      color: var(--code-alternation);
+    }
+    .regex-delimiter,
+    .regex-flags {
+      color: var(--p-text);
     }
   }
 }
@@ -243,6 +271,12 @@ body,
   --code-deleted: var(--code-boolean);
   --code-inserted-highlight: #e5ffef;
   --code-deleted-highlight: #fff3f8;
+  --code-quantifier: #5588ff;
+  --code-escape: #cc00cc;
+  --code-charset-punctuation: #dd7700;
+  --code-anchor: #884400;
+  --code-group: #ccaa00;
+  --code-alternation: #00aa00;
 }
 
 .dark-mode {
@@ -282,6 +316,12 @@ body,
   --code-deleted: #ffb7d1;
   --code-inserted-highlight: var(--surface-information);
   --code-deleted-highlight: var(--surface-warning);
+  --code-quantifier: #5588ff;
+  --code-escape: #cc00cc;
+  --code-charset-punctuation: #dd7700;
+  --code-anchor: #884400;
+  --code-group: #ccaa00;
+  --code-alternation: #00aa00;
 }
 
 video {


### PR DESCRIPTION
* Update migration guide to use safer migration commands from https://github.com/Shopify/app-bridge/pull/3183
* Fix glob paths
* Fix some copy mistakes
* Delete shadow bevel regex

co author: @chloerice commits from [here](https://github.com/Shopify/polaris/compare/update-migration-guide?expand=1) and [here](https://github.com/Shopify/polaris/pull/10911)