### PR TITLE
Remove REM units from Polaris icons

### DIFF
--- a/.changeset/fluffy-socks-cheer.md
+++ b/.changeset/fluffy-socks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': patch
+---
+
+Removed REM units from SkeletonIcon

--- a/polaris-icons/icons/SkeletonIcon.svg
+++ b/polaris-icons/icons/SkeletonIcon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><rect width="14" height="14" x="3" y="3" fill-opacity=".12" rx="0.25rem" ry="0.25rem"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><rect width="14" height="14" x="3" y="3" fill-opacity=".12" rx="4"/></svg>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Using REMs in Polaris icon SVGs was causing issue with usage on mobile.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR simplifies our icons by using implicit pixel values in Polaris icon SVGs. Only the `SkeletonIcon` should be affected. There should be not visual changes.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
