### PR TITLE
[PageActions, Page SecondaryAction] Fix destructive state

### DIFF
--- a/.changeset/hungry-feet-suffer.md
+++ b/.changeset/hungry-feet-suffer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed destructive states for PageActions and Page SecondaryActions

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -20,6 +20,7 @@ export function SecondaryAction({
   helpText,
   onAction,
   getOffsetWidth,
+  destructive,
   ...rest
 }: SecondaryAction) {
   const secondaryActionsRef = useRef<HTMLDivElement>(null);
@@ -33,7 +34,7 @@ export function SecondaryAction({
   const buttonMarkup = (
     <Button
       onClick={onAction}
-      tone={rest.destructive ? 'critical' : undefined}
+      tone={destructive ? 'critical' : undefined}
       {...rest}
     >
       {children}

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -9,6 +9,7 @@ import styles from './SecondaryAction.scss';
 
 interface SecondaryAction extends ButtonProps {
   helpText?: React.ReactNode;
+  destructive?: boolean;
   onAction?(): void;
   getOffsetWidth?(width: number): void;
 }
@@ -30,7 +31,11 @@ export function SecondaryAction({
   }, [getOffsetWidth]);
 
   const buttonMarkup = (
-    <Button onClick={onAction} {...rest}>
+    <Button
+      onClick={onAction}
+      tone={rest.destructive ? 'critical' : undefined}
+      {...rest}
+    >
       {children}
     </Button>
   );

--- a/polaris-react/src/components/Button/utils.tsx
+++ b/polaris-react/src/components/Button/utils.tsx
@@ -30,7 +30,8 @@ export function buttonFrom(
   overrides?: Partial<ButtonProps>,
   key?: any,
 ) {
-  const variant = !overrides?.variant && plain ? 'plain' : overrides?.variant;
+  const plainVariant = plain ? 'plain' : undefined;
+  const destructiveVariant = destructive ? 'primary' : undefined;
   const tone = !overrides?.tone && destructive ? 'critical' : overrides?.tone;
 
   return (
@@ -38,7 +39,7 @@ export function buttonFrom(
       key={key}
       onClick={onAction}
       tone={tone}
-      variant={variant}
+      variant={plainVariant || destructiveVariant}
       {...action}
       {...overrides}
     >


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes: https://github.com/Shopify/polaris/issues/11034

Matches v11 behaviour: https://codesandbox.io/s/naughty-resonance-23mqts?file=/App.tsx

**v11**
![image](https://screenshot.click/27-46-nkg99-mvnpf.png)

**v12 before**
![image](https://screenshot.click/27-45-8if4j-t6yey.png)

**v12 after**
![image](https://screenshot.click/27-45-rw3u4-jrbre.png)

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
