### PR TITLE
[Polaris][IndexTable] fix z-index for nested rows

### DIFF
--- a/.changeset/five-geckos-end.md
+++ b/.changeset/five-geckos-end.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+fix z-index for IndexTable rows of type `child`

--- a/polaris-react/src/components/IndexTable/IndexTable.module.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.module.scss
@@ -282,7 +282,7 @@ $loading-panel-height: 53px;
       var(--pc-index-table-checkbox-width-sm) +
         var(--pc-index-table-checkbox-padding-left)
     );
-    --pc-table-shifted-checkbox-z-index: 32;
+    --pc-table-shifted-checkbox-z-index: 30;
 
     .TableCell-first {
       left: var(--pc-index-table-checkbox-child-offset);


### PR DESCRIPTION
Issue: after Admin was bumped with new Polaris version we started to have with issue with IndexTable SelectAllActions Bar:
Comment from @LA1CH3 

>  buggy behavior with the new IndexTable UX, specific to moving the “N selected” to the bottom of the table. With “child” rows we’re seeing its z-index a bit jacked where its partially hidden under rows.

[Link to thread](https://shopify.slack.com/archives/C4Y8N30KD/p1706554593503719)

### WHY are these changes introduced?

This PR changes .Polaris-IndexTable__TableRow.Polaris-IndexTable__TableRow--child .Polaris-IndexTable__TableCell--first making `z-index` to  it 30 instead of 32 (as floating bar has `z-index` 32);

Before (in Admin):
 

https://github.com/Shopify/polaris/assets/104942025/603813ec-a4b8-481a-aae9-43b85d262c0d




Now (in Admin):




https://github.com/Shopify/polaris/assets/104942025/71662d90-2f61-49af-9201-84afbd392d36


### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩
1. Test on my web spin:
[Spin](https://admin.web.admin-fix-z-index-for-nested-rows.oksana-azarova.us.spin.dev/store/shop1/products/2)
[Draft web PR](https://github.com/Shopify/web/pull/116585), just as a proof with added snapshot 

- create product with at least two options and more than 10 option values for the first one of them  - so it results in nested table UI with pagination
- select variants to see floating bar
- expand one of the variant groups
- scroll table and make sure you floating SelectAllActions bar always visible

3. Test on your spin:

- spin up web
- make sure `admin_pdp_variants_250_ux ` is enabled
- Add snapshot from this comment https://github.com/Shopify/polaris/pull/11523#issuecomment-1915448232 `yarn add @shopify/polaris@0.0.0-snapshot-release-20240129194958`
- repeat steps listed above how to create product 

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
