### PR TITLE
[IndexTable] Fix header tooltip styling

### DIFF
--- a/.changeset/weak-roses-doubt.md
+++ b/.changeset/weak-roses-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed styling on `IndexTable` component header tooltip

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -902,8 +902,8 @@ function IndexTableBase({
 
     const defaultHeaderTooltipProps = {
       ...defaultTooltipProps,
-      padding: '4' as Padding,
-      borderRadius: '2' as BorderRadius,
+      padding: '400' as Padding,
+      borderRadius: '200' as BorderRadius,
       content: heading.tooltipContent,
       preferredPosition: 'above' as TooltipOverlayProps['preferredPosition'],
     };


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issue reported during v12 bughunt for incorrect Tooltip styling on IndexTable headers.

### WHAT is this pull request doing?

Fixes values passed in from `defaultHeaderTooltipProps` to use the correct padding and border radius token values.
    <details>
      <summary>IndexTable Heading — before</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/176a0b58-88b2-4ba6-9bba-2a10819dec2f" alt="IndexTable Heading — before">
    </details>
    <details>
      <summary>IndexTable Heading — after</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/635cbef9-3fec-46a5-a65a-6fa61d77abdf" alt="IndexTable Heading — after">
    </details>

### How to 🎩

[Storybook](https://5d559397bae39100201eedc1-noluxcicog.chromatic.com/?path=/story/all-components-indextable--with-heading-tooltips)
[Prod storybook](https://storybook.polaris.shopify.com/?path=/story/all-components-indextable--with-heading-tooltips)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
