### PR TITLE
[Actions] Ensure incorrect values are filtered out before iterating

### DIFF
--- a/.changeset/forty-feet-fail.md
+++ b/.changeset/forty-feet-fail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated Actions to safeguard against incorrect prop shapes being passed to it

--- a/polaris-react/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/polaris-react/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -161,12 +161,12 @@ export function Actions({actions, groups, onActionRollup}: Props) {
     return isVisibleGroup;
   });
 
-  const hiddenActionObjects = hiddenActions.map(
-    (index) => actionsOrDefault[index],
-  );
-  const hiddenGroupObjects = hiddenGroups.map(
-    (index) => groupsOrDefault[index],
-  );
+  const hiddenActionObjects = hiddenActions
+    .map((index) => actionsOrDefault[index])
+    .filter((action) => action != null);
+  const hiddenGroupObjects = hiddenGroups
+    .map((index) => groupsOrDefault[index])
+    .filter((group) => group != null);
 
   const groupsMarkup = filteredGroups.map((group) => {
     const {title, actions: groupActions, ...rest} = group;

--- a/polaris-react/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
+++ b/polaris-react/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
@@ -234,6 +234,74 @@ describe('<Actions />', () => {
       children: 'mock content 2',
     });
   });
+
+  it('filters out values from the hiddenActions array if they do not match the actions array', () => {
+    mockGetVisibleAndHiddenActionsIndices({
+      visibleActions: [0, 1],
+      visibleGroups: [],
+      hiddenActions: [2, 3, 4, 5],
+      hiddenGroups: [],
+    });
+
+    const wrapper = mountWithApp(
+      <ActionMenu
+        actions={[
+          {content: 'mock content 0'},
+          {content: 'mock content 1'},
+          {content: 'mock content 2'},
+        ]}
+      />,
+    );
+
+    forceMeasurement(wrapper);
+
+    expect(wrapper).toContainReactComponent(SecondaryAction, {
+      children: 'mock content 0',
+    });
+    expect(wrapper).toContainReactComponent(SecondaryAction, {
+      children: 'mock content 1',
+    });
+    expect(wrapper).toContainReactComponent(SecondaryAction, {
+      children: 'More actions',
+    });
+    expect(wrapper).not.toContainReactComponent(SecondaryAction, {
+      children: 'mock content 2',
+    });
+  });
+
+  it('filters out values from the hiddenGroups array if they do not match the groups array', () => {
+    mockGetVisibleAndHiddenActionsIndices({
+      visibleActions: [],
+      visibleGroups: [0, 1],
+      hiddenActions: [],
+      hiddenGroups: [2, 3, 4, 5],
+    });
+
+    const wrapper = mountWithApp(
+      <ActionMenu
+        groups={[
+          {title: 'Menu group 0', actions: [{content: 'mock content 0'}]},
+          {title: 'Menu group 1', actions: [{content: 'mock content 1'}]},
+          {title: 'Menu group 2', actions: [{content: 'mock content 2'}]},
+        ]}
+      />,
+    );
+
+    forceMeasurement(wrapper);
+
+    expect(wrapper).toContainReactComponent(SecondaryAction, {
+      children: 'Menu group 0',
+    });
+    expect(wrapper).toContainReactComponent(SecondaryAction, {
+      children: 'Menu group 1',
+    });
+    expect(wrapper).toContainReactComponent(SecondaryAction, {
+      children: 'More actions',
+    });
+    expect(wrapper).not.toContainReactComponent(SecondaryAction, {
+      children: 'Menu group 2',
+    });
+  });
 });
 
 function findWrapper(wrapper: CustomRoot<any, any>) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a [bug](https://app.bugsnag.com/shopify/shopify-web-client/timeline?filters[event.since]=7d&filters[error.status]=open&filters[error]=65e257c1fa853900080d195d&filters[release.seen_in]=172541221c00bcb5afbd4779e553710d0eaed216&pivot_tab=event) that was detected last week where incorrect value types were passed down to the `Actions` component within the `Page` component which was causing pages to 500.

### WHAT is this pull request doing?

We create an array of hidden actions and hidden groups to render within the ActionList, depending on how much space there is to render regular actions & groups. We call a typeguard function on each item in that array, using the `'X' in y` syntax to determine the type of the value. Some of the values in the array when used in production are `undefined`, so trying to run `'X' in undefined` throws an error. By filtering the data that creates the array which we iterate on, we can be sure that the values exist before we pass them to the typeguard function.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Spin instance: https://admin.web.more-actions-bug-2.marc-thomas.eu.spin.dev/store/shop1/products/10

Should not be able to get an error in the console relating to the bug if you navigate between products with long and short titles

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
