### PR TITLE
New design guidance pages with video will open the video in a video player on mobile

### DIFF
--- a/polaris.shopify.com/content/design/pro-design-language.md
+++ b/polaris.shopify.com/content/design/pro-design-language.md
@@ -181,7 +181,7 @@ status: New
 
       <Grid.Cell columnSpan={{xs: 6, sm: 6, md: 6, lg: 8, xl: 8}}>
 
-        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay muted loop>
+        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls muted loop>
           <source src="/images/design/pro/pro-design-language-08-juicy-realness.mp4" type="video/mp4" />
 
           A series of buttons in every state, default, hovered and clicked
@@ -202,7 +202,7 @@ status: New
 
       <Grid.Cell columnSpan={{xs: 6, sm: 6, md: 6, lg: 8, xl: 8}}>
 
-        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay muted loop>
+        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls muted loop>
           <source src="/images/design/pro/pro-design-language-09-juicy-quick.mp4" type="video/mp4" />
 
           Navigation opening/closing animation
@@ -223,7 +223,7 @@ status: New
 
       <Grid.Cell columnSpan={{xs: 6, sm: 6, md: 6, lg: 8, xl: 8}}>
 
-        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay muted loop>
+        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls muted loop>
           <source src="/images/design/pro/pro-design-language-10-juicy-animation.mp4" type="video/mp4" />
 
           Animation of a checkbox being ticked in an index page


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/polaris/issues/10936

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Currently for `Pro design language` video started playing automatically.
- Made changes accordingly to remove autoplay.

Videos 
**Before**

https://github.com/Shopify/polaris/assets/132813311/877bac9b-741a-446c-9acb-4b521f9c69f8

**After**


https://github.com/Shopify/polaris/assets/132813311/9fde429d-31b1-42e6-ba8e-1fa7a21abcbb






<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
