### PR TITLE
Remove references to se23/summer editions 2023/etc

### DIFF
--- a/.changeset/silent-rats-roll.md
+++ b/.changeset/silent-rats-roll.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Remove references to se23/summer editions 2023/etc.

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -198,7 +198,7 @@ export function All() {
                 </InlineStack>
               </BlockStack>
             )}
-            {/* TODO: Re-enable the following examples when designs are available (post se23) */}
+            {/* TODO: Re-enable the following examples when designs are available (see https://github.com/Shopify/polaris-internal/issues/1411) */}
             {/* <BlockStack gap="200">
               <Text as="h2" variant="headingSm">
                 Tone with icon only

--- a/polaris-react/src/styles/_common.scss
+++ b/polaris-react/src/styles/_common.scss
@@ -18,11 +18,3 @@
 @import './shared/interaction-state';
 
 @import '../../../node_modules/@shopify/polaris-tokens/dist/scss/media-queries';
-
-// Ideally we'd use :where here so we don't introduce higher specificity with the
-// tag+attribute selector.
-// However, we're still supporting iOS 12 for embedded web views in some apps, which
-// unfortunately doesn't support :where https://caniuse.com/?search=%3Awhere
-
-// 🚨 WARNING: Refrain from using the `se23` flag, this will be deprecated post v12.
-$se23: 'html[class~="Polaris-Summer-Editions-2023"]';


### PR DESCRIPTION
Confirmed with the following regex: `[sS](ummer)?([-_ ])?[eE](ditions?)?([-_ ])?2(02)?3`.