### PR TITLE
Fix token -> color nav selection issue

### DIFF
--- a/polaris.shopify.com/content/tokens/index.mdx
+++ b/polaris.shopify.com/content/tokens/index.mdx
@@ -3,5 +3,11 @@ title: Tokens
 description: Tokens are variables that represent design decisions such as color, typography, and spacing, in a consistent and reusable way.
 order: 8
 icon: EyeDropperMinor
-url: /tokens/color
+showTOC: false
 ---
+
+# Tokens
+
+<Lede>{frontmatter.description}</Lede>
+
+<TokensNav />

--- a/polaris.shopify.com/pages/[...slug].tsx
+++ b/polaris.shopify.com/pages/[...slug].tsx
@@ -318,14 +318,7 @@ export const getStaticProps: GetStaticProps<Props, {slug: string[]}> = async ({
       async (end) => {
         // Flatten each group to an array of objects
         const tokenGroupObjects = mapValues(tokenGroups, (tokens) =>
-          Object.entries(tokens)
-            .map(([name, value]) => ({name, ...value}))
-            // Some tokens have custom sorting for display
-            .sort((token) =>
-              token.name.includes('ease') || token.name.includes('linear')
-                ? -1
-                : 1,
-            ),
+          Object.entries(tokens).map(([name, value]) => ({name, ...value})),
         );
         scope.tokens = tokenGroupObjects;
         end();

--- a/polaris.shopify.com/src/components/TokensNav/TokensNav.tsx
+++ b/polaris.shopify.com/src/components/TokensNav/TokensNav.tsx
@@ -1,20 +1,11 @@
+import type {Theme} from '@shopify/polaris-tokens';
+
 import styles from './TokensNav.module.scss';
 import Link from 'next/link';
 import {slugify} from '../../utils/various';
 
 interface Props {
-  selected?:
-    | 'border'
-    | 'breakpoints'
-    | 'color'
-    | 'font'
-    | 'height'
-    | 'motion'
-    | 'shadow'
-    | 'space'
-    | 'text'
-    | 'width'
-    | 'zIndex';
+  selected?: keyof Theme;
 }
 
 export type NavItem = {


### PR DESCRIPTION
Fixes this issue:

<img width="299" alt="Screenshot 2023-12-09 at 08 32 07" src="https://github.com/Shopify/polaris/assets/612020/5e721618-7ba9-4da9-8c1d-76e60ccd4fe5">

Side-effect is introducing a new `Tokens` index page:

<img width="978" alt="Screenshot 2023-12-09 at 08 38 11" src="https://github.com/Shopify/polaris/assets/612020/008277ba-8052-4f45-8e4e-42787096d9cd">

Also tightens up the type used for token group names to come from the tokens package correctly (thanks @aaronccasanova!).

Check it out: https://polaris-staging.shopifycloud.com/tokens/breakpoints