### PR TITLE
[Button] Updated button base color tokens

### DIFF
--- a/.changeset/thin-bottles-dream.md
+++ b/.changeset/thin-bottles-dream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated `Button` base state colors to use `fill` tokens

--- a/polaris-react/src/styles/shared/_buttons.scss
+++ b/polaris-react/src/styles/shared/_buttons.scss
@@ -13,7 +13,7 @@
   min-width: 28px;
   margin: 0;
   padding: var(--p-space-150) var(--p-space-300);
-  background: var(--p-color-bg-surface);
+  background: var(--p-color-bg-fill);
   box-shadow: var(--p-shadow-200);
   border-radius: var(--p-border-radius-200);
   color: var(--p-color-text);
@@ -30,7 +30,7 @@
   }
 
   &:hover {
-    background: var(--p-color-bg-surface-hover);
+    background: var(--p-color-bg-fill-hover);
     outline: var(--p-border-width-025) solid transparent;
   }
 
@@ -50,7 +50,7 @@
   }
 
   &.pressed {
-    background: var(--p-color-bg-fill-tertiary-active);
+    background: var(--p-color-bg-fill-selected);
     box-shadow: var(--p-shadow-inset-200);
     color: var(--p-color-text);
     border-color: var(--p-color-border-inverse);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #[11120](https://github.com/Shopify/polaris/issues/11120)

Button base using unexpected color tokens

### WHAT is this pull request doing?

Updates Button base color tokens for default, hover, active, and pressed states to use `--p-color-bg-fill-` tokens

before | after
--|--
![2023-11-06 16 03 37](https://github.com/Shopify/polaris/assets/8629173/265a9ff9-e84c-442a-8947-28b2484c8c8c) | ![2023-11-06 16 03 54](https://github.com/Shopify/polaris/assets/8629173/67682d36-6aef-4640-aaf4-16d4fc246b0d)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
