### PR TITLE
Changed the icon color for the Magic tone of the Badge component.

### DIFF
--- a/.changeset/tasty-doors-arrive.md
+++ b/.changeset/tasty-doors-arrive.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris': minor
+'@shopify/polaris': patch
 ---
 
 Changed the icon color from icon-magic to text-magic for the Magic tone of the Badge component.

--- a/.changeset/tasty-doors-arrive.md
+++ b/.changeset/tasty-doors-arrive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Changed the icon color from icon-magic to text-magic for the Magic tone of the Badge component.

--- a/polaris-react/src/components/Badge/Badge.module.scss
+++ b/polaris-react/src/components/Badge/Badge.module.scss
@@ -130,7 +130,7 @@
   color: var(--p-color-text-magic);
 
   svg {
-    fill: var(--p-color-icon-magic);
+    fill: var(--p-color-text-magic);
   }
 }
 


### PR DESCRIPTION
This PR changes the icon color from icon-magic to text-magic for the Magic tone of the Badge component. Designs in review with @heyjoethomas 

<img width="1409" alt="Screenshot 2024-01-05 at 11 05 54" src="https://github.com/Shopify/polaris/assets/8492201/c75c6266-a33f-4d8b-9308-815fa669ac28">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
