### PR TITLE
Fix visual regressions in `Select` across browsers and operating systems

### DIFF
--- a/.changeset/itchy-onions-punch.md
+++ b/.changeset/itchy-onions-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix visual regressions in `Select` across browsers and operating systems

--- a/polaris-react/src/components/Select/Select.module.scss
+++ b/polaris-react/src/components/Select/Select.module.scss
@@ -107,6 +107,8 @@
   // Even though the input is invisible, text styles apply to the options menu
   font-size: var(--p-font-size-400);
   font-weight: var(--p-font-weight-regular);
+  // Safari requires the font-family to be added to the <select> element
+  font-family: var(--p-font-family-sans);
   line-height: var(--p-font-line-height-500);
   letter-spacing: initial;
   position: absolute;

--- a/polaris-react/src/components/Select/Select.module.scss
+++ b/polaris-react/src/components/Select/Select.module.scss
@@ -124,6 +124,9 @@
   opacity: 0;
   appearance: none;
   border: none;
+  // Google chrome on Windows requires padding to be added otherwise <option> has no space
+  padding: var(--p-space-150) var(--p-space-200) var(--p-space-150)
+    var(--p-space-300);
 
   @media (--p-breakpoints-md-up) {
     font-size: var(--p-font-size-350);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1409

Fix visual regressions in the native `<select>` element across browsers and operating systems.

- [Storybook with visual regressions](https://storybook.polaris.shopify.com)
- [Storybook with fixes to select](https://5d559397bae39100201eedc1-rdgeosoute.chromatic.com)

**Safari on macOS Sonoma 14.3**
| Before | After |
| --- | --- |
| <img width="571" alt="Screenshot 2024-01-31 at 7 12 42 pm" src="https://github.com/Shopify/polaris/assets/19199063/1d758a1b-9019-4fe6-945f-9ba325bb592b"> | <img width="573" alt="Screenshot 2024-01-31 at 7 12 56 pm" src="https://github.com/Shopify/polaris/assets/19199063/786d9cb3-d8a6-41de-ae8a-a6560ba9b198"> | 

**Chrome on Windows 11**
| Before | After |
| --- | --- |
| ![Screenshot 2024-01-31 194251](https://github.com/Shopify/polaris/assets/19199063/7c2502f1-fba5-4e93-8609-20bed404a027) | ![Screenshot 2024-01-31 194243](https://github.com/Shopify/polaris/assets/19199063/c03030ca-cc69-4320-a098-8c0541300982) |


### WHAT is this pull request doing?

- Adds the font family to the select to ensure the correct font is rendered in webkit
- Adds the padding to the select to ensure the correct spacing is added to `<option>` in Google Chrome on Windows 11

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
