### PR TITLE
[V12 migrations] Fix shadow card mappings

### DIFF
--- a/.changeset/breezy-gorillas-fix.md
+++ b/.changeset/breezy-gorillas-fix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Removed shadow-card-experimental tokens from v12 shadow migration

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-shadow/tests/v12-styles-replace-custom-property-shadow.input.scss
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-shadow/tests/v12-styles-replace-custom-property-shadow.input.scss
@@ -10,9 +10,6 @@
   box-shadow: var(--p-shadow-xl);
   box-shadow: var(--p-shadow-2xl);
   box-shadow: var(--p-shadow-bevel-experimental);
-  box-shadow: var(--p-shadow-card-sm-experimental);
-  box-shadow: var(--p-shadow-card-md-experimental);
-  box-shadow: var(--p-shadow-card-lg-experimental);
   box-shadow: var(--p-shadow-button-experimental);
   box-shadow: var(--p-shadow-button-hover-experimental);
   box-shadow: var(--p-shadow-button-disabled-experimental);

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-shadow/tests/v12-styles-replace-custom-property-shadow.output.scss
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-shadow/tests/v12-styles-replace-custom-property-shadow.output.scss
@@ -10,9 +10,6 @@
   box-shadow: var(--p-shadow-500);
   box-shadow: var(--p-shadow-600);
   box-shadow: var(--p-shadow-bevel-100);
-  box-shadow: var(--p-shadow-100);
-  box-shadow: var(--p-shadow-200);
-  box-shadow: var(--p-shadow-300);
   box-shadow: var(--p-shadow-button);
   box-shadow: var(--p-shadow-button-hover);
   box-shadow: inset 0 0 0 1px rgba(227, 227, 227, 1);

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-shadow/transform.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-shadow/transform.ts
@@ -19,9 +19,6 @@ const replacementMaps = {
     '--p-shadow-xl': '--p-shadow-500',
     '--p-shadow-2xl': '--p-shadow-600',
     '--p-shadow-bevel-experimental': '--p-shadow-bevel-100',
-    '--p-shadow-card-sm-experimental': '--p-shadow-100',
-    '--p-shadow-card-md-experimental': '--p-shadow-200',
-    '--p-shadow-card-lg-experimental': '--p-shadow-300',
     '--p-shadow-button-experimental': '--p-shadow-button',
     '--p-shadow-button-hover-experimental': '--p-shadow-button-hover',
     '--p-shadow-button-disabled-experimental':

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -2323,9 +2323,9 @@ To replace deprecated `shadow` custom properties, you can run the [v12-styles-re
 | `--p-shadow-xl`                                       | `--p-shadow-500`                         |
 | `--p-shadow-2xl`                                      | `--p-shadow-600`                         |
 | `--p-shadow-bevel-experimental`                       | `--p-shadow-bevel-100`                   |
-| `--p-shadow-card-sm-experimental`                     | `--p-shadow-100`                         |
-| `--p-shadow-card-md-experimental`                     | `--p-shadow-200`                         |
-| `--p-shadow-card-lg-experimental`                     | `--p-shadow-300`                         |
+| `--p-shadow-card-sm-experimental`                     | use the `Card` component instead         |
+| `--p-shadow-card-md-experimental`                     | use the `Card` component instead         |
+| `--p-shadow-card-lg-experimental`                     | use the `Card` component instead         |
 | `--p-shadow-button-experimental`                      | `--p-shadow-button`                      |
 | `--p-shadow-button-hover-experimental`                | `--p-shadow-button-hover`                |
 | `--p-shadow-button-disabled-experimental`             | `inset 0 0 0 1px rgba(227, 227, 227, 1)` |


### PR DESCRIPTION
Previously, we mapped shadow card experimental values like `--p-shadow-card-sm-experimental` -> `--p-shadow-100` in our migrations and migration guide which aren't actually visually equivalent.

Instead, consumers should be manually migrating to use the `Card` component instead. `Card` with the shadow bevel is part of our new design language while the old experimental shadow card values are not.

This token should not be used in a lot of places since it was experimental.