### PR TITLE
Apply flat button styles for `light-mobile` theme

### DIFF
--- a/.changeset/fifty-kings-run.md
+++ b/.changeset/fifty-kings-run.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'@shopify/polaris-tokens': minor
+---
+
+Applied native mobile styles to Button component for the light-mobile theme

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -35,8 +35,8 @@
   box-shadow: var(--pc-button-box-shadow);
   color: var(--pc-button-color);
 
-  font-size: var(--p-font-size-325);
-  font-weight: var(--p-font-weight-medium);
+  font-size: var(--p-font-size-350);
+  font-weight: var(--p-font-weight-semibold);
   line-height: var(--p-font-line-height-500);
 
   cursor: pointer;
@@ -45,6 +45,7 @@
 
   @media (--p-breakpoints-md-up) {
     font-size: var(--p-font-size-300);
+    font-weight: var(--p-font-weight-medium);
     line-height: var(--p-font-line-height-400);
   }
 }
@@ -125,13 +126,7 @@
 
 // VARIANTS
 .variantPrimary {
-  // stylelint-disable  -- custom button tokens
-  --pc-button-bg-gradient: linear-gradient(
-    180deg,
-    rgba(48, 48, 48, 0) 63.53%,
-    rgba(255, 255, 255, 0.15) 100%
-  );
-  // stylelint-enable
+  --pc-button-bg-gradient: var(--p-color-button-bg-gradient-primary);
   --pc-button-box-shadow: var(--p-shadow-button-primary);
   --pc-button-box-shadow_active: var(--p-shadow-button-primary-inset);
   --pc-button-bg: var(--pc-button-bg-gradient), var(--p-color-bg-fill-brand);
@@ -185,9 +180,13 @@
   --pc-button-bg_disabled: transparent;
   margin: calc(-1 * var(--pc-button-padding-block))
     calc(-1 * var(--pc-button-padding-inline));
-  font-size: var(--p-font-size-325);
+  font-size: var(--p-font-size-350);
   font-weight: var(--p-font-weight-regular);
-  line-height: var(--p-font-line-height-400);
+  line-height: var(--p-font-line-height-500);
+
+  @media (--p-breakpoints-md-up) {
+    font-size: var(--p-font-size-325);
+  }
 }
 
 .variantPlain:focus-visible,
@@ -356,7 +355,9 @@
 // INTERACTION
 .pressable:active:not(.variantTertiary, .variantPlain, .variantMonochromePlain)
   > * {
-  transform: translate3d(0, 1px, 0);
+  @media (--p-breakpoints-md-up) {
+    transform: translate3d(0, 1px, 0);
+  }
 }
 
 // UTILITIES

--- a/polaris-tokens/src/themes/base/color.ts
+++ b/polaris-tokens/src/themes/base/color.ts
@@ -107,6 +107,7 @@ export type ColorBackgroundAlias =
   | 'avatar-three-bg-fill'
   | 'avatar-two-bg-fill'
   | 'backdrop-bg'
+  | 'button-bg-gradient-primary'
   | 'checkbox-bg-surface-disabled'
   | 'input-bg-surface-active'
   | 'input-bg-surface-hover'
@@ -1130,6 +1131,10 @@ export const color: {
   },
   'color-backdrop-bg': {
     value: colors.blackAlpha[14],
+  },
+  'color-button-bg-gradient-primary': {
+    value:
+      'linear-gradient(180deg, rgba(48, 48, 48, 0) 63.53%, rgba(255, 255, 255, 0.15) 100%)',
   },
   'color-checkbox-bg-surface-disabled': {
     value: colors.blackAlpha[7],

--- a/polaris-tokens/src/themes/light-mobile.ts
+++ b/polaris-tokens/src/themes/light-mobile.ts
@@ -2,12 +2,57 @@ import {createVar} from '../utils';
 
 import {createMetaTheme, createMetaThemePartial} from './utils';
 
+const buttonShadow = `0 0 0 ${createVar('border-width-025')} ${createVar(
+  'color-border',
+)} inset`;
+
 export const metaThemeLightMobilePartial = createMetaThemePartial({
+  color: {
+    'color-button-bg-gradient-primary': {
+      value: 'none',
+    },
+  },
   shadow: {
     'shadow-100': {
       value: 'none',
     },
     'shadow-bevel-100': {
+      value: 'none',
+    },
+    'shadow-button': {
+      value: buttonShadow,
+    },
+    'shadow-button-hover': {
+      value: buttonShadow,
+    },
+    'shadow-button-inset': {
+      value: buttonShadow,
+    },
+    'shadow-button-primary': {
+      value: 'none',
+    },
+    'shadow-button-primary-hover': {
+      value: 'none',
+    },
+    'shadow-button-primary-inset': {
+      value: 'none',
+    },
+    'shadow-button-primary-critical': {
+      value: 'none',
+    },
+    'shadow-button-primary-critical-hover': {
+      value: 'none',
+    },
+    'shadow-button-primary-critical-inset': {
+      value: 'none',
+    },
+    'shadow-button-primary-success': {
+      value: 'none',
+    },
+    'shadow-button-primary-success-hover': {
+      value: 'none',
+    },
+    'shadow-button-primary-success-inset': {
       value: 'none',
     },
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-internal/issues/1399

This PR updates the `light-mobile` theme to match the Polaris Mobile native flat style.

- Removes the primary gradient
- Removes the shadow bevel effect
- Applies a solid "border" around the default (secondary) button style
- Only applies the "pressed" transition movement for non-mobile screens
- Updates the font size and weight to match mobile on small screens

🌀 [Spin URL](https://admin.web.mobile-button.sam-rose.us.spin.dev/store/shop1)

### WHAT is this pull request doing?

| Desktop | Mobile |
| --- | --- |
| <img width="576" alt="desktop" src="https://github.com/Shopify/polaris/assets/11774595/4d0ead6e-3855-4bf8-9041-3e8acdffbbdf"> | <img width="576" alt="mobile" src="https://github.com/Shopify/polaris/assets/11774595/dad25a9d-c0a2-4d4c-a8e9-0a44bd86dfb2"> |


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
