### PR TITLE
[Actions] Tweak the way the action menu gets calculated

### DIFF
--- a/.changeset/fifty-kids-begin.md
+++ b/.changeset/fifty-kids-begin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[ActionMenu] Improved test reliability for non-rolled up actions

--- a/.changeset/fifty-kids-begin.md
+++ b/.changeset/fifty-kids-begin.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-[ActionMenu] Improved test reliability for non-rolled up actions
+Improved test reliability for non-rolled up actions in `ActionMenu`

--- a/polaris-react/src/components/ActionMenu/components/Actions/Actions.module.scss
+++ b/polaris-react/src/components/ActionMenu/components/Actions/Actions.module.scss
@@ -13,6 +13,11 @@
   }
 }
 
+.ActionsLayout--measuring {
+  visibility: hidden;
+  height: 0;
+}
+
 .ActionsLayoutMeasurer {
   display: flex;
   flex-wrap: wrap;

--- a/polaris-react/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
+++ b/polaris-react/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
@@ -8,6 +8,7 @@ import {Actions, MenuGroup, RollupActions, SecondaryAction} from '../..';
 import {Tooltip} from '../../../../Tooltip';
 import type {getVisibleAndHiddenActionsIndices} from '../utilities';
 import {ActionsMeasurer} from '../components';
+import styles from '../Actions.module.scss';
 
 jest.mock('../components/ActionsMeasurer', () => ({
   ActionsMeasurer() {
@@ -71,9 +72,11 @@ describe('<Actions />', () => {
         <ActionMenu actions={actionsBeforeOverriddenOrder} />,
       );
 
+      const wrappingDiv = findWrapper(wrapper);
+
       forceMeasurement(wrapper);
 
-      expect(wrapper.findAll(SecondaryAction)).toHaveLength(3);
+      expect(wrappingDiv!.findAll(SecondaryAction)).toHaveLength(3);
     });
 
     it('renders a <Tooltip /> when helpText is set on an action', () => {
@@ -232,6 +235,18 @@ describe('<Actions />', () => {
     });
   });
 });
+
+function findWrapper(wrapper: CustomRoot<any, any>) {
+  const wrappingDiv = wrapper.findWhere<'div'>((node) => {
+    return (
+      node.is('div') &&
+      Boolean(node.prop('className')) &&
+      node.prop('className')!.includes(styles.ActionsLayout)
+    );
+  });
+
+  return wrappingDiv;
+}
 
 function forceMeasurement(wrapper: CustomRoot<any, any>) {
   wrapper.act(() => {

--- a/polaris-react/src/components/ActionMenu/components/Actions/utilities.ts
+++ b/polaris-react/src/components/ActionMenu/components/Actions/utilities.ts
@@ -1,6 +1,6 @@
 export function getVisibleAndHiddenActionsIndices(
-  actions: any[],
-  groups: any[],
+  actions: any[] = [],
+  groups: any[] = [],
   disclosureWidth: number,
   actionsWidths: number[],
   containerWidth: number,

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback} from 'react';
+import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {
   DeleteIcon,

--- a/polaris-react/src/components/Tabs/tests/Tabs.test.tsx
+++ b/polaris-react/src/components/Tabs/tests/Tabs.test.tsx
@@ -82,7 +82,7 @@ describe('Tabs', () => {
   };
 
   describe('focus management', () => {
-    it.only('passes focus index to tab measurer', () => {
+    it('passes focus index to tab measurer', () => {
       const tabToFocus = 1;
       const relatedTarget = document.createElement('div');
       const wrapper = mountWithApp(<Tabs {...mockProps} tabs={tabs} />);

--- a/polaris-react/src/components/Tabs/tests/Tabs.test.tsx
+++ b/polaris-react/src/components/Tabs/tests/Tabs.test.tsx
@@ -82,7 +82,7 @@ describe('Tabs', () => {
   };
 
   describe('focus management', () => {
-    it('passes focus index to tab measurer', () => {
+    it.only('passes focus index to tab measurer', () => {
       const tabToFocus = 1;
       const relatedTarget = document.createElement('div');
       const wrapper = mountWithApp(<Tabs {...mockProps} tabs={tabs} />);


### PR DESCRIPTION
### WHY are these changes introduced?

The way that the Actions within the ActionMenu get populated currently mean that on the initial render, we render no buttons at all as we are waiting for a calculation to occur. This works fine in the real world, but causes issues for tests which expect the presence of buttons. This PR attempts to ensure our components are more predictable in test cases and also robust in real world examples.


### WHAT is this pull request doing?

The ActionsMeasurer component used a `requestAnimationFrame` within the `useCallback` to calculate the values needed to determine which actions to show and which to roll up. This is an unnecessary code complexity that can be simplified to just run inside the `useCallback`. 

We were finding that using the `requestAnimationFrame` here was causing extra event loop ticks to be created in test suites and creating side effects and adding no benefit whatsoever, so removing it is a no-brainer.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Spin URL: https://admin.web.bulk-ui-3.marc-thomas.eu.spin.dev/store/shop1/products/13


### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
