### PR TITLE
Fixed ref error and removed bulk action warning

### DIFF
--- a/.changeset/brave-pans-relate.md
+++ b/.changeset/brave-pans-relate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed ref error in `Tabs` for `CreateViewModal` and removed promoted bulk action warnings

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -276,8 +276,7 @@
       },
       "BulkActions": {
         "actionsActivatorLabel": "Actions",
-        "moreActionsActivatorLabel": "More actions",
-        "warningMessage": "To provide a better user experience. There should only be a maximum of {maxPromotedActions} promoted actions."
+        "moreActionsActivatorLabel": "More actions"
       }
     },
     "SkeletonPage": {

--- a/polaris-react/src/components/BulkActions/BulkActions.tsx
+++ b/polaris-react/src/components/BulkActions/BulkActions.tsx
@@ -26,8 +26,6 @@ type BulkActionListSection = ActionListSection;
 
 type TransitionStatus = 'entering' | 'entered' | 'exiting' | 'exited';
 
-const MAX_PROMOTED_ACTIONS = 2;
-
 const BUTTONS_NODE_ADDITIONAL_WIDTH = 64;
 
 export interface BulkActionsProps {
@@ -206,19 +204,6 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
       this.props;
 
     const actionSections = this.actionSections();
-
-    if (
-      promotedActions &&
-      promotedActions.length > MAX_PROMOTED_ACTIONS &&
-      process.env.NODE_ENV === 'development'
-    ) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        i18n.translate('Polaris.ResourceList.BulkActions.warningMessage', {
-          maxPromotedActions: MAX_PROMOTED_ACTIONS,
-        }),
-      );
-    }
 
     const {popoverVisible, measuring} = this.state;
 

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -603,13 +603,17 @@ export const Tabs = ({
                     disabled ? (
                       newTab
                     ) : (
-                      <Tooltip
-                        content={i18n.translate('Polaris.Tabs.newViewTooltip')}
-                        preferredPosition="above"
-                        hoverDelay={400}
-                      >
-                        {newTab}
-                      </Tooltip>
+                      <div>
+                        <Tooltip
+                          content={i18n.translate(
+                            'Polaris.Tabs.newViewTooltip',
+                          )}
+                          preferredPosition="above"
+                          hoverDelay={400}
+                        >
+                          {newTab}
+                        </Tooltip>
+                      </div>
                     )
                   }
                 />


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/11133, https://github.com/Shopify/polaris/issues/11134

The pull request address two issues.

`Tooltips` is a functional component that doesn't use `forwardRef`. However, the modal component focuses it's activator for accessibility reasons. The tabs component is providing a modal with a tooltip as it's activator, resulting in the console error.

The second issue is the promoted bulk actions warning. This warning message display when more than 2 promoted bulk actions are used. However, we don't follow this internally, in our component examples, or have supporting documentation for.

### WHAT is this pull request doing?

#### Old - Bulk Action warning

<img width="476" alt="Screenshot 2023-11-03 at 10 17 42 AM" src="https://github.com/Shopify/polaris/assets/24610840/1fd22fa4-29b2-4537-8218-e9aabde90939">

#### Old - ref error
<img width="775" alt="Screenshot 2023-11-03 at 10 20 32 AM" src="https://github.com/Shopify/polaris/assets/24610840/864ba8e9-8e13-4481-8c45-661faef31da8">

### How to 🎩

View a story with over 2 bulk actions. For example `all-components-indextable--with-multiple-promoted-bulk-actions`. The warning should be gone.

View a story with the add view action. For example `all-components-indexfilters--default`. The error should be gone.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
