### PR TITLE
Lower z-index of Filters container to be below Card shadow bevel

### DIFF
--- a/.changeset/selfish-ads-reflect.md
+++ b/.changeset/selfish-ads-reflect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Raised the z-index of `Filter`s container to be below `Card` shadow bevel

--- a/.changeset/selfish-ads-reflect.md
+++ b/.changeset/selfish-ads-reflect.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Raised the z-index of `Filter`s container to be below `Card` shadow bevel
+Lowered the z-index of `Filter`s container to be below `Card` shadow bevel

--- a/polaris-react/src/components/Filters/Filters.module.scss
+++ b/polaris-react/src/components/Filters/Filters.module.scss
@@ -2,7 +2,8 @@
 
 .Container {
   position: relative;
-  z-index: var(--p-z-index-1);
+  // stylelint-disable-next-line -- z-index below Card shadow bevel (32)
+  z-index: 30;
   border-bottom: var(--p-border-width-025) solid var(--p-color-border-secondary);
   border-top-left-radius: var(--p-border-radius-200);
   border-top-right-radius: var(--p-border-radius-200);


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-internal/issues/1343
Part of https://github.com/Shopify/polaris-internal/issues/1354

### WHAT is this pull request doing?

Lower `Filter` container z-index (currently `100`) to be below `Card`'s shadow bevel z-index which is `32`. This is a similar bug/fix as [this issue](https://github.com/Shopify/polaris/pull/11411). 

|Before|After|
|-|-|
|<img width="503" alt="Screenshot 2024-01-17 at 3 53 30 PM" src="https://github.com/Shopify/polaris/assets/20652326/88edab7c-aed8-44b8-9f5c-b9bd319405dc">|<img width="382" alt="Screenshot 2024-01-17 at 4 48 45 PM" src="https://github.com/Shopify/polaris/assets/20652326/7dc33fc8-333b-4e1d-afa7-f3efed5ad7a1">|

### How to 🎩

https://admin.web.web-kkgf.sophie-schneider.us.spin.dev/store/shop1/orders
1. Press search button on index table

or

verify shadow bevel is on the filter search bar in this story https://5d559397bae39100201eedc1-vszwcambil.chromatic.com/?path=/story/all-components-indexfilters--with-filtering-by-default (vs.[ on prod](https://storybook.polaris.shopify.com/?path=/story/all-components-indexfilters--with-filtering-by-default))


### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
