### PR TITLE
Add v13 font migration documentation

### DIFF
--- a/.changeset/hot-peas-visit.md
+++ b/.changeset/hot-peas-visit.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Added migration documentation to replace deprecated `font` variants and custom properties in polaris-react v13.0.0

--- a/polaris.shopify.com/content/version-guides/migrating-from-v12-to-v13.mdx
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v12-to-v13.mdx
@@ -226,23 +226,33 @@ To replace deprecated `font` custom properties, you can run the [v13-styles-repl
     code={{
       title:
         'Check RegExp for hardcoded font custom properties across all file types',
-      code: String.raw`(?:--p-font-size-750|--p-font-size-800|--p-font-size-900|--p-font-size-1000|--p-font-letter-spacing-denser|--p-font-letter-spacing-densest|--p-font-line-height-1000|--p-font-line-height-1200)(?![\w-])`,
+      code: String.raw`(?:--p-font-size-750|--p-font-size-800|--p-font-size-900|--p-font-size-1000|--p-font-letter-spacing-denser|--p-font-letter-spacing-densest|--p-font-line-height-1000|--p-font-line-height-1200)|--p-text-heading-3xl-font-family|--p-text-heading-3xl-font-size|--p-text-heading-3xl-font-weight|--p-text-heading-3xl-font-letter-spacing|--p-text-heading-3xl-font-line-height|--p-text-heading-2xl-font-family|--p-text-heading-2xl-font-size|--p-text-heading-2xl-font-weight|--p-text-heading-2xl-font-letter-spacing|--p-text-heading-2xl-font-line-height(?![\w-])`,
     }}
   />
 </CollapsibleDetails>
 
 <CollapsibleDetails summary="➡️ Token replacement mappings">
 
-| Deprecated Token                  | Replacement Value               |
-| --------------------------------- | ------------------------------- |
-| `--p-font-size-750`               | `--p-font-size-600`             |
-| `--p-font-size-800`               | `--p-font-size-600`             |
-| `--p-font-size-900`               | `--p-font-size-600`             |
-| `--p-font-size-1000`              | `--p-font-size-600`             |
-| `--p-font-letter-spacing-denser`  | `--p-font-letter-spacing-dense` |
-| `--p-font-letter-spacing-densest` | `--p-font-letter-spacing-dense` |
-| `--p-font-line-height-1000`       | `--p-font-line-height-800`      |
-| `--p-font-line-height-1200`       | `--p-font-line-height-800`      |
+| Deprecated Token                           | Replacement Value                         |
+| ------------------------------------------ | ----------------------------------------- |
+| `--p-font-size-750`                        | `--p-font-size-600`                       |
+| `--p-font-size-800`                        | `--p-font-size-600`                       |
+| `--p-font-size-900`                        | `--p-font-size-600`                       |
+| `--p-font-size-1000`                       | `--p-font-size-600`                       |
+| `--p-font-letter-spacing-denser`           | `--p-font-letter-spacing-dense`           |
+| `--p-font-letter-spacing-densest`          | `--p-font-letter-spacing-dense`           |
+| `--p-font-line-height-1000`                | `--p-font-line-height-800`                |
+| `--p-font-line-height-1200`                | `--p-font-line-height-800`                |
+| `--p-text-heading-2xl-font-family`         | `--p-text-heading-xl-font-family`         |
+| `--p-text-heading-2xl-font-size`           | `--p-text-heading-xl-font-size`           |
+| `--p-text-heading-2xl-font-weight`         | `--p-text-heading-xl-font-weight`         |
+| `--p-text-heading-2xl-font-letter-spacing` | `--p-text-heading-xl-font-letter-spacing` |
+| `--p-text-heading-2xl-font-line-height`    | `--p-text-heading-xl-font-line-height`    |
+| `--p-text-heading-3xl-font-family`         | `--p-text-heading-xl-font-family`         |
+| `--p-text-heading-3xl-font-size`           | `--p-text-heading-xl-font-size`           |
+| `--p-text-heading-3xl-font-weight`         | `--p-text-heading-xl-font-weight`         |
+| `--p-text-heading-3xl-font-letter-spacing` | `--p-text-heading-xl-font-letter-spacing` |
+| `--p-text-heading-3xl-font-line-height`    | `--p-text-heading-xl-font-line-height`    |
 
 </CollapsibleDetails>
 

--- a/polaris.shopify.com/content/version-guides/migrating-from-v12-to-v13.mdx
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v12-to-v13.mdx
@@ -226,7 +226,7 @@ To replace deprecated `font` custom properties, you can run the [v13-styles-repl
     code={{
       title:
         'Check RegExp for hardcoded font custom properties across all file types',
-      code: String.raw`(?:--p-font-size-750|--p-font-size-800|--p-font-size-900|--p-font-size-1000|--p-font-letter-spacing-denser|--p-font-letter-spacing-densest|--p-font-line-height-1000|--p-font-line-height-1200)|--p-text-heading-3xl-font-family|--p-text-heading-3xl-font-size|--p-text-heading-3xl-font-weight|--p-text-heading-3xl-font-letter-spacing|--p-text-heading-3xl-font-line-height|--p-text-heading-2xl-font-family|--p-text-heading-2xl-font-size|--p-text-heading-2xl-font-weight|--p-text-heading-2xl-font-letter-spacing|--p-text-heading-2xl-font-line-height(?![\w-])`,
+      code: String.raw`(?:--p-font-size-750|--p-font-size-900|--p-font-size-1000|--p-font-letter-spacing-denser|--p-font-letter-spacing-densest|--p-font-line-height-1000|--p-font-line-height-1200)|--p-text-heading-3xl-font-family|--p-text-heading-3xl-font-size|--p-text-heading-3xl-font-weight|--p-text-heading-3xl-font-letter-spacing|--p-text-heading-3xl-font-line-height|--p-text-heading-2xl-font-family|--p-text-heading-2xl-font-size|--p-text-heading-2xl-font-weight|--p-text-heading-2xl-font-letter-spacing|--p-text-heading-2xl-font-line-height(?![\w-])`,
     }}
   />
 </CollapsibleDetails>
@@ -236,7 +236,6 @@ To replace deprecated `font` custom properties, you can run the [v13-styles-repl
 | Deprecated Token                           | Replacement Value                         |
 | ------------------------------------------ | ----------------------------------------- |
 | `--p-font-size-750`                        | `--p-font-size-600`                       |
-| `--p-font-size-800`                        | `--p-font-size-600`                       |
 | `--p-font-size-900`                        | `--p-font-size-600`                       |
 | `--p-font-size-1000`                       | `--p-font-size-600`                       |
 | `--p-font-letter-spacing-denser`           | `--p-font-letter-spacing-dense`           |

--- a/polaris.shopify.com/content/version-guides/migrating-from-v12-to-v13.mdx
+++ b/polaris.shopify.com/content/version-guides/migrating-from-v12-to-v13.mdx
@@ -15,7 +15,7 @@ order: 1
 
 Upgrading to Polaris v13 from v12 requires several automated and manual migrations of token, component, and component prop names that have been removed, replaced, or renamed. The bulk of migrations are automated using the [@shopify/polaris-migrator](/tools/polaris-migrator) CLI tool, with the edge cases handled by find and replace in your code editor using provided RegExp searches. You can reference the [recommended migration workflow](#migration-workflow) or [glossary](#glossary) sections for additional migration support.
 
-Not on v12 yet? You'll need to follow the [migration guides](https://github.com/Shopify/polaris/tree/main/documentation/guides) for previous major versions before upgrading to v13.
+Not on v12 yet? You'll need to follow the [Migrating from v11 to v12 guide](/version-guides/migrating-from-v11-to-v12) and/or older [migration guides](https://github.com/Shopify/polaris/tree/main/documentation/guides) for previous major versions before upgrading to v13.
 
 <Code
   code={{
@@ -116,6 +116,133 @@ git commit -m "[Manual] Migrate X from Polaris v12 to v13"
 - **➡️ Token replacement mappings (or other mapping tables)**: These tables show you at a glance what our migrators are finding and replacing. They are useful to cross reference when dealing with edge cases and manual migrations
 - **🔔 Stepped migration**: These are migrations that must be run in a specific order due to overlapping replacement values. These migrations have been broken out into steps that can be targeted using the `--step` flag when running the migration
 - **💡 Migration example**: A simple diff showing how the migration should be modifying your code
+
+</CollapsibleDetails>
+
+## Component migrations
+
+### Text
+
+#### Replace `variant="heading2xl"` prop with `variant="headingXl"`
+
+<Code
+  code={{
+    title: 'polaris-migrator codemod',
+    className: 'language-bash',
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Text --fromProp variant --fromValue heading2xl --toValue headingXl "**/*.{ts,tsx}"`,
+  }}
+/>
+
+<CollapsibleDetails summary="✅ Post-migration RegExp validation">
+
+<Code
+  code={{
+    className: 'language-regex',
+    title: `Check RegExp for outdated <Text variant="heading2xl" /> prop`,
+    code: String.raw`<Text[^>\w](?:[^>]|\n)*?variant="heading2xl"`,
+  }}
+/>
+
+</CollapsibleDetails>
+
+<CollapsibleDetails summary="💡 Migration example">
+
+```diff
+- <Text variant="heading2xl">
++ <Text variant="headingXl">
+```
+
+</CollapsibleDetails>
+
+#### Replace `variant="heading3xl"` prop with `variant="headingXl"`
+
+<Code
+  code={{
+    title: 'polaris-migrator codemod',
+    className: 'language-bash',
+    code: String.raw`npx @shopify/polaris-migrator react-update-component-prop --componentName Text --fromProp variant --fromValue heading3xl --toValue headingXl "**/*.{ts,tsx}"`,
+  }}
+/>
+
+<CollapsibleDetails summary="✅ Post-migration RegExp validation">
+
+<Code
+  code={{
+    className: 'language-regex',
+    title: `Check RegExp for outdated <Text variant="heading3xl" /> prop`,
+    code: String.raw`<Text[^>\w](?:[^>]|\n)*?variant="heading3xl"`,
+  }}
+/>
+
+</CollapsibleDetails>
+
+<CollapsibleDetails summary="💡 Migration example">
+
+```diff
+- <Text variant="heading3xl">
++ <Text variant="headingXl">
+```
+
+</CollapsibleDetails>
+
+## Token migrations
+
+### Font
+
+To replace deprecated `font` custom properties, you can run the [v13-styles-replace-custom-property-font](/tools/polaris-migrator#v13-styles-replace-custom-property-font) migration then validate with RegExp. Please reference the [recommended migration workflow](#migration-workflow) section below for additional migration support.
+
+<CollapsibleDetails summary="💡 Migration example">
+
+```diff
+- font-size: var(--p-font-size-750);
++ font-size: var(--p-font-size-600);
+```
+
+```diff
+- letter-spacing: var(--p-font-letter-spacing-denser);
++ letter-spacing: var(--p-font-letter-spacing-dense);
+```
+
+```diff
+- line-height: var(--p-font-line-height-1000);
++ line-height: var(--p-font-line-height-800);
+```
+
+</CollapsibleDetails>
+
+<Code
+  code={{
+    title: 'polaris-migrator codemod',
+    className: 'language-bash',
+    code: String.raw`npx @shopify/polaris-migrator v13-styles-replace-custom-property-font "**/*.{css,scss}"`,
+
+}}
+/>
+
+<CollapsibleDetails summary="✅ Post-migration RegExp validation">
+  After migrating, use the following RegExp to check for any additional
+  instances of `font` custom properties across all file types:
+  <Code
+    code={{
+      title:
+        'Check RegExp for hardcoded font custom properties across all file types',
+      code: String.raw`(?:--p-font-size-750|--p-font-size-800|--p-font-size-900|--p-font-size-1000|--p-font-letter-spacing-denser|--p-font-letter-spacing-densest|--p-font-line-height-1000|--p-font-line-height-1200)(?![\w-])`,
+    }}
+  />
+</CollapsibleDetails>
+
+<CollapsibleDetails summary="➡️ Token replacement mappings">
+
+| Deprecated Token                  | Replacement Value               |
+| --------------------------------- | ------------------------------- |
+| `--p-font-size-750`               | `--p-font-size-600`             |
+| `--p-font-size-800`               | `--p-font-size-600`             |
+| `--p-font-size-900`               | `--p-font-size-600`             |
+| `--p-font-size-1000`              | `--p-font-size-600`             |
+| `--p-font-letter-spacing-denser`  | `--p-font-letter-spacing-dense` |
+| `--p-font-letter-spacing-densest` | `--p-font-letter-spacing-dense` |
+| `--p-font-line-height-1000`       | `--p-font-line-height-800`      |
+| `--p-font-line-height-1200`       | `--p-font-line-height-800`      |
 
 </CollapsibleDetails>
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1388
Fixes https://github.com/Shopify/polaris-internal/issues/1428
Related to #11596

### WHAT is this pull request doing?

Adds migration documentation for the removal of the `Text` `heading-3xl` and `heading-2xl` variants/classes/alias tokens as well as associated primitive tokens. 

![Screenshot 2024-02-13 at 10 41 28 AM](https://github.com/Shopify/polaris/assets/21976492/cc83d845-2cf0-439c-a060-8ee6147ad2a7)

![Screenshot 2024-02-13 at 10 41 46 AM](https://github.com/Shopify/polaris/assets/21976492/f36826c6-4ccd-486b-8297-165c7f43da19)