### PR TITLE
Add `replacmentMaps` option to generic `react-update-component-prop` migration

### DIFF
--- a/.changeset/good-hornets-travel.md
+++ b/.changeset/good-hornets-travel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Added `replacmentMaps` option to generic `react-update-component-prop` migration

--- a/polaris-migrator/src/migrations/react-update-component-prop/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/react-update-component-prop/tests/transform.test.ts
@@ -76,6 +76,29 @@ const fixtures = [
       toValue: 'new-value',
     },
   },
+  {
+    name: 'with-replacement-maps',
+    options: {
+      replacementMaps: {
+        MyComponent1: [
+          {
+            fromProp: 'prop1',
+            toProp: 'newProp1',
+            fromValue: 'value-1',
+            toValue: 'new-value-1',
+          },
+        ],
+        MyComponent2: [
+          {
+            fromProp: 'prop2',
+            toProp: 'newProp2',
+            fromValue: 'value-2',
+            toValue: 'new-value-2',
+          },
+        ],
+      },
+    },
+  },
 ];
 
 for (const fixture of fixtures) {

--- a/polaris-migrator/src/migrations/react-update-component-prop/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/react-update-component-prop/tests/transform.test.ts
@@ -80,20 +80,26 @@ const fixtures = [
     name: 'with-replacement-maps',
     options: {
       replacementMaps: {
-        MyComponent1: [
+        MyComponentA: [
           {
             fromProp: 'prop1',
             toProp: 'newProp1',
             fromValue: 'value-1',
             toValue: 'new-value-1',
           },
-        ],
-        MyComponent2: [
           {
+            fromPropType: 'boolean',
             fromProp: 'prop2',
             toProp: 'newProp2',
-            fromValue: 'value-2',
             toValue: 'new-value-2',
+          },
+        ],
+        MyComponentB: [
+          {
+            fromProp: 'prop3',
+            toProp: 'newProp3',
+            fromValue: 'value-3',
+            toValue: 'new-value-3',
           },
         ],
       },

--- a/polaris-migrator/src/migrations/react-update-component-prop/tests/with-replacement-maps.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-component-prop/tests/with-replacement-maps.input.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+// @ts-expect-error
+import {MyComponent1, MyComponent2 as CustomComponent} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const MyComponentWrapper = MyComponent1;
+
+export function App() {
+  return (
+    <>
+      <MyComponent1 prop1="value-1" foo="bar">
+        Hello
+        <Child prop1="value-1" />
+        <MyComponentWrapper />
+      </MyComponent1>
+      <CustomComponent prop2="value-2" foo="bar">
+        Hello
+        <Child prop2="value-2" />
+        <MyComponentWrapper />
+      </CustomComponent>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-component-prop/tests/with-replacement-maps.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-component-prop/tests/with-replacement-maps.input.tsx
@@ -1,24 +1,28 @@
 import React from 'react';
-// @ts-expect-error
-import {MyComponent1, MyComponent2 as CustomComponent} from '@shopify/polaris';
+import {
+  // @ts-expect-error
+  MyComponentA,
+  // @ts-expect-error
+  MyComponentB as MyComponentBAlias,
+} from '@shopify/polaris';
 
 declare function Child(props: any): JSX.Element;
 
-const MyComponentWrapper = MyComponent1;
+const MyComponentAWrapper = MyComponentA;
 
 export function App() {
   return (
     <>
-      <MyComponent1 prop1="value-1" foo="bar">
+      <MyComponentA prop1="value-1" prop2 foo="bar">
         Hello
-        <Child prop1="value-1" />
-        <MyComponentWrapper />
-      </MyComponent1>
-      <CustomComponent prop2="value-2" foo="bar">
+        <Child prop1="value-1" prop2 />
+        <MyComponentAWrapper />
+      </MyComponentA>
+      <MyComponentBAlias prop3="value-3" foo="bar">
         Hello
-        <Child prop2="value-2" />
-        <MyComponentWrapper />
-      </CustomComponent>
+        <Child prop3="value-3" />
+        <MyComponentAWrapper />
+      </MyComponentBAlias>
     </>
   );
 }

--- a/polaris-migrator/src/migrations/react-update-component-prop/tests/with-replacement-maps.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-component-prop/tests/with-replacement-maps.output.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+// @ts-expect-error
+import {MyComponent1, MyComponent2 as CustomComponent} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const MyComponentWrapper =
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+  MyComponent1;
+
+export function App() {
+  return (
+    <>
+      <MyComponent1 newProp1="new-value-1" foo="bar">
+        Hello
+        <Child prop1="value-1" />
+        <MyComponentWrapper />
+      </MyComponent1>
+      <CustomComponent newProp2="new-value-2" foo="bar">
+        Hello
+        <Child prop2="value-2" />
+        <MyComponentWrapper />
+      </CustomComponent>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-component-prop/tests/with-replacement-maps.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-component-prop/tests/with-replacement-maps.output.tsx
@@ -1,26 +1,30 @@
 import React from 'react';
-// @ts-expect-error
-import {MyComponent1, MyComponent2 as CustomComponent} from '@shopify/polaris';
+import {
+  // @ts-expect-error
+  MyComponentA,
+  // @ts-expect-error
+  MyComponentB as MyComponentBAlias,
+} from '@shopify/polaris';
 
 declare function Child(props: any): JSX.Element;
 
-const MyComponentWrapper =
+const MyComponentAWrapper =
   /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
-  MyComponent1;
+  MyComponentA;
 
 export function App() {
   return (
     <>
-      <MyComponent1 newProp1="new-value-1" foo="bar">
+      <MyComponentA newProp1="new-value-1" newProp2="new-value-2" foo="bar">
         Hello
-        <Child prop1="value-1" />
-        <MyComponentWrapper />
-      </MyComponent1>
-      <CustomComponent newProp2="new-value-2" foo="bar">
+        <Child prop1="value-1" prop2 />
+        <MyComponentAWrapper />
+      </MyComponentA>
+      <MyComponentBAlias newProp3="new-value-3" foo="bar">
         Hello
-        <Child prop2="value-2" />
-        <MyComponentWrapper />
-      </CustomComponent>
+        <Child prop3="value-3" />
+        <MyComponentAWrapper />
+      </MyComponentBAlias>
     </>
   );
 }

--- a/polaris-migrator/src/migrations/react-update-component-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-update-component-prop/transform.ts
@@ -15,9 +15,7 @@ import {
   normalizeImportSourcePaths,
 } from '../../utilities/imports';
 
-export interface MigrationOptions extends Options {
-  relative?: boolean;
-  componentName: string;
+interface ReplacementOptions {
   fromPropType?: 'string' | 'boolean';
   fromProp: string;
   toProp?: string;
@@ -25,23 +23,58 @@ export interface MigrationOptions extends Options {
   toValue?: string;
 }
 
+interface ReplacementMaps {
+  [componentName: string]: ReplacementOptions[];
+}
+
+export interface MigrationOptions extends Options, ReplacementOptions {
+  relative?: boolean;
+  componentName?: string;
+  replacementMaps?: ReplacementMaps;
+}
+
 export default function transformer(
   file: FileInfo,
   {jscodeshift: j}: API,
   options: MigrationOptions,
 ) {
-  const {
-    componentName,
-    fromPropType = 'string',
-    fromProp,
-    toProp,
-    fromValue,
-    toValue,
-  } = options;
-
-  if (!componentName || !fromProp) {
-    throw new Error('Missing required options: componentName, fromProp');
+  if (
+    options.replacementMaps &&
+    (options.componentName ||
+      options.fromPropType ||
+      options.fromProp ||
+      options.toProp ||
+      options.fromValue ||
+      options.toValue)
+  ) {
+    throw new Error(
+      'Cannot provide both `replacementMaps` and `componentName`, `fromPropType`, `fromProp`, `toProp`, `fromValue`, or `toValue`',
+    );
   }
+
+  let replacementMaps: ReplacementMaps | undefined;
+
+  if (options.replacementMaps) {
+    replacementMaps = options.replacementMaps;
+  } else {
+    if (!options.componentName || !options.fromProp) {
+      throw new Error('Missing required options: componentName, fromProp');
+    }
+
+    replacementMaps = {
+      [options.componentName]: [
+        {
+          fromPropType: options.fromPropType,
+          fromProp: options.fromProp,
+          toProp: options.toProp,
+          fromValue: options.fromValue,
+          toValue: options.toValue,
+        },
+      ],
+    };
+  }
+
+  if (!replacementMaps) return;
 
   const source = j(file.source);
 
@@ -52,116 +85,135 @@ export default function transformer(
     return;
   }
 
-  const componentNames = componentName.split('.');
-  const targetComponentName = componentNames[0];
+  for (const replacementMapEntry of Object.entries(replacementMaps)) {
+    const [componentName, replacementOptions] = replacementMapEntry;
 
-  const sourcePaths = normalizeImportSourcePaths(j, source, {
-    relative: options.relative,
-    from: targetComponentName,
-    to: targetComponentName,
-  });
+    for (const replacementOption of replacementOptions) {
+      const {
+        fromPropType = 'string',
+        fromProp,
+        toProp,
+        fromValue,
+        toValue,
+      } = replacementOption;
 
-  if (!sourcePaths) return;
+      const componentNames = componentName.split('.');
+      const targetComponentName = componentNames[0];
 
-  if (!hasImportSpecifier(j, source, targetComponentName, sourcePaths.from)) {
-    return;
-  }
-
-  const localElementName =
-    getImportSpecifierName(j, source, targetComponentName, sourcePaths.from) ||
-    targetComponentName;
-
-  componentNames[0] = localElementName;
-
-  source.find(j.JSXElement).forEach((element) => {
-    if (
-      element.node.openingElement.name.type === 'JSXIdentifier' &&
-      element.node.openingElement.name.name !== localElementName
-    ) {
-      return;
-    }
-
-    const nameChain = getNameChain(element.node.openingElement.name);
-
-    if (
-      nameChain.length === componentNames.length &&
-      componentNames.every((name, index) => name === nameChain[index])
-    ) {
-      const allAttributes = element.node.openingElement.attributes ?? [];
-
-      if (
-        // Early exit on spread operators
-        allAttributes.some((attribute) => attribute.type !== 'JSXAttribute')
-      ) {
-        insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
-        return;
-      }
-
-      const jsxAttributes = allAttributes as JSXAttribute[];
-
-      const fromPropAttribute = jsxAttributes.find(
-        (attribute) => attribute.name.name === fromProp,
-      );
-
-      if (
-        fromPropAttribute &&
-        (fromPropType === 'boolean'
-          ? fromPropAttribute.value !== null
-          : fromPropAttribute.value?.type !== 'StringLiteral')
-      ) {
-        insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
-        return;
-      }
-
-      jsxAttributes.forEach((jsxAttribute) => {
-        if (
-          !(
-            jsxAttribute.type === 'JSXAttribute' &&
-            jsxAttribute.name.name === fromProp
-          )
-        ) {
-          return jsxAttribute;
-        }
-
-        // Current jsxAttribute matches target fromProp
-
-        const attributeValueValue =
-          jsxAttribute.value?.type === 'StringLiteral'
-            ? jsxAttribute.value.value
-            : null;
-
-        if (
-          toProp &&
-          toProp !== fromProp &&
-          (!fromValue || fromValue === attributeValueValue)
-        ) {
-          jsxAttribute.name.name = toProp;
-        }
-
-        if (fromValue && fromValue !== attributeValueValue) return jsxAttribute;
-
-        jsxAttribute.value = toValue
-          ? j.stringLiteral(toValue)
-          : jsxAttribute.value;
+      const sourcePaths = normalizeImportSourcePaths(j, source, {
+        relative: options.relative,
+        from: targetComponentName,
+        to: targetComponentName,
       });
-    }
-  });
 
-  source
-    .find(j.Identifier)
-    .filter((path) => path.node.name === localElementName)
-    .forEach((path) => {
-      if (path.node.type !== 'Identifier') return;
+      if (!sourcePaths) continue;
 
       if (
-        path.parent.value.type === 'ImportSpecifier' ||
-        path.parent.value.type === 'MemberExpression'
+        !hasImportSpecifier(j, source, targetComponentName, sourcePaths.from)
       ) {
-        return;
+        continue;
       }
 
-      insertCommentBefore(j, path, POLARIS_MIGRATOR_COMMENT);
-    });
+      const localElementName =
+        getImportSpecifierName(
+          j,
+          source,
+          targetComponentName,
+          sourcePaths.from,
+        ) || targetComponentName;
+
+      componentNames[0] = localElementName;
+
+      source.find(j.JSXElement).forEach((element) => {
+        if (
+          element.node.openingElement.name.type === 'JSXIdentifier' &&
+          element.node.openingElement.name.name !== localElementName
+        ) {
+          return;
+        }
+
+        const nameChain = getNameChain(element.node.openingElement.name);
+
+        if (
+          nameChain.length === componentNames.length &&
+          componentNames.every((name, index) => name === nameChain[index])
+        ) {
+          const allAttributes = element.node.openingElement.attributes ?? [];
+
+          if (
+            // Early exit on spread operators
+            allAttributes.some((attribute) => attribute.type !== 'JSXAttribute')
+          ) {
+            insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
+            return;
+          }
+
+          const jsxAttributes = allAttributes as JSXAttribute[];
+
+          const fromPropAttribute = jsxAttributes.find(
+            (attribute) => attribute.name.name === fromProp,
+          );
+
+          if (
+            fromPropAttribute &&
+            (fromPropType === 'boolean'
+              ? fromPropAttribute.value !== null
+              : fromPropAttribute.value?.type !== 'StringLiteral')
+          ) {
+            insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
+            return;
+          }
+
+          jsxAttributes.forEach((jsxAttribute) => {
+            if (
+              !(
+                jsxAttribute.type === 'JSXAttribute' &&
+                jsxAttribute.name.name === fromProp
+              )
+            ) {
+              return jsxAttribute;
+            }
+
+            const attributeValueValue =
+              jsxAttribute.value?.type === 'StringLiteral'
+                ? jsxAttribute.value.value
+                : null;
+
+            if (
+              toProp &&
+              toProp !== fromProp &&
+              (!fromValue || fromValue === attributeValueValue)
+            ) {
+              jsxAttribute.name.name = toProp;
+            }
+
+            if (fromValue && fromValue !== attributeValueValue)
+              return jsxAttribute;
+
+            jsxAttribute.value = toValue
+              ? j.stringLiteral(toValue)
+              : jsxAttribute.value;
+          });
+        }
+      });
+
+      source
+        .find(j.Identifier)
+        .filter((path) => path.node.name === localElementName)
+        .forEach((path) => {
+          if (path.node.type !== 'Identifier') return;
+
+          if (
+            path.parent.value.type === 'ImportSpecifier' ||
+            path.parent.value.type === 'MemberExpression'
+          ) {
+            return;
+          }
+
+          insertCommentBefore(j, path, POLARIS_MIGRATOR_COMMENT);
+        });
+    }
+  }
 
   return source.toSource();
 }

--- a/polaris-migrator/src/migrations/react-update-component-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-update-component-prop/transform.ts
@@ -85,23 +85,77 @@ export default function transformer(
     return;
   }
 
-  for (const replacementMapEntry of Object.entries(replacementMaps)) {
-    const [componentName, replacementOptions] = replacementMapEntry;
+  interface LocalElementConfig {
+    componentNames: string[];
+    replacementOptions: ReplacementOptions[];
+  }
 
-    const componentNames = componentName.split('.');
-    const targetComponentName = componentNames[0];
+  const localElementConfigs = Object.fromEntries(
+    Object.entries(replacementMaps)
+      .map((replacementMapEntry): null | [string, LocalElementConfig] => {
+        const [componentName, replacementOptions] = replacementMapEntry;
 
-    const sourcePaths = normalizeImportSourcePaths(j, source, {
-      relative: options.relative,
-      from: targetComponentName,
-      to: targetComponentName,
-    });
+        const componentNames = componentName.split('.');
+        const targetComponentName = componentNames[0];
+
+        const sourcePaths = normalizeImportSourcePaths(j, source, {
+          relative: options.relative,
+          from: targetComponentName,
+          to: targetComponentName,
+        });
+
+        if (
+          !sourcePaths ||
+          !hasImportSpecifier(j, source, targetComponentName, sourcePaths.from)
+        ) {
+          return null;
+        }
+
+        const localElementName =
+          getImportSpecifierName(
+            j,
+            source,
+            targetComponentName,
+            sourcePaths.from,
+          ) || targetComponentName;
+
+        componentNames[0] = localElementName;
+
+        return [
+          localElementName,
+          {
+            componentNames,
+            replacementOptions,
+          },
+        ];
+      })
+      .filter(Boolean) as [string, LocalElementConfig][],
+  );
+
+  source.find(j.JSXElement).forEach((element) => {
+    const elementNames = getElementNames(element.node.openingElement.name);
+
+    const localElementConfig = localElementConfigs[elementNames[0]];
+
+    if (!localElementConfig) return;
+
+    const {componentNames, replacementOptions} = localElementConfig;
 
     if (
-      !sourcePaths ||
-      !hasImportSpecifier(j, source, targetComponentName, sourcePaths.from)
+      elementNames.length !== componentNames.length ||
+      !componentNames.every((name, index) => name === elementNames[index])
     ) {
-      continue;
+      return;
+    }
+
+    const allAttributes = element.node.openingElement.attributes ?? [];
+
+    if (
+      // Early exit on spread operators
+      allAttributes.some((attribute) => attribute.type !== 'JSXAttribute')
+    ) {
+      insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
+      return;
     }
 
     for (const replacementOption of replacementOptions) {
@@ -112,117 +166,81 @@ export default function transformer(
         fromValue,
         toValue,
       } = replacementOption;
+      const jsxAttributes = allAttributes as JSXAttribute[];
 
-      const localElementName =
-        getImportSpecifierName(
-          j,
-          source,
-          targetComponentName,
-          sourcePaths.from,
-        ) || targetComponentName;
+      const fromPropAttribute = jsxAttributes.find(
+        (attribute) => attribute.name.name === fromProp,
+      );
 
-      componentNames[0] = localElementName;
+      if (
+        fromPropAttribute &&
+        (fromPropType === 'boolean'
+          ? fromPropAttribute.value !== null
+          : fromPropAttribute.value?.type !== 'StringLiteral')
+      ) {
+        insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
+        return;
+      }
 
-      source.find(j.JSXElement).forEach((element) => {
+      jsxAttributes.forEach((jsxAttribute) => {
         if (
-          element.node.openingElement.name.type === 'JSXIdentifier' &&
-          element.node.openingElement.name.name !== localElementName
+          !(
+            jsxAttribute.type === 'JSXAttribute' &&
+            jsxAttribute.name.name === fromProp
+          )
+        ) {
+          return jsxAttribute;
+        }
+
+        const attributeValueValue =
+          jsxAttribute.value?.type === 'StringLiteral'
+            ? jsxAttribute.value.value
+            : null;
+
+        if (
+          toProp &&
+          toProp !== fromProp &&
+          (!fromValue || fromValue === attributeValueValue)
+        ) {
+          jsxAttribute.name.name = toProp;
+        }
+
+        if (fromValue && fromValue !== attributeValueValue) return jsxAttribute;
+
+        jsxAttribute.value = toValue
+          ? j.stringLiteral(toValue)
+          : jsxAttribute.value;
+      });
+    }
+  });
+
+  Object.keys(localElementConfigs).forEach((localElementName) => {
+    source
+      .find(j.Identifier)
+      .filter((path) => path.node.name === localElementName)
+      .forEach((path) => {
+        if (path.node.type !== 'Identifier') return;
+
+        if (
+          path.parent.value.type === 'ImportSpecifier' ||
+          path.parent.value.type === 'MemberExpression'
         ) {
           return;
         }
 
-        const nameChain = getNameChain(element.node.openingElement.name);
-
-        if (
-          nameChain.length === componentNames.length &&
-          componentNames.every((name, index) => name === nameChain[index])
-        ) {
-          const allAttributes = element.node.openingElement.attributes ?? [];
-
-          if (
-            // Early exit on spread operators
-            allAttributes.some((attribute) => attribute.type !== 'JSXAttribute')
-          ) {
-            insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
-            return;
-          }
-
-          const jsxAttributes = allAttributes as JSXAttribute[];
-
-          const fromPropAttribute = jsxAttributes.find(
-            (attribute) => attribute.name.name === fromProp,
-          );
-
-          if (
-            fromPropAttribute &&
-            (fromPropType === 'boolean'
-              ? fromPropAttribute.value !== null
-              : fromPropAttribute.value?.type !== 'StringLiteral')
-          ) {
-            insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
-            return;
-          }
-
-          jsxAttributes.forEach((jsxAttribute) => {
-            if (
-              !(
-                jsxAttribute.type === 'JSXAttribute' &&
-                jsxAttribute.name.name === fromProp
-              )
-            ) {
-              return jsxAttribute;
-            }
-
-            const attributeValueValue =
-              jsxAttribute.value?.type === 'StringLiteral'
-                ? jsxAttribute.value.value
-                : null;
-
-            if (
-              toProp &&
-              toProp !== fromProp &&
-              (!fromValue || fromValue === attributeValueValue)
-            ) {
-              jsxAttribute.name.name = toProp;
-            }
-
-            if (fromValue && fromValue !== attributeValueValue)
-              return jsxAttribute;
-
-            jsxAttribute.value = toValue
-              ? j.stringLiteral(toValue)
-              : jsxAttribute.value;
-          });
-        }
+        insertCommentBefore(j, path, POLARIS_MIGRATOR_COMMENT);
       });
-
-      source
-        .find(j.Identifier)
-        .filter((path) => path.node.name === localElementName)
-        .forEach((path) => {
-          if (path.node.type !== 'Identifier') return;
-
-          if (
-            path.parent.value.type === 'ImportSpecifier' ||
-            path.parent.value.type === 'MemberExpression'
-          ) {
-            return;
-          }
-
-          insertCommentBefore(j, path, POLARIS_MIGRATOR_COMMENT);
-        });
-    }
-  }
+  });
 
   return source.toSource();
 }
 
-function getNameChain(name: JSXOpeningElement['name']): string[] {
+function getElementNames(name: JSXOpeningElement['name']): string[] {
   if (name.type === 'JSXIdentifier') {
     return [name.name];
   }
   if (name.type === 'JSXMemberExpression') {
-    return [...getNameChain(name.object), name.property.name];
+    return [...getElementNames(name.object), name.property.name];
   }
   return [];
 }


### PR DESCRIPTION
This PR introduces an internal `replacementMaps` option to the generic `react-update-component-prop` migration. The option is intended for use in other Polaris migrations to allow multi-component prop updates. For example:

```js
// example-update-component-prop-color.ts
export default function transform(fileInfo, api, options) {
  return reactUpdateComponentProp(fileInfo, api, {
    replacementMaps: {
      Box: [
        {
          fromProp: 'background',
          fromValue: 'bg',
          toValue: 'bg-surface',
        },
        {
          fromProp: 'background',
          toProp: 'text-primary',
          fromValue: 'text-brand',
        },
      ],
      Banner: [
        {
          fromProp: 'status',
          toProp: 'tone',
        },
      ],
    },
  })
}
```