### PR TITLE
Add pattern variants to site cache and normalise cache to be keyed by URLs

### DIFF
--- a/polaris.shopify.com/content/coming-soon/index.mdx
+++ b/polaris.shopify.com/content/coming-soon/index.mdx
@@ -1,5 +1,5 @@
 ---
 title: Coming soon
 hideChildren: true
-url: /coming-soon/view-transitions
+noIndex: true
 ---

--- a/polaris.shopify.com/content/patterns/app-settings-layout/index.mdx
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/index.mdx
@@ -5,6 +5,7 @@ lede: Lets merchants scan and find groups of settings in apps.
 url: /patterns/app-settings-layout
 previewImg: /images/patterns/app-settings-layout/pattern-thumbnail-app-settings.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8217
+hideChildren: true
 variants:
   - 'variants/default.mdx'
 ---

--- a/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.mdx
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.mdx
@@ -1,5 +1,6 @@
 ---
-hideFromNav: true
+title: Default
+noIndex: true
 ---
 
 <HowItHelps>

--- a/polaris.shopify.com/content/patterns/date-picking/index.mdx
+++ b/polaris.shopify.com/content/patterns/date-picking/index.mdx
@@ -5,6 +5,7 @@ lede: Lets merchants select a date or a date range
 url: /patterns/date-picking
 previewImg: /images/patterns/date-picking/pattern-thumbnail-date-picking.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/7853
+hideChildren: true
 variants:
   - 'variants/single-date.mdx'
   - 'variants/date-range.mdx'

--- a/polaris.shopify.com/content/patterns/date-picking/variants/date-list.mdx
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/date-list.mdx
@@ -1,7 +1,6 @@
 ---
 title: Date list
-slug: date-list
-hideFromNav: true
+url: /patterns/date-picking/date-list
 ---
 
 This enables merchants to select a date or a date range from a list of preset dates.

--- a/polaris.shopify.com/content/patterns/date-picking/variants/date-range.mdx
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/date-range.mdx
@@ -1,7 +1,6 @@
 ---
 title: Date range
-slug: date-range
-hideFromNav: true
+url: /patterns/date-picking/date-range
 ---
 
 This enables merchants to select a date range.

--- a/polaris.shopify.com/content/patterns/date-picking/variants/single-date.mdx
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/single-date.mdx
@@ -1,7 +1,6 @@
 ---
 title: Single date
-slug: single-date
-hideFromNav: true
+url: /patterns/date-picking/single-date
 ---
 
 This enables merchants to type a specific date or pick it from a calendar.

--- a/polaris.shopify.com/content/patterns/new-features/index.mdx
+++ b/polaris.shopify.com/content/patterns/new-features/index.mdx
@@ -5,6 +5,7 @@ lede: Help merchants discover new and impactful features.
 url: /patterns/new-features
 previewImg: /images/patterns/new-feature/new-feature-cover.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/6751
+hideChildren: true
 variants:
   - 'variants/default.mdx'
 ---

--- a/polaris.shopify.com/content/patterns/new-features/variants/default.mdx
+++ b/polaris.shopify.com/content/patterns/new-features/variants/default.mdx
@@ -1,5 +1,6 @@
 ---
-hideFromNav: true
+title: Default
+noIndex: true
 ---
 
 As the Shopify admin UI continues to evolve, it's natural for teams to want to draw attention to new features and improvements. However, we strongly advise against using "new" badges or blue pips to highlight these additions within individual sections like Products, Orders, and Customers.

--- a/polaris.shopify.com/content/patterns/resource-details-layout/index.mdx
+++ b/polaris.shopify.com/content/patterns/resource-details-layout/index.mdx
@@ -5,6 +5,7 @@ lede: Lets merchants create, view, and edit resource objects.
 url: /patterns/resource-details-layout
 previewImg: /images/patterns/resource-details-layout/pattern-thumbnail-resource-details.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8216
+hideChildren: true
 variants:
   - 'variants/default.mdx'
 ---

--- a/polaris.shopify.com/content/patterns/resource-details-layout/variants/default.mdx
+++ b/polaris.shopify.com/content/patterns/resource-details-layout/variants/default.mdx
@@ -1,5 +1,6 @@
 ---
-hideFromNav: true
+title: Default
+noIndex: true
 ---
 
 <HowItHelps>

--- a/polaris.shopify.com/content/patterns/resource-index-layout/index.mdx
+++ b/polaris.shopify.com/content/patterns/resource-index-layout/index.mdx
@@ -5,6 +5,7 @@ lede: Lets merchants organize and take action on resource objects.
 url: /patterns/resource-index-layout
 previewImg: /images/patterns/resource-index-layout/pattern-thumbnail-resource-index.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8215
+hideChildren: true
 variants:
   - 'variants/default.mdx'
 ---

--- a/polaris.shopify.com/content/patterns/resource-index-layout/variants/default.mdx
+++ b/polaris.shopify.com/content/patterns/resource-index-layout/variants/default.mdx
@@ -1,5 +1,6 @@
 ---
-hideFromNav: true
+title: Default
+noIndex: true
 ---
 
 <HowItHelps>

--- a/polaris.shopify.com/pages/[...slug].tsx
+++ b/polaris.shopify.com/pages/[...slug].tsx
@@ -362,6 +362,7 @@ const catchAllTemplateExcludeList = [
   '/icons',
   '/sandbox',
   '/tools/stylelint-polaris/rules',
+  '/coming-soon',
 ];
 
 // We want to render component index & group pages, but not the individual

--- a/polaris.shopify.com/src/components/Frame/Frame.tsx
+++ b/polaris.shopify.com/src/components/Frame/Frame.tsx
@@ -212,7 +212,10 @@ function NavItem({
 
             if (!child.slug) return null;
 
-            const isExpandable = child.children && !child.hideChildren;
+            const isExpandable =
+              child.children &&
+              Object.keys(child.children).length &&
+              !child.hideChildren;
             const id = (child.slug || key).replace(/\//g, '');
             const navAriaId = `nav-${id}`;
             const segments = asPath.slice(1).split('/');

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import {useRouter} from 'next/router';
 
 import type {
-  PatternVariantFontMatter,
+  PatternVariantFrontMatter,
   PatternFrontMatter,
   SerializedMdx,
 } from '../../types';
@@ -24,7 +24,7 @@ import {SideBySide} from '../Markdown/components/SideBySide';
 
 export type PatternMDX = SerializedMdx<
   Omit<PatternFrontMatter, 'variants'> & {
-    variants: SerializedMdx<PatternVariantFontMatter>[];
+    variants: SerializedMdx<PatternVariantFrontMatter>[];
   }
 >;
 
@@ -45,7 +45,7 @@ const SingleVariant = ({children, variants}: VariantRendererProps) =>
 const TabbedVariants = ({children, variants}: VariantRendererProps) => {
   const router = useRouter();
   let exampleIndex = variants.findIndex(
-    ({frontmatter: {slug}}) => slug === router.query.slug?.[1],
+    ({frontmatter: {url}}) => url === router.asPath,
   );
 
   if (exampleIndex === -1) {
@@ -59,10 +59,10 @@ const TabbedVariants = ({children, variants}: VariantRendererProps) => {
           {variants.map((variant) => (
             <Tab
               as={Link}
-              href={`/patterns/${router.query.slug?.[0]}/${variant.frontmatter.slug}`}
+              href={variant.frontmatter.url!}
               shallow
               className={styles.Tab}
-              key={`${variant.frontmatter.slug}-tab`}
+              key={`${variant.frontmatter.url}-tab`}
             >
               <span>{variant.frontmatter.title}</span>
             </Tab>
@@ -72,7 +72,7 @@ const TabbedVariants = ({children, variants}: VariantRendererProps) => {
         <Tab.Panels>
           {variants.map((variant) => (
             <Tab.Panel
-              key={`${variant.frontmatter.slug}-panel`}
+              key={`${variant.frontmatter.url}-panel`}
               className={styles.TabPanel}
             >
               {children(variant)}

--- a/polaris.shopify.com/src/components/Subnav/Subnav.tsx
+++ b/polaris.shopify.com/src/components/Subnav/Subnav.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
-import navJSON from '../../../.cache/nav';
-import {NavJSON, NavItem} from '../../types';
+import nav from '../../../.cache/nav';
+import {NavItem} from '../../types';
 import {className} from '../../utils/various';
 
 import styles from './Subnav.module.scss';
@@ -12,7 +12,6 @@ import icons from '../../icons';
 import {useEffect, useState} from 'react';
 
 type PolarisIcon = keyof typeof polarisIcons;
-const nav = navJSON.children as NavJSON;
 
 interface NavObject {
   [key: string]: NavItem;

--- a/polaris.shopify.com/src/types.ts
+++ b/polaris.shopify.com/src/types.ts
@@ -58,7 +58,7 @@ export type FrontMatter = {
   title: string;
   navTitle?: string;
   draft?: boolean;
-  noIndex?: boolean;
+  noIndex?: true;
   category?: string;
   url?: string;
   description?: string;
@@ -84,21 +84,15 @@ export type FrontMatter = {
   variants?: string[];
 };
 
-export type PatternFrontMatter = Omit<FrontMatter, 'description'> & {
+export type PatternFrontMatter = Omit<FrontMatter, 'description' | 'lede'> & {
   /* Description is shown on Patterns index page, and as the meta description on detail page */
   description: string;
   /* Lede is the first paragraph on the detail page, above variants */
   lede: string;
-  previewImg?: string;
-  order?: number;
-  githubDiscussionsLink?: string;
   variants?: string[];
 };
 
-export type PatternVariantFontMatter = {
-  title?: string;
-  slug?: string;
-};
+export type PatternVariantFrontMatter = FrontMatter;
 
 export type MarkdownFile = {
   frontMatter: any;
@@ -118,7 +112,7 @@ export const foundationsCategories = [
   'tools',
 ] as const;
 
-export type FoundationsCategory = typeof foundationsCategories[number];
+export type FoundationsCategory = (typeof foundationsCategories)[number];
 
 export const searchResultCategories = [
   'foundations',
@@ -128,7 +122,7 @@ export const searchResultCategories = [
   'icons',
 ] as const;
 
-export type SearchResultCategory = typeof searchResultCategories[number];
+export type SearchResultCategory = (typeof searchResultCategories)[number];
 
 export interface SearchResult {
   id: string;

--- a/polaris.shopify.com/src/utils/various.ts
+++ b/polaris.shopify.com/src/utils/various.ts
@@ -1,5 +1,3 @@
-import pages from '../../.cache/site';
-import type {PatternFrontMatter} from '../types';
 import type {BreakpointsAlias} from '@shopify/polaris-tokens';
 import {breakpointsAliases} from '@shopify/polaris-tokens';
 
@@ -7,30 +5,6 @@ export function isObject(value: any) {
   const type = typeof value;
   return value != null && (type === 'object' || type === 'function');
 }
-
-interface PatternJSON {
-  [key: string]: {
-    frontMatter: PatternFrontMatter;
-  };
-}
-
-export const patterns: PatternJSON = Object.keys(pages)
-  .filter((slug) => slug.startsWith('patterns/'))
-  .sort((a, b) => a.localeCompare(b))
-  .reduce((memo, key) => {
-    // @ts-expect-error Yes it is compatible Typescript. Shhhh.
-    memo[key] = pages[key];
-    return memo;
-  }, {} as PatternJSON);
-
-export const legacyPatterns: PatternJSON = Object.keys(pages)
-  .filter((slug) => slug.startsWith('patterns-legacy/'))
-  .sort((a, b) => a.localeCompare(b))
-  .reduce((memo, key) => {
-    // @ts-expect-error Yes it is compatible Typescript. Shhhh.
-    memo[key] = pages[key];
-    return memo;
-  }, {} as PatternJSON);
 
 export const slugify = (str: string): string => {
   return (


### PR DESCRIPTION
Continuation of https://github.com/Shopify/polaris/pull/11298: this PR ensures we get the remaining missing URLs into `.cache/site.ts`:

```diff
+ "/patterns/date-picking/date-list",
+ "/patterns/date-picking/date-range",
+ "/patterns/date-picking/single-date",
```

The `.cache/site.ts` file used to be an object keyed by the file system path. That didn't work for `content/patterns/date-picking/variants/date-list.mdx` because the `/variants` isn't part of the url.

So I refactored it to key by the actual URL as set in the variant's frontmatter.

Now, the `.cache/site.ts` has an object who's keys are the same as the generated `sitemap.xml` (actually more! Because the old site scraper was missing a couple :scream:)