### PR TITLE
[IndexTable] Fix mac os scrollbar bug

### DIFF
--- a/.changeset/little-pugs-teach.md
+++ b/.changeset/little-pugs-teach.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed an issue where scrollbars weren't showing up in IndexTable on mac os when show when scrolling preference is selected

--- a/polaris-react/src/components/IndexTable/IndexTable.module.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.module.scss
@@ -11,6 +11,7 @@
   // stylelint-enable
   position: relative;
   border-radius: 0;
+  scrollbar-color: auto;
 
   @media (--p-breakpoints-sm-up) {
     border-radius: inherit;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes a bug (already patched for web) where the scrollbars weren't showing up when 'Show scroll bars when scrolling' was selected. 

![image](https://github.com/Shopify/polaris/assets/6844391/23c9466e-acad-4bf8-86d0-facea50b85f0)

### WHAT is this pull request doing?

Resets the scrollbar colors. I looked for a more global solution but it seems like this component is the only one affected and our stories don't have access to app provider / frame css so it might be awkward to add the reset there
