### PR TITLE
[ContextualSaveBar] Update icon from CircleAlertMajor to RiskMajor

### DIFF
--- a/.changeset/hip-houses-accept.md
+++ b/.changeset/hip-houses-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated `ContextualSaveBar` icon to `RiskMajor` and updated logos in examples to Shopify logo

--- a/polaris-react/src/components/ContextualSaveBar/ContextualSaveBar.stories.tsx
+++ b/polaris-react/src/components/ContextualSaveBar/ContextualSaveBar.stories.tsx
@@ -12,9 +12,9 @@ export function Default() {
     <div style={{height: '250px'}}>
       <Frame
         logo={{
-          width: 124,
+          width: 86,
           contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
         }}
       >
         <ContextualSaveBar
@@ -38,9 +38,9 @@ export function WithFlushContents() {
     <div style={{height: '250px'}}>
       <Frame
         logo={{
-          width: 124,
+          width: 86,
           contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
         }}
       >
         <ContextualSaveBar
@@ -63,9 +63,9 @@ export function WithFullWidth() {
     <div style={{height: '250px'}}>
       <Frame
         logo={{
-          width: 124,
+          width: 86,
           contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
         }}
       >
         <ContextualSaveBar

--- a/polaris-react/src/components/Frame/Frame.stories.tsx
+++ b/polaris-react/src/components/Frame/Frame.stories.tsx
@@ -312,13 +312,12 @@ function InAnApplicationComponent() {
   );
 
   const logo = {
-    width: 124,
+    width: 86,
     topBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
     contextualSaveBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
-    url: '#',
-    accessibilityLabel: 'Jaded Pixel',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
+    accessibilityLabel: 'Shopify',
   };
 
   return (
@@ -655,13 +654,12 @@ function WithAnOffsetComponent() {
   );
 
   const logo = {
-    width: 124,
+    width: 86,
     topBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
     contextualSaveBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
-    url: '#',
-    accessibilityLabel: 'Jaded Pixel',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
+    accessibilityLabel: 'Shopify',
   };
 
   return (
@@ -1013,13 +1011,12 @@ function WithSidebarEnabled() {
   );
 
   const logo = {
-    width: 124,
+    width: 86,
     topBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
     contextualSaveBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
-    url: '#',
-    accessibilityLabel: 'Jaded Pixel',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
+    accessibilityLabel: 'Shopify',
   };
 
   return (

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {CircleAlertMajor} from '@shopify/polaris-icons';
+import {RiskMajor} from '@shopify/polaris-icons';
 
 import {Button} from '../../../Button';
 import {Image} from '../../../Image';
@@ -126,7 +126,7 @@ export function ContextualSaveBar({
         {logoMarkup}
         <div className={contentsClassName}>
           <div className={styles.MessageContainer}>
-            <Icon source={CircleAlertMajor} />
+            <Icon source={RiskMajor} />
             {message && (
               <Text as="h2" variant="headingMd" tone="text-inverse" truncate>
                 {message}

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -54,11 +54,11 @@ function TopBarWrapper({
   }, []);
 
   const logo = {
-    width: 92,
+    width: 86,
     topBarSource:
-      'https://cdn.shopify.com/shopifycloud/brochure/assets/brand-assets/shopify-logo-monotone-white-7edf88561b256e005e9b9d003c283c39dcbd74ec844dfc9a3912edeec39b4d7e.svg',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
     url: '#',
-    accessibilityLabel: 'Hem Canada',
+    accessibilityLabel: 'Shopify',
   };
 
   const userMenuMarkup = (

--- a/polaris.shopify.com/pages/examples/contextual-save-bar-default.tsx
+++ b/polaris.shopify.com/pages/examples/contextual-save-bar-default.tsx
@@ -7,9 +7,9 @@ function Example() {
     <div style={{height: '250px'}}>
       <Frame
         logo={{
-          width: 124,
+          width: 86,
           contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
         }}
       >
         <ContextualSaveBar

--- a/polaris.shopify.com/pages/examples/contextual-save-bar-with-flush-contents.tsx
+++ b/polaris.shopify.com/pages/examples/contextual-save-bar-with-flush-contents.tsx
@@ -7,9 +7,9 @@ function Example() {
     <div style={{height: '250px'}}>
       <Frame
         logo={{
-          width: 124,
+          width: 86,
           contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
         }}
       >
         <ContextualSaveBar

--- a/polaris.shopify.com/pages/examples/contextual-save-bar-with-full-width.tsx
+++ b/polaris.shopify.com/pages/examples/contextual-save-bar-with-full-width.tsx
@@ -7,9 +7,9 @@ function Example() {
     <div style={{height: '250px'}}>
       <Frame
         logo={{
-          width: 124,
+          width: 86,
           contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
         }}
       >
         <ContextualSaveBar

--- a/polaris.shopify.com/pages/examples/frame-in-an-application.tsx
+++ b/polaris.shopify.com/pages/examples/frame-in-an-application.tsx
@@ -292,13 +292,12 @@ function FrameExample() {
   );
 
   const logo = {
-    width: 124,
+    width: 86,
     topBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
     contextualSaveBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
-    url: '#',
-    accessibilityLabel: 'Jaded Pixel',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
+    accessibilityLabel: 'Shopify',
   };
 
   return (

--- a/polaris.shopify.com/pages/examples/frame-with-an-offset.tsx
+++ b/polaris.shopify.com/pages/examples/frame-with-an-offset.tsx
@@ -292,13 +292,12 @@ function FrameExample() {
   );
 
   const logo = {
-    width: 124,
+    width: 86,
     topBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
     contextualSaveBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
-    url: '#',
-    accessibilityLabel: 'Jaded Pixel',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
+    accessibilityLabel: 'Shopify',
   };
 
   return (

--- a/polaris.shopify.com/pages/examples/top-bar-default.tsx
+++ b/polaris.shopify.com/pages/examples/top-bar-default.tsx
@@ -32,13 +32,12 @@ function TopBarExample() {
   const handleNavigationToggle = useCallback(() => {
     console.log('toggle navigation visibility');
   }, []);
-
   const logo = {
-    width: 124,
     topBarSource:
-      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
+      'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
+    width: 86,
     url: '#',
-    accessibilityLabel: 'Jaded Pixel',
+    accessibilityLabel: 'Shopify',
   };
 
   const userMenuMarkup = (


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR updates the ContextualSaveBar icon from CircleAlertMajor to RiskMajor. It also updates the examples to render the Shopify logo instead of an app logo.

| [Before](https://storybook.polaris.shopify.com/?path=/story/all-components-contextualsavebar--default) | [After](https://5d559397bae39100201eedc1-vcjcqwedfu.chromatic.com/?path=/story/all-components-contextualsavebar--default)|
|--------|--------|
|<img width="1228" alt="Screenshot 2023-10-30 at 3 28 02 PM" src="https://github.com/Shopify/polaris/assets/18447883/01e75949-1e49-44bb-bfdd-02b1131b85aa"> | <img width="1227" alt="Screenshot 2023-10-30 at 3 29 18 PM" src="https://github.com/Shopify/polaris/assets/18447883/6875beb4-d2d4-41fe-9a5f-8cdecaf3c24b">|

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
