### PR TITLE
Add workaround for `font-optical-sizing` issue in Safari 16

### DIFF
--- a/.changeset/few-colts-attend.md
+++ b/.changeset/few-colts-attend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added workaround for `font-optical-sizing` issue in Safari 16

--- a/polaris-react/src/components/AppProvider/AppProvider.scss
+++ b/polaris-react/src/components/AppProvider/AppProvider.scss
@@ -92,3 +92,8 @@ button::-moz-focus-inner,
 [type='submit']::-moz-focus-inner {
   border-style: none;
 }
+
+// stylelint-disable-next-line selector-no-qualifying-type -- Workaround for `font-optical-sizing` issue in Safari 16 (https://clagnut.com/blog/2423)
+html[class~='Polaris-Safari-16-Remove-Font-Optical-Sizing'] {
+  font-variation-settings: 'opsz' 0;
+}

--- a/polaris-react/src/components/AppProvider/AppProvider.scss
+++ b/polaris-react/src/components/AppProvider/AppProvider.scss
@@ -93,7 +93,8 @@ button::-moz-focus-inner,
   border-style: none;
 }
 
-// stylelint-disable-next-line selector-no-qualifying-type -- Workaround for `font-optical-sizing` issue in Safari 16 (https://clagnut.com/blog/2423)
-html[class~='Polaris-Safari-16-Remove-Font-Optical-Sizing'] {
-  font-variation-settings: 'opsz' 0;
+// stylelint-disable-next-line selector-no-qualifying-type -- Workaround for `font-optical-sizing` issue in Safari 16 (Adapted from https://clagnut.com/blog/2423)
+html[class~='Polaris-Safari-16-Font-Optical-Sizing-Patch'] {
+  // Inter's "opsz" axis ranges from 14 to 32. This patch optimizes for smaller and less legible text by setting "opsz" 14 for all font sizes.
+  font-variation-settings: 'opsz' 14;
 }

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -118,7 +118,7 @@ export class AppProvider extends Component<AppProviderProps, State> {
 
       if (isSafari16) {
         document.documentElement.classList.add(
-          'Polaris-Safari-16-Remove-Font-Optical-Sizing',
+          'Polaris-Safari-16-Font-Optical-Sizing-Patch',
         );
       }
     }

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -108,6 +108,19 @@ export class AppProvider extends Component<AppProviderProps, State> {
       this.stickyManager.setContainer(document);
       this.setBodyStyles();
       this.setRootAttributes();
+
+      const isSafari16 =
+        navigator.userAgent.includes('Safari') &&
+        !navigator.userAgent.includes('Chrome') &&
+        (navigator.userAgent.includes('Version/16.1') ||
+          navigator.userAgent.includes('Version/16.2') ||
+          navigator.userAgent.includes('Version/16.3'));
+
+      if (isSafari16) {
+        document.documentElement.classList.add(
+          'Polaris-Safari-16-Remove-Font-Optical-Sizing',
+        );
+      }
     }
     measureScrollbars();
   }


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris-internal/issues/1395

This PR adds a workaround for the `font-optical-sizing` issue in Safari 16

It's important to note this solution is NOT the best merchant experience we can provide, but resolves the immediate issue of thin `font-weights` rendering across the Admin. I suggest we follow up this PR with an exploration to match`opsz` values to each `Text` variant `font-size` as described by the [Google Fonts Glossary](https://fonts.google.com/knowledge/glossary/optical_size_axis):

> the numeric value for this axis should match the rendered font size in typographic points (1/72nd of an inch) in print, although browsers instead match it to the CSS px unit, since they have no concept of physical size

| Before | After |
| - | - |
| ![Screenshot 2024-01-25 at 3 56 16 PM](https://github.com/Shopify/polaris/assets/32409546/f2399cc9-29a4-40a5-96fc-6949b7e59502) | ![Screenshot 2024-01-25 at 3 55 27 PM](https://github.com/Shopify/polaris/assets/32409546/bbb9e56c-ff0d-4067-b0f7-c24401ea4d69) |

Screenshot of the `Polaris-Safari-16-Remove-Font-Optical-Sizing` class applying in the iOS 16.2 simulator:

![Screenshot 2024-01-25 at 4 17 35 PM](https://github.com/Shopify/polaris/assets/32409546/14cadda9-8e01-4ed6-ac1f-0e739d01bfcf)



