### PR TITLE
[topbar]: fixes the color of the hamburger icon

### DIFF
--- a/.changeset/unlucky-poets-occur.md
+++ b/.changeset/unlucky-poets-occur.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixes an issue where the color of the hamerburger icon was not inherit the color

--- a/.changeset/unlucky-poets-occur.md
+++ b/.changeset/unlucky-poets-occur.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fixes an issue where the color of the hamerburger icon was not inherit the color
+`TopBar` Fixed .NavigationIcon styles to ensure Icon color is properly inherited. 

--- a/polaris-react/src/components/TopBar/TopBar.scss
+++ b/polaris-react/src/components/TopBar/TopBar.scss
@@ -97,8 +97,8 @@ $right-column: 1fr;
   margin-right: var(--p-space-200);
   padding: var(--p-space-200);
   border-radius: var(--p-border-radius-100);
-  fill: var(--p-color-icon-inverse);
-  transition: var(--p-motion-duration-150) fill var(--p-motion-ease)
+  color: var(--p-color-icon-inverse);
+  transition: var(--p-motion-duration-150) color var(--p-motion-ease)
     var(--p-motion-duration-50);
 
   &.focused:active {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes: https://github.com/Shopify/polaris-internal/issues/1311 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Relies on the color CSS attribute so that the polaris Icon can inherit and apply the color properly

```css
.Polaris-Icon svg {
  fill: currentColor;
}
```

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
