### PR TITLE
[Modal] Fix activator not gaining focus when modal is closed

### DIFF
--- a/.changeset/empty-poets-wait.md
+++ b/.changeset/empty-poets-wait.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fix modal activator not regaining focus when the modal is closed

--- a/.changeset/empty-poets-wait.md
+++ b/.changeset/empty-poets-wait.md
@@ -2,4 +2,5 @@
 '@shopify/polaris': minor
 ---
 
-Fix modal activator not regaining focus when the modal is closed
+- Fixed `Modal` `activator` not regaining focus on close
+- Added an `activatorWrapper` prop to `Modal` to support setting the element that wraps the `activator`

--- a/polaris-react/src/components/Box/Box.tsx
+++ b/polaris-react/src/components/Box/Box.tsx
@@ -18,7 +18,7 @@ import type {ResponsiveProp} from '../../utilities/css';
 
 import styles from './Box.scss';
 
-type Element = 'div' | 'span' | 'section' | 'legend' | 'ul' | 'li';
+export type Element = 'div' | 'span' | 'section' | 'legend' | 'ul' | 'li';
 
 type LineStyles = 'solid' | 'dashed';
 type Overflow = 'hidden' | 'scroll';

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useRef, useId, cloneElement} from 'react';
+import React, {useState, useCallback, useRef, useId} from 'react';
 import {TransitionGroup} from 'react-transition-group';
 
 import {focusFirstFocusableNode} from '../../utilities/focus';
@@ -7,6 +7,7 @@ import {WithinContentContext} from '../../utilities/within-content-context';
 import {wrapWithComponent} from '../../utilities/components';
 import {Backdrop} from '../Backdrop';
 import {Box} from '../Box';
+import type {Element} from '../Box';
 import {InlineStack} from '../InlineStack';
 import {Scrollable} from '../Scrollable';
 import {Spinner} from '../Spinner';
@@ -59,6 +60,11 @@ export interface ModalProps extends FooterProps {
   onScrolledToBottom?(): void;
   /** The element or the RefObject that activates the Modal */
   activator?: React.RefObject<HTMLElement> | React.ReactElement;
+  /**
+   * The element type to wrap the activator in
+   * @default 'div'
+   */
+  activatorWrapper?: Element;
   /** Removes Scrollable container from the modal content */
   noScroll?: boolean;
 }
@@ -82,6 +88,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   secondaryActions,
   onScrolledToBottom,
   activator,
+  activatorWrapper = 'div',
   onClose,
   onIFrameLoad,
   onTransitionEnd,
@@ -112,6 +119,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       activator && isRef(activator)
         ? activator && activator.current
         : activatorRef.current;
+
     if (activatorElement) {
       requestAnimationFrame(() => focusFirstFocusableNode(activatorElement));
     }
@@ -217,9 +225,11 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   const animated = !instant;
 
   const activatorMarkup =
-    activator && !isRef(activator)
-      ? cloneElement(activator, {ref: activatorRef})
-      : null;
+    activator && !isRef(activator) ? (
+      <Box ref={activatorRef} as={activatorWrapper}>
+        {activator}
+      </Box>
+    ) : null;
 
   return (
     <WithinContentContext.Provider value>

--- a/polaris-react/src/components/Modal/tests/Modal.test.tsx
+++ b/polaris-react/src/components/Modal/tests/Modal.test.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import React, {useRef} from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
@@ -27,17 +28,31 @@ jest.mock('react-transition-group', () => {
   };
 });
 
+jest.mock('../../TrapFocus', () => ({
+  ...jest.requireActual('../../TrapFocus'),
+  TrapFocus({children}: {children: ReactNode}) {
+    return <div>{children}</div>;
+  },
+}));
+
 describe('<Modal>', () => {
   let scrollSpy: jest.SpyInstance;
+  let requestAnimationFrameSpy: jest.SpyInstance;
 
   beforeEach(() => {
     scrollSpy = jest.spyOn(window, 'scroll');
     animationFrame.mock();
+    requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
+    requestAnimationFrameSpy.mockImplementation((cb: () => number) => {
+      cb();
+      return 1;
+    });
   });
 
   afterEach(() => {
     animationFrame.restore();
     scrollSpy.mockRestore();
+    requestAnimationFrameSpy.mockRestore();
   });
 
   it('has a child with contentContext', () => {
@@ -513,10 +528,41 @@ describe('<Modal>', () => {
       }).not.toThrow();
     });
 
-    // Causes a circular dependency that causes the whole test file to be unrunnable
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('focuses the activator when the activator is an element on close', () => {
+    it('wraps the activator in a div by default', () => {
+      const activator = <Button />;
+
+      const modal = mountWithApp(
+        <Modal title="foo" onClose={noop} open={false} activator={activator} />,
+      );
+
+      expect(modal).toContainReactComponent(Box, {
+        as: 'div',
+        children: activator,
+      });
+    });
+
+    it('wraps the activator in a span if activatorWrapper is provided', () => {
+      const activator = <Button />;
+
+      const modal = mountWithApp(
+        <Modal
+          title="foo"
+          onClose={noop}
+          open={false}
+          activator={activator}
+          activatorWrapper="span"
+        />,
+      );
+
+      expect(modal).toContainReactComponent(Box, {
+        as: 'span',
+        children: activator,
+      });
+    });
+
+    it('focuses the activator on close when the activator is an element', () => {
       const id = 'activator-id';
+
       const modal = mountWithApp(
         <Modal
           title="foo"
@@ -527,21 +573,22 @@ describe('<Modal>', () => {
       );
 
       modal.find(Dialog)!.trigger('onExited');
-      const activator = modal.find('button', {id})!.domNode;
+
+      const activator = modal.find('button', {
+        id,
+      })!.domNode;
 
       expect(document.activeElement).toBe(activator);
     });
 
-    // Causes a circular dependency that causes the whole test file to be unrunnable
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('focuses the activator when the activator a ref on close', () => {
-      const buttonId = 'buttonId';
+    it('focuses the activator on close when the activator is a ref', () => {
+      const id = 'buttonId';
       const TestHarness = () => {
         const buttonRef = useRef<HTMLDivElement>(null);
 
         const button = (
           <div ref={buttonRef}>
-            <Button id={buttonId} />
+            <Button id={id} />
           </div>
         );
 
@@ -557,11 +604,11 @@ describe('<Modal>', () => {
 
       testHarness.find(Modal)!.find(Dialog)!.trigger('onExited');
 
-      expect(document.activeElement).toBe(
-        testHarness.findWhere(
-          (wrap) => wrap.is('button') && wrap.prop('id') === buttonId,
-        )!.domNode,
-      );
+      const activator = testHarness.find('button', {
+        id,
+      })!.domNode;
+
+      expect(document.activeElement).toBe(activator);
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes the modal activator not regaining focus when the modal is closed.

Will also resolve https://github.com/Shopify/polaris/issues/10493.

### WHAT is this pull request doing?

Previously [in this PR](https://github.com/Shopify/polaris/pull/10086), the `Box` was removed in favour of using `cloneElement`. This was done in order to obtain inline styling since the `Box` is a `div` by default. However, `cloneElement` was also passing the `ref` as a prop, which assumes that the activator you are passing also accepts `ref`, which in most cases is not the case (i.e, `Button`). As a result, the `ref` to the activator was always null.

This PR reverts this change and reimplements the `Box` so that the `ref` can be maintained. This PR also introduces a new prop `activatorWrapper`, which enables the consumer to optionally convert the `Box` into whatever element they choose. In the case of inline styling, we can now set the activator to be a `span`. This new prop `activatorWrapper` is a consistent pattern across this repo, i.e [`<Tooltip />`](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/Tooltip/Tooltip.tsx#L41).

### How to 🎩

Since many modals across the admin are either passing a ref, or simply do not have the activator hooked up, I added a simple example to the top of the orders list page in the admin with an **element activator**.

https://github.com/Shopify/polaris/assets/22782157/b3adc6cd-f7b3-4b7a-b3cb-302193263865

- [Orders list: With these changes](https://admin.web.web-f7y7.laura-aubin.us.spin.dev/store/shop1/orders)
- Open the modal by clicking on the button `Open test modal`.
- Press tab. Once on the exit button, press enter to close the modal.
- Ensure focus is redirected back to the `Open test modal` button.
- Ensure that the following console error does not exist:

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()
```

Here is the same example implemented on a separate Spinstance **without these changes**:

- [Orders list: Without these changes](https://admin.web.test-modal-master.laura-aubin.us.spin.dev/store/shop1/orders)
- Note that opening the modal and closing it redirects focus to the body of the page.
- Note that the console error exists.

<br>

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
