### PR TITLE
[OptionList] Support hover styles for multiple selection variant 

### DIFF
--- a/.changeset/shaggy-bugs-kneel.md
+++ b/.changeset/shaggy-bugs-kneel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed hover styles to multiple selection variant of `OptionList`

--- a/polaris-react/src/components/OptionList/components/Option/Option.module.scss
+++ b/polaris-react/src/components/OptionList/components/Option/Option.module.scss
@@ -54,6 +54,7 @@ $control-vertical-adjustment: 2px;
   &.select:hover:not(.disabled),
   &.active {
     font-weight: var(--p-font-weight-semibold);
+    background: var(--p-color-bg-surface-secondary-active);
   }
 
   .Media {
@@ -81,21 +82,6 @@ $control-vertical-adjustment: 2px;
     background: var(--p-color-bg-surface-secondary-active);
   }
 
-  // stylelint-disable-next-line selector-max-specificity -- specificity buster
-  &.select,
-  &.select:hover:not(.disabled) {
-    background-color: var(--p-color-bg-surface-secondary-selected);
-    // stylelint-disable-next-line -- no way to select parent Checkbox class without :has()
-    &.CheckboxLabel {
-      background-color: transparent;
-    }
-
-    // stylelint-disable-next-line selector-max-specificity -- recolor icon on select
-    svg {
-      fill: var(--p-color-icon-active);
-    }
-  }
-
   // stylelint-disable-next-line selector-max-specificity -- style consolidation
   &:hover:not(.disabled),
   &:active:not(.disabled),
@@ -116,12 +102,20 @@ $control-vertical-adjustment: 2px;
 }
 
 .MultiSelectOption {
+  &.select {
+    // stylelint-disable-next-line -- no way to select parent Checkbox class without :has()
+    &.CheckboxLabel {
+      background-color: transparent;
+    }
+
+    svg {
+      fill: var(--p-color-icon-active);
+    }
+  }
+
   // stylelint-disable-next-line selector-max-specificity -- specificity buster
-  &:active:not(.disabled),
-  &.select,
-  &.select:hover:not(.disabled),
-  &:hover:not(.disabled) {
-    background-color: transparent;
+  &.select:hover:not(.disabled) {
+    background-color: var(--p-color-bg-surface-secondary-hover);
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/11647

The OptionList component doesn't support hover styles when it's used as a multi-select. This PR aims to add that support. We follow the same behaviour as the single select, with the exception we show the hover on selected rows as well, since the checkbox is the main indicator for the selected state.

### WHAT is this pull request doing?

Move some css around and add the hover styles to the multi select class.

Before:
![22-54-35phd-db2jh](https://github.com/Shopify/polaris/assets/39638939/10c7331a-b737-4240-a4f6-bacaba1ccef8)

After:
![22-58-6wzil-9rfsi](https://github.com/Shopify/polaris/assets/39638939/215b8e77-7f5b-45da-9d31-0e8f1b735975)


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
