### PR TITLE
[ActionList] Fix wrapping issue with prefix/suffix icons

### DIFF
--- a/.changeset/blue-impalas-sleep.md
+++ b/.changeset/blue-impalas-sleep.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[ActionList] Fixed wrapping issue while using prefix and/or suffix icons

--- a/polaris-react/src/components/ActionList/ActionList.stories.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.stories.tsx
@@ -137,24 +137,37 @@ export function WithAnIconAndASuffix() {
         autofocusTarget="first-node"
         onClose={toggleActive}
       >
-        <ActionList
-          actionRole="menuitem"
-          items={[
-            {
-              active: true,
-              content: 'Import file',
-              icon: ImportIcon,
-              suffix: <Icon source={CheckSmallIcon} />,
-            },
-            {content: 'Export file', icon: ExportIcon},
-            {
-              disabled: true,
-              content: 'Disable file',
-              icon: ImportIcon,
-              suffix: <Icon source={CheckSmallIcon} />,
-            },
-          ]}
-        />
+        <div style={{width: '200px'}}>
+          <ActionList
+            actionRole="menuitem"
+            items={[
+              {
+                active: true,
+                content: 'Import file',
+                icon: ImportIcon,
+                suffix: <Icon source={CheckSmallIcon} />,
+              },
+              {content: 'Export file', icon: ExportIcon},
+              {
+                content: 'Manage your blog articles',
+                icon: ImportIcon,
+                suffix: <Icon source={CheckSmallIcon} />,
+              },
+              {
+                content: `Manage uploaded images`,
+                icon: ImportIcon,
+                suffix: <Icon source={CheckSmallIcon} />,
+                truncate: true,
+              },
+              {
+                disabled: true,
+                content: 'Disable file',
+                icon: ImportIcon,
+                suffix: <Icon source={CheckSmallIcon} />,
+              },
+            ]}
+          />
+        </div>
       </Popover>
     </div>
   );

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -106,7 +106,7 @@ export function Item({
   const textMarkup = <span className={styles.Text}>{contentMarkup}</span>;
 
   const contentElement = (
-    <InlineStack blockAlign="center" gap="150" wrap={!truncate}>
+    <InlineStack blockAlign="center" gap="150" wrap={false}>
       {prefixMarkup}
       {textMarkup}
       {badgeMarkup}


### PR DESCRIPTION
### WHY are these changes introduced?

When an action list item can't fit on a single row, it starts stacking vertically with the prefix and suffix icons unless `truncate` is used. 

<img width="260" alt="image" src="https://github.com/Shopify/polaris/assets/8934059/4e951b6e-ab16-4bb3-aac7-bcbbfb4fff69">

I think a better default is to allow the text to wrap and center the icons vertically with it.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR set `wrap={false}` on the item's InlineStack container. This allows the text to wrap while staying on the same row as its prefix and suffix which looks like this:

<img width="249" alt="image" src="https://github.com/Shopify/polaris/assets/8934059/c65460a7-b29d-426b-b3f7-ad3e1559ef93">

As we can also see above, passing `truncate={true}` still works as expected.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

I updated the "With and icon and suffix" story with a fixed width container and some longer items to make it easy to tophat these use cases.

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
