### PR TITLE
[BulkActions | SelectAllActions] Add backwards compatibility for BulkActions and SelectAllActions

### DIFF
--- a/.changeset/breezy-balloons-leave.md
+++ b/.changeset/breezy-balloons-leave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[BulkActions and SelectAllActions] Ensure backwards compatibilility after prop reorganisation between components

--- a/polaris-react/src/components/BulkActions/BulkActions.stories.tsx
+++ b/polaris-react/src/components/BulkActions/BulkActions.stories.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import type {ComponentMeta} from '@storybook/react';
+
+import {BulkActions} from './BulkActions';
+
+export default {
+  component: BulkActions,
+} as ComponentMeta<typeof BulkActions>;
+
+export function Default() {
+  const promotedActions = [
+    {
+      content: 'Capture payments',
+      onAction: () => console.log('Todo: implement payment capture'),
+    },
+    {
+      title: 'Edit customers',
+      actions: [
+        {
+          content: 'Add customers',
+          onAction: () => console.log('Todo: implement adding customers'),
+        },
+        {
+          content: 'Delete customers',
+          onAction: () => console.log('Todo: implement deleting customers'),
+        },
+      ],
+    },
+    {
+      title: 'Export',
+      actions: [
+        {
+          content: 'Export as PDF',
+          onAction: () => console.log('Todo: implement PDF exporting'),
+        },
+        {
+          content: 'Export as CSV',
+          onAction: () => console.log('Todo: implement CSV exporting'),
+        },
+      ],
+    },
+  ];
+  const actions = [
+    {
+      content: 'Add tags',
+      onAction: () => console.log('Todo: implement bulk add tags'),
+    },
+    {
+      content: 'Remove tags',
+      onAction: () => console.log('Todo: implement bulk remove tags'),
+    },
+    {
+      content: 'Delete customers',
+      onAction: () => console.log('Todo: implement bulk delete'),
+    },
+  ];
+  return (
+    <BulkActions
+      selectMode
+      onToggleAll={() => console.log('toggling all')}
+      accessibilityLabel="Select all items"
+      selected={false}
+      promotedActions={promotedActions}
+      actions={actions}
+    />
+  );
+}
+
+export function WithDeprecatedProps() {
+  const promotedActions = [
+    {
+      content: 'Capture payments',
+      onAction: () => console.log('Todo: implement payment capture'),
+    },
+    {
+      title: 'Edit customers',
+      actions: [
+        {
+          content: 'Add customers',
+          onAction: () => console.log('Todo: implement adding customers'),
+        },
+        {
+          content: 'Delete customers',
+          onAction: () => console.log('Todo: implement deleting customers'),
+        },
+      ],
+    },
+    {
+      title: 'Export',
+      actions: [
+        {
+          content: 'Export as PDF',
+          onAction: () => console.log('Todo: implement PDF exporting'),
+        },
+        {
+          content: 'Export as CSV',
+          onAction: () => console.log('Todo: implement CSV exporting'),
+        },
+      ],
+    },
+  ];
+  const actions = [
+    {
+      content: 'Add tags',
+      onAction: () => console.log('Todo: implement bulk add tags'),
+    },
+    {
+      content: 'Remove tags',
+      onAction: () => console.log('Todo: implement bulk remove tags'),
+    },
+    {
+      content: 'Delete customers',
+      onAction: () => console.log('Todo: implement bulk delete'),
+    },
+  ];
+  return (
+    <BulkActions
+      selectMode
+      onToggleAll={() => console.log('toggling all')}
+      accessibilityLabel="Select all items"
+      selected={false}
+      promotedActions={promotedActions}
+      actions={actions}
+      isSticky
+      width={500}
+    />
+  );
+}

--- a/polaris-react/src/components/BulkActions/BulkActions.tsx
+++ b/polaris-react/src/components/BulkActions/BulkActions.tsx
@@ -59,6 +59,10 @@ export interface BulkActionsProps {
   innerRef?: React.Ref<any>;
   /** The size of the buttons to render */
   buttonSize?: Extract<ButtonProps['size'], 'micro' | 'medium'>;
+  /** @deprecated If the BulkActions is currently sticky in view */
+  isSticky?: boolean;
+  /** @deprecated The width of the BulkActions */
+  width?: number;
 }
 
 type CombinedProps = BulkActionsProps & {
@@ -226,6 +230,8 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
       selected,
       innerRef,
       buttonSize = 'micro',
+      width,
+      isSticky,
     } = this.props;
     const actionSections = this.actionSections();
 
@@ -348,10 +354,15 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
         {(status: TransitionStatus) => {
           const groupClassName = classNames(
             styles.Group,
+            !isSticky && styles['Group-not-sticky'],
             status && styles[`Group-${status}`],
           );
           return (
-            <div className={groupClassName} ref={this.groupNode}>
+            <div
+              className={groupClassName}
+              ref={this.groupNode}
+              style={width ? {width} : undefined}
+            >
               <EventListener event="resize" handler={this.handleResize} />
               <div
                 className={styles.ButtonGroupWrapper}

--- a/polaris-react/src/components/BulkActions/tests/BulkActions.test.tsx
+++ b/polaris-react/src/components/BulkActions/tests/BulkActions.test.tsx
@@ -9,6 +9,7 @@ import {BulkActionButton, BulkActionMenu} from '../components';
 import type {BulkActionButtonProps} from '../components';
 import {BulkActions} from '../BulkActions';
 import type {BulkAction, BulkActionsProps} from '../BulkActions';
+import styles from '../BulkActions.module.scss';
 
 interface Props {
   bulkActions: BulkActionButtonProps['content'][];
@@ -397,6 +398,50 @@ describe('<BulkActions />', () => {
 
       expect(bulkActions).toContainReactComponent(Tooltip, {
         content: 'More actions',
+      });
+    });
+  });
+
+  describe('deprecated props', () => {
+    describe('isSticky', () => {
+      it('adds the not-sticky class name if isSticky is falsy', () => {
+        const bulkActions = mountWithApp(
+          <BulkActions {...bulkActionProps} isSticky={false} />,
+        );
+
+        expect(bulkActions).toContainReactComponent('div', {
+          className: expect.stringContaining(styles['Group-not-sticky']),
+        });
+      });
+
+      it('does not add the not-sticky class name if isSticky is truthy', () => {
+        const bulkActions = mountWithApp(
+          <BulkActions {...bulkActionProps} isSticky />,
+        );
+
+        expect(bulkActions).not.toContainReactComponent('div', {
+          className: expect.stringContaining(styles['Group-not-sticky']),
+        });
+      });
+    });
+
+    describe('width', () => {
+      it('adds an inline style width if present', () => {
+        const bulkActions = mountWithApp(
+          <BulkActions {...bulkActionProps} width={200} />,
+        );
+
+        expect(bulkActions).toContainReactComponent('div', {
+          style: {width: 200},
+        });
+      });
+
+      it('does not add an inline style width if not present', () => {
+        const bulkActions = mountWithApp(<BulkActions {...bulkActionProps} />);
+
+        expect(bulkActions).not.toContainReactComponent('div', {
+          style: {width: 200},
+        });
       });
     });
   });

--- a/polaris-react/src/components/SelectAllActions/SelectAllActions.stories.tsx
+++ b/polaris-react/src/components/SelectAllActions/SelectAllActions.stories.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import type {ComponentMeta} from '@storybook/react';
+
+import {SelectAllActions} from './SelectAllActions';
+
+export default {
+  component: SelectAllActions,
+} as ComponentMeta<typeof SelectAllActions>;
+
+export function Default() {
+  const paginatedSelectAllAction = {
+    content: 'Select all',
+    onAction: () => console.log('paginatedSelectAllAction clicked'),
+  };
+  return (
+    <SelectAllActions
+      label="3 selected"
+      selectMode
+      isSticky
+      hasPagination={false}
+    />
+  );
+}
+
+export function WithPaginatedSelectAllText() {
+  const paginatedSelectAllAction = {
+    content: 'Select all',
+    onAction: () => console.log('paginatedSelectAllAction clicked'),
+  };
+  return (
+    <SelectAllActions
+      label="3 selected"
+      selectMode
+      paginatedSelectAllText="50 items selected"
+      paginatedSelectAllAction={paginatedSelectAllAction}
+      isSticky
+      hasPagination={false}
+    />
+  );
+}
+
+export function WithPagination() {
+  const paginatedSelectAllAction = {
+    content: 'Select all',
+    onAction: () => console.log('paginatedSelectAllAction clicked'),
+  };
+  return (
+    <SelectAllActions
+      label="3 selected"
+      selectMode
+      paginatedSelectAllText="Select all"
+      paginatedSelectAllAction={paginatedSelectAllAction}
+      isSticky
+      hasPagination
+    />
+  );
+}
+
+export function WithDeprecatedProps() {
+  const paginatedSelectAllAction = {
+    content: 'Select all',
+    onAction: () => console.log('paginatedSelectAllAction clicked'),
+  };
+  return (
+    <SelectAllActions
+      label="3 selected"
+      selectMode
+      paginatedSelectAllText="Select all"
+      paginatedSelectAllAction={paginatedSelectAllAction}
+      isSticky
+      hasPagination
+      accessibilityLabel="Select all items"
+      selected
+      onToggleAll={() => console.log('onToggleAll called')}
+    />
+  );
+}

--- a/polaris-react/src/components/SelectAllActions/SelectAllActions.tsx
+++ b/polaris-react/src/components/SelectAllActions/SelectAllActions.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useRef, forwardRef} from 'react';
 import {Transition} from 'react-transition-group';
 
 import {classNames} from '../../utilities/css';
@@ -7,11 +7,13 @@ import {UnstyledButton} from '../UnstyledButton';
 import {Box} from '../Box';
 import {Text} from '../Text';
 import {InlineStack} from '../InlineStack';
+import {CheckableButton} from '../CheckableButton';
 
 import styles from './SelectAllActions.module.scss';
 
 type TransitionStatus = 'entering' | 'entered' | 'exiting' | 'exited';
 
+type AriaLive = 'off' | 'polite' | undefined;
 export interface SelectAllActionsProps {
   /** Label for the bulk actions */
   label?: string;
@@ -27,17 +29,29 @@ export interface SelectAllActionsProps {
   isSticky?: boolean;
   /** Whether there is a Pagination element on the associated table. Disables the vertical appear animation if so */
   hasPagination?: boolean;
+  /** @deprecated Visually hidden text for screen readers */
+  accessibilityLabel?: string;
+  /** @deprecated State of the bulk actions checkbox */
+  selected?: boolean | 'indeterminate';
+  /** @deprecated Callback when the select all checkbox is clicked */
+  onToggleAll?(): void;
 }
 
-export const SelectAllActions = ({
-  label,
-  selectMode,
-  paginatedSelectAllText,
-  paginatedSelectAllAction,
-  disabled,
-  isSticky,
-  hasPagination,
-}: SelectAllActionsProps) => {
+export const SelectAllActions = forwardRef(function SelectAllActions(
+  {
+    label,
+    selectMode,
+    paginatedSelectAllText,
+    paginatedSelectAllAction,
+    disabled,
+    isSticky,
+    hasPagination,
+    accessibilityLabel,
+    selected,
+    onToggleAll,
+  }: SelectAllActionsProps,
+  ref,
+) {
   const nodeRef = useRef<HTMLDivElement>(null);
   const paginatedSelectAllActionMarkup = paginatedSelectAllAction ? (
     <UnstyledButton
@@ -57,6 +71,23 @@ export const SelectAllActions = ({
       {paginatedSelectAllActionMarkup}
     </div>
   ) : null;
+
+  const ariaLive: AriaLive = hasTextAndAction ? 'polite' : undefined;
+
+  const checkableButtonProps = {
+    accessibilityLabel,
+    label: hasTextAndAction ? paginatedSelectAllText : label,
+    selected,
+    onToggleAll,
+    disabled,
+    ariaLive,
+    ref,
+  };
+
+  const checkableButtonMarkup =
+    accessibilityLabel && onToggleAll ? (
+      <CheckableButton {...checkableButtonProps} />
+    ) : null;
 
   const markup = (
     <Transition timeout={0} in={selectMode} key="markup" nodeRef={nodeRef}>
@@ -81,6 +112,7 @@ export const SelectAllActions = ({
               paddingInlineEnd="400"
             >
               <InlineStack gap="200" align="start" blockAlign="center">
+                {checkableButtonMarkup}
                 <Text as="span" variant="bodySm" fontWeight="medium">
                   {hasTextAndAction ? paginatedSelectAllText : label}
                 </Text>
@@ -93,4 +125,4 @@ export const SelectAllActions = ({
     </Transition>
   );
   return markup;
-};
+});

--- a/polaris-react/src/components/SelectAllActions/tests/SelectAllActions.test.tsx
+++ b/polaris-react/src/components/SelectAllActions/tests/SelectAllActions.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Transition, CSSTransition} from 'react-transition-group';
 import {mountWithApp} from 'tests/utilities';
 
+import {CheckableButton} from '../../CheckableButton';
 import {UnstyledButton} from '../../UnstyledButton';
 import {SelectAllActions} from '../SelectAllActions';
 import styles from '../SelectAllActions.module.scss';
@@ -101,6 +102,85 @@ describe('<SelectAllActions />', () => {
           .find(UnstyledButton, {onClick: spy})!
           .trigger('onClick');
         expect(spy).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('deprecated props', () => {
+    describe('accessibilityLabel', () => {
+      it('gets passed down to the CheckableButton if present and onToggleAll is present', () => {
+        const {accessibilityLabel} = selectAllActionProps;
+        const selectAllActions = mountWithApp(
+          <SelectAllActions
+            {...selectAllActionProps}
+            onToggleAll={() => {}}
+            accessibilityLabel={accessibilityLabel}
+          />,
+        );
+
+        expect(selectAllActions).toContainReactComponent(CheckableButton, {
+          accessibilityLabel,
+        });
+      });
+
+      it('will not render a CheckableButton if the prop is not present', () => {
+        const {accessibilityLabel, ...props} = selectAllActionProps;
+        const selectAllActions = mountWithApp(
+          <SelectAllActions {...props} onToggleAll={() => {}} />,
+        );
+
+        expect(selectAllActions).not.toContainReactComponent(CheckableButton, {
+          accessibilityLabel,
+        });
+      });
+    });
+
+    describe('onToggleAll', () => {
+      it('gets passed down to the CheckableButton if present and accessibilityLabel is present', () => {
+        const {accessibilityLabel} = selectAllActionProps;
+        const selectAllActions = mountWithApp(
+          <SelectAllActions
+            {...selectAllActionProps}
+            onToggleAll={() => {}}
+            accessibilityLabel={accessibilityLabel}
+          />,
+        );
+
+        expect(selectAllActions).toContainReactComponent(CheckableButton, {
+          onToggleAll: expect.any(Function),
+        });
+      });
+
+      it('will not render a CheckableButton if the prop is not present', () => {
+        const {accessibilityLabel, ...props} = selectAllActionProps;
+        const selectAllActions = mountWithApp(
+          <SelectAllActions
+            {...props}
+            accessibilityLabel={accessibilityLabel}
+          />,
+        );
+
+        expect(selectAllActions).not.toContainReactComponent(CheckableButton, {
+          onToggleAll: expect.any(Function),
+        });
+      });
+    });
+
+    describe('selected', () => {
+      it('gets passed down to the CheckableButton if present and accessibilityLabel and onToggleAll is present', () => {
+        const {accessibilityLabel} = selectAllActionProps;
+        const selectAllActions = mountWithApp(
+          <SelectAllActions
+            {...selectAllActionProps}
+            onToggleAll={() => {}}
+            accessibilityLabel={accessibilityLabel}
+            selected
+          />,
+        );
+
+        expect(selectAllActions).toContainReactComponent(CheckableButton, {
+          selected: true,
+        });
       });
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

As part of a recent update to how we do Bulk UI in IndexTable and ResourceLists, we moved some props around between the SelectAllActions and BulkActions components. We need to ensure that these props remain on the components and get deprecated, rather than remove them entirely to ensure that the update doesn't fall into a breaking release, rather than a minor one.

This PR re-introduces the props that were moved between BulkActions and SelectAllActions, and includes tests to ensure functionality remains as it was if these deprecated props were provided, and stories to show how the components look with the deprecated props.

I have not added the BulkActions and SelectAllAction stories to the polaris.shopify.com site as these components should only really ever be consumed internally by other Polaris components.

### How to 🎩

Snapshot testing: https://admin.web.deprecated-props-playground.marc-thomas.eu.spin.dev/store/shop1/products?selectedView=all
Storybook: https://5d559397bae39100201eedc1-pihlxmllju.chromatic.com/

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
