### PR TITLE
[Tabs] Restores the `edit-columns` icon, causing a breaking change

### DIFF
--- a/.changeset/rare-rings-sing.md
+++ b/.changeset/rare-rings-sing.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Restores the Tab's `edit-columns` action type

--- a/polaris-react/locales/cs.json
+++ b/polaris-react/locales/cs.json
@@ -213,6 +213,7 @@
         "rename": "Přejmenovat zobrazení",
         "duplicate": "Duplikování zobrazení",
         "edit": "Upravit zobrazení",
+        "editColumns": "Upravit sloupce",
         "delete": "Odstranit zobrazení",
         "copy": "{name} – kopie",
         "deleteModal": {

--- a/polaris-react/locales/da.json
+++ b/polaris-react/locales/da.json
@@ -213,6 +213,7 @@
         "rename": "Omdøb visning",
         "duplicate": "Dupliker visning",
         "edit": "Rediger visning",
+        "editColumns": "Rediger kolonner",
         "delete": "Slet visning",
         "copy": "Kopi af {name}",
         "deleteModal": {

--- a/polaris-react/locales/de.json
+++ b/polaris-react/locales/de.json
@@ -213,6 +213,7 @@
         "rename": "Ansicht umbenennen",
         "duplicate": "Ansicht duplizieren",
         "edit": "Ansicht bearbeiten",
+        "editColumns": "Spalten bearbeiten",
         "delete": "Ansicht löschen",
         "copy": "Kopie von {name}",
         "deleteModal": {

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -294,6 +294,7 @@
         "rename": "Rename view",
         "duplicate": "Duplicate view",
         "edit": "Edit view",
+        "editColumns": "Edit columns",
         "delete": "Delete view",
         "copy": "Copy of {name}",
         "deleteModal": {

--- a/polaris-react/locales/es.json
+++ b/polaris-react/locales/es.json
@@ -213,6 +213,7 @@
         "rename": "Cambiar nombre de vista",
         "duplicate": "Duplicar vista",
         "edit": "Editar vista",
+        "editColumns": "Editar columnas",
         "delete": "Eliminar vista",
         "copy": "Copia de {name}",
         "deleteModal": {

--- a/polaris-react/locales/fi.json
+++ b/polaris-react/locales/fi.json
@@ -213,6 +213,7 @@
         "rename": "Nimeä näkymä uudelleen",
         "duplicate": "Kopioi näkymä",
         "edit": "Muokkaa näkymää",
+        "editColumns": "Muokkaa sarakkeita",
         "delete": "Poista näkymä",
         "copy": "Kopio tiedostosta {name}",
         "deleteModal": {

--- a/polaris-react/locales/fr.json
+++ b/polaris-react/locales/fr.json
@@ -213,6 +213,7 @@
         "rename": "Renommer la vue",
         "duplicate": "Dupliquer la vue",
         "edit": "Modifier la vue",
+        "editColumns": "Modifier les colonnes",
         "delete": "Supprimer la vue",
         "copy": "Copie de {name}",
         "deleteModal": {

--- a/polaris-react/locales/it.json
+++ b/polaris-react/locales/it.json
@@ -213,6 +213,7 @@
         "rename": "Rinomina vista",
         "duplicate": "Duplica vista",
         "edit": "Modifica vista",
+        "editColumns": "Modifica colonne",
         "delete": "Elimina vista",
         "copy": "Copia di {name}",
         "deleteModal": {

--- a/polaris-react/locales/ja.json
+++ b/polaris-react/locales/ja.json
@@ -213,6 +213,7 @@
         "rename": "ビューの名前を変更",
         "duplicate": "ビューを複製",
         "edit": "ビューを編集",
+        "editColumns": "列を編集",
         "delete": "ビューを削除",
         "copy": "{name}のコピー",
         "deleteModal": {

--- a/polaris-react/locales/ko.json
+++ b/polaris-react/locales/ko.json
@@ -213,6 +213,7 @@
         "rename": "보기 이름 바꾸기",
         "duplicate": "보기 복제",
         "edit": "보기 편집",
+        "editColumns": "열 편집",
         "delete": "보기 삭제",
         "copy": "{name}의 사본",
         "deleteModal": {

--- a/polaris-react/locales/nb.json
+++ b/polaris-react/locales/nb.json
@@ -213,6 +213,7 @@
         "rename": "Gi visning nytt navn",
         "duplicate": "Dupliser visning",
         "edit": "Rediger visning",
+        "editColumns": "Rediger kolonner",
         "delete": "Slett visning",
         "copy": "Kopi av {name}",
         "deleteModal": {

--- a/polaris-react/locales/nl.json
+++ b/polaris-react/locales/nl.json
@@ -213,6 +213,7 @@
         "rename": "Naam van weergave wijzigen",
         "duplicate": "Weergave dupliceren",
         "edit": "Weergave bewerken",
+        "editColumns": "Kolommen bewerken",
         "delete": "Weergave verwijderen",
         "copy": "Kopie van {name}",
         "deleteModal": {

--- a/polaris-react/locales/pl.json
+++ b/polaris-react/locales/pl.json
@@ -213,6 +213,7 @@
         "rename": "Zmień nazwę widoku",
         "duplicate": "Duplikuj widok",
         "edit": "Edytuj widok",
+        "editColumns": "Edytuj kolumny",
         "delete": "Usuń widok",
         "copy": "Kopia {name}",
         "deleteModal": {

--- a/polaris-react/locales/pt-BR.json
+++ b/polaris-react/locales/pt-BR.json
@@ -213,6 +213,7 @@
         "rename": "Renomear visualização",
         "duplicate": "Duplicar visualização",
         "edit": "Editar visualização",
+        "editColumns": "Editar colunas",
         "delete": "Excluir visualização",
         "copy": "Cópia de {name}",
         "deleteModal": {

--- a/polaris-react/locales/pt-PT.json
+++ b/polaris-react/locales/pt-PT.json
@@ -213,6 +213,7 @@
         "rename": "Renomear visualização",
         "duplicate": "Duplicar visualização",
         "edit": "Editar visualização",
+        "editColumns": "Editar colunas",
         "delete": "Eliminar visualização",
         "copy": "Cópia de {name}",
         "deleteModal": {

--- a/polaris-react/locales/sv.json
+++ b/polaris-react/locales/sv.json
@@ -213,6 +213,7 @@
         "rename": "Döp om vy",
         "duplicate": "Duplicera vy",
         "edit": "Redigera vy",
+        "editColumns": "Redigera kolumner",
         "delete": "Radera vy",
         "copy": "Kopia av {name}",
         "deleteModal": {

--- a/polaris-react/locales/th.json
+++ b/polaris-react/locales/th.json
@@ -213,6 +213,7 @@
         "rename": "เปลี่ยนชื่อมุมมอง",
         "duplicate": "ทำซ้ำมุมมอง",
         "edit": "แก้ไขมุมมอง",
+        "editColumns": "แก้ไขคอลัมน์",
         "delete": "ลบมุมมอง",
         "copy": "สำเนาของ {name}",
         "deleteModal": {

--- a/polaris-react/locales/tr.json
+++ b/polaris-react/locales/tr.json
@@ -213,6 +213,7 @@
         "rename": "Görünümü yeniden adlandır",
         "duplicate": "Görünümü çoğalt",
         "edit": "Görünümü düzenle",
+        "editColumns": "Sütunları düzenle",
         "delete": "Görünümü sil",
         "copy": "{name} kopyası",
         "deleteModal": {

--- a/polaris-react/locales/vi.json
+++ b/polaris-react/locales/vi.json
@@ -213,6 +213,7 @@
         "rename": "Đổi tên chế độ xem",
         "duplicate": "Sao chép chế độ xem",
         "edit": "Chỉnh sửa chế độ xem",
+        "editColumns": "Sửa cột",
         "delete": "Xóa chế độ xem",
         "copy": "Bản sao của {name}",
         "deleteModal": {

--- a/polaris-react/locales/zh-CN.json
+++ b/polaris-react/locales/zh-CN.json
@@ -213,6 +213,7 @@
         "rename": "重命名视图",
         "duplicate": "复制视图",
         "edit": "编辑视图",
+        "editColumns": "编辑列",
         "delete": "删除视图",
         "copy": "{name} 的副本",
         "deleteModal": {

--- a/polaris-react/locales/zh-TW.json
+++ b/polaris-react/locales/zh-TW.json
@@ -213,6 +213,7 @@
         "rename": "重新命名檢視畫面",
         "duplicate": "複製檢視畫面",
         "edit": "編輯檢視畫面",
+        "editColumns": "編輯欄",
         "delete": "刪除檢視畫面",
         "copy": "{name}的副本",
         "deleteModal": {

--- a/polaris-react/src/components/Tabs/Tabs.stories.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.stories.tsx
@@ -108,7 +108,12 @@ export function Fitted() {
   );
 }
 
-type AlphaTabAction = 'rename' | 'edit' | 'duplicate' | 'delete';
+type AlphaTabAction =
+  | 'rename'
+  | 'edit'
+  | 'edit-columns'
+  | 'duplicate'
+  | 'delete';
 
 export function WithActions() {
   const sleep = (ms: number) =>
@@ -156,6 +161,11 @@ export function WithActions() {
             },
             {
               type: 'edit' as AlphaTabAction,
+              onAction: () => {},
+              onPrimaryAction: () => {},
+            },
+            {
+              type: 'edit-columns' as AlphaTabAction,
               onAction: () => {},
               onPrimaryAction: () => {},
             },

--- a/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
@@ -14,6 +14,7 @@ import type {
 import {
   InfoMinor,
   DuplicateMinor,
+  Columns3Minor,
   EditMinor,
   DeleteMinor,
   ChevronDownMinor,
@@ -219,6 +220,10 @@ export const Tab = forwardRef(
       edit: {
         icon: EditMinor,
         content: i18n.translate('Polaris.Tabs.Tab.edit'),
+      },
+      'edit-columns': {
+        icon: Columns3Minor,
+        content: i18n.translate('Polaris.Tabs.Tab.editColumns'),
       },
       delete: {
         icon: DeleteMinor,

--- a/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -26,6 +26,11 @@ describe('Tab', () => {
         onPrimaryAction: jest.fn(),
       },
       {
+        type: 'edit-columns',
+        onAction: jest.fn(),
+        onPrimaryAction: jest.fn(),
+      },
+      {
         type: 'duplicate',
         onAction: jest.fn(),
         onPrimaryAction: jest.fn(),
@@ -156,6 +161,11 @@ describe('Tab', () => {
               onAction: expect.any(Function),
             },
             {
+              content: 'Edit columns',
+              icon: expect.any(Function),
+              onAction: expect.any(Function),
+            },
+            {
               content: 'Duplicate view',
               icon: expect.any(Function),
               onAction: expect.any(Function),
@@ -198,6 +208,12 @@ describe('Tab', () => {
               disabled: true,
             },
             {
+              content: 'Edit columns',
+              icon: expect.any(Function),
+              onAction: expect.any(Function),
+              disabled: true,
+            },
+            {
               content: 'Duplicate view',
               icon: expect.any(Function),
               onAction: expect.any(Function),
@@ -217,6 +233,7 @@ describe('Tab', () => {
       it.each([
         ['rename', 'Rename view'],
         ['edit', 'Edit view'],
+        ['edit-columns', 'Edit columns'],
         ['duplicate', 'Duplicate view'],
         ['delete', 'Delete view'],
       ])(

--- a/polaris-react/src/components/Tabs/types.ts
+++ b/polaris-react/src/components/Tabs/types.ts
@@ -2,7 +2,12 @@ import type {ReactNode} from 'react';
 
 import type {ActionListItemDescriptor} from '../../types';
 
-export type TabAction = 'rename' | 'edit' | 'duplicate' | 'delete';
+export type TabAction =
+  | 'rename'
+  | 'edit'
+  | 'edit-columns'
+  | 'duplicate'
+  | 'delete';
 
 interface TabActionDescriptor
   extends Omit<ActionListItemDescriptor, 'onAction'> {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a breaking change introduced on this [PR](https://github.com/Shopify/polaris/pull/10800#pullrequestreview-1764420233) where the `edit-columns` action type was removed. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Restores the `edit-columns` action 

<img width="162" alt="Screenshot 2023-12-06 at 2 58 53 a m" src="https://github.com/Shopify/polaris/assets/5873627/2b1cb7cb-91c6-4700-92d6-c11615612b0f">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
