### PR TITLE
Fix the toast icon color and simplify the implementation

### DIFF
--- a/.changeset/big-rules-smoke.md
+++ b/.changeset/big-rules-smoke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+`<Toast>` Fix icon color to properly inherit the parent color

--- a/polaris-react/src/components/Frame/components/Toast/Toast.scss
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.scss
@@ -42,10 +42,6 @@ $Backdrop-opacity: 0.88;
 
 .LeadingIcon {
   margin-right: var(--p-space-150);
-
-  svg {
-    fill: currentColor;
-  }
 }
 
 .CloseButton {
@@ -60,10 +56,6 @@ $Backdrop-opacity: 0.88;
   color: var(--p-color-icon-inverse);
   cursor: pointer;
   margin-left: var(--p-space-200);
-
-  svg {
-    fill: currentColor;
-  }
 
   &:focus {
     outline: none;

--- a/polaris-react/src/components/Frame/components/Toast/Toast.tsx
+++ b/polaris-react/src/components/Frame/components/Toast/Toast.tsx
@@ -50,7 +50,7 @@ export function Toast({
 
   const dismissMarkup = (
     <button type="button" className={styles.CloseButton} onClick={onDismiss}>
-      <Icon source={CancelSmallMinor} />
+      <Icon source={CancelSmallMinor} tone="inherit" />
     </button>
   );
 
@@ -69,7 +69,7 @@ export function Toast({
 
   const leadingIconMarkup = error ? (
     <div className={styles.LeadingIcon}>
-      <Icon source={AlertMinor} tone="base" />
+      <Icon source={AlertMinor} tone="inherit" />
     </div>
   ) : null;
 


### PR DESCRIPTION
A part of https://github.com/Shopify/polaris/issues/11337

### WHY are these changes introduced?

| Before | After |
| --- | --- |
| <img width="234" alt="290345776-525f1b14-b8ef-4066-9e9c-fc5b3ddaa684" src="https://github.com/Shopify/polaris/assets/19199063/4253765e-abad-4808-a826-2cf5d6d159c3"> | ![Screenshot 2023-12-14 at 10 04 34 am](https://github.com/Shopify/polaris/assets/19199063/bd94ab7e-4836-481d-a142-ef4b02523659) |

### WHAT is this pull request doing?

Uses the `inherit` property to properly render the icon with the parent color.