### PR TITLE
[IndexFilters] Prevent keyboard shortcuts working if component has no search field or filters

### DIFF
--- a/.changeset/sour-walls-kneel.md
+++ b/.changeset/sour-walls-kneel.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Updated IndexFilters to not add the keyboard shortcuts when there is no search field or filters
+Fixed `IndexFilters` responding to keyboard shortcuts when there is no search field or filters

--- a/.changeset/sour-walls-kneel.md
+++ b/.changeset/sour-walls-kneel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated IndexFilters to not add the keyboard shortcuts when there is no search field or filters

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -168,7 +168,8 @@ export function IndexFilters({
   useOnValueChange(mode, handleModeChange);
 
   useEventListener('keydown', (event) => {
-    if (disableKeyboardShortcuts) return;
+    const hasNoFiltersOrSearch = hideQueryField && hideFilters;
+    if (disableKeyboardShortcuts || hasNoFiltersOrSearch) return;
 
     const {key} = event;
     const tag = document?.activeElement?.tagName;

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -100,7 +100,8 @@ export interface IndexFiltersProps
   filteringAccessibilityTooltip?: string;
   /** Whether the filter should close when clicking inside another Popover. */
   closeOnChildOverlayClick?: boolean;
-  /** Optional override to the default keyboard shortcuts available */
+  /** Optional override to the default keyboard shortcuts available. Should be set to true for all instances
+   * of this component not controlling a root-level index */
   disableKeyboardShortcuts?: boolean;
   /** Whether to display the edit columns button with the other default mode filter actions */
   showEditColumnsButton?: boolean;

--- a/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
+++ b/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
@@ -269,6 +269,28 @@ describe('IndexFilters', () => {
 
       expect(onEditStart).toHaveBeenCalledWith(IndexFiltersMode.Filtering);
     });
+
+    it('does nothing if hideQueryField and hideFilters are true', () => {
+      const onEditStart = jest.fn();
+
+      mountWithApp(
+        <IndexFilters
+          {...defaultProps}
+          mode={IndexFiltersMode.Default}
+          onEditStart={onEditStart}
+          hideQueryField
+          hideFilters
+        />,
+      );
+
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'f',
+        }),
+      );
+
+      expect(onEditStart).not.toHaveBeenCalledWith(IndexFiltersMode.Filtering);
+    });
   });
 
   describe('pressing escape', () => {
@@ -315,6 +337,25 @@ describe('IndexFilters', () => {
       );
 
       expect(defaultProps.cancelAction!.onAction).toHaveBeenCalled();
+    });
+
+    it('does nothing if hideQueryField and hideFilters are true', () => {
+      mountWithApp(
+        <IndexFilters
+          {...defaultProps}
+          mode={IndexFiltersMode.Filtering}
+          hideQueryField
+          hideFilters
+        />,
+      );
+
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+        }),
+      );
+
+      expect(defaultProps.cancelAction!.onAction).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/11664

Fixes a issue where pressing the F key to toggle the filtering mode of the IndexFilters was still toggling  even when the component had no search field or filters. This resulted in the default mode vanishing from the screen and unable to get it back unless one performs a manual refresh of the page.

### WHAT is this pull request doing?

Returns early from the keydown event listener if both the `hideQueryField` and `hideFilters` props are `true`.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Spin URL: https://admin.web.index-filter-keyboard-shortcut.marc-thomas.eu.spin.dev/store/shop1/orders (I've updated the Orders index to remove search and filters to showcase the change)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
