### PR TITLE
Use the `Text` component to apply `Button` text styles

### DIFF
--- a/.changeset/ten-squids-nail.md
+++ b/.changeset/ten-squids-nail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Used `Text` component to apply text styles for `Button`

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -34,20 +34,9 @@
   border-radius: var(--p-border-radius-200);
   box-shadow: var(--pc-button-box-shadow);
   color: var(--pc-button-color);
-
-  font-size: var(--p-font-size-350);
-  font-weight: var(--p-font-weight-semibold);
-  line-height: var(--p-font-line-height-500);
-
   cursor: pointer;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
-
-  @media (--p-breakpoints-md-up) {
-    font-size: var(--p-font-size-300);
-    font-weight: var(--p-font-weight-medium);
-    line-height: var(--p-font-line-height-400);
-  }
 }
 
 // stylelint-disable selector-max-specificity -- Duplicate selectors to bump specificity to be greater than Icon's svg fill (0, 1, 1)
@@ -167,7 +156,7 @@
   --pc-button-color_active: var(--p-color-text-link-active);
 }
 
-.variantPlain:is(:hover, :active, :focus-visible) {
+.variantPlain:is(:hover, :active, :focus-visible):not(.removeUnderline) {
   text-decoration: underline;
 }
 
@@ -180,13 +169,6 @@
   --pc-button-bg_disabled: transparent;
   margin: calc(-1 * var(--pc-button-padding-block))
     calc(-1 * var(--pc-button-padding-inline));
-  font-size: var(--p-font-size-350);
-  font-weight: var(--p-font-weight-regular);
-  line-height: var(--p-font-line-height-500);
-
-  @media (--p-breakpoints-md-up) {
-    font-size: var(--p-font-size-325);
-  }
 }
 
 .variantPlain:focus-visible,
@@ -257,8 +239,6 @@
 .sizeLarge {
   --pc-button-padding-block: var(--p-space-150);
   --pc-button-padding-inline: var(--p-space-300);
-  font-size: var(--p-font-size-325);
-  line-height: var(--p-font-line-height-500);
   min-height: var(--p-height-900);
   min-width: var(--p-height-900);
 
@@ -355,9 +335,7 @@
 // INTERACTION
 .pressable:active:not(.variantTertiary, .variantPlain, .variantMonochromePlain)
   > * {
-  @media (--p-breakpoints-md-up) {
-    transform: translate3d(0, 1px, 0);
-  }
+  transform: translate3d(0, 1px, 0);
 }
 
 // UTILITIES

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -5,6 +5,7 @@ import {
   ChevronUpIcon,
 } from '@shopify/polaris-icons';
 
+import {useBreakpoints} from '../../utilities/breakpoints';
 import type {BaseButton, IconSource} from '../../types';
 import {classNames, variationName} from '../../utilities/css';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
@@ -12,6 +13,8 @@ import type {MouseUpBlurHandler} from '../../utilities/focus';
 import {useI18n} from '../../utilities/i18n';
 import {Icon} from '../Icon';
 import {Spinner} from '../Spinner';
+import {Text} from '../Text';
+import type {TextProps} from '../Text';
 import {UnstyledButton} from '../UnstyledButton';
 import type {UnstyledButtonProps} from '../UnstyledButton';
 
@@ -121,6 +124,7 @@ export function Button({
 }: ButtonProps) {
   const i18n = useI18n();
   const isDisabled = disabled || loading;
+  const {smUp} = useBreakpoints();
 
   const className = classNames(
     styles.Button,
@@ -164,14 +168,24 @@ export function Button({
     <span className={loading ? styles.hidden : styles.Icon}>{iconSource}</span>
   ) : null;
 
+  const hasPlainText = ['plain', 'monochromePlain'].includes(variant);
+  let textFontWeight: TextProps['fontWeight'] = 'medium';
+  if (hasPlainText) {
+    textFontWeight = 'regular';
+  } else if (variant === 'primary') {
+    textFontWeight = smUp ? 'medium' : 'semibold';
+  }
+
   const childMarkup = children ? (
-    <span
-      className={removeUnderline ? styles.removeUnderline : ''}
+    <Text
+      as="span"
+      variant={size === 'large' || hasPlainText ? 'bodyMd' : 'bodySm'}
+      fontWeight={textFontWeight}
       // Fixes Safari bug that doesn't re-render button text to correct color
       key={disabled ? 'text-disabled' : 'text'}
     >
       {children}
-    </span>
+    </Text>
   ) : null;
 
   const spinnerSVGMarkup = loading ? (

--- a/polaris-react/src/components/Button/tests/Button.test.tsx
+++ b/polaris-react/src/components/Button/tests/Button.test.tsx
@@ -356,15 +356,6 @@ describe('<Button />', () => {
         className: expect.stringContaining('removeUnderline'),
       });
     });
-
-    it('passes prop to <span/> className', () => {
-      const children = 'Sample children';
-      const button = mountWithApp(<Button removeUnderline>{children}</Button>);
-      const childrenSpan = button.find('span', {children})!;
-      expect(childrenSpan).toHaveReactProps({
-        className: expect.stringContaining('removeUnderline'),
-      });
-    });
   });
 
   describe('dataPrimaryLink', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Cleans up the button CSS by re-using the Text component styles to apply the proper `Button` typography.

This PR also removed the media query for applying the button "press" transition only on screens above mobile. The pressed transition should now apply to all screen sizes.