### PR TITLE
Rename `button-bg-gradient-primary` token to `button-gradient-bg-fill`

### DIFF
--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -126,7 +126,7 @@
 
 // VARIANTS
 .variantPrimary {
-  --pc-button-bg-gradient: var(--p-color-button-bg-gradient-primary);
+  --pc-button-bg-gradient: var(--p-color-button-gradient-bg-fill);
   --pc-button-box-shadow: var(--p-shadow-button-primary);
   --pc-button-box-shadow_active: var(--p-shadow-button-primary-inset);
   --pc-button-bg: var(--pc-button-bg-gradient), var(--p-color-bg-fill-brand);

--- a/polaris-tokens/src/themes/base/color.ts
+++ b/polaris-tokens/src/themes/base/color.ts
@@ -107,7 +107,7 @@ export type ColorBackgroundAlias =
   | 'avatar-three-bg-fill'
   | 'avatar-two-bg-fill'
   | 'backdrop-bg'
-  | 'button-bg-gradient-primary'
+  | 'button-gradient-bg-fill'
   | 'checkbox-bg-surface-disabled'
   | 'input-bg-surface-active'
   | 'input-bg-surface-hover'
@@ -1132,7 +1132,7 @@ export const color: {
   'color-backdrop-bg': {
     value: colors.blackAlpha[14],
   },
-  'color-button-bg-gradient-primary': {
+  'color-button-gradient-bg-fill': {
     value:
       'linear-gradient(180deg, rgba(48, 48, 48, 0) 63.53%, rgba(255, 255, 255, 0.15) 100%)',
   },

--- a/polaris-tokens/src/themes/light-mobile.ts
+++ b/polaris-tokens/src/themes/light-mobile.ts
@@ -8,7 +8,7 @@ const buttonShadow = `0 0 0 ${createVar('border-width-025')} ${createVar(
 
 export const metaThemeLightMobilePartial = createMetaThemePartial({
   color: {
-    'color-button-bg-gradient-primary': {
+    'color-button-gradient-bg-fill': {
       value: 'none',
     },
   },


### PR DESCRIPTION
This fixes the button token to follow our [semantic token naming convention](https://polaris.shopify.com/design/colors/color-tokens#semantic-tokens).