### PR TITLE
The dropzone's small size has been adjusted to match the small size of the thumbnail.

### DIFF
--- a/.changeset/slimy-jokes-press.md
+++ b/.changeset/slimy-jokes-press.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated DropZone minimum size from 50px to 40px to fit within a small Thumbnail

--- a/polaris-react/src/components/DropZone/DropZone.module.scss
+++ b/polaris-react/src/components/DropZone/DropZone.module.scss
@@ -3,7 +3,7 @@
 $dropzone-border-style: dashed;
 $dropzone-min-height-large: 120px;
 $dropzone-min-height-medium: 100px;
-$dropzone-min-height-small: 50px;
+$dropzone-min-height-small: 40px;
 
 $dropzone-stacking-order: (
   outline: 29,

--- a/polaris-react/src/components/DropZone/DropZone.module.scss
+++ b/polaris-react/src/components/DropZone/DropZone.module.scss
@@ -111,6 +111,13 @@ $dropzone-stacking-order: (
   padding: 0;
   align-items: center;
   min-height: $dropzone-min-height-small;
+
+  /* This creates a square with a 1:1 aspect ratio */
+  &::before {
+    content: '';
+    /* stylelint-disable-next-line -- set padding top to full width of the element to maintain 1:1 aspect ratio */
+    padding-top: 100%;
+  }
 }
 
 .measuring {

--- a/polaris-react/src/components/DropZone/DropZone.stories.tsx
+++ b/polaris-react/src/components/DropZone/DropZone.stories.tsx
@@ -381,8 +381,20 @@ export function SmallSized() {
             Small sized Drop zone
           </Text>
         </div>
-        <div style={{width: 50, height: 50}}>
+        <div style={{width: 40, height: 40}}>
           <DropZone>
+            <DropZone.FileUpload />
+          </DropZone>
+        </div>
+      </BlockStack>
+      <BlockStack gap="200">
+        <div>
+          <Text as="h2" variant="headingMd">
+            Small sized Drop zone without outline
+          </Text>
+        </div>
+        <div style={{width: 40, height: 40}}>
+          <DropZone outline={false}>
             <DropZone.FileUpload />
           </DropZone>
         </div>
@@ -394,7 +406,7 @@ export function SmallSized() {
           </Text>
           <Text as="p">Drag file in to see error state</Text>
         </div>
-        <div style={{width: 50, height: 50}}>
+        <div style={{width: 40, height: 40}}>
           <DropZone error>
             <DropZone.FileUpload />
           </DropZone>
@@ -406,7 +418,7 @@ export function SmallSized() {
             Small sized Drop zone with disabled state
           </Text>
         </div>
-        <div style={{width: 50, height: 50}}>
+        <div style={{width: 40, height: 40}}>
           <DropZone disabled>
             <DropZone.FileUpload />
           </DropZone>

--- a/polaris-react/src/components/DropZone/DropZone.stories.tsx
+++ b/polaris-react/src/components/DropZone/DropZone.stories.tsx
@@ -376,21 +376,10 @@ export function SmallSized() {
   return (
     <BlockStack gap="400">
       <BlockStack gap="200">
-        <div>
-          <Text as="h2" variant="headingMd">
-            Small sized Drop zone (50px)
-          </Text>
-        </div>
-        <div style={{width: 50, height: 50}}>
-          <DropZone>
-            <DropZone.FileUpload />
-          </DropZone>
-        </div>
-        <div>
-          <Text as="h2" variant="headingMd">
-            Small sized Drop zone (40px)
-          </Text>
-        </div>
+        <Text as="h2" variant="headingMd">
+          Small sized Drop zone (40px)
+        </Text>
+
         <div style={{width: 40, height: 40}}>
           <DropZone>
             <DropZone.FileUpload />
@@ -398,11 +387,10 @@ export function SmallSized() {
         </div>
       </BlockStack>
       <BlockStack gap="200">
-        <div>
-          <Text as="h2" variant="headingMd">
-            Small sized Drop zone without outline
-          </Text>
-        </div>
+        <Text as="h2" variant="headingMd">
+          Small sized Drop zone without outline
+        </Text>
+
         <div style={{width: 40, height: 40}}>
           <DropZone outline={false}>
             <DropZone.FileUpload />
@@ -410,12 +398,11 @@ export function SmallSized() {
         </div>
       </BlockStack>
       <BlockStack gap="200">
-        <div>
-          <Text as="h2" variant="headingMd">
-            Small sized Drop zone with error
-          </Text>
-          <Text as="p">Drag file in to see error state</Text>
-        </div>
+        <Text as="h2" variant="headingMd">
+          Small sized Drop zone with error
+        </Text>
+        <Text as="p">Drag file in to see error state</Text>
+
         <div style={{width: 40, height: 40}}>
           <DropZone error>
             <DropZone.FileUpload />
@@ -423,11 +410,10 @@ export function SmallSized() {
         </div>
       </BlockStack>
       <BlockStack gap="200">
-        <div>
-          <Text as="h2" variant="headingMd">
-            Small sized Drop zone with disabled state
-          </Text>
-        </div>
+        <Text as="h2" variant="headingMd">
+          Small sized Drop zone with disabled state
+        </Text>
+
         <div style={{width: 40, height: 40}}>
           <DropZone disabled>
             <DropZone.FileUpload />

--- a/polaris-react/src/components/DropZone/DropZone.stories.tsx
+++ b/polaris-react/src/components/DropZone/DropZone.stories.tsx
@@ -378,7 +378,17 @@ export function SmallSized() {
       <BlockStack gap="200">
         <div>
           <Text as="h2" variant="headingMd">
-            Small sized Drop zone
+            Small sized Drop zone (50px)
+          </Text>
+        </div>
+        <div style={{width: 50, height: 50}}>
+          <DropZone>
+            <DropZone.FileUpload />
+          </DropZone>
+        </div>
+        <div>
+          <Text as="h2" variant="headingMd">
+            Small sized Drop zone (40px)
           </Text>
         </div>
         <div style={{width: 40, height: 40}}>

--- a/polaris-react/src/components/DropZone/components/FileUpload/FileUpload.module.scss
+++ b/polaris-react/src/components/DropZone/components/FileUpload/FileUpload.module.scss
@@ -14,7 +14,7 @@
 }
 
 .small {
-  padding: var(--p-space-300);
+  padding: var(--p-space-200);
 }
 
 .FileUpload img {

--- a/polaris.shopify.com/pages/examples/drop-zone-small-sized.tsx
+++ b/polaris.shopify.com/pages/examples/drop-zone-small-sized.tsx
@@ -4,7 +4,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function DropZoneExample() {
   return (
-    <div style={{width: 50, height: 50}}>
+    <div style={{width: 40, height: 40}}>
       <DropZone>
         <DropZone.FileUpload />
       </DropZone>


### PR DESCRIPTION
While working on new Variants card on PDP, I've noticed  that [Drop zone](https://polaris.shopify.com/components/selection-and-input/drop-zone?example=drop-zone-small-sized) automatically calculates the size of the node it’s being applied and defines wether it should be Large/Medium/Small sized drop zone. The problem I faced - it sets $dropzone-min-height-small: 50px; which doesn’t work for thumbnails of size "small", as they have a height of 40px (--p-height-1000). 

I considered several possible solutions, suggested in thread [here](https://shopify.slack.com/archives/C4Y8N30KD/p1707762462537299):
1. Ship changes to Polaris DropZone and prevent automatically calculates the size of area so it can be regulated on consumer level by setting height and width of parent block. But since Polaris drop zone is being used across 37 files within the Admin and it's size not always is regulated by parent block, like for example ([UploadApplePayCertificateModals](https://github.com/Shopify/web/blob/4a0de2c34d7cb55ad499e8e2e60d5e463bb5c61d/app/sections/Apps/AppManage/components/AppCapabilities/components/StorefrontApiIntegration/components/IOSBuySDKCard/ApplePay/components/UploadApplePayCertificateModals/UploadApplePayCertificateModals.tsx#L164), [ImagePicker](https://github.com/Shopify/web/blob/4a0de2c34d7cb55ad499e8e2e60d5e463bb5c61d/app/sections/Checkout/CheckoutEditor/components/Workspace/components/Branding/components/BrandingSettingRenderer/components/BrandingImageSetting/components/ImagePicker/ImagePicker.tsx#L160), etc), also even if there is already fixed height for parent block, places like this should be revised across the Admin too, because as soon as we remove `min-height `- some of the DropZones could be broken until we update `web` code. Example in sandbox: https://screenshot.click/13-45-xs5hg-mkfsk.mp4

2. Second possible solutions I can see here - adjust dropzone's small size to be the same as [thumbnail](https://polaris.shopify.com/components/images-and-icons/thumbnail) small size, by setting it's min-height to 40px. It seems to be a change for 10 px, but now it's going to fit small sized thumbnails - **Proposal Implemented in this PR**

Resolves issue: https://github.com/Shopify/temp-project-mover-syfiawoo-20250331132715/issues/649

### WHY are these changes introduced?

The dropzone's small size has been adjusted to match the small size of the thumbnail.


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩
How it was before:
![image](https://github.com/Shopify/polaris/assets/104942025/04f9d9f7-5a23-4297-b92b-4469eb6bd969)


How it Looks now:
<img width="785" alt="image" src="https://github.com/Shopify/polaris/assets/104942025/9257d933-8eaf-4584-8b40-77e9a38bf2b8">

Updated Polaris website as well: 
<img width="959" alt="image" src="https://github.com/Shopify/polaris/assets/104942025/d752e831-c713-4367-ab37-022367e717c5">


My Spin with applied snapshot: https://admin.web.oa-variant-image-dropzone-2.oksana-azarova.us.spin.dev/store/shop1/products/1

<img width="1806" alt="image" src="https://github.com/Shopify/polaris/assets/104942025/b08c074d-22fd-44da-8e0c-36e2eac1494a">

You can also test it on your own spin, just make sure  `admin_pdp_variants_250_ux` beta is On and you created your branch from `oa-variant-image-dropzone` branch

Steps:

1. Created product with several options, that will result on grouped variants view
2. Expand one of the grouped rows and make sure drop zone does not expands table row and doesn't have height bigger that a small thumbnail.



🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
