### PR TITLE
Automatically release `polaris-for-vscode` after `polaris-tokens`

### DIFF
--- a/.github/workflows/publish-polaris-for-vscode.yml
+++ b/.github/workflows/publish-polaris-for-vscode.yml
@@ -3,7 +3,10 @@ name: Release Polaris for VS Code
 on:
   push:
     tags:
-      - 'vscode*' # Push events to matching vscode*
+      - 'shopify/polaris-tokens*' # Publish when a new version of polaris-tokens is released
+      - 'polaris-for-vscode*' # Push events to matching polaris-for-vscode*
+    branches:
+      - main
 
 jobs:
   release:

--- a/documentation/Releasing.md
+++ b/documentation/Releasing.md
@@ -3,19 +3,24 @@
 ## 📸 Snapshot releases
 
 [Snapshot releases](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md) are a way to test your changes in a consuming project without publishing a new version. You can create a snapshot from your pull request if:
+
 - CI is passing on your feature branch
 - Your feature branch has **at least one** pending [changeset](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#adding-a-changeset)
 
 ### 📦 Polaris npm packages
 
 1. Add a comment with the `/snapit` slash command in your feature branch PR
-3. The github-actions bot will react to your comment with 👀 once the `snapit.yml` workflow is running, then react with a 🚀 and post a comment listing install commands for the snapshots of each npm package that will be included in the next version release
+2. The github-actions bot will react to your comment with 👀 once the `snapit.yml` workflow is running, then react with a 🚀 and post a comment listing install commands for the snapshots of each npm package that will be included in the next version release
 
 ### 👩‍💻 [polaris-for-vscode](/polaris-for-vscode)
 
+The `polaris-for-vscode` extension is published to the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Shopify.polaris-for-vscode) after every new release of `@shopify/polaris-tokens`. The extension is published using the [`publish-polaris-for-vscode.yml`](/github/workflows/publish-polaris-for-vscode.yml) workflow.
+
+You can create a manual release of the extension by following these steps:
+
 - [Draft a new release](https://github.com/Shopify/polaris/releases)
 - Target the commit that you want to release
-- Create a new tag with the prefix `vscode`
+- Create a new tag with the prefix `polaris-for-vscode` (example: `polaris-for-vscode@0.8.0`)
 - This will trigger the [publish-polaris-for-vscode.yml](https://github.com/Shopify/polaris/blob/main/.github/workflows/publish-polaris-for-vscode.yml) workflow
 
 ## Version releases
@@ -23,6 +28,7 @@
 Polaris uses [Changesets](https://github.com/changesets/changesets) to handle releasing new versions of the packages in the `Shopify/polaris` repository.
 
 We have a [GitHub action](https://github.com/changesets/action) that:
+
 - Creates a `changeset-release/main` branch and opens a PR titled **"[Version Packages](https://github.com/Shopify/polaris/pulls?q=is%3Apr+version+packages+is%3Aopen)"** that always has an up-to-date run of `changeset version`
 - Keeps the `changeset-release/main` branch up to date whenever a pull request is merged to `main`
 - Performs a release when the `changeset-release/main` branch merged into the `main` branch
@@ -39,13 +45,13 @@ Steps for creating a new prerelease branch if `next` doesn't currently exist.
 1. Create a new `next` branch for prerelease development
 2. Run `yarn changeset pre enter beta`
 3. Adjust the release workflow file (`.github/workflows/release.yml`) to run on the `next` branch:
-    ```yml
-    on:
-      push:
-        branches:
-          - main
-          - next
-    ```
+   ```yml
+   on:
+     push:
+       branches:
+         - main
+         - next
+   ```
 4. Branch future work from the `next` branch
 5. Create changesets, merge to the prerelease branch (`next`)
 6. Releasing PRs should now be generated for the prerelease branch 🎉
@@ -56,27 +62,32 @@ Anyone at Shopify can perfom a version release. Ping the `@Shopify/polaris-team`
 
 ### Steps to perform a version release:
 
-#### 1.  🧪 Test the "Version Packages" PR
-  - Create a [snapshot release](https://github.com/Shopify/polaris/edit/main/documentation/Releasing.md#-snapshot-releases) of the **"[Version Packages](https://github.com/Shopify/polaris/pulls?q=is%3Apr+version+packages+is%3Aopen)"** PR
-  - Create a new branch in a `Shopify/web` Spinstance that upgrades `@shopify/polaris` to its snapshot release
+#### 1. 🧪 Test the "Version Packages" PR
 
-#### 2.  🚢 Publish the release
-  - Once CI passes in the `Shopify/web` upgrade branch, approve and merge the **"[Version Packages](https://github.com/Shopify/polaris/pulls?q=is%3Apr+version+packages+is%3Aopen)"** PR
-  - Merging the **"[Version Packages](https://github.com/Shopify/polaris/pulls?q=is%3Apr+version+packages+is%3Aopen)"** PR triggers the `release.yml` workflow that publishes the packages
+- Create a [snapshot release](https://github.com/Shopify/polaris/edit/main/documentation/Releasing.md#-snapshot-releases) of the **"[Version Packages](https://github.com/Shopify/polaris/pulls?q=is%3Apr+version+packages+is%3Aopen)"** PR
+- Create a new branch in a `Shopify/web` Spinstance that upgrades `@shopify/polaris` to its snapshot release
 
-#### 3.  🕸️ Upgrade `@shopify/polaris` in `Shopify/web`
-  - Draft a PR for the `Shopify/web` upgrade branch with:
-    - Version Packages PR link
-    - Tl;dr of the key things to tophat
-    - Spinstance URL
-    - "Key dependencies" and "Polaris" labels
-    - Contributors listed in the Version Packages PR description tagged as reviewers
-  - Once the release is available on [npm](https://www.npmjs.com/package/@shopify/polaris), install the new version of `@shopify/polaris` in the `Shopify/web` upgrade PR
-  - Send a link to the `Shopify/web` upgrade PR in a group Slack DM to the contributors requesting they tophat their changes in the Spinstance and flag regressions or approve the PR
+#### 2. 🚢 Publish the release
 
-#### 4.  🚀 Upgrade `@shopify/polaris` in [`Shopify/shopify-frontend-template-react`](https://github.com/Shopify/shopify-frontend-template-react)
-#### 5.  🦄 Unicorn the release contributors
-#### 6.  📣 Announce the new `@shopify/polaris` version and share the 🦄 Unicorn in the #polaris Slack channel and in the Polaris Updates and Engineering groups in Workplace 🎉
+- Once CI passes in the `Shopify/web` upgrade branch, approve and merge the **"[Version Packages](https://github.com/Shopify/polaris/pulls?q=is%3Apr+version+packages+is%3Aopen)"** PR
+- Merging the **"[Version Packages](https://github.com/Shopify/polaris/pulls?q=is%3Apr+version+packages+is%3Aopen)"** PR triggers the `release.yml` workflow that publishes the packages
+
+#### 3. 🕸️ Upgrade `@shopify/polaris` in `Shopify/web`
+
+- Draft a PR for the `Shopify/web` upgrade branch with:
+  - Version Packages PR link
+  - Tl;dr of the key things to tophat
+  - Spinstance URL
+  - "Key dependencies" and "Polaris" labels
+  - Contributors listed in the Version Packages PR description tagged as reviewers
+- Once the release is available on [npm](https://www.npmjs.com/package/@shopify/polaris), install the new version of `@shopify/polaris` in the `Shopify/web` upgrade PR
+- Send a link to the `Shopify/web` upgrade PR in a group Slack DM to the contributors requesting they tophat their changes in the Spinstance and flag regressions or approve the PR
+
+#### 4. 🚀 Upgrade `@shopify/polaris` in [`Shopify/shopify-frontend-template-react`](https://github.com/Shopify/shopify-frontend-template-react)
+
+#### 5. 🦄 Unicorn the release contributors
+
+#### 6. 📣 Announce the new `@shopify/polaris` version and share the 🦄 Unicorn in the #polaris Slack channel and in the Polaris Updates and Engineering groups in Workplace 🎉
 
 ## 🔗 Style guide deploys
 


### PR DESCRIPTION
This adds a condition to automatically release a new version of `polaris-for-vscode` after upldating the `@shopify/polaris-tokens` package.

`@shopify/polaris-tokens` is the only package dependency in `polaris-for-vscode`. When we update our tokens, we should also publish a new version of the VS Code extension to the marketplace with the latest tokens.

This will also keep the ability to trigger the workflow with the current process of creating a new release, but it changes the prefix from `vscode@x.x.x` to follow the convention of our other packages by using the package name `polaris-for-vscode@x.x.x`