### PR TITLE
Update dropzone container background color

### DIFF
--- a/.changeset/weak-points-kick.md
+++ b/.changeset/weak-points-kick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Update dropzone container background color when no Outline

--- a/polaris-react/src/components/DropZone/DropZone.module.scss
+++ b/polaris-react/src/components/DropZone/DropZone.module.scss
@@ -59,6 +59,10 @@ $dropzone-stacking-order: (
   &:hover {
     outline: var(--p-border-width-025) solid transparent;
   }
+
+  &.noOutline {
+    background-color: transparent;
+  }
 }
 
 .hasOutline {

--- a/polaris-react/src/components/DropZone/DropZone.tsx
+++ b/polaris-react/src/components/DropZone/DropZone.tsx
@@ -326,6 +326,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
   const classes = classNames(
     styles.DropZone,
     outline && styles.hasOutline,
+    !outline && styles.noOutline,
     focused && styles.focused,
     (active || dragging) && styles.isDragging,
     disabled && styles.isDisabled,


### PR DESCRIPTION
### WHY are these changes introduced?
When the DropZone component is used without an outline etc.., it defaults to a faint background color (`--p-color-input-bg-surface`). This works well when there are no files and the placeholder occupies the same space as the DropZone. However, when files are present, the DropZone and placeholder may not be the same size. This discrepancy results in the faint background color becoming visible, leading to the UI looking off.

<img width="1800" alt="Screenshot 2024-02-12 at 9 49 09 PM" src="https://github.com/Shopify/polaris/assets/41344212/c2c53c82-63c5-4c68-9ced-5175f333f4fa">



### WHAT is this pull request doing?
This pull request primarily focuses on improving the UI of the `DropZone` component. The changes include a new background color for the dropzone container and the addition of a `noOutline` class to handle the new styling. 

* [`polaris-react/src/components/DropZone/DropZone.module.scss`](diffhunk://#diff-9e3485b7ce88cb47f090c0169f9c2767f4feb0a882d1571e62278f12c469722fR62-R65): Added a new `noOutline` class which sets the background color to `transparent`.
* [`polaris-react/src/components/DropZone/DropZone.tsx`](diffhunk://#diff-1ada6dc0086b97d3a426d17fd4df3681b33b21f1a9af9a096702e72d10f4a60cR329): Modified the `classNames` function in `DropZone` to include the new `noOutline` class when `outline` is `false`.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
