### PR TITLE
[Banner] Reposition dismiss icon for `InlineIconBanner` variant when `hideIcon` is true

### DIFF
--- a/.changeset/plenty-pens-decide.md
+++ b/.changeset/plenty-pens-decide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed Banner InlineIconBanner variant dismiss icon position when hideIcon is true

--- a/polaris-react/src/components/Banner/Banner.scss
+++ b/polaris-react/src/components/Banner/Banner.scss
@@ -40,6 +40,10 @@
   }
 }
 
+.DismissIcon {
+  display: flex;
+}
+
 // stylelint-disable -- Duplicate selectors to bump specificity for button svg color override
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#increasing_specificity_by_duplicating_selector
 

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -301,11 +301,17 @@ export function All() {
       <AllBanners
         title={undefined}
         hideIcon
+        onDismiss={() => {}}
         children={
-          <Text as="p">
-            Changing the phone number for this customer will unsubscribe them
-            from SMS marketing text messages until they provide consent.
-          </Text>
+          <>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </>
         }
       />
       <Text as="h2" variant="headingMd">

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -242,10 +242,12 @@ export function InlineIconBanner({
     useState<InlineStackProps['blockAlign']>('center');
   const contentNode = useRef<HTMLDivElement>(null);
   const iconNode = useRef<HTMLDivElement>(null);
+  const dismissIconNode = useRef<HTMLDivElement>(null);
 
   const handleResize = useCallback(() => {
     const contentHeight = contentNode.current?.offsetHeight;
-    const iconBoxHeight = iconNode.current?.offsetHeight;
+    const iconBoxHeight =
+      iconNode.current?.offsetHeight || dismissIconNode.current?.offsetHeight;
 
     if (!contentHeight || !iconBoxHeight) return;
 
@@ -281,7 +283,9 @@ export function InlineIconBanner({
             </Box>
           </InlineStack>
         </Box>
-        {dismissButton}
+        <div ref={dismissIconNode} className={styles.DismissIcon}>
+          {dismissButton}
+        </div>
       </InlineStack>
     </Box>
   );


### PR DESCRIPTION
## Before
When `<Banner hideIcon onDismiss={() => {}} />` 

[Sandbox demo](https://polaris.shopify.com/sandbox?code=N4Igxg9gJgpiBcIA8AhAhgOwzATgAgAsBLWASUgzwgwBEiBnAWwfoF5gAKASj1YD48wAL5C%2BAZRhQ8AVwAueAA656ComCJpZDGRlhVGGbQ1kw8GTdPp5cOCPnpF5ANwgAbaQtmaYjPGjBglpha0r5QbnY%2BAI7Spq5o0lDBRKEANHiyEF6%2BOD5%2BSjgajOkwaDGmRAr0aHgxaKZoAEZ4RK6uEC0YTjAYmbl43YVeWlYw8nUOfjhgxCZgmXiNpV6mTo71eFBqXnj00r3WAB4KrmpNEAB0eAByPh09RL6V1b4u7p7evjEaA24eXlYHPI0CpcOZZNJ8Al5NBHH45HgAGbSADmjnS9EktWkPwomJi%2Bwh%2BEYaBRhk2EVyowgVm%2BeBwmiI1FWfw%2BJl8%2BJxZhg9HUhKut3KijstmxDDqvh5snSdPC7VyTyqoTFNTldl2cLQjDG6TxMHmY0h6TQW1UvKIAxgp2luyx3xqGGoZlCEusKSsjFhGR8CjsNSIGHUUEJMnk8UakWs8jV-RJZK1flOrrquE0v3ewx8VwAqvIHr4TXhmIYSZbDFqZTirI76LIcMqYIdcOphkzsL5pG0E5AcL7CoDLOpVGHzoUaRWzAwLQi0EmcVJG9YapBGJ6tng9XUiQB%2BPAARSr8PZltc1mVKX6uQUuQIPVgQzFnSX6f%2B3hPcJ5mOxCcMxFPntcKUNFMTdpAsHB0m6U9WncL4uRjPIYGVZE0TTGIOjeV9q07eJFDQQpwO3JAAHp0CwXA%2BBAVIQFkW9tXoBAAG0QHaMBZxgeAehAABdaiAHcSFohj4EY7ihCAA)

<img width="402" alt="Screenshot 2023-10-27 at 1 28 59 PM" src="https://github.com/Shopify/polaris/assets/20652326/5285e7e4-15f4-44d9-8e09-bed6e9ef4810">

## After

https://5d559397bae39100201eedc1-uuqgzxigsi.chromatic.com/?path=/story/all-components-banner--all
<img width="1183" alt="Screenshot 2023-10-27 at 2 04 36 PM" src="https://github.com/Shopify/polaris/assets/20652326/f5e1e94d-6ede-4dfe-90a7-7bc983f38726">
