### PR TITLE
[Button] `monochromePlain` should not have an underline in default state

### DIFF
--- a/.changeset/light-ducks-dance.md
+++ b/.changeset/light-ducks-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[`Button`] Remove underline from `monochromePlain` default state

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -173,7 +173,6 @@
 
 .variantMonochromePlain {
   --pc-button-icon-fill: var(--p-color-icon);
-  text-decoration: underline;
 }
 
 .variantPlain,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1359

### WHAT is this pull request doing?

Removes underline style from `monochromePlain` Button default state.

| Before | After | 
| -- | -- | 
|![Screenshot 2024-01-23 at 9 02 33 AM](https://github.com/Shopify/polaris/assets/21976492/05fcd390-765b-43fa-9a3d-f45cdbe74bdc)|![Screenshot 2024-01-23 at 9 03 24 AM](https://github.com/Shopify/polaris/assets/21976492/7acccebe-5d69-45ff-a360-15886021f72d)| 

### How to 🎩

- 📕 [Storybook Before](https://storybook.polaris.shopify.com/?path=/story/all-components-button--monochrome-plain)
- 📕 [Storybook After](https://5d559397bae39100201eedc1-qbsnvtphsr.chromatic.com/?path=/story/all-components-button--monochrome-plain)
- 🌀 [Spin](https://admin.web.mp-button-underline.laura-griffee.us.spin.dev/store/shop1/orders) 
    - I couldn't find a monochromePlain button but I just pasted in the style for the CSS class on a button (ex: `Polaris-Button--variantMonochromePlain` versus `Polaris-Button--variantPrimary`) and the confirmed the underline is not there!

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
