### PR TITLE
[Tooltip] Fix underline contrast

### DIFF
--- a/.changeset/strange-cameras-roll.md
+++ b/.changeset/strange-cameras-roll.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Increased contrast on Tooltip underline

--- a/polaris-react/src/components/Tooltip/Tooltip.module.scss
+++ b/polaris-react/src/components/Tooltip/Tooltip.module.scss
@@ -3,6 +3,5 @@
 }
 
 .HasUnderline {
-  border-bottom: var(--p-border-width-050) dotted
-    var(--p-color-border-secondary);
+  border-bottom: var(--p-border-width-050) dotted var(--p-color-border);
 }

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -12,6 +12,7 @@ import {
   InlineStack,
   BlockStack,
   Popover,
+  Card,
 } from '@shopify/polaris';
 import type {TooltipProps} from '@shopify/polaris';
 
@@ -461,13 +462,13 @@ export function Alignment() {
 
 export function HasUnderline() {
   return (
-    <Box paddingBlockStart="2400">
+    <Card padding="400">
       <Tooltip active content="This tooltip has an underline" hasUnderline>
         <Text variant="bodyLg" fontWeight="bold" as="span">
           Order #1001
         </Text>
       </Tooltip>
-    </Box>
+    </Card>
   );
 }
 

--- a/polaris.shopify.com/content/components/overlays/tooltip.mdx
+++ b/polaris.shopify.com/content/components/overlays/tooltip.mdx
@@ -23,6 +23,9 @@ examples:
   - fileName: tooltip-with-suffix.tsx
     title: With suffix
     description: Use when merchants benefit from information supplemental to the tooltip content. For example, to present a keyboard shortcut beside the content of a tooltip that describes an icon button.
+  - fileName: tooltip-with-underline.tsx
+    title: With underline
+    description: Use to apply a dotted underline to the activator.
 previewImg: /images/components/overlays/tooltip.png
 ---
 

--- a/polaris.shopify.com/pages/examples/tooltip-with-underline.tsx
+++ b/polaris.shopify.com/pages/examples/tooltip-with-underline.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {Card, Tooltip, Text} from '@shopify/polaris';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TooltipExample() {
+  return (
+    <div style={{padding: '75px 0'}}>
+      <Card padding="400">
+        <Tooltip active content="This tooltip has an underline" hasUnderline>
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Order #1001
+          </Text>
+        </Tooltip>
+      </Card>
+    </div>
+  );
+}
+
+export default withPolarisExample(TooltipExample);


### PR DESCRIPTION
### WHY are these changes introduced?

This slightly increases the contrast on the underline. Maybe we need a new token for dotted borders cc @sarahill 

Fixes https://github.com/Shopify/polaris-internal/issues/1364

### WHAT is this pull request doing?

Before | After
---|---
![image](https://screenshot.click/18-20-6boe5-pnt9r.png) | ![image](https://screenshot.click/18-21-g0c9q-eygvb.png)