### PR TITLE
Add documentation back for deprecated components

### DIFF
--- a/polaris.shopify.com/content/components/deprecated/contextual-save-bar.mdx
+++ b/polaris.shopify.com/content/components/deprecated/contextual-save-bar.mdx
@@ -38,3 +38,71 @@ The contextual save bar tells merchants their options once they have made change
   API](https://shopify.dev/docs/api/app-bridge-library/reference/contextual-save-bar)
   instead.
 </StatusBanner>
+
+<Examples />
+
+<Props componentName={frontmatter.title} />
+
+## Required components
+
+The contextual save bar component must be wrapped in the [frame](https://polaris.shopify.com/components/deprecated/frame) component.
+
+---
+
+## Best practices
+
+The contextual save bar component should:
+
+- Become visible when a form on the page has unsaved changes
+- Be used to save or discard in-progress changes
+- Provide brief and helpful context on the nature of in-progress changes
+- Save all changes on the page. Avoid scenarios where multiple forms on a single page can be edited at the same time. If specific sections of a page need to be independently editable, use an Edit button to launch a [modal dialog](https://polaris.shopify.com/components/deprecated/modal) for each section where changes can be made and saved.
+
+---
+
+## Content guidelines
+
+Messages in the contextual save bar component should be informative, clear, and concise. They should follow the \{adjective}+\{noun} pattern. Don’t use full sentences.
+
+The standard message content is
+
+- “Unsaved changes” when editing existing content
+- “Unsaved \{resource name}” when creating a new object
+
+<DoDont>
+
+#### Do
+
+- Unsaved changes
+- Unsaved product
+
+#### Don’t
+
+- You have unsaved changes
+- Red and white striped shirt not yet saved
+
+</DoDont>
+
+Actions in the contextual save bar component should consist of a strong verb that encourages action. They should not include a noun.
+
+<DoDont>
+
+#### Do
+
+- Save
+- Discard
+
+#### Don’t
+
+- Save changes
+- Discard changes
+
+</DoDont>
+
+---
+
+## Related components
+
+- To wrap your entire application, [use the frame component](https://polaris.shopify.com/components/deprecated/frame)
+- To build the outer wrapper of a page, including page title and associated actions, [use the page component](https://polaris.shopify.com/components/layout-and-structure/page)
+- To wrap form elements and handle the submission of a form, [use the form component](https://polaris.shopify.com/components/form)

--- a/polaris.shopify.com/content/components/deprecated/frame.mdx
+++ b/polaris.shopify.com/content/components/deprecated/frame.mdx
@@ -38,3 +38,27 @@ The frame component, while not visible in the user interface itself, provides th
 <StatusBanner status={frontmatter.status}>
   This component is no longer supported.
 </StatusBanner>
+
+<Examples />
+
+<Props componentName={frontmatter.title} />
+
+## Best practices
+
+For the best experience when creating an application frame, use the following components:
+
+- [Top bar](https://polaris.shopify.com/components/deprecated/top-bar)
+- [Navigation](https://polaris.shopify.com/components/deprecated/navigation)
+- [Contextual save bar](https://polaris.shopify.com/components/deprecated/contextual-save-bar)
+- [Toast](https://polaris.shopify.com/components/deprecated/toast)
+- [Loading](https://polaris.shopify.com/components/deprecated/loading)
+
+---
+
+## Related components
+
+- To display the navigation component on small screens, to provide search and a user menu, or to style the [frame](https://polaris.shopify.com/components/deprecated/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/deprecated/top-bar) component.
+- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/deprecated/navigation) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/deprecated/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/deprecated/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/deprecated/loading) component.

--- a/polaris.shopify.com/content/components/deprecated/loading.mdx
+++ b/polaris.shopify.com/content/components/deprecated/loading.mdx
@@ -28,3 +28,36 @@ The loading component is used to indicate to merchants that a page is loading or
   API](https://shopify.dev/docs/api/app-bridge-library/reference/loading)
   instead.
 </StatusBanner>
+
+<Examples />
+
+<Props componentName={frontmatter.title} />
+
+## Required components
+
+The loading component must be wrapped in the [frame](https://polaris.shopify.com/components/deprecated/frame) component.
+
+---
+
+## Best practices
+
+The loading component should:
+
+- Indicate that the page requested is loading.
+- Indicate that an upload has started and the action will soon complete.
+- Be used to give feedback for an entire page load or a page mutation like saving a product.
+- Be used alongside a component or page element that contains `aria-busy` to represent what is loading.
+
+---
+
+## Related components
+
+- To indicate that an action has been received, use the [Spinner](https://polaris.shopify.com/components/spinner)
+- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](https://polaris.shopify.com/components/progress-bar) component.
+- To better represent loading content, use [Skeleton page](https://polaris.shopify.com/components/skeleton-page) along with [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/skeleton-display-text) components.
+
+---
+
+## Accessibility
+
+The loading component is implemented using the [ARIA 1.1 progressbar pattern](https://www.w3.org/TR/wai-aria-1.1/#progressbar). It outputs an ARIA `role="progressbar"` and uses `aria-valuemin`, `aria-value-max`, and `aria-valuenow` to convey the loaded percentage to screen reader users.

--- a/polaris.shopify.com/content/components/deprecated/modal.mdx
+++ b/polaris.shopify.com/content/components/deprecated/modal.mdx
@@ -72,3 +72,209 @@ Modals are overlays that require merchants to take an action before they can con
   This component is no longer supported. Please use the [App Bridge Modal
   API](https://shopify.dev/docs/api/app-bridge-library/reference/modal) instead.
 </StatusBanner>
+
+<Examples />
+
+<Props componentName={frontmatter.title} />
+
+## Best practices
+
+Use modals for confirmations and conditional changes. They should be thought of as temporary and not be used for information or actions that need to live on in the UI in a persistent way. Don’t use modals to display complex forms or large amounts of information.
+
+Modals should:
+
+- Require that merchants take an action.
+- Close when merchants press the `X` button, the `Cancel` button, the <kbd>Esc</kbd> key, or when merchants click or tap the area outside the modal.
+- Not have more than two buttons (primary and secondary) at the bottom. This prevents unclear action hierarchy and crowding on mobile screens. Since modals are for focused tasks, they should have focused actions. In some cases however, a [tertiary action](#tertiary-actions) may be appropriate.
+
+---
+
+## Content guidelines
+
+### Title
+
+Modal titles should:
+
+- Use a clear \{verb\}+\{noun\} question or statement
+- Follow the content guidelines for [headings and subheadings](https://polaris.shopify.com/content/actionable-language#headings-and-subheadings)
+
+<DoDont>
+
+#### Do
+
+- Edit email address
+- Delete customer?
+- Discard unsaved changes?
+
+#### Don’t
+
+- Edit the email address for this order
+- Are you sure you want to delete customer?
+- Discard?
+
+</DoDont>
+
+### Body content
+
+Body content should be:
+
+- Actionable: start sentences with imperative verbs when telling a merchant what actions are available to them (especially something new). Don’t use permissive language like "you can".
+
+<DoDont>
+
+#### Do
+
+- Notification emails will be sent to this address.
+- This can’t be undone.
+
+#### Don’t
+
+- You can edit the email address where emails will be sent.
+- Are you sure you want to delete the variant Dark Blue Tee/Small/Silk? You cannot reverse this.
+
+</DoDont>
+
+- Structured for merchant success: always put the most critical information first.
+- Clear: use the verb “need” to help merchants understand when they’re required to do something.
+
+<DoDont>
+
+#### Do
+
+- To buy a shipping label, you need to enter the total weight of your shipment, including packaging.
+
+#### Don’t
+
+- To buy a shipping label, you must enter the total weight of your shipment, including packaging.
+
+</DoDont>
+
+### Primary and secondary actions
+
+Actions should be:
+
+- Clear and predictable: merchants should be able to anticipate what will happen when they click a button. Never deceive a merchant by mislabeling an action.
+
+<DoDont>
+
+#### Do
+
+- Create order
+- Buy shipping label
+
+#### Don’t
+
+- New order
+- Buy
+
+</DoDont>
+
+- Action-led: actions should always lead with a strong verb that encourages action. To provide enough context to merchants use the \{verb\}+\{noun\} format on actions except in the case of common actions like Save, Close, Cancel, or OK.
+
+<DoDont>
+
+#### Do
+
+- Activate Apple Pay
+- View shipping settings
+
+#### Don’t
+
+- Try Apple Pay
+- View your settings
+
+</DoDont>
+
+- Scannable: avoid unnecessary words and articles such as the, an, or a.
+
+<DoDont>
+
+#### Do
+
+- Add menu item
+
+#### Don’t
+
+- Add a menu item
+
+</DoDont>
+
+### Tertiary actions
+
+Tertiary actions should:
+
+- Only be used when the action requires the context of the content in the modal
+- Never be used to dismiss the modal
+
+<DoDont>
+
+#### Do
+
+![Screenshot of modal with a plain button as a tertiary action](/images/components/deprecated/modal/do-use-plain-button-for-tertiary-action@2x.png)
+
+Use a plain button for a tertiary action if needed
+
+#### Don’t
+
+![Screenshot of modal with a destructive button as a tertiary action](/images/components/deprecated/modal/dont-use-destructive-tertiary-action@2x.png)
+
+Use a tertiary action for a destructive action
+
+</DoDont>
+
+### Footer
+
+Body content should be:
+
+- Actionable: start sentences with imperative verbs when telling a merchant what actions are available to them (especially something new). Don’t use permissive language like "you can".
+
+<DoDont>
+
+#### Do
+
+- Notification emails will be sent to this address.
+
+#### Don’t
+
+- You can edit the email address where emails will be sent.
+
+</DoDont>
+
+- Structured for merchant success: always put the most critical information first.
+- Clear: use the verb “need” to help merchants understand when they’re required to do something.
+
+<DoDont>
+
+#### Do
+
+- To buy a shipping label, you need to enter the total weight of your shipment, including packaging.
+
+#### Don’t
+
+- To buy a shipping label, you must enter the total weight of your shipment, including packaging.
+
+</DoDont>
+
+---
+
+## Related components
+
+- To present large amounts of additional information or actions that don’t require confirmation, [use the collapsible component](https://polaris.shopify.com/components/collapsible) to expand content in place within the page
+- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](https://polaris.shopify.com/components/overlays/popover)
+- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
+
+---
+
+## Accessibility
+
+- Modals use ARIA `role=”dialog”` to convey to screen reader users that they work like native dialog windows.
+- If you set the `title` prop to give the modal component a heading, then the `title` is used to label the dialog element with `aria-labelledby`. This helps to convey the purpose of the modal to screen reader users when it displays.
+- After a modal is closed, in order to return focus to the button that launched it, pass the button to the modal as an `activator`.
+- To ensure that [Toast](https://polaris.shopify.com/components/deprecated/toast)s are read out by a screen reader when a Modal is open, apps should be wrapped in a [Frame](https://polaris.shopify.com/components/deprecated/frame) component.
+
+### Keyboard support
+
+- When a modal opens, focus moves automatically to the modal container so it can be accessed by keyboard users
+- While the modal is open, keyboard focus shouldn’t leave the modal
+- Merchants can dismiss the modal with the keyboard by activating the `X` button, the `Cancel` button if one is provided, or by pressing the <kbd>Esc</kbd> key
+- After a modal is closed, focus returns to the button that launched it

--- a/polaris.shopify.com/content/components/deprecated/navigation.mdx
+++ b/polaris.shopify.com/content/components/deprecated/navigation.mdx
@@ -65,3 +65,188 @@ The navigation component is used to display the primary navigation in the sideba
   API](https://shopify.dev/docs/api/app-bridge-library/reference/navigation-menu)
   instead.
 </StatusBanner>
+
+<Examples />
+
+<Props componentName={frontmatter.title} />
+
+## Required components
+
+The navigation component must be passed to the [frame](https://polaris.shopify.com/components/deprecated/frame) component. The mobile version of the navigation component appears in the [top bar](https://polaris.shopify.com/components/deprecated/top-bar) component.
+
+---
+
+## Best practices
+
+The navigation component should:
+
+- Contain primary navigation items that perform an action when clicked. Each action should navigate to a URL or trigger another action like a modal overlay.
+- Only use secondary actions for supplementary actions to the primary actions.
+- Provide a non-primary link or action as a secondary action to a section or an item.
+- Group navigation items into sections based on related categories.
+- Use a section title to clarify the category of a section.
+- Use a major icon for item actions.
+- Use a minor icon for secondary actions.
+- Use the provided navigation section component to group navigation items.
+- Not add additional components, like [badge](/components/feedback-indicators/badge), in navigation items. Example: Don‘t add the [New badge](/patterns-legacy/new-badge).
+
+---
+
+## Content guidelines
+
+Navigation should:
+
+- Use sentence case for primary and secondary navigation items
+
+<DoDont>
+
+#### Do
+
+- Online store
+
+#### Don’t
+
+- Online Store
+
+</DoDont>
+
+- Use as few words as possible to describe each item label
+
+<DoDont>
+
+#### Do
+
+- Products
+
+#### Don’t
+
+- Products in your store
+
+</DoDont>
+
+- Use all caps for section labels
+
+<DoDont>
+
+#### Do
+
+- SALES CHANNELS
+
+#### Don’t
+
+- Sales channels
+
+</DoDont>
+
+---
+
+## Navigation section
+
+A navigation section groups together related navigation items. Navigation sections can be clarified by a heading. Merchants can use a section to easily find navigation items within a specific category.
+
+### Section properties
+
+| Prop      | Type                   | Description                                                                                   |
+| --------- | ---------------------- | --------------------------------------------------------------------------------------------- |
+| items     | [Item[]](#type-item)   | A collection of navigation items to be rendered inside the section                            |
+| icon      | IconProps['source']    | An icon to be displayed next to the section title                                             |
+| title     | string                 | A string property providing a title for the navigation section                                |
+| fill      | boolean                | A boolean property indicating whether the section should take up all vertical space available |
+| rollup    | [Rollup](#type-rollup) | An object determining the collapsing behavior of the navigation section                       |
+| action    | [Action](#type-action) | Renders an icon-only action as a supplementary action next to the section title               |
+| separator | boolean                | A boolean property indicating whether the section should have a visual separator              |
+
+### Navigation section item
+
+The content of the navigation component consists of navigation items. Each item is a link or action a merchant can take.
+
+#### Item properties
+
+| Prop                  | Type                                        | Description                                                                                                                                             |
+| --------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| url                   | string                                      | A location for the navigation item to navigate to when clicked                                                                                          |
+| matches               | boolean                                     | A boolean property indicating whether the navigation item should respond to a closely matching location property                                        |
+| exactMatch            | boolean                                     | A boolean property indicating whether the navigation item should respond to an exactly matching location property                                       |
+| matchPaths            | string[]                                    | A string property providing a collection of additional paths for the navigation item to respond to                                                      |
+| excludePaths          | string[]                                    | A string property providing an explicit collection of paths the navigation item should not respond to                                                   |
+| icon                  | IconProps['source']                         | An icon to be displayed next to the navigation. Please prefer minor icons here. If a major icon has to be used, set the `shouldResizeIcon` prop to true |
+| badge                 | string \| null                              | A string property allowing content to be displayed in a badge next to the navigation item                                                               |
+| label                 | string                                      | A string property allowing content to be displayed as link text in the navigation item                                                                  |
+| disabled              | boolean                                     | A boolean property indicating whether the navigation item is disabled                                                                                   |
+| new                   | boolean                                     | Indicate whether the navigation item is new by adding an indicator dot to the parent and badge to the item (overwritten by the badge prop)              |
+| accessibilityLabel    | string                                      | A visually hidden label for screen readers to understand the content of a navigation item                                                               |
+| selected              | boolean                                     | A boolean property indicating whether the navigation item is the currently-selected item                                                                |
+| shouldResizeIcon      | boolean                                     | Will allow for major icons to be displayed at the same size as minor icons                                                                              |
+| subNavigationItems    | [SubNavigationItem[]](#sub-navigation-item) | A collection of navigation items rendered as nested secondary navigation items                                                                          |
+| secondaryAction       | [SecondaryAction](#secondary-action)        | Renders an icon-only action as a supplementary action next to a navigation item                                                                         |
+| secondaryActions      | [SecondaryAction[]](#secondary-action)      | Renders one or two icon-only actions as supplementary actions next to a navigation item                                                                 |
+| onClick()             | function                                    | A callback function to handle clicking on a navigation item                                                                                             |
+| truncateText          | boolean                                     | A boolean property to allow text that exceeds the width of the navigation item to be truncated with ellipsis                                            |
+| displayActionsOnHover | boolean                                     | A boolean to only display secondary actions when being the nabigation item is hovered (Only on desktop)                                                 |
+
+### SubNavigationItem
+
+#### Properties
+
+| Prop         | Type     | Description                                                                                                                                |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| url          | string   | A location for the navigation item to navigate to when clicked                                                                             |
+| matches      | boolean  | A boolean property indicating whether the navigation item should respond to a closely matching location property                           |
+| exactMatch   | boolean  | A boolean property indicating whether the navigation item should respond to an exactly matching location property                          |
+| matchPaths   | string[] | A string property providing a collection of additional paths for the navigation item to respond to                                         |
+| excludePaths | string[] | A string property providing an explicit collection of paths the navigation item should not respond to                                      |
+| external     | boolean  | Indicates whether this is an external link. If it is, an external link icon will be shown next to the label                                |
+| label        | string   | A string property allowing content to be displayed as link text in the navigation item                                                     |
+| disabled     | boolean  | A boolean property indicating whether the navigation item is disabled                                                                      |
+| new          | boolean  | Indicate whether the navigation item is new by adding an indicator dot to the parent and badge to the item (overwritten by the badge prop) |
+| onClick()    | function | A callback function to handle clicking on a navigation item                                                                                |
+
+### SecondaryAction
+
+#### Properties
+
+| Prop               | Type                                                                      | Description                                                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| url                | string                                                                    | A location for the navigation item to navigate to when clicked                                                                                          |
+| accessibilityLabel | string                                                                    | A visually hidden label for screen readers to understand the content of a navigation item                                                               |
+| icon               | IconProps['source']                                                       | An icon to be displayed next to the navigation. Please prefer minor icons here. If a major icon has to be used, set the `shouldResizeIcon` prop to true |
+| onClick()          | function                                                                  | A callback function to handle clicking on a navigation item                                                                                             |
+| tooltip            | [TooltipProps](https://polaris.shopify.com/components/tooltip#navigation) | Options for displaying a tooltip when you hover over the action button                                                                                  |
+
+### Navigation section rollup
+
+Rollup allows items in a navigation section to roll up and be revealed when they are of use to the merchant.
+
+#### Rollup properties
+
+| Prop       | Type   | Description                                                              |
+| ---------- | ------ | ------------------------------------------------------------------------ |
+| after      | number | A number of items after which the navigation section should be collapsed |
+| view       | string | A string property providing content for the section view action          |
+| hide       | string | A string property providing content for the section hide action          |
+| activePath | string | A string property representing the current URL of your application       |
+
+### Navigation section action
+
+Action allows a complementary icon-only action to render next to the section title.
+
+#### Action properties
+
+| Prop               | Type                                                                      | Description                                                                        |
+| ------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| icon               | IconProps['source']                                                       | An icon to be displayed as the content of the action                               |
+| accessibilityLabel | string                                                                    | A visually hidden label for screen readers to understand the content of the action |
+| onClick()          | function                                                                  | A callback function to handle clicking on the action                               |
+| tooltip            | [TooltipProps](https://polaris.shopify.com/components/tooltip#navigation) | Options for displaying a tooltip when you hover over the action button             |
+
+---
+
+## Related components
+
+- To provide the structure for the navigation component, including the left sidebar and the top bar use the [frame](https://polaris.shopify.com/components/deprecated/frame) component.
+- To display the navigation component on small screens, to provide search and a user menu, or to theme the [frame](https://polaris.shopify.com/components/deprecated/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/deprecated/top-bar) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/deprecated/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/deprecated/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/deprecated/loading) component.
+- To alternate among related views within the same context, use the [tabs](https://polaris.shopify.com/components/tabs) component.
+- To embed a single action or link within a larger span of text, use the [link](https://polaris.shopify.com/components/link) component.

--- a/polaris.shopify.com/content/components/deprecated/toast.mdx
+++ b/polaris.shopify.com/content/components/deprecated/toast.mdx
@@ -46,3 +46,123 @@ The toast component is a non-disruptive message that appears at the bottom of th
   This component is no longer supported. Please use the [App Bridge Toast
   API](https://shopify.dev/docs/api/app-bridge-library/reference/toast) instead.
 </StatusBanner>
+
+<Examples />
+
+<Props componentName={frontmatter.title} />
+
+## Required components
+
+The toast component must be wrapped in the [frame](https://polaris.shopify.com/components/deprecated/frame) component.
+
+---
+
+## Best practices
+
+Toast should:
+
+- Be used for short messages to confirm an action
+- Not go over 3 words
+- Rarely be used for error messages
+
+When to use:
+
+- For success messages
+- Only for non-critical errors that are relevant in the moment and can be explained in 3 words. For example, if there’s an internet connection issue, the toast would say, Internet disconnected.
+
+When not to use:
+
+- Avoid using toast for error messages. Always try to use a banner to prominently inform merchants about persistent errors.
+
+---
+
+## Content guidelines
+
+### Message
+
+Toast messages should be:
+
+- Short and affirmative
+- Written in the pattern of: noun + verb
+
+<DoDont>
+
+#### Do
+
+- Product updated
+- Collection added
+- Customer updated
+- Internet disconnected
+- Connection timed out
+
+#### Don’t
+
+- No internet connection
+- Can’t charge negative tax rates
+- Your online store has a maximum of 20 themes. Delete unused themes to add more.
+- Your product has been successfully updated
+- We were unable to save the customer
+- Your Order was Archived Today
+- Discount: Saved successfully
+
+</DoDont>
+
+### Toast with action
+
+Only include an action in toast if the same action is available elsewhere on the page. For example:
+
+- If merchants need to reload a section, offer the call to action [Reload] in the toast. If they miss the toast message, they can also refresh the entire page.
+- If merchants delete an image, offer the option to [Undo] the deletion. If they miss it in the toast message, they can still retrieve it from somewhere else.
+
+Action should:
+
+- Keep the action label short, preferably 1 verb.
+- Not have actions, like [Cancel], for dismissing toast. The [X] to dismiss is already included in the component.
+- Be used with a duration of at least 10,000 milliseconds for accessibility.
+
+<DoDont>
+
+#### Do
+
+- Undo
+- Change
+- Edit
+- View
+- Retry
+
+#### Don’t
+
+- OK
+- Got it
+- Cancel product
+- Continue to collection
+- Dismiss
+
+</DoDont>
+
+---
+
+## Related components
+
+- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](https://polaris.shopify.com/components/overlays/popover)
+- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
+
+---
+
+## Accessibility
+
+The content of the toast component is implemented as an ARIA live region using `aria-live="assertive"`. When the toast appears, screen readers will interrupt any announcement a screen reader is currently making.
+
+Avoid using toast for critical information that merchants need to act on immediately. Toast might be difficult for merchants with low vision or low dexterity to access because it:
+
+- Disappears automatically
+- Can’t be easily accessed with the keyboard
+- Might appear outside the proximity of the merchant’s current focus
+
+To ensure that Toasts are read out by a screen reader when a Modal is open, apps should be wrapped in a [Frame](https://polaris.shopify.com/components/deprecated/frame) component.
+
+### Toast with action
+
+Make sure that merchants can also accomplish the action in the toast another way, since the toast action may be difficult to access for some merchants. If the toast action is not available somewhere else on the page, for example a retry action that reloads a section, it should have a fallback action, for example a browser refresh.
+
+Toast with action should persist for at least 10,000 milliseconds to give the merchant enough time to act on it.

--- a/polaris.shopify.com/content/components/deprecated/top-bar.mdx
+++ b/polaris.shopify.com/content/components/deprecated/top-bar.mdx
@@ -35,3 +35,124 @@ The top bar is a header component that allows merchants to search, access menus,
 <StatusBanner status={frontmatter.status}>
   This component is no longer supported.
 </StatusBanner>
+
+<Examples />
+
+<Props componentName={frontmatter.title} />
+
+## Required components
+
+The top bar component must be passed to the [frame](https://polaris.shopify.com/components/deprecated/frame) component.
+
+---
+
+## Best practices
+
+The top bar component should:
+
+- Not provide global navigation for an application
+  - Use the [navigation component](https://polaris.shopify.com/components/deprecated/navigation) instead
+- Include search to help merchants find resources and navigate an application
+- Include a user menu component to indicate the logged-in merchant and provide them with global actions
+- Provide a color through the [app provider](https://polaris.shopify.com/components/app-provider) component to style the background
+- The global menu text should contrast with the rest of the top bar and pass the minimum contrast ratio of the WCAG 2.0 guidelines
+- Use an SVG file for the logo
+- Use a logo that passes the minimum contrast ratio of the WCAG 2.0 guidelines when compared to the top bar background color
+- Show the navigation toggle so it appears on small screen
+
+---
+
+## Content guidelines
+
+### Placeholder content
+
+The placeholder content for the search field should:
+
+- Always say "Search"
+- Never include an ellipsis
+
+<DoDont>
+
+#### Do
+
+- Search
+
+#### Don’t
+
+- search...
+
+</DoDont>
+
+---
+
+## Top bar menu
+
+A component that composes together an activator and a popover containing an action list to create a dropdown menu.
+
+### Menu properties
+
+| Prop             | Type                          | Description                                                                                        |
+| ---------------- | ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| activatorContent | React.ReactNode               | Accepts an activator component that renders inside of a button that opens the menu                 |
+| actions          | ActionListProps['sections']   | An array of action objects that are rendered inside of a popover triggered by this menu            |
+| message          | [MessageProps](#type-message) | Accepts a message that facilitates direct, urgent communication with the merchant through the menu |
+| open             | boolean                       | A boolean property indicating whether the menu is currently open                                   |
+| onOpen()         | function                      | A callback function to handle opening the menu popover                                             |
+| onClose()        | function                      | A callback function to handle closing the menu popover                                             |
+
+## Top bar user menu
+
+A specialized menu component that is activated by a user avatar.
+
+### Menu properties
+
+| Prop       | Type                          | Description                                                                                             |
+| ---------- | ----------------------------- | ------------------------------------------------------------------------------------------------------- |
+| actions    | \{items: IconableAction[]\}[] | An array of action objects that are rendered inside of a popover triggered by this menu                 |
+| message    | [MessageProps](#type-message) | Accepts a message that facilitates direct, urgent communication with the merchant through the user menu |
+| name       | string                        | A string detailing the merchant’s full name to be displayed in the user menu                            |
+| detail     | string                        | A string allowing further details on the merchant’s name displayed in the user menu                     |
+| initials   | AvatarProps['initials']       | The merchant’s initials, rendered in place of an avatar image when not provided                         |
+| avatar     | AvatarProps['source']         | An avatar image representing the merchant                                                               |
+| open       | boolean                       | A boolean property indicating whether the user menu is currently open                                   |
+| onToggle() | function                      | A callback function to handle opening and closing the user menu                                         |
+
+### Top bar menu message
+
+#### Message properties
+
+| Prop        | Type                                              | Description                               |
+| ----------- | ------------------------------------------------- | ----------------------------------------- |
+| title       | string                                            | A title for the message                   |
+| description | string                                            | A description for the message             |
+| action      | \{onClick(): void; content: string\}              | An action to render near the message      |
+| link        | \{to: string; content: string\}                   | A link to view the content of the message |
+| badge       | \{content: string; status: BadgeProps['status']\} | A badge to render near the message        |
+
+---
+
+## Top bar search field
+
+A text field component that is tailor-made for a search use-case.
+
+### Search field properties
+
+| Prop                    | Type     | Description                                                                      |
+| ----------------------- | -------- | -------------------------------------------------------------------------------- |
+| value                   | string   | Initial value for the input                                                      |
+| placeholder             | string   | Hint text to display                                                             |
+| focused                 | boolean  | Force the focus state on the input                                               |
+| active                  | boolean  | Force a state where search is active but the text field component is not focused |
+| onChange(value: string) | function | Callback when value is changed                                                   |
+| onFocus()               | function | Callback when input is focused                                                   |
+| onBlur()                | function | Callback when focus is removed                                                   |
+
+---
+
+## Related components
+
+- To provide the structure for the top bar component, as well as the primary navigation use the [frame](https://polaris.shopify.com/components/deprecated/frame) component.
+- To display the primary navigation within the frame of an application, use the [navigation](https://polaris.shopify.com/components/deprecated/navigation) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/deprecated/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/deprecated/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/deprecated/loading) component.


### PR DESCRIPTION
### WHY are these changes introduced?

This change adds back the documentation to deprecated components and keeps the recommendation to migrate to AppBridge. This is related to the feedback received in https://github.com/Shopify/polaris/issues/11460.

### WHAT is this pull request doing?

- [x] Adds component documentation back to deprecrated components
- [x] Ensures documentation links to other deprecated components and not internal only routes
