### PR TITLE
[IndexTable] Only run sticky logic if we have a defined rootBounds object 

### DIFF
--- a/.changeset/moody-worms-search.md
+++ b/.changeset/moody-worms-search.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated logic in use-is-select-all-actions-sticky logic to not set any sticky behaviour if we do not have access to the root element

--- a/.changeset/moody-worms-search.md
+++ b/.changeset/moody-worms-search.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Updated logic in use-is-select-all-actions-sticky logic to not set any sticky behaviour if we do not have access to the root element
+Updated `useIsSelectAllActionsSticky` logic to not set any sticky behaviour if we do not have access to the root element

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -31,9 +31,6 @@ import {IndexTable} from './IndexTable';
 
 export default {
   component: IndexTable,
-  parameters: {
-    layout: 'fullscreen',
-  },
 } as ComponentMeta<typeof IndexTable>;
 
 export function Default() {

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -6900,3 +6900,100 @@ export function WithinAModal() {
     </Frame>
   );
 }
+
+export function WithUnmountingTable() {
+  const [isShowing, setIsShowing] = useState(true);
+  const orders = [
+    {
+      id: '1020',
+      order: '#1020',
+      date: 'Jul 20 at 4:34pm',
+      customer: 'Jaydon Stanton',
+      total: '$969.44',
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+    {
+      id: '1019',
+      order: '#1019',
+      date: 'Jul 20 at 3:46pm',
+      customer: 'Ruben Westerfelt',
+      total: '$701.19',
+      paymentStatus: <Badge progress="partiallyComplete">Partially paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+    {
+      id: '1018',
+      order: '#1018',
+      date: 'Jul 20 at 3.44pm',
+      customer: 'Leo Carder',
+      total: '$798.24',
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+  ];
+  const resourceName = {
+    singular: 'order',
+    plural: 'orders',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(orders);
+
+  const rowMarkup = orders.map(
+    (
+      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+      index,
+    ) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {order}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{date}</IndexTable.Cell>
+        <IndexTable.Cell>{customer}</IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <>
+      <button onClick={() => setIsShowing(!isShowing)}>Toggle</button>
+      {isShowing && (
+        <LegacyCard>
+          <IndexTable
+            resourceName={resourceName}
+            itemCount={orders.length}
+            selectedItemsCount={
+              allResourcesSelected ? 'All' : selectedResources.length
+            }
+            onSelectionChange={handleSelectionChange}
+            headings={[
+              {title: 'Order'},
+              {title: 'Date'},
+              {title: 'Customer'},
+              {title: 'Total', alignment: 'end'},
+              {title: 'Payment status'},
+              {title: 'Fulfillment status'},
+            ]}
+          >
+            {rowMarkup}
+          </IndexTable>
+        </LegacyCard>
+      )}
+    </>
+  );
+}

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -31,6 +31,9 @@ import {IndexTable} from './IndexTable';
 
 export default {
   component: IndexTable,
+  parameters: {
+    layout: 'fullscreen',
+  },
 } as ComponentMeta<typeof IndexTable>;
 
 export function Default() {
@@ -6971,7 +6974,6 @@ export function WithUnmountingTable() {
 
   return (
     <>
-      <button onClick={() => setIsShowing(!isShowing)}>Toggle</button>
       {isShowing && (
         <LegacyCard>
           <IndexTable
@@ -6994,6 +6996,7 @@ export function WithUnmountingTable() {
           </IndexTable>
         </LegacyCard>
       )}
+      <button onClick={() => setIsShowing(!isShowing)}>Toggle</button>
     </>
   );
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -653,6 +653,14 @@ function IndexTableBase({
   const promotedActions = shouldShowActions ? promotedBulkActions : [];
   const actions = shouldShowActions ? bulkActions : [];
 
+  // eslint-disable-next-line no-console
+  console.log({
+    selectAllActionsOffsetBottom,
+    isSelectAllActionsSticky,
+    tableMeasurerRef,
+    selectAllActionsIntersectionRef,
+  });
+
   const selectAllActionsMarkup =
     shouldShowActions && !condensed ? (
       <div

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -653,16 +653,6 @@ function IndexTableBase({
   const promotedActions = shouldShowActions ? promotedBulkActions : [];
   const actions = shouldShowActions ? bulkActions : [];
 
-  // eslint-disable-next-line no-console
-  console.log({
-    selectAllActionsOffsetBottom,
-    isSelectAllActionsSticky,
-    tableMeasurerRef,
-    selectAllActionsIntersectionRef,
-    selectAllActionsAbsoluteOffset,
-    isScrolledPastTop,
-  });
-
   const selectAllActionsMarkup =
     shouldShowActions && !condensed ? (
       <div

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -659,6 +659,8 @@ function IndexTableBase({
     isSelectAllActionsSticky,
     tableMeasurerRef,
     selectAllActionsIntersectionRef,
+    selectAllActionsAbsoluteOffset,
+    isScrolledPastTop,
   });
 
   const selectAllActionsMarkup =

--- a/polaris-react/src/components/SelectAllActions/hooks/tests/use-is-select-all-actions-sticky.test.tsx
+++ b/polaris-react/src/components/SelectAllActions/hooks/tests/use-is-select-all-actions-sticky.test.tsx
@@ -158,6 +158,84 @@ describe('useIsSelectAllActionsSticky', () => {
     });
   });
 
+  describe('when the table is off screen', () => {
+    it('will set isSelectAllActionsSticky to true if we are intersecting', () => {
+      const component = mountWithApp(<Component selectMode />);
+
+      const table = component.find('div');
+
+      component.act(() => {
+        intersectionObserver.simulate({
+          isIntersecting: true,
+          target: table!.domNode!,
+          boundingClientRect: {
+            top: 100,
+            height: 100,
+            width: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            x: 0,
+            y: 0,
+            toJSON: jest.fn(),
+          },
+          rootBounds: {
+            height: 150,
+            top: 0,
+            width: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            x: 0,
+            y: 0,
+            toJSON: jest.fn(),
+          },
+        });
+      });
+
+      const result = component.find('p')?.text();
+      expect(result).toBe('true');
+    });
+
+    it('will not set isSelectAllActionsSticky to true if we are intersecting but the rootBounds is large enough', () => {
+      const component = mountWithApp(<Component selectMode />);
+
+      const table = component.find('div');
+
+      component.act(() => {
+        intersectionObserver.simulate({
+          isIntersecting: true,
+          target: table!.domNode!,
+          boundingClientRect: {
+            top: 100,
+            height: 100,
+            width: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            x: 0,
+            y: 0,
+            toJSON: jest.fn(),
+          },
+          rootBounds: {
+            height: 250,
+            top: 0,
+            width: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            x: 0,
+            y: 0,
+            toJSON: jest.fn(),
+          },
+        });
+      });
+
+      const result = component.find('p')?.text();
+      expect(result).toBe('false');
+    });
+  });
+
   function setGetComputedStyle({
     overflow,
     overflowX,

--- a/polaris-react/src/components/SelectAllActions/hooks/use-is-select-all-actions-sticky.ts
+++ b/polaris-react/src/components/SelectAllActions/hooks/use-is-select-all-actions-sticky.ts
@@ -71,6 +71,10 @@ export function useIsSelectAllActionsSticky({
 
   const handleIntersect = (entries: IntersectionObserverEntry[]) => {
     entries.forEach((entry: IntersectionObserverEntry) => {
+      console.log(
+        'setting is sticky from handleIntersect function',
+        !entry.isIntersecting,
+      );
       setIsSticky(!entry.isIntersecting);
     });
   };
@@ -85,6 +89,10 @@ export function useIsSelectAllActionsSticky({
         entry.boundingClientRect.top + entry.boundingClientRect.height >
         rootBoundsHeight;
       if (hasTableOffscreen) {
+        console.log(
+          'settings from handleTableIntersect with table being offscreen',
+          entry,
+        );
         setIsSticky(entry.isIntersecting);
       }
       setIsScrolledPastTop(isScrolledPastTop);

--- a/polaris-react/src/components/SelectAllActions/hooks/use-is-select-all-actions-sticky.ts
+++ b/polaris-react/src/components/SelectAllActions/hooks/use-is-select-all-actions-sticky.ts
@@ -71,20 +71,12 @@ export function useIsSelectAllActionsSticky({
 
   const handleIntersect = (entries: IntersectionObserverEntry[]) => {
     entries.forEach((entry: IntersectionObserverEntry) => {
-      console.log(
-        'setting is sticky from handleIntersect function',
-        !entry.isIntersecting,
-      );
       setIsSticky(!entry.isIntersecting);
     });
   };
 
   const handleTableIntersect = (entries: IntersectionObserverEntry[]) => {
     entries.forEach((entry: IntersectionObserverEntry) => {
-      console.log('handling table intersect', entry);
-      if (!entry.rootBounds) {
-        return;
-      }
       const isScrolledPastTop =
         entry.boundingClientRect.top > 0 && !entry.isIntersecting;
       const rootBoundsHeight = entry.rootBounds?.height || 0;
@@ -92,11 +84,7 @@ export function useIsSelectAllActionsSticky({
       const hasTableOffscreen =
         entry.boundingClientRect.top + entry.boundingClientRect.height >
         rootBoundsHeight;
-      if (hasTableOffscreen) {
-        console.log(
-          'settings from handleTableIntersect with table being offscreen',
-          entry,
-        );
+      if (hasTableOffscreen && entry.rootBounds) {
         setIsSticky(entry.isIntersecting);
       }
       setIsScrolledPastTop(isScrolledPastTop);

--- a/polaris-react/src/components/SelectAllActions/hooks/use-is-select-all-actions-sticky.ts
+++ b/polaris-react/src/components/SelectAllActions/hooks/use-is-select-all-actions-sticky.ts
@@ -81,6 +81,10 @@ export function useIsSelectAllActionsSticky({
 
   const handleTableIntersect = (entries: IntersectionObserverEntry[]) => {
     entries.forEach((entry: IntersectionObserverEntry) => {
+      console.log('handling table intersect', entry);
+      if (!entry.rootBounds) {
+        return;
+      }
       const isScrolledPastTop =
         entry.boundingClientRect.top > 0 && !entry.isIntersecting;
       const rootBoundsHeight = entry.rootBounds?.height || 0;


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes when rendering IndexTables within iframes, the `rootBounds` object on the `IntersectionObserverEntry` entity can be `null`, rather than an object containing dimensions of the root itself. We were defaulting the `entry.rootBounds.height` value to 0 if it didn't exist. This was causing these IndexTables to incorrectly calculate whether the SelectAllActions was sticky or not. We should not change the sticky state of the SelectAllActions if we have no `rootBounds` object as we wouldn't be able to accurately determine the sticky state.

### How to 🎩

Codesandbox link: https://codesandbox.io/p/sandbox/lucid-cherry-pc5tyr?file=%2Fpackage.json%3A5%2C23

Try changing the Polaris version to `latest` in `package.json` and toggle the IndexTable a few times to see the issue happening. Then confirm that with the snapshot it no longer happens.

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
