### PR TITLE
[Combobox] - Fix handleChange when children changes based on input

### DIFF
--- a/.changeset/many-hairs-lay.md
+++ b/.changeset/many-hairs-lay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Combobox handles properly children that depends on external factors

--- a/.changeset/many-hairs-lay.md
+++ b/.changeset/many-hairs-lay.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Combobox handles properly children that depends on external factors
+Fixed `Combobox` not rendering `Popover` until the second firing of the `onChange` event

--- a/polaris-react/src/components/Combobox/Combobox.stories.tsx
+++ b/polaris-react/src/components/Combobox/Combobox.stories.tsx
@@ -102,6 +102,92 @@ export function Default() {
   );
 }
 
+export function WithChildrenBasedOnInput() {
+  const deselectedOptions = useMemo(
+    () => [
+      {value: 'rustic', label: 'Rustic'},
+      {value: 'antique', label: 'Antique'},
+      {value: 'vinyl', label: 'Vinyl'},
+      {value: 'vintage', label: 'Vintage'},
+      {value: 'refurbished', label: 'Refurbished'},
+    ],
+    [],
+  );
+
+  const [selectedOption, setSelectedOption] = useState();
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(deselectedOptions);
+
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
+
+      if (value === '') {
+        setOptions(deselectedOptions);
+        return;
+      }
+
+      const filterRegex = new RegExp(value, 'i');
+      const resultOptions = deselectedOptions.filter((option) =>
+        option.label.match(filterRegex),
+      );
+      setOptions(resultOptions);
+    },
+    [deselectedOptions],
+  );
+
+  const updateSelection = useCallback(
+    (selected) => {
+      const matchedOption = options.find((option) => {
+        return option.value.match(selected);
+      });
+
+      setSelectedOption(selected);
+      setInputValue((matchedOption && matchedOption.label) || '');
+    },
+    [options],
+  );
+
+  const optionsMarkup =
+    options.length > 0
+      ? options.map((option) => {
+          const {label, value} = option;
+
+          return (
+            <Listbox.Option
+              key={`${value}`}
+              value={value}
+              selected={selectedOption === value}
+              accessibilityLabel={label}
+            >
+              {label}
+            </Listbox.Option>
+          );
+        })
+      : null;
+
+  return (
+    <div style={{height: '225px'}}>
+      <Combobox
+        activator={
+          <Combobox.TextField
+            prefix={<Icon source={SearchIcon} />}
+            onChange={updateText}
+            label="Search tags"
+            labelHidden
+            value={inputValue}
+            placeholder="Search tags"
+          />
+        }
+      >
+        {inputValue.length > 0 && options.length > 0 ? (
+          <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
+        ) : null}
+      </Combobox>
+    </div>
+  );
+}
+
 export function WithManualSelection() {
   const deselectedOptions = useMemo(
     () => [

--- a/polaris-react/src/components/Combobox/Combobox.tsx
+++ b/polaris-react/src/components/Combobox/Combobox.tsx
@@ -52,7 +52,9 @@ export function Combobox({
   const [textFieldLabelId, setTextFieldLabelId] = useState<string>();
   const [listboxId, setListboxId] = useState<string>();
   const [textFieldFocused, setTextFieldFocused] = useState<boolean>(false);
-  const shouldOpen = Boolean(!popoverActive && Children.count(children) > 0);
+  const shouldOpen = !popoverActive;
+  const popoverActiveWithChildren =
+    popoverActive && Children.count(children) > 0;
   const ref = useRef<PopoverPublicAPI | null>(null);
 
   const handleClose = useCallback(() => {
@@ -151,7 +153,7 @@ export function Combobox({
   return (
     <Popover
       ref={ref}
-      active={popoverActive}
+      active={popoverActiveWithChildren}
       activator={
         <ComboboxTextFieldContext.Provider value={textFieldContextValue}>
           {activator}

--- a/polaris-react/src/components/Combobox/tests/Combobox.test.tsx
+++ b/polaris-react/src/components/Combobox/tests/Combobox.test.tsx
@@ -111,7 +111,7 @@ describe('<Combobox />', () => {
       return (
         <Combobox
           activator={
-            <TextField
+            <Combobox.TextField
               onChange={handleChange}
               label=""
               value=""
@@ -119,11 +119,14 @@ describe('<Combobox />', () => {
             />
           }
         >
-          {inputValue.length > 0 ? (
-            <Listbox>
-              <Listbox.Option accessibilityLabel="Option 1" value="option1" />
-            </Listbox>
-          ) : null}
+          {
+            // eslint-disable-next-line jest/no-if
+            inputValue.length > 0 ? (
+              <Listbox>
+                <Listbox.Option accessibilityLabel="Option 1" value="option1" />
+              </Listbox>
+            ) : null
+          }
         </Combobox>
       );
     }

--- a/polaris-react/src/components/Combobox/tests/Combobox.test.tsx
+++ b/polaris-react/src/components/Combobox/tests/Combobox.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {TextField} from '../../TextField';
@@ -94,6 +94,43 @@ describe('<Combobox />', () => {
     );
 
     triggerFocus(combobox);
+
+    expect(combobox).toContainReactComponent(Popover, {
+      active: true,
+    });
+  });
+
+  it('renders an active Popover when the text input has content and children depends on that text input', () => {
+    function ComboboxWithHandledChange() {
+      const handleChange = (value: string) => {
+        setInputValue(value);
+      };
+
+      const [inputValue, setInputValue] = useState('');
+
+      return (
+        <Combobox
+          activator={
+            <TextField
+              onChange={handleChange}
+              label=""
+              value=""
+              autoComplete="off"
+            />
+          }
+        >
+          {inputValue.length > 0 ? (
+            <Listbox>
+              <Listbox.Option accessibilityLabel="Option 1" value="option1" />
+            </Listbox>
+          ) : null}
+        </Combobox>
+      );
+    }
+
+    const combobox = mountWithApp(<ComboboxWithHandledChange />);
+
+    combobox.find(TextField)?.trigger('onChange', 'value');
 
     expect(combobox).toContainReactComponent(Popover, {
       active: true,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

When a Combobox has children that is rendered based on an input change, our previous implementation failed to mark the popover as active. This was due to the fact that the `handleChange` was triggered before the re render of the parent component, and at that point the `Combobox` is unaware of the "future" children.

As a small example: 

```
    function ComboboxWithHandledChange() {
      const handleChange = (value: string) => {
        setInputValue(value);
      };

      const [inputValue, setInputValue] = useState('');

      return (
        <Combobox
          activator={
            <Combobox.TextField
              onChange={handleChange}
              label=""
              value=""
              autoComplete="off"
            />
          }
        >
          {inputValue.length > 0 ? (
            <Listbox>
              <Listbox.Option accessibilityLabel="Option 1" value="option1" />
            </Listbox>
          ) : null}
        </Combobox>
      );
    }
```

1. Initially the input is empty, hence the `Combobox` has no children
2. The user types something, let's say "t"
3. The callback `handleChange` of the `Combobox` is called, which checks the value `shouldOpen` -> `Boolean(!popoverActive && Children.count(children) > 0)`. At this point the parent component has not been re-rendered, so the children is still `null` and not a `Listbox`; this results on `popoverActive` not being set to true.
4. The popover is then not marked as `active`.
5. After the parent re-renders, the `Combobox` re-renders again but as `popoverActive` is set to false, the `Popover` is not marked as `active`.

With the fix, we have changed `shouldOpen` to assert if there's been a callback call (`handleChange` or `handleFocus`) and then in rendering time, we set the `active` property of the `Popover` based on `shouldOpen` has been set and if there's any Children. 

### WHAT is this pull request doing?

This PR addresses the aforementioned issue, changing the logic of `shouldOpen` to just ensure if the popover is currently active or not. Then when rendering the `Popover` we ensure that `shouldOpen` has been called (which has set `popoverActive` to true) and that there's children passed to the `Combobox`.

### How to 🎩

- Check the new Unit Test added
- Run Storybook and with this path: `?path=/story/all-components-combobox--with-children-based-on-input`

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
