### PR TITLE
[stylelint-polaris] Add postcss-scss and stylelint-scss as dependencies 

### DIFF
--- a/.changeset/perfect-kings-relax.md
+++ b/.changeset/perfect-kings-relax.md
@@ -2,4 +2,4 @@
 '@shopify/stylelint-polaris': minor
 ---
 
-Add postcss-scss and stylelint-scss as dependencies
+Added postcss-scss and stylelint-scss as dependencies

--- a/.changeset/perfect-kings-relax.md
+++ b/.changeset/perfect-kings-relax.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': minor
+---
+
+Add postcss-scss and stylelint-scss as dependencies

--- a/stylelint-polaris/package.json
+++ b/stylelint-polaris/package.json
@@ -35,6 +35,8 @@
     "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
+    "stylelint-scss": "^4.4.0",
+    "postcss-scss": "^4.0.9",
     "postcss-value-parser": "^4.2.0",
     "postcss-media-query-parser": "^0.2.3",
     "@shopify/polaris-tokens": "^8.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18184,10 +18184,23 @@ postcss-scss@^4.0.2, postcss-scss@^4.0.4:
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.4.tgz#aa8f60e19ee18259bc193db9e4b96edfce3f3b1f"
   integrity sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==
 
+postcss-scss@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.9.tgz#a03c773cd4c9623cb04ce142a52afcec74806685"
+  integrity sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==
+
 postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5, postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.9:
   version "6.0.10"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
   integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-selector-parser@^6.0.11:
+  version "6.0.15"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz#11cc2b21eebc0b99ea374ffb9887174855a01535"
+  integrity sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -21016,6 +21029,16 @@ stylelint-scss@^4.0.0:
     postcss-resolve-nested-selector "^0.1.1"
     postcss-selector-parser "^6.0.6"
     postcss-value-parser "^4.1.0"
+
+stylelint-scss@^4.4.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-4.7.0.tgz#f986bf8c5a4b93eae2b67d3a3562eef822657908"
+  integrity sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==
+  dependencies:
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^6.0.11"
+    postcss-value-parser "^4.2.0"
 
 stylelint@^14.15.0:
   version "14.15.0"


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, consumers of `stylelint-polaris`, which leverages `postcss-scss` and `stylelint-scss` internally, are required to install these packages as `devDependencies`. This is the case even if they are not directly utilized within their applications. A more streamlined approach would be to incorporate these packages directly within the `stylelint-polaris` package as dependencies. This adjustment would enable consumers to eliminate these packages from their `devDependencies`, thereby simplifying their dependency management and making the dependencies more transparent.

### How to 🎩

Testing snapshot https://github.com/Shopify/web/pull/119693

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
