### PR TITLE
Update `stylelint-polaris` version matchups chart

### DIFF
--- a/.changeset/silver-baboons-laugh.md
+++ b/.changeset/silver-baboons-laugh.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Update stylelint-polaris version matchups chart

--- a/polaris.shopify.com/content/tools/stylelint-polaris.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris.md
@@ -122,6 +122,8 @@ There are over 40 rules configured in Stylelint Polaris to help you avoid errors
 | 11.0.0                     | 10.48.0          |
 | 12.0.0                     | 10.49.0          |
 | 13.0.0                     | 11.0.0           |
+| 14.0.0                     | 11.12.0          |
+| 15.0.0                     | 12.0.0           |
 
 _\*@shopify/stylelint-polaris v5.0.0 was the first stable release_
 


### PR DESCRIPTION
### WHY are these changes introduced?

Keeps our stylelint-polaris version matchups chart up to date with the latest releases.


### WHAT is this pull request doing?
Adds the following versions to the stylelint-polaris version matchups chart:

| @shopify/stylelint-polaris | @shopify/polaris |
| -------------------------- | ---------------- |
| 14.0.0                     | 11.12.0          |
| 15.0.0                     | 12.0.0           |