### PR TITLE
Fix link to tokens from global search

### DIFF
--- a/.changeset/serious-socks-cheat.md
+++ b/.changeset/serious-socks-cheat.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed link to tokens from global search

--- a/polaris.shopify.com/src/components/TokenList/TokenList.tsx
+++ b/polaris.shopify.com/src/components/TokenList/TokenList.tsx
@@ -145,7 +145,7 @@ function TokenListItem({
 
   const searchAttributes = useGlobalSearchResult();
   const isClickableSearchResult = !!searchAttributes?.tabIndex;
-  const url = `/tokens/${category}#${searchAttributes?.id}`;
+  const url = `/tokens/${slugify(category)}#${name}`;
 
   const customOnClickHandler = () => {
     uuid &&


### PR DESCRIPTION
Closes #11056

## Fixed token link in global search

https://github.com/Shopify/polaris/assets/11774595/c7915bff-2938-4481-8f8e-c589f4d991dd

