### PR TITLE
Fix incompatible types between IndexTable and useIndexResourceState

### DIFF
--- a/.changeset/lovely-snakes-peel.md
+++ b/.changeset/lovely-snakes-peel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed incompatible type between IndexTable and useIndexResourceState

--- a/polaris-react/src/utilities/use-index-resource-state.ts
+++ b/polaris-react/src/utilities/use-index-resource-state.ts
@@ -53,6 +53,8 @@ export function useIndexResourceState<T extends {[key: string]: unknown}>(
       selectionType: SelectionType,
       isSelecting: boolean,
       selection?: string | Range,
+      // This is not used in the function, but needed to keep the type compatible with IndexProviderProps onSelectionChange
+      _position?: number,
     ) => {
       if (selectionType === SelectionType.All) {
         setAllResourcesSelected(isSelecting);


### PR DESCRIPTION
### WHY are these changes introduced?

The IndexTable's `onSelectionChange` has four arguments, while the `useIndexResourceState` `handleSelectionChange` only accepts three. This means that in a use case like this
```
<IndexTable
   onSelectionChange={(...args) => {
         handleSelectionChange(...args);
         setIsShowingAllValues(true);
      }}
/>
```
typescript will throw an error due to the difference in arguments (expected 2-3 arguments but got 4).

Reference: [Slack conversation](https://shopify.slack.com/archives/C4Y8N30KD/p1696530965331049)

### WHAT is this pull request doing?

This does not affect the util's functionality, only the type for the arguments.

