### PR TITLE
[IndexTable, IndexFilters] Fix total column alignment in the Style Guide

### DIFF
--- a/.changeset/small-spiders-add.md
+++ b/.changeset/small-spiders-add.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix column content alignment for the IndexTable and IndexFilters total column

--- a/polaris.shopify.com/pages/examples/index-filters-default.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-default.tsx
@@ -319,7 +319,11 @@ function IndexFiltersDefaultExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-filters-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-disabled.tsx
@@ -319,7 +319,11 @@ function IndexFiltersDisabledExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-filters-with-edit-colums-button.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-edit-colums-button.tsx
@@ -319,7 +319,11 @@ function IndexFiltersDefaultExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-filters-with-filtering-mode.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-filtering-mode.tsx
@@ -320,7 +320,11 @@ function IndexFiltersWithFilteringModeExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-filters-with-no-filters.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-no-filters.tsx
@@ -196,7 +196,11 @@ function IndexFiltersWithNoFiltersExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-filters-with-no-search-or-filters.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-no-search-or-filters.tsx
@@ -190,7 +190,11 @@ function IndexFiltersWithNoSearchOrFiltersExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-filters-with-no-search.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-no-search.tsx
@@ -319,7 +319,11 @@ function IndexFiltersDefault() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-filters-with-pinned-filters.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-pinned-filters.tsx
@@ -319,7 +319,11 @@ function IndexFiltersWithPinnedFiltersExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-default.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-default.tsx
@@ -65,7 +65,11 @@ function SimpleIndexTableExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-bulk-actions-and-selection-across-pages.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-bulk-actions-and-selection-across-pages.tsx
@@ -65,7 +65,11 @@ function IndexTableWithBulkActionsAndSelectionAcrossPagesExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-bulk-actions.tsx
@@ -65,7 +65,11 @@ function IndexTableWithBulkActionsExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-disabled-rows.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-disabled-rows.tsx
@@ -80,7 +80,11 @@ function IndexTableWithDisabledRowsExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-filtering.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-filtering.tsx
@@ -290,7 +290,11 @@ function IndexTableWithFilteringExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-loading-state.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-loading-state.tsx
@@ -320,7 +320,11 @@ function IndexTableWithLoadingExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-multiple-promoted-bulk-actions.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-multiple-promoted-bulk-actions.tsx
@@ -65,7 +65,11 @@ function IndexTableWithMultiplePromotedBulkActionsExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-pagination.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-pagination.tsx
@@ -65,7 +65,11 @@ function IndexTableWithPaginationExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-sticky-last-column.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-sticky-last-column.tsx
@@ -65,7 +65,11 @@ function StickyLastCellIndexTableExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-with-views-search-filter-sorting.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-with-views-search-filter-sorting.tsx
@@ -320,7 +320,11 @@ function IndexTableWithViewsSearchFilterSorting() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>

--- a/polaris.shopify.com/pages/examples/index-table-without-checkboxes.tsx
+++ b/polaris.shopify.com/pages/examples/index-table-without-checkboxes.tsx
@@ -56,7 +56,11 @@ function IndexTableWithoutCheckboxesExample() {
         </IndexTable.Cell>
         <IndexTable.Cell>{date}</IndexTable.Cell>
         <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
         <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
         <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
       </IndexTable.Row>


### PR DESCRIPTION
### WHY are these changes introduced?

This PR fixes the alignment for the total column:

<img width="772" alt="Screenshot 2023-11-29 at 4 59 53 PM" src="https://github.com/Shopify/polaris/assets/22782157/f13618cf-a682-4b83-b0fc-ab37560c0ded">

### WHAT is this pull request doing?

Applies `<Text as="span" alignment="end" numeric>` to all `total` examples for `IndexTable` and `IndexFilters`.

Note: There is no need to fix the columns for the condensed screens as they do not have a column header.

### How to 🎩

- Ensure that the alignment for the `total` column is correct for all `IndexTable` and `IndexFilters` examples.
- Pull this branch locally.
- Run `yarn turbo run dev --filter=polaris.shopify.com`
- This command automatically opens `http://localhost:3000/` which did not work for me. However I found that `http://localhost:51778/` worked instead. In the case that this url is unique per user, you can find it in the console here:

<kbd><img width="599" alt="Screenshot 2023-11-29 at 6 05 40 PM" src="https://github.com/Shopify/polaris/assets/22782157/943d3b53-338c-4ef4-828a-7f084ef85ddb"></kbd>

<br>

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
