### PR TITLE
[Header] Add logic to conditionally set the max-width on the subtitle within `Title`

### DIFF
--- a/.changeset/smooth-ears-remember.md
+++ b/.changeset/smooth-ears-remember.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated `Page` sub-components to only restrict the width of the subtitle if secondary actions or action groups are present

--- a/polaris-react/src/components/ActionMenu/components/Actions/Actions.module.scss
+++ b/polaris-react/src/components/ActionMenu/components/Actions/Actions.module.scss
@@ -1,5 +1,10 @@
 @import '../../../../styles/common';
 
+.ActionsLayoutOuter {
+  position: relative;
+  width: 100%;
+}
+
 .ActionsLayout {
   display: flex;
   flex-wrap: wrap;
@@ -19,6 +24,7 @@
 }
 
 .ActionsLayoutMeasurer {
+  position: absolute;
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/polaris-react/src/components/Page/components/Header/Header.module.scss
+++ b/polaris-react/src/components/Page/components/Header/Header.module.scss
@@ -6,14 +6,13 @@ $action-menu-rollup-computed-width: 40px;
   grid-area: title;
   margin-top: var(--p-space-100);
   align-self: center;
-  flex: 1 1 auto;
 
   @media (--p-breakpoints-sm-up) {
     margin-top: 0;
   }
 
-  .mediumTitle & {
-    min-width: fit-content;
+  &.TitleWrapperExpand {
+    flex: 1 1 auto;
   }
 }
 

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -99,7 +99,7 @@ export function Header({
       isReactElement(secondaryActions)) &&
     !actionGroups.length;
 
-  const hasSubtitleMaxWidth =
+  const hasActionGroupsOrSecondaryActions =
     actionGroups.length > 0 ||
     (isInterface(secondaryActions) && secondaryActions.length > 0) ||
     isReactElement(secondaryActions);
@@ -126,13 +126,18 @@ export function Header({
     ) : null;
 
   const pageTitleMarkup = (
-    <div className={styles.TitleWrapper}>
+    <div
+      className={classNames(
+        styles.TitleWrapper,
+        !hasActionGroupsOrSecondaryActions && styles.TitleWrapperExpand,
+      )}
+    >
       <Title
         title={title}
         subtitle={subtitle}
         titleMetadata={titleMetadata}
         compactTitle={compactTitle}
-        hasSubtitleMaxWidth={hasSubtitleMaxWidth}
+        hasSubtitleMaxWidth={hasActionGroupsOrSecondaryActions}
       />
     </div>
   );

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -99,6 +99,11 @@ export function Header({
       isReactElement(secondaryActions)) &&
     !actionGroups.length;
 
+  const hasSubtitleMaxWidth =
+    actionGroups.length > 0 ||
+    (isInterface(secondaryActions) && secondaryActions.length > 0) ||
+    isReactElement(secondaryActions);
+
   const breadcrumbMarkup = backAction ? (
     <div className={styles.BreadcrumbWrapper}>
       <Box maxWidth="100%" paddingInlineEnd="100" printHidden>
@@ -127,6 +132,7 @@ export function Header({
         subtitle={subtitle}
         titleMetadata={titleMetadata}
         compactTitle={compactTitle}
+        hasSubtitleMaxWidth={hasSubtitleMaxWidth}
       />
     </div>
   );

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.module.scss
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.module.scss
@@ -33,9 +33,12 @@
 .SubTitle {
   margin-top: var(--p-space-050);
   color: var(--p-color-text-secondary);
-  max-width: 45ch;
 
   &.SubtitleCompact {
     margin-top: var(--p-space-050);
+  }
+
+  &.SubtitleMaxWidth {
+    max-width: 45ch;
   }
 }

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
@@ -15,6 +15,10 @@ export interface TitleProps {
   titleMetadata?: React.ReactNode;
   /** Removes spacing between title and subtitle */
   compactTitle?: boolean;
+  /** Whether or not to add a max-width to the subtitle. Gets calculated by
+   * the presence of either the secondaryActions or actionGroups props on the
+   * Header that consumes this component */
+  hasSubtitleMaxWidth?: boolean;
 }
 
 export function Title({
@@ -22,6 +26,7 @@ export function Title({
   subtitle,
   titleMetadata,
   compactTitle,
+  hasSubtitleMaxWidth,
 }: TitleProps) {
   const className = classNames(
     styles.Title,
@@ -46,6 +51,7 @@ export function Title({
       className={classNames(
         styles.SubTitle,
         compactTitle && styles.SubtitleCompact,
+        hasSubtitleMaxWidth && styles.SubtitleMaxWidth,
       )}
     >
       <Text as="p" variant="bodySm">

--- a/polaris-react/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/polaris-react/src/components/Page/components/Header/tests/Header.test.tsx
@@ -13,6 +13,7 @@ import {Text} from '../../../../Text';
 import type {LinkAction, MenuActionDescriptor} from '../../../../../types';
 import {Header} from '../Header';
 import type {HeaderProps} from '../Header';
+import {Title} from '../components';
 
 describe('<Header />', () => {
   const mockProps: HeaderProps = {
@@ -398,5 +399,74 @@ describe('<Header />', () => {
       },
     );
     expect(header.findAll(ButtonGroup)).toHaveLength(0);
+  });
+
+  describe('Title', () => {
+    it('will add the hasSubtitleMaxWidth prop if actionGroups has a length', () => {
+      const header = mountWithApp(
+        <Header
+          title="Hello, world!"
+          primaryAction={primaryAction}
+          actionGroups={[{title: 'First group', actions: []}]}
+        />,
+      );
+
+      expect(header).toContainReactComponent(Title, {
+        hasSubtitleMaxWidth: true,
+      });
+    });
+
+    it('will add the hasSubtitleMaxWidth prop if secondaryActions has a length', () => {
+      const header = mountWithApp(
+        <Header
+          title="Hello, world!"
+          primaryAction={primaryAction}
+          secondaryActions={secondaryActions}
+        />,
+      );
+
+      expect(header).toContainReactComponent(Title, {
+        hasSubtitleMaxWidth: true,
+      });
+    });
+
+    it('will add the hasSubtitleMaxWidth prop if secondaryActions is a valid react element', () => {
+      const header = mountWithApp(
+        <Header
+          title="Hello, world!"
+          primaryAction={primaryAction}
+          secondaryActions={<div>I am an action</div>}
+        />,
+      );
+
+      expect(header).toContainReactComponent(Title, {
+        hasSubtitleMaxWidth: true,
+      });
+    });
+
+    it('will not add the hasSubtitleMaxWidth prop if no secondaryActions or actionGroups detected', () => {
+      const header = mountWithApp(
+        <Header title="Hello, world!" primaryAction={primaryAction} />,
+      );
+
+      expect(header).toContainReactComponent(Title, {
+        hasSubtitleMaxWidth: false,
+      });
+    });
+
+    it('will not add the hasSubtitleMaxWidth prop if empty secondaryActions and actionGroups detected', () => {
+      const header = mountWithApp(
+        <Header
+          title="Hello, world!"
+          primaryAction={primaryAction}
+          secondaryActions={[]}
+          actionGroups={[]}
+        />,
+      );
+
+      expect(header).toContainReactComponent(Title, {
+        hasSubtitleMaxWidth: false,
+      });
+    });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

We set the max-width of the subtitle within the `Title` component to `45ch` to enable the calculation of which actions to roll up and which actions to render normally in the `Header` component. However, for `Header` instances that do not have any `actionGroups` or `secondaryActions` props, we are truncating this subtitle unnecessarily.

This PR introduces logic to only set the max-width on the subtitle if we detect presence of either `actionGroups` or `secondaryActions`.

Also fixes a bug with how the measurer is rendered which could cause actions to shift out of the layout bounds to the right hand side slightly.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Spin URL: https://admin.web.subtitle-change.marc-thomas.eu.spin.dev/store/shop1
Resume Spin URL: https://spin-control.shopify.io/instances/subtitle-change.marc-thomas.eu.spin.dev
Chromatic URL: https://5d559397bae39100201eedc1-qshafnkgoy.chromatic.com/?path=/story/all-components-page--default


### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
