### PR TITLE
Load Inter from Shopify CDN instead of Google

### DIFF
--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -1,11 +1,6 @@
-<link rel="preconnect" href="https://fonts.googleapis.com/" />
-<link
-  rel="preconnect"
-  href="https://fonts.gstatic.com/"
-  crossorigin="anonymous"
-/>
+<link rel="preconnect" href="https://cdn.shopify.com/" />
 <link
   id="inter-font-link"
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap"
+  href="https://cdn.shopify.com/static/fonts/inter/inter.css"
   rel="stylesheet"
 />

--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -59,17 +59,13 @@ ReactDOM.render(
 );
 ```
 
-4. Load the web font [Inter](https://fonts.google.com/specimen/Inter).
+4. Load the web font [Inter](https://github.com/rsms/inter).
 
 ```html
-<link rel="preconnect" href="https://fonts.googleapis.com/" />
+<link rel="preconnect" href="https://cdn.shopify.com/" />
 <link
-  rel="preconnect"
-  href="https://fonts.gstatic.com/"
-  crossorigin="anonymous"
-/>
-<link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap"
+  rel="stylesheet"
+  href="https://cdn.shopify.com/static/fonts/inter/inter.css"
 />
 ```
 

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.md
@@ -2811,14 +2811,20 @@ Instead of importing `tokens` directly you should use the `useTheme` hook when y
 
 ### A new web font
 
-The new design language comes with a web font called [Inter via Google Fonts](https://fonts.google.com/specimen/Inter).
-Polaris references this font but does not load it. Your app will need to load the font, otherwise it will fallback to the user's system font.
+The new design language comes with a web font called [Inter](https://github.com/rsms/inter).
+
+Polaris references this font but does not load it. Your app will need to load the font, otherwise it will fallback to the user's system font. You can load this font from Shopify by adding the following to your app's `<head>`:
 
 {/* prettier-ignore */}
 ```html
-<link rel="preconnect" href="https://fonts.googleapis.com/" />
-<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous" />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap" />
+<link
+  rel="preconnect"
+  href="https://cdn.shopify.com/"
+/>
+<link
+  rel="stylesheet"
+  href="https://cdn.shopify.com/static/fonts/inter/inter.css"
+/>
 ```
 
 ### Icons

--- a/polaris.shopify.com/pages/_document.tsx
+++ b/polaris.shopify.com/pages/_document.tsx
@@ -4,8 +4,9 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        <link rel="preconnect" href="https://cdn.shopify.com/" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@450;550;650;700&display=swap"
+          href="https://cdn.shopify.com/static/fonts/inter/inter.css"
           rel="stylesheet"
         ></link>
       </Head>

--- a/polaris.shopify.com/scripts/gen-og-images.mjs
+++ b/polaris.shopify.com/scripts/gen-og-images.mjs
@@ -81,7 +81,7 @@ const generateHTML = async (url, slug) => {
 
   const html = `
   <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@650');
+  @import url('https://cdn.shopify.com/static/fonts/inter/inter.css');
 
   * {
     margin: 0;


### PR DESCRIPTION
This PR makes the following updates

- update the Polaris usage documentation for adding the Inter font from Shopify
- updates Storybook to load the inter font from Shopify