### PR TITLE
Render at least 1162 less empty spans in shopify/web

### DIFF
--- a/.changeset/smart-insects-compare.md
+++ b/.changeset/smart-insects-compare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Conditionally render the accessibilityLabel when it is provided

--- a/polaris-react/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/polaris-react/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -3,7 +3,6 @@ import {mountWithApp} from 'tests/utilities';
 
 import type {CallbackAction, LinkAction} from '../../../types';
 import {Breadcrumbs} from '../Breadcrumbs';
-import {Text} from '../../Text';
 
 describe('<Breadcrumbs />', () => {
   describe('url', () => {
@@ -85,8 +84,8 @@ describe('<Breadcrumbs />', () => {
     };
     const wrapper = mountWithApp(<Breadcrumbs backAction={linkBackAction} />);
 
-    expect(wrapper).toContainReactComponent(Text, {
-      visuallyHidden: true,
+    expect(wrapper).toContainReactComponent('a', {
+      'aria-label': linkBackAction.content,
     });
   });
 });

--- a/polaris-react/src/components/Icon/Icon.tsx
+++ b/polaris-react/src/components/Icon/Icon.tsx
@@ -84,9 +84,11 @@ export function Icon({source, tone, accessibilityLabel}: IconProps) {
 
   return (
     <span className={className}>
-      <Text as="span" visuallyHidden>
-        {accessibilityLabel}
-      </Text>
+      {accessibilityLabel && (
+        <Text as="span" visuallyHidden>
+          {accessibilityLabel}
+        </Text>
+      )}
       {contentMarkup[sourceType]}
     </span>
   );

--- a/polaris-react/src/components/Icon/tests/Icon.test.tsx
+++ b/polaris-react/src/components/Icon/tests/Icon.test.tsx
@@ -18,6 +18,14 @@ describe('<Icon />', () => {
         visuallyHidden: true,
       });
     });
+
+    it('does not render the label when not provided', () => {
+      const element = mountWithApp(<Icon source="placeholder" />).find('span');
+
+      expect(element).not.toContainReactComponent(Text, {
+        visuallyHidden: true,
+      });
+    });
   });
 
   describe('source', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

The accessibility label was rendered every time with the `<Icon>` component however many times the `accessibilityLabel` prop is not added to the component.

### WHAT is this pull request doing?

Removes the accessibility label unless the prop is added.
