### PR TITLE
[Card] Add default value for `roundedAbove` prop

### DIFF
--- a/.changeset/big-donuts-watch.md
+++ b/.changeset/big-donuts-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added Card component default value for roundedAbove prop

--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -27,7 +27,9 @@ export interface CardProps {
    * padding={{xs: '200', sm: '300', md: '400', lg: '500', xl: '600'}}
    */
   padding?: Spacing;
-  /** Border radius value above a set breakpoint */
+  /** Border radius value above a set breakpoint
+   * @default 'sm'
+   */
   roundedAbove?: BreakpointsAlias;
 }
 
@@ -35,16 +37,11 @@ export const Card = ({
   children,
   background = 'bg-surface',
   padding = {xs: '400'},
-  roundedAbove,
+  roundedAbove = 'sm',
 }: CardProps) => {
   const breakpoints = useBreakpoints();
   const defaultBorderRadius: BorderRadiusAliasOrScale = '300';
-
-  let hasBorderRadius = !roundedAbove;
-
-  if (roundedAbove && breakpoints[`${roundedAbove}Up`]) {
-    hasBorderRadius = true;
-  }
+  const hasBorderRadius = Boolean(breakpoints[`${roundedAbove}Up`]);
 
   return (
     <WithinContentContext.Provider value>


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris-internal/issues/1197
Fixes #11142

* [Discussion](https://github.com/Shopify/polaris-internal/issues/1197) on whether or not `Card` `roundedAbove` should have a default value
* My [reasoning](https://github.com/Shopify/polaris-internal/issues/1197#issuecomment-1808581215) for why it should

https://admin.web.web-90hf.sophie-schneider.us.spin.dev/store/shop1/discounts/1

|Before|After|
|-|-|
|<img width="308" alt="Screenshot 2023-11-13 at 11 38 31 AM" src="https://github.com/Shopify/polaris/assets/20652326/f33339b5-d7ef-4c0d-9d70-52836be12f00">|<img width="310" alt="Screenshot 2023-11-13 at 11 48 49 AM" src="https://github.com/Shopify/polaris/assets/20652326/f0bc00ac-633b-4b53-b533-e0358487ecfe">|
