### PR TITLE
[Page] Ensure subtitle has sensible max-width

### DIFF
--- a/.changeset/shiny-days-jam.md
+++ b/.changeset/shiny-days-jam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated the subtitle of the Page Header to have a sensible max-width

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -328,6 +328,7 @@ export function WithActionGroupsAndActions() {
   return (
     <Page
       title="List of products"
+      subtitle="Brow Code Professional USA & Canada, Brow Code Professional New Zealand, and 8 other stores have charges on this bill"
       secondaryActions={[
         {
           content: 'Send test',

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.module.scss
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.module.scss
@@ -33,6 +33,7 @@
 .SubTitle {
   margin-top: var(--p-space-050);
   color: var(--p-color-text-secondary);
+  max-width: 45ch;
 
   &.SubtitleCompact {
     margin-top: var(--p-space-050);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a visual bug in the Page component where if a really long subtitle is passed, it can push out the Page actions. We shouldn't really be having lines of text this long as it is bad for readability. We've set the max-width of the subtitle to `45ch` which is at the lower end of the recommended line length.

### WHAT is this pull request doing?
Before:
<img width="1624" alt="Screenshot 2024-02-07 at 09 37 43" src="https://github.com/Shopify/polaris/assets/2562596/2c943777-f1de-4232-97ff-49c779a5c947">

After:
<img width="1624" alt="Screenshot 2024-02-07 at 09 37 32" src="https://github.com/Shopify/polaris/assets/2562596/3ead2142-e0e5-461e-aa16-2ea3ab402080">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
