### PR TITLE
Remove autoplay for Motion pages

### DIFF
--- a/.changeset/rich-eagles-design.md
+++ b/.changeset/rich-eagles-design.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Removed autoplay from all videos on Motion design guidance pages

--- a/polaris.shopify.com/content/design/motion/creating-motion.md
+++ b/polaris.shopify.com/content/design/motion/creating-motion.md
@@ -24,7 +24,7 @@ Transitions should be smooth and fluid, guiding merchants’ attention and maint
       width="100%"
       height="auto"
       controls
-      autoPlay
+      
       playsInline
       muted
       loop
@@ -49,7 +49,6 @@ Transitions should be smooth and fluid, guiding merchants’ attention and maint
         width="100%"
         height="auto"
         controls
-        autoPlay
         playsInline
         muted
         loop
@@ -69,7 +68,6 @@ Transitions should be smooth and fluid, guiding merchants’ attention and maint
         width="100%"
         height="auto"
         controls
-        autoPlay
         playsInline
         muted
         loop
@@ -94,7 +92,7 @@ Animations should be simple and purposeful, used to enhance understanding or pro
 
 #### Do
 
-<video width="100%" height="auto" controls autoPlay playsInline muted loop>
+<video width="100%" height="auto" controls playsInline muted loop>
   <source
     src="/images/design/motion/creating/02-animation-do.mp4"
     type="video/mp4"
@@ -110,7 +108,6 @@ tone of the interface.
     width="100%"
     height="auto"
     controls
-    autoPlay
     playsInline
     muted
     loop
@@ -132,7 +129,7 @@ Timing is crucial in motion design. Motion is fast enough to not cause delay, bu
 
 #### Do
 
-<video width="100%" height="auto" controls autoPlay playsInline muted loop>
+<video width="100%" height="auto" controls playsInline muted loop>
   <source
     src="/images/design/motion/creating/03-timing-do.mp4"
     type="video/mp4"
@@ -148,7 +145,6 @@ the motion to merchant expectations.
     width="100%"
     height="auto"
     controls
-    autoPlay
     playsInline
     muted
     loop

--- a/polaris.shopify.com/content/design/motion/index.md
+++ b/polaris.shopify.com/content/design/motion/index.md
@@ -29,15 +29,7 @@ Motion has a clear purpose. It helps merchants understand the interface and the 
 >
   <Grid.Cell area="a">
     <Do>
-      <video
-        width="100%"
-        height="auto"
-        controls
-        autoPlay
-        playsInline
-        muted
-        loop
-      >
+      <video width="100%" height="auto" controls playsInline muted loop>
         <source
           src="/images/design/motion/overview/01-purposeful-do.mp4"
           type="video/mp4"
@@ -50,15 +42,7 @@ Motion has a clear purpose. It helps merchants understand the interface and the 
   </Grid.Cell>
   <Grid.Cell area="b">
     <Dont>
-      <video
-        width="100%"
-        height="auto"
-        controls
-        autoPlay
-        playsInline
-        muted
-        loop
-      >
+      <video width="100%" height="auto" controls playsInline muted loop>
         <source
           src="/images/design/motion/overview/01-purposeful-dont.mp4"
           type="video/mp4"
@@ -81,15 +65,7 @@ Motion should be a reaction to merchant interactions, providing immediate visual
 >
   <Grid.Cell area="a">
     <Do>
-      <video
-        width="100%"
-        height="auto"
-        controls
-        autoPlay
-        playsInline
-        muted
-        loop
-      >
+      <video width="100%" height="auto" controls playsInline muted loop>
         <source
           src="/images/design/motion/overview/02-responsive-do.mp4"
           type="video/mp4"
@@ -102,15 +78,7 @@ Motion should be a reaction to merchant interactions, providing immediate visual
   </Grid.Cell>
   <Grid.Cell area="b">
     <Dont>
-      <video
-        width="100%"
-        height="auto"
-        controls
-        autoPlay
-        playsInline
-        muted
-        loop
-      >
+      <video width="100%" height="auto" controls playsInline muted loop>
         <source
           src="/images/design/motion/overview/02-responsive-dont.mp4"
           type="video/mp4"
@@ -135,15 +103,7 @@ A snappy animation starts rapidly, and slows down towards the end, making the tr
 >
   <Grid.Cell area="a">
     <Do>
-      <video
-        width="100%"
-        height="auto"
-        controls
-        autoPlay
-        playsInline
-        muted
-        loop
-      >
+      <video width="100%" height="auto" controls playsInline muted loop>
         <source
           src="/images/design/motion/overview/03-snappy-do.mp4"
           type="video/mp4"
@@ -156,15 +116,7 @@ A snappy animation starts rapidly, and slows down towards the end, making the tr
   </Grid.Cell>
   <Grid.Cell area="b">
     <Dont>
-      <video
-        width="100%"
-        height="auto"
-        controls
-        autoPlay
-        playsInline
-        muted
-        loop
-      >
+      <video width="100%" height="auto" controls playsInline muted loop>
         <source
           src="/images/design/motion/overview/03-snappy-dont.mp4"
           type="video/mp4"

--- a/polaris.shopify.com/content/design/motion/using-motion.md
+++ b/polaris.shopify.com/content/design/motion/using-motion.md
@@ -24,7 +24,6 @@ Motion can be used to provide feedback, helping merchants understand the results
       width="100%"
       height="auto"
       controls
-      autoPlay
       playsInline
       muted
       loop
@@ -49,7 +48,6 @@ Motion can be used to provide feedback, helping merchants understand the results
 
         height="auto"
         controls
-        autoPlay
         playsInline
         muted
         loop
@@ -71,7 +69,6 @@ Motion can be used to provide feedback, helping merchants understand the results
 
         height="auto"
         controls
-        autoPlay
         playsInline
         muted
         loop
@@ -100,7 +97,6 @@ Motion can guide merchant attention during navigation, helping to maintain conte
 
       height="auto"
       controls
-      autoPlay
       playsInline
       muted
       loop
@@ -126,7 +122,6 @@ Motion can guide merchant attention during navigation, helping to maintain conte
 
         height="auto"
         controls
-        autoPlay
         playsInline
         muted
         loop
@@ -148,7 +143,6 @@ Motion can guide merchant attention during navigation, helping to maintain conte
 
         height="auto"
         controls
-        autoPlay
         playsInline
         muted
         loop
@@ -177,7 +171,6 @@ Motion can be used to indicate loading states, keeping merchants informed and en
 
       height="auto"
       controls
-      autoPlay
       playsInline
       muted
       loop
@@ -211,7 +204,6 @@ Motion can be used to indicate loading states, keeping merchants informed and en
 
         height="auto"
         controls
-        autoPlay
         playsInline
         muted
         loop


### PR DESCRIPTION
Removes the `autoPlay` from videos on the Motion design guidance page. It is currently a bit overwhelming when all the videos play automatically on load.

## Before

https://github.com/Shopify/polaris/assets/11774595/d4143ca4-4cd5-4629-abb9-d266a5b69772


## After

https://github.com/Shopify/polaris/assets/11774595/7a168940-0de3-4369-97a1-2dfbff6d7fd0