### PR TITLE
Migrations for `Text` `heading3xl` and `heading2xl` removal

### DIFF
--- a/.changeset/spicy-dryers-nail.md
+++ b/.changeset/spicy-dryers-nail.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris-migrator': minor
+'polaris.shopify.com': minor
+---
+
+Created migration to replace deprecated `font` custom properties in polaris-react v13.0.0

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/transform.test.ts
@@ -1,0 +1,12 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v13-styles-replace-custom-property-font';
+const fixtures = ['v13-styles-replace-custom-property-font'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+    extension: 'scss',
+  });
+}

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.input.scss
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.input.scss
@@ -1,6 +1,5 @@
 .font {
   font-size: var(--p-font-size-750);
-  font-size: var(--p-font-size-800);
   font-size: var(--p-font-size-900);
   font-size: var(--p-font-size-1000);
   font-size: var(--p-text-heading-2xl-font-size);

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.input.scss
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.input.scss
@@ -1,0 +1,10 @@
+.font {
+  font-size: var(--p-font-size-750);
+  font-size: var(--p-font-size-800);
+  font-size: var(--p-font-size-900);
+  font-size: var(--p-font-size-1000);
+  letter-spacing: var(--p-font-letter-spacing-denser);
+  letter-spacing: var(--p-font-letter-spacing-densest);
+  line-height: var(--p-font-line-height-1000);
+  line-height: var(--p-font-line-height-1200);
+}

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.input.scss
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.input.scss
@@ -3,8 +3,18 @@
   font-size: var(--p-font-size-800);
   font-size: var(--p-font-size-900);
   font-size: var(--p-font-size-1000);
+  font-size: var(--p-text-heading-2xl-font-size);
+  font-size: var(--p-text-heading-3xl-font-size);
   letter-spacing: var(--p-font-letter-spacing-denser);
   letter-spacing: var(--p-font-letter-spacing-densest);
+  letter-spacing: var(--p-text-heading-2xl-font-letter-spacing);
+  letter-spacing: var(--p-text-heading-3xl-font-letter-spacing);
   line-height: var(--p-font-line-height-1000);
   line-height: var(--p-font-line-height-1200);
+  line-height: var(--p-text-heading-2xl-font-line-height);
+  line-height: var(--p-text-heading-3xl-font-line-height);
+  font-family: var(--p-text-heading-2xl-font-family);
+  font-family: var(--p-text-heading-3xl-font-family);
+  font-weight: var(--p-text-heading-2xl-font-weight);
+  font-weight: var(--p-text-heading-3xl-font-weight);
 }

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.output.scss
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.output.scss
@@ -2,7 +2,6 @@
   font-size: var(--p-font-size-600);
   font-size: var(--p-font-size-600);
   font-size: var(--p-font-size-600);
-  font-size: var(--p-font-size-600);
   font-size: var(--p-text-heading-xl-font-size);
   font-size: var(--p-text-heading-xl-font-size);
   letter-spacing: var(--p-font-letter-spacing-dense);

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.output.scss
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.output.scss
@@ -1,0 +1,10 @@
+.font {
+  font-size: var(--p-font-size-600);
+  font-size: var(--p-font-size-600);
+  font-size: var(--p-font-size-600);
+  font-size: var(--p-font-size-600);
+  letter-spacing: var(--p-font-letter-spacing-dense);
+  letter-spacing: var(--p-font-letter-spacing-dense);
+  line-height: var(--p-font-line-height-800);
+  line-height: var(--p-font-line-height-800);
+}

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.output.scss
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.output.scss
@@ -3,8 +3,18 @@
   font-size: var(--p-font-size-600);
   font-size: var(--p-font-size-600);
   font-size: var(--p-font-size-600);
+  font-size: var(--p-text-heading-xl-font-size);
+  font-size: var(--p-text-heading-xl-font-size);
   letter-spacing: var(--p-font-letter-spacing-dense);
   letter-spacing: var(--p-font-letter-spacing-dense);
+  letter-spacing: var(--p-text-heading-xl-font-letter-spacing);
+  letter-spacing: var(--p-text-heading-xl-font-letter-spacing);
   line-height: var(--p-font-line-height-800);
   line-height: var(--p-font-line-height-800);
+  line-height: var(--p-text-heading-xl-font-line-height);
+  line-height: var(--p-text-heading-xl-font-line-height);
+  font-family: var(--p-text-heading-xl-font-family);
+  font-family: var(--p-text-heading-xl-font-family);
+  font-weight: var(--p-text-heading-xl-font-weight);
+  font-weight: var(--p-text-heading-xl-font-weight);
 }

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/transform.ts
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/transform.ts
@@ -1,0 +1,20 @@
+import type {FileInfo, API} from 'jscodeshift';
+
+import stylesReplaceCustomProperty from '../styles-replace-custom-property/transform';
+
+export default function transformer(fileInfo: FileInfo, _: API) {
+  return stylesReplaceCustomProperty(fileInfo, _, {replacementMaps});
+}
+
+const replacementMaps = {
+  '/.+/': {
+    '--p-font-size-750': '--p-font-size-600',
+    '--p-font-size-800': '--p-font-size-600',
+    '--p-font-size-900': '--p-font-size-600',
+    '--p-font-size-1000': '--p-font-size-600',
+    '--p-font-letter-spacing-denser': '--p-font-letter-spacing-dense',
+    '--p-font-letter-spacing-densest': '--p-font-letter-spacing-dense',
+    '--p-font-line-height-1000': '--p-font-line-height-800',
+    '--p-font-line-height-1200': '--p-font-line-height-800',
+  },
+};

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/transform.ts
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/transform.ts
@@ -9,7 +9,6 @@ export default function transformer(fileInfo: FileInfo, _: API) {
 const replacementMaps = {
   '/.+/': {
     '--p-font-size-750': '--p-font-size-600',
-    '--p-font-size-800': '--p-font-size-600',
     '--p-font-size-900': '--p-font-size-600',
     '--p-font-size-1000': '--p-font-size-600',
     '--p-font-letter-spacing-denser': '--p-font-letter-spacing-dense',

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/transform.ts
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/transform.ts
@@ -16,5 +16,19 @@ const replacementMaps = {
     '--p-font-letter-spacing-densest': '--p-font-letter-spacing-dense',
     '--p-font-line-height-1000': '--p-font-line-height-800',
     '--p-font-line-height-1200': '--p-font-line-height-800',
+    '--p-text-heading-3xl-font-family': '--p-text-heading-xl-font-family',
+    '--p-text-heading-3xl-font-size': '--p-text-heading-xl-font-size',
+    '--p-text-heading-3xl-font-weight': '--p-text-heading-xl-font-weight',
+    '--p-text-heading-3xl-font-letter-spacing':
+      '--p-text-heading-xl-font-letter-spacing',
+    '--p-text-heading-3xl-font-line-height':
+      '--p-text-heading-xl-font-line-height',
+    '--p-text-heading-2xl-font-family': '--p-text-heading-xl-font-family',
+    '--p-text-heading-2xl-font-size': '--p-text-heading-xl-font-size',
+    '--p-text-heading-2xl-font-weight': '--p-text-heading-xl-font-weight',
+    '--p-text-heading-2xl-font-letter-spacing':
+      '--p-text-heading-xl-font-letter-spacing',
+    '--p-text-heading-2xl-font-line-height':
+      '--p-text-heading-xl-font-line-height',
   },
 };

--- a/polaris.shopify.com/content/tools/polaris-migrator.mdx
+++ b/polaris.shopify.com/content/tools/polaris-migrator.mdx
@@ -37,6 +37,35 @@ npx @shopify/polaris-migrator <migration> <path>
 
 ## Migrations
 
+### @shopify/polaris-react v13.0.0
+
+If you are upgrading Polaris from v12 to v13 please follow our [migration guide](/version-guides/migrating-from-v12-to-v13).
+
+#### `v13-styles-replace-custom-property-font`
+
+Replace deprecated font CSS custom properties with corresponding Polaris custom property replacement values.
+
+```diff
+- font-size: var(--p-font-size-750);
++ font-size: var(--p-font-size-600);
+```
+
+```diff
+- letter-spacing: var(--p-font-letter-spacing-denser);
++ letter-spacing: var(--p-font-letter-spacing-dense);
+```
+
+```diff
+- line-height: var(--p-font-line-height-1000);
++ line-height: var(--p-font-line-height-800);
+```
+
+<br />
+
+```sh
+npx @shopify/polaris-migrator v13-styles-replace-custom-property-font <path>
+```
+
 ### @shopify/polaris-icons v8.0.0
 
 #### `icons-v8-update-names`


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1427

We need migrations for primitive tokens associated with  the removal of the Text `heading-3xl` and `heading-2xl` variants/classes/alias tokens.

### WHAT is this pull request doing?

This PR creates a migration for deprecated `font` custom properties in v13 using the generic codemod [`styles-replace-custom-property`](https://github.com/Shopify/polaris/pull/8265).

#### v13-styles-replace-custom-property-font
| Deprecated CSS Custom Property            | Replacement Value                  |
| -- | -- | 
| `--p-font-size-750`  | `--p-font-size-600` | 
| `--p-font-size-800`  | `--p-font-size-600` | 
| `--p-font-size-900` | `--p-font-size-600` | 
| `--p-font-size-1000` | `--p-font-size-600` | 
| `--p-font-letter-spacing-denser` | `--p-font-letter-spacing-dense` | 
| `--p-font-letter-spacing-densest` | `--p-font-letter-spacing-dense` | 
| `--p-font-line-height-1000` | `--p-font-line-height-800` | 
| `--p-font-line-height-1200` | `--p-font-line-height-800` | 
|`--p-text-heading-3xl-font-family`| `--p-text-heading-xl-font-family`|
|`--p-text-heading-3xl-font-size`| `--p-text-heading-xl-font-size`|
| `--p-text-heading-3xl-font-weight`| `--p-text-heading-xl-font-weight`|
|`--p-text-heading-3xl-font-letter-spacing`|  `--p-text-heading-xl-font-letter-spacing`|
| `--p-text-heading-3xl-font-line-height`|  `--p-text-heading-xl-font-line-height`|
|`--p-text-heading-2xl-font-family`| `--p-text-heading-xl-font-family`|
| `--p-text-heading-2xl-font-size`| `--p-text-heading-xl-font-size`|
| `--p-text-heading-2xl-font-weight`| `--p-text-heading-xl-font-weight`|
| `--p-text-heading-2xl-font-letter-spacing`|  `--p-text-heading-xl-font-letter-spacing`|
|`--p-text-heading-2xl-font-line-height`| `--p-text-heading-xl-font-line-height`|
>[!NOTE]
>Major version upgrade guidance is located [on a separate PR on the v13 branch](https://github.com/Shopify/polaris/pull/11597). 