### PR TITLE
[IndexTable]: optimizes and add more stuff to `use-index-resource-state`

### DIFF
--- a/.changeset/good-lizards-brush.md
+++ b/.changeset/good-lizards-brush.md
@@ -1,0 +1,8 @@
+---
+'@shopify/polaris': minor
+---
+
+- adds dirty and unselected states to `use-index-resource-state`
+- adds stronger types to `use-index-resource-state`
+- Keeps the same array interface of the API but uses `Set` under the hood for performance optimization.
+  - Set was used since it offers O(1) direct access to its values. In some cases we removed O(N) traversal times since we cared about access lookup.

--- a/polaris-react/src/utilities/tests/use-index-resource-state.test.tsx
+++ b/polaris-react/src/utilities/tests/use-index-resource-state.test.tsx
@@ -588,19 +588,19 @@ describe('useIndexResourceState', () => {
       const mockComponent = mountWithApp(
         <MockComponent
           resources={resources}
-          options={{selectedResources: [idOne, idTwo, idThree]}}
+          options={{selectedResources: [idOne, idThree]}}
         />,
       );
 
       mockComponent
         .find(TypedChild)!
-        .trigger('handleSelectionChange', SelectionType.Single, true, '1');
+        .trigger('handleSelectionChange', SelectionType.Single, false, '1');
 
       expect(mockComponent).toContainReactComponent(TypedChild, {
-        selectedResources: [idOne, idTwo, idThree],
+        selectedResources: [idThree],
         allResourcesSelected: false,
         dirty: true,
-        unselectedResources: [],
+        unselectedResources: [idOne],
       });
 
       mockComponent
@@ -608,10 +608,10 @@ describe('useIndexResourceState', () => {
         .trigger('handleSelectionChange', SelectionType.All, true);
 
       expect(mockComponent).toContainReactComponent(TypedChild, {
-        selectedResources: [],
+        selectedResources: [idOne, idTwo, idThree],
         allResourcesSelected: true,
         dirty: true,
-        unselectedResources: [idOne, idTwo, idThree],
+        unselectedResources: [],
       });
 
       mockComponent.find(TypedChild)!.trigger('clearSelection');

--- a/polaris-react/src/utilities/tests/use-index-resource-state.test.tsx
+++ b/polaris-react/src/utilities/tests/use-index-resource-state.test.tsx
@@ -6,18 +6,7 @@ import {
   SelectionType,
 } from '../use-index-resource-state';
 
-interface TypedChildProps {
-  onClick: ReturnType<typeof useIndexResourceState>['handleSelectionChange'];
-  allResourcesSelected: ReturnType<
-    typeof useIndexResourceState
-  >['allResourcesSelected'];
-  selectedResources: ReturnType<
-    typeof useIndexResourceState
-  >['selectedResources'];
-  removeSelectedResources: ReturnType<
-    typeof useIndexResourceState
-  >['removeSelectedResources'];
-}
+interface TypedChildProps extends ReturnType<typeof useIndexResourceState> {}
 
 describe('useIndexResourceState', () => {
   function TypedChild(_: TypedChildProps) {
@@ -28,7 +17,7 @@ describe('useIndexResourceState', () => {
     resources = [],
     options,
   }: {
-    resources?: T[];
+    resources?: readonly T[];
     options?: Parameters<typeof useIndexResourceState>[1];
   }) {
     const {
@@ -36,38 +25,20 @@ describe('useIndexResourceState', () => {
       allResourcesSelected,
       handleSelectionChange,
       removeSelectedResources,
-    } = useIndexResourceState(resources, options);
-
-    return (
-      <TypedChild
-        onClick={handleSelectionChange}
-        selectedResources={selectedResources}
-        allResourcesSelected={allResourcesSelected}
-        removeSelectedResources={removeSelectedResources}
-      />
-    );
-  }
-
-  function MockClearComponent<T extends {[key: string]: unknown}>({
-    resources = [],
-    options,
-  }: {
-    resources?: T[];
-    options?: Parameters<typeof useIndexResourceState>[1];
-  }) {
-    const {
-      selectedResources,
-      allResourcesSelected,
+      dirty,
+      unselectedResources,
       clearSelection,
-      removeSelectedResources,
     } = useIndexResourceState(resources, options);
 
     return (
       <TypedChild
-        onClick={clearSelection}
+        handleSelectionChange={handleSelectionChange}
         selectedResources={selectedResources}
         allResourcesSelected={allResourcesSelected}
         removeSelectedResources={removeSelectedResources}
+        dirty={dirty}
+        unselectedResources={unselectedResources}
+        clearSelection={clearSelection}
       />
     );
   }
@@ -122,7 +93,7 @@ describe('useIndexResourceState', () => {
 
       mockComponent
         .find(TypedChild)!
-        .trigger('onClick', SelectionType.Page, true);
+        .trigger('handleSelectionChange', SelectionType.Page, true);
 
       expect(mockComponent).toContainReactComponent(TypedChild, {
         selectedResources: [selectedID],
@@ -139,7 +110,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Page, true);
+          .trigger('handleSelectionChange', SelectionType.Page, true);
       }
 
       expect(throwResourceSelectionError).toThrow(
@@ -161,7 +132,7 @@ describe('useIndexResourceState', () => {
 
       mockComponent
         .find(TypedChild)!
-        .trigger('onClick', SelectionType.Page, true);
+        .trigger('handleSelectionChange', SelectionType.Page, true);
 
       expect(mockComponent).toContainReactComponent(TypedChild, {
         selectedResources: [selectedID],
@@ -177,7 +148,7 @@ describe('useIndexResourceState', () => {
 
       mockComponent
         .find(TypedChild)!
-        .trigger('onClick', SelectionType.Page, true);
+        .trigger('handleSelectionChange', SelectionType.Page, true);
 
       expect(mockComponent).toContainReactComponent(TypedChild, {
         selectedResources: [selectedID],
@@ -199,7 +170,7 @@ describe('useIndexResourceState', () => {
 
       mockComponent
         .find(TypedChild)!
-        .trigger('onClick', SelectionType.Page, true);
+        .trigger('handleSelectionChange', SelectionType.Page, true);
 
       expect(mockComponent).toContainReactComponent(TypedChild, {
         selectedResources: [selectedID],
@@ -214,7 +185,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.All, true);
+          .trigger('handleSelectionChange', SelectionType.All, true);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           allResourcesSelected: true,
@@ -228,7 +199,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.All, false);
+          .trigger('handleSelectionChange', SelectionType.All, false);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           allResourcesSelected: false,
@@ -242,7 +213,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Single, false, '1');
+          .trigger('handleSelectionChange', SelectionType.Single, false, '1');
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           allResourcesSelected: false,
@@ -260,7 +231,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Single, true, id);
+          .trigger('handleSelectionChange', SelectionType.Single, true, id);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [id],
@@ -279,7 +250,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Single, false, id);
+          .trigger('handleSelectionChange', SelectionType.Single, false, id);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [],
@@ -305,7 +276,7 @@ describe('useIndexResourceState', () => {
 
           mockComponent
             .find(TypedChild)!
-            .trigger('onClick', SelectionType.All, true);
+            .trigger('handleSelectionChange', SelectionType.All, true);
 
           expect(mockComponent).toContainReactComponent(TypedChild, {
             selectedResources: [idOne],
@@ -323,7 +294,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.All, true);
+          .trigger('handleSelectionChange', SelectionType.All, true);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [idOne, idTwo],
@@ -343,7 +314,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.All, false);
+          .trigger('handleSelectionChange', SelectionType.All, false);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [],
@@ -369,7 +340,7 @@ describe('useIndexResourceState', () => {
 
           mockComponent
             .find(TypedChild)!
-            .trigger('onClick', SelectionType.All, true);
+            .trigger('handleSelectionChange', SelectionType.All, true);
 
           expect(mockComponent).toContainReactComponent(TypedChild, {
             selectedResources: [idOne],
@@ -387,7 +358,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Page, true);
+          .trigger('handleSelectionChange', SelectionType.Page, true);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [idOne, idTwo],
@@ -407,7 +378,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Page, false);
+          .trigger('handleSelectionChange', SelectionType.Page, false);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [],
@@ -434,7 +405,12 @@ describe('useIndexResourceState', () => {
 
           mockComponent
             .find(TypedChild)!
-            .trigger('onClick', SelectionType.Multi, true, [0, 1]);
+            .trigger(
+              'handleSelectionChange',
+              SelectionType.Multi,
+              true,
+              [0, 1],
+            );
 
           expect(mockComponent).toContainReactComponent(TypedChild, {
             selectedResources: [idOne],
@@ -450,7 +426,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Multi, true);
+          .trigger('handleSelectionChange', SelectionType.Multi, true);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources,
@@ -468,7 +444,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Multi, true, [0, 1]);
+          .trigger('handleSelectionChange', SelectionType.Multi, true, [0, 1]);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [idOne, idTwo],
@@ -489,7 +465,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Multi, false, [0, 1]);
+          .trigger('handleSelectionChange', SelectionType.Multi, false, [0, 1]);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [idThree],
@@ -516,7 +492,12 @@ describe('useIndexResourceState', () => {
 
           mockComponent
             .find(TypedChild)!
-            .trigger('onClick', SelectionType.Range, true, [0, 2]);
+            .trigger(
+              'handleSelectionChange',
+              SelectionType.Range,
+              true,
+              [0, 2],
+            );
 
           expect(mockComponent).toContainReactComponent(TypedChild, {
             selectedResources: [idTwo, idThree],
@@ -535,7 +516,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Range, true, [0, 2]);
+          .trigger('handleSelectionChange', SelectionType.Range, true, [0, 2]);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [idOne, idTwo, idThree],
@@ -554,7 +535,7 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Range, true, [0, 2]);
+          .trigger('handleSelectionChange', SelectionType.Range, true, [0, 2]);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [idOne, idTwo, idThree],
@@ -575,10 +556,24 @@ describe('useIndexResourceState', () => {
 
         mockComponent
           .find(TypedChild)!
-          .trigger('onClick', SelectionType.Range, false, [0, 2]);
+          .trigger('handleSelectionChange', SelectionType.Range, false, [0, 2]);
 
         expect(mockComponent).toContainReactComponent(TypedChild, {
           selectedResources: [],
+        });
+      });
+    });
+
+    describe('dirty', () => {
+      it('sets dirty to true when a selection is made', () => {
+        const mockComponent = mountWithApp(<MockComponent />);
+
+        mockComponent
+          .find(TypedChild)!
+          .trigger('handleSelectionChange', SelectionType.Single, true, '1');
+
+        expect(mockComponent).toContainReactComponent(TypedChild, {
+          dirty: true,
         });
       });
     });
@@ -591,16 +586,41 @@ describe('useIndexResourceState', () => {
       const idThree = '3';
       const resources = [{id: idOne}, {id: idTwo}, {id: idThree}];
       const mockComponent = mountWithApp(
-        <MockClearComponent
+        <MockComponent
           resources={resources}
           options={{selectedResources: [idOne, idTwo, idThree]}}
         />,
       );
 
-      mockComponent.find(TypedChild)!.trigger('onClick');
+      mockComponent
+        .find(TypedChild)!
+        .trigger('handleSelectionChange', SelectionType.Single, true, '1');
+
+      expect(mockComponent).toContainReactComponent(TypedChild, {
+        selectedResources: [idOne, idTwo, idThree],
+        allResourcesSelected: false,
+        dirty: true,
+        unselectedResources: [],
+      });
+
+      mockComponent
+        .find(TypedChild)!
+        .trigger('handleSelectionChange', SelectionType.All, true);
 
       expect(mockComponent).toContainReactComponent(TypedChild, {
         selectedResources: [],
+        allResourcesSelected: true,
+        dirty: true,
+        unselectedResources: [idOne, idTwo, idThree],
+      });
+
+      mockComponent.find(TypedChild)!.trigger('clearSelection');
+
+      expect(mockComponent).toContainReactComponent(TypedChild, {
+        selectedResources: [],
+        allResourcesSelected: false,
+        dirty: true,
+        unselectedResources: [],
       });
     });
   });
@@ -612,7 +632,7 @@ describe('useIndexResourceState', () => {
       const idThree = '3';
       const resources = [{id: idOne}, {id: idTwo}, {id: idThree}];
       const mockComponent = mountWithApp(
-        <MockClearComponent
+        <MockComponent
           resources={resources}
           options={{selectedResources: [idOne, idTwo, idThree]}}
         />,

--- a/polaris-react/src/utilities/use-index-resource-state.ts
+++ b/polaris-react/src/utilities/use-index-resource-state.ts
@@ -110,20 +110,26 @@ export function useIndexResourceState<T extends {[key: string]: unknown}>(
             return newSelectedResources;
           });
           break;
+
         case SelectionType.All:
         case SelectionType.Page: {
           const resourceList = resourceFilter
             ? resources.filter(resourceFilter)
             : resources;
+          const mappedResources = new Set(resourceList.map(resourceIDResolver));
+
           const hasRoomForMoreSelection =
             isSelecting && selectedResources.size < resourceList.length;
-          const resourceIDs = new Set(resourceList.map(resourceIDResolver));
 
           setSelectedResources(
-            hasRoomForMoreSelection ? resourceIDs : new Set(),
+            hasRoomForMoreSelection || isSelecting
+              ? mappedResources
+              : new Set(),
           );
           setUnselectedResources(
-            hasRoomForMoreSelection ? new Set() : resourceIDs,
+            hasRoomForMoreSelection || isSelecting
+              ? new Set()
+              : mappedResources,
           );
           break;
         }

--- a/polaris-react/src/utilities/use-index-resource-state.ts
+++ b/polaris-react/src/utilities/use-index-resource-state.ts
@@ -54,6 +54,8 @@ export function useIndexResourceState<T extends {[key: string]: unknown}>(
   const [dirty, setDirty] = useState(false);
 
   const prevPreCheckedResourcesRef = useRef(preCheckedResources);
+  const initialSelectedResources = useRef(selectedResources);
+  const initialUnselectedResources = useRef(unselectedResources);
 
   useEffect(() => {
     if (!isEqual(prevPreCheckedResourcesRef.current, preCheckedResources)) {
@@ -67,6 +69,16 @@ export function useIndexResourceState<T extends {[key: string]: unknown}>(
       prevPreCheckedResourcesRef.current = preCheckedResources;
     }
   }, [dirty, preCheckedResources, unselectedResources]);
+
+  useEffect(() => {
+    if (
+      dirty &&
+      isEqual(initialSelectedResources.current, selectedResources) &&
+      isEqual(initialUnselectedResources.current, unselectedResources)
+    ) {
+      setDirty(false);
+    }
+  }, [dirty, selectedResources, unselectedResources]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Closes: https://github.com/Shopify/admin-comms/issues/1261

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

This PR introduces `2` new states for the `use-index-resource-state` hook.
1. `Dirty` -- A boolean that reflects the dirty state of the IndexTable
2. `UnselectedResources` -- A string array of IDs. This array adds/removes IDs that were previously selected. It's initially set to an empty array.

Also, there were some performance improvements by using a `Set` instead of an `Array`. In a lot of cases we are concerned with the lookup access and using a `Set` gives us a O(1) access time compared to O(N) on the array since we were using operations like `filter`.

The hook's API returned object still exposes an array and not a `Set`.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
