### PR TITLE
fix(polaris.shopify.com): `TokenList.Item` url for clickable search result

### DIFF
--- a/.changeset/eight-meals-end.md
+++ b/.changeset/eight-meals-end.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Fixed `TokenList.Item` url for clickable search result

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
@@ -448,9 +448,9 @@ function SearchResults({
                     description: true,
                   }}
                 >
-                  {results.map(({id, meta}) => {
+                  {results.map(({id, meta, url}) => {
                     if (!meta.tokens) return null;
-                    const {token, category} = meta.tokens;
+                    const {token} = meta.tokens;
                     const resultIndex = resultsInRenderedOrder.findIndex(
                       (r) => {
                         return r.id === id;
@@ -463,12 +463,12 @@ function SearchResults({
                         value={{currentItemId, id}}
                       >
                         <TokenList.Item
-                          category={category}
                           token={token}
                           uuid={uuid}
                           customOnClick={captureSearchClick}
                           searchTerm={searchTerm}
                           rank={rank}
+                          url={url}
                         />
                       </SearchContext.Provider>
                     );

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -123,29 +123,28 @@ function getFigmaUsageForToken(
 }
 
 interface TokenListItemProps {
-  category: string;
   token: TokenPropertiesWithName;
   customOnClick?: Function;
   searchTerm?: string;
   rank?: number;
   uuid?: string;
+  url?: string;
 }
 
 function TokenListItem({
-  category,
   token: {name, value, description},
   customOnClick,
   searchTerm,
   rank,
   uuid,
+  url,
 }: TokenListItemProps) {
   const figmaUsage = getFigmaUsageForToken(name, value);
   const tokenNameWithPrefix = `--p-${name}`;
   const [copy, didJustCopy] = useCopyToClipboard(tokenNameWithPrefix);
 
   const searchAttributes = useGlobalSearchResult();
-  const isClickableSearchResult = !!searchAttributes?.tabIndex;
-  const url = `/tokens/${category}#${searchAttributes?.id}`;
+  const isClickableSearchResult = !!searchAttributes?.tabIndex && url;
 
   const customOnClickHandler = () => {
     uuid &&

--- a/polaris.shopify.com/src/components/TokensPage/TokensPage.tsx
+++ b/polaris.shopify.com/src/components/TokensPage/TokensPage.tsx
@@ -146,11 +146,7 @@ function TokensPage({tokenGroup}: Props) {
                   : 1,
               )
               .map((token) => (
-                <TokenList.Item
-                  key={token.name}
-                  category={tokenGroup}
-                  token={token}
-                />
+                <TokenList.Item key={token.name} token={token} />
               ))}
           </TokenList>
         </div>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #11056 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

When I investigated the problem, I noticed the `api/search/v0` will return a perfect URL for each result it gives, so instead of manually creating the link, I used the returned URL by the API, which navigates to the correct page.


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
