### PR TITLE
[BlockStack] Add `id` prop to the returned component

### DIFF
--- a/.changeset/wild-planets-confess.md
+++ b/.changeset/wild-planets-confess.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Add missing `id` prop to the `<BlockStack />`.
+Passed missing `id` prop to the root element of `BlockStack`

--- a/.changeset/wild-planets-confess.md
+++ b/.changeset/wild-planets-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Add missing `id` prop to the `<BlockStack />`.

--- a/polaris-react/src/components/BlockStack/BlockStack.tsx
+++ b/polaris-react/src/components/BlockStack/BlockStack.tsx
@@ -76,6 +76,7 @@ export const BlockStack = ({
     as,
     {
       className,
+      id,
       style: sanitizeCustomProperties(style),
       ...restProps,
     },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #11196 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
It seems we missed returning the `id` prop when we created the final element with the React `createElement` API.

```js
export const BlockStack = ({
  as = 'div',
  children,
  align,
  inlineAlign,
  gap,
  id,
  reverseOrder = false,
  ...restProps
}: BlockStackProps) => {
  ...

  return React.createElement(
    as,
    {
      className,
      // Missed the id prop in the final return component
      style: sanitizeCustomProperties(style),
      ...restProps,
    },
    children,
  );
};
```

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
