### PR TITLE
[Docs] Fix a broken link in IconDetails component

### DIFF
--- a/polaris.shopify.com/src/components/IconDetails/IconDetails.tsx
+++ b/polaris.shopify.com/src/components/IconDetails/IconDetails.tsx
@@ -38,7 +38,7 @@ function IconDetails({fileName, iconData}: Props) {
     componentUsage: `<Icon\n  source={${fileName}}\n  tone="base"\n/>`,
   };
   const figmaUIKitURl =
-    'https://www.figma.com/community/file/1110993965108325096';
+    'https://www.figma.com/community/file/1293614863849914283';
   const polarisIconsUrl =
     'https://www.npmjs.com/package/@shopify/polaris-icons#usage';
   const iconComponentUrl = '/components/icon';


### PR DESCRIPTION
Right now the Icon details page has a link to a figma page that 404s

### WHY are these changes introduced?

- resolves: https://github.com/Shopify/polaris/issues/11435

### WHAT is this pull request doing?

Change the icon details link from: 
https://www.figma.com/community/file/1110993965108325096
to 
https://www.figma.com/community/file/1293614863849914283

### Is this the right page to link to? 
I just found what looked like the right community page but I haven't confirmed with anyone from the polaris team!

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Test that the link goes to the right page now. 

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
