### PR TITLE
Remove unneccessary `.applyColor` class name from `<Icon>`

### DIFF
--- a/.changeset/rich-drinks-pull.md
+++ b/.changeset/rich-drinks-pull.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Remove unneccessary `.applyColor` class name from `<Icon>`

--- a/polaris-react/src/components/Icon/Icon.scss
+++ b/polaris-react/src/components/Icon/Icon.scss
@@ -7,9 +7,6 @@
   max-height: 100%;
   max-width: 100%;
   margin: auto;
-}
-
-.applyColor {
   color: var(--p-color-bg-surface);
 }
 

--- a/polaris-react/src/components/Icon/Icon.tsx
+++ b/polaris-react/src/components/Icon/Icon.tsx
@@ -59,7 +59,6 @@ export function Icon({source, tone, accessibilityLabel}: IconProps) {
   const className = classNames(
     styles.Icon,
     tone && styles[variationName('tone', tone)],
-    tone && styles.applyColor,
   );
 
   const SourceComponent = source;


### PR DESCRIPTION
### WHY are these changes introduced?

Looking at the Icon css code there is a classname for `.applyColor` that was being added to the component every time. It could be safely consolidated with the .Icon class name

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
