### PR TITLE
Fix changeset versioning

### DIFF
--- a/.changeset/calm-lobsters-study.md
+++ b/.changeset/calm-lobsters-study.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris': patch
----
-
-Remove .Polaris-Summer-Editions-2023 class from html element.

--- a/.changeset/ninety-baboons-help.md
+++ b/.changeset/ninety-baboons-help.md
@@ -1,6 +1,0 @@
----
-'@shopify/polaris-icons': minor
-'@shopify/polaris': patch
----
-
-Updated icon set with consistency improvements

--- a/.changeset/smooth-ears-remember.md
+++ b/.changeset/smooth-ears-remember.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris': minor
----
-
-Updated `Page` sub-components to only restrict the width of the subtitle if secondary actions or action groups are present

--- a/.changeset/tame-jokes-brake.md
+++ b/.changeset/tame-jokes-brake.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris': patch
----
-
-Reduced `ActionList.Item` padding and gap

--- a/polaris-icons/CHANGELOG.md
+++ b/polaris-icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 8.4.0
+
+### Minor Changes
+
+- [#11609](https://github.com/Shopify/polaris/pull/11609) [`c9e217d9d`](https://github.com/Shopify/polaris/commit/c9e217d9d7e1291ce7b83e51c1e1876718895e93) Thanks [@sam-b-rose](https://github.com/sam-b-rose)! - Updated icon set with consistency improvements
+
 ## 8.3.0
 
 ### Minor Changes

--- a/polaris-icons/package.json
+++ b/polaris-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/polaris-icons",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify Inc.",
   "main": "dist/index.js",

--- a/polaris-react/CHANGELOG.md
+++ b/polaris-react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 12.17.0
+
+### Minor Changes
+
+- [#11602](https://github.com/Shopify/polaris/pull/11602) [`ae04f0d37`](https://github.com/Shopify/polaris/commit/ae04f0d37d142c7454d23533793a00ef4db65816) Thanks [@mrcthms](https://github.com/mrcthms)! - Updated `Page` sub-components to only restrict the width of the subtitle if secondary actions or action groups are present
+
+### Patch Changes
+
+- [#11564](https://github.com/Shopify/polaris/pull/11564) [`9839180d9`](https://github.com/Shopify/polaris/commit/9839180d9a113d92d9205a899546d493ca561f97) Thanks [@jesstelford](https://github.com/jesstelford)! - Remove .Polaris-Summer-Editions-2023 class from html element.
+
+* [#11605](https://github.com/Shopify/polaris/pull/11605) [`ef91b21e2`](https://github.com/Shopify/polaris/commit/ef91b21e2bdfe6bbf410460aeef8057905f1c82a) Thanks [@yurm04](https://github.com/yurm04)! - Reduced `ActionList.Item` padding and gap
+
 ## 12.16.0
 
 ### Minor Changes

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/polaris",
   "description": "Shopify’s admin product component library",
-  "version": "12.16.0",
+  "version": "12.17.0",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-internal/issues/1442

Rectifies changeset versions of released polaris packages accidentally by snapit.

### WHAT is this pull request doing?

- Bumps polaris version to 12.17.0 
- Bumps polaris-icons to 8.4.0
- Adds CHANGELOG.md entries for changes in those versions
- Removes corresponding changeset entries 