### PR TITLE
[Badge] Removed `experimental` flag from `tone` types

### DIFF
--- a/.changeset/neat-badgers-hammer.md
+++ b/.changeset/neat-badgers-hammer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Removed `experimental` flag from Badge `tone` types

--- a/polaris-react/src/components/Badge/types.ts
+++ b/polaris-react/src/components/Badge/types.ts
@@ -5,13 +5,13 @@ export type Tone =
   | 'critical'
   | 'attention'
   | 'new'
-  | 'info-strong-experimental'
-  | 'success-strong-experimental'
-  | 'warning-strong-experimental'
-  | 'critical-strong-experimental'
-  | 'attention-strong-experimental'
-  | 'read-only-experimental'
-  | 'enabled-experimental';
+  | 'info-strong'
+  | 'success-strong'
+  | 'warning-strong'
+  | 'critical-strong'
+  | 'attention-strong'
+  | 'read-only'
+  | 'enabled';
 
 export enum ToneValue {
   Info = 'info',
@@ -20,13 +20,13 @@ export enum ToneValue {
   Critical = 'critical',
   Attention = 'attention',
   New = 'new',
-  InfoStrong = 'info-strong-experimental',
-  SuccessStrong = 'success-strong-experimental',
-  WarningStrong = 'warning-strong-experimental',
-  CriticalStrong = 'critical-strong-experimental',
-  AttentionStrong = 'attention-strong-experimental',
-  ReadOnly = 'read-only-experimental',
-  Enabled = 'enabled-experimental',
+  InfoStrong = 'info-strong',
+  SuccessStrong = 'success-strong',
+  WarningStrong = 'warning-strong',
+  CriticalStrong = 'critical-strong',
+  AttentionStrong = 'attention-strong',
+  ReadOnly = 'read-only',
+  Enabled = 'enabled',
 }
 
 export type Progress = 'incomplete' | 'partiallyComplete' | 'complete';


### PR DESCRIPTION
### WHY are these changes introduced?

Cleans up `experimental` flag from Badge `tone` types.

### WHAT is this pull request doing?

[PR storybook](https://5d559397bae39100201eedc1-jgmoujeqeb.chromatic.com/?path=/story/all-components-badge--all)
[Prod storybook](https://storybook.polaris.shopify.com/?path=/story/all-components-badge--all)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
