### PR TITLE
[Button] Remove bevel from pressed focused state

### DIFF
--- a/.changeset/proud-yaks-invent.md
+++ b/.changeset/proud-yaks-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Removed bevel from `pressed` `Button` when focused

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -47,8 +47,8 @@
   }
 
   // stylelint-disable selector-max-specificity -- focus styles
-  &:focus:not(.variantPrimary):not(.variantTertiary):not(.variantPlain):not(.variantMonochromePlain),
-  &:focus-visible:not(.variantPrimary):not(.variantTertiary):not(.variantPlain):not(.variantMonochromePlain) {
+  &:focus:not(.variantPrimary):not(.variantTertiary):not(.variantPlain):not(.variantMonochromePlain):not(.pressed),
+  &:focus-visible:not(.variantPrimary):not(.variantTertiary):not(.variantPlain):not(.variantMonochromePlain):not(.pressed) {
     // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- custom property
     box-shadow: var(--pc-button-shadow);
   }


### PR DESCRIPTION
Removes bevel from `Button` pressed focused state

before | after
--|--
![2023-11-06 16 24 28](https://github.com/Shopify/polaris/assets/8629173/0d82b3dd-7993-4feb-849e-1fdefe30a5c2) | ![2023-11-06 16 24 12](https://github.com/Shopify/polaris/assets/8629173/87db0c03-0c8b-47e3-bd38-ee860c158b5b)
