### PR TITLE
Allow polaris/media-query-allowed-list rule to be disabled

### DIFF
--- a/.changeset/stale-trees-obey.md
+++ b/.changeset/stale-trees-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': minor
+---
+
+Allow polaris/media-query-allowed-list lint rule to be disabled

--- a/stylelint-polaris/plugins/media-query-allowed-list/index.js
+++ b/stylelint-polaris/plugins/media-query-allowed-list/index.js
@@ -8,6 +8,7 @@ const {
   isString,
   isRegExp,
   matchesStringOrRegExp,
+  isBoolean,
 } = require('../../utils');
 
 const ruleName = 'polaris/media-query-allowed-list';
@@ -26,6 +27,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
  * @property {AllowedPatterns} allowedMediaTypes
  * @property {AllowedPatterns} allowedMediaFeatureNames
  * @property {AllowedPatterns} allowedScssInterpolations
+ * @property {boolean} disabled
  */
 
 const {rule} = stylelint.createPlugin(
@@ -51,6 +53,11 @@ const {rule} = stylelint.createPlugin(
           possible: [isString, isRegExp],
           optional: true,
         },
+        {
+          actual: primary.disabled,
+          possible: [isBoolean],
+          optional: true,
+        },
       );
 
       if (!validOptions) {
@@ -63,7 +70,12 @@ const {rule} = stylelint.createPlugin(
         allowedMediaTypes = [],
         allowedMediaFeatureNames = [],
         allowedScssInterpolations = [],
+        disabled,
       } = primary;
+
+      if (disabled) {
+        return;
+      }
 
       // Pass `primary.allowedMediaFeatureNames` to the
       // built-in `media-feature-name-allowed-list` rule

--- a/stylelint-polaris/plugins/media-query-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/media-query-allowed-list/index.test.js
@@ -122,3 +122,19 @@ testRule({
     },
   ],
 });
+
+testRule({
+  ruleName,
+  plugins: [__dirname],
+  config: {
+    disabled: true,
+  },
+  customSyntax: 'postcss-scss',
+  accept: [
+    {
+      code: '@media (width: 0px) {}',
+      description: 'Defining media queries with width when rule is disabled',
+    },
+  ],
+  reject: [],
+});


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Currently, it's not possible to disable the `polaris/media-query-allowed-list` rule from `polaris/coverage`. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR adds a new option called `disabled` to allow the rule to be disabled. 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

Configuration being tested and implemented on https://github.com/Shopify/web/pull/117384

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
