### PR TITLE
[PositionedOverlay] Add scroll support for all scroll containers

### DIFF
--- a/.changeset/olive-forks-call.md
+++ b/.changeset/olive-forks-call.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added `PositionedOverlay` scroll support for all scroll containers

--- a/polaris-react/src/components/Popover/Popover.stories.tsx
+++ b/polaris-react/src/components/Popover/Popover.stories.tsx
@@ -19,6 +19,7 @@ import {
   EmptySearchResult,
   Text,
   BlockStack,
+  Card,
 } from '@shopify/polaris';
 import {SearchIcon} from '@shopify/polaris-icons';
 
@@ -829,6 +830,49 @@ export function WithSubduedPane() {
         </Popover.Pane>
       </Popover>
     </div>
+  );
+}
+
+export function WithScrollContainer() {
+  const [popoverActive, setPopoverActive] = useState(true);
+
+  const togglePopoverActive = useCallback(
+    () => setPopoverActive((popoverActive) => !popoverActive),
+    [],
+  );
+
+  const activator = (
+    <Button onClick={togglePopoverActive} disclosure size="large">
+      Scroll me!
+    </Button>
+  );
+
+  return (
+    <Card>
+      <div style={{height: '300px', overflow: 'scroll'}}>
+        <div style={{height: '600px', overflow: 'hidden'}}>
+          <Box paddingBlock="2400" />
+          <Popover
+            active={popoverActive}
+            activator={activator}
+            onClose={togglePopoverActive}
+            ariaHaspopup={false}
+            sectioned
+          >
+            <Popover.Pane>
+              <Box padding="400">
+                <Text as="p">Popover content</Text>
+              </Box>
+            </Popover.Pane>
+            <Popover.Pane subdued>
+              <Box padding="400">
+                <Text as="p">Subdued popover pane</Text>
+              </Box>
+            </Popover.Pane>
+          </Popover>
+        </div>
+      </div>
+    </Card>
   );
 }
 

--- a/polaris-react/src/components/Popover/Popover.stories.tsx
+++ b/polaris-react/src/components/Popover/Popover.stories.tsx
@@ -20,6 +20,7 @@ import {
   Text,
   BlockStack,
   Card,
+  InlineStack,
 } from '@shopify/polaris';
 import {SearchIcon} from '@shopify/polaris-icons';
 
@@ -849,27 +850,30 @@ export function WithScrollContainer() {
 
   return (
     <Card>
-      <div style={{height: '300px', overflow: 'scroll'}}>
-        <div style={{height: '600px', overflow: 'hidden'}}>
-          <Box paddingBlock="2400" />
-          <Popover
-            active={popoverActive}
-            activator={activator}
-            onClose={togglePopoverActive}
-            ariaHaspopup={false}
-            sectioned
-          >
-            <Popover.Pane>
-              <Box padding="400">
-                <Text as="p">Popover content</Text>
-              </Box>
-            </Popover.Pane>
-            <Popover.Pane subdued>
-              <Box padding="400">
-                <Text as="p">Subdued popover pane</Text>
-              </Box>
-            </Popover.Pane>
-          </Popover>
+      <div style={{height: '300px', width: '300px', overflow: 'scroll'}}>
+        <div style={{height: '400px', width: '400px', overflow: 'hidden'}}>
+          <Box paddingBlock="1000" />
+          <InlineStack>
+            <Box paddingInline="1000" />
+            <Popover
+              active={popoverActive}
+              activator={activator}
+              onClose={togglePopoverActive}
+              ariaHaspopup={false}
+              sectioned
+            >
+              <Popover.Pane>
+                <Box padding="400">
+                  <Text as="p">Popover content</Text>
+                </Box>
+              </Popover.Pane>
+              <Popover.Pane subdued>
+                <Box padding="400">
+                  <Text as="p">Subdued popover pane</Text>
+                </Box>
+              </Popover.Pane>
+            </Popover>
+          </InlineStack>
         </div>
       </div>
     </Card>

--- a/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -4,7 +4,6 @@ import {classNames} from '../../utilities/css';
 import {getRectForNode, Rect} from '../../utilities/geometry';
 // eslint-disable-next-line import/no-deprecated
 import {EventListener} from '../EventListener';
-import {Scrollable} from '../Scrollable';
 import {layer, dataPolarisTopBar} from '../shared';
 
 import {
@@ -198,20 +197,37 @@ export class PositionedOverlay extends PureComponent<
     this.overlay = node;
   };
 
+  private isScrollContainer = (node: HTMLElement) => {
+    if (node.scrollHeight <= node.clientHeight) {
+      return false;
+    }
+
+    const overflowY = window.getComputedStyle(node).overflowY;
+
+    if (overflowY === 'visible' || overflowY === 'hidden') {
+      return false;
+    }
+
+    return true;
+  };
+
   private setScrollableContainers = () => {
     const containers: (HTMLElement | Document)[] = [];
-    let scrollableContainer = Scrollable.forNode(this.props.activator);
+    let currentNode: HTMLElement | ParentNode | null = this.props.activator;
 
-    if (scrollableContainer) {
-      containers.push(scrollableContainer);
-
-      while (scrollableContainer?.parentElement) {
-        scrollableContainer = Scrollable.forNode(
-          scrollableContainer.parentElement,
-        );
-
-        containers.push(scrollableContainer);
+    while (currentNode !== null) {
+      if (
+        currentNode instanceof HTMLElement &&
+        this.isScrollContainer(currentNode)
+      ) {
+        containers.push(currentNode);
       }
+
+      currentNode = currentNode.parentNode;
+    }
+
+    if (!containers.length) {
+      containers.push(document);
     }
 
     this.scrollableContainers = containers;

--- a/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/polaris-react/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -198,17 +198,24 @@ export class PositionedOverlay extends PureComponent<
   };
 
   private isScrollContainer = (node: HTMLElement) => {
-    if (node.scrollHeight <= node.clientHeight) {
+    const yOverflow = node.scrollHeight > node.clientHeight;
+    const xOverflow = node.scrollWidth > node.clientWidth;
+
+    if (!yOverflow && !xOverflow) {
       return false;
     }
 
-    const overflowY = window.getComputedStyle(node).overflowY;
+    const styles = window.getComputedStyle(node);
+    const yScroll =
+      styles.overflowY === 'auto' || styles.overflowY === 'scroll';
+    const xScroll =
+      styles.overflowX === 'auto' || styles.overflowX === 'scroll';
 
-    if (overflowY === 'visible' || overflowY === 'hidden') {
-      return false;
+    if ((yOverflow && yScroll) || (xOverflow && xScroll)) {
+      return true;
     }
 
-    return true;
+    return false;
   };
 
   private setScrollableContainers = () => {

--- a/polaris-react/src/components/PositionedOverlay/utilities/math.ts
+++ b/polaris-react/src/components/PositionedOverlay/utilities/math.ts
@@ -117,7 +117,12 @@ export function calculateHorizontalPosition(
 export function rectIsOutsideOfRect(inner: Rect, outer: Rect) {
   const {center} = inner;
 
-  return center.y < outer.top || center.y > outer.top + outer.height;
+  return (
+    center.y < outer.top ||
+    center.y > outer.top + outer.height ||
+    inner.left < outer.left ||
+    inner.left + inner.width > outer.left + outer.width
+  );
 }
 
 export function intersectionWithViewport(

--- a/polaris-react/src/components/PositionedOverlay/utilities/math.ts
+++ b/polaris-react/src/components/PositionedOverlay/utilities/math.ts
@@ -117,12 +117,7 @@ export function calculateHorizontalPosition(
 export function rectIsOutsideOfRect(inner: Rect, outer: Rect) {
   const {center} = inner;
 
-  return (
-    center.y < outer.top ||
-    center.y > outer.top + outer.height ||
-    inner.left < outer.left ||
-    inner.left + inner.width > outer.left + outer.width
-  );
+  return center.y < outer.top || center.y > outer.top + outer.height;
 }
 
 export function intersectionWithViewport(


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-internal/issues/1246

### WHAT is this pull request doing?

Before, the `PositionedOverlay` component (used by `Popover` and `Tooltip`) only scrolled with Polaris `Scrollable` components or the window. 

This PR adds support for all scroll containers so that `Popover` and `Tooltip` will always scroll with containers, even if its not wrapped in a `Scrollable`. 

|Before|After|
|-|-|
|![Before-Scroll-Popover](https://github.com/Shopify/polaris/assets/20652326/f96652a0-bd20-4305-899e-6242ebb30496)|![After-Scroll-Popover](https://github.com/Shopify/polaris/assets/20652326/55cb30df-90e5-45b6-b337-819e9e05e376)|
|![before-taxes-overlay](https://github.com/Shopify/polaris/assets/20652326/c421bee0-0d64-4a06-a291-ee7e59d65382)|![after-taxes-overlay](https://github.com/Shopify/polaris/assets/20652326/d66cbfc5-7298-47f3-bd7a-a3b8e2d0a364)|

### Alternative approaches

I picked this approach since it decouples `PositionedOverlay` from `Scrollable` and doesn't require any extra setup or knowledge from consumers, it should "just work". If this approach is undesirable, we could also either:

1. Extend `Tooltip` and `Popover` to accept a `ref` to custom scrollable containers and keep automatic `Scrollable` detection
2. Export `data-polaris-scrollable` or another more generic attribute that consumers can add to their custom scroll elements. Then update `Tooltip` and `Popover` documentation to require proper scroll container setup
3. Extend the `Scrollable` component to support the scrolling features in the settings modal, refactor the settings modal to use `Scrollable`, and update `Tooltip` and `Popover` documentation to require that all scroll containers are `Scrollable`s

### How to 🎩

* https://5d559397bae39100201eedc1-fdxylxukuv.chromatic.com/?path=/story/all-components-popover--with-scroll-container

* https://admin.web.web-ya2s.sophie-schneider.us.spin.dev/store/shop1/settings/taxes
1. Go to Taxes settings
4. Click "Sort" on the `Manage sales tax collection` card
5. Scroll so the "Sort" button moves
6. Make sure popover moves with button and closes when the button leaves the viewport

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
