### PR TITLE
[DataTable] Fix sticky header example in documentation

### DIFF
--- a/.changeset/cyan-bulldogs-behave.md
+++ b/.changeset/cyan-bulldogs-behave.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed sticky header example in docs

--- a/polaris.shopify.com/pages/examples/data-table-with-sticky-header-enabled.tsx
+++ b/polaris.shopify.com/pages/examples/data-table-with-sticky-header-enabled.tsx
@@ -3,7 +3,7 @@ import {useState, useCallback} from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function FullDataTableExample() {
-  const [sortedRows, setSortedRows] = useState<TableData[][]>([]);
+  const [sortedRows, setSortedRows] = useState<TableData[][] | null>(null);
 
   const initiallySortedRows: TableData[][] = [
     [


### PR DESCRIPTION
### WHY are these changes introduced?

The current example in documentation is broken in production
<img width="1204" alt="image" src="https://github.com/Shopify/polaris/assets/17794897/b23e017f-ba3e-48a0-a8ac-d6764b328bd8">

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Since we used empty array as initial value for `sortedRows` state which is truthy by default. We should stick with `null` to correct it and be consistent with other examples 😉 

<img width="1210" alt="image" src="https://github.com/Shopify/polaris/assets/17794897/9f669e7e-6f5e-4ab5-9b5f-14b9589dcda1">


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
