### PR TITLE
Fixed issue with textarea not bubbling up to parent

### DIFF
--- a/.changeset/young-yaks-type.md
+++ b/.changeset/young-yaks-type.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fixed `TextField` events not bubbling up when `multiline`

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -261,11 +261,15 @@ export function TextField({
   const buttonPressTimer = useRef<number>();
   const spinnerRef = useRef<HTMLDivElement>(null);
 
+  const getInputRef = useCallback(() => {
+    return multiline ? textAreaRef.current : inputRef.current;
+  }, [multiline]);
+
   useEffect(() => {
-    const input = multiline ? textAreaRef.current : inputRef.current;
+    const input = getInputRef();
     if (!input || focused === undefined) return;
     focused ? input.focus() : input.blur();
-  }, [focused, verticalContent, multiline]);
+  }, [focused, verticalContent, getInputRef]);
 
   useEffect(() => {
     const input = inputRef.current;
@@ -506,7 +510,7 @@ export function TextField({
     setFocus(true);
 
     if (selectTextOnFocus && !suggestion) {
-      const input = multiline ? textAreaRef.current : inputRef.current;
+      const input = getInputRef();
       input?.select();
     }
 
@@ -649,7 +653,7 @@ export function TextField({
       return;
     }
 
-    inputRef.current?.focus();
+    getInputRef()?.focus();
   }
 
   function handleClickChild(event: React.MouseEvent) {
@@ -667,7 +671,7 @@ export function TextField({
     }
 
     setFocus(true);
-    inputRef.current?.focus();
+    getInputRef()?.focus();
   }
 
   function handleClearButtonPress() {
@@ -752,11 +756,11 @@ export function TextField({
   }
 
   function isInput(target: HTMLElement | EventTarget) {
+    const input = getInputRef();
     return (
       target instanceof HTMLElement &&
-      inputRef.current &&
-      (inputRef.current.contains(target) ||
-        inputRef.current.contains(document.activeElement))
+      input &&
+      (input.contains(target) || input.contains(document.activeElement))
     );
   }
 

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -115,6 +115,28 @@ describe('<TextField />', () => {
       expect(onClick).toHaveBeenCalled();
     });
 
+    it('bubbles up to the parent element when it occurs in the textarea', () => {
+      const onClick = jest.fn();
+      const event = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      });
+      const textField = mountWithApp(
+        <div onClick={onClick}>
+          <TextField
+            type="text"
+            label="TextField"
+            autoComplete="off"
+            multiline
+          />
+        </div>,
+      );
+
+      textField.find('textarea')!.domNode?.dispatchEvent(event);
+      expect(onClick).toHaveBeenCalled();
+    });
+
     it('bubbles up to the parent element when it occurs in the spinner', () => {
       const onClick = jest.fn();
       const event = new MouseEvent('click', {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
- Textarea element in `<TextField/>` was not bubbling up events
- This bug prevents popover component from closing when clicking input

Before fix:

https://github.com/Shopify/polaris/assets/5440293/ee00d911-b637-4a97-b442-caa6aef9e395

After fix:

https://github.com/Shopify/polaris/assets/5440293/506a4c73-c927-45b2-a5e1-9b34a42450ed

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Includes textarea check when determining whether to stop propagation of events

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->
- Go to playground: http://243.27.5.31:6006/?path=/story/playground--details-page
- Click any Popover to open it
- Click on a multi-line `<TextField/>` component
- Verify that the popover closes

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
