### PR TITLE
Fix issue with double // in URLs

### DIFF
--- a/polaris.shopify.com/src/components/Page/Page.tsx
+++ b/polaris.shopify.com/src/components/Page/Page.tsx
@@ -37,7 +37,7 @@ function Layout({
     githubIssueSubject,
   )}&amp;labels=polaris.shopify.com`;
   const editOnGithubUrl = editPageLinkPath
-    ? `https://github.com/Shopify/polaris/tree/main/${editPageLinkPath}`
+    ? `https://github.com/Shopify/polaris/tree/main${editPageLinkPath}`
     : '';
 
   return (


### PR DESCRIPTION
Fixes the issue seen in `yarn build` where URLs have the wrong slashes.

```
polaris.shopify.com:build: Invalid href passed to next/router: https://github.com/Shopify/polaris/tree/main//polaris.shopify.com/content/design/motion/using-motion.md, repeated forward-slashes (//) or backslashes \ are not valid in the href
```
