### PR TITLE
[Navigation] Change `padding-top` to `space-100` for small viewports

### DIFF
--- a/.changeset/hip-oranges-joke.md
+++ b/.changeset/hip-oranges-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[Navigation] Removed sm media query for padding top

--- a/.changeset/hip-oranges-joke.md
+++ b/.changeset/hip-oranges-joke.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-[Navigation] Removed sm media query for padding top
+[Navigation] Updated `padding-top` to `space-100` for small viewports

--- a/polaris-react/src/components/Navigation/Navigation.module.scss
+++ b/polaris-react/src/components/Navigation/Navigation.module.scss
@@ -57,7 +57,11 @@ $nav-max-width: 360px;
   flex-direction: column;
   align-items: stretch;
   max-width: 100%;
-  padding-top: var(--p-space-400);
+  padding-top: var(--p-space-100);
+
+  @media #{$p-breakpoints-md-up} {
+    padding-top: var(--p-space-400);
+  }
 
   &:focus {
     outline: none;

--- a/polaris-react/src/components/Navigation/Navigation.module.scss
+++ b/polaris-react/src/components/Navigation/Navigation.module.scss
@@ -57,13 +57,10 @@ $nav-max-width: 360px;
   flex-direction: column;
   align-items: stretch;
   max-width: 100%;
+  padding-top: var(--p-space-400);
 
   &:focus {
     outline: none;
-  }
-
-  @media #{$p-breakpoints-md-up} {
-    padding-top: var(--p-space-400);
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

addresses https://github.com/Shopify/polaris/issues/10218 <!-- link to issue if one exists -->

Note: the issue with the arrow cutting off was addressed previously

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Changing `padding-top` to `space-100` for small viewports

| Before | After |
| -- | -- | 
|![before](https://github.com/Shopify/polaris/assets/20652326/75dabab3-20d7-426d-9553-23d08200f950)|![after](https://github.com/Shopify/polaris/assets/4642404/667a9347-0e40-4bc1-83f8-db0e646a30c4)|

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
