### PR TITLE
[Button] Bump icon fill specificity

### DIFF
--- a/.changeset/young-carrots-happen.md
+++ b/.changeset/young-carrots-happen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Button` icon fill specificity to be greater than `Icon`'s fill style

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -43,14 +43,15 @@
   user-select: none;
   -webkit-tap-highlight-color: transparent;
 
-  svg {
-    fill: var(--pc-button-icon-fill);
-  }
-
   @media (--p-breakpoints-md-up) {
     font-size: var(--p-font-size-300);
     line-height: var(--p-font-line-height-400);
   }
+}
+
+// Bump specificity to override Icon svg fill
+.Button.Button svg {
+  fill: var(--pc-button-icon-fill);
 }
 
 .Button:hover {


### PR DESCRIPTION
### WHY are these changes introduced?

|Spin|Staging|
|-|-|
|<img width="840" alt="Screenshot 2024-01-09 at 4 37 01 PM" src="https://github.com/Shopify/web/assets/20652326/cb4b71a2-f730-4d30-9562-7e07caf8ca9b">|<img width="842" alt="Screenshot 2024-01-09 at 4 37 16 PM" src="https://github.com/Shopify/web/assets/20652326/3943bc4b-8060-41de-8adb-323af4443c15">|


The `Button` icon fill specificity was the same as `Icon`'s fill specificity `(0, 1, 1)` which were causing inconsistent results locally vs. production. This PR bumps `Button`'s icon fill to `(0, 2, 1)` so that it is always greater than `Icon`'s fill

### How to 🎩

- Make sure storybook's icon buttons still look the same
- check on staging 
