### PR TITLE
docs: fix scripts to load the Inter web font

### DIFF
--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -70,6 +70,7 @@ ReactDOM.render(
 />
 <link
   href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap"
+  rel="stylesheet"
 />
 ```
 


### PR DESCRIPTION
As I followed the README guide of `polaris-react`, I noticed the web font would only load if I added `rel="stylesheet"` to the link tag. It works as per instruction from https://fonts.google.com/specimen/Inter