### PR TITLE
[Text] Deprecate `heading2xl` and `heading3xl`

### DIFF
--- a/.changeset/silent-apples-shout.md
+++ b/.changeset/silent-apples-shout.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Added ability to mark prop values as deprecated

--- a/documentation/Deprecation guidelines.md
+++ b/documentation/Deprecation guidelines.md
@@ -1,25 +1,74 @@
 # Deprecation guidelines
 
-- Ship backwards compatible changes which include supporting both the old and new API (make sure the full upgrade path is available)
-- Support backwards compatibility for at least half of a major release cycle, but never more that 2 major release cycles
-  - For example, before or part of 3.5, okay to remove in 4.0. After 3.5, remove in 5.0
-  - Large changes consider a full major release cycle. For example, a large change in 3.1 would be removed in 5.0. But a large change in 2.9 would never wait until 5.0 to remove
-- Use the `@deprecated` doc tag for props and components ([for example, add above where the component is defined](https://github.com/Shopify/polaris/blob/8e49e4c65fbbf25d40617ba2d0ff0b3747320f17/src/components/Navigation/components/UserMenu/UserMenu.tsx#L27)), state the reason, and upgrade path
-- For significant deprecations, add a section to the component documentation with rationale. State the upgrade path and include a link to a new component if applicable
-- Call out deprecations in our [changelog](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)
+Follow these guidelines for deprecating components, props, prop values, and tokens in future major versions of Polaris. A month before the next major version release ensure that deprecations have been announced and any migrations needed are documented/available.
 
-## Deprecation console message guidelines
+## Components
 
-Use `warn` for `Deprecation` messages.
+- Mark the component as deprecated
+  - Add `@deprecated` warning to component
+    ```tsx
+    /** @deprecated Use the [COMPONENT_NAME] component instead */
+    export function ExampleComponent(props: ExampleComponentProps) {
+    ```
+  - Update documentation on polaris.shopify.com ([examples](https://github.com/Shopify/polaris/blob/969ef1b1389ca4062767814a05761cc2e204ee2e/polaris.shopify.com/content/components/deprecated))
+- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/blob/f91c4b661b1d9540dd515c6f073aeeb62e914023/polaris-migrator/src/migrations))
+- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
+  - Document deprecation reason
+  - Document any alternatives
+  - Document automated migration(s)
+  - Document manual migration(s)
+- Remove component in next major Polaris version branch
 
-```js
-console.warn(
-  'Deprecation: The `title` property on Tabs has been deprecated. Use `content` instead.',
-);
-```
+## Props
 
-Deprecation messages warn developers when component APIs are in the process of being replaced. It’s important to notify developers of [breaking changes](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#breaking-changes) ahead of their release.
+- Mark the prop as deprecated
+  - Add `@deprecated` warning to component
+    ````tsx
+      /** Decsription of the prop
+       * @deprecated Use [SOMETHING] instead
+      */
+      exampleProp?: boolean;
+      ```
+    ````
+  - Check documentation is updated on polaris.shopify.com
+- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/blob/f91c4b661b1d9540dd515c6f073aeeb62e914023/polaris-migrator/src/migrations))
+- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
+  - Document deprecation reason
+  - Document any alternatives
+  - Document automated migration(s)
+  - Document manual migration(s)
+- Remove prop in next major Polaris version branch
 
-## Examples
+## Prop values
 
-- [Deprecation of `Navigation.UserMenu`](https://github.com/Shopify/polaris/pull/849).
+- Mark the prop value as deprecated
+  - Add component and deprecated prop value to `componentUnionTypeDeprecations` ([example](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/pages/components/%5Bgroup%5D/%5Bcomponent%5D/index.tsx#L80))
+    ```tsx
+    const componentUnionTypeDeprecations: {
+      [componentName: string]: {
+        [typeName: string]: string[];
+      };
+    } = {
+      Text: {
+        Variant: ['heading2xl', 'heading3xl'],
+      },
+    };
+    ```
+  - Check documentation is updated on polaris.shopify.com
+- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/blob/f91c4b661b1d9540dd515c6f073aeeb62e914023/polaris-migrator/src/migrations))
+- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
+  - Document deprecation reason
+  - Document any alternatives
+  - Document automated migration(s)
+  - Document manual migration(s)
+- Remove prop value in next major Polaris version branch
+
+## Tokens
+
+- Mark the token as deprecated in `stylelint-polaris` ([example](https://github.com/Shopify/polaris/tree/main/stylelint-polaris/plugins/custom-property-disallowed-list))
+- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/blob/f91c4b661b1d9540dd515c6f073aeeb62e914023/polaris-migrator/src/migrations))
+- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L1451))
+  - Document any alternatives
+  - Document automated migration(s)
+  - Document manual migration(s)
+- Remove token in next major Polaris version branch

--- a/documentation/Deprecation guidelines.md
+++ b/documentation/Deprecation guidelines.md
@@ -1,6 +1,6 @@
 # Deprecation guidelines
 
-Follow these guidelines for deprecating components, props, prop values, and tokens in future major versions of Polaris. A month before the next major version release ensure that deprecations have been announced and any migrations needed are documented/available.
+Follow these guidelines for deprecating [components](#components), [props](#props), [prop values](#prop-values), and [tokens](#tokens) in future major versions of Polaris. A month before the next major version release ensure that deprecations have been announced and any migrations needed are documented/available.
 
 ## Components
 
@@ -24,8 +24,8 @@ Follow these guidelines for deprecating components, props, prop values, and toke
 - Mark the prop as deprecated
   - Add `@deprecated` warning to component
     ````tsx
-      /** Decsription of the prop
-       * @deprecated Use [SOMETHING] instead
+      /** Description of the prop
+       * @deprecated Use [REPLACEMENT_ADVICE] instead
       */
       exampleProp?: boolean;
       ```
@@ -41,8 +41,8 @@ Follow these guidelines for deprecating components, props, prop values, and toke
 
 ## Prop values
 
-- Mark the prop value as deprecated
-  - Add component and deprecated prop value to `componentUnionTypeDeprecations` ([example](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/pages/components/%5Bgroup%5D/%5Bcomponent%5D/index.tsx#L80))
+- Mark the prop value(s) as deprecated
+  - Add component, prop, and deprecated prop value(s) to `componentUnionTypeDeprecations` ([example](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/pages/components/%5Bgroup%5D/%5Bcomponent%5D/index.tsx#L80))
     ```tsx
     const componentUnionTypeDeprecations: {
       [componentName: string]: {

--- a/documentation/Deprecation guidelines.md
+++ b/documentation/Deprecation guidelines.md
@@ -10,9 +10,9 @@ Follow these guidelines for deprecating [components](#components), [props](#prop
     /** @deprecated Use the [COMPONENT_NAME] component instead */
     export function ExampleComponent(props: ExampleComponentProps) {
     ```
-  - Update documentation on polaris.shopify.com ([examples](https://github.com/Shopify/polaris/blob/969ef1b1389ca4062767814a05761cc2e204ee2e/polaris.shopify.com/content/components/deprecated))
-- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/blob/f91c4b661b1d9540dd515c6f073aeeb62e914023/polaris-migrator/src/migrations))
-- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
+  - Update documentation on polaris.shopify.com ([examples](https://github.com/Shopify/polaris/tree/main/polaris.shopify.com/content/components/deprecated))
+- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/tree/main/polaris-migrator/src/migrations))
+- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/tree/main/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
   - Document deprecation reason
   - Document any alternatives
   - Document automated migration(s)
@@ -31,8 +31,8 @@ Follow these guidelines for deprecating [components](#components), [props](#prop
       ```
     ````
   - Check documentation is updated on polaris.shopify.com
-- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/blob/f91c4b661b1d9540dd515c6f073aeeb62e914023/polaris-migrator/src/migrations))
-- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
+- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/tree/main/polaris-migrator/src/migrations))
+- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/tree/main/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
   - Document deprecation reason
   - Document any alternatives
   - Document automated migration(s)
@@ -42,7 +42,7 @@ Follow these guidelines for deprecating [components](#components), [props](#prop
 ## Prop values
 
 - Mark the prop value(s) as deprecated
-  - Add component, prop, and deprecated prop value(s) to `componentUnionTypeDeprecations` ([example](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/pages/components/%5Bgroup%5D/%5Bcomponent%5D/index.tsx#L80))
+  - Add component, prop, and deprecated prop value(s) to `componentUnionTypeDeprecations` ([example](https://github.com/Shopify/polaris/tree/main/polaris.shopify.com/pages/components/%5Bgroup%5D/%5Bcomponent%5D/index.tsx#L80))
     ```tsx
     const componentUnionTypeDeprecations: {
       [componentName: string]: {
@@ -55,8 +55,8 @@ Follow these guidelines for deprecating [components](#components), [props](#prop
     };
     ```
   - Check documentation is updated on polaris.shopify.com
-- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/blob/f91c4b661b1d9540dd515c6f073aeeb62e914023/polaris-migrator/src/migrations))
-- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
+- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/tree/main/polaris-migrator/src/migrations))
+- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/tree/main/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L122))
   - Document deprecation reason
   - Document any alternatives
   - Document automated migration(s)
@@ -66,8 +66,8 @@ Follow these guidelines for deprecating [components](#components), [props](#prop
 ## Tokens
 
 - Mark the token as deprecated in `stylelint-polaris` ([example](https://github.com/Shopify/polaris/tree/main/stylelint-polaris/plugins/custom-property-disallowed-list))
-- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/blob/f91c4b661b1d9540dd515c6f073aeeb62e914023/polaris-migrator/src/migrations))
-- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/blob/text-2xl-3xl-deprecation/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L1451))
+- Create automated migration(s) ([examples](https://github.com/Shopify/polaris/tree/main/polaris-migrator/src/migrations))
+- Add supporting documentation for deprecation in next major version guide ([examples](https://github.com/Shopify/polaris/tree/main/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx#L1451))
   - Document any alternatives
   - Document automated migration(s)
   - Document manual migration(s)

--- a/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
+++ b/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
@@ -146,7 +146,7 @@ export const getStaticProps: GetStaticProps<
         componentUnionTypeDeprecations[componentDirName],
       )) {
         if (!type[typeName]) continue;
-        console.log(type[typeName]);
+
         const typeValue = type[typeName].value;
 
         if (typeof typeValue !== 'string') continue;

--- a/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
+++ b/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
@@ -72,6 +72,16 @@ function load(filePath: string): string {
   return fs.readFileSync(filePath, 'utf-8');
 }
 
+const componentUnionTypeDeprecations: {
+  [componentName: string]: {
+    [typeName: string]: string[];
+  };
+} = {
+  Text: {
+    Variant: ['heading2xl', 'heading3xl'],
+  },
+};
+
 export const getStaticProps: GetStaticProps<
   Props,
   {component: string; group: string}
@@ -130,6 +140,27 @@ export const getStaticProps: GetStaticProps<
       `polaris-react/src/components/${componentDirName}/${componentDirName}.tsx`,
       mdx.frontmatter.status || '',
     );
+
+    if (componentUnionTypeDeprecations[componentDirName]) {
+      for (const [typeName, deprecatedValues] of Object.entries(
+        componentUnionTypeDeprecations[componentDirName],
+      )) {
+        if (!type[typeName]) continue;
+        console.log(type[typeName]);
+        const typeValue = type[typeName].value;
+
+        if (typeof typeValue !== 'string') continue;
+
+        const values = typeValue
+          .split(' | ')
+          .map((value) => value.replace(/'([^']+)'/, '$1'))
+          .map((value) =>
+            deprecatedValues.includes(value) ? `${value} (deprecated)` : value,
+          );
+
+        type[typeName].value = values.map((value) => `'${value}'`).join(' | ');
+      }
+    }
 
     const props: Props = {
       mdx,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1378
Part of https://github.com/Shopify/polaris-internal/issues/1289


### WHAT is this pull request doing?

- Deprecates `Text` `variant` prop `heading2xl` and `heading3xl` values
    - There's no way for us to easily create editor based deprecation warnings right now for component prop values in union types so this just marks the value deprecated on the doc site
- Adds new functionality to mark prop values as deprecated on doc site
- Updates deprecation documentation to reflect current practices 

| Before | After | 
| -- | -- | 
| ![polaris shopify com_components_typography_text](https://github.com/Shopify/polaris/assets/21976492/1f00b250-8af3-4aad-b447-f84aad71a3dc)|![localhost_3000_components_typography_text](https://github.com/Shopify/polaris/assets/21976492/e495b5e0-668c-4035-a8a5-65907a26a957)|

### How to 🎩
- Check out the screenshots above or locally spin up the doc site
- [Updated deprecation documentation](https://github.com/Shopify/polaris/blob/baaa84070426fa5327ab8f994a1812c70b5b9c5b/documentation/Deprecation%20guidelines.md)


