### PR TITLE
Update v13-styles-replace-custom-property-font migration

### DIFF
--- a/.changeset/chatty-lizards-reflect.md
+++ b/.changeset/chatty-lizards-reflect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Updated migration to replace deprecated `font` custom properties in polaris-react v13.0.0

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.input.scss
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.input.scss
@@ -1,5 +1,6 @@
 .font {
   font-size: var(--p-font-size-750);
+  font-size: var(--p-font-size-800);
   font-size: var(--p-font-size-900);
   font-size: var(--p-font-size-1000);
   font-size: var(--p-text-heading-2xl-font-size);

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.output.scss
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/tests/v13-styles-replace-custom-property-font.output.scss
@@ -2,6 +2,7 @@
   font-size: var(--p-font-size-600);
   font-size: var(--p-font-size-600);
   font-size: var(--p-font-size-600);
+  font-size: var(--p-font-size-600);
   font-size: var(--p-text-heading-xl-font-size);
   font-size: var(--p-text-heading-xl-font-size);
   letter-spacing: var(--p-font-letter-spacing-dense);

--- a/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/transform.ts
+++ b/polaris-migrator/src/migrations/v13-styles-replace-custom-property-font/transform.ts
@@ -9,6 +9,7 @@ export default function transformer(fileInfo: FileInfo, _: API) {
 const replacementMaps = {
   '/.+/': {
     '--p-font-size-750': '--p-font-size-600',
+    '--p-font-size-800': '--p-font-size-600',
     '--p-font-size-900': '--p-font-size-600',
     '--p-font-size-1000': '--p-font-size-600',
     '--p-font-letter-spacing-denser': '--p-font-letter-spacing-dense',


### PR DESCRIPTION
Reverting the incorrect removal of the `font-size-800`  ➡️ `font-size-600` migration