### PR TITLE
Add `v12-react-update-component-prop-{space,border,shadow}` migration

### DIFF
--- a/polaris-migrator/src/migrations/react-update-component-prop/utils.ts
+++ b/polaris-migrator/src/migrations/react-update-component-prop/utils.ts
@@ -1,4 +1,4 @@
-import type {ReplacementMaps} from '../react-update-component-prop/transform';
+import type {ReplacementMaps} from './transform';
 
 type ComponentFromProp = string;
 

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/tests/basic.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/tests/basic.input.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {Box} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper = Box;
+
+export function App() {
+  return (
+    <>
+      <Box borderWidth="1" borderRadius="3">
+        Hello
+        <Child borderRadius="1" />
+        <BoxWrapper />
+      </Box>
+      <Box
+        borderWidth="1-experimental"
+        borderRadius="0-experimental"
+        padding="100"
+      >
+        Hello
+        <Child borderRadius="1" />
+        <BoxWrapper />
+      </Box>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/tests/basic.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/tests/basic.output.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Box} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper =
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+  Box;
+
+export function App() {
+  return (
+    <>
+      <Box borderWidth="1" borderRadius="300">
+        Hello
+        <Child borderRadius="1" />
+        <BoxWrapper />
+      </Box>
+      <Box borderWidth="1-experimental" borderRadius="0" padding="100">
+        Hello
+        <Child borderRadius="1" />
+        <BoxWrapper />
+      </Box>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/tests/transform.test.ts
@@ -1,0 +1,15 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v12-react-update-component-prop-border-radius';
+const fixtures = [
+  {
+    name: 'basic',
+  },
+];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture: fixture.name,
+    transform,
+  });
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/transform.ts
@@ -1,0 +1,39 @@
+import type {FileInfo, API} from 'jscodeshift';
+
+import {replacementMaps} from '../v12-styles-replace-custom-property-border/transform';
+import reactUpdateComponentProp from '../react-update-component-prop/transform';
+import type {ComponentReplacementOptions} from '../react-update-component-prop/utils';
+import {getReplacementMaps} from '../react-update-component-prop/utils';
+
+const radiusReplacementMap = Object.fromEntries(
+  Object.entries(replacementMaps['/.+/']).filter(
+    ([key]) => !key.includes('border-width'),
+  ),
+);
+
+const normalizedReplacementMap = Object.fromEntries(
+  Object.entries(radiusReplacementMap).map(([fromValue, toValue]) => [
+    fromValue.replace('--p-border-radius-', ''),
+    toValue.replace('--p-border-radius-', ''),
+  ]),
+);
+
+const componentReplacementOptions: ComponentReplacementOptions = {
+  Box: [
+    'borderRadius',
+    'borderEndStartRadius',
+    'borderEndEndRadius',
+    'borderStartStartRadius',
+    'borderStartEndRadius',
+  ],
+  Tooltip: ['borderRadius'],
+};
+
+export default function transformer(fileInfo: FileInfo, _: API) {
+  return reactUpdateComponentProp(fileInfo, _, {
+    replacementMaps: getReplacementMaps(
+      componentReplacementOptions,
+      normalizedReplacementMap,
+    ),
+  });
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-radius/transform.ts
@@ -2,7 +2,7 @@ import type {FileInfo, API} from 'jscodeshift';
 
 import {replacementMaps} from '../v12-styles-replace-custom-property-border/transform';
 import reactUpdateComponentProp from '../react-update-component-prop/transform';
-import type {ComponentReplacementOptions} from '../react-update-component-prop/utils';
+import type {ComponentFromPropsMap} from '../react-update-component-prop/utils';
 import {getReplacementMaps} from '../react-update-component-prop/utils';
 
 const radiusReplacementMap = Object.fromEntries(
@@ -18,7 +18,7 @@ const normalizedReplacementMap = Object.fromEntries(
   ]),
 );
 
-const componentReplacementOptions: ComponentReplacementOptions = {
+const componentFromPropsMap: ComponentFromPropsMap = {
   Box: [
     'borderRadius',
     'borderEndStartRadius',
@@ -32,7 +32,7 @@ const componentReplacementOptions: ComponentReplacementOptions = {
 export default function transformer(fileInfo: FileInfo, _: API) {
   return reactUpdateComponentProp(fileInfo, _, {
     replacementMaps: getReplacementMaps(
-      componentReplacementOptions,
+      componentFromPropsMap,
       normalizedReplacementMap,
     ),
   });

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-width/tests/basic.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-width/tests/basic.input.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {Box, Divider} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper = Box;
+
+export function App() {
+  return (
+    <>
+      <Box borderWidth="1" borderRadius="3">
+        Hello
+        <Child borderWidth="1" />
+        <BoxWrapper />
+      </Box>
+      <Box
+        borderWidth="1-experimental"
+        borderRadius="0-experimental"
+        padding="100"
+      >
+        Hello
+        <Child borderWidth="1" />
+        <BoxWrapper />
+      </Box>
+      <Divider borderWidth="2-experimental" />
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-width/tests/basic.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-width/tests/basic.output.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Box, Divider} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper =
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+  Box;
+
+export function App() {
+  return (
+    <>
+      <Box borderWidth="025" borderRadius="3">
+        Hello
+        <Child borderWidth="1" />
+        <BoxWrapper />
+      </Box>
+      <Box borderWidth="0165" borderRadius="0-experimental" padding="100">
+        Hello
+        <Child borderWidth="1" />
+        <BoxWrapper />
+      </Box>
+      <Divider borderWidth="025" />
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-width/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-width/tests/transform.test.ts
@@ -1,0 +1,15 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v12-react-update-component-prop-border-width';
+const fixtures = [
+  {
+    name: 'basic',
+  },
+];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture: fixture.name,
+    transform,
+  });
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-border-width/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-border-width/transform.ts
@@ -1,0 +1,40 @@
+import type {FileInfo, API} from 'jscodeshift';
+
+import {replacementMaps} from '../v12-styles-replace-custom-property-border/transform';
+import reactUpdateComponentProp from '../react-update-component-prop/transform';
+import type {ComponentReplacementOptions} from '../react-update-component-prop/utils';
+import {getReplacementMaps} from '../react-update-component-prop/utils';
+
+const widthReplacementMap = Object.fromEntries(
+  Object.entries(replacementMaps['/.+/']).filter(
+    ([key]) => !key.includes('border-radius'),
+  ),
+);
+
+const normalizedReplacementMap = Object.fromEntries(
+  Object.entries(widthReplacementMap).map(([fromValue, toValue]) => [
+    fromValue.replace('--p-border-width-', ''),
+    toValue.replace('--p-border-width-', ''),
+  ]),
+);
+
+const componentReplacementOptions: ComponentReplacementOptions = {
+  Box: [
+    'borderWidth',
+    'borderBlockStartWidth',
+    'borderBlockEndWidth',
+    'borderInlineStartWidth',
+    'borderInlineEndWidth',
+    'outlineWidth',
+  ],
+  Divider: ['borderWidth'],
+};
+
+export default function transformer(fileInfo: FileInfo, _: API) {
+  return reactUpdateComponentProp(fileInfo, _, {
+    replacementMaps: getReplacementMaps(
+      componentReplacementOptions,
+      normalizedReplacementMap,
+    ),
+  });
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/transform.ts
@@ -5,9 +5,8 @@ import {
   replacementMap1,
   replacementMap2,
 } from '../v12-styles-replace-custom-property-color/transform';
-
-import type {ComponentFromPropsMap} from './utils';
-import {getReplacementMaps} from './utils';
+import type {ComponentFromPropsMap} from '../react-update-component-prop/utils';
+import {getReplacementMaps} from '../react-update-component-prop/utils';
 
 const normalizedReplacementMap1 = Object.fromEntries(
   Object.entries(replacementMap1).map(([fromValue, toValue]) => [

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-shadow/tests/basic.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-shadow/tests/basic.input.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {Box} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper = Box;
+
+export function App() {
+  return (
+    <>
+      <Box shadow="sm" padding="0">
+        Hello
+        <Child shadow="sm" />
+        <BoxWrapper />
+        <Box shadow="border-inset-experimental" />
+        <Box shadow="card-lg-experimental" />
+      </Box>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-shadow/tests/basic.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-shadow/tests/basic.output.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {Box} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper =
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+  Box;
+
+export function App() {
+  return (
+    <>
+      <Box shadow="200" padding="0">
+        Hello
+        <Child shadow="sm" />
+        <BoxWrapper />
+        <Box shadow="border-inset" />
+        <Box shadow="300" />
+      </Box>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-shadow/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-shadow/tests/transform.test.ts
@@ -1,0 +1,15 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v12-react-update-component-prop-space';
+const fixtures = [
+  {
+    name: 'basic',
+  },
+];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture: fixture.name,
+    transform,
+  });
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-shadow/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-shadow/transform.ts
@@ -1,33 +1,19 @@
 import type {FileInfo, API} from 'jscodeshift';
 
-import {replacementMaps} from '../v12-styles-replace-custom-property-border/transform';
+import {replacementMaps} from '../v12-styles-replace-custom-property-shadow/transform';
 import reactUpdateComponentProp from '../react-update-component-prop/transform';
 import type {ComponentFromPropsMap} from '../react-update-component-prop/utils';
 import {getReplacementMaps} from '../react-update-component-prop/utils';
 
-const widthReplacementMap = Object.fromEntries(
-  Object.entries(replacementMaps['/.+/']).filter(
-    ([key]) => !key.includes('border-radius'),
-  ),
-);
-
 const normalizedReplacementMap = Object.fromEntries(
-  Object.entries(widthReplacementMap).map(([fromValue, toValue]) => [
-    fromValue.replace('--p-border-width-', ''),
-    toValue.replace('--p-border-width-', ''),
+  Object.entries(replacementMaps['/.+/']).map(([fromValue, toValue]) => [
+    fromValue.replace('--p-shadow-', ''),
+    toValue.replace('--p-shadow-', ''),
   ]),
 );
 
 const componentFromPropsMap: ComponentFromPropsMap = {
-  Box: [
-    'borderWidth',
-    'borderBlockStartWidth',
-    'borderBlockEndWidth',
-    'borderInlineStartWidth',
-    'borderInlineEndWidth',
-    'outlineWidth',
-  ],
-  Divider: ['borderWidth'],
+  Box: ['shadow'],
 };
 
 export default function transformer(fileInfo: FileInfo, _: API) {

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-space/tests/basic.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-space/tests/basic.input.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {Box, BlockStack} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper = Box;
+
+export function App() {
+  return (
+    <>
+      <Box padding="1" paddingBlockStart="1_5-experimental" insetInlineEnd="0">
+        Hello
+        <Child padding="1" />
+        <BoxWrapper />
+      </Box>
+      <BlockStack gap="20">
+        Hello
+        <Child />
+        <BoxWrapper />
+      </BlockStack>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-space/tests/basic.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-space/tests/basic.output.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Box, BlockStack} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper =
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+  Box;
+
+export function App() {
+  return (
+    <>
+      <Box padding="100" paddingBlockStart="150" insetInlineEnd="0">
+        Hello
+        <Child padding="1" />
+        <BoxWrapper />
+      </Box>
+      <BlockStack gap="2000">
+        Hello
+        <Child />
+        <BoxWrapper />
+      </BlockStack>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-space/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-space/tests/transform.test.ts
@@ -1,0 +1,15 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v12-react-update-component-prop-space';
+const fixtures = [
+  {
+    name: 'basic',
+  },
+];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture: fixture.name,
+    transform,
+  });
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-space/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-space/transform.ts
@@ -2,7 +2,7 @@ import type {FileInfo, API} from 'jscodeshift';
 
 import {replacementMaps} from '../v12-styles-replace-custom-property-space/transform';
 import reactUpdateComponentProp from '../react-update-component-prop/transform';
-import type {ComponentReplacementOptions} from '../react-update-component-prop/utils';
+import type {ComponentFromPropsMap} from '../react-update-component-prop/utils';
 import {getReplacementMaps} from '../react-update-component-prop/utils';
 
 const normalizedReplacementMap = Object.fromEntries(
@@ -12,7 +12,7 @@ const normalizedReplacementMap = Object.fromEntries(
   ]),
 );
 
-const componentReplacementOptions: ComponentReplacementOptions = {
+const componentFromPropsMap: ComponentFromPropsMap = {
   Bleed: [
     'marginInline',
     'marginBlock',
@@ -68,7 +68,7 @@ const componentReplacementOptions: ComponentReplacementOptions = {
 export default function transformer(fileInfo: FileInfo, _: API) {
   return reactUpdateComponentProp(fileInfo, _, {
     replacementMaps: getReplacementMaps(
-      componentReplacementOptions,
+      componentFromPropsMap,
       normalizedReplacementMap,
     ),
   });

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-space/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-space/transform.ts
@@ -1,0 +1,75 @@
+import type {FileInfo, API} from 'jscodeshift';
+
+import {replacementMaps} from '../v12-styles-replace-custom-property-space/transform';
+import reactUpdateComponentProp from '../react-update-component-prop/transform';
+import type {ComponentReplacementOptions} from '../react-update-component-prop/utils';
+import {getReplacementMaps} from '../react-update-component-prop/utils';
+
+const normalizedReplacementMap = Object.fromEntries(
+  Object.entries(replacementMaps['/.+/']).map(([fromValue, toValue]) => [
+    fromValue.replace('--p-space-', ''),
+    toValue.replace('--p-space-', ''),
+  ]),
+);
+
+const componentReplacementOptions: ComponentReplacementOptions = {
+  Bleed: [
+    'marginInline',
+    'marginBlock',
+    'marginBlockStart',
+    'marginBlockEnd',
+    'marginInlineStart',
+    'marginInlineEnd',
+  ],
+  BlockStack: ['gap'],
+  Box: [
+    'padding',
+    'paddingBlockStart',
+    'paddingBlockEnd',
+    'paddingInlineStart',
+    'paddingInlineEnd',
+    'insetBlockStart',
+    'insetBlockEnd',
+    'insetInlineStart',
+    'insetInlineEnd',
+  ],
+  Card: ['padding'],
+  Checkbox: [
+    'bleed',
+    'bleedBlockStart',
+    'bleedBlockEnd',
+    'bleedInlineStart',
+    'bleedInlineEnd',
+  ],
+  Choice: [
+    'bleed',
+    'bleedBlockStart',
+    'bleedBlockEnd',
+    'bleedInlineStart',
+    'bleedInlineEnd',
+  ],
+  Grid: ['gap', 'gapX', 'gapY'],
+  HorizontalGrid: ['gap'],
+  HorizontalStack: ['gap'],
+  InlineGrid: ['gap'],
+  InlineStack: ['gap'],
+  RadioButton: [
+    'bleed',
+    'bleedBlockStart',
+    'bleedBlockEnd',
+    'bleedInlineStart',
+    'bleedInlineEnd',
+  ],
+  Stack: ['gap'],
+  Tooltip: ['padding'],
+  VerticalStack: ['gap'],
+};
+
+export default function transformer(fileInfo: FileInfo, _: API) {
+  return reactUpdateComponentProp(fileInfo, _, {
+    replacementMaps: getReplacementMaps(
+      componentReplacementOptions,
+      normalizedReplacementMap,
+    ),
+  });
+}

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/transform.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-border/transform.ts
@@ -6,7 +6,7 @@ export default function transformer(fileInfo: FileInfo, _: API) {
   return stylesReplaceCustomProperty(fileInfo, _, {replacementMaps});
 }
 
-const replacementMaps = {
+export const replacementMaps = {
   '/.+/': {
     '--p-border-radius-0-experimental': '--p-border-radius-0',
     '--p-border-radius-05': '--p-border-radius-050',

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-shadow/transform.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-shadow/transform.ts
@@ -6,7 +6,7 @@ export default function transformer(fileInfo: FileInfo, _: API) {
   return stylesReplaceCustomProperty(fileInfo, _, {replacementMaps});
 }
 
-const replacementMaps = {
+export const replacementMaps = {
   '/.+/': {
     '--p-shadow-inset-lg': '--p-shadow-inset-200',
     '--p-shadow-inset-md': '--p-shadow-inset-200',

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-space/transform.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-space/transform.ts
@@ -6,7 +6,7 @@ export default function transformer(fileInfo: FileInfo, _: API) {
   return stylesReplaceCustomProperty(fileInfo, _, {replacementMaps});
 }
 
-const replacementMaps = {
+export const replacementMaps = {
   '/.+/': {
     '--p-space-05': '--p-space-050',
     '--p-space-1': '--p-space-100',


### PR DESCRIPTION
This PR introduces a `v12-react-update-component-prop-space`, `v12-react-update-component-prop-border`, `v12-react-update-component-prop-shadow` migrations that targets and updates a collection of Polaris component props using v11 token aliases.

> Note: This is a companion to the [v12-replace-custom-property-color](https://github.com/Shopify/polaris/blob/00952a33a37164110a23e1a6ab7795976b075349/polaris-migrator/src/migrations/v12-styles-replace-custom-property-color/transform.ts#L7) migration and consumes it's replacement maps for consistency.

Example usage:

```sh
npx @shopify/polaris v12-react-update-component-prop-space '**/*.{ts,tsx}'
```