### PR TITLE
[FormLayout.Item] Fix inputs overflowing viewport on mobile when text is enlarged

### DIFF
--- a/.changeset/seven-ways-agree.md
+++ b/.changeset/seven-ways-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `FormLayout.Item` overflowing viewport at xs breakpoint when user settings enlarge text size

--- a/polaris-react/src/components/FormLayout/FormLayout.module.scss
+++ b/polaris-react/src/components/FormLayout/FormLayout.module.scss
@@ -8,6 +8,10 @@ $item-horizontal-spacing: var(--p-space-300);
 
   &.grouped {
     min-width: $item-min-size;
+
+    @media (--p-breakpoints-xs-only) {
+      min-width: 100%;
+    }
   }
 
   &.condensed {


### PR DESCRIPTION
### WHY are these changes introduced?

This PR fixes a bug found during an accessibility audit of the Shopify native mobile apps. Currently, inputs composed within a FormLayout or FormLayout.Group overflow the viewport when text is enlarged on a small screen device (replicatable in the browser, see instructions in the tophatting section).

### WHAT is this pull request doing?

This PR ensures the min-width is flexible to the viewport size regardless of the pixel value of 1rem (which increases when user text/font size settings are enlarged).

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] ~Updated the component's `README.md` with documentation changes~
- [ ] ~[Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide~
