### PR TITLE
Exit prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@shopify/polaris-cli": "0.2.25",


### PR DESCRIPTION
Run `yarn changeset pre exit` to exit prerelease mode.

This was also [done in `main`](https://github.com/Shopify/polaris/commit/560897ed0e75d17bf3f5e37fc091c7020821ff76) before releasing v12.

Snapshots won't work when in prerelease mode. We can now exit prerelease since v12 has been officially released.

See the [Changesets Prerelease documentation](https://github.com/changesets/changesets/blob/main/docs/prereleases.md) for more details.