### PR TITLE
[polaris.shopify.com] Fix layout-tokens do usages

### DIFF
--- a/polaris.shopify.com/content/design/layout/layout-tokens.md
+++ b/polaris.shopify.com/content/design/layout/layout-tokens.md
@@ -83,12 +83,14 @@ description: Apply consistent and harmonious space within and between ui element
             <Grid.Cell columnSpan={{xs: 6}}>
                 <Do>
                 ![](/images/design/layout/tokens/layout-tokens-card-gap@2x.png)
+
                 Always use semantic tokens over primitive ones when possible.
                 </Do>
             </Grid.Cell>
             <Grid.Cell columnSpan={{xs: 6}}>
                 <Do>
                 ![](/images/design/layout/tokens/layout-tokens-button-gap@2x.png)
+
                 Only use semantic tokens for the type of space as specified.
                 </Do>
             </Grid.Cell>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Due to the way that DirectiveCard has been [written](https://github.com/Shopify/polaris/pull/10597),  whitespace is necessary in order for the mdx compile to consider the image as a separate node. Otherwise it will wrap the image and the paragraph below it in a single p tag. 

### WHAT is this pull request doing?

Just adds white space between the image tag and the paragraph below. 

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
