### PR TITLE
[EphemeralPresenceManager] Add support for hovercard presence

### DIFF
--- a/.changeset/nervous-laws-sparkle.md
+++ b/.changeset/nervous-laws-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added support for hovercard tracking to `EphemeralPresenceManager`

--- a/polaris-react/src/components/EphemeralPresenceManager/EphemeralPresenceManager.tsx
+++ b/polaris-react/src/components/EphemeralPresenceManager/EphemeralPresenceManager.tsx
@@ -20,6 +20,7 @@ type PresenceCounter = {
 
 const defaultState = {
   tooltip: 0,
+  hovercard: 0,
 };
 
 export function EphemeralPresenceManager({


### PR DESCRIPTION
### WHY are these changes introduced?

This PR unblocks [HoverCard](https://github.com/Shopify/polaris/pull/10504) from tracking presence using the `useEphemeralPresenceManager` hook. The component and hook logic are both agnostic to the actual list of supported keys defined in the default state object, so no additional tests are needed.