### PR TITLE
[Scrollable] Add new scrollbar properties

### DIFF
--- a/.changeset/silver-timers-lick.md
+++ b/.changeset/silver-timers-lick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added scrollbarWidth and scrollbarGutter properties to Scrollable

--- a/polaris-react/src/components/Scrollable/Scrollable.module.scss
+++ b/polaris-react/src/components/Scrollable/Scrollable.module.scss
@@ -106,6 +106,6 @@
   scrollbar-gutter: stable;
 }
 
-.scrollbarGutterStableBothEdges {
+.scrollbarGutterStableboth-edges {
   scrollbar-gutter: stable both-edges;
 }

--- a/polaris-react/src/components/Scrollable/Scrollable.module.scss
+++ b/polaris-react/src/components/Scrollable/Scrollable.module.scss
@@ -93,3 +93,19 @@
 .vertical {
   overflow-y: auto;
 }
+
+.scrollbarWidthThin {
+  scrollbar-width: thin;
+}
+
+.scrollbarWidthNone {
+  scrollbar-width: none;
+}
+
+.scrollbarGutterStable {
+  scrollbar-gutter: stable;
+}
+
+.scrollbarGutterStableBothEdges {
+  scrollbar-gutter: stable both-edges;
+}

--- a/polaris-react/src/components/Scrollable/Scrollable.stories.tsx
+++ b/polaris-react/src/components/Scrollable/Scrollable.stories.tsx
@@ -165,6 +165,102 @@ export function WithHorizonalScrollPrevention() {
   );
 }
 
+export function WithGutterAndThinDragHandle() {
+  return (
+    <Scrollable
+      shadow
+      style={{height: '100px', width: '200px'}}
+      horizontal={false}
+      scrollbarGutter="stable"
+      scrollbarWidth="thin"
+    >
+      <div>
+        <p>Last updated on: September 6, 2022</p>
+
+        <p>
+          Welcome to Shopify! By signing up for a Shopify Account (as defined in
+          Section 1) or by using any Shopify Services (as defined below), you
+          are agreeing to be bound by the following terms and conditions (the “
+          <strong>Terms of Service</strong>”).
+        </p>
+
+        <p>
+          As used in these Terms of Service, “<strong>we</strong>”, “
+          <strong>us</strong>”, “<strong>our</strong>” and “
+          <strong>Shopify</strong>” means the applicable Shopify Contracting
+          Party (as defined in Section 13 below), and “<strong>you</strong>”
+          means the Shopify User (if registering for or using a Shopify Service
+          as an individual), or the business employing the Shopify User (if
+          registering for or using a Shopify Service as a business) and any of
+          its affiliates.
+        </p>
+
+        <p>
+          Shopify provides a complete commerce platform that enables merchants
+          to unify their commerce activities. Among other features, this
+          platform includes a range of tools for merchants to build and
+          customize online stores, sell in multiple places (including web,
+          mobile, social media, online marketplaces and other online locations
+          (“<strong>Online Services</strong>”) and in person (“
+          <strong>POS Services</strong>”)), manage products, inventory,
+          payments, fulfillment, shipping, business operations, marketing and
+          advertising, and engage with existing and potential customers. Any
+          such service or services offered by Shopify are referred to in these
+          Terms of Services as the “<strong>Service(s)</strong>”. Any new
+          features or tools which are added to the current Services will also be
+          subject to the Terms of Service. You can review the current version of
+          the Terms of Service at any time at
+          <a href="https://www.shopify.com/legal/terms">
+            https://www.shopify.com/legal/terms
+          </a>
+          .
+        </p>
+
+        <p>
+          You must read, agree with and accept all of the terms and conditions
+          contained or expressly referenced in these Terms of Service, including
+          Shopify’s
+          <a href="https://www.shopify.com/legal/aup">Acceptable Use Policy</a>
+          (“<strong>AUP</strong>”) and
+          <a href="https://www.shopify.com/legal/privacy">Privacy Policy</a>,
+          and, if applicable, the
+          <a href="https://www.shopify.com/legal/eu-terms">
+            Supplementary Terms of Service for E.U. Merchants
+          </a>
+          (“<strong>EU Terms</strong>”), the Shopify
+          <a href="https://www.shopify.com/legal/api-terms">
+            API License and Terms of Use
+          </a>
+          (“<strong>API Terms</strong>”) and the Shopify
+          <a href="https://www.shopify.com/legal/dpa">
+            Data Processing Addendum
+          </a>
+          (“<strong>DPA</strong>”) before you may sign up for a Shopify Account
+          or use any Shopify Service. Additionally, if you offer goods or
+          services in relation to COVID-19, you must read, acknowledge and agree
+          to the
+          <a href="/legal/rules-of-engagement-covid19">
+            Rules of Engagement for Sale of COVID-19 Related Products
+          </a>
+          .
+        </p>
+
+        <p>
+          <strong>
+            Everyday language summaries are provided for convenience only and
+            appear in bold near each section, but these summaries are not
+            legally binding. Please read the Terms of Service, including any
+            document referred to in these Terms of Service, for the complete
+            picture of your legal requirements. By using Shopify or any Shopify
+            services, you are agreeing to these terms. Be sure to occasionally
+            check back for updates.
+          </strong>
+        </p>
+      </div>
+    </Scrollable>
+  );
+}
+
 export function ScrollToChildComponent() {
   return (
     <LegacyCard title="Terms of service" sectioned>

--- a/polaris-react/src/components/Scrollable/Scrollable.tsx
+++ b/polaris-react/src/components/Scrollable/Scrollable.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 
 import {debounce} from '../../utilities/debounce';
-import {toCamelCase, classNames, variationName} from '../../utilities/css';
+import {classNames, variationName} from '../../utilities/css';
 import {
   StickyManager,
   StickyManagerContext,
@@ -41,14 +41,10 @@ export interface ScrollableProps extends React.HTMLProps<HTMLDivElement> {
   hint?: boolean;
   /** Adds a tabIndex to scrollable when children are not focusable */
   focusable?: boolean;
-  /** Browser determined scrollbar width
-   * @default 'auto'
-   */
-  scrollbarWidth?: 'thin' | 'none' | 'auto';
-  /** Adds space to one or both sides to prevent content shift when scrolling is necessary
-   * @default 'auto'
-   */
-  scrollbarGutter?: 'stable' | 'stable both-edges' | 'auto';
+  /** Browser determined scrollbar width */
+  scrollbarWidth?: 'thin' | 'none';
+  /** Adds space to one or both sides to prevent content shift when scrolling is necessary */
+  scrollbarGutter?: 'stable' | 'stable both-edges';
   /** Called when scrolled to the bottom of the scroll area */
   onScrolledToBottom?(): void;
 }
@@ -71,8 +67,8 @@ const ScrollableComponent = forwardRef<ScrollableRef, ScrollableProps>(
       shadow,
       hint,
       focusable,
-      scrollbarWidth = 'auto',
-      scrollbarGutter = 'auto',
+      scrollbarWidth,
+      scrollbarGutter,
       onScrolledToBottom,
       ...rest
     }: ScrollableProps,
@@ -156,7 +152,9 @@ const ScrollableComponent = forwardRef<ScrollableRef, ScrollableProps>(
       shadow && bottomShadow && styles.hasBottomShadow,
       scrollbarWidth && styles[variationName('scrollbarWidth', scrollbarWidth)],
       scrollbarGutter &&
-        styles[toCamelCase(variationName('scrollbarGutter', scrollbarGutter))],
+        styles[
+          variationName('scrollbarGutter', scrollbarGutter.replace(' ', ''))
+        ],
     );
 
     return (

--- a/polaris-react/src/components/Scrollable/Scrollable.tsx
+++ b/polaris-react/src/components/Scrollable/Scrollable.tsx
@@ -6,9 +6,10 @@ import React, {
   useImperativeHandle,
   forwardRef,
 } from 'react';
+import {camelCase} from 'change-case';
 
 import {debounce} from '../../utilities/debounce';
-import {classNames} from '../../utilities/css';
+import {classNames, variationName} from '../../utilities/css';
 import {
   StickyManager,
   StickyManagerContext,
@@ -41,6 +42,14 @@ export interface ScrollableProps extends React.HTMLProps<HTMLDivElement> {
   hint?: boolean;
   /** Adds a tabIndex to scrollable when children are not focusable */
   focusable?: boolean;
+  /** Browser determined scrollbar width
+   * @default 'auto'
+   */
+  scrollbarWidth?: 'thin' | 'none' | 'auto';
+  /** Adds space to one or both sides to prevent content shift when scrolling is necessary
+   * @default 'auto'
+   */
+  scrollbarGutter?: 'stable' | 'stable both-edges' | 'auto';
   /** Called when scrolled to the bottom of the scroll area */
   onScrolledToBottom?(): void;
 }
@@ -63,6 +72,8 @@ const ScrollableComponent = forwardRef<ScrollableRef, ScrollableProps>(
       shadow,
       hint,
       focusable,
+      scrollbarWidth = 'auto',
+      scrollbarGutter = 'auto',
       onScrolledToBottom,
       ...rest
     }: ScrollableProps,
@@ -144,6 +155,9 @@ const ScrollableComponent = forwardRef<ScrollableRef, ScrollableProps>(
       horizontal && styles.horizontal,
       shadow && topShadow && styles.hasTopShadow,
       shadow && bottomShadow && styles.hasBottomShadow,
+      scrollbarWidth && styles[variationName('scrollbarWidth', scrollbarWidth)],
+      scrollbarGutter &&
+        styles[camelCase(variationName('scrollbarGutter', scrollbarGutter))],
     );
 
     return (

--- a/polaris-react/src/components/Scrollable/Scrollable.tsx
+++ b/polaris-react/src/components/Scrollable/Scrollable.tsx
@@ -6,10 +6,9 @@ import React, {
   useImperativeHandle,
   forwardRef,
 } from 'react';
-import {camelCase} from 'change-case';
 
 import {debounce} from '../../utilities/debounce';
-import {classNames, variationName} from '../../utilities/css';
+import {toCamelCase, classNames, variationName} from '../../utilities/css';
 import {
   StickyManager,
   StickyManagerContext,
@@ -157,7 +156,7 @@ const ScrollableComponent = forwardRef<ScrollableRef, ScrollableProps>(
       shadow && bottomShadow && styles.hasBottomShadow,
       scrollbarWidth && styles[variationName('scrollbarWidth', scrollbarWidth)],
       scrollbarGutter &&
-        styles[camelCase(variationName('scrollbarGutter', scrollbarGutter))],
+        styles[toCamelCase(variationName('scrollbarGutter', scrollbarGutter))],
     );
 
     return (

--- a/polaris-react/src/utilities/css.ts
+++ b/polaris-react/src/utilities/css.ts
@@ -106,3 +106,7 @@ export function getResponsiveValue<T = string>(
     ]),
   );
 }
+
+export function toCamelCase(string: string) {
+  return string.replace(/(-| )([a-z])/g, (_, __, match) => match.toUpperCase());
+}

--- a/polaris-react/src/utilities/css.ts
+++ b/polaris-react/src/utilities/css.ts
@@ -106,7 +106,3 @@ export function getResponsiveValue<T = string>(
     ]),
   );
 }
-
-export function toCamelCase(string: string) {
-  return string.replace(/(-| )([a-z])/g, (_, __, match) => match.toUpperCase());
-}

--- a/polaris.shopify.com/content/components/utilities/scrollable.mdx
+++ b/polaris.shopify.com/content/components/utilities/scrollable.mdx
@@ -18,6 +18,9 @@ examples:
   - fileName: scrollable-default.tsx
     title: Default
     description: Use when you need to make a region within the page independently scrollable. It’s often used in modals and other panes where it’s helpful to provide an extra visual cue that content exists below or above the fold.
+  - fileName: scrollable-with-gutter.tsx
+    title: Thin with scrollbar gutter
+    description: Use to prevent content shift when container becomes scrollable.
   - fileName: scrollable-to-child-component.tsx
     title: To child component
     description: Use when you need to programmatically scroll a child component into view in the scrollable container.

--- a/polaris.shopify.com/pages/examples/scrollable-with-gutter.tsx
+++ b/polaris.shopify.com/pages/examples/scrollable-with-gutter.tsx
@@ -1,0 +1,35 @@
+import {LegacyCard, Scrollable} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function ScrollableExample() {
+  return (
+    <LegacyCard title="Terms of service" sectioned>
+      <Scrollable
+        shadow
+        style={{height: '100px'}}
+        focusable
+        scrollbarGutter="stable"
+        scrollbarWidth="thin"
+      >
+        <p>
+          By signing up for the Shopify service (“Service”) or any of the
+          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+          the following terms and conditions (“Terms of Service”). The Services
+          offered by Shopify under the Terms of Service include various products
+          and services to help you create and manage a retail store, whether an
+          online store (“Online Services”), a physical retail store (“POS
+          Services”), or both. Any new features or tools which are added to the
+          current Service shall be also subject to the Terms of Service. You can
+          review the current version of the Terms of Service at any time at
+          https://www.shopify.com/legal/terms. Shopify reserves the right to
+          update and change the Terms of Service by posting updates and changes
+          to the Shopify website. You are advised to check the Terms of Service
+          from time to time for any updates or changes that may impact you.
+        </p>
+      </Scrollable>
+    </LegacyCard>
+  );
+}
+
+export default withPolarisExample(ScrollableExample);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-internal/issues/1193

scrollbar-width was just introduced to chrome / edge v121 but it's been available in firefox for some time now. We can make use of the feature as it rolls out to the remaining browsers.

Example Navigation:

Before | After
---|---
![image](https://github.com/Shopify/polaris/assets/6844391/1e0d1d13-47ca-49a2-abbb-29f07d4666b9) | ![image](https://github.com/Shopify/polaris/assets/6844391/ae311bca-3ecd-46c3-b374-e1d5551d3702)
