### PR TITLE
[Card] Set border radius to 0 when it is the same width as the window

### DIFF
--- a/.changeset/wise-ladybugs-cover.md
+++ b/.changeset/wise-ladybugs-cover.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Set Card border radius to 0 when it is the same width as the window

--- a/polaris-react/src/components/Card/Card.stories.tsx
+++ b/polaris-react/src/components/Card/Card.stories.tsx
@@ -100,3 +100,22 @@ export function WithSubduedSection() {
     </Card>
   );
 }
+
+export function FullWindowWidth() {
+  return (
+    <BlockStack gap="400">
+      <Bleed marginInline="400">
+        <Card>Card with same width as window</Card>
+      </Bleed>
+      <Bleed marginInline="400">
+        <Card roundedAbove="sm">
+          Card with roundedAbove sm and same width as window
+        </Card>
+      </Bleed>
+      <Card>Card with smaller width than window</Card>
+      <Card roundedAbove="md">
+        Card with roundedAbove md and smaller width than window
+      </Card>
+    </BlockStack>
+  );
+}

--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -4,13 +4,14 @@ import type {
   BorderRadiusAliasOrScale,
   SpaceScale,
 } from '@shopify/polaris-tokens';
-import React from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {useBreakpoints} from '../../utilities/breakpoints';
 import type {ResponsiveProp} from '../../utilities/css';
 import {Box} from '../Box';
 import {ShadowBevel} from '../ShadowBevel';
 import {WithinContentContext} from '../../utilities/within-content-context';
+import {useEventListener} from '../../utilities/use-event-listener';
 
 type Spacing = ResponsiveProp<SpaceScale>;
 
@@ -39,12 +40,28 @@ export const Card = ({
 }: CardProps) => {
   const breakpoints = useBreakpoints();
   const defaultBorderRadius: BorderRadiusAliasOrScale = '300';
+  const cardNode = useRef<HTMLDivElement>(null);
 
-  let hasBorderRadius = !roundedAbove;
+  const defaultRoundedAbove =
+    roundedAbove && breakpoints[`${roundedAbove}Up`] ? true : !roundedAbove;
+  const [hasBorderRadius, setHasBorderRadius] =
+    useState<boolean>(defaultRoundedAbove);
 
-  if (roundedAbove && breakpoints[`${roundedAbove}Up`]) {
-    hasBorderRadius = true;
-  }
+  const handleResize = useCallback(() => {
+    if (breakpoints.smUp) return;
+
+    const cardWidth = cardNode.current?.offsetWidth;
+    const windowWidth = window.innerWidth;
+
+    if (cardWidth === undefined || cardWidth === null) return;
+
+    windowWidth - cardWidth < 1
+      ? setHasBorderRadius(false)
+      : setHasBorderRadius(defaultRoundedAbove);
+  }, [breakpoints.smUp, defaultRoundedAbove]);
+
+  useEffect(() => handleResize(), [handleResize]);
+  useEventListener('resize', handleResize);
 
   return (
     <WithinContentContext.Provider value>
@@ -59,6 +76,7 @@ export const Card = ({
           overflowX="hidden"
           overflowY="hidden"
           minHeight="100%"
+          ref={cardNode}
         >
           {children}
         </Box>


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris-internal/issues/1197

* [Discussion](https://github.com/Shopify/polaris-internal/issues/1197) on whether or not `Card` `roundedAbove` should have a default value

Solution: Instead of setting a default value for `roundedAbove`, only enforce square corners on Cards when their width is the same width as the window

|Before|After|
|-|-|

