### PR TITLE
[IndexTable] Allow paginatedSelectAllAction to be visible without having to provide bulkActions prop

### DIFF
--- a/.changeset/breezy-beers-explode.md
+++ b/.changeset/breezy-beers-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated IndexTable so that no bulk actions are required to see the paginated select all text

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1075,6 +1075,7 @@ export function WithSelectionAndNoBulkActions() {
           allResourcesSelected ? 'All' : selectedResources.length
         }
         onSelectionChange={handleSelectionChange}
+        hasMoreItems
         headings={[
           {title: 'Name'},
           {title: 'Location'},

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -461,11 +461,6 @@ function IndexTableBase({
     );
   }, [tableInitialized, resizeTableScrollBar, condensed]);
 
-  const hasBulkActions = Boolean(
-    (promotedBulkActions && promotedBulkActions.length > 0) ||
-      (bulkActions && bulkActions.length > 0),
-  );
-
   const headingsMarkup = headings
     .map(renderHeading)
     .reduce<JSX.Element[]>((acc, heading) => acc.concat(heading), []);
@@ -1125,7 +1120,7 @@ function IndexTableBase({
   }
 
   function getPaginatedSelectAllAction() {
-    if (!selectable || !hasBulkActions || !hasMoreItems) {
+    if (!selectable || !hasMoreItems) {
       return;
     }
 

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -426,6 +426,27 @@ describe('<IndexTable>', () => {
       expect(index.find(BulkActions)).toContainReactText(customString);
     });
 
+    it('does not need the bulkActions or promotedBulkActions props present to render the custom select all string', () => {
+      const onSelectionChangeSpy = jest.fn();
+      const customString = 'Foo bar baz';
+      const index = mountWithApp(
+        <IndexTable
+          {...defaultProps}
+          selectable
+          hasMoreItems
+          selectedItemsCount={1}
+          itemCount={2}
+          bulkActions={undefined}
+          promotedBulkActions={undefined}
+          onSelectionChange={onSelectionChangeSpy}
+          paginatedSelectAllActionText={customString}
+        >
+          {mockTableItems.map(mockRenderRow)}
+        </IndexTable>,
+      );
+      expect(index.find(BulkActions)).toContainReactText(customString);
+    });
+
     it('toggles all page resources when onToggleAll is triggered', () => {
       const onSelectionChangeSpy = jest.fn();
       const index = mountWithApp(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/11669

When using the IndexTable in Polaris, currently if you want to have the action saying "Select all X+ customers", you have to provide a `bulkActions` prop. This doesn't make sense, as we support tables without bulk actions, and there is no relationship between selecting all resources, and the presence of bulk actions.

It should be possible to show the "Select all X+ customers" action without relying on the presence of the `bulkActions` prop.

### WHAT is this pull request doing?

Removes the need for `bulkActions` prop on the IndexTable to show the "Select all X+ customers" action.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Spin URL (remove bulk actions from Products index to show that the select all action is present): https://admin.web.index-table-select-all-action.marc-thomas.eu.spin.dev/store/shop1/products?selectedView=all

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
