### PR TITLE
[IndexFilters] Ensure tabs never flicker between collapsed and expanded when the loading state appears

### DIFF
--- a/.changeset/beige-trains-check.md
+++ b/.changeset/beige-trains-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated IndexFilters to always fill the space where the loading spinner appears to ensure Tabs do not switch between collapsed and expanded

--- a/polaris-react/src/components/IndexFilters/IndexFilters.module.scss
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.module.scss
@@ -49,8 +49,12 @@ $spinner-size: 20px;
 }
 
 .DesktopLoading {
+  position: absolute;
+  right: 100%;
+  top: 50%;
   height: 20px;
   width: 20px;
+  transform: translateY(-50%);
 }
 
 .TabsLoading svg {
@@ -87,6 +91,7 @@ $spinner-size: 20px;
 }
 
 .ActionWrap {
+  position: relative;
   display: flex;
   gap: var(--p-space-200);
   align-items: center;
@@ -94,7 +99,6 @@ $spinner-size: 20px;
   padding: var(--p-space-150) var(--p-space-200);
 
   @media (--p-breakpoints-md-down) {
-    position: relative;
     padding: var(--p-space-200);
     height: 3rem;
     border-left: var(--p-border-width-025) solid var(--p-color-border-secondary);

--- a/polaris-react/src/components/IndexFilters/IndexFilters.module.scss
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.module.scss
@@ -48,6 +48,11 @@ $spinner-size: 20px;
   }
 }
 
+.DesktopLoading {
+  height: 20px;
+  width: 20px;
+}
+
 .TabsLoading svg {
   display: block;
 }

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -402,7 +402,11 @@ export function IndexFilters({
                       )}
                     </div>
                     <div className={styles.ActionWrap}>
-                      {isLoading && !mdDown && <Spinner size="small" />}
+                      {!mdDown && (
+                        <div className={styles.DesktopLoading}>
+                          {isLoading ? <Spinner size="small" /> : null}
+                        </div>
+                      )}
                       {mode === IndexFiltersMode.Default ? (
                         <>
                           {hideFilters && hideQueryField ? null : (

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -402,7 +402,7 @@ export function IndexFilters({
                       )}
                     </div>
                     <div className={styles.ActionWrap}>
-                      {!mdDown && (
+                      {isLoading && !mdDown && (
                         <div className={styles.DesktopLoading}>
                           {isLoading ? <Spinner size="small" /> : null}
                         </div>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes a bug that occurs when the length of tabs is close to the available space provided. When the loading spinner gets added to the UI, the available space decreases by 20px. When this occurs, the Tabs component will automatically roll up tabs that do not fit behind the More views button. When showing an ephemeral state such as the loading state, this UI flicker can be very distracting for merchants.

The fix involves ensuring that the loading element is removed from the flow of the document by absolutely positioning it.

### Before


https://github.com/Shopify/polaris/assets/2562596/e5fc727d-20d6-4b69-a584-23e5567af242



### After


https://github.com/Shopify/polaris/assets/2562596/93d058d7-5546-401a-992f-dcbfb3fca5e6




### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
