### PR TITLE
Adding performance mark to PageSkeleton unmount for load tracking.

### DIFF
--- a/.changeset/gold-sheep-crash.md
+++ b/.changeset/gold-sheep-crash.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Adding a performance mark to page skeleton unmount.
+Added a performance mark to `SkeletonPage` unmount.

--- a/.changeset/gold-sheep-crash.md
+++ b/.changeset/gold-sheep-crash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Adding a performance mark to page skeleton unmount.

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -36,11 +36,6 @@ export function SkeletonPage({
     // performance mark on skeleton unmount to help with page load tracking
     return () => {
       const mark = performance?.mark?.('polaris:page_skeleton:unmount');
-      console.log(
-        'unmounting skeleton...',
-        mark,
-        performance.getEntries().length,
-      );
     };
   }, []);
 

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -35,7 +35,7 @@ export function SkeletonPage({
   useEffect(() => {
     // performance mark on skeleton unmount to help with page load tracking
     return () => {
-      const mark = performance?.mark?.('polaris:page_skeleton:unmount');
+      performance?.mark?.('polaris:page_skeleton:unmount');
     };
   }, []);
 

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
 import {useI18n} from '../../utilities/i18n';
 import {Box} from '../Box';
@@ -31,6 +31,13 @@ export function SkeletonPage({
   backAction,
 }: SkeletonPageProps) {
   const i18n = useI18n();
+
+  useEffect(() => {
+    // performance mark on skeleton unmount to help with page load tracking
+    return () => {
+      performance.mark('polaris:page_skeleton:unmount');
+    }
+  }, [])
 
   const titleContent = title ? (
     <h1 className={styles.Title}>{title}</h1>

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -35,9 +35,14 @@ export function SkeletonPage({
   useEffect(() => {
     // performance mark on skeleton unmount to help with page load tracking
     return () => {
-      performance.mark('polaris:page_skeleton:unmount');
-    }
-  }, [])
+      const mark = performance?.mark?.('polaris:page_skeleton:unmount');
+      console.log(
+        'unmounting skeleton...',
+        mark,
+        performance.getEntries().length,
+      );
+    };
+  }, []);
 
   const titleContent = title ? (
     <h1 className={styles.Title}>{title}</h1>


### PR DESCRIPTION
### WHY are these changes introduced?

This allows us to measure how long it takes from start of pageload to page skeleton removal without refactoring a large amount of code.


### WHAT is this pull request doing?

Adds a performance mark when the page skeleton is unmounted. There is no accessibility impact or extra documentation on this, so I didn't tophat those.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
