### PR TITLE
Update `SkeletonTabs` to reflect `Tabs`

### DIFF
--- a/.changeset/smooth-lemons-appear.md
+++ b/.changeset/smooth-lemons-appear.md
@@ -2,4 +2,5 @@
 '@shopify/polaris': minor
 ---
 
-Updated `SkeletonTabs` to reflect `Tabs` design
+- Updated `SkeletonTabs` to reflect `Tabs` design
+- Added `fitted` prop

--- a/.changeset/smooth-lemons-appear.md
+++ b/.changeset/smooth-lemons-appear.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated `SkeletonTabs` to reflect `Tabs` design

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
@@ -38,3 +38,17 @@
     background-color: grayText;
   }
 }
+
+.fitted {
+  flex-wrap: nowrap;
+
+  .Tab {
+    flex: none;
+    justify-content: flex-start;
+
+    @media #{$p-breakpoints-md-up} {
+      flex: 1 1 100%;
+      justify-content: center;
+    }
+  }
+}

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
@@ -14,7 +14,7 @@
   display: flex;
   align-items: center;
   // Tab height + padding
-  height: calc(var(--p-height-800) + var(--p-height-300));
+  height: calc(var(--p-height-800) + var(--p-height-400));
   padding: var(--p-space-200) var(--p-space-300);
   margin-right: var(--p-space-100);
 
@@ -24,7 +24,7 @@
 
   @media #{$p-breakpoints-md-up} {
     // Tab height + padding
-    height: calc(var(--p-height-700) + var(--p-height-300));
+    height: calc(var(--p-height-700) + var(--p-height-400));
   }
 }
 

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
@@ -3,6 +3,10 @@
 .Tabs {
   display: flex;
   width: 100%;
+
+  @media #{$p-breakpoints-md-down} {
+    overflow: auto;
+  }
 }
 
 .Tab {

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
@@ -1,33 +1,36 @@
+@import '../../styles/common';
+
 .Tabs {
   display: flex;
   width: 100%;
-  border-bottom: var(--p-border-width-025) solid var(--p-color-border-secondary);
 }
 
 .Tab {
   position: relative;
-  padding: calc(var(--p-space-500) + var(--p-space-050)) var(--p-space-400);
+  display: flex;
+  align-items: center;
+  // Tab height + padding
+  height: calc(var(--p-height-800) + var(--p-height-300));
+  padding: var(--p-space-200) var(--p-space-300);
+  margin-right: var(--p-space-100);
 
-  &:first-child::before {
-    background-color: var(--p-color-border-hover);
+  &:last-child {
+    margin-right: 0;
   }
 
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: -1px;
-    left: var(--p-space-300);
-    right: var(--p-space-300);
-    height: var(--p-border-width-050);
-    border-top-left-radius: var(--p-border-radius-100);
-    border-top-right-radius: var(--p-border-radius-100);
+  @media #{$p-breakpoints-md-up} {
+    // Tab height + padding
+    height: calc(var(--p-height-700) + var(--p-height-300));
   }
 }
 
-.Tab-short {
-  width: 80px;
-}
+.TabText {
+  width: var(--p-width-1600);
+  height: var(--p-space-300);
+  background-color: var(--p-color-bg-fill-tertiary);
+  border-radius: var(--p-border-radius-100);
 
-.Tab-long {
-  width: 100px;
+  @media screen and (-ms-high-contrast: active) {
+    background-color: grayText;
+  }
 }

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
@@ -3,9 +3,10 @@
 .Tabs {
   display: flex;
   width: 100%;
+  overflow: auto;
 
-  @media #{$p-breakpoints-md-down} {
-    overflow: auto;
+  @media #{$p-breakpoints-md-up} {
+    overflow: visible;
   }
 }
 
@@ -43,7 +44,6 @@
   flex-wrap: nowrap;
 
   .Tab {
-    flex: none;
     justify-content: flex-start;
 
     @media #{$p-breakpoints-md-up} {

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.module.scss
@@ -51,4 +51,10 @@
       justify-content: center;
     }
   }
+
+  .TabText {
+    @media #{$p-breakpoints-md-up} {
+      width: 100%;
+    }
+  }
 }

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.stories.tsx
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.stories.tsx
@@ -1,23 +1,36 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
-import {LegacyCard, SkeletonTabs} from '@shopify/polaris';
+import type {Meta} from '@storybook/react';
+import {BlockStack, LegacyCard, SkeletonTabs} from '@shopify/polaris';
 
 export default {
   component: SkeletonTabs,
-} as ComponentMeta<typeof SkeletonTabs>;
+} as Meta<typeof SkeletonTabs>;
 
-export function Default() {
+export function All() {
   return (
-    <LegacyCard>
-      <SkeletonTabs />
-    </LegacyCard>
+    <BlockStack gap="500">
+      <Default />
+      <WithACustomCount />
+      <InsideOfACard />
+    </BlockStack>
   );
 }
 
+export function Default() {
+  return <SkeletonTabs />;
+}
+
 export function WithACustomCount() {
+  return <SkeletonTabs count={4} />;
+}
+
+export function InsideOfACard() {
   return (
     <LegacyCard>
-      <SkeletonTabs count={4} />
+      <SkeletonTabs count={6} />
+      <LegacyCard.Section title="Something">
+        <p>Tab X selected</p>
+      </LegacyCard.Section>
     </LegacyCard>
   );
 }

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.stories.tsx
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.stories.tsx
@@ -12,6 +12,7 @@ export function All() {
       <Default />
       <WithACustomCount />
       <InsideOfACard />
+      <InsideOfACardFitted />
     </BlockStack>
   );
 }
@@ -27,10 +28,25 @@ export function WithACustomCount() {
 export function InsideOfACard() {
   return (
     <LegacyCard>
-      <SkeletonTabs count={6} />
-      <LegacyCard.Section title="Something">
-        <p>Tab X selected</p>
-      </LegacyCard.Section>
+      <div>
+        <SkeletonTabs count={6} />
+        <LegacyCard.Section title="TabName">
+          <p>Tab X selected</p>
+        </LegacyCard.Section>
+      </div>
+    </LegacyCard>
+  );
+}
+
+export function InsideOfACardFitted() {
+  return (
+    <LegacyCard>
+      <div>
+        <SkeletonTabs fitted />
+        <LegacyCard.Section title="TabName">
+          <p>Tab X selected</p>
+        </LegacyCard.Section>
+      </div>
     </LegacyCard>
   );
 }

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.tsx
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.tsx
@@ -6,11 +6,13 @@ import styles from './SkeletonTabs.module.scss';
 
 export interface SkeletonTabsProps {
   count?: number;
+  /** Fit tabs to container */
+  fitted?: boolean;
 }
 
-export function SkeletonTabs({count = 2}: SkeletonTabsProps) {
+export function SkeletonTabs({count = 2, fitted = false}: SkeletonTabsProps) {
   return (
-    <div className={styles.Tabs}>
+    <div className={classNames(styles.Tabs, fitted && styles.fitted)}>
       {[...Array(count).keys()].map((key) => {
         return (
           <div key={key} className={classNames(styles.Tab)}>

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.tsx
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
-import {SkeletonBodyText} from '../SkeletonBodyText';
 
 import styles from './SkeletonTabs.module.scss';
 
@@ -13,12 +12,9 @@ export function SkeletonTabs({count = 2}: SkeletonTabsProps) {
   return (
     <div className={styles.Tabs}>
       {[...Array(count).keys()].map((key) => {
-        const tabWidthClassName =
-          key % 2 === 0 ? styles['Tab-short'] : styles['Tab-long'];
-
         return (
-          <div key={key} className={classNames(styles.Tab, tabWidthClassName)}>
-            <SkeletonBodyText lines={1} />
+          <div key={key} className={classNames(styles.Tab)}>
+            <div className={styles.TabText} />
           </div>
         );
       })}

--- a/polaris.shopify.com/content/components/feedback-indicators/skeleton-tabs.mdx
+++ b/polaris.shopify.com/content/components/feedback-indicators/skeleton-tabs.mdx
@@ -12,7 +12,10 @@ examples:
   - fileName: skeleton-tabs-default.tsx
     title: Default
   - fileName: skeleton-tabs-with-a-custom-count.tsx
-    title: With a custom count
+    title: With custom count
+  - fileName: skeleton-tabs-fitted.tsx
+    title: Fitted
+    description: Use when tabs contain a few (2 or 3) items within a narrow column.
 previewImg: /images/components/feedback-indicators/skeleton-tabs.png
 ---
 

--- a/polaris.shopify.com/pages/examples/skeleton-tabs-fitted.tsx
+++ b/polaris.shopify.com/pages/examples/skeleton-tabs-fitted.tsx
@@ -1,0 +1,13 @@
+import {LegacyCard, SkeletonTabs} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function SkeletonExample() {
+  return (
+    <LegacyCard>
+      <SkeletonTabs fitted />
+    </LegacyCard>
+  );
+}
+
+export default withPolarisExample(SkeletonExample);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10279

### WHAT is this pull request doing?
✨[Figma Mockups](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/branch/12F2Pi4uZ3PJQgTPjbHgPh/Polaris-Gen-3-Components?type=design&node-id=113973-39695&mode=design&t=reR54kMq05COztXb-11)✨ for changes

Updates the design of `SkeletonTabs` so it reflects the new `Tabs` versus `LegacyTabs`. 

Below is a quick video demonstrating how the updated `SkeletonTabs` inside of a `LegacyCard` (only focus on examples inside the cards) should switch with `Tabs` without any shifting or jank.

**MD Breakpoint and above** 

https://github.com/Shopify/polaris/assets/21976492/32eab494-79d8-49d2-a02a-70f7f19ee22b


**Below MD Breakpoint**

https://github.com/Shopify/polaris/assets/21976492/f9aee399-204a-40b8-8860-9774f7700840

**Doc Site**
| Before | After |
| -- | -- |
|![polaris shopify com_components_feedback-indicators_skeleton-tabs](https://github.com/Shopify/polaris/assets/21976492/de6e4a5e-e66a-426f-85ec-ed61887ce192)| ![localhost_3000_components_feedback-indicators_skeleton-tabs_example=skeleton-tabs-default](https://github.com/Shopify/polaris/assets/21976492/3a888091-bd74-44c7-aa4b-f8fd33107ae2)|

| New Tab |
| -- |
|![localhost_3000_components_feedback-indicators_skeleton-tabs_example=skeleton-tabs-fitted (1)](https://github.com/Shopify/polaris/assets/21976492/9d93b624-3ffc-4d73-a97c-00aa9fc94336)|


### How to 🎩
- [📚 Storybook](https://5d559397bae39100201eedc1-oszzjwcnmf.chromatic.com/?path=/story/all-components-skeletontabs--all)

I tried my best to find one of the 7 instances of this component in the admin but struck out and was not able to tophat. 

### 🎩 checklist
- [ ] ~Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)~ I tried my best to find one of the 7 instances of this component in the admin but struck out and was not able to tophat. 
- [X] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
