### PR TITLE
[Button] Fix border radius for connectedTop buttons in ButtonGroup

### DIFF
--- a/.changeset/old-phones-watch.md
+++ b/.changeset/old-phones-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed border radius styles for `Button` within `ButtonGroup` when `connectedTop` prop applied

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -398,4 +398,12 @@
     white-space: nowrap;
   }
 }
+
+[data-buttongroup-connected-top='true'] > *:first-child .Button {
+  border-top-left-radius: var(--p-border-radius-0);
+}
+
+[data-buttongroup-connected-top='true'] > *:last-child .Button {
+  border-top-right-radius: var(--p-border-radius-0);
+}
 /* stylelint-enable -- selector-max-combinators */

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -377,7 +377,9 @@
 
 // BUTTON GROUP
 /* stylelint-disable -- selector-max-combinators */
-[data-buttongroup-variant='segmented'] > *:not(:first-child) .Button {
+[data-buttongroup-variant='segmented']
+  > *:not(:first-child)
+  .Button:is(.variantPrimary) {
   margin-left: calc(-1 * var(--p-space-025));
 }
 
@@ -406,4 +408,5 @@
 [data-buttongroup-connected-top='true'] > *:last-child .Button {
   border-top-right-radius: var(--p-border-radius-0);
 }
+
 /* stylelint-enable -- selector-max-combinators */

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.module.scss
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.module.scss
@@ -49,7 +49,7 @@
     z-index: var(--pc-button-group-item);
   }
 
-  .Item-focused:not(:active) {
+  .Item-focused {
     // stylelint-disable-next-line  -- custom property
     z-index: var(--pc-button-group-focused);
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fix for [#1396](https://github.com/Shopify/polaris-internal/issues/1396).

### WHAT is this pull request doing?

Fixes incorrect border radius styles for `Button` inside the `ButtonGroup` where the `connectedTop` prop is applied.

Also modifies the logic that originally applied a negative left margin for all segmented buttons to only apply on `variant="primary"` buttons. This was causing spacing issues where the width of the ButtonGroup was 1px smaller than the sibling element that it was supposed to match a 0 border radius with.
  <details>
    <summary>ButtonGroup connectedTop — before</summary>
    <img src="https://github.com/Shopify/polaris/assets/26749317/cc8a6f6b-f0c7-4b06-a3d7-3a415e38d5d6" alt="ButtonGroup connectedTop — before">
  </details>
  <details>
    <summary>ButtonGroup connectedTop — after</summary>
    <img src="https://github.com/Shopify/polaris/assets/26749317/d3b037d3-835f-4ea3-91ef-4ee191a58186" alt="ButtonGroup connectedTop — after">
  </details>

### How to 🎩

[Spin URL](https://admin.web.button-group-fix.lo-kim.us.spin.dev/store/shop1/settings/branding)

- Scroll down to "Logo" card section
- Click "Add a default logo"
- Click the high five image and press done

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
