### PR TITLE
Add `key` prop to `Select` component option

### DIFF
--- a/.changeset/rude-jokes-design.md
+++ b/.changeset/rude-jokes-design.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added the `key` prop to `Select` component `StrictOption`

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -20,6 +20,8 @@ interface StrictOption {
   disabled?: boolean;
   /** Element to display to the left of the option label. Does not show in the dropdown. */
   prefix?: React.ReactNode;
+  /** Unique key applied to the option element. Defaults to option value prop when undefined. */
+  key?: string;
 }
 
 interface HideableStrictOption extends StrictOption {
@@ -272,9 +274,9 @@ function flattenOptions(
 }
 
 function renderSingleOption(option: HideableStrictOption): React.ReactNode {
-  const {value, label, prefix: _prefix, ...rest} = option;
+  const {value, label, prefix: _prefix, key, ...rest} = option;
   return (
-    <option key={value} value={value} {...rest}>
+    <option key={key ?? value} value={value} {...rest}>
       {label}
     </option>
   );


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/discussions/11111 issue where you have two identical option values that trigger a React `key` warning.

<img width="2032" alt="Screenshot 2023-11-14 at 2 37 08 PM" src="https://github.com/Shopify/polaris/assets/4642404/41bf28be-f929-44c1-a468-79c74967b40f">

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds an optional `key` prop to `Select` component options. If the `key` prop is undefined the key will default to the option `value` (which is the current behavior)
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
