### PR TITLE
[ChoiceList] Improve the type safety and correctness of ChoiceList

### DIFF
--- a/.changeset/old-guests-cover.md
+++ b/.changeset/old-guests-cover.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Improve the type safety and accuracy of ChoiceList

--- a/polaris-react/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
+import type {ChoiceListProps} from '@shopify/polaris';
 import {ChoiceList, TextField} from '@shopify/polaris';
 
 export default {
@@ -52,14 +53,16 @@ export function Magic() {
     'hidden',
   ]);
 
+  const choices: ChoiceListProps<HiddenOptionalRequired>['choices'] = [
+    {label: 'Hidden', value: 'hidden'},
+    {label: 'Optional', value: 'optional'},
+    {label: 'Required', value: 'required'},
+  ];
+
   return (
     <ChoiceList
       title="Company name"
-      choices={[
-        {label: 'Hidden', value: 'hidden'},
-        {label: 'Optional', value: 'optional'},
-        {label: 'Required', value: 'required'},
-      ]}
+      choices={choices}
       selected={selected}
       onChange={setSelected}
       tone="magic"

--- a/polaris-react/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -6,10 +6,12 @@ export default {
   component: ChoiceList,
 } as ComponentMeta<typeof ChoiceList>;
 
-export function Default() {
-  const [selected, setSelected] = useState(['hidden']);
+type HiddenOptionalRequired = 'hidden' | 'optional' | 'required';
 
-  const handleChange = useCallback((value) => setSelected(value), []);
+export function Default() {
+  const [selected, setSelected] = useState<HiddenOptionalRequired[]>([
+    'hidden',
+  ]);
 
   return (
     <ChoiceList
@@ -20,15 +22,15 @@ export function Default() {
         {label: 'Required', value: 'required'},
       ]}
       selected={selected}
-      onChange={handleChange}
+      onChange={setSelected}
     />
   );
 }
 
 export function WithError() {
-  const [selected, setSelected] = useState(['hidden']);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
+  const [selected, setSelected] = useState([
+    'hidden' as HiddenOptionalRequired,
+  ]);
 
   return (
     <ChoiceList
@@ -39,16 +41,16 @@ export function WithError() {
         {label: 'Required', value: 'required'},
       ]}
       selected={selected}
-      onChange={handleChange}
+      onChange={setSelected}
       error="Company name cannot be hidden at this time"
     />
   );
 }
 
 export function Magic() {
-  const [selected, setSelected] = useState(['hidden']);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
+  const [selected, setSelected] = useState<HiddenOptionalRequired[]>([
+    'hidden',
+  ]);
 
   return (
     <ChoiceList
@@ -59,16 +61,14 @@ export function Magic() {
         {label: 'Required', value: 'required'},
       ]}
       selected={selected}
-      onChange={handleChange}
+      onChange={setSelected}
       tone="magic"
     />
   );
 }
 
 export function WithMultiChoice() {
-  const [selected, setSelected] = useState(['hidden']);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
+  const [selected, setSelected] = useState([] as string[]);
 
   return (
     <ChoiceList
@@ -89,15 +89,13 @@ export function WithMultiChoice() {
         },
       ]}
       selected={selected}
-      onChange={handleChange}
+      onChange={setSelected}
     />
   );
 }
 
 export function MagicWithMultiChoice() {
-  const [selected, setSelected] = useState(['hidden']);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
+  const [selected, setSelected] = useState<string[]>([]);
 
   return (
     <ChoiceList
@@ -118,34 +116,29 @@ export function MagicWithMultiChoice() {
         },
       ]}
       selected={selected}
-      onChange={handleChange}
+      onChange={setSelected}
       tone="magic"
     />
   );
 }
 
 export function WithChildrenContent() {
-  const [selected, setSelected] = useState(['none']);
+  const [selected, setSelected] = useState([
+    'none' as 'none' | 'minimum_purchase' | 'minimum_quantity',
+  ]);
   const [textFieldValue, setTextFieldValue] = useState('');
-
-  const handleChoiceListChange = useCallback((value) => setSelected(value), []);
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
 
   const renderChildren = useCallback(
     () => (
       <TextField
         label="Minimum Quantity"
         labelHidden
-        onChange={handleTextFieldChange}
+        onChange={setTextFieldValue}
         value={textFieldValue}
         autoComplete="off"
       />
     ),
-    [handleTextFieldChange, textFieldValue],
+    [textFieldValue],
   );
 
   return (
@@ -164,7 +157,7 @@ export function WithChildrenContent() {
         },
       ]}
       selected={selected}
-      onChange={handleChoiceListChange}
+      onChange={setSelected}
     />
   );
 }
@@ -173,25 +166,18 @@ export function WithDynamicChildrenContent() {
   const [selected, setSelected] = useState(['none']);
   const [textFieldValue, setTextFieldValue] = useState('');
 
-  const handleChoiceListChange = useCallback((value) => setSelected(value), []);
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
   const renderChildren = useCallback(
     (isSelected) =>
       isSelected && (
         <TextField
           label="Minimum Quantity"
           labelHidden
-          onChange={handleTextFieldChange}
+          onChange={setTextFieldValue}
           value={textFieldValue}
           autoComplete="off"
         />
       ),
-    [handleTextFieldChange, textFieldValue],
+    [textFieldValue],
   );
 
   return (
@@ -212,7 +198,7 @@ export function WithDynamicChildrenContent() {
           },
         ]}
         selected={selected}
-        onChange={handleChoiceListChange}
+        onChange={setSelected}
       />
     </div>
   );

--- a/polaris-react/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -29,8 +29,8 @@ export function Default() {
 }
 
 export function WithError() {
-  const [selected, setSelected] = useState([
-    'hidden' as HiddenOptionalRequired,
+  const [selected, setSelected] = useState<HiddenOptionalRequired[]>([
+    'hidden',
   ]);
 
   return (
@@ -71,7 +71,7 @@ export function Magic() {
 }
 
 export function WithMultiChoice() {
-  const [selected, setSelected] = useState([] as string[]);
+  const [selected, setSelected] = useState<string[]>([]);
 
   return (
     <ChoiceList
@@ -126,9 +126,7 @@ export function MagicWithMultiChoice() {
 }
 
 export function WithChildrenContent() {
-  const [selected, setSelected] = useState([
-    'none' as 'none' | 'minimum_purchase' | 'minimum_quantity',
-  ]);
+  const [selected, setSelected] = useState(['none']);
   const [textFieldValue, setTextFieldValue] = useState('');
 
   const renderChildren = useCallback(

--- a/polaris-react/src/components/ChoiceList/ChoiceList.tsx
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.tsx
@@ -31,7 +31,7 @@ export interface ChoiceListProps<TValue extends string = string> {
   /** Label for list of choices */
   title: React.ReactNode;
   /** Collection of choices */
-  choices: Choice<TValue>[] | readonly Choice<TValue>[];
+  choices: Choice<TValue>[];
   /** Collection of selected choices */
   selected: TValue[];
   /** Name for form input */

--- a/polaris-react/src/components/ChoiceList/ChoiceList.tsx
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.tsx
@@ -10,9 +10,9 @@ import {Bleed} from '../Bleed';
 
 import styles from './ChoiceList.scss';
 
-interface Choice {
+interface Choice<TValue extends string> {
   /** Value of the choice */
-  value: string;
+  value: TValue;
   /** Label for the choice */
   label: React.ReactNode;
   /** A unique identifier for the choice */
@@ -27,13 +27,13 @@ interface Choice {
   renderChildren?(isSelected: boolean): React.ReactNode | false;
 }
 
-export interface ChoiceListProps {
+export interface ChoiceListProps<TValue extends string = string> {
   /** Label for list of choices */
   title: React.ReactNode;
   /** Collection of choices */
-  choices: Choice[];
+  choices: Choice<TValue>[] | readonly Choice<TValue>[];
   /** Collection of selected choices */
-  selected: string[];
+  selected: TValue[];
   /** Name for form input */
   name?: string;
   /** Allow merchants to select multiple options at once */
@@ -45,12 +45,12 @@ export interface ChoiceListProps {
   /** Disable all choices **/
   disabled?: boolean;
   /** Callback when the selected choices change */
-  onChange?(selected: string[], name: string): void;
+  onChange?(selected: TValue[], name: string): void;
   /** Indicates the tone of the choice list */
   tone?: 'magic';
 }
 
-export function ChoiceList({
+export function ChoiceList<TValue extends string>({
   title,
   titleHidden,
   allowMultiple,
@@ -61,7 +61,7 @@ export function ChoiceList({
   disabled = false,
   name: nameProp,
   tone,
-}: ChoiceListProps) {
+}: ChoiceListProps<TValue>) {
   // Type asserting to any is required for TS3.2 but can be removed when we update to 3.3
   // see https://github.com/Microsoft/TypeScript/issues/28768
   const ControlComponent: any = allowMultiple ? Checkbox : RadioButton;
@@ -97,7 +97,7 @@ export function ChoiceList({
       );
     }
 
-    const isSelected = choiceIsSelected(choice, selected);
+    const isSelected = selected.includes(choice.value);
     const renderedChildren = choice.renderChildren
       ? choice.renderChildren(isSelected)
       : null;
@@ -116,7 +116,7 @@ export function ChoiceList({
             label={label}
             disabled={choiceDisabled || disabled}
             fill={{xs: true, sm: false}}
-            checked={choiceIsSelected(choice, selected)}
+            checked={isSelected}
             helpText={helpText}
             onChange={handleChange}
             ariaDescribedBy={
@@ -154,14 +154,10 @@ export function ChoiceList({
 
 function noop() {}
 
-function choiceIsSelected({value}: Choice, selected: string[]) {
-  return selected.includes(value);
-}
-
-function updateSelectedChoices(
-  {value}: Choice,
+function updateSelectedChoices<TValue extends string>(
+  {value}: Choice<TValue>,
   checked: boolean,
-  selected: string[],
+  selected: TValue[],
   allowMultiple = false,
 ) {
   if (checked) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The TypeScript types for ChoiceList weren't quite right. It says that `selected`, `choices.value`, and `onChange` were simple strings. This works for a lot of cases, but using either an enum or string literals, this breaks down a bit. Here's a simple example:

```tsx
function Test() {
  const [selected, setSelected] = useState<
    ('hidden' | 'optional' | 'required')[]
  >(['hidden']);

  return (
    <ChoiceList
      title="Company name"
      choices={[
        {label: 'Hidden', value: 'hidden'},
        {label: 'Optional', value: 'optional'},
        {label: 'Required', value: 'required'},
      ]}
      selected={selected}
      onChange={setSelected}
    />
  );
}
```
![image](https://github.com/Shopify/polaris/assets/1019769/27963f36-0b32-4f72-a941-1634a9d44dcf)

### WHAT is this pull request doing?

This PR improves the TypeScript types to use generics. The type still needs to extend a string, but now, we can know exactly _what type of string_ it is. The type will be inferred by `selected` and will propagate to the `choices.value` and `onChange` handlers.

<details>
  <summary>Default case: not supplying any types</summary>
  In this case, `selected` is inferred as `string[]` so it should effectively behave as before.

![image](https://github.com/Shopify/polaris/assets/1019769/554a5dd5-96c1-40dc-a5c6-b9196131cccf)

</details>

<details>
<summary>useState generic case</summary>
In this case, supplying the real type of `selected` will allow `onChange` to be typed properly

![image](https://github.com/Shopify/polaris/assets/1019769/f299b887-57c7-411c-98c2-6466ef1f01fd)

This also has the benefit that you cannot supply any choice values that are not allowed
![image](https://github.com/Shopify/polaris/assets/1019769/f3910577-7f15-4071-811d-872acba45931)

</details>

<details>
<summary>useState type-casting case</summary>
In this case, as with the above, TS will supply the proper type to `onChange`

![image](https://github.com/Shopify/polaris/assets/1019769/447c29d9-7ffd-424c-a5e4-cff69174e1f9)

Similar to above, this also has the benefit that you cannot supply any choice values that are not allowed

![image](https://github.com/Shopify/polaris/assets/1019769/f1bd5309-3d7e-4306-a5bd-6a6912b08d4a)

</details>

## Caveat
There's one caveat to this change that is worth pointing out. If the user has correctly typed their `useState` to something besides string[] AND they are not defining their `choices` inline, TS will type-widen their value's type to `string` and will cause a TS issue. They will need to type the choices to fix this. For example:

```tsx
type HiddenOptionalRequired = 'hidden' | 'optional' | 'required';

export function Default() {
  const [selected, setSelected] = useState<HiddenOptionalRequired[]>([
    'hidden',
  ]);

  const choices: ChoiceListProps<HiddenOptionalRequired>['choices'] = [
    {label: 'Hidden', value: 'hidden'},
    {label: 'Optional', value: 'optional'},
    {label: 'Required', value: 'required'},
  ];

  return (
    <ChoiceList
      title="Company name"
      choices={choices}
      selected={selected}
      onChange={setSelected}
    />
  );
}
```

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
