### PR TITLE
Update `@shopify/polaris-migrator` to accept a file list via `stdin`

### DIFF
--- a/.changeset/poor-llamas-taste.md
+++ b/.changeset/poor-llamas-taste.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Updated the `migrate` function to accept a file list

--- a/.changeset/poor-llamas-taste.md
+++ b/.changeset/poor-llamas-taste.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-migrator': minor
 ---
 
-Updated the `migrate` function to accept a file list
+Updated the CLI to accept a file list via `stdin`

--- a/polaris-migrator/src/cli.ts
+++ b/polaris-migrator/src/cli.ts
@@ -60,8 +60,7 @@ export const cliConfig = createCLIConfig({
     stdin: {
       alias: 's',
       type: 'boolean',
-      description:
-        'If true, each line of the standard input is used as a path.',
+      description: 'If true, each line of the standard input is used as a path',
     },
   },
 });

--- a/polaris-migrator/src/migrate.ts
+++ b/polaris-migrator/src/migrate.ts
@@ -38,7 +38,6 @@ export async function migrate(
     }
 
     const filepaths = globby.sync(files, {cwd: process.cwd()});
-
     if (filepaths.length === 0) {
       throw new Error(`No files found for ${files}`);
     }


### PR DESCRIPTION
Updates the Polaris migrator CLI to accept a file list via `stdin`.

Example usage with redirects:

```sh
npx @shopify/polaris-migrator styles-replace-custom-property \
  --decl=color \
  --from=--p-text \
  --to=--p-color-text \
  --stdin < file-list.txt
```

Example usage with piping:

```sh
git diff --name-only | npx @shopify/polaris-migrator styles-replace-custom-property \
  --decl=color \
  --from=--p-text \
  --to=--p-color-text \
  --stdin
```