### PR TITLE
[Sandbox] Enforce null origin for sandbox preview iframes

### DIFF
--- a/patches/playroom+0.28.0.patch
+++ b/patches/playroom+0.28.0.patch
@@ -256,7 +256,7 @@ index 9285b94..899cf7e 100644
          ...style,
          transition: 'opacity .3s ease',
 diff --git a/node_modules/playroom/src/Playroom/Preview.tsx b/node_modules/playroom/src/Playroom/Preview.tsx
-index 0183aaf..39cebbd 100644
+index 0183aaf..c5faef1 100644
 --- a/node_modules/playroom/src/Playroom/Preview.tsx
 +++ b/node_modules/playroom/src/Playroom/Preview.tsx
 @@ -43,6 +43,16 @@ export default ({ themes, components, FrameComponent }: PreviewProps) => {
@@ -271,7 +271,7 @@ index 0183aaf..39cebbd 100644
 +  // it.
 +  // See: https://github.com/seek-oss/playroom/issues/159#issuecomment-637945761
 +  // Also: https://stackoverflow.com/a/18678703
-+  const isInSameOriginIFrame = !!window.frameElement;
++  const isInSameOriginIFrame = window.origin === 'null' || !!window.frameElement;
 +
    return (
      <CatchErrors code={code}>

--- a/patches/playroom+0.28.0.patch
+++ b/patches/playroom+0.28.0.patch
@@ -37,7 +37,7 @@ index 56defa7..1e7cf3b 100644
      },
      module: {
 diff --git a/node_modules/playroom/src/Playroom/Frame.tsx b/node_modules/playroom/src/Playroom/Frame.tsx
-index b175d74..ce3e7ef 100644
+index b175d74..9a320fd 100644
 --- a/node_modules/playroom/src/Playroom/Frame.tsx
 +++ b/node_modules/playroom/src/Playroom/Frame.tsx
 @@ -1,9 +1,9 @@
@@ -48,11 +48,11 @@ index b175d74..ce3e7ef 100644
  import CatchErrors from './CatchErrors/CatchErrors';
  // @ts-ignore
  import RenderCode from './RenderCode/RenderCode';
-+import { INCOMING_CODE, READY_TO_RECEIVE } from './constants';
++import { INCOMING_CODE, ARE_YOU_READY, READY_TO_RECEIVE } from './constants';
  
  interface FrameProps {
    themes: Record<string, any>;
-@@ -18,11 +18,21 @@ export default function Frame({
+@@ -18,11 +18,24 @@ export default function Frame({
    components,
    FrameComponent,
  }: FrameProps) {
@@ -66,14 +66,17 @@ index b175d74..ce3e7ef 100644
 +  const [themeName, setThemeName] = useState('');
 +  useEffect(() => {
 +    const listener = (e: any) => {
-+      if (e.data && e.data.type === INCOMING_CODE ) {
-+        setCode(e.data.code);
-+        setThemeName(e.data.themeName);
-+      };
-+
++      switch(e.data?.type) {
++        case ARE_YOU_READY:
++          e.source.postMessage({ type: READY_TO_RECEIVE, ready: true }, e.origin);
++          break;
++        case INCOMING_CODE:
++          setCode(e.data.code);
++          setThemeName(e.data.themeName);
++          break;
++      }
 +    }
 +    window.addEventListener('message', listener);
-+    window.parent.postMessage({ type: READY_TO_RECEIVE, ready: true }, window.origin);
 +    return () => window.removeEventListener('message', listener);
 +  }, []);
  
@@ -129,14 +132,19 @@ index 5b4af43..4800827 100644
                style={{ width: frame.width }}
                data-testid="previewFrame"
 diff --git a/node_modules/playroom/src/Playroom/Frames/Iframe.tsx b/node_modules/playroom/src/Playroom/Frames/Iframe.tsx
-index 9285b94..c268bdb 100644
+index 9285b94..899cf7e 100644
 --- a/node_modules/playroom/src/Playroom/Frames/Iframe.tsx
 +++ b/node_modules/playroom/src/Playroom/Frames/Iframe.tsx
-@@ -6,22 +6,29 @@ import React, {
+@@ -2,26 +2,33 @@ import React, {
+   useState,
+   useEffect,
+   useRef,
++  useCallback,
+   AllHTMLAttributes,
    MutableRefObject,
  } from 'react';
  import { useIntersection } from 'react-use';
-+import { READY_TO_RECEIVE, INCOMING_CODE } from '../constants';
++import { ARE_YOU_READY, READY_TO_RECEIVE, INCOMING_CODE } from '../constants';
  
  import playroomConfig from '../../config';
  
@@ -147,7 +155,6 @@ index 9285b94..c268bdb 100644
    intersectionRootRef: MutableRefObject<Element | null>;
  }
  
-+
  export default function Iframe({
    intersectionRootRef,
 +  code,
@@ -163,46 +170,76 @@ index 9285b94..c268bdb 100644
    const iframeRef = useRef<HTMLIFrameElement | null>(null);
    const intersection = useIntersection(iframeRef, {
      root: intersectionRootRef.current,
-@@ -32,35 +39,41 @@ export default function Iframe({
+@@ -29,8 +36,17 @@ export default function Iframe({
+     threshold: 0,
+   });
+ 
++  const postMessageToIframe = useCallback((message) => {
++    // Note that we're sending the message to '*', rather than some
++    // specific origin. Sandboxed iframes without the 'allow-same-origin'
++    // header don't have an origin which we can target.
++    // See: https://web.dev/articles/sandboxed-iframes
++    iframeRef.current?.contentWindow?.postMessage(message, '*');
++  }, []);
++
    const intersectionRatio = intersection?.intersectionRatio ?? null;
  
++  // Only render the iframe once it's actually on screen
    useEffect(() => {
--    if (intersectionRatio === null) {
--      return;
-+    if (intersectionRatio === null) return;
-+    const listener = (e: any) => {
-+      if (e.data.type === READY_TO_RECEIVE && e.source === iframeRef.current?.contentWindow) {
-+        setReadyToPost(true);
-+        const contentWindow = iframeRef.current?.contentWindow;
-+        if (contentWindow) {
-+          contentWindow.postMessage({ type: INCOMING_CODE,  themeName, code }, window.origin);
-+        }
-+      }
+     if (intersectionRatio === null) {
+       return;
+@@ -41,26 +57,56 @@ export default function Iframe({
      }
-+    window.addEventListener('message', listener);
- 
-     if (intersectionRatio > 0 && src !== renderedSrc) {
-       setRenderedSrc(src);
-     }
-+    return () => window.removeEventListener('message', listener);
    }, [intersectionRatio, src, renderedSrc]);
  
++  // A call-and-response / ping-pong to wait for the iframe to declare itself
++  // ready. Why do we do polling instead of just having the iframe send a
++  // message to `window.origin`? Because sandboxded iframes without the
++  // 'allow-same-origin' header don't have an origin which it can target. So
++  // instead we send messages to the iframe which can then use `event.origin`.
    useEffect(() => {
 -    if (renderedSrc !== null) {
 -      const location = iframeRef.current?.contentWindow?.location;
--
++    // If the iframe isn't on screen / loaded yet, no need to poll yet.
++    // If the iframe is already ready, don't do anything.
++    if (!loaded || readyToPost) {
++      return;
++    }
+ 
 -      if (location) {
 -        location.replace(renderedSrc);
-+    if (readyToPost) {
-+      const contentWindow = iframeRef.current?.contentWindow;
-+      if (contentWindow) {
-+        contentWindow.postMessage({ type: INCOMING_CODE,  themeName, code }, window.origin);
++    // Listen to hear if the iframe says is ready
++    const listener = (e: any) => {
++      if (e.data.type === READY_TO_RECEIVE && e.source === iframeRef.current?.contentWindow) {
++        cleanup();
++        setReadyToPost(true);
        }
      }
 -  }, [renderedSrc]);
-+  }, [readyToPost, code])
++    window.addEventListener('message', listener);
 +
++    // Start polling the iframe asking if it's ready yet
++    const timeoutId = window.setTimeout(() => {
++      postMessageToIframe({ type: ARE_YOU_READY });
++    }, 500);
 +
++    const cleanup = () => {
++      window.removeEventListener('message', listener);
++      window.clearTimeout(timeoutId);
++    }
++
++    return cleanup;
++  }, [readyToPost, loaded])
++
++  // Each time the code changes (and the iframe is ready to receive), send the
++  // updated code
++  useEffect(() => {
++    if (!readyToPost) {
++      return;
++    }
++
++    postMessageToIframe({ type: INCOMING_CODE,  themeName, code });
++  }, [readyToPost, themeName, code])
  
    return (
      <iframe
@@ -219,7 +256,7 @@ index 9285b94..c268bdb 100644
          ...style,
          transition: 'opacity .3s ease',
 diff --git a/node_modules/playroom/src/Playroom/Preview.tsx b/node_modules/playroom/src/Playroom/Preview.tsx
-index 0183aaf..2d1d5d5 100644
+index 0183aaf..39cebbd 100644
 --- a/node_modules/playroom/src/Playroom/Preview.tsx
 +++ b/node_modules/playroom/src/Playroom/Preview.tsx
 @@ -43,6 +43,16 @@ export default ({ themes, components, FrameComponent }: PreviewProps) => {
@@ -256,10 +293,11 @@ index 0183aaf..2d1d5d5 100644
  };
 diff --git a/node_modules/playroom/src/Playroom/constants.ts b/node_modules/playroom/src/Playroom/constants.ts
 new file mode 100644
-index 0000000..90c35d0
+index 0000000..c7f8e29
 --- /dev/null
 +++ b/node_modules/playroom/src/Playroom/constants.ts
-@@ -0,0 +1,2 @@
+@@ -0,0 +1,3 @@
++export const ARE_YOU_READY = "PLAYROOM_ARE_YOU_READY";
 +export const READY_TO_RECEIVE = "PLAYROOM_READY_TO_RECEIVE";
 +export const INCOMING_CODE = "PLAYROOM_INCOMING_CODE";
 diff --git a/node_modules/playroom/src/utils/compileJsx.ts b/node_modules/playroom/src/utils/compileJsx.ts

--- a/polaris.shopify.com/pages/sandbox/index.tsx
+++ b/polaris.shopify.com/pages/sandbox/index.tsx
@@ -1,10 +1,9 @@
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useRef} from 'react';
 import type {InferGetServerSidePropsType, GetServerSideProps} from 'next';
 import {useRouter} from 'next/router';
 
-import SandboxHeader from '../src/components/SandboxHeader';
-import SandboxHelpDialog from '../src/components/SandboxHelpDialog';
-import SandboxContainer from '../src/components/SandboxContainer';
+import SandboxHeader from '../../src/components/SandboxHeader';
+import SandboxContainer from '../../src/components/SandboxContainer';
 
 export const getServerSideProps: GetServerSideProps = async ({query}) => {
   // We need to pass initial query param to our nested iframe
@@ -18,29 +17,12 @@ export const getServerSideProps: GetServerSideProps = async ({query}) => {
   };
 };
 
-const MS_DELAY_BEFORE_SHOW_ONBOARDING = 500;
-
 export default function Sandbox({
   initialSearchParams,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const router = useRouter();
   const searchValue = useRef('');
-  const [isHelpOpen, setHelpIsOpen] = useState(false);
-
-  // After the page has rendered at least once, we might show the help dialog
-  // (so it animates onto the screen nicely)
-  useEffect(() => {
-    const helpTimeout = setTimeout(() => {
-      const hasAlreadyBeenOnboarded = localStorage.getItem('onboarded');
-      if (hasAlreadyBeenOnboarded) {
-        return;
-      }
-      localStorage.setItem('onboarded', 'true');
-      setHelpIsOpen(true);
-    }, MS_DELAY_BEFORE_SHOW_ONBOARDING);
-    return () => clearTimeout(helpTimeout);
-  }, []);
 
   useEffect(() => {
     /**
@@ -71,13 +53,13 @@ export default function Sandbox({
     return () => clearInterval(iframeUrlPoll);
   }, [router]);
 
+  const copyUrl = `${
+    typeof window !== 'undefined' ? window.location.origin : ''
+  }/sandbox${initialSearchParams}`;
+
   return (
     <SandboxContainer>
-      <SandboxHeader
-        setHelpIsOpen={setHelpIsOpen}
-        url={typeof window !== 'undefined' ? window.location.href : ''}
-      />
-      <SandboxHelpDialog {...{isOpen: isHelpOpen, setIsOpen: setHelpIsOpen}} />
+      <SandboxHeader copyUrl={copyUrl} />
       <iframe
         id="main"
         ref={iframeRef}

--- a/polaris.shopify.com/pages/sandbox/preview.tsx
+++ b/polaris.shopify.com/pages/sandbox/preview.tsx
@@ -1,0 +1,47 @@
+import type {InferGetServerSidePropsType, GetServerSideProps} from 'next';
+
+import SandboxHeader from '../../src/components/SandboxHeader';
+import SandboxContainer from '../../src/components/SandboxContainer';
+
+export const getServerSideProps: GetServerSideProps = async ({query}) => {
+  // We need to pass initial query param to our nested iframe
+  const initialSearchParams = new URLSearchParams(
+    query as Record<string, string>,
+  ).toString();
+  return {
+    props: {
+      initialSearchParams: `?${initialSearchParams}`,
+    },
+  };
+};
+
+export default function Sandbox({
+  initialSearchParams,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const copyUrl = `${
+    typeof window !== 'undefined' ? window.location.origin : ''
+  }/sandbox/preview${initialSearchParams}`;
+  const editUrl = `${
+    typeof window !== 'undefined' ? window.location.origin : ''
+  }/sandbox${initialSearchParams}`;
+
+  return (
+    <SandboxContainer>
+      <SandboxHeader copyUrl={copyUrl} editUrl={editUrl} />
+      <iframe
+        id="main"
+        // Important: DO NOT add "allow-same-origin" - it will open a
+        // security/XSS hole.
+        sandbox="allow-scripts"
+        style={{
+          border: 0,
+          padding: 0,
+          margin: 0,
+        }}
+        src={`/playroom/preview${initialSearchParams}`}
+        width="100%"
+        height="100%"
+      />
+    </SandboxContainer>
+  );
+}

--- a/polaris.shopify.com/playroom.config.js
+++ b/polaris.shopify.com/playroom.config.js
@@ -66,5 +66,19 @@ module.exports = {
       ],
     },
   }),
-  iframeSandbox: 'allow-scripts allow-same-origin',
+  // IMPORTANT SECURITY NOTES:
+  // NOTE: DO NOT add "allow-same-origin" and "allow-scripts" together;
+  // > Setting both the allow-scripts and allow-same-origin keywords together
+  // > when the embedded page has the same origin as the page containing the
+  // > iframe allows the embedded page to simply remove the sandbox attribute
+  // > and then reload itself, effectively breaking out of the sandbox
+  // > altogether.
+  // - https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox
+  //
+  // NOTE: DO NOT EVER add "allow-same-origin"; it will open up access to
+  // cookies and other things on *.shopify.com (because we host Playroom on
+  // polaris.shopify.com) to malicious scripts. We've patched Playroom to
+  // not need access to the same origin, so there shouldn't be any need to
+  // enable it.
+  iframeSandbox: 'allow-scripts',
 };

--- a/polaris.shopify.com/playroom/FrameComponent.tsx
+++ b/polaris.shopify.com/playroom/FrameComponent.tsx
@@ -38,6 +38,14 @@ const mockFrameContext = {
   },
 };
 
+function inIframe() {
+  try {
+    return window.self !== window.top;
+  } catch (e) {
+    return true;
+  }
+}
+
 export default function FrameComponent({
   theme = enTranslations,
   children,
@@ -47,6 +55,9 @@ export default function FrameComponent({
 }) {
   const [features, setFeatures] =
     useState<React.ComponentProps<typeof AppProvider>['features']>();
+  // Don't render anything until we've done our client-side check for iframe
+  // security.
+  const [content, setContent] = useState(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   // Tell parent frame of the initial size on first render
@@ -86,11 +97,35 @@ export default function FrameComponent({
     }
   }, []);
 
+  // Don't render anything on the server, only render on the client.
+  useEffect(() => {
+    // window.origin is set to "null" when the page is loaded in a sandboxed iframe without access to the same origin
+    if (window.origin === 'null') {
+      setContent(children);
+    } else {
+      if (!inIframe()) {
+        // Raw window, not embedded in an iframe at all, so redirect to the correct page (useful for old links before we enforced iframe sandboxing)
+        const url = new URL(window.location.href);
+        url.pathname = '/sandbox/preview';
+        window.location.replace(url.toString());
+      } else if (window.frameElement) {
+        // Embedded on our own domain, but with insecure sandbox settings (frameElement only has a value on same-origin iframes).
+        console.error(
+          'Refusing to load example on same origin with allow-same-origin enabled. Hint: ensure the iframe has a "sandbox" attribute WITHOUT "allow-same-origin" set.',
+        );
+      } else {
+        // Embedded on a cross-origin domain, so throw an error
+        console.error('Unable to load example on cross-origin domain');
+      }
+      setContent(null);
+    }
+  }, [children]);
+
   return (
     <AppProvider i18n={theme || enTranslations} features={features}>
       <FrameContext.Provider value={mockFrameContext}>
         <div id="polaris-sandbox-wrapper" ref={wrapperRef}>
-          {children}
+          {content}
         </div>
       </FrameContext.Provider>
     </AppProvider>

--- a/polaris.shopify.com/src/components/PatternsExample/PatternsExample.tsx
+++ b/polaris.shopify.com/src/components/PatternsExample/PatternsExample.tsx
@@ -250,6 +250,7 @@ const PatternsExample = ({
         id="live-preview-iframe"
         defaultHeight={'400px'}
         src={previewUrl}
+        sandbox="allow-scripts"
       />
     </ExampleWrapper>
   );
@@ -282,6 +283,7 @@ const PatternsExample = ({
           defaultHeight={defaultHeight}
           minHeight={minHeight}
           src={previewUrl}
+          sandbox="allow-scripts"
         />
       </ExampleWrapper>
     </dialog>

--- a/polaris.shopify.com/src/components/PlayroomLink/PlayroomLink.tsx
+++ b/polaris.shopify.com/src/components/PlayroomLink/PlayroomLink.tsx
@@ -1,5 +1,4 @@
 import {createUrl} from 'playroom';
-import {playroom} from '../../../constants';
 import styles from './PlayroomLink.module.scss';
 
 const getAppCode = (code: string) => {
@@ -29,7 +28,7 @@ const PlayroomButton = (props: Props) => {
   const {code} = props;
 
   const encodedCode = createUrl({
-    baseUrl: playroom.baseUrl,
+    baseUrl: '/sandbox/',
     code: getAppCode(code), //encodeURL(getAppCode(code));
     themes: ['locale:en'],
     paramType: 'search',

--- a/polaris.shopify.com/src/components/SandboxHeader/SandboxHeader.module.scss
+++ b/polaris.shopify.com/src/components/SandboxHeader/SandboxHeader.module.scss
@@ -13,16 +13,17 @@
 
 .Buttons {
   display: flex;
-  gap: 0.5rem;
+  gap: 1.5rem;
 
-  button {
+  button,
+  a {
     display: flex;
     align-items: center;
     gap: 0.25rem;
     background: transparent;
     font-size: var(--font-size-300);
-    min-width: 6rem;
     text-align: center;
+    color: var(--text);
 
     &:hover {
       color: var(--text-strong);

--- a/polaris.shopify.com/src/components/SandboxHeader/SandboxHeader.tsx
+++ b/polaris.shopify.com/src/components/SandboxHeader/SandboxHeader.tsx
@@ -1,40 +1,68 @@
+import {useState, useEffect, Fragment} from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 
-import {ClipboardMinor} from '@shopify/polaris-icons';
+import {ClipboardMinor, EditMinor} from '@shopify/polaris-icons';
 import {useCopyToClipboard} from '../../utils/hooks';
 import Icon from '../Icon';
+import SandboxHelpDialog from '../SandboxHelpDialog';
 
 import styles from './SandboxHeader.module.scss';
 
 interface Props {
-  url: string;
-  setHelpIsOpen: (open: boolean) => void;
+  copyUrl: string;
+  editUrl?: string;
 }
 
-function SandboxHeader({url, setHelpIsOpen}: Props) {
-  const [copy, didJustCopy] = useCopyToClipboard(url);
+const MS_DELAY_BEFORE_SHOW_ONBOARDING = 500;
+
+function SandboxHeader({copyUrl, editUrl}: Props) {
+  const [copy, didJustCopy] = useCopyToClipboard(copyUrl);
+  const [isHelpOpen, setHelpIsOpen] = useState(false);
+
+  // After the page has rendered at least once, we might show the help dialog
+  // (so it animates onto the screen nicely)
+  useEffect(() => {
+    const helpTimeout = setTimeout(() => {
+      const hasAlreadyBeenOnboarded = localStorage.getItem('onboarded');
+      if (hasAlreadyBeenOnboarded) {
+        return;
+      }
+      localStorage.setItem('onboarded', 'true');
+      setHelpIsOpen(true);
+    }, MS_DELAY_BEFORE_SHOW_ONBOARDING);
+    return () => clearTimeout(helpTimeout);
+  }, []);
 
   return (
-    <div className={styles.Header}>
-      <Link href="/" className={styles.Logo}>
-        <Image
-          src="/images/shopify-logo.svg"
-          width={24}
-          height={24}
-          alt="Shopify logo"
-        />
-        Polaris Sandbox
-      </Link>
+    <Fragment>
+      <div className={styles.Header}>
+        <Link href="/" className={styles.Logo}>
+          <Image
+            src="/images/shopify-logo.svg"
+            width={24}
+            height={24}
+            alt="Shopify logo"
+          />
+          Polaris Sandbox
+        </Link>
 
-      <div className={styles.Buttons}>
-        <button onClick={() => setHelpIsOpen(true)}>Learn more</button>
-        <button className={styles.CopyURLButton} onClick={copy}>
-          <Icon source={ClipboardMinor} width="1em" height="1em" />
-          {didJustCopy ? 'Copied!' : 'Copy URL'}
-        </button>
+        <div className={styles.Buttons}>
+          <button onClick={() => setHelpIsOpen(true)}>Learn more</button>
+          <button className={styles.CopyURLButton} onClick={copy}>
+            <Icon source={ClipboardMinor} width="1em" height="1em" />
+            {didJustCopy ? 'Copied!' : 'Copy URL'}
+          </button>
+          {editUrl ? (
+            <Link href={editUrl}>
+              <Icon source={EditMinor} width="1em" height="1em" />
+              Edit
+            </Link>
+          ) : null}
+        </div>
       </div>
-    </div>
+      <SandboxHelpDialog {...{isOpen: isHelpOpen, setIsOpen: setHelpIsOpen}} />
+    </Fragment>
   );
 }
 


### PR DESCRIPTION
The sandbox environment (powered by [SEEK Playroom](https://github.com/seek-oss/playroom)) had an incorrectly configured `sandbox` attribute on the preview iframes: It contained both `allow-scripts` and `allow-same-origin` which effectively undermines the `sandbox` attribute entirely:

> "Setting both the allow-scripts and allow-same-origin keywords together  when the embedded page has the same origin as the page containing the  iframe allows the embedded page to simply remove the sandbox attribute  and then reload itself, effectively breaking out of the sandbox  altogether." - https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox

This is called a "Reflected XSS" attack, and given it's on a subdomain of `shopify.com`, that makes it also a "Subdomain take-over".

The attacks possible from malicious code are limited to:

- **Phishing attacks**
    - An attacker can impersonate a Shopify login form (which may seem legitimate given it's on a `*.shopify.com` domain), capturing a user's credentials.
- **Circumventing CORS / same-origin policies**
	- An attacker could set `document.domain = 'shopify.com'`, and if any other subdomain or [shopify.com](http://shopify.com/) itself also sets `document.domain = 'shopify.com'`, then the malicious script would gain access to that domain's cookies, and circumvent any CORS and same-origin policies set.
	- However, `document.domain` is a deprecated web standard, and I'd be surprised if any of our sites are using it. (A [quick grokt](https://grokt.shopify.io/results?q=document%5C.domain%5Cs*%3D) doesn't show up anything of concern)
- **Session Fixation Attack**
	- An attacker could perform a [session fixation](https://owasp.org/www-community/attacks/Session_fixation) attack against folks logging in to [admin.shopify.com](http://admin.shopify.com/) by creating a malicious script to set the user's session token to that of the attackers, granting the attacker access to the user's account.
	- However, this would require the session cookie on [admin.shopify.com](http://admin.shopify.com/) to be setting `Domain=`[shopify.com](http://shopify.com/) which it's not.
- **Denial of Service Cookie Bomb**
	- A malicious script can create such a large set of cookies on the root domain that it leads to a DoS against all *.shopify.com domains.
	- This does *not* read any cookies from *.shopify.com, only sets arbitrarily large amounts of them.

The fix is to ensure the previews are only ever loaded within iframes that have the `sandbox` attribute set _without_ the `allow-same-origin` option.