### PR TITLE
Update `light-mobile` theme shadow bevel and Card gap spacing

### DIFF
--- a/.changeset/pretty-olives-rhyme.md
+++ b/.changeset/pretty-olives-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'@shopify/polaris-tokens': minor
+---
+
+Removed the Card shadow bevel and decreased Card gap spacing for the mobile theme

--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -41,11 +41,13 @@ export const Card = ({
 }: CardProps) => {
   const breakpoints = useBreakpoints();
   const defaultBorderRadius: BorderRadiusAliasOrScale = '300';
+  const isSmUp = Boolean(breakpoints.smUp);
   const hasBorderRadius = Boolean(breakpoints[`${roundedAbove}Up`]);
 
   return (
     <WithinContentContext.Provider value>
       <ShadowBevel
+        bevel={isSmUp}
         boxShadow="100"
         borderRadius={hasBorderRadius ? defaultBorderRadius : '0'}
         zIndex="32"

--- a/polaris-tokens/src/themes/light-mobile.ts
+++ b/polaris-tokens/src/themes/light-mobile.ts
@@ -3,6 +3,19 @@ import {createVar} from '../utils';
 import {createMetaTheme, createMetaThemePartial} from './utils';
 
 export const metaThemeLightMobilePartial = createMetaThemePartial({
+  shadow: {
+    'shadow-100': {
+      value: 'none',
+    },
+    'shadow-bevel-100': {
+      value: 'none',
+    },
+  },
+  space: {
+    'space-card-gap': {
+      value: createVar('space-200'),
+    },
+  },
   text: {
     // heading-2xl
     'text-heading-2xl-font-size': {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1397

Related to https://github.com/Shopify/polaris-internal/issues/1398

### WHAT is this pull request doing?

- Reduces the `spacing-card-gap` from `16px` to `8px` for Shopify Mobile
- Removes the Card bevel by setting:
  - `shadow-100` to `none`
  - `shadow-bevel-100` to `none`

I was a bit hesitant to override the shadow scale tokens. However, this may make sense in this case given Mobile doesn't use shadows.

We could create a separate theme token `--p-shadow-card` and `--p-shadow-card-bevel` as an alternative.

This PR will affect other components that also use `shadow-100`:

- Data Table (sticky header)
- Fullscreen Bar
- Index Table (sticky header)
- Legacy Card
- Top Bar

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the componeent's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
