### PR TITLE
[Button] Improve `pressed` state for tertiary Button

### DIFF
--- a/.changeset/twelve-houses-wash.md
+++ b/.changeset/twelve-houses-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated tertiary Button pressed state to include background colour and remove border-radius

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -468,6 +468,7 @@
   --pc-button-text: var(--p-color-text);
   --pc-button-color-hover: var(--p-color-bg-fill-transparent-hover);
   --pc-button-color-active: var(--p-color-bg-fill-transparent-active);
+  --pc-button-color-depressed: var(--p-color-bg-fill-transparent-active);
   // stylelint-enable
   box-shadow: none;
 
@@ -490,6 +491,10 @@
     svg {
       fill: var(--p-color-icon-disabled);
     }
+  }
+
+  &.pressed {
+    box-shadow: none;
   }
 
   &:active {

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -495,6 +495,10 @@
 
   &.pressed {
     box-shadow: none;
+
+    &:is(:hover, :focus, :active) {
+      box-shadow: none;
+    }
   }
 
   &:active {

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -267,6 +267,9 @@ export function Tertiary() {
           <Button variant="tertiary" disabled>
             Label
           </Button>
+          <Button variant="tertiary" pressed>
+            Label
+          </Button>
           <Button variant="tertiary" icon={PlusMinor}>
             Label
           </Button>
@@ -295,6 +298,9 @@ export function Tertiary() {
         <InlineStack gap="400" blockAlign="end">
           <Button variant="tertiary">Label</Button>
           <Button variant="tertiary" disabled>
+            Label
+          </Button>
+          <Button variant="tertiary" pressed>
             Label
           </Button>
           <Button variant="tertiary" icon={PlusMinor}>


### PR DESCRIPTION
### WHY are these changes introduced?

The `pressed` state for tertiary buttons is currently unsatisfactory. Only a faint box-shadow appears when pressed. It should use the same state as the `:active` state.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
