### PR TITLE
[polaris.shopify.com] Fix component page feedback links

### DIFF
--- a/.changeset/hungry-gifts-lay.md
+++ b/.changeset/hungry-gifts-lay.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Removed props table feedback link, added footer link to create component issues

--- a/polaris.shopify.com/src/components/Page/Page.tsx
+++ b/polaris.shopify.com/src/components/Page/Page.tsx
@@ -60,6 +60,9 @@ function Layout({
               <Link href={editOnGithubUrl}>Edit this page</Link>
             )}
             <Link href={feedbackUrl}>Leave feedback</Link>
+            <Link href="https://github.com/Shopify/polaris/issues/new/choose">
+              Create an issue
+            </Link>
           </p>
         </footer>
       </Box>

--- a/polaris.shopify.com/src/components/Page/Page.tsx
+++ b/polaris.shopify.com/src/components/Page/Page.tsx
@@ -1,5 +1,5 @@
 import {useTOC} from '../../utils/hooks';
-import {className} from '../../utils/various';
+import {className, toPascalCase} from '../../utils/various';
 import Longform from '../Longform';
 import Container from '../Container';
 import {Box} from '../Box';
@@ -39,6 +39,8 @@ function Layout({
   const editOnGithubUrl = editPageLinkPath
     ? `https://github.com/Shopify/polaris/tree/main${editPageLinkPath}`
     : '';
+  const isComponentPage = asPath.includes('/components/');
+  const componentTitle = toPascalCase(asPath.split('/').pop() ?? '');
 
   return (
     <Container className={className(styles.Page, showTOC && styles.showTOC)}>
@@ -60,9 +62,13 @@ function Layout({
               <Link href={editOnGithubUrl}>Edit this page</Link>
             )}
             <Link href={feedbackUrl}>Leave feedback</Link>
-            <Link href="https://github.com/Shopify/polaris/issues/new/choose">
-              Create an issue
-            </Link>
+            {isComponentPage && (
+              <Link
+                href={`https://github.com/Shopify/polaris/issues/new/choose?title=[${componentTitle}]`}
+              >
+                Create an issue
+              </Link>
+            )}
           </p>
         </footer>
       </Box>

--- a/polaris.shopify.com/src/components/PropsTable/PropsTable.module.scss
+++ b/polaris.shopify.com/src/components/PropsTable/PropsTable.module.scss
@@ -132,3 +132,13 @@
 .SyntaxNumber {
   color: var(--code-number);
 }
+
+.CopyButton {
+  opacity: 0.5;
+  background: none;
+  margin-inline-start: 0.25rem;
+
+  &:hover {
+    opacity: 1;
+  }
+}

--- a/polaris.shopify.com/src/components/PropsTable/PropsTable.tsx
+++ b/polaris.shopify.com/src/components/PropsTable/PropsTable.tsx
@@ -5,6 +5,10 @@ import Longform from '../Longform';
 import {motion, AnimatePresence} from 'framer-motion';
 import StatusBadge from '../StatusBadge';
 import {className, toPascalCase} from '../../utils/various';
+import {ClipboardMinor} from '@shopify/polaris-icons';
+import {useCopyToClipboard} from '../../utils/hooks';
+import Icon from '../Icon';
+import Tooltip from '../Tooltip';
 
 interface Props {
   componentName: string;
@@ -30,13 +34,15 @@ const TypeContext = createContext<{
 }>({types: {}});
 
 function PropsTable({types, componentName}: Props) {
-  const feedbackTitle = '[polaris.shopify.com] Props table feedback';
-  const feedbackUrl = `https://github.com/shopify/polaris/issues/new?title=${encodeURIComponent(
-    feedbackTitle,
-  )}&amp;labels=polaris.shopify.com`;
-
   const propsName = `${toPascalCase(componentName).replace(/\s/g, '')}Props`;
   const propsForComponent = types[propsName];
+  const origin =
+    typeof window !== 'undefined'
+      ? window.location.origin
+      : 'https://polaris.shopify.com';
+  const path = typeof window !== 'undefined' ? window.location.pathname : '';
+  const url = `${origin}${path}#props`;
+  const [copy, didJustCopy] = useCopyToClipboard(url);
 
   if (!propsForComponent) throw new Error('Could not find props for component');
 
@@ -46,11 +52,22 @@ function PropsTable({types, componentName}: Props) {
     <TypeContext.Provider value={{types}}>
       <div className={styles.PropsTable}>
         <Longform firstParagraphIsLede={false}>
-          <h2 id="props">Props</h2>
-          <p>
-            Want to help make this feature better? Please{' '}
-            <a href={feedbackUrl}>share your feedback</a>.
-          </p>
+          <h2 id="props">
+            Props
+            <Tooltip
+              ariaLabel="Copy to clipboard"
+              renderContent={() => <p>{didJustCopy ? 'Copied' : 'Copy'}</p>}
+            >
+              <button
+                className={styles.CopyButton}
+                onClick={() => {
+                  copy();
+                }}
+              >
+                <Icon source={ClipboardMinor} width={16} height={16} />
+              </button>
+            </Tooltip>
+          </h2>
         </Longform>
 
         {!propsAreDefinedUsingInterface && (


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

We're getting feedback in the wrong places https://github.com/Shopify/polaris/issues/11378

This removes the prop table feedback link, I think we're happy with what we have for now, and adds a new link to the footer for creating issues.

Also adds a copy to clipboard link for the props table

![image](https://github.com/Shopify/polaris/assets/6844391/20002eaa-1e3d-4037-801b-b0cc3e2f1e99)
