### PR TITLE
[Select] Fix onFocus and onBlur events

### DIFF
--- a/.changeset/kind-avocados-sparkle.md
+++ b/.changeset/kind-avocados-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+- Fixed `onFocus` and `onBlur` events of Select component

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -71,9 +71,9 @@ export interface SelectProps {
   /** Callback when selection is changed */
   onChange?(selected: string, id: string): void;
   /** Callback when select is focused */
-  onFocus?(): void;
+  onFocus?(event?: React.FocusEvent<HTMLSelectElement>): void;
   /** Callback when focus is removed */
-  onBlur?(): void;
+  onBlur?(event?: React.FocusEvent<HTMLSelectElement>): void;
   /** Visual required indicator, add an asterisk to label */
   requiredIndicator?: boolean;
   /** Indicates the tone of the select */
@@ -114,9 +114,21 @@ export function Select({
     disabled && styles.disabled,
   );
 
-  const handleFocus = useCallback(() => {
-    toggleFocused();
-  }, [toggleFocused]);
+  const handleFocus = useCallback(
+    (event: React.FocusEvent<HTMLSelectElement>) => {
+      toggleFocused();
+      onFocus?.(event);
+    },
+    [onFocus, toggleFocused],
+  );
+
+  const handleBlur = useCallback(
+    (event: React.FocusEvent<HTMLSelectElement>) => {
+      toggleFocused();
+      onBlur?.(event);
+    },
+    [onBlur, toggleFocused],
+  );
 
   const handleChange = onChange
     ? (event: React.ChangeEvent<HTMLSelectElement>) =>
@@ -196,14 +208,8 @@ export function Select({
           value={value}
           className={styles.Input}
           disabled={disabled}
-          onFocus={() => {
-            handleFocus();
-            onFocus?.();
-          }}
-          onBlur={() => {
-            toggleFocused();
-            onBlur?.();
-          }}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           onChange={handleChange}
           aria-invalid={Boolean(error)}
           aria-describedby={


### PR DESCRIPTION
### WHY are these changes introduced?

This is a followup of https://github.com/Shopify/polaris/pull/11219 with fixes after some tests started failing.

### WHAT is this pull request doing?

Events were working properly and we weren't really using the event object before but now we pass it to the underlying  `onFocus` and `onBlur` events.

This is tophatted and tests are passing.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
