### PR TITLE
[Button] Fix spinner alignment

### DIFF
--- a/.changeset/four-hotels-behave.md
+++ b/.changeset/four-hotels-behave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Button` spinner icon alignment

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -77,10 +77,6 @@
 .pressed.pressed:focus-visible svg {
   fill: var(--pc-button-icon-fill_pressed);
 }
-
-.Spinner.Spinner svg {
-  fill: var(--pc-button-icon-fill_disabled);
-}
 // stylelint-enable selector-max-specificity
 
 .Button:hover {
@@ -379,9 +375,14 @@
 // SPINNER
 .Spinner {
   position: absolute;
-  top: calc(var(--pc-button-padding-block) / 2 + 50%);
+  top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+
+  svg {
+    fill: var(--pc-button-icon-fill_disabled);
+    vertical-align: middle;
+  }
 }
 
 // BUTTON GROUP


### PR DESCRIPTION
### WHY are these changes introduced?

|Before|After|
|-|-|
|<img width="314" alt="Screenshot 2024-01-11 at 4 14 45 PM" src="https://github.com/Shopify/polaris/assets/20652326/8fa894da-4e4a-43fd-933c-5f38e2b7f57b">|<img width="330" alt="Screenshot 2024-01-11 at 4 14 33 PM" src="https://github.com/Shopify/polaris/assets/20652326/2c03fee3-6414-4331-8107-6f57e0da1214">|

See [storybook diff](https://shopify.chromatic.com/test?appId=5d559397bae39100201eedc1&id=65a05a50e6f9df1898f2ec7c) for a closer look
