### PR TITLE
Remove custom icon from dropzone that was used in a test

### DIFF
--- a/.changeset/light-peaches-reply.md
+++ b/.changeset/light-peaches-reply.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Remove unused custom icon from dropzone that was used in a test

--- a/polaris-react/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/polaris-react/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -5,7 +5,6 @@ import {UploadMajor} from '@shopify/polaris-icons';
 import {Text} from '../../../../Text';
 import {DropZoneContext} from '../../../context';
 import {FileUpload} from '../FileUpload';
-import {uploadArrow as uploadArrowImage} from '../../../images';
 import {Icon} from '../../../../Icon';
 
 describe('<FileUpload />', () => {
@@ -48,9 +47,10 @@ describe('<FileUpload />', () => {
         </DropZoneContext.Provider>,
       );
 
-      expect(fileUpload).not.toContainReactComponent('img', {
-        src: uploadArrowImage,
+      expect(fileUpload).not.toContainReactComponent(Icon, {
+        source: UploadMajor,
       });
+
       expect(fileUpload).not.toContainReactComponent(Text);
 
       expect(fileUpload).toContainReactComponent('div', {
@@ -68,9 +68,7 @@ describe('<FileUpload />', () => {
       </DropZoneContext.Provider>,
     );
 
-    expect(fileUpload).not.toContainReactComponent('img', {
-      src: uploadArrowImage,
-    });
+    expect(fileUpload).not.toContainReactComponent(Icon, {source: UploadMajor});
     expect(fileUpload).not.toContainReactComponent(Text);
 
     expect(fileUpload).toContainReactComponent('div', {

--- a/polaris-react/src/components/DropZone/images/index.ts
+++ b/polaris-react/src/components/DropZone/images/index.ts
@@ -1,1 +1,0 @@
-export {default as uploadArrow} from './upload-arrow.svg';

--- a/polaris-react/src/components/DropZone/images/upload-arrow.svg
+++ b/polaris-react/src/components/DropZone/images/upload-arrow.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M20 10a10 10 0 11-20 0 10 10 0 0120 0zM5.3 8.3l4-4a1 1 0 011.4 0l4 4a1 1 0 01-1.4 1.4L11 7.4V15a1 1 0 11-2 0V7.4L6.7 9.7a1 1 0 01-1.4-1.4z" fill="#5C5F62"/></svg>


### PR DESCRIPTION
### WHY are these changes introduced?

- Removing an icon only used in test files

### WHAT is this pull request doing?

- Deleting an icon that is no longer used

