### PR TITLE
Remove version from icons yml file

### DIFF
--- a/.changeset/wild-ties-join.md
+++ b/.changeset/wild-ties-join.md
@@ -9,3 +9,5 @@ Update icons for `Jobs`, `JobsFilled`, `Automation`, `AutomationFilled`, `GiftCa
 Added new icons for `ShippingLabel`, `ShippingLabelFilled`, `Bill`, `BillFilled`, `UsersPermissions`, `UsersPermissionsFilled`, `ActivityLog`, `ActivityLogFilled`, `Instagram`, `Tips`
 
 Removed icons `ReportFilledMinor`, `ReportMinor`, `ListMajor`, `ListFilledMajor`
+
+Remove `version` from icon `.yml` files

--- a/polaris-icons/icons/AbandonedCart.yml
+++ b/polaris-icons/icons/AbandonedCart.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AbandonedCartFilled.yml
+++ b/polaris-icons/icons/AbandonedCartFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - funnel
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Accessibility.yml
+++ b/polaris-icons/icons/Accessibility.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Activities.yml
+++ b/polaris-icons/icons/Activities.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ActivityLog.yml
+++ b/polaris-icons/icons/ActivityLog.yml
@@ -6,7 +6,6 @@ keywords:
   - Activity
 authors:
   - José Torre
-version: 1
 date_added: 2023-11-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/ActivityLogFilled.yml
+++ b/polaris-icons/icons/ActivityLogFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - Activity
 authors:
   - José Torre
-version: 1
 date_added: 2023-11-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Add.yml
+++ b/polaris-icons/icons/Add.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AddCode.yml
+++ b/polaris-icons/icons/AddCode.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AddImage.yml
+++ b/polaris-icons/icons/AddImage.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AddNote.yml
+++ b/polaris-icons/icons/AddNote.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AddProduct.yml
+++ b/polaris-icons/icons/AddProduct.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Anthony Menecola
   - Joe Thomas
-version: 2
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Adjust.yml
+++ b/polaris-icons/icons/Adjust.yml
@@ -10,7 +10,6 @@ authors:
   - Chris Poirier
   - Lauren Mayers
   - Joe Thomas
-version: 1
 date_added: 2022-02-02
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Affiliate.yml
+++ b/polaris-icons/icons/Affiliate.yml
@@ -6,7 +6,6 @@ authors:
 description: N/A
 keywords:
   - N/A
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Alert.yml
+++ b/polaris-icons/icons/Alert.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Analytics.yml
+++ b/polaris-icons/icons/Analytics.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-01-17
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AnalyticsBarHorizontal.yml
+++ b/polaris-icons/icons/AnalyticsBarHorizontal.yml
@@ -7,6 +7,5 @@ keywords:
 authors:
   - Rachel Ng
   - Joe Thomas
-version: 1
 date_added: 2023-04-26
 date_modified: 2023-06-23

--- a/polaris-icons/icons/AnalyticsBarStacked.yml
+++ b/polaris-icons/icons/AnalyticsBarStacked.yml
@@ -7,6 +7,5 @@ keywords:
 authors:
   - Rachel Ng
   - Joe Thomas
-version: 1
 date_added: 2023-04-26
 date_modified: 2023-06-23

--- a/polaris-icons/icons/AnalyticsCohort.yml
+++ b/polaris-icons/icons/AnalyticsCohort.yml
@@ -8,6 +8,5 @@ keywords:
 authors:
   - Rachel Ng
   - Joe Thomas
-version: 1
 date_added: 2023-04-26
 date_modified: 2023-06-23

--- a/polaris-icons/icons/AnalyticsDonut.yml
+++ b/polaris-icons/icons/AnalyticsDonut.yml
@@ -7,6 +7,5 @@ keywords:
 authors:
   - Rachel Ng
   - Joe Thomas
-version: 1
 date_added: 2023-04-26
 date_modified: 2023-06-23

--- a/polaris-icons/icons/AnalyticsFilled.yml
+++ b/polaris-icons/icons/AnalyticsFilled.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/AnalyticsFunnel.yml
+++ b/polaris-icons/icons/AnalyticsFunnel.yml
@@ -7,6 +7,5 @@ keywords:
 authors:
   - Rachel Ng
   - Joe Thomas
-version: 1
 date_added: 2023-04-26
 date_modified: 2023-06-23

--- a/polaris-icons/icons/AnalyticsLine.yml
+++ b/polaris-icons/icons/AnalyticsLine.yml
@@ -7,6 +7,5 @@ keywords:
 authors:
   - Rachel Ng
   - Joe Thomas
-version: 1
 date_added: 2023-04-26
 date_modified: 2023-06-23

--- a/polaris-icons/icons/AnalyticsTable.yml
+++ b/polaris-icons/icons/AnalyticsTable.yml
@@ -6,6 +6,5 @@ keywords:
 authors:
   - Rachel Ng
   - Joe Thomas
-version: 1
 date_added: 2023-04-26
 date_modified: 2023-06-23

--- a/polaris-icons/icons/AnyClickModel.yml
+++ b/polaris-icons/icons/AnyClickModel.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Alison Munn Garcia
   - Joe Thomas
-version: 1
 date_added: 2023-04-21
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AppExtension.yml
+++ b/polaris-icons/icons/AppExtension.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Apps.yml
+++ b/polaris-icons/icons/Apps.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 2
 date_added: 2022-01-19
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AppsFilled.yml
+++ b/polaris-icons/icons/AppsFilled.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Archive.yml
+++ b/polaris-icons/icons/Archive.yml
@@ -7,7 +7,6 @@ description: Used to denote the action of archiving an item or resource.
 keywords:
   - archive
   - box
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ArrowDown.yml
+++ b/polaris-icons/icons/ArrowDown.yml
@@ -8,5 +8,4 @@ authors:
   - Joe Thomas
 date_added: 2018-11-14
 date_modified: 2023-06-23
-version: 1
 exclusive_use:

--- a/polaris-icons/icons/ArrowLeft.yml
+++ b/polaris-icons/icons/ArrowLeft.yml
@@ -8,7 +8,6 @@ keywords:
   - arrow
   - left
   - previous
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ArrowRight.yml
+++ b/polaris-icons/icons/ArrowRight.yml
@@ -8,7 +8,6 @@ keywords:
   - arrow
   - right
   - next
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ArrowUp.yml
+++ b/polaris-icons/icons/ArrowUp.yml
@@ -7,7 +7,6 @@ description: Used to represent a positive trend when looking at analytical infor
 keywords:
   - arrow
   - up
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Attachment.yml
+++ b/polaris-icons/icons/Attachment.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/AttachmentFilled.yml
+++ b/polaris-icons/icons/AttachmentFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - files
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Automation.yml
+++ b/polaris-icons/icons/Automation.yml
@@ -10,7 +10,6 @@ keywords:
   - cog
   - automated
   - gear
-version: 1
 date_added: 2019-10-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/AutomationFilled.yml
+++ b/polaris-icons/icons/AutomationFilled.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Backspace.yml
+++ b/polaris-icons/icons/Backspace.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Balance.yml
+++ b/polaris-icons/icons/Balance.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Brian Potstra
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BalanceFilled.yml
+++ b/polaris-icons/icons/BalanceFilled.yml
@@ -10,7 +10,6 @@ keywords:
   - payout
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Bank.yml
+++ b/polaris-icons/icons/Bank.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BankFilled.yml
+++ b/polaris-icons/icons/BankFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Barcode.yml
+++ b/polaris-icons/icons/Barcode.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Behavior.yml
+++ b/polaris-icons/icons/Behavior.yml
@@ -5,7 +5,6 @@ keywords:
   - cursor
 authors:
   - Joe Thomas
-version: 1
 date_added: 2022-06-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BehaviorFilled.yml
+++ b/polaris-icons/icons/BehaviorFilled.yml
@@ -5,7 +5,6 @@ keywords:
   - cursor
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Bill.yml
+++ b/polaris-icons/icons/Bill.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - José Torre
-version: 1
 date_added: 2023-11-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/BillFilled.yml
+++ b/polaris-icons/icons/BillFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - José Torre
-version: 1
 date_added: 2023-11-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementDollar.yml
+++ b/polaris-icons/icons/BillingStatementDollar.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementDollarFilled.yml
+++ b/polaris-icons/icons/BillingStatementDollarFilled.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementEuro.yml
+++ b/polaris-icons/icons/BillingStatementEuro.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementEuroFilled.yml
+++ b/polaris-icons/icons/BillingStatementEuroFilled.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementPound.yml
+++ b/polaris-icons/icons/BillingStatementPound.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementPoundFilled.yml
+++ b/polaris-icons/icons/BillingStatementPoundFilled.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementRupee.yml
+++ b/polaris-icons/icons/BillingStatementRupee.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementRupeeFilled.yml
+++ b/polaris-icons/icons/BillingStatementRupeeFilled.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementYen.yml
+++ b/polaris-icons/icons/BillingStatementYen.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BillingStatementYenFilled.yml
+++ b/polaris-icons/icons/BillingStatementYenFilled.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Block.yml
+++ b/polaris-icons/icons/Block.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Rozina Szogyenyi
   - Joe Thomas
-version: 1
 date_added: 2021-08-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Blockquote.yml
+++ b/polaris-icons/icons/Blockquote.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Blog.yml
+++ b/polaris-icons/icons/Blog.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Bold.yml
+++ b/polaris-icons/icons/Bold.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Joe Thomas
   - Russell Baylis
-version: 1
 date_added: 2023-06-30
 date_modified: 2023-07-19`
 exclusive_use:

--- a/polaris-icons/icons/Bug.yml
+++ b/polaris-icons/icons/Bug.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Button.yml
+++ b/polaris-icons/icons/Button.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Rozina Szogyenyi
   - Joe Thomas
-version: 1
 date_added: 2021-08-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ButtonCornerPill.yml
+++ b/polaris-icons/icons/ButtonCornerPill.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Laura Forbes
   - Joe Thomas
-version: 1
 date_added: 2021-02-09
 date_modified: 2023-06-23
 exclusive_use: Made for Shopify Email Editor

--- a/polaris-icons/icons/ButtonCornerRounded.yml
+++ b/polaris-icons/icons/ButtonCornerRounded.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Laura Forbes
   - Joe Thomas
-version: 1
 date_added: 2021-02-09
 date_modified: 2023-06-23
 exclusive_use: Made for Shopify Email Editor

--- a/polaris-icons/icons/ButtonCornerSquare.yml
+++ b/polaris-icons/icons/ButtonCornerSquare.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Laura Forbes
   - Joe Thomas
-version: 1
 date_added: 2021-02-09
 date_modified: 2023-06-23
 exclusive_use: Made for Shopify Email Editor

--- a/polaris-icons/icons/BuyButton.yml
+++ b/polaris-icons/icons/BuyButton.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BuyButtonButtonLayout.yml
+++ b/polaris-icons/icons/BuyButtonButtonLayout.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BuyButtonHorizontalLayout.yml
+++ b/polaris-icons/icons/BuyButtonHorizontalLayout.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/BuyButtonVerticalLayout.yml
+++ b/polaris-icons/icons/BuyButtonVerticalLayout.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Calendar.yml
+++ b/polaris-icons/icons/Calendar.yml
@@ -12,5 +12,4 @@ authors:
   - Joe Thomas
 date_added: 2018-11-14
 date_modified: 2023-06-23
-version: 1
 exclusive_use:

--- a/polaris-icons/icons/CalendarTick.yml
+++ b/polaris-icons/icons/CalendarTick.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CalendarTime.yml
+++ b/polaris-icons/icons/CalendarTime.yml
@@ -13,5 +13,4 @@ authors:
   - Joe Thomas
 date_added: 2023-01-12
 date_modified: 2023-06-23
-version: 1
 exclusive_use:

--- a/polaris-icons/icons/Camera.yml
+++ b/polaris-icons/icons/Camera.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Cancel.yml
+++ b/polaris-icons/icons/Cancel.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-10-28
 date_modified: 2023-07-28
 exclusive_use:

--- a/polaris-icons/icons/CancelSmall.yml
+++ b/polaris-icons/icons/CancelSmall.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Capital.yml
+++ b/polaris-icons/icons/Capital.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Mo Mozafarian
   - Joe Thomas
-version: 1
 date_added: 2019-09-03
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CapitalFilled.yml
+++ b/polaris-icons/icons/CapitalFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - plant
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/CapturePayment.yml
+++ b/polaris-icons/icons/CapturePayment.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CardReader.yml
+++ b/polaris-icons/icons/CardReader.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CardReaderChip.yml
+++ b/polaris-icons/icons/CardReaderChip.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CardReaderTap.yml
+++ b/polaris-icons/icons/CardReaderTap.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CaretDown.yml
+++ b/polaris-icons/icons/CaretDown.yml
@@ -10,7 +10,6 @@ authors:
   - Adam Whitcroft
   - Jordan Ouellette
   - Joe Thomas
-version: 2
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CaretUp.yml
+++ b/polaris-icons/icons/CaretUp.yml
@@ -10,7 +10,6 @@ authors:
   - Adam Whitcroft
   - Jordan Ouellette
   - Joe Thomas
-version: 2
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Cart.yml
+++ b/polaris-icons/icons/Cart.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CartDown.yml
+++ b/polaris-icons/icons/CartDown.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CartDownFilled.yml
+++ b/polaris-icons/icons/CartDownFilled.yml
@@ -5,7 +5,6 @@ keywords:
   - checkout
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/CartFilled.yml
+++ b/polaris-icons/icons/CartFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - shopping
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/CartUp.yml
+++ b/polaris-icons/icons/CartUp.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CashDollar.yml
+++ b/polaris-icons/icons/CashDollar.yml
@@ -8,7 +8,6 @@ authors:
   - Nayeob Kim
   - Leina Leung
   - Joe Thomas
-version: 1
 date_added: 2022-09-19
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CashDollarFilled.yml
+++ b/polaris-icons/icons/CashDollarFilled.yml
@@ -5,7 +5,6 @@ keywords:
   - money
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/CashEuro.yml
+++ b/polaris-icons/icons/CashEuro.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CashPound.yml
+++ b/polaris-icons/icons/CashPound.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CashRupee.yml
+++ b/polaris-icons/icons/CashRupee.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CashYen.yml
+++ b/polaris-icons/icons/CashYen.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Categories.yml
+++ b/polaris-icons/icons/Categories.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Channels.yml
+++ b/polaris-icons/icons/Channels.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Chat.yml
+++ b/polaris-icons/icons/Chat.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Checklist.yml
+++ b/polaris-icons/icons/Checklist.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ChecklistAlternate.yml
+++ b/polaris-icons/icons/ChecklistAlternate.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Checkout.yml
+++ b/polaris-icons/icons/Checkout.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ChevronDown.yml
+++ b/polaris-icons/icons/ChevronDown.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ChevronLeft.yml
+++ b/polaris-icons/icons/ChevronLeft.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ChevronRight.yml
+++ b/polaris-icons/icons/ChevronRight.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ChevronUp.yml
+++ b/polaris-icons/icons/ChevronUp.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleAlert.yml
+++ b/polaris-icons/icons/CircleAlert.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-21
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleCancel.yml
+++ b/polaris-icons/icons/CircleCancel.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleChevronDown.yml
+++ b/polaris-icons/icons/CircleChevronDown.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleChevronLeft.yml
+++ b/polaris-icons/icons/CircleChevronLeft.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleChevronRight.yml
+++ b/polaris-icons/icons/CircleChevronRight.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleChevronUp.yml
+++ b/polaris-icons/icons/CircleChevronUp.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleDisable.yml
+++ b/polaris-icons/icons/CircleDisable.yml
@@ -13,7 +13,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleDisabled.yml
+++ b/polaris-icons/icons/CircleDisabled.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleDots.yml
+++ b/polaris-icons/icons/CircleDots.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleDown.yml
+++ b/polaris-icons/icons/CircleDown.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleInformation.yml
+++ b/polaris-icons/icons/CircleInformation.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleLeft.yml
+++ b/polaris-icons/icons/CircleLeft.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleMinus.yml
+++ b/polaris-icons/icons/CircleMinus.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleMinusOutline.yml
+++ b/polaris-icons/icons/CircleMinusOutline.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CirclePlus.yml
+++ b/polaris-icons/icons/CirclePlus.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CirclePlusOutline.yml
+++ b/polaris-icons/icons/CirclePlusOutline.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleRight.yml
+++ b/polaris-icons/icons/CircleRight.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleTick.yml
+++ b/polaris-icons/icons/CircleTick.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Anne Michel
   - Joe Thomas
-version: 1
 date_added: 2021-11-11
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleTickOutline.yml
+++ b/polaris-icons/icons/CircleTickOutline.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CircleUp.yml
+++ b/polaris-icons/icons/CircleUp.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Clipboard.yml
+++ b/polaris-icons/icons/Clipboard.yml
@@ -8,7 +8,6 @@ authors:
   - Adam Whitcroft
   - José Torre
   - Joe Thomas
-version: 2
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Clock.yml
+++ b/polaris-icons/icons/Clock.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-11
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Code.yml
+++ b/polaris-icons/icons/Code.yml
@@ -19,7 +19,6 @@ authors:
   - 'n'
   - g
   - Joe Thomas
-version: 1
 date_added: 2022-09-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CollectionReference.yml
+++ b/polaris-icons/icons/CollectionReference.yml
@@ -8,7 +8,6 @@ authors:
   - Sai Nihas
   - Leina Leung
   - Joe Thomas
-version: 1
 date_added: 2023-01-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Collections.yml
+++ b/polaris-icons/icons/Collections.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CollectionsFilled.yml
+++ b/polaris-icons/icons/CollectionsFilled.yml
@@ -7,7 +7,6 @@ keywords:
   - swing
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/ColorNone.yml
+++ b/polaris-icons/icons/ColorNone.yml
@@ -15,7 +15,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Colors.yml
+++ b/polaris-icons/icons/Colors.yml
@@ -8,7 +8,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Column1.yml
+++ b/polaris-icons/icons/Column1.yml
@@ -11,4 +11,3 @@ authors:
 exclusive_use: Shopify Email
 date_added: 2021-01-12
 date_modified: 2023-06-23
-version: 1

--- a/polaris-icons/icons/ColumnWithText.yml
+++ b/polaris-icons/icons/ColumnWithText.yml
@@ -18,7 +18,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Columns2.yml
+++ b/polaris-icons/icons/Columns2.yml
@@ -11,4 +11,3 @@ authors:
 exclusive_use: Shopify Email
 date_added: 2021-01-12
 date_modified: 2023-06-23
-version: 1

--- a/polaris-icons/icons/Columns3.yml
+++ b/polaris-icons/icons/Columns3.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Andrea Crouch
   - Joe Thomas
-version: 2
 date_added: 2022-01-05
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Compose.yml
+++ b/polaris-icons/icons/Compose.yml
@@ -10,7 +10,6 @@ authors:
   - Anthony Menecola
   - Jesse Bennett-Chamberlain
   - Joe Thomas
-version: 1
 date_added: 2020-07-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Confetti.yml
+++ b/polaris-icons/icons/Confetti.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Connect.yml
+++ b/polaris-icons/icons/Connect.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Content.yml
+++ b/polaris-icons/icons/Content.yml
@@ -8,7 +8,6 @@ authors:
   - Sai Nihas
   - Rusty Baylis
   - Joe Thomas
-version: 1
 date_added: 2023-01-23
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ContentFilled.yml
+++ b/polaris-icons/icons/ContentFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - metaobjects
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Conversation.yml
+++ b/polaris-icons/icons/Conversation.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CreditCard.yml
+++ b/polaris-icons/icons/CreditCard.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CreditCardCancel.yml
+++ b/polaris-icons/icons/CreditCardCancel.yml
@@ -9,7 +9,6 @@ authors:
   - Elushika Weerakoon
   - Zackery Wilson
   - Joe Thomas
-version: 1
 date_added: 2022-04-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CreditCardPercent.yml
+++ b/polaris-icons/icons/CreditCardPercent.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CreditCardSecure.yml
+++ b/polaris-icons/icons/CreditCardSecure.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CurrencyConvert.yml
+++ b/polaris-icons/icons/CurrencyConvert.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CustomerMinus.yml
+++ b/polaris-icons/icons/CustomerMinus.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CustomerPlus.yml
+++ b/polaris-icons/icons/CustomerPlus.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Customers.yml
+++ b/polaris-icons/icons/Customers.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-11-19
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/CustomersFilled.yml
+++ b/polaris-icons/icons/CustomersFilled.yml
@@ -5,7 +5,6 @@ keywords:
   - user
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/DataDrivenModel.yml
+++ b/polaris-icons/icons/DataDrivenModel.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Serene Chen
   - Joe Thomas
-version: 1
 date_added: 2022-10-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DataVisualization.yml
+++ b/polaris-icons/icons/DataVisualization.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Decimal.yml
+++ b/polaris-icons/icons/Decimal.yml
@@ -8,5 +8,4 @@ authors:
   - Joe Thomas
 date_added: 2023-01-12
 date_modified: 2023-06-23
-version: 1
 exclusive_use:

--- a/polaris-icons/icons/Delete.yml
+++ b/polaris-icons/icons/Delete.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Desktop.yml
+++ b/polaris-icons/icons/Desktop.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DetailedPopUp.yml
+++ b/polaris-icons/icons/DetailedPopUp.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Alex Page
   - Joe Thomas
-version: 2
 date_added: 2020-09-21
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DiamondAlert.yml
+++ b/polaris-icons/icons/DiamondAlert.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Jesse Bennett-Chamberlain
   - Joe Thomas
-version: 1
 date_added: 2023-01-16
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DigitalMediaReceiver.yml
+++ b/polaris-icons/icons/DigitalMediaReceiver.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DiscountAutomatic.yml
+++ b/polaris-icons/icons/DiscountAutomatic.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DiscountCode.yml
+++ b/polaris-icons/icons/DiscountCode.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Discounts.yml
+++ b/polaris-icons/icons/Discounts.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-01-17
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DiscountsFilled.yml
+++ b/polaris-icons/icons/DiscountsFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - discount
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Dispute.yml
+++ b/polaris-icons/icons/Dispute.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DnsSettings.yml
+++ b/polaris-icons/icons/DnsSettings.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DockFloating.yml
+++ b/polaris-icons/icons/DockFloating.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Jon Rundle
   - Joe Thomas
-version: 1
 date_added: 2023-04-28
 date_modified: 2023-06-23
 exclusive_use: Magic Chat

--- a/polaris-icons/icons/DockSide.yml
+++ b/polaris-icons/icons/DockSide.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Jon Rundle
   - Joe Thomas
-version: 1
 date_added: 2023-04-28
 date_modified: 2023-06-23
 exclusive_use: Magic Chat

--- a/polaris-icons/icons/DomainNew.yml
+++ b/polaris-icons/icons/DomainNew.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - José Torre
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/DomainRedirect.yml
+++ b/polaris-icons/icons/DomainRedirect.yml
@@ -7,7 +7,6 @@ authors:
   - Kyryll Odobetskiy
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2022-02-23
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Domains.yml
+++ b/polaris-icons/icons/Domains.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - José Torre
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/DomainsFilled.yml
+++ b/polaris-icons/icons/DomainsFilled.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/DraftOrders.yml
+++ b/polaris-icons/icons/DraftOrders.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DraftOrdersFilled.yml
+++ b/polaris-icons/icons/DraftOrdersFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - pending
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/DragDrop.yml
+++ b/polaris-icons/icons/DragDrop.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-21
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DragHandle.yml
+++ b/polaris-icons/icons/DragHandle.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Dropdown.yml
+++ b/polaris-icons/icons/Dropdown.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Jordan Ouellette
   - Joe Thomas
-version: 3
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Duplicate.yml
+++ b/polaris-icons/icons/Duplicate.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/DynamicSource.yml
+++ b/polaris-icons/icons/DynamicSource.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Russell Baylis
   - Joe Thomas
-version: 1
 date_added: 2022-09-06
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Edit.yml
+++ b/polaris-icons/icons/Edit.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Email.yml
+++ b/polaris-icons/icons/Email.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/EmailNewsletter.yml
+++ b/polaris-icons/icons/EmailNewsletter.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Embed.yml
+++ b/polaris-icons/icons/Embed.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/EnableSelection.yml
+++ b/polaris-icons/icons/EnableSelection.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-21
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Enter.yml
+++ b/polaris-icons/icons/Enter.yml
@@ -10,7 +10,6 @@ authors:
   - Ashley Allen
   - José Torre
   - Joe Thomas
-version: 1
 date_added: 2023-01-20
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Envelope.yml
+++ b/polaris-icons/icons/Envelope.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Exchange.yml
+++ b/polaris-icons/icons/Exchange.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ExistingInventory.yml
+++ b/polaris-icons/icons/ExistingInventory.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Exit.yml
+++ b/polaris-icons/icons/Exit.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Jose Torre
   - Joe Thomas
-version: 1
 date_added: 2021-05-11
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ExploreImages.yml
+++ b/polaris-icons/icons/ExploreImages.yml
@@ -7,6 +7,5 @@ authors:
   - Osama ghazal
   - Alejandro Echandia
   - Joe Thomas
-version: 1
 date_added: 2023-04-05
 date_modified: 2023-06-23

--- a/polaris-icons/icons/Export.yml
+++ b/polaris-icons/icons/Export.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Extend.yml
+++ b/polaris-icons/icons/Extend.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - David Goligorsky
   - Joe Thomas
-version: 1
 date_added: 2023-03-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/External.yml
+++ b/polaris-icons/icons/External.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ExternalSmall.yml
+++ b/polaris-icons/icons/ExternalSmall.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/EyeDropper.yml
+++ b/polaris-icons/icons/EyeDropper.yml
@@ -17,7 +17,6 @@ authors:
   - 'n'
   - g
   - Joe Thomas
-version: 1
 date_added: 2022-09-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Facebook.yml
+++ b/polaris-icons/icons/Facebook.yml
@@ -6,7 +6,6 @@ keywords:
   - social media
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-20
 date_modified: 2023-07-28
 exclusive_use:

--- a/polaris-icons/icons/Favicon.yml
+++ b/polaris-icons/icons/Favicon.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Favorite.yml
+++ b/polaris-icons/icons/Favorite.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 2
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FeaturedCollection.yml
+++ b/polaris-icons/icons/FeaturedCollection.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FeaturedContent.yml
+++ b/polaris-icons/icons/FeaturedContent.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/File.yml
+++ b/polaris-icons/icons/File.yml
@@ -9,5 +9,4 @@ authors:
   - Joe Thomas
 date_added: 2023-01-17
 date_modified: 2023-06-23
-version: 1
 exclusive_use:

--- a/polaris-icons/icons/FileFilled.yml
+++ b/polaris-icons/icons/FileFilled.yml
@@ -9,5 +9,4 @@ authors:
   - José Torre
 date_added: 2023-07-06
 date_modified: 2023-11-07
-version: 1
 exclusive_use:

--- a/polaris-icons/icons/Filter.yml
+++ b/polaris-icons/icons/Filter.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Demi Peppas
   - Joe Thomas
-version: 1
 date_added: 2022-09-07
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Finances.yml
+++ b/polaris-icons/icons/Finances.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Sam Yuan
   - Joe Thomas
-version: 3
 date_added: 2022-01-17
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FirstClickModel.yml
+++ b/polaris-icons/icons/FirstClickModel.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Serene Chen
   - Joe Thomas
-version: 1
 date_added: 2022-10-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FirstOrder.yml
+++ b/polaris-icons/icons/FirstOrder.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FirstVisit.yml
+++ b/polaris-icons/icons/FirstVisit.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-07-24
 exclusive_use:

--- a/polaris-icons/icons/Flag.yml
+++ b/polaris-icons/icons/Flag.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FlipCamera.yml
+++ b/polaris-icons/icons/FlipCamera.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Folder.yml
+++ b/polaris-icons/icons/Folder.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FolderDown.yml
+++ b/polaris-icons/icons/FolderDown.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FolderMinus.yml
+++ b/polaris-icons/icons/FolderMinus.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FolderPlus.yml
+++ b/polaris-icons/icons/FolderPlus.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FolderUp.yml
+++ b/polaris-icons/icons/FolderUp.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FollowUpEmail.yml
+++ b/polaris-icons/icons/FollowUpEmail.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Food.yml
+++ b/polaris-icons/icons/Food.yml
@@ -9,7 +9,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Footer.yml
+++ b/polaris-icons/icons/Footer.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Forms.yml
+++ b/polaris-icons/icons/Forms.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 2
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FraudProtect.yml
+++ b/polaris-icons/icons/FraudProtect.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FraudProtectPending.yml
+++ b/polaris-icons/icons/FraudProtectPending.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FraudProtectUnprotected.yml
+++ b/polaris-icons/icons/FraudProtectUnprotected.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FulfillmentFulfilled.yml
+++ b/polaris-icons/icons/FulfillmentFulfilled.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Flavia Scudeler
   - Joe Thomas
-version: 1
 date_added: 2022-08-10
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/FulfillmentOnHold.yml
+++ b/polaris-icons/icons/FulfillmentOnHold.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Flavia Scudeler
   - Joe Thomas
-version: 1
 date_added: 2022-08-10
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/GamesConsole.yml
+++ b/polaris-icons/icons/GamesConsole.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Gauge.yml
+++ b/polaris-icons/icons/Gauge.yml
@@ -7,6 +7,5 @@ keywords:
 authors:
   - Arushi Singh
   - Joe Thomas
-version: 1
 date_added: 2023-05-31
 date_modified: 2023-06-23

--- a/polaris-icons/icons/GiftCard.yml
+++ b/polaris-icons/icons/GiftCard.yml
@@ -8,7 +8,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/GiftCardFilled.yml
+++ b/polaris-icons/icons/GiftCardFilled.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Globe.yml
+++ b/polaris-icons/icons/Globe.yml
@@ -6,7 +6,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Grammar.yml
+++ b/polaris-icons/icons/Grammar.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Hashtag.yml
+++ b/polaris-icons/icons/Hashtag.yml
@@ -7,7 +7,6 @@ keywords:
   - num
 authors:
   - Joe Thomas
-version: 1
 date_added: 2022-06-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Header.yml
+++ b/polaris-icons/icons/Header.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Heart.yml
+++ b/polaris-icons/icons/Heart.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Hide.yml
+++ b/polaris-icons/icons/Hide.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/HideKeyboard.yml
+++ b/polaris-icons/icons/HideKeyboard.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Hint.yml
+++ b/polaris-icons/icons/Hint.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Home.yml
+++ b/polaris-icons/icons/Home.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-01-17
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/HomeFilled.yml
+++ b/polaris-icons/icons/HomeFilled.yml
@@ -8,7 +8,6 @@ keywords:
   - start
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/HorizontalDots.yml
+++ b/polaris-icons/icons/HorizontalDots.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ICON_TEMPLATES/IconNameSet.yml
+++ b/polaris-icons/icons/ICON_TEMPLATES/IconNameSet.yml
@@ -21,7 +21,6 @@ authors:
   # - Co-author’s name (optional)
   # (delete this comment block)
   - N/A
-version: 1
 date_added: YYYY-MM-DD
 date_modified: YYYY-MM-DD
 # Optional: fill exclusive_use if the icon should *only* be used

--- a/polaris-icons/icons/Icons.yml
+++ b/polaris-icons/icons/Icons.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/IconsFilled.yml
+++ b/polaris-icons/icons/IconsFilled.yml
@@ -5,7 +5,6 @@ keywords:
   - shapes
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/IdentityCard.yml
+++ b/polaris-icons/icons/IdentityCard.yml
@@ -13,7 +13,6 @@ authors:
   - Fayçal Sabaou
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2022-08-24
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/IdentityCardFilled.yml
+++ b/polaris-icons/icons/IdentityCardFilled.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Illustration.yml
+++ b/polaris-icons/icons/Illustration.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Image.yml
+++ b/polaris-icons/icons/Image.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ImageAlt.yml
+++ b/polaris-icons/icons/ImageAlt.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ImageWithText.yml
+++ b/polaris-icons/icons/ImageWithText.yml
@@ -13,7 +13,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ImageWithTextOverlay.yml
+++ b/polaris-icons/icons/ImageWithTextOverlay.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Images.yml
+++ b/polaris-icons/icons/Images.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Import.yml
+++ b/polaris-icons/icons/Import.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ImportStore.yml
+++ b/polaris-icons/icons/ImportStore.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - José Torre
   - Joe Thomas
-version: 1
 date_added: 2019-03-12
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/InactiveLocation.yml
+++ b/polaris-icons/icons/InactiveLocation.yml
@@ -9,7 +9,6 @@ authors:
   - James Findlater
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2022-11-02
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Incoming.yml
+++ b/polaris-icons/icons/Incoming.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Indent.yml
+++ b/polaris-icons/icons/Indent.yml
@@ -10,7 +10,6 @@ keywords:
   - text editing
 authors:
   - Russell Baylis
-version: 1
 date_added: 2023-06-30
 date_modified: 2023-06-30
 exclusive_use:

--- a/polaris-icons/icons/Info.yml
+++ b/polaris-icons/icons/Info.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/InsertDynamicSource.yml
+++ b/polaris-icons/icons/InsertDynamicSource.yml
@@ -21,7 +21,6 @@ keywords:
 authors:
   - Russell Baylis
   - Joe Thomas
-version: 1
 date_added: 2022-09-06
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Instagram.yml
+++ b/polaris-icons/icons/Instagram.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-20
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Install.yml
+++ b/polaris-icons/icons/Install.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Inventory.yml
+++ b/polaris-icons/icons/Inventory.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/InventoryFilled.yml
+++ b/polaris-icons/icons/InventoryFilled.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Invite.yml
+++ b/polaris-icons/icons/Invite.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Iq.yml
+++ b/polaris-icons/icons/Iq.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Italic.yml
+++ b/polaris-icons/icons/Italic.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Joe Thomas
   - Russell Baylis
-version: 1
 date_added: 2023-06-30
 date_modified: 2023-07-19
 exclusive_use:

--- a/polaris-icons/icons/Jobs.yml
+++ b/polaris-icons/icons/Jobs.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - José Torre
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/JobsFilled.yml
+++ b/polaris-icons/icons/JobsFilled.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Key.yml
+++ b/polaris-icons/icons/Key.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Keyboard.yml
+++ b/polaris-icons/icons/Keyboard.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Arda Karaçizmeli
   - Joe Thomas
-version: 1
 date_added: 2023-04-11
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/LabelPrinter.yml
+++ b/polaris-icons/icons/LabelPrinter.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/LandingPage.yml
+++ b/polaris-icons/icons/LandingPage.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Language.yml
+++ b/polaris-icons/icons/Language.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-07-17
 exclusive_use:

--- a/polaris-icons/icons/LanguageFilled.yml
+++ b/polaris-icons/icons/LanguageFilled.yml
@@ -5,7 +5,6 @@ keywords:
   - international
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-17
 exclusive_use:

--- a/polaris-icons/icons/LastClickModel.yml
+++ b/polaris-icons/icons/LastClickModel.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Serene Chen
   - Joe Thomas
-version: 1
 date_added: 2022-10-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/LastNonDirectClickModel.yml
+++ b/polaris-icons/icons/LastNonDirectClickModel.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Serene Chen
   - Joe Thomas
-version: 1
 date_added: 2022-10-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Legal.yml
+++ b/polaris-icons/icons/Legal.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/LegalFilled.yml
+++ b/polaris-icons/icons/LegalFilled.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/LinearModel.yml
+++ b/polaris-icons/icons/LinearModel.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Serene Chen
   - Joe Thomas
-version: 1
 date_added: 2022-10-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Link.yml
+++ b/polaris-icons/icons/Link.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/LiveView.yml
+++ b/polaris-icons/icons/LiveView.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/LiveViewFilled.yml
+++ b/polaris-icons/icons/LiveViewFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Location.yml
+++ b/polaris-icons/icons/Location.yml
@@ -7,7 +7,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/LocationFilled.yml
+++ b/polaris-icons/icons/LocationFilled.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Locations.yml
+++ b/polaris-icons/icons/Locations.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Lock.yml
+++ b/polaris-icons/icons/Lock.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/LockFilled.yml
+++ b/polaris-icons/icons/LockFilled.yml
@@ -7,7 +7,6 @@ keywords:
   - secure
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/LogOut.yml
+++ b/polaris-icons/icons/LogOut.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/LogoBlock.yml
+++ b/polaris-icons/icons/LogoBlock.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Magic.yml
+++ b/polaris-icons/icons/Magic.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - David Goligorsky
   - Joe Thomas
-version: 1
 date_added: 2023-01-12
 date_modified: 2023-06-23
 exclusive_use: For use related to feature using machine learning / artificial intelligence.

--- a/polaris-icons/icons/ManagedStore.yml
+++ b/polaris-icons/icons/ManagedStore.yml
@@ -8,7 +8,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/MarkFulfilled.yml
+++ b/polaris-icons/icons/MarkFulfilled.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MarkPaid.yml
+++ b/polaris-icons/icons/MarkPaid.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Marketing.yml
+++ b/polaris-icons/icons/Marketing.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-01-17
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MarketingFilled.yml
+++ b/polaris-icons/icons/MarketingFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Markets.yml
+++ b/polaris-icons/icons/Markets.yml
@@ -9,7 +9,6 @@ authors:
   - Justina Chua
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2022-03-09
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/MarketsFilled.yml
+++ b/polaris-icons/icons/MarketsFilled.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Maximize.yml
+++ b/polaris-icons/icons/Maximize.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Measurement.yml
+++ b/polaris-icons/icons/Measurement.yml
@@ -19,7 +19,6 @@ authors:
   - 'n'
   - g
   - Joe Thomas
-version: 1
 date_added: 2022-09-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Mention.yml
+++ b/polaris-icons/icons/Mention.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Merge.yml
+++ b/polaris-icons/icons/Merge.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Bilal Karim
   - Joe Thomas
-version: 1
 date_added: 2022-04-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Metafields.yml
+++ b/polaris-icons/icons/Metafields.yml
@@ -7,7 +7,6 @@ authors:
   - Leina Leung
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2022-08-24
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/MetafieldsFilled.yml
+++ b/polaris-icons/icons/MetafieldsFilled.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Metaobject.yml
+++ b/polaris-icons/icons/Metaobject.yml
@@ -7,7 +7,6 @@ authors:
   - Sai Nihas
   - Russell Baylis
   - Joe Thomas
-version: 1
 date_added: 2023-01-24
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MetaobjectReference.yml
+++ b/polaris-icons/icons/MetaobjectReference.yml
@@ -7,7 +7,6 @@ authors:
   - Sai Nihas
   - Russell Baylis
   - Joe Thomas
-version: 1
 date_added: 2023-01-24
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Microphone.yml
+++ b/polaris-icons/icons/Microphone.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Minimize.yml
+++ b/polaris-icons/icons/Minimize.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Minus.yml
+++ b/polaris-icons/icons/Minus.yml
@@ -13,7 +13,6 @@ authors:
   - Adam Whitcroft
   - Nayeob Kim
   - Joe Thomas
-version: 2
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Mobile.yml
+++ b/polaris-icons/icons/Mobile.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MobileAccept.yml
+++ b/polaris-icons/icons/MobileAccept.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MobileBackArrow.yml
+++ b/polaris-icons/icons/MobileBackArrow.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MobileCancel.yml
+++ b/polaris-icons/icons/MobileCancel.yml
@@ -13,7 +13,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MobileChevron.yml
+++ b/polaris-icons/icons/MobileChevron.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MobileHamburger.yml
+++ b/polaris-icons/icons/MobileHamburger.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MobileHorizontalDots.yml
+++ b/polaris-icons/icons/MobileHorizontalDots.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MobilePlus.yml
+++ b/polaris-icons/icons/MobilePlus.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MobileVerticalDots.yml
+++ b/polaris-icons/icons/MobileVerticalDots.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Moneris.yml
+++ b/polaris-icons/icons/Moneris.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Money.yml
+++ b/polaris-icons/icons/Money.yml
@@ -21,7 +21,6 @@ authors:
   - 'n'
   - g
   - Joe Thomas
-version: 1
 date_added: 2022-09-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/MoneyFilled.yml
+++ b/polaris-icons/icons/MoneyFilled.yml
@@ -10,7 +10,6 @@ keywords:
   - cash
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Nature.yml
+++ b/polaris-icons/icons/Nature.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - José Torre
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Navigation.yml
+++ b/polaris-icons/icons/Navigation.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Note.yml
+++ b/polaris-icons/icons/Note.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Notification.yml
+++ b/polaris-icons/icons/Notification.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/NotificationFilled.yml
+++ b/polaris-icons/icons/NotificationFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - bell
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/OnlineStore.yml
+++ b/polaris-icons/icons/OnlineStore.yml
@@ -7,7 +7,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2022-01-17
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/OrderStatus.yml
+++ b/polaris-icons/icons/OrderStatus.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/OrderedList.yml
+++ b/polaris-icons/icons/OrderedList.yml
@@ -13,7 +13,6 @@ authors:
   - Joe Thomas
   - José Torre
   - Russell Baylis
-version: 1
 date_added: 2023-06-30
 date_modified: 2023-06-30
 exclusive_use:

--- a/polaris-icons/icons/Orders.yml
+++ b/polaris-icons/icons/Orders.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-01-17
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/OrdersFilled.yml
+++ b/polaris-icons/icons/OrdersFilled.yml
@@ -5,7 +5,6 @@ keywords:
   - orders
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Organization.yml
+++ b/polaris-icons/icons/Organization.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Anna Borg
   - Joe Thomas
-version: 1
 date_added: 2022-09-20
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Outdent.yml
+++ b/polaris-icons/icons/Outdent.yml
@@ -10,7 +10,6 @@ keywords:
   - text editing
 authors:
   - Russell Baylis
-version: 1
 date_added: 2023-06-30
 date_modified: 2023-06-30
 exclusive_use:

--- a/polaris-icons/icons/Outgoing.yml
+++ b/polaris-icons/icons/Outgoing.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Package.yml
+++ b/polaris-icons/icons/Package.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PackageFilled.yml
+++ b/polaris-icons/icons/PackageFilled.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Page.yml
+++ b/polaris-icons/icons/Page.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PageDown.yml
+++ b/polaris-icons/icons/PageDown.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PageMinus.yml
+++ b/polaris-icons/icons/PageMinus.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PagePlus.yml
+++ b/polaris-icons/icons/PagePlus.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PageReference.yml
+++ b/polaris-icons/icons/PageReference.yml
@@ -8,7 +8,6 @@ authors:
   - Sai Nihas
   - Leina Leung
   - Joe Thomas
-version: 1
 date_added: 2023-01-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PageUp.yml
+++ b/polaris-icons/icons/PageUp.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PaginationEnd.yml
+++ b/polaris-icons/icons/PaginationEnd.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PaginationStart.yml
+++ b/polaris-icons/icons/PaginationStart.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PaintBrush.yml
+++ b/polaris-icons/icons/PaintBrush.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PaperCheck.yml
+++ b/polaris-icons/icons/PaperCheck.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Kathleen Robertson
   - Joe Thomas
-version: 1
 date_added: 2023-01-19
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Passkey.yml
+++ b/polaris-icons/icons/Passkey.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Ashley Allen
   - Joe Thomas
-version: 1
 date_added: 2022-11-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PasskeyFilled.yml
+++ b/polaris-icons/icons/PasskeyFilled.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Pause.yml
+++ b/polaris-icons/icons/Pause.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PauseCircle.yml
+++ b/polaris-icons/icons/PauseCircle.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Payments.yml
+++ b/polaris-icons/icons/Payments.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PaymentsFilled.yml
+++ b/polaris-icons/icons/PaymentsFilled.yml
@@ -8,7 +8,6 @@ keywords:
   - payment
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/PersonalizedText.yml
+++ b/polaris-icons/icons/PersonalizedText.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Natalie Hercun
   - Joe Thomas
-version: 1
 date_added: 2023-04-11
 date_modified: 2023-06-23
 exclusive_use: For use related to feature using personalized text

--- a/polaris-icons/icons/Phone.yml
+++ b/polaris-icons/icons/Phone.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PhoneIn.yml
+++ b/polaris-icons/icons/PhoneIn.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PhoneOut.yml
+++ b/polaris-icons/icons/PhoneOut.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Pin.yml
+++ b/polaris-icons/icons/Pin.yml
@@ -9,7 +9,6 @@ authors:
   - Chris Blinstrub
   - Joe Thomas
   - José Torre
-version: 2
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/PinUnfilled.yml
+++ b/polaris-icons/icons/PinUnfilled.yml
@@ -7,7 +7,6 @@ authors:
   - Adam Whitcroft
   - Chris Blinstrub
   - Joe Thomas
-version: 1
 date_added: 2023-01-30
 date_modified: 2023-07-13
 exclusive_use:

--- a/polaris-icons/icons/Pintrest.yml
+++ b/polaris-icons/icons/Pintrest.yml
@@ -5,7 +5,6 @@ keywords:
   - Social media
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-20
 date_modified: 2023-07-28
 exclusive_use:

--- a/polaris-icons/icons/Plan.yml
+++ b/polaris-icons/icons/Plan.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - David Goligorsky
   - Joe Thomas
-version: 1
 date_added: 2022-07-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PlanFilled.yml
+++ b/polaris-icons/icons/PlanFilled.yml
@@ -11,7 +11,6 @@ keywords:
   - Staircase
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Play.yml
+++ b/polaris-icons/icons/Play.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PlayCircle.yml
+++ b/polaris-icons/icons/PlayCircle.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Plus.yml
+++ b/polaris-icons/icons/Plus.yml
@@ -9,7 +9,6 @@ authors:
   - Adam Whitcroft
   - Marc Thomas
   - Joe Thomas
-version: 2
 date_added: 2022-05-05
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PointOfSale.yml
+++ b/polaris-icons/icons/PointOfSale.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Popular.yml
+++ b/polaris-icons/icons/Popular.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PositionBasedModel.yml
+++ b/polaris-icons/icons/PositionBasedModel.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Serene Chen
   - Joe Thomas
-version: 1
 date_added: 2022-10-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/PriceLookup.yml
+++ b/polaris-icons/icons/PriceLookup.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Print.yml
+++ b/polaris-icons/icons/Print.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ProductCost.yml
+++ b/polaris-icons/icons/ProductCost.yml
@@ -7,7 +7,6 @@ authors:
   - Adam Whitcroft
   - Anthony Menecola
   - Joe Thomas
-version: 1
 date_added: 2022-08-08
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ProductReference.yml
+++ b/polaris-icons/icons/ProductReference.yml
@@ -8,7 +8,6 @@ authors:
   - Sai Nihas
   - Leina Leung
   - Joe Thomas
-version: 1
 date_added: 2023-01-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ProductReturns.yml
+++ b/polaris-icons/icons/ProductReturns.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Clara Petit
   - Joe Thomas
-version: 1
 date_added: 2020-07-08
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Products.yml
+++ b/polaris-icons/icons/Products.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-01-17
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ProductsFilled.yml
+++ b/polaris-icons/icons/ProductsFilled.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Profile.yml
+++ b/polaris-icons/icons/Profile.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Promote.yml
+++ b/polaris-icons/icons/Promote.yml
@@ -9,7 +9,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/PromoteFilled.yml
+++ b/polaris-icons/icons/PromoteFilled.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/QuestionMark.yml
+++ b/polaris-icons/icons/QuestionMark.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/QuestionMarkInverse.yml
+++ b/polaris-icons/icons/QuestionMarkInverse.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Liz Khoo
   - Joe Thomas
-version: 1
 date_added: 2021-07-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/QuickSale.yml
+++ b/polaris-icons/icons/QuickSale.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ReadTime.yml
+++ b/polaris-icons/icons/ReadTime.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Receipt.yml
+++ b/polaris-icons/icons/Receipt.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/RecentSearches.yml
+++ b/polaris-icons/icons/RecentSearches.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Redo.yml
+++ b/polaris-icons/icons/Redo.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-11
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Referral.yml
+++ b/polaris-icons/icons/Referral.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-11-05
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ReferralCode.yml
+++ b/polaris-icons/icons/ReferralCode.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-11-05
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Refresh.yml
+++ b/polaris-icons/icons/Refresh.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Refund.yml
+++ b/polaris-icons/icons/Refund.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/RemoveProduct.yml
+++ b/polaris-icons/icons/RemoveProduct.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Anthony Menecola
   - Joe Thomas
-version: 2
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/RepeatOrder.yml
+++ b/polaris-icons/icons/RepeatOrder.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Replace.yml
+++ b/polaris-icons/icons/Replace.yml
@@ -13,7 +13,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Replay.yml
+++ b/polaris-icons/icons/Replay.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Reports.yml
+++ b/polaris-icons/icons/Reports.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - José Torre
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Reset.yml
+++ b/polaris-icons/icons/Reset.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Resources.yml
+++ b/polaris-icons/icons/Resources.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Return.yml
+++ b/polaris-icons/icons/Return.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Returns.yml
+++ b/polaris-icons/icons/Returns.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Jenna Stephens-Wells
   - Joe Thomas
-version: 1
 date_added: 2022-11-29
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/RichText.yml
+++ b/polaris-icons/icons/RichText.yml
@@ -10,5 +10,4 @@ authors:
   - Joe Thomas
 date_added: 2023-01-12
 date_modified: 2023-06-23
-version: 1
 exclusive_use:

--- a/polaris-icons/icons/Risk.yml
+++ b/polaris-icons/icons/Risk.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Rows2.yml
+++ b/polaris-icons/icons/Rows2.yml
@@ -11,4 +11,3 @@ authors:
 exclusive_use: Shopify Email
 date_added: 2023-01-25
 date_modified: 2023-06-23
-version: 1

--- a/polaris-icons/icons/Sandbox.yml
+++ b/polaris-icons/icons/Sandbox.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Brian Potstra
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Save.yml
+++ b/polaris-icons/icons/Save.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Search.yml
+++ b/polaris-icons/icons/Search.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Section.yml
+++ b/polaris-icons/icons/Section.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Secure.yml
+++ b/polaris-icons/icons/Secure.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Select.yml
+++ b/polaris-icons/icons/Select.yml
@@ -11,7 +11,6 @@ authors:
   - Adam Whitcroft
   - Jordan Ouellette
   - Joe Thomas
-version: 2
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Send.yml
+++ b/polaris-icons/icons/Send.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Settings.yml
+++ b/polaris-icons/icons/Settings.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SettingsFilled.yml
+++ b/polaris-icons/icons/SettingsFilled.yml
@@ -6,7 +6,6 @@ keywords:
   - cog
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/Share.yml
+++ b/polaris-icons/icons/Share.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ShareIos.yml
+++ b/polaris-icons/icons/ShareIos.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Shipment.yml
+++ b/polaris-icons/icons/Shipment.yml
@@ -15,7 +15,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ShipmentFilled.yml
+++ b/polaris-icons/icons/ShipmentFilled.yml
@@ -15,7 +15,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/ShippingLabel.yml
+++ b/polaris-icons/icons/ShippingLabel.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - José Torre
-version: 1
 date_added: 2023-11-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/ShippingLabelFilled.yml
+++ b/polaris-icons/icons/ShippingLabelFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - José Torre
-version: 1
 date_added: 2023-11-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Shopcodes.yml
+++ b/polaris-icons/icons/Shopcodes.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SidebarLeft.yml
+++ b/polaris-icons/icons/SidebarLeft.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SidebarRight.yml
+++ b/polaris-icons/icons/SidebarRight.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Sidekick.yml
+++ b/polaris-icons/icons/Sidekick.yml
@@ -6,7 +6,6 @@ keywords:
   - chat
 authors:
   - Arda Karacizmeli
-version: 1
 date_added: 2023-07-31
 date_modified: 2023-07-31
 exclusive_use: Internal Shopify use only for the Sidekick app.

--- a/polaris-icons/icons/Simplify.yml
+++ b/polaris-icons/icons/Simplify.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - David Goligorsky
   - Joe Thomas
-version: 1
 date_added: 2023-03-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Slideshow.yml
+++ b/polaris-icons/icons/Slideshow.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SmileyHappy.yml
+++ b/polaris-icons/icons/SmileyHappy.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SmileyJoy.yml
+++ b/polaris-icons/icons/SmileyJoy.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SmileyNeutral.yml
+++ b/polaris-icons/icons/SmileyNeutral.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SmileySad.yml
+++ b/polaris-icons/icons/SmileySad.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Snapchat.yml
+++ b/polaris-icons/icons/Snapchat.yml
@@ -5,7 +5,6 @@ keywords:
   - Social media
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-20
 date_modified: 2023-07-28
 exclusive_use:

--- a/polaris-icons/icons/SocialAd.yml
+++ b/polaris-icons/icons/SocialAd.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SocialPost.yml
+++ b/polaris-icons/icons/SocialPost.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SoftPack.yml
+++ b/polaris-icons/icons/SoftPack.yml
@@ -13,7 +13,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Sort.yml
+++ b/polaris-icons/icons/Sort.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/SortAscending.yml
+++ b/polaris-icons/icons/SortAscending.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 2
 date_added: 2019-03-15
 date_modified: 2023-07-17
 exclusive_use:

--- a/polaris-icons/icons/SortDescending.yml
+++ b/polaris-icons/icons/SortDescending.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 2
 date_added: 2019-03-15
 date_modified: 2023-07-17
 exclusive_use:

--- a/polaris-icons/icons/Sound.yml
+++ b/polaris-icons/icons/Sound.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/StarFilled.yml
+++ b/polaris-icons/icons/StarFilled.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Sara Hill
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/StarOutline.yml
+++ b/polaris-icons/icons/StarOutline.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Sara Hill
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/StatusActive.yml
+++ b/polaris-icons/icons/StatusActive.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Brandon Law
   - Joe Thomas
-version: 1
 date_added: 2022-07-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Stop.yml
+++ b/polaris-icons/icons/Stop.yml
@@ -4,7 +4,6 @@ keywords:
   - stop
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-06-21
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Store.yml
+++ b/polaris-icons/icons/Store.yml
@@ -8,7 +8,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2021-02-22
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/StoreDetails.yml
+++ b/polaris-icons/icons/StoreDetails.yml
@@ -4,7 +4,6 @@ keywords:
   - store
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/StoreDetailsFilled.yml
+++ b/polaris-icons/icons/StoreDetailsFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - store
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/StoreFilled.yml
+++ b/polaris-icons/icons/StoreFilled.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/StoreStatus.yml
+++ b/polaris-icons/icons/StoreStatus.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Tablet.yml
+++ b/polaris-icons/icons/Tablet.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TapChip.yml
+++ b/polaris-icons/icons/TapChip.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Tax.yml
+++ b/polaris-icons/icons/Tax.yml
@@ -8,7 +8,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/TaxFilled.yml
+++ b/polaris-icons/icons/TaxFilled.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Team.yml
+++ b/polaris-icons/icons/Team.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Template.yml
+++ b/polaris-icons/icons/Template.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Demi Peppas
   - Joe Thomas
-version: 1
 date_added: 2022-07-05
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Text.yml
+++ b/polaris-icons/icons/Text.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TextAlignmentCenter.yml
+++ b/polaris-icons/icons/TextAlignmentCenter.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Arthur Gouveia
   - Joe Thomas
-version: 1
 date_added: 2019-08-07
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TextAlignmentLeft.yml
+++ b/polaris-icons/icons/TextAlignmentLeft.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Arthur Gouveia
   - Joe Thomas
-version: 1
 date_added: 2019-08-07
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TextAlignmentRight.yml
+++ b/polaris-icons/icons/TextAlignmentRight.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Arthur Gouveia
   - Joe Thomas
-version: 1
 date_added: 2019-08-07
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TextBlock.yml
+++ b/polaris-icons/icons/TextBlock.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TextColor.yml
+++ b/polaris-icons/icons/TextColor.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Joe Thomas
   - Russell Baylis
-version: 1
 date_added: 2023-06-30
 date_modified: 2023-06-30
 exclusive_use:

--- a/polaris-icons/icons/ThemeEdit.yml
+++ b/polaris-icons/icons/ThemeEdit.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ThemeStore.yml
+++ b/polaris-icons/icons/ThemeStore.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-11
 date_modified: 2023-06-23
 exclusive_use: Shopify theme store

--- a/polaris-icons/icons/Themes.yml
+++ b/polaris-icons/icons/Themes.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-11
 date_modified: 2023-06-23
 exclusive_use: Shopify themes

--- a/polaris-icons/icons/ThumbsDown.yml
+++ b/polaris-icons/icons/ThumbsDown.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - David Goligorsky
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ThumbsUp.yml
+++ b/polaris-icons/icons/ThumbsUp.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - David Goligorsky
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Tick.yml
+++ b/polaris-icons/icons/Tick.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TickSmall.yml
+++ b/polaris-icons/icons/TickSmall.yml
@@ -11,7 +11,6 @@ authors:
   - Adam Whitcroft
   - Nayeob Kim
   - Joe Thomas
-version: 2
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use: Checkbox

--- a/polaris-icons/icons/Tiktok.yml
+++ b/polaris-icons/icons/Tiktok.yml
@@ -5,7 +5,6 @@ keywords:
   - Social media
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-20
 date_modified: 2023-07-28
 exclusive_use:

--- a/polaris-icons/icons/TimeDecayModel.yml
+++ b/polaris-icons/icons/TimeDecayModel.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Serene Chen
   - Joe Thomas
-version: 1
 date_added: 2022-10-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TimelineAttachment.yml
+++ b/polaris-icons/icons/TimelineAttachment.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Brian Potstra
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Tips.yml
+++ b/polaris-icons/icons/Tips.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - José Torre
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Title.yml
+++ b/polaris-icons/icons/Title.yml
@@ -11,7 +11,6 @@ keywords:
 authors:
   - Rozina Szogyenyi
   - Joe Thomas
-version: 1
 date_added: 2021-08-18
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Toggle.yml
+++ b/polaris-icons/icons/Toggle.yml
@@ -6,7 +6,6 @@ keywords:
   - switch
 authors:
   - Joe Thomas
-version: 1
 date_added: 2022-06-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Tools.yml
+++ b/polaris-icons/icons/Tools.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Transaction.yml
+++ b/polaris-icons/icons/Transaction.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TransactionFeeDollar.yml
+++ b/polaris-icons/icons/TransactionFeeDollar.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TransactionFeeEuro.yml
+++ b/polaris-icons/icons/TransactionFeeEuro.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TransactionFeePound.yml
+++ b/polaris-icons/icons/TransactionFeePound.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TransactionFeeRupee.yml
+++ b/polaris-icons/icons/TransactionFeeRupee.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TransactionFeeYen.yml
+++ b/polaris-icons/icons/TransactionFeeYen.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Transfer.yml
+++ b/polaris-icons/icons/Transfer.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TransferFilled.yml
+++ b/polaris-icons/icons/TransferFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-06
 date_modified: 2023-07-06
 exclusive_use:

--- a/polaris-icons/icons/TransferIn.yml
+++ b/polaris-icons/icons/TransferIn.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TransferOut.yml
+++ b/polaris-icons/icons/TransferOut.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/TransferWithinShopify.yml
+++ b/polaris-icons/icons/TransferWithinShopify.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Translate.yml
+++ b/polaris-icons/icons/Translate.yml
@@ -5,7 +5,6 @@ keywords:
   - international
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-17
 date_modified: 2023-07-17
 exclusive_use:

--- a/polaris-icons/icons/Transport.yml
+++ b/polaris-icons/icons/Transport.yml
@@ -10,7 +10,6 @@ authors:
   - Adam Whitcroft
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Troubleshoot.yml
+++ b/polaris-icons/icons/Troubleshoot.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Tumblr.yml
+++ b/polaris-icons/icons/Tumblr.yml
@@ -5,7 +5,6 @@ keywords:
   - social media
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-08-11
 date_modified: 2023-08-11
 # Optional: fill exclusive_use if the icon should *only* be used

--- a/polaris-icons/icons/Twitch.yml
+++ b/polaris-icons/icons/Twitch.yml
@@ -5,7 +5,6 @@ keywords:
   - Social media
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-28
 date_modified: 2023-07-28
 exclusive_use:

--- a/polaris-icons/icons/Twitter.yml
+++ b/polaris-icons/icons/Twitter.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Joe Thomas
   - José Torre
-version: 1
 date_added: 2023-07-20
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Type.yml
+++ b/polaris-icons/icons/Type.yml
@@ -11,7 +11,6 @@ keywords:
   - text
 authors:
   - Joe Thomas
-version: 1
 date_added: 2022-06-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Underline.yml
+++ b/polaris-icons/icons/Underline.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Joe Thomas
   - Russell Baylis
-version: 1
 date_added: 2023-06-30
 date_modified: 2023-06-30
 exclusive_use:

--- a/polaris-icons/icons/Undo.yml
+++ b/polaris-icons/icons/Undo.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-11
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Unfulfilled.yml
+++ b/polaris-icons/icons/Unfulfilled.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/UnknownDevice.yml
+++ b/polaris-icons/icons/UnknownDevice.yml
@@ -6,7 +6,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/UpdateInventory.yml
+++ b/polaris-icons/icons/UpdateInventory.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Upload.yml
+++ b/polaris-icons/icons/Upload.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Alex Page
   - Joe Thomas
-version: 2
 date_added: 2020-09-21
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/UsersAndPermissions.yml
+++ b/polaris-icons/icons/UsersAndPermissions.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - José Torre
-version: 1
 date_added: 2023-11-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/UsersAndPermissionsFilled.yml
+++ b/polaris-icons/icons/UsersAndPermissionsFilled.yml
@@ -4,7 +4,6 @@ keywords:
   - N/A
 authors:
   - José Torre
-version: 1
 date_added: 2023-11-07
 date_modified: 2023-11-07
 exclusive_use:

--- a/polaris-icons/icons/Variant.yml
+++ b/polaris-icons/icons/Variant.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/View.yml
+++ b/polaris-icons/icons/View.yml
@@ -12,7 +12,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2018-11-14
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ViewportNarrow.yml
+++ b/polaris-icons/icons/ViewportNarrow.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ViewportShort.yml
+++ b/polaris-icons/icons/ViewportShort.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-08-26
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ViewportTall.yml
+++ b/polaris-icons/icons/ViewportTall.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2022-08-26
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/ViewportWide.yml
+++ b/polaris-icons/icons/ViewportWide.yml
@@ -10,7 +10,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-02-25
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Vimeo.yml
+++ b/polaris-icons/icons/Vimeo.yml
@@ -5,7 +5,6 @@ keywords:
   - social media
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-08-11
 date_modified: 2023-08-11
 # Optional: fill exclusive_use if the icon should *only* be used

--- a/polaris-icons/icons/Vocabulary.yml
+++ b/polaris-icons/icons/Vocabulary.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-01
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Volume.yml
+++ b/polaris-icons/icons/Volume.yml
@@ -8,7 +8,6 @@ authors:
   - Sai Nihas
   - Leina Leung
   - Joe Thomas
-version: 1
 date_added: 2023-01-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Wand.yml
+++ b/polaris-icons/icons/Wand.yml
@@ -9,7 +9,6 @@ keywords:
 authors:
   - Jordan Ouellette
   - Joe Thomas
-version: 1
 date_added: 2021-12-13
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Wearable.yml
+++ b/polaris-icons/icons/Wearable.yml
@@ -7,7 +7,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Weight.yml
+++ b/polaris-icons/icons/Weight.yml
@@ -7,7 +7,6 @@ authors:
   - Sai Nihas
   - Leina Leung
   - Joe Thomas
-version: 1
 date_added: 2023-01-12
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Wholesale.yml
+++ b/polaris-icons/icons/Wholesale.yml
@@ -8,7 +8,6 @@ keywords:
 authors:
   - Adam Whitcroft
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Wifi.yml
+++ b/polaris-icons/icons/Wifi.yml
@@ -5,7 +5,6 @@ keywords:
 authors:
   - N/A
   - Joe Thomas
-version: 1
 date_added: 2019-03-15
 date_modified: 2023-06-23
 exclusive_use:

--- a/polaris-icons/icons/Youtube.yml
+++ b/polaris-icons/icons/Youtube.yml
@@ -5,7 +5,6 @@ keywords:
   - social media
 authors:
   - Joe Thomas
-version: 1
 date_added: 2023-07-20
 date_modified: 2023-07-28
 exclusive_use:

--- a/polaris-icons/rollup.config.mjs
+++ b/polaris-icons/rollup.config.mjs
@@ -22,13 +22,7 @@ const iconPaths = globby.sync(path.join(iconBasePath, '*.yml'));
 const iconExports = [];
 const iconTypes = [];
 const iconMetadata = {};
-const ommitedKeys = [
-  'version',
-  'exclusive_use',
-  'authors',
-  'date_modified',
-  'date_added',
-];
+const ommitedKeys = ['exclusive_use', 'authors', 'date_modified', 'date_added'];
 
 iconPaths.forEach((filename) => {
   const iconData = jsYaml.load(fs.readFileSync(filename), {


### PR DESCRIPTION
### WHY are these changes introduced?

The version value in the icons yml file is confusing and duplicated with the package version. This removes the extra version value in each icon file to only use the package version.

### WHAT is this pull request doing?

Removes the confusing version value in the icons `.yml` files.