### PR TITLE
[InlineError] Fixed icon size and alignment

### DIFF
--- a/.changeset/lanky-flamingos-kick.md
+++ b/.changeset/lanky-flamingos-kick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed the icon spacing in `InlineError`

--- a/polaris-react/src/components/InlineError/InlineError.module.scss
+++ b/polaris-react/src/components/InlineError/InlineError.module.scss
@@ -9,10 +9,9 @@
 .Icon {
   fill: var(--p-color-text-critical);
   margin-left: calc(-1 * var(--p-space-050));
-  margin-right: var(--p-space-100);
+  margin-right: var(--p-space-200);
 
   svg {
-    padding: var(--p-space-050);
     margin-left: var(--p-space-050);
     margin-right: var(--p-space-050);
   }

--- a/polaris-react/src/components/InlineError/InlineError.module.scss
+++ b/polaris-react/src/components/InlineError/InlineError.module.scss
@@ -9,7 +9,7 @@
 .Icon {
   fill: var(--p-color-text-critical);
   margin-left: calc(-1 * var(--p-space-050));
-  margin-right: var(--p-space-200);
+  margin-right: var(--p-space-100);
 
   svg {
     padding: var(--p-space-050);

--- a/polaris-react/src/components/InlineError/InlineError.module.scss
+++ b/polaris-react/src/components/InlineError/InlineError.module.scss
@@ -8,7 +8,7 @@
 
 .Icon {
   fill: var(--p-color-text-critical);
-  margin-left: calc(-1 * var(--p-space-050));
+  margin-left: calc(-1 * var(--p-space-100));
   margin-right: var(--p-space-200);
 
   svg {


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-internal/issues/1224

### WHY are these changes introduced?

With the reduction in the size of our icons within their viewbox from 20px to 16px, the spacing of the icon in `InlineError` looks excessive. 

### WHAT is this pull request doing?

This PR:
- [x] Fixes the `InlineError` icon size and spacing by removing its padding
- [x] Makes the `InlineError` flush with composed inputs by increasing its negative left margin from 2px to 4px

| Before| After |
|--------|--------|
|![Screenshot 2024-02-26 at 4 08 58 PM](https://github.com/Shopify/polaris/assets/18447883/6b6d1e30-69a3-432d-9309-8c419fb3d83d)|![Screenshot 2024-02-26 at 4 08 24 PM](https://github.com/Shopify/polaris/assets/18447883/46b32af3-1eb2-4a90-98e4-9d4df09369a7)|

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
