### PR TITLE
[Card] Add storybook examples for Card compositions

### DIFF
--- a/.changeset/empty-squids-prove.md
+++ b/.changeset/empty-squids-prove.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added documentation for `Card` examples to support `LegacyCard` compositions

--- a/polaris-react/src/components/Card/Card.stories.tsx
+++ b/polaris-react/src/components/Card/Card.stories.tsx
@@ -1,6 +1,23 @@
-import React from 'react';
+import React, {useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Card, BlockStack, Bleed, Box, List, Text} from '@shopify/polaris';
+import {
+  ActionList,
+  BlockStack,
+  Bleed,
+  Box,
+  Button,
+  ButtonGroup,
+  Card,
+  Icon,
+  Image,
+  InlineGrid,
+  InlineStack,
+  List,
+  Popover,
+  ResourceList,
+  Text,
+} from '@shopify/polaris';
+import {ProductsMinor} from '@shopify/polaris-icons';
 
 export default {
   component: Card,
@@ -10,7 +27,7 @@ export function Default() {
   return (
     <Card roundedAbove="sm">
       <BlockStack gap="200">
-        <Text as="h3" variant="headingSm">
+        <Text as="h2" variant="headingSm">
           Online store dashboard
         </Text>
         <p>View a summary of your online store’s performance.</p>
@@ -23,7 +40,7 @@ export function WithResponsiveBorderRadius() {
   return (
     <Card roundedAbove="sm">
       <BlockStack gap="200">
-        <Text as="h3" variant="headingSm">
+        <Text as="h2" variant="headingSm">
           Online store dashboard
         </Text>
         <p>View a summary of your online store’s performance.</p>
@@ -36,7 +53,7 @@ export function WithResponsivePadding() {
   return (
     <Card padding={{xs: '500', sm: '600', md: '800'}} roundedAbove="sm">
       <BlockStack gap={{xs: '400', sm: '500'}}>
-        <Text as="h3" variant="headingSm">
+        <Text as="h2" variant="headingSm">
           Online store dashboard
         </Text>
         <p>View a summary of your online store’s performance.</p>
@@ -49,7 +66,7 @@ export function WithSubduedBackground() {
   return (
     <Card background="bg-surface-secondary" roundedAbove="sm">
       <BlockStack gap="200">
-        <Text as="h3" variant="headingSm">
+        <Text as="h2" variant="headingSm">
           Online store dashboard
         </Text>
         <p>View a summary of your online store’s performance.</p>
@@ -58,11 +75,78 @@ export function WithSubduedBackground() {
   );
 }
 
+export function WithSingleSection() {
+  return (
+    <Card roundedAbove="sm">
+      <Text as="h2" variant="headingSm">
+        Online store dashboard
+      </Text>
+      <Box paddingBlockStart="200">
+        <Text as="p" variant="bodyMd">
+          View a summary of your online store’s performance.
+        </Text>
+      </Box>
+    </Card>
+  );
+}
+
+export function WithMultipleSections() {
+  return (
+    <Card roundedAbove="sm">
+      <Text as="h2" variant="headingSm">
+        Online store dashboard
+      </Text>
+      <Box paddingBlock="200">
+        <Text as="p" variant="bodyMd">
+          View a summary of your online store’s performance.
+        </Text>
+      </Box>
+      <Box paddingBlockStart="200">
+        <Text as="p" variant="bodyMd">
+          View a summary of your online store’s performance, including sales,
+          visitors, top products, and referrals.
+        </Text>
+      </Box>
+    </Card>
+  );
+}
+
+export function WithMultipleTitledSections() {
+  return (
+    <Card roundedAbove="sm">
+      <Text as="h2" variant="headingSm">
+        Online store dashboard
+      </Text>
+      <Box paddingBlock="200">
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Reports
+          </Text>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </BlockStack>
+      </Box>
+      <Box paddingBlockStart="200">
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Summary
+          </Text>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance, including sales,
+            visitors, top products, and referrals.
+          </Text>
+        </BlockStack>
+      </Box>
+    </Card>
+  );
+}
+
 export function WithSubduedSection() {
   return (
     <Card roundedAbove="sm">
       <BlockStack gap="200">
-        <Text as="h3" variant="headingSm">
+        <Text as="h2" variant="headingSm">
           Staff accounts
         </Text>
         <Box paddingBlockEnd="200">
@@ -85,6 +169,569 @@ export function WithSubduedSection() {
           </BlockStack>
         </Box>
       </Bleed>
+    </Card>
+  );
+}
+
+export function WithSubsection() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Customer
+          </Text>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </BlockStack>
+        <Box>
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Addresses
+            </Text>
+            <Box>
+              <Text as="p" variant="bodyMd">
+                123 First St
+              </Text>
+              <Text as="p" variant="bodyMd">
+                Somewhere
+              </Text>
+              <Text as="p" variant="bodyMd">
+                The Universe
+              </Text>
+            </Box>
+            <Box>
+              <Text as="p" variant="bodyMd">
+                123 Second St
+              </Text>
+              <Text as="p" variant="bodyMd">
+                Somewhere
+              </Text>
+              <Text as="p" variant="bodyMd">
+                The Universe
+              </Text>
+            </Box>
+          </BlockStack>
+        </Box>
+        <Box>
+          <Text as="p" variant="bodyMd">
+            A single subsection without a sibling has no visual appearance
+          </Text>
+        </Box>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithFlushSection() {
+  return (
+    <Card roundedAbove="sm">
+      <Bleed marginInline="400" marginBlockStart="400">
+        <Image
+          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+          alt="a sheet with purple and orange stripes"
+        />
+      </Bleed>
+      <Box paddingBlockStart="400">
+        <Text as="p" variant="bodyMd">
+          You can use sales reports to see information about your customers’
+          orders based on criteria such as sales over time, by channel, or by
+          staff.
+        </Text>
+      </Box>
+    </Card>
+  );
+}
+
+export function WithFlushSectionAndSubduedSection() {
+  return (
+    <Card roundedAbove="sm">
+      <Bleed marginInline="400" marginBlock="400">
+        <Image
+          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+          alt="a sheet with purple and orange stripes"
+        />
+        <Box background="bg-surface-secondary" padding="400">
+          <Text as="p" variant="bodyMd">
+            You can use sales reports to see information about your customers’
+            orders based on criteria such as sales over time, by channel, or by
+            staff.
+          </Text>
+        </Box>
+      </Bleed>
+    </Card>
+  );
+}
+
+export function WithSectionsAndAction() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Customer
+          </Text>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </BlockStack>
+        <BlockStack gap="200">
+          <InlineGrid columns="1fr auto">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Contact Information
+            </Text>
+            <Button
+              variant="plain"
+              onClick={() => {}}
+              accessibilityLabel="Edit"
+            >
+              Edit
+            </Button>
+          </InlineGrid>
+          <Text as="p" variant="bodyMd">
+            john.smith@example.com
+          </Text>
+        </BlockStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithSectionsAndDestructiveAction() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Customer
+          </Text>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </BlockStack>
+        <BlockStack gap="200">
+          <InlineGrid columns="1fr auto">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Contact Information
+            </Text>
+            <ButtonGroup>
+              <Button
+                variant="plain"
+                tone="critical"
+                onClick={() => {}}
+                accessibilityLabel="Delete"
+              >
+                Delete
+              </Button>
+              <Button
+                variant="plain"
+                onClick={() => {}}
+                accessibilityLabel="Edit"
+              >
+                Edit
+              </Button>
+            </ButtonGroup>
+          </InlineGrid>
+          <Text as="p" variant="bodyMd">
+            john.smith@example.com
+          </Text>
+        </BlockStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithSeparateHeader() {
+  const [actionActive, toggleAction] = useState(false);
+
+  const handleToggleAction = () => {
+    toggleAction(!actionActive);
+  };
+
+  const items = [{content: 'Member'}, {content: 'Admin'}];
+
+  const disclosureButtonActivator = (
+    <Button variant="plain" disclosure onClick={handleToggleAction}>
+      Add account
+    </Button>
+  );
+
+  const disclosureButton = (
+    <Popover
+      active={actionActive}
+      activator={disclosureButtonActivator}
+      onClose={handleToggleAction}
+    >
+      <ActionList items={items} />
+    </Popover>
+  );
+
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <InlineGrid columns="1fr auto">
+          <Text as="h2" variant="headingSm">
+            Staff accounts
+          </Text>
+          <ButtonGroup>
+            <Button
+              variant="plain"
+              onClick={() => {}}
+              accessibilityLabel="Preview"
+            >
+              Preview
+            </Button>
+            {disclosureButton}
+          </ButtonGroup>
+        </InlineGrid>
+        <List>
+          <List.Item>Felix Crafford</List.Item>
+          <List.Item>Ezequiel Manno</List.Item>
+        </List>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithHeaderActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <InlineGrid columns="1fr auto">
+          <Text as="h2" variant="headingSm">
+            Variants
+          </Text>
+          <Button
+            variant="plain"
+            onClick={() => {}}
+            accessibilityLabel="Add variant"
+          >
+            Add variant
+          </Button>
+        </InlineGrid>
+        <Text as="p" variant="bodyMd">
+          Add variants if this product comes in multiple versions, like
+          different sizes or colors.
+        </Text>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithFooterActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Shipment 1234
+        </Text>
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Items
+          </Text>
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </BlockStack>
+        <InlineStack align="end">
+          <ButtonGroup>
+            <Button onClick={() => {}} accessibilityLabel="Edit shipment">
+              Edit shipment
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => {}}
+              accessibilityLabel="Add tracking number"
+            >
+              Add tracking number
+            </Button>
+          </ButtonGroup>
+        </InlineStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithMultipleFooterActions() {
+  const [actionActive, toggleAction] = useState(false);
+
+  const handleToggleAction = () => {
+    toggleAction(!actionActive);
+  };
+
+  const items = [
+    {content: 'Cancel shipment', destructive: true},
+    {content: 'Add another shipment', disabled: true},
+  ];
+
+  const disclosureButtonActivator = (
+    <Button disclosure accessibilityLabel="More" onClick={handleToggleAction}>
+      More
+    </Button>
+  );
+
+  const disclosureButton = (
+    <Popover
+      active={actionActive}
+      activator={disclosureButtonActivator}
+      onClose={handleToggleAction}
+    >
+      <ActionList items={items} />
+    </Popover>
+  );
+
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Shipment 1234
+        </Text>
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Items
+          </Text>
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </BlockStack>
+        <InlineStack align="end">
+          <ButtonGroup>
+            {disclosureButton}
+            <Button
+              variant="primary"
+              onClick={() => {}}
+              accessibilityLabel="Add tracking number"
+            >
+              Add tracking number
+            </Button>
+          </ButtonGroup>
+        </InlineStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithCustomFooterActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="500">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Secure your account with 2-step authentication
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Two-step authentication adds an extra layer of security when logging
+            in to your account. A special code will be required each time you
+            log in, ensuring only you can access your account.
+          </Text>
+        </BlockStack>
+        <InlineStack align="end">
+          <ButtonGroup>
+            <Button
+              onClick={() => {}}
+              accessibilityLabel="Enable two-step authentication"
+            >
+              Enable two-step authentication
+            </Button>
+            <Button variant="plain">Learn more</Button>
+          </ButtonGroup>
+        </InlineStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithDestructiveFooterActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Shipment 1234
+        </Text>
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Items
+          </Text>
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </BlockStack>
+        <InlineStack align="end">
+          <ButtonGroup>
+            <Button
+              variant="primary"
+              tone="critical"
+              onClick={() => {}}
+              accessibilityLabel="Cancel shipment"
+            >
+              Cancel shipment
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => {}}
+              accessibilityLabel="Add tracking number"
+            >
+              Add tracking number
+            </Button>
+          </ButtonGroup>
+        </InlineStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithCustomReactNodeTitle() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Products
+        </Text>
+        <BlockStack inlineAlign="start">
+          <InlineStack gap="400">
+            <Icon source={ProductsMinor} />
+            <Text as="h3" variant="headingSm">
+              New Products
+            </Text>
+          </InlineStack>
+        </BlockStack>
+        <List>
+          <List.Item>Socks</List.Item>
+          <List.Item>Super Shoes</List.Item>
+        </List>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithAllElements() {
+  const [actionActive, toggleAction] = useState(false);
+
+  const handleToggleAction = () => {
+    toggleAction(!actionActive);
+  };
+
+  const items = [{content: 'Gross Sales'}, {content: 'Net Sales'}];
+
+  const disclosureButtonActivator = (
+    <Button variant="plain" disclosure onClick={handleToggleAction}>
+      View Sales
+    </Button>
+  );
+
+  const disclosureButton = (
+    <Popover
+      active={actionActive}
+      activator={disclosureButtonActivator}
+      onClose={handleToggleAction}
+    >
+      <ActionList items={items} />
+    </Popover>
+  );
+
+  const salesMarkup = (
+    <Box>
+      <ResourceList
+        resourceName={{singular: 'sale', plural: 'sales'}}
+        items={[
+          {
+            sales: 'Orders',
+            amount: 'USD$0.00',
+            url: '#',
+          },
+          {
+            sales: 'Returns',
+            amount: '-USD$250.00',
+            url: '#',
+          },
+        ]}
+        renderItem={(item) => {
+          const {sales, amount, url} = item;
+          return (
+            <ResourceList.Item
+              id={sales}
+              url={url}
+              accessibilityLabel={`View Sales for ${sales}`}
+            >
+              <InlineStack align="space-between">
+                <div>{sales}</div>
+                <div>{amount}</div>
+              </InlineStack>
+            </ResourceList.Item>
+          );
+        }}
+      />
+    </Box>
+  );
+
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <InlineGrid columns="1fr auto">
+          <Text as="h2" variant="headingSm">
+            Sales
+          </Text>
+          <ButtonGroup>
+            <Button variant="plain">Total Sales</Button>
+            {disclosureButton}
+          </ButtonGroup>
+        </InlineGrid>
+        <BlockStack gap="400">
+          <Text as="p" variant="bodyMd">
+            You can use sales reports to see information about your customers’
+            orders based on criteria such as sales over time, by channel, or by
+            staff.
+          </Text>
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Total Sales Breakdown
+          </Text>
+        </BlockStack>
+        {salesMarkup}
+        <Bleed marginInline="400">
+          <Box
+            background="bg-surface-secondary"
+            paddingBlock="300"
+            paddingInline="400"
+          >
+            <BlockStack gap="200">
+              <Text as="h3" variant="headingSm" fontWeight="medium">
+                Deactivated reports
+              </Text>
+              <List>
+                <List.Item>Payouts</List.Item>
+                <List.Item>Total Sales By Channel</List.Item>
+              </List>
+            </BlockStack>
+          </Box>
+        </Bleed>
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Note
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The sales reports are available only if your store is on the Shopify
+            plan or higher.
+          </Text>
+          <InlineStack align="end">
+            <ButtonGroup>
+              <Button onClick={() => {}} accessibilityLabel="Dismiss">
+                Dismiss
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => {}}
+                accessibilityLabel="Export Report"
+              >
+                Export Report
+              </Button>
+            </ButtonGroup>
+          </InlineStack>
+        </BlockStack>
+      </BlockStack>
     </Card>
   );
 }

--- a/polaris-react/src/components/Card/Card.stories.tsx
+++ b/polaris-react/src/components/Card/Card.stories.tsx
@@ -62,7 +62,7 @@ export function WithResponsivePadding() {
   );
 }
 
-export function WithSubduedBackground() {
+export function WithSubdued() {
   return (
     <Card background="bg-surface-secondary" roundedAbove="sm">
       <BlockStack gap="200">
@@ -75,7 +75,23 @@ export function WithSubduedBackground() {
   );
 }
 
-export function WithSingleSection() {
+export function WithSubduedForSecondaryContent() {
+  return (
+    <Card background="bg-surface-secondary" roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h3" variant="headingSm" fontWeight="medium">
+          Deactivated staff accounts
+        </Text>
+        <List>
+          <List.Item>Felix Crafford</List.Item>
+          <List.Item>Ezequiel Manno</List.Item>
+        </List>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithSection() {
   return (
     <Card roundedAbove="sm">
       <Text as="h2" variant="headingSm">
@@ -86,6 +102,37 @@ export function WithSingleSection() {
           View a summary of your online store’s performance.
         </Text>
       </Box>
+    </Card>
+  );
+}
+
+export function WithSubduedSection() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Staff accounts
+        </Text>
+        <Box paddingBlockEnd="200">
+          <List>
+            <List.Item>Felix Crafford</List.Item>
+            <List.Item>Ezequiel Manno</List.Item>
+          </List>
+        </Box>
+      </BlockStack>
+      <Bleed marginBlockEnd="400" marginInline="400">
+        <Box background="bg-surface-secondary" padding="400">
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Deactivated staff accounts
+            </Text>
+            <List>
+              <List.Item>Felix Crafford</List.Item>
+              <List.Item>Ezequiel Manno</List.Item>
+            </List>
+          </BlockStack>
+        </Box>
+      </Bleed>
     </Card>
   );
 }
@@ -142,37 +189,6 @@ export function WithMultipleTitledSections() {
   );
 }
 
-export function WithSubduedSection() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Staff accounts
-        </Text>
-        <Box paddingBlockEnd="200">
-          <List>
-            <List.Item>Felix Crafford</List.Item>
-            <List.Item>Ezequiel Manno</List.Item>
-          </List>
-        </Box>
-      </BlockStack>
-      <Bleed marginBlockEnd="400" marginInline="400">
-        <Box background="bg-surface-secondary" padding="400">
-          <BlockStack gap="200">
-            <Text as="h3" variant="headingSm" fontWeight="medium">
-              Deactivated staff accounts
-            </Text>
-            <List>
-              <List.Item>Felix Crafford</List.Item>
-              <List.Item>Ezequiel Manno</List.Item>
-            </List>
-          </BlockStack>
-        </Box>
-      </Bleed>
-    </Card>
-  );
-}
-
 export function WithSubsection() {
   return (
     <Card roundedAbove="sm">
@@ -224,7 +240,7 @@ export function WithSubsection() {
   );
 }
 
-export function WithFlushSection() {
+export function WithFlushedSection() {
   return (
     <Card roundedAbove="sm">
       <Bleed marginInline="400" marginBlockStart="400">
@@ -244,7 +260,7 @@ export function WithFlushSection() {
   );
 }
 
-export function WithFlushSectionAndSubduedSection() {
+export function WithFlushedSectionAndSubduedSection() {
   return (
     <Card roundedAbove="sm">
       <Bleed marginInline="400" marginBlock="400">
@@ -264,7 +280,7 @@ export function WithFlushSectionAndSubduedSection() {
   );
 }
 
-export function WithSectionsAndAction() {
+export function WithSectionsAndActions() {
   return (
     <Card roundedAbove="sm">
       <BlockStack gap="400">

--- a/polaris-react/src/components/Card/Card.stories.tsx
+++ b/polaris-react/src/components/Card/Card.stories.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {
-  Card,
-  BlockStack,
-  Bleed,
-  Box,
-  Divider,
-  List,
-  Text,
-} from '@shopify/polaris';
+import {Card, BlockStack, Bleed, Box, List, Text} from '@shopify/polaris';
 
 export default {
   component: Card,
@@ -16,9 +8,9 @@ export default {
 
 export function Default() {
   return (
-    <Card>
-      <BlockStack gap="500">
-        <Text as="h3" variant="headingMd">
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h3" variant="headingSm">
           Online store dashboard
         </Text>
         <p>View a summary of your online store’s performance.</p>
@@ -27,24 +19,11 @@ export function Default() {
   );
 }
 
-export function WithBackgroundSubdued() {
-  return (
-    <Card background="bg-surface-tertiary">
-      <BlockStack gap="500">
-        <Text as="h3" variant="headingMd">
-          Online store dashboard
-        </Text>
-        <p>View a summary of your online store’s performance.</p>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithBorderRadiusRoundedAbove() {
+export function WithResponsiveBorderRadius() {
   return (
     <Card roundedAbove="sm">
-      <BlockStack gap="500">
-        <Text as="h3" variant="headingMd">
+      <BlockStack gap="200">
+        <Text as="h3" variant="headingSm">
           Online store dashboard
         </Text>
         <p>View a summary of your online store’s performance.</p>
@@ -57,7 +36,20 @@ export function WithResponsivePadding() {
   return (
     <Card padding={{xs: '500', sm: '600', md: '800'}} roundedAbove="sm">
       <BlockStack gap={{xs: '400', sm: '500'}}>
-        <Text as="h3" variant="headingMd">
+        <Text as="h3" variant="headingSm">
+          Online store dashboard
+        </Text>
+        <p>View a summary of your online store’s performance.</p>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export function WithSubduedBackground() {
+  return (
+    <Card background="bg-surface-secondary" roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h3" variant="headingSm">
           Online store dashboard
         </Text>
         <p>View a summary of your online store’s performance.</p>
@@ -69,25 +61,21 @@ export function WithResponsivePadding() {
 export function WithSubduedSection() {
   return (
     <Card roundedAbove="sm">
-      <BlockStack gap="500">
-        <Text as="h3" variant="headingMd">
+      <BlockStack gap="200">
+        <Text as="h3" variant="headingSm">
           Staff accounts
         </Text>
-        <Box paddingBlockEnd="500">
+        <Box paddingBlockEnd="200">
           <List>
             <List.Item>Felix Crafford</List.Item>
             <List.Item>Ezequiel Manno</List.Item>
           </List>
         </Box>
       </BlockStack>
-      <Bleed
-        marginBlockEnd={{xs: '400', sm: '500'}}
-        marginInline={{xs: '400', sm: '500'}}
-      >
-        <Divider />
-        <Box background="bg-surface-tertiary" padding={{xs: '400', sm: '500'}}>
+      <Bleed marginBlockEnd="400" marginInline="400">
+        <Box background="bg-surface-secondary" padding="400">
           <BlockStack gap="200">
-            <Text variant="headingSm" as="h3">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
               Deactivated staff accounts
             </Text>
             <List>

--- a/polaris-react/src/components/Card/Card.stories.tsx
+++ b/polaris-react/src/components/Card/Card.stories.tsx
@@ -201,12 +201,12 @@ export function WithSubsection() {
             John Smith
           </Text>
         </BlockStack>
-        <Box>
+        <div>
           <BlockStack gap="200">
             <Text as="h3" variant="headingSm" fontWeight="medium">
               Addresses
             </Text>
-            <Box>
+            <div>
               <Text as="p" variant="bodyMd">
                 123 First St
               </Text>
@@ -216,8 +216,8 @@ export function WithSubsection() {
               <Text as="p" variant="bodyMd">
                 The Universe
               </Text>
-            </Box>
-            <Box>
+            </div>
+            <div>
               <Text as="p" variant="bodyMd">
                 123 Second St
               </Text>
@@ -227,14 +227,14 @@ export function WithSubsection() {
               <Text as="p" variant="bodyMd">
                 The Universe
               </Text>
-            </Box>
+            </div>
           </BlockStack>
-        </Box>
-        <Box>
+        </div>
+        <div>
           <Text as="p" variant="bodyMd">
             A single subsection without a sibling has no visual appearance
           </Text>
-        </Box>
+        </div>
       </BlockStack>
     </Card>
   );
@@ -314,7 +314,7 @@ export function WithSectionsAndActions() {
   );
 }
 
-export function WithSectionsAndDestructiveAction() {
+export function WithSectionsAndCriticalAction() {
   return (
     <Card roundedAbove="sm">
       <BlockStack gap="400">
@@ -560,7 +560,7 @@ export function WithCustomFooterActions() {
   );
 }
 
-export function WithDestructiveFooterActions() {
+export function WithCriticalFooterActions() {
   return (
     <Card roundedAbove="sm">
       <BlockStack gap="200">
@@ -650,7 +650,7 @@ export function WithAllElements() {
   );
 
   const salesMarkup = (
-    <Box>
+    <div>
       <ResourceList
         resourceName={{singular: 'sale', plural: 'sales'}}
         items={[
@@ -681,7 +681,7 @@ export function WithAllElements() {
           );
         }}
       />
-    </Box>
+    </div>
   );
 
   return (

--- a/polaris.shopify.com/content/components/layout-and-structure/card.mdx
+++ b/polaris.shopify.com/content/components/layout-and-structure/card.mdx
@@ -26,7 +26,7 @@ examples:
   - fileName: card-default.tsx
     title: Default
     description: >-
-      By default, cards have an 8px border radius and uses `--p-color-bg-surface` as the background and `--p-shadow-300` as the shadow. There is padding of `space-5` (20px) around children and `space-4` (16px) for small screens.
+      By default, cards have an 8px border radius and uses `--p-color-bg-surface` as the background and `--p-shadow-300` as the shadow. There is padding of `space-500` (20px) around children and `space-400` (16px) for small screens.
   - fileName: card-with-subdued-background.tsx
     title: With subdued background
     description: >-
@@ -35,10 +35,10 @@ examples:
     title: With varying padding
     description: >-
       Use the `padding` property to adjust the spacing within a card. You can also specify spacing values at different breakpoints.
-  - fileName: card-with-rounded-corners.tsx
-    title: Rounded corners
+  - fileName: card-with-responsive-border-radius.tsx
+    title: With responsive border radius
     description: >-
-      Use the `padding` property to adjust the spacing of content within a card. The `padding` prop supports responsive spacing with the [Breakpoints tokens](https://polaris.shopify.com/tokens/breakpoints).
+      Use the `roundedAbove` property to adjust the border radius of the card based on a set breakpoint.
 previewImg: /images/components/layout-and-structure/card.png
 ---
 

--- a/polaris.shopify.com/content/components/layout-and-structure/card.mdx
+++ b/polaris.shopify.com/content/components/layout-and-structure/card.mdx
@@ -26,7 +26,7 @@ examples:
   - fileName: card-default.tsx
     title: Default
     description: >-
-      By default, cards have an 8px border radius and uses `--p-color-bg-surface` as the background and `--p-shadow-300` as the shadow. There is padding of `space-500` (20px) around children and `space-400` (16px) for small screens.
+      By default, cards have an 8px border radius and uses `--p-color-bg-surface` as the background and `--p-shadow-300` as the shadow. There is padding of `space-400` (16px) around children.
   - fileName: card-with-subdued-background.tsx
     title: With subdued background
     description: >-
@@ -39,6 +39,70 @@ examples:
     title: With responsive border radius
     description: >-
       Use the `roundedAbove` property to adjust the border radius of the card based on a set breakpoint.
+  - fileName: card-with-section.tsx
+    title: With section
+    description: >-
+      Use when you have a distinct piece of information to communicate to merchants.
+  - fileName: card-with-subdued-section.tsx
+    title: With subdued section
+    description: >-
+      Use to indicate when one of the sections in your card contains inactive or disabled content.
+  - fileName: card-with-multiple-sections.tsx
+    title: With multiple sections
+    description: >-
+      Use when you have two related but distinct pieces of information to communicate to merchants. Multiple sections can help break up complicated concepts to make them easier to scan and understand.
+  - fileName: card-with-multiple-titled-sections.tsx
+    title: With multiple titled sections
+    description: >-
+      Use when you have two related but distinct pieces of information to communicate to merchants that are complex enough to require a title to introduce them.
+  - fileName: card-with-subsection.tsx
+    title: With subsection
+    description: >-
+      Use when your card sections need further categorization.
+  - fileName: card-with-flushed-section.tsx
+    title: With flushed section
+    description: >-
+      Use when you need further control over the spacing of your card sections.
+  - fileName: card-with-sections-and-actions.tsx
+    title: With sections and actions
+    description: >-
+      Use when your card section has actions that apply only to that section.
+  - fileName: card-with-sections-and-destructive-action.tsx
+    title: With sections and destructive action
+    description: >-
+      Use when a card action applies only to one section and will delete merchant data or be otherwise difficult to recover from.
+  - fileName: card-with-separate-header.tsx
+    title: With separate header
+    description: >-
+      Use to be able to use custom React elements as header content.
+  - fileName: card-with-header-actions.tsx
+    title: With header actions
+    description: >-
+      Use for less important card actions, or actions merchants may do before reviewing the contents of the card. For example, merchants may want to add items to a card containing a long list, or enter a customer’s new address.
+  - fileName: card-with-footer-actions.tsx
+    title: With footer actions
+    description: >-
+      Use footer actions for a card’s most important actions, or actions merchants should do after reviewing the contents of the card. For example, merchants should review the contents of a shipment before an important action like adding tracking information.
+  - fileName: card-with-multiple-footer-actions.tsx
+    title: With multiple footer actions
+    description: >-
+      Use when there are multiple secondary footer actions that are rendered in an action list popover activated by a disclosure button.
+  - fileName: card-with-custom-footer-actions.tsx
+    title: With custom footer actions
+    description: >-
+      Use to present actionable content that is optional or not the primary purpose of the page.
+  - fileName: card-with-destructive-footer-actions.tsx
+    title: With destructive footer action
+    description: >-
+      Use when a card action will delete merchant data or be otherwise difficult to recover from.
+  - fileName: card-with-custom-react-node-title.tsx
+    title: With custom React Node title
+    description: >-
+      Use to render custom content such as icons, links, or buttons in a card section’s header.
+  - fileName: card-with-all-elements.tsx
+    title: With all elements
+    description: >-
+      Use as a broad example that includes using other layout components to build out the card.
 previewImg: /images/components/layout-and-structure/card.png
 ---
 

--- a/polaris.shopify.com/content/components/layout-and-structure/card.mdx
+++ b/polaris.shopify.com/content/components/layout-and-structure/card.mdx
@@ -67,8 +67,8 @@ examples:
     title: With sections and actions
     description: >-
       Use when your card section has actions that apply only to that section.
-  - fileName: card-with-sections-and-destructive-action.tsx
-    title: With sections and destructive action
+  - fileName: card-with-sections-and-critical-action.tsx
+    title: With sections and critical action
     description: >-
       Use when a card action applies only to one section and will delete merchant data or be otherwise difficult to recover from.
   - fileName: card-with-separate-header.tsx
@@ -91,8 +91,8 @@ examples:
     title: With custom footer actions
     description: >-
       Use to present actionable content that is optional or not the primary purpose of the page.
-  - fileName: card-with-destructive-footer-actions.tsx
-    title: With destructive footer action
+  - fileName: card-with-critical-footer-actions.tsx
+    title: With critical footer action
     description: >-
       Use when a card action will delete merchant data or be otherwise difficult to recover from.
   - fileName: card-with-custom-react-node-title.tsx

--- a/polaris.shopify.com/pages/examples/card-default.tsx
+++ b/polaris.shopify.com/pages/examples/card-default.tsx
@@ -2,7 +2,7 @@ import {Card, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function CardExample() {
+function CardDefault() {
   return (
     <Card>
       <Text as="h2" variant="bodyMd">
@@ -12,4 +12,4 @@ function CardExample() {
   );
 }
 
-export default withPolarisExample(CardExample);
+export default withPolarisExample(CardDefault);

--- a/polaris.shopify.com/pages/examples/card-with-all-elements.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-all-elements.tsx
@@ -1,0 +1,147 @@
+import React, {useState} from 'react';
+import {
+  ActionList,
+  Bleed,
+  BlockStack,
+  Box,
+  Button,
+  ButtonGroup,
+  Card,
+  InlineGrid,
+  InlineStack,
+  List,
+  Popover,
+  ResourceList,
+  Text,
+} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithAllElements() {
+  const [actionActive, toggleAction] = useState(false);
+
+  const handleToggleAction = () => {
+    toggleAction(!actionActive);
+  };
+
+  const items = [{content: 'Gross Sales'}, {content: 'Net Sales'}];
+
+  const disclosureButtonActivator = (
+    <Button variant="plain" disclosure onClick={handleToggleAction}>
+      View Sales
+    </Button>
+  );
+
+  const disclosureButton = (
+    <Popover
+      active={actionActive}
+      activator={disclosureButtonActivator}
+      onClose={handleToggleAction}
+    >
+      <ActionList items={items} />
+    </Popover>
+  );
+
+  const salesMarkup = (
+    <Box>
+      <ResourceList
+        resourceName={{singular: 'sale', plural: 'sales'}}
+        items={[
+          {
+            sales: 'Orders',
+            amount: 'USD$0.00',
+            url: '#',
+          },
+          {
+            sales: 'Returns',
+            amount: '-USD$250.00',
+            url: '#',
+          },
+        ]}
+        renderItem={(item) => {
+          const {sales, amount, url} = item;
+          return (
+            <ResourceList.Item
+              id={sales}
+              url={url}
+              accessibilityLabel={`View Sales for ${sales}`}
+            >
+              <InlineStack align="space-between">
+                <div>{sales}</div>
+                <div>{amount}</div>
+              </InlineStack>
+            </ResourceList.Item>
+          );
+        }}
+      />
+    </Box>
+  );
+
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <InlineGrid columns="1fr auto">
+          <Text as="h2" variant="headingSm">
+            Sales
+          </Text>
+          <ButtonGroup>
+            <Button variant="plain">Total Sales</Button>
+            {disclosureButton}
+          </ButtonGroup>
+        </InlineGrid>
+        <BlockStack gap="400">
+          <Text as="p" variant="bodyMd">
+            You can use sales reports to see information about your customers’
+            orders based on criteria such as sales over time, by channel, or by
+            staff.
+          </Text>
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Total Sales Breakdown
+          </Text>
+        </BlockStack>
+        {salesMarkup}
+        <Bleed marginInline="400">
+          <Box
+            background="bg-surface-secondary"
+            paddingBlock="300"
+            paddingInline="400"
+          >
+            <BlockStack gap="200">
+              <Text as="h3" variant="headingSm" fontWeight="medium">
+                Deactivated reports
+              </Text>
+              <List>
+                <List.Item>Payouts</List.Item>
+                <List.Item>Total Sales By Channel</List.Item>
+              </List>
+            </BlockStack>
+          </Box>
+        </Bleed>
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Note
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The sales reports are available only if your store is on the Shopify
+            plan or higher.
+          </Text>
+          <InlineStack align="end">
+            <ButtonGroup>
+              <Button onClick={() => {}} accessibilityLabel="Dismiss">
+                Dismiss
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => {}}
+                accessibilityLabel="Export Report"
+              >
+                Export Report
+              </Button>
+            </ButtonGroup>
+          </InlineStack>
+        </BlockStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithAllElements);

--- a/polaris.shopify.com/pages/examples/card-with-all-elements.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-all-elements.tsx
@@ -42,7 +42,7 @@ function CardWithAllElements() {
   );
 
   const salesMarkup = (
-    <Box>
+    <div>
       <ResourceList
         resourceName={{singular: 'sale', plural: 'sales'}}
         items={[
@@ -73,7 +73,7 @@ function CardWithAllElements() {
           );
         }}
       />
-    </Box>
+    </div>
   );
 
   return (

--- a/polaris.shopify.com/pages/examples/card-with-critical-footer-actions.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-critical-footer-actions.tsx
@@ -10,7 +10,7 @@ import {
 } from '@shopify/polaris';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function CardWithDestructiveFooterActions() {
+function CardWithCriticalFooterActions() {
   return (
     <Card roundedAbove="sm">
       <BlockStack gap="200">
@@ -50,4 +50,4 @@ function CardWithDestructiveFooterActions() {
   );
 }
 
-export default withPolarisExample(CardWithDestructiveFooterActions);
+export default withPolarisExample(CardWithCriticalFooterActions);

--- a/polaris.shopify.com/pages/examples/card-with-custom-footer-actions.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-custom-footer-actions.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  BlockStack,
+  Button,
+  ButtonGroup,
+  Card,
+  InlineStack,
+  Text,
+} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithCustomFooterActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="500">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Secure your account with 2-step authentication
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Two-step authentication adds an extra layer of security when logging
+            in to your account. A special code will be required each time you
+            log in, ensuring only you can access your account.
+          </Text>
+        </BlockStack>
+        <InlineStack align="end">
+          <ButtonGroup>
+            <Button
+              onClick={() => {}}
+              accessibilityLabel="Enable two-step authentication"
+            >
+              Enable two-step authentication
+            </Button>
+            <Button variant="plain">Learn more</Button>
+          </ButtonGroup>
+        </InlineStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithCustomFooterActions);

--- a/polaris.shopify.com/pages/examples/card-with-custom-react-node-title.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-custom-react-node-title.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  BlockStack,
+  Card,
+  Icon,
+  InlineStack,
+  List,
+  Text,
+} from '@shopify/polaris';
+import {ProductsMinor} from '@shopify/polaris-icons';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithCustomReactNodeTitle() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Products
+        </Text>
+        <BlockStack inlineAlign="start">
+          <InlineStack gap="400">
+            <Icon source={ProductsMinor} />
+            <Text as="h3" variant="headingSm">
+              New Products
+            </Text>
+          </InlineStack>
+        </BlockStack>
+        <List>
+          <List.Item>Socks</List.Item>
+          <List.Item>Super Shoes</List.Item>
+        </List>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithCustomReactNodeTitle);

--- a/polaris.shopify.com/pages/examples/card-with-destructive-footer-actions.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-destructive-footer-actions.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  BlockStack,
+  Button,
+  ButtonGroup,
+  Card,
+  InlineStack,
+  List,
+  Text,
+} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithDestructiveFooterActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Shipment 1234
+        </Text>
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Items
+          </Text>
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </BlockStack>
+        <InlineStack align="end">
+          <ButtonGroup>
+            <Button
+              variant="primary"
+              tone="critical"
+              onClick={() => {}}
+              accessibilityLabel="Cancel shipment"
+            >
+              Cancel shipment
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => {}}
+              accessibilityLabel="Add tracking number"
+            >
+              Add tracking number
+            </Button>
+          </ButtonGroup>
+        </InlineStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithDestructiveFooterActions);

--- a/polaris.shopify.com/pages/examples/card-with-flushed-section.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-flushed-section.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Bleed, Box, Card, Image, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithFlushedSection() {
+  return (
+    <Card roundedAbove="sm">
+      <Bleed marginInline="400" marginBlock="400">
+        <Image
+          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+          alt="a sheet with purple and orange stripes"
+        />
+        <Box background="bg-surface-secondary" padding="400">
+          <Text as="p" variant="bodyMd">
+            You can use sales reports to see information about your customers’
+            orders based on criteria such as sales over time, by channel, or by
+            staff.
+          </Text>
+        </Box>
+      </Bleed>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithFlushedSection);

--- a/polaris.shopify.com/pages/examples/card-with-footer-actions.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-footer-actions.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {
+  BlockStack,
+  Button,
+  ButtonGroup,
+  Card,
+  InlineStack,
+  List,
+  Text,
+} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithFooterActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Shipment 1234
+        </Text>
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Items
+          </Text>
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </BlockStack>
+        <InlineStack align="end">
+          <ButtonGroup>
+            <Button onClick={() => {}} accessibilityLabel="Edit shipment">
+              Edit shipment
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => {}}
+              accessibilityLabel="Add tracking number"
+            >
+              Add tracking number
+            </Button>
+          </ButtonGroup>
+        </InlineStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithFooterActions);

--- a/polaris.shopify.com/pages/examples/card-with-header-actions.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-header-actions.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {BlockStack, Button, Card, InlineGrid, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithHeaderActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <InlineGrid columns="1fr auto">
+          <Text as="h2" variant="headingSm">
+            Variants
+          </Text>
+          <Button
+            variant="plain"
+            onClick={() => {}}
+            accessibilityLabel="Add variant"
+          >
+            Add variant
+          </Button>
+        </InlineGrid>
+        <Text as="p" variant="bodyMd">
+          Add variants if this product comes in multiple versions, like
+          different sizes or colors.
+        </Text>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithHeaderActions);

--- a/polaris.shopify.com/pages/examples/card-with-multiple-footer-actions.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-multiple-footer-actions.tsx
@@ -1,0 +1,75 @@
+import React, {useState} from 'react';
+import {
+  ActionList,
+  BlockStack,
+  Button,
+  ButtonGroup,
+  Card,
+  InlineStack,
+  List,
+  Popover,
+  Text,
+} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithMultipleFooterActions() {
+  const [actionActive, toggleAction] = useState(false);
+
+  const handleToggleAction = () => {
+    toggleAction(!actionActive);
+  };
+
+  const items = [
+    {content: 'Cancel shipment', destructive: true},
+    {content: 'Add another shipment', disabled: true},
+  ];
+
+  const disclosureButtonActivator = (
+    <Button disclosure accessibilityLabel="More" onClick={handleToggleAction}>
+      More
+    </Button>
+  );
+
+  const disclosureButton = (
+    <Popover
+      active={actionActive}
+      activator={disclosureButtonActivator}
+      onClose={handleToggleAction}
+    >
+      <ActionList items={items} />
+    </Popover>
+  );
+
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Shipment 1234
+        </Text>
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Items
+          </Text>
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </BlockStack>
+        <InlineStack align="end">
+          <ButtonGroup>
+            {disclosureButton}
+            <Button
+              variant="primary"
+              onClick={() => {}}
+              accessibilityLabel="Add tracking number"
+            >
+              Add tracking number
+            </Button>
+          </ButtonGroup>
+        </InlineStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithMultipleFooterActions);

--- a/polaris.shopify.com/pages/examples/card-with-multiple-sections.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-multiple-sections.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Box, Card, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithMultipleSections() {
+  return (
+    <Card roundedAbove="sm">
+      <Text as="h2" variant="headingSm">
+        Online store dashboard
+      </Text>
+      <Box paddingBlock="200">
+        <Text as="p" variant="bodyMd">
+          View a summary of your online store’s performance.
+        </Text>
+      </Box>
+      <Box paddingBlockStart="200">
+        <Text as="p" variant="bodyMd">
+          View a summary of your online store’s performance, including sales,
+          visitors, top products, and referrals.
+        </Text>
+      </Box>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithMultipleSections);

--- a/polaris.shopify.com/pages/examples/card-with-multiple-titled-sections.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-multiple-titled-sections.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {BlockStack, Box, Card, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithMultipleTitledSections() {
+  return (
+    <Card roundedAbove="sm">
+      <Text as="h2" variant="headingSm">
+        Online store dashboard
+      </Text>
+      <Box paddingBlock="200">
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Reports
+          </Text>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </BlockStack>
+      </Box>
+      <Box paddingBlockStart="200">
+        <BlockStack gap="200">
+          <Text as="h3" variant="headingSm" fontWeight="medium">
+            Summary
+          </Text>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance, including sales,
+            visitors, top products, and referrals.
+          </Text>
+        </BlockStack>
+      </Box>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithMultipleTitledSections);

--- a/polaris.shopify.com/pages/examples/card-with-responsive-border-radius.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-responsive-border-radius.tsx
@@ -2,7 +2,7 @@ import {Card, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function CardExample() {
+function CardWithResponsiveBorderRadius() {
   return (
     <Card roundedAbove="md" background="bg-surface-secondary">
       <Text as="h2" variant="bodyMd">
@@ -12,4 +12,4 @@ function CardExample() {
   );
 }
 
-export default withPolarisExample(CardExample);
+export default withPolarisExample(CardWithResponsiveBorderRadius);

--- a/polaris.shopify.com/pages/examples/card-with-section.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-section.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {Box, Card, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithSection() {
+  return (
+    <Card roundedAbove="sm">
+      <Text as="h2" variant="headingSm">
+        Online store dashboard
+      </Text>
+      <Box paddingBlockStart="200">
+        <Text as="p" variant="bodyMd">
+          View a summary of your online store’s performance.
+        </Text>
+      </Box>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithSection);

--- a/polaris.shopify.com/pages/examples/card-with-sections-and-actions.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-sections-and-actions.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {BlockStack, Button, Card, InlineGrid, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithSectionsAndActions() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Customer
+          </Text>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </BlockStack>
+        <BlockStack gap="200">
+          <InlineGrid columns="1fr auto">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Contact Information
+            </Text>
+            <Button
+              variant="plain"
+              onClick={() => {}}
+              accessibilityLabel="Edit"
+            >
+              Edit
+            </Button>
+          </InlineGrid>
+          <Text as="p" variant="bodyMd">
+            john.smith@example.com
+          </Text>
+        </BlockStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithSectionsAndActions);

--- a/polaris.shopify.com/pages/examples/card-with-sections-and-critical-action.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-sections-and-critical-action.tsx
@@ -9,7 +9,7 @@ import {
 } from '@shopify/polaris';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function CardWithSectionsAndDestructiveAction() {
+function CardWithSectionsAndCriticalAction() {
   return (
     <Card roundedAbove="sm">
       <BlockStack gap="400">
@@ -53,4 +53,4 @@ function CardWithSectionsAndDestructiveAction() {
   );
 }
 
-export default withPolarisExample(CardWithSectionsAndDestructiveAction);
+export default withPolarisExample(CardWithSectionsAndCriticalAction);

--- a/polaris.shopify.com/pages/examples/card-with-sections-and-destructive-action.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-sections-and-destructive-action.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {
+  BlockStack,
+  Button,
+  ButtonGroup,
+  Card,
+  InlineGrid,
+  Text,
+} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithSectionsAndDestructiveAction() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Customer
+          </Text>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </BlockStack>
+        <BlockStack gap="200">
+          <InlineGrid columns="1fr auto">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Contact Information
+            </Text>
+            <ButtonGroup>
+              <Button
+                variant="plain"
+                tone="critical"
+                onClick={() => {}}
+                accessibilityLabel="Delete"
+              >
+                Delete
+              </Button>
+              <Button
+                variant="plain"
+                onClick={() => {}}
+                accessibilityLabel="Edit"
+              >
+                Edit
+              </Button>
+            </ButtonGroup>
+          </InlineGrid>
+          <Text as="p" variant="bodyMd">
+            john.smith@example.com
+          </Text>
+        </BlockStack>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithSectionsAndDestructiveAction);

--- a/polaris.shopify.com/pages/examples/card-with-separate-header.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-separate-header.tsx
@@ -1,0 +1,67 @@
+import React, {useState} from 'react';
+import {
+  ActionList,
+  BlockStack,
+  Button,
+  ButtonGroup,
+  Card,
+  InlineGrid,
+  List,
+  Popover,
+  Text,
+} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithSeparateHeader() {
+  const [actionActive, toggleAction] = useState(false);
+
+  const handleToggleAction = () => {
+    toggleAction(!actionActive);
+  };
+
+  const items = [{content: 'Member'}, {content: 'Admin'}];
+
+  const disclosureButtonActivator = (
+    <Button variant="plain" disclosure onClick={handleToggleAction}>
+      Add account
+    </Button>
+  );
+
+  const disclosureButton = (
+    <Popover
+      active={actionActive}
+      activator={disclosureButtonActivator}
+      onClose={handleToggleAction}
+    >
+      <ActionList items={items} />
+    </Popover>
+  );
+
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <InlineGrid columns="1fr auto">
+          <Text as="h2" variant="headingSm">
+            Staff accounts
+          </Text>
+          <ButtonGroup>
+            <Button
+              variant="plain"
+              onClick={() => {}}
+              accessibilityLabel="Preview"
+            >
+              Preview
+            </Button>
+            {disclosureButton}
+          </ButtonGroup>
+        </InlineGrid>
+        <List>
+          <List.Item>Felix Crafford</List.Item>
+          <List.Item>Ezequiel Manno</List.Item>
+        </List>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithSeparateHeader);

--- a/polaris.shopify.com/pages/examples/card-with-subdued-background.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-subdued-background.tsx
@@ -1,15 +1,21 @@
-import {Card, Text} from '@shopify/polaris';
+import {BlockStack, Card, List, Text} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function CardExample() {
+function CardWithSubduedBackground() {
   return (
     <Card background="bg-surface-secondary">
-      <Text as="h2" variant="bodyMd">
-        Content inside a card
-      </Text>
+      <BlockStack gap="200">
+        <Text as="h3" variant="headingSm" fontWeight="medium">
+          Deactivated staff accounts
+        </Text>
+        <List>
+          <List.Item>Felix Crafford</List.Item>
+          <List.Item>Ezequiel Manno</List.Item>
+        </List>
+      </BlockStack>
     </Card>
   );
 }
 
-export default withPolarisExample(CardExample);
+export default withPolarisExample(CardWithSubduedBackground);

--- a/polaris.shopify.com/pages/examples/card-with-subdued-section.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-subdued-section.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {Bleed, BlockStack, Box, Card, List, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithSubduedSection() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Staff accounts
+        </Text>
+        <Box paddingBlockEnd="200">
+          <List>
+            <List.Item>Felix Crafford</List.Item>
+            <List.Item>Ezequiel Manno</List.Item>
+          </List>
+        </Box>
+      </BlockStack>
+      <Bleed marginBlockEnd="400" marginInline="400">
+        <Box background="bg-surface-secondary" padding="400">
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Deactivated staff accounts
+            </Text>
+            <List>
+              <List.Item>Felix Crafford</List.Item>
+              <List.Item>Ezequiel Manno</List.Item>
+            </List>
+          </BlockStack>
+        </Box>
+      </Bleed>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithSubduedSection);

--- a/polaris.shopify.com/pages/examples/card-with-subsection.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-subsection.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {BlockStack, Box, Card, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function CardWithSubsection() {
+  return (
+    <Card roundedAbove="sm">
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Customer
+          </Text>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </BlockStack>
+        <Box>
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Addresses
+            </Text>
+            <Box>
+              <Text as="p" variant="bodyMd">
+                123 First St
+              </Text>
+              <Text as="p" variant="bodyMd">
+                Somewhere
+              </Text>
+              <Text as="p" variant="bodyMd">
+                The Universe
+              </Text>
+            </Box>
+            <Box>
+              <Text as="p" variant="bodyMd">
+                123 Second St
+              </Text>
+              <Text as="p" variant="bodyMd">
+                Somewhere
+              </Text>
+              <Text as="p" variant="bodyMd">
+                The Universe
+              </Text>
+            </Box>
+          </BlockStack>
+        </Box>
+        <Box>
+          <Text as="p" variant="bodyMd">
+            A single subsection without a sibling has no visual appearance
+          </Text>
+        </Box>
+      </BlockStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(CardWithSubsection);

--- a/polaris.shopify.com/pages/examples/card-with-subsection.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-subsection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {BlockStack, Box, Card, Text} from '@shopify/polaris';
+import {BlockStack, Card, Text} from '@shopify/polaris';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function CardWithSubsection() {
@@ -14,12 +14,12 @@ function CardWithSubsection() {
             John Smith
           </Text>
         </BlockStack>
-        <Box>
+        <div>
           <BlockStack gap="200">
             <Text as="h3" variant="headingSm" fontWeight="medium">
               Addresses
             </Text>
-            <Box>
+            <div>
               <Text as="p" variant="bodyMd">
                 123 First St
               </Text>
@@ -29,8 +29,8 @@ function CardWithSubsection() {
               <Text as="p" variant="bodyMd">
                 The Universe
               </Text>
-            </Box>
-            <Box>
+            </div>
+            <div>
               <Text as="p" variant="bodyMd">
                 123 Second St
               </Text>
@@ -40,14 +40,14 @@ function CardWithSubsection() {
               <Text as="p" variant="bodyMd">
                 The Universe
               </Text>
-            </Box>
+            </div>
           </BlockStack>
-        </Box>
-        <Box>
+        </div>
+        <div>
           <Text as="p" variant="bodyMd">
             A single subsection without a sibling has no visual appearance
           </Text>
-        </Box>
+        </div>
       </BlockStack>
     </Card>
   );

--- a/polaris.shopify.com/pages/examples/card-with-varying-padding.tsx
+++ b/polaris.shopify.com/pages/examples/card-with-varying-padding.tsx
@@ -2,7 +2,7 @@ import {Card, Text, BlockStack} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
-function CardExample() {
+function CardWithVaryingPadding() {
   return (
     <BlockStack gap="400">
       <Card>
@@ -43,4 +43,4 @@ const Placeholder = ({label = '', height = 'auto', width = 'auto'}) => {
   );
 };
 
-export default withPolarisExample(CardExample);
+export default withPolarisExample(CardWithVaryingPadding);


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [#1222](https://github.com/Shopify/polaris-internal/issues/1222).

With `Card` marked stable with the v12 release, we should have storybook examples for the different ways it can be composed with the other layout components to recreate the UI that the `LegacyCard` component supported via props.

### WHAT is this pull request doing?

Recreates all the `LegacyCard` compositions that were supported via props using Card and other layout primitives (e.g., `InlineStack`, `Bleed`).

Updates `Card` examples to match any `LegacyCard` spacing/font styling changes post uplift/v12.

Adds:
- Storybook examples 
- Style guide examples
- Updates documentation for Card post v12
  <details>
    <summary>New examples on styleguide</summary>
    <img src="https://github.com/Shopify/polaris/assets/26749317/984fa0e6-e009-4af5-b0fa-8a5c5b8a38d1" alt="New examples on styleguide">
  </details>

### How to 🎩

[New Card storybook](https://5d559397bae39100201eedc1-fbxsmfwane.chromatic.com/?path=/story/all-components-card--default)
[LegacyCard storybook](https://storybook.polaris.shopify.com/?path=/story/all-components-legacycard--default)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
