### PR TITLE
[Page] Update titleMetadata documentation

### DIFF
--- a/.changeset/six-yaks-shave.md
+++ b/.changeset/six-yaks-shave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated Page titleMetadata documentation

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
@@ -10,7 +10,7 @@ export interface TitleProps {
   title?: string;
   /** Page subtitle, in regular type */
   subtitle?: string;
-  /** Important and non-interactive status information shown immediately after the title. */
+  /** Important status information shown immediately after the title. */
   titleMetadata?: React.ReactNode;
   /** Removes spacing between title and subtitle */
   compactTitle?: boolean;


### PR DESCRIPTION
`titleMetadata` is currently being used in orders for the location picker. It's sometimes useful to have interactive content here