### PR TITLE
Remove .Polaris-Summer-Editions-2023 class from html element

### DIFF
--- a/.changeset/calm-lobsters-study.md
+++ b/.changeset/calm-lobsters-study.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Remove .Polaris-Summer-Editions-2023 class from html element.

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -22,10 +22,7 @@ import {
 } from '../../utilities/sticky-manager';
 import {LinkContext} from '../../utilities/link';
 import type {LinkLikeComponent} from '../../utilities/link';
-import {
-  classNamePolarisSummerEditions2023,
-  FeaturesContext,
-} from '../../utilities/features';
+import {FeaturesContext} from '../../utilities/features';
 import type {FeaturesConfig} from '../../utilities/features';
 
 import './AppProvider.scss';
@@ -157,8 +154,6 @@ export class AppProvider extends Component<AppProviderProps, State> {
         themeName === activeThemeName,
       );
     });
-
-    document.documentElement.classList.add(classNamePolarisSummerEditions2023);
   };
 
   getThemeName = (): ThemeName => this.props.theme ?? themeNameDefault;

--- a/polaris-react/src/utilities/features/context.ts
+++ b/polaris-react/src/utilities/features/context.ts
@@ -2,9 +2,6 @@ import {createContext} from 'react';
 
 import type {FeaturesConfig} from './types';
 
-export const classNamePolarisSummerEditions2023 =
-  'Polaris-Summer-Editions-2023';
-
 export const FeaturesContext = createContext<FeaturesConfig | undefined>(
   undefined,
 );

--- a/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v11-to-v12.mdx
@@ -2895,3 +2895,8 @@ The following component's children cannot be above the bevel's `z-index` elevati
 
 Custom elements that were styled to look like the previous Polaris design language will need to be updated.
 Take the opportunity to put custom styles and components on mainline Polaris using our [components](/components) and [tokens](/tokens/color).
+
+### `.Polaris-Summer-Editions-2023` class
+
+The `<html>` element no longer receives the `.Polaris-Summer-Editions-2023` class.
+If your styles rely on this class as part of a CSS selector, you can safely remove it.


### PR DESCRIPTION
~~**DO NOT MERGE**: See the associated ticket for details on when this can be merged.~~

Cleaning up some left-over feature flag code that is no longer in use since the [v12 release](https://github.com/Shopify/polaris/releases/tag/%40shopify%2Fpolaris%4012.0.0).