### PR TITLE
[IndexTable | Heading] Add support for headings with padding right

### DIFF
--- a/.changeset/poor-students-add.md
+++ b/.changeset/poor-students-add.md
@@ -2,5 +2,5 @@
 '@shopify/polaris': minor
 ---
 
-1. Added IndexTable heading props to support additional right padding
-2. Fixed an issue where headings with sort and tooltip don't align right properly.
+- Added the `paddingEnd` prop to the `IndexTableHeading` interface to support additional right padding
+- Fixed sortable `IndexTable` headings with a tooltip not being right aligned properly 

--- a/.changeset/poor-students-add.md
+++ b/.changeset/poor-students-add.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+---
+
+1. Added IndexTable heading props to support additional right padding
+2. Fixed an issue where headings with sort and tooltip don't align right properly.

--- a/.changeset/poor-students-add.md
+++ b/.changeset/poor-students-add.md
@@ -2,5 +2,5 @@
 '@shopify/polaris': minor
 ---
 
-- Added the `paddingEnd` prop to the `IndexTableHeading` interface to support additional right padding
-- Fixed sortable `IndexTable` headings with a tooltip not being right aligned properly 
+- Added the `paddingBlockEnd` prop to the `IndexTableHeading` interface to support additional right padding
+- Fixed sortable `IndexTable` headings with a tooltip not being right aligned properly

--- a/polaris-react/src/components/IndexTable/IndexTable.module.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.module.scss
@@ -837,9 +837,17 @@ $loading-panel-height: 53px;
 .TableHeading-align-end {
   text-align: right;
 
-  [class*='TooltipContainer'] {
+  [class*='TooltipContainer'],
+  [class*='SortableTableHeadingWithCustomMarkup'] {
     justify-content: end;
   }
+}
+
+.TableHeading-extra-padding-right {
+  // stylelint-disable -- polaris component custom properties
+  --pc-index-table-heading-extra-padding-right: 0rem;
+  padding-right: var(--pc-index-table-heading-extra-padding-right);
+  // stylelint-enable
 }
 
 .TableHeading-sortable {

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -2994,7 +2994,7 @@ export function WithSortableCustomHeadings() {
   );
 }
 
-export function WithHeadingWithPaddingEnd() {
+export function WithHeadingWithPaddingBlockEnd() {
   const [sortIndex, setSortIndex] = useState(0);
   const [sortDirection, setSortDirection] =
     useState<IndexTableProps['sortDirection']>('descending');
@@ -3169,7 +3169,7 @@ export function WithHeadingWithPaddingEnd() {
             tooltipContent:
               'I am a wide Amount spent tooltip that stays when clicked',
             tooltipWidth: 'wide',
-            paddingEnd: '600',
+            paddingBlockEnd: '600',
           },
           {title: 'Location'},
           {title: 'Fulfillment status'},

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -2994,6 +2994,201 @@ export function WithSortableCustomHeadings() {
   );
 }
 
+export function WithHeadingWithPaddingEnd() {
+  const [sortIndex, setSortIndex] = useState(0);
+  const [sortDirection, setSortDirection] =
+    useState<IndexTableProps['sortDirection']>('descending');
+
+  const sortToggleLabels = {
+    0: {ascending: 'A-Z', descending: 'Z-A'},
+    1: {ascending: 'Ascending', descending: 'Descending'},
+    2: {ascending: 'Newest', descending: 'Oldest'},
+    3: {ascending: 'Ascending', descending: 'Ascending'},
+    4: {ascending: 'A-Z', descending: 'Z-A'},
+    5: {ascending: 'A-Z', descending: 'Z-A'},
+    6: {ascending: 'A-Z', descending: 'Z-A'},
+    7: {ascending: 'A-Z', descending: 'Z-A'},
+  };
+
+  const initialRows = [
+    {
+      id: '3411',
+      url: '#',
+      name: 'Mae Jemison',
+      date: '2022-02-04',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$2,400',
+      fulfillmentStatus: 'Fulfilled',
+      paymentStatus: 'Paid',
+      notes: '',
+    },
+    {
+      id: '2561',
+      url: '#',
+      date: '2022-01-19',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+      fulfillmentStatus: 'Fulfilled',
+      paymentStatus: 'Not paid',
+      notes: 'This customer lives on the 3rd floor',
+    },
+    {
+      id: '1245',
+      url: '#',
+      date: '2021-12-12',
+      name: 'Anne-Marie Johnson',
+      location: 'Portland, USA',
+      orders: 10,
+      amountSpent: '$250',
+      fulfillmentStatus: 'Fulfilled',
+      paymentStatus: 'Not paid',
+      notes: '',
+    },
+    {
+      id: '8741',
+      url: '#',
+      date: '2022-05-11',
+      name: 'Bradley Stevens',
+      location: 'Hialeah, USA',
+      orders: 5,
+      amountSpent: '$26',
+      fulfillmentStatus: 'Unfulfilled',
+      paymentStatus: 'Not paid',
+      notes: 'This customer has requested fragile delivery',
+    },
+  ];
+  const [sortedRows, setSortedRows] = useState(
+    sortRows(initialRows, sortIndex, sortDirection),
+  );
+
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const rows = sortedRows ?? initialRows;
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(rows);
+
+  function handleClickSortHeading(index, direction) {
+    setSortIndex(index);
+    setSortDirection(direction);
+    const newSortedRows = sortRows(rows, index, direction);
+    setSortedRows(newSortedRows);
+  }
+
+  function sortRows(localRows, index, direction) {
+    return [...localRows].sort((rowA, rowB) => {
+      const key = index === 0 ? 'name' : 'location';
+      if (rowA[key] < rowB[key]) {
+        return direction === 'descending' ? -1 : 1;
+      }
+      if (rowA[key] > rowB[key]) {
+        return direction === 'descending' ? 1 : -1;
+      }
+      return 0;
+    });
+  }
+
+  const rowMarkup = rows.map(
+    (
+      {
+        id,
+        name,
+        date,
+        location,
+        orders,
+        amountSpent,
+        fulfillmentStatus,
+        paymentStatus,
+        notes,
+      },
+      index,
+    ) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <Text fontWeight="bold" as="span">
+            {name}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{date}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {orders}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Box paddingInlineEnd="600">
+            <Text as="span" alignment="end" numeric>
+              {amountSpent}
+            </Text>
+          </Box>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{location}</IndexTable.Cell>
+        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+        <IndexTable.Cell>{notes}</IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <LegacyCard>
+      <IndexTable
+        condensed={useBreakpoints().smDown}
+        resourceName={resourceName}
+        itemCount={rows.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {
+            title: 'Name',
+            tooltipContent: 'I am a wide tooltip describing the Name column',
+            tooltipWidth: 'wide',
+          },
+          {title: 'Date', tooltipContent: 'I am the Date tooltip'},
+          {
+            alignment: 'end',
+            id: 'order-count',
+            title: 'Order count',
+          },
+          {
+            alignment: 'end',
+            title: 'Amount spent',
+            tooltipContent:
+              'I am a wide Amount spent tooltip that stays when clicked',
+            tooltipWidth: 'wide',
+            paddingEnd: '600',
+          },
+          {title: 'Location'},
+          {title: 'Fulfillment status'},
+          {title: 'Payment status'},
+          {title: 'Notes'},
+        ]}
+        sortable={[true, true, false, true, true, false, false]}
+        sortDirection={sortDirection}
+        sortColumnIndex={sortIndex}
+        onSort={handleClickSortHeading}
+        sortToggleLabels={sortToggleLabels}
+        lastColumnSticky
+      >
+        {rowMarkup}
+      </IndexTable>
+    </LegacyCard>
+  );
+}
+
 export function WithCustomTooltips() {
   const customers = [
     {

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -67,7 +67,7 @@ interface IndexTableHeadingBase {
    */
   defaultSortDirection?: IndexTableSortDirection;
   /** Horizontal end spacing around title. Accepts a spacing token. */
-  paddingEnd?: SpaceScale;
+  paddingBlockEnd?: SpaceScale;
 }
 
 interface IndexTableHeadingTitleString extends IndexTableHeadingBase {
@@ -937,8 +937,8 @@ function IndexTableBase({
     }
 
     const style = {
-      '--pc-index-table-heading-extra-padding-right': heading.paddingEnd
-        ? `var(--p-space-${heading.paddingEnd})`
+      '--pc-index-table-heading-extra-padding-right': heading.paddingBlockEnd
+        ? `var(--p-space-${heading.paddingBlockEnd})`
         : '0',
     } as React.CSSProperties;
 
@@ -1037,7 +1037,8 @@ function IndexTableBase({
           <div
             style={style}
             className={classNames(
-              heading.paddingEnd && styles['TableHeading-extra-padding-right'],
+              heading.paddingBlockEnd &&
+                styles['TableHeading-extra-padding-right'],
             )}
           >
             <Tooltip
@@ -1057,7 +1058,8 @@ function IndexTableBase({
           <div
             className={classNames(
               styles.SortableTableHeadingWithCustomMarkup,
-              heading.paddingEnd && styles['TableHeading-extra-padding-right'],
+              heading.paddingBlockEnd &&
+                styles['TableHeading-extra-padding-right'],
             )}
             style={style}
           >
@@ -1087,7 +1089,8 @@ function IndexTableBase({
         <div
           style={style}
           className={classNames(
-            heading.paddingEnd && styles['TableHeading-extra-padding-right'],
+            heading.paddingBlockEnd &&
+              styles['TableHeading-extra-padding-right'],
           )}
         >
           <Tooltip {...defaultHeaderTooltipProps} activatorWrapper="span">
@@ -1108,7 +1111,7 @@ function IndexTableBase({
       <div
         style={style}
         className={classNames(
-          heading.paddingEnd && styles['TableHeading-extra-padding-right'],
+          heading.paddingBlockEnd && styles['TableHeading-extra-padding-right'],
         )}
       >
         {headingContent}

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -2,6 +2,7 @@ import React, {useRef, useState, useEffect, useCallback, useMemo} from 'react';
 import {SortAscendingMajor, SortDescendingMajor} from '@shopify/polaris-icons';
 import {CSSTransition} from 'react-transition-group';
 import {themeDefault, toPx} from '@shopify/polaris-tokens';
+import type {SpaceScale} from '@shopify/polaris-tokens';
 
 import {debounce} from '../../utilities/debounce';
 import {useToggle} from '../../utilities/use-toggle';
@@ -65,6 +66,8 @@ interface IndexTableHeadingBase {
    * When not specified, the value from IndexTable.defaultSortDirection will be used.
    */
   defaultSortDirection?: IndexTableSortDirection;
+  /** Horizontal end spacing around title. Accepts a spacing token. */
+  paddingEnd?: SpaceScale;
 }
 
 interface IndexTableHeadingTitleString extends IndexTableHeadingBase {
@@ -933,6 +936,12 @@ function IndexTableBase({
       headingContent = heading.title;
     }
 
+    const style = {
+      '--pc-index-table-heading-extra-padding-right': heading.paddingEnd
+        ? `var(--p-space-${heading.paddingEnd})`
+        : '0',
+    } as React.CSSProperties;
+
     if (sortable?.[index]) {
       const isCurrentlySorted = index === sortColumnIndex;
       const isPreviouslySorted =
@@ -1025,20 +1034,33 @@ function IndexTableBase({
       if (!heading.tooltipContent) {
         return (
           // Regular header with sort icon and sort direction tooltip
-          <Tooltip
-            {...defaultTooltipProps}
-            content={sortTooltipContent}
-            preferredPosition="above"
+          <div
+            style={style}
+            className={classNames(
+              heading.paddingEnd && styles['TableHeading-extra-padding-right'],
+            )}
           >
-            {sortMarkup}
-          </Tooltip>
+            <Tooltip
+              {...defaultTooltipProps}
+              content={sortTooltipContent}
+              preferredPosition="above"
+            >
+              {sortMarkup}
+            </Tooltip>
+          </div>
         );
       }
 
       if (heading.tooltipContent) {
         return (
           // Header text and sort icon have separate tooltips
-          <div className={styles.SortableTableHeadingWithCustomMarkup}>
+          <div
+            className={classNames(
+              styles.SortableTableHeadingWithCustomMarkup,
+              heading.paddingEnd && styles['TableHeading-extra-padding-right'],
+            )}
+            style={style}
+          >
             <UnstyledButton {...defaultSortButtonProps}>
               <Tooltip {...defaultHeaderTooltipProps}>
                 <span className={styles.TableHeadingUnderline}>
@@ -1062,20 +1084,36 @@ function IndexTableBase({
     if (heading.tooltipContent) {
       return (
         // Non-sortable header with tooltip
-        <Tooltip {...defaultHeaderTooltipProps} activatorWrapper="span">
-          <span
-            className={classNames(
-              styles.TableHeadingUnderline,
-              styles.SortableTableHeaderWrapper,
-            )}
-          >
-            {headingContent}
-          </span>
-        </Tooltip>
+        <div
+          style={style}
+          className={classNames(
+            heading.paddingEnd && styles['TableHeading-extra-padding-right'],
+          )}
+        >
+          <Tooltip {...defaultHeaderTooltipProps} activatorWrapper="span">
+            <span
+              className={classNames(
+                styles.TableHeadingUnderline,
+                styles.SortableTableHeaderWrapper,
+              )}
+            >
+              {headingContent}
+            </span>
+          </Tooltip>
+        </div>
       );
     }
 
-    return headingContent;
+    return (
+      <div
+        style={style}
+        className={classNames(
+          heading.paddingEnd && styles['TableHeading-extra-padding-right'],
+        )}
+      >
+        {headingContent}
+      </div>
+    );
   }
 
   function handleSelectPage(checked: boolean) {

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -363,10 +363,11 @@ describe('<IndexTable>', () => {
       expect(index).toContainReactComponent('table', {
         className: 'Table Table-sticky Table-sticky-last',
       });
-      expect(index).toContainReactComponent('th', {
-        children: title,
+      const lastHeading = index.find('th', {
         className: 'TableHeading TableHeading-last',
       });
+      expect(lastHeading).not.toBeNull();
+      expect(lastHeading).toContainReactText(title);
     });
 
     it('does not render a sticky last heading if `lastColumnSticky` prop is true and last heading is hidden', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Works towards https://github.com/Shopify/temp-project-mover-Archetypically-20250409144733/issues/135
Web PR: https://github.com/Shopify/web/pull/112306

As part of right aligning numbers on the Inventory index, we want to make space for the activator carat for right-aligned columns (see screenshot below).  We've decided that we want to add space to the right of the columns, as prototyped in the Figma files.  This PR will allow for extra padding to be added to the right of the heading when `heading.paddingBlockEnd` is passed in.

<img width="150" alt="234105756-0e73e9f8-0232-4315-ae30-132bb21262a3" src="https://github.com/Shopify/polaris/assets/7861746/c48e4add-9696-47e3-bb5e-38eaa7cf383c">

#### Other Considerations

`heading.paddingBlockEnd` will take a space token.  We've considered adding a paddingBlockEnd prop to the `IndexTable.Cell` as well, but have decided against it since we can already control the amount of padding via its children.

We've also considered passing in the `title` as a React Node on the `IndexTable.heading` component with additional padding on the left or right side of the text.  However, there is currently an issue where right-aligned headings will show an underline that extends past the text.
<img width="600" alt="Screenshot 2023-11-24 at 2 14 56 PM" src="https://github.com/Shopify/polaris/assets/7861746/e501cd0b-789d-4fa7-a84b-9838dc951d37">
<img width="400" alt="Screenshot 2023-11-24 at 2 15 45 PM" src="https://github.com/Shopify/polaris/assets/7861746/31e94155-2402-47c2-9e44-1e48f638d4c9">

There is also additional right padding in headings in IndexTable's in other product areas (e.g. Product).  We may want to update those headings to use this new prop.


<img width="1220" alt="Screenshot 2023-11-27 at 2 53 58 PM" src="https://github.com/Shopify/polaris/assets/7861746/8632e253-eba0-4b79-96d3-0b040814d61c">


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds the optional `paddingBlockEnd` prop to `IndexTable.headings`

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

#### Admin Web: https://admin.web.index-table-headings-align-end-with-padding.teri-leung.us.spin.dev/store/shop1/products/inventory?selectedColumns=VARIANT_NAME%2CSKU%2CUNAVAILABLE_QUANTITY%2CCOMMITTED_QUANTITY%2CAVAILABLE_QUANTITY%2CON_HAND_QUANTITY%2CINCOMING_QUANTITY&location_id=1

Check that everything works on the index pages (for Inventory, Orders, MetaFields etc)

#### Storybook:
<img width="1097" alt="Screenshot 2023-11-24 at 2 29 00 PM" src="https://github.com/Shopify/polaris/assets/7861746/e878f896-1796-478e-a574-450adf693831">

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
