### PR TITLE
[IconsPage] Fixed Facebook and Instagram icon not being shown in search results

### DIFF
--- a/polaris-icons/icons/FacebookMinor.yml
+++ b/polaris-icons/icons/FacebookMinor.yml
@@ -1,8 +1,8 @@
 name: Facebook
-set: Minor
-description: Facebook logo
+set: minor
+description: Used to represent Facebook.
 keywords:
-  - facebook
+  - Facebook
   - social media
 authors:
   - Joe Thomas

--- a/polaris-icons/icons/InstagramMinor.yml
+++ b/polaris-icons/icons/InstagramMinor.yml
@@ -1,8 +1,8 @@
 name: Instagram
-set: Minor
-description: Instagram logo
+set: minor
+description: Used to represent Instagram.
 keywords:
-  - instagram
+  - Instagram
   - social media
 authors:
   - Joe Thomas

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -74,8 +74,6 @@ function IconsPage() {
     : router.query.icon ?? '';
   const currentSearchText = router.query.q ? `${router.query.q}` : '';
 
-  console.log(minorIcons);
-
   useEffect(() => {
     if (router.isReady && activeIcon) {
       scrollToActiveIcon(activeIcon);

--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -74,6 +74,8 @@ function IconsPage() {
     : router.query.icon ?? '';
   const currentSearchText = router.query.q ? `${router.query.q}` : '';
 
+  console.log(minorIcons);
+
   useEffect(() => {
     if (router.isReady && activeIcon) {
       scrollToActiveIcon(activeIcon);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issue [#11368](https://github.com/Shopify/polaris/issues/11368) that I opened!

The `set` value for the facebook and instagram icons was set to `Minor` instead of `minor`, which caused them to be missed in the minor icons array on the `Icons` page.

### WHAT is this pull request doing?
I realized that the facebook and instagram icons weren't showing up because of a casing issue. Now these icons should show up in both local and global search!

<img width="1000" alt="Screenshot 2023-12-20 at 2 09 34 PM" src="https://github.com/Shopify/polaris/assets/52360534/07f9abe5-ca7a-47b9-b4cb-d247c16144f3">

<img width="1000" alt="Screenshot 2023-12-20 at 2 10 58 PM" src="https://github.com/Shopify/polaris/assets/52360534/4c955cc8-7831-4cf9-b705-e5a062119cdf">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
