### PR TITLE
[Page] prevent vertical content shift of header title with metadata

### DIFF
--- a/.changeset/smooth-bats-jump.md
+++ b/.changeset/smooth-bats-jump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[Page] prevent vertical content shift of header with metadata and actions

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
-  DeleteMinor,
-  PlusMinor,
   ArrowDownMinor,
+  DeleteMinor,
   ExternalMinor,
-  ViewMinor,
   MobileVerticalDotsMajor,
+  PlusMinor,
+  ViewMinor,
 } from '@shopify/polaris-icons';
 import {
   Badge,
   Button,
   LegacyCard,
+  LegacyStack,
   Page,
   PageActions,
-  LegacyStack,
 } from '@shopify/polaris';
 
 export default {
@@ -330,6 +330,34 @@ export function WithContentAfterTitle() {
       backAction={{content: 'Products', url: '#'}}
       title="Jar With Lock-Lid"
       titleMetadata={<Badge tone="attention">Verified</Badge>}
+      primaryAction={{content: 'Save', disabled: true}}
+      secondaryActions={[
+        {content: 'Duplicate'},
+        {content: 'View on your store'},
+      ]}
+      pagination={{
+        hasPrevious: true,
+        hasNext: true,
+      }}
+    >
+      <LegacyCard title="Credit card" sectioned>
+        <p>Credit card information</p>
+      </LegacyCard>
+    </Page>
+  );
+}
+
+export function WithContentAfterTitleAndSubtitle() {
+  return (
+    <Page
+      backAction={{content: 'Products', url: '#'}}
+      title="Jar With Lock-Lid"
+      titleMetadata={
+        <Button disclosure size="large">
+          All locations
+        </Button>
+      }
+      subtitle="Created: May 3, 2019 to June 2, 2019"
       primaryAction={{content: 'Save', disabled: true}}
       secondaryActions={[
         {content: 'Duplicate'},

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.scss
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.scss
@@ -6,22 +6,13 @@
   font-weight: var(--p-font-weight-bold);
   font-size: var(--p-font-size-500);
   line-height: var(--p-font-line-height-600);
-}
 
-.TitleWithSubtitle {
-  margin-top: 0;
-}
-
-.SubTitle {
-  margin-top: var(--p-space-050);
-  color: var(--p-color-text-secondary);
-
-  &.SubtitleCompact {
-    margin-top: var(--p-space-050);
+  &.TitleWithSubtitle {
+    margin-top: 0;
   }
 }
 
-.TitleWithMetadataWrapper {
+.TitleWrapper {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -37,9 +28,13 @@
       display: inline;
     }
   }
+}
 
-  .TitleMetadata {
-    margin-top: 0;
-    vertical-align: bottom;
+.SubTitle {
+  margin-top: var(--p-space-050);
+  color: var(--p-color-text-secondary);
+
+  &.SubtitleCompact {
+    margin-top: var(--p-space-050);
   }
 }

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {classNames} from '../../../../../../utilities/css';
+import {Bleed} from '../../../../../Bleed';
 import {Text} from '../../../../../Text';
 
 import styles from './Title.scss';
@@ -30,16 +31,14 @@ export function Title({
   const titleMarkup = title ? <h1 className={className}>{title}</h1> : null;
 
   const titleMetadataMarkup = titleMetadata ? (
-    <div className={styles.TitleMetadata}>{titleMetadata}</div>
+    <Bleed marginBlock="100">{titleMetadata}</Bleed>
   ) : null;
 
-  const wrappedTitleMarkup = titleMetadata ? (
-    <div className={styles.TitleWithMetadataWrapper}>
+  const wrappedTitleMarkup = (
+    <div className={styles.TitleWrapper}>
       {titleMarkup}
       {titleMetadataMarkup}
     </div>
-  ) : (
-    titleMarkup
   );
 
   const subtitleMarkup = subtitle ? (


### PR DESCRIPTION
### WHY are these changes introduced?

Refresh of https://github.com/Shopify/polaris/pull/10545 post v12

Fixes: https://github.com/Shopify/web/issues/103405

Inconsistent Header height within the `Page` component is leading to the Header shifting vertically when navigating between pages with different properties enabled (e.g. metadata, actions). This pull request makes adjustments to combat the shifting.

### WHAT is this pull request doing?

- Consistent Header row height of 28px
   - Header Title will always have 2px of vertical padding to bring the 24px line height to 28px in total for the container
   - Allow for bleeding of the Title metadata, so metadata can be larger than Title without impacting alignment (e.g. Location picker)
- Removes vertical alignment and margin-top of Title metadata, which had no impact to aesthetic
- Reorganizes CSS to make class/style relationships clearer
- Adds new Storybook to highlight problem

NOTE: This is a bit of a bandaid fix. We should likely rewrite this component to utilize a grid layout to have a more resilient solution for achieving the desired aesthetic, but considering the variability in configurations of this component that is a sizable effort. However, I think we'd need to understand the desired aesthetic when a subtitle exists along with title metadata content that is larger than the title to determine the optimal solution. 

### How to 🎩

[Spin - Web](https://admin.web.polaris-page-header-position.matt-kubej.us.spin.dev/store/shop1/orders?inContextTimeframe=none)
[Spin - Polaris Storybook](https://storybook.web.polaris-page-header-position.matt-kubej.us.spin.dev/?path=/story/all-components-page--with-content-after-title-and-subtitle)

Validate when navigating amongst root pages (e.g. draft orders, products) that the Page Header does not shift with/without the presence of title metadata and actions. Also, validate that the Header row has contents vertically centered.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
