### PR TITLE
[polaris.shopify.com] Remove anchor in url during client-side render

### DIFF
--- a/polaris.shopify.com/src/components/Subnav/Subnav.tsx
+++ b/polaris.shopify.com/src/components/Subnav/Subnav.tsx
@@ -9,13 +9,28 @@ import {useRouter} from 'next/router';
 import {Icon} from '@shopify/polaris';
 import * as polarisIcons from '@shopify/polaris-icons';
 import icons from '../../icons';
+import {useEffect, useState} from 'react';
 
 type PolarisIcon = keyof typeof polarisIcons;
 const nav = navJSON.children as NavJSON;
 
+interface NavObject {
+  [key: string]: NavItem;
+}
+
+type NavObjects = NavObject | undefined;
+
 function Subnav() {
   const {asPath} = useRouter();
-  const navItems = getNavItems(asPath);
+  const [navItems, setNavItems] = useState<NavObjects>();
+
+  /**
+   * We need to run this on the client side because anchor links are not passed
+   * to the server
+   */
+  useEffect(() => {
+    setNavItems(getNavItems(asPath));
+  }, [asPath]);
 
   if (!navItems) {
     console.warn('No subnav items found for path:', asPath);
@@ -57,6 +72,13 @@ function Subnav() {
 }
 
 function getNavItems(path: string): {[key: string]: NavItem} | undefined {
+  const anchor = path.indexOf('#');
+
+  // remove the anchor link from path if exists
+  if (anchor >= 0) {
+    path = path.substring(0, anchor);
+  }
+
   const paths = path.split('/').filter((segment) => segment);
 
   const navItemPath = paths.join('.children.');


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #11205

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Checking for an anchor `#` segment in url path on client side 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
