### PR TITLE
[polaris.shopify.com] Set up deep linking to component examples

### DIFF
--- a/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
+++ b/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
@@ -57,7 +57,10 @@ const Components = ({
         components={{
           Examples: () =>
             Boolean(examples.length) ? (
-              <ComponentExamples examples={examples} />
+              <ComponentExamples
+                examples={examples}
+                componentTitle={mdx.frontmatter.title}
+              />
             ) : null,
           Props: ({componentName}) =>
             type && mdx.frontmatter.status !== 'Deprecated' ? (

--- a/polaris.shopify.com/src/components/ComponentExamples/ComponentExamples.module.scss
+++ b/polaris.shopify.com/src/components/ComponentExamples/ComponentExamples.module.scss
@@ -26,11 +26,20 @@
     }
 
     &[aria-selected='true'] {
-      background: var(--search-highlight-color);
-      &:focus {
-        box-shadow: var(--focus-outline);
-      }
+      background: var(--surface-active);
     }
+
+    &:focus {
+      box-shadow: var(--focus-outline);
+    }
+  }
+}
+
+.Tab {
+  display: hidden;
+
+  &.selected {
+    display: block;
   }
 }
 

--- a/polaris.shopify.com/src/components/ComponentExamples/ComponentExamples.tsx
+++ b/polaris.shopify.com/src/components/ComponentExamples/ComponentExamples.tsx
@@ -1,11 +1,15 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useState, useRef} from 'react';
 import type {SerializedMdx} from '../../types';
 import styles from './ComponentExamples.module.scss';
 import CodesandboxButton from '../CodesandboxButton';
+import {className as classNames} from '../../utils/various';
 import Code from '../Code';
 import {Tab} from '@headlessui/react';
 import {className} from '../../utils/various';
 import Markdown from '../Markdown';
+import {useRouter} from 'next/router';
+import {useSearchParams} from 'next/navigation';
+import style from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark';
 
 const exampleIframeId = 'example-iframe';
 const iframePadding = 192;
@@ -49,9 +53,10 @@ function formatHTML(html: string): string {
 }
 
 const ComponentExamples = ({examples}: Props) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
   const [htmlCode, setHTMLCode] = useState('');
   const [iframeHeight, setIframeHeight] = useState(400);
+  const router = useRouter();
+  const params = useSearchParams();
 
   const handleExampleLoad = () => {
     let attempts = 0;
@@ -81,61 +86,165 @@ const ComponentExamples = ({examples}: Props) => {
     return () => clearInterval(waitForExampleContentToRender);
   };
 
+  const defaultExampleName = examples[0].fileName.replace('.tsx', '');
+  let exampleName = params.get('example') || defaultExampleName;
+  let exampleFilename =
+    (exampleName ? exampleName : defaultExampleName) + '.tsx';
+  let exampleIndex = examples.findIndex(
+    (obj) => obj.fileName === exampleFilename,
+  );
+
+  const updateSelectedExample = (index: number) => {
+    exampleName = examples[index].fileName.replace('.tsx', '');
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: {...router.query, example: exampleName},
+      },
+      undefined,
+      {shallow: true},
+    );
+  };
+
+  const examplesMarkup = examples.map(
+    ({fileName, description, code}, index) => {
+      const exampleUrl = `/examples/${fileName.replace('.tsx', '')}`;
+      const isSelected = index === exampleIndex ? true : false;
+      const classes = classNames(
+        styles.Tab,
+        isSelected ? styles.selected : undefined,
+      );
+
+      return (
+        <div
+          id={`tabpanel-${index}`}
+          key={fileName}
+          role="tabpanel"
+          tabIndex={0}
+          className={classes}
+          aria-labelledby={`tab-${index}`}
+        >
+          {description ? <Markdown {...description} /> : null}
+          <div className={styles.ExampleFrame}>
+            <iframe
+              src={exampleUrl}
+              height={iframeHeight}
+              onLoad={handleExampleLoad}
+              id={exampleIframeId}
+            />
+            <div className={className(styles.Buttons, 'light-mode')}>
+              <CodesandboxButton
+                className={styles.CodesandboxButton}
+                code={code}
+              />
+            </div>
+          </div>
+
+          <Code
+            code={[
+              {title: 'React', code: code.trim()},
+              {title: 'HTML', code: htmlCode},
+            ]}
+          />
+        </div>
+      );
+    },
+  );
+
+  const tablistId = 'component-examples-tablist';
+
+  const examplesLength = examples.length - 1;
+
+  const setSelectedToPreviousTab = (event) => {
+    if (exampleIndex === 0) {
+      setSelectedTab(examplesLength);
+    } else {
+      const index = exampleIndex - 1;
+      setSelectedTab(index);
+    }
+  };
+
+  const setSelectedToNextTab = (event) => {
+    if (exampleIndex === examplesLength) {
+      setSelectedTab(0);
+    } else {
+      const index = exampleIndex + 1;
+      setSelectedTab(index);
+    }
+  };
+
+  const setSelectedTab = (index: number) => {
+    exampleIndex = index;
+    updateSelectedExample(index);
+  };
+
+  const onKeyDownHandler = (event) => {
+    switch (event.key) {
+      case 'ArrowLeft':
+        setSelectedToPreviousTab(event);
+        break;
+
+      case 'ArrowRight':
+        setSelectedToNextTab(event);
+        break;
+
+      case 'Home':
+        setSelectedTab(0);
+        break;
+
+      case 'End':
+        setSelectedTab(examplesLength);
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  const buttonRefs = useRef([]);
+
   useEffect(() => {
-    setSelectedIndex(0);
+    buttonRefs.current = buttonRefs.current.slice(0, examples.length);
   }, [examples]);
 
+  useEffect(() => {
+    const currentButtonRef = buttonRefs.current[exampleIndex];
+    if (currentButtonRef) {
+      currentButtonRef.focus();
+    }
+  }, [exampleIndex]);
+
+  const tabButtons = examples.map((example, index) => {
+    return (
+      <button
+        id={`tab-${index}`}
+        key={example.fileName}
+        onClick={() => updateSelectedExample(index)}
+        aria-controls={`tabpanel-${index}`}
+        tabIndex={index === exampleIndex ? 0 : -1}
+        ref={(el) => (buttonRefs.current[index] = el)}
+        {...(index === exampleIndex ? {'aria-selected': 'true'} : {})}
+      >
+        <span>{example.title}</span>
+      </button>
+    );
+  });
+
   return (
-    <Tab.Group
-      defaultIndex={0}
-      selectedIndex={selectedIndex}
-      onChange={setSelectedIndex}
-    >
-      <Tab.List>
-        <div className={styles.ExamplesList} id="examples">
-          {examples.map((example) => {
-            return (
-              <Tab key={example.fileName}>
-                <span>{example.title}</span>
-              </Tab>
-            );
-          })}
+    <>
+      <h3 id={tablistId}>Component examples</h3>
+      <div className="tabs" aria-labelledby={tablistId}>
+        <div
+          className={styles.ExamplesList}
+          id="examples"
+          role="tablist"
+          onKeyDown={onKeyDownHandler}
+        >
+          {tabButtons}
         </div>
-      </Tab.List>
-
-      <Tab.Panels>
-        {examples.map(({fileName, description, code}) => {
-          const exampleUrl = `/examples/${fileName.replace('.tsx', '')}`;
-
-          return (
-            <Tab.Panel key={fileName}>
-              {description ? <Markdown {...description} /> : null}
-              <div className={styles.ExampleFrame}>
-                <iframe
-                  src={exampleUrl}
-                  height={iframeHeight}
-                  onLoad={handleExampleLoad}
-                  id={exampleIframeId}
-                />
-                <div className={className(styles.Buttons, 'light-mode')}>
-                  <CodesandboxButton
-                    className={styles.CodesandboxButton}
-                    code={code}
-                  />
-                </div>
-              </div>
-
-              <Code
-                code={[
-                  {title: 'React', code: code.trim()},
-                  {title: 'HTML', code: htmlCode},
-                ]}
-              />
-            </Tab.Panel>
-          );
-        })}
-      </Tab.Panels>
-    </Tab.Group>
+      </div>
+      {examplesMarkup[exampleIndex]}
+    </>
   );
 };
 

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -405,3 +405,15 @@ button {
     margin: 0 !important;
   }
 }
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  white-space: nowrap;
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The component pages did not allow you to link to a specific component example within the page. For example, the `/components/actions/button` page has 16 different examples of using the `Button` component. It's not possible to specifically link to the `Select disclosure` example so that it automatically loads when you share the link with someone. Instead you would share `/components/actions/button` and ask that person to "click the Select disclosure example."

This PR adds a query parameter that passes an example name so that you can link to `/components/actions/button?example=button-selected-disclosure` and have it load on the page automatically.


https://github.com/Shopify/polaris/assets/4642404/c66ced3b-098a-40db-8a9e-7e1259015c6e



<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
* adding an `examples` query parameter that gets parsed to get the name of the example to load
* Refactoring the markup to build a custom tab/tabpanel ui and replacing the headless-ui `Tabs`
* Managing the keyboard focus for tab/tabpanel and include all necessary aria labels according to [WAI aria guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/) (tested with macOS VoiceOver and keyboard only use)

🧠 Some reasoning behind this decision
> * Refactoring the markup to build a custom tab/tabpanel ui and replacing the headless-ui `Tabs`

The headless-ui Tabs did not play nicely with the query parameters and changing the state on interaction. I tried a few different approaches, but the Tabs would either lose focus on tab select or only ever should the default/first tab. I believe this is because when the query parameter would update the component would re-render and the Tab would lose it's state. Unfortunately I could not find a workaround for this

To avoid rebuilding the tabs I also tried to set up a `/components/[group]/[component]/[[...example]]` route using [next.js optional segment routing](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes) and similar to what the [patterns page does](https://github.com/Shopify/polaris/blob/8568e5141c8a795ae0ba9036b702d4e3c94d0d9a/polaris.shopify.com/pages/patterns/%5B...slug%5D.tsx#L168). I couldn't get this to work since we would want `/components/[group]/[component]` and `/components/[group]/[component]/[[...example]]` to be handled by the same page route, but next.js did not like that and kept throwing me hydration errors and not exposing the `[[...example]]` context parameter.

⚠️ **One known quirk**

You may notice that when loading a url with the example query param that the selected/active example tab button starts with the first example and then quickly switches to the correct example. This is because the query parameters are not available on the server side so the correct example is only loaded when the page hydrates. I couldn't find a fast/easy way to address this issue. Some ideas I considered were to give the tabs a "loading" state, but I didn't want to open that can of worms for (what I thought was) a quick fix. IMO this feels like a minor enough issue that the benefit of shipping this new as is still outweighs the quirk. Happy to chat about it if there are concerns still.

https://github.com/Shopify/polaris/assets/4642404/a41b4be9-1947-4590-8f83-3aecd323c7bb



<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
1. Go to a component page
2. Click on a component example. The url should update with the query parameter of that example
3. Copy the url
4. Navigate to a different page
5. Paste the copied url
6. The component page should load with the component example in the `example` query parameter

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
