### PR TITLE
Fix truncate issue for text in ContextualSaveBar

### DIFF
--- a/.changeset/neat-squids-add.md
+++ b/.changeset/neat-squids-add.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fix truncate issue for text in ContextualSaveBar

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.module.scss
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.module.scss
@@ -70,11 +70,15 @@
   display: flex;
   flex-direction: row;
   gap: var(--p-space-200);
+  overflow: hidden;
+  margin-right: var(--p-space-200);
 
   // stylelint-disable -- Icon overrides specific to Contextual Save Bar
-  & [class*='Polaris-Icon__Svg'],
-  & [class*='Icon-Svg'] {
+  & [class*='Polaris-Icon__Svg'] {
     fill: var(--p-color-text-inverse);
+  }
+  & [class*='Polaris-Icon'] {
+    flex-shrink: 0;
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where the text in contextual save bar was not truncating and instead overflows by pushing the actions outside the viewport.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2024-02-20 at 10 00](https://github.com/Shopify/polaris/assets/41344212/81a9c794-bbdd-4d40-b8cb-113ff51fdbd4) | ![Screenshot 2024-02-20 at 9 59](https://github.com/Shopify/polaris/assets/41344212/53d2f988-f3a3-4517-89e4-5648d6ebe41c)  |

### WHAT is this pull request doing?
* [`polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.module.scss`](diffhunk://#diff-654612881065e78ef49ae5b04a227d423e5dd71663e4128c00bb39cac649fccdR73-R82): Added `overflow: hidden;` and `margin-right: var(--p-space-200);` to improve the layout and spacing of the component. Also added `flex-shrink: 0;` to prevent the icon from shrinking.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
