### PR TITLE
Update `TextField` with inline suggestion examples

### DIFF
--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -585,35 +585,33 @@ export function WithInlineSuggestion() {
   );
 
   const [value, setValue] = useState('');
-  const [suggestion, setSuggestion] = useState('');
+  const [suggestion, setSuggestion] = useState<string | undefined>();
 
-  const handleSuggestion = useCallback(
-    (nextValue) => {
-      const nextSuggestion = suggestions.find((suggestion) =>
-        suggestion.toLowerCase().startsWith(nextValue.toLowerCase()),
-      );
+  const handleChange = useCallback(
+    (value: string) => {
+      const suggestion =
+        value &&
+        suggestions.find((suggestion) =>
+          suggestion.toLowerCase().startsWith(value.toLowerCase()),
+        );
 
-      if (nextSuggestion) setSuggestion(nextSuggestion);
+      setValue(value);
+      setSuggestion(suggestion);
     },
     [suggestions],
   );
 
-  useEffect(() => {
-    if (value !== suggestion) handleSuggestion(value);
-  }, [handleSuggestion, suggestion, value]);
-
-  const handleChange = useCallback((value) => {
-    setValue(value);
-    setSuggestion('');
-  }, []);
-
   const handleKeyDown = useCallback(
-    (event) => {
-      if (event.key === 'Enter') {
-        handleChange(suggestion);
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        setValue(suggestion || value);
+        setSuggestion('');
+      } else if (event.key === 'Backspace') {
+        setValue(value);
+        setSuggestion('');
       }
     },
-    [suggestion, handleChange],
+    [value, suggestion],
   );
 
   return (
@@ -624,6 +622,7 @@ export function WithInlineSuggestion() {
         value={value}
         onChange={handleChange}
         suggestion={suggestion}
+        autoComplete="off"
       />
     </div>
   );

--- a/polaris.shopify.com/pages/examples/text-field-with-inline-suggestion.tsx
+++ b/polaris.shopify.com/pages/examples/text-field-with-inline-suggestion.tsx
@@ -1,11 +1,5 @@
 import {TextField} from '@shopify/polaris';
-import {
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-  KeyboardEventHandler,
-} from 'react';
+import {useState, useCallback, useMemo} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function TextFieldWithSuggestionExample() {

--- a/polaris.shopify.com/pages/examples/text-field-with-inline-suggestion.tsx
+++ b/polaris.shopify.com/pages/examples/text-field-with-inline-suggestion.tsx
@@ -73,35 +73,33 @@ function TextFieldWithSuggestionExample() {
   );
 
   const [value, setValue] = useState('');
-  const [suggestion, setSuggestion] = useState('');
+  const [suggestion, setSuggestion] = useState<string | undefined>();
 
-  const handleSuggestion = useCallback(
-    (nextValue: string) => {
-      const nextSuggestion = suggestions.find((suggestion) =>
-        suggestion.toLowerCase().startsWith(nextValue.toLowerCase()),
-      );
+  const handleChange = useCallback(
+    (value: string) => {
+      const suggestion =
+        value &&
+        suggestions.find((suggestion) =>
+          suggestion.toLowerCase().startsWith(value.toLowerCase()),
+        );
 
-      if (nextSuggestion) setSuggestion(nextSuggestion);
+      setValue(value);
+      setSuggestion(suggestion);
     },
     [suggestions],
   );
 
-  useEffect(() => {
-    if (value !== suggestion) handleSuggestion(value);
-  }, [handleSuggestion, suggestion, value]);
-
-  const handleChange = useCallback((value: string) => {
-    setValue(value);
-    setSuggestion('');
-  }, []);
-
-  const handleKeyDown = useCallback<KeyboardEventHandler>(
-    (event) => {
-      if (event.key === 'Enter') {
-        handleChange(suggestion);
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        setValue(suggestion || value);
+        setSuggestion('');
+      } else if (event.key === 'Backspace') {
+        setValue(value);
+        setSuggestion('');
       }
     },
-    [suggestion, handleChange],
+    [value, suggestion],
   );
 
   return (


### PR DESCRIPTION
Closes #11041

### WHAT is this pull request doing?

This PR updates the `TextField` "with inline suggestion" examples in Storybook and the Polaris site to address the issues identified in #11041.

**Before:**
- Tabbing off the input and refocusing shows faint suggestion text
- Unable to delete the input text with backspace

https://github.com/Shopify/polaris/assets/32409546/938dbc7f-c7b4-470e-a495-d595db3806d3

**After:**

https://github.com/Shopify/polaris/assets/32409546/2f7c2fad-9dbe-452c-89e6-28ca7d761d41

### How to 🎩

Storybook: https://5d559397bae39100201eedc1-ipqwelasua.chromatic.com/?path=/story/all-components-textfield--with-inline-suggestion

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
