### PR TITLE
Add controlled prop to open the Tooltip

### DIFF
--- a/.changeset/three-plants-smile.md
+++ b/.changeset/three-plants-smile.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Added controlled prop to open the `Tooltip`
+Added the `open` prop to `Tooltip` to support programmatic control of its active state

--- a/.changeset/three-plants-smile.md
+++ b/.changeset/three-plants-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added controlled prop to open the `Tooltip`

--- a/.changeset/three-plants-smile.md
+++ b/.changeset/three-plants-smile.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Added the `open` prop to `Tooltip` to support programmatic control of its active state
+Added the `open` prop to `Tooltip` to support programmatic control of its active state. Added the `defaultOpen` prop to `Tooltip` to supersede the `active` prop for setting the initial active state. Deprecated the `active` prop on `Tooltip` to be removed in Polaris v13.

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -505,6 +505,39 @@ export function WithControlledState() {
   );
 }
 
+export function WithUncontrolledState() {
+  return (
+    <Box paddingBlockStart="2400">
+      <InlineStack gap="2400">
+        <Tooltip
+          content="This tooltip should render on load and hover"
+          defaultOpen
+        >
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Default open true
+          </Text>
+        </Tooltip>
+        <Tooltip
+          content="This tooltip should render on hover"
+          defaultOpen={false}
+        >
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Default open false
+          </Text>
+        </Tooltip>
+        <Tooltip
+          content="This tooltip should render on hover"
+          defaultOpen={undefined}
+        >
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Default open undefined
+          </Text>
+        </Tooltip>
+      </InlineStack>
+    </Box>
+  );
+}
+
 export function ActiveStates() {
   const [popoverActive, setPopoverActive] = useState(false);
   const [tooltipActive, setTooltipActive] =

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import {QuestionCircleIcon} from '@shopify/polaris-icons';
 import type {ComponentMeta} from '@storybook/react';
 import {
@@ -489,18 +489,26 @@ export function PersistOnClick() {
 export function WithControlledState() {
   const [open, setOpen] = useState(false);
 
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, []);
+
   return (
     <Box paddingBlockStart="2400">
-      <BlockStack gap="300" inlineAlign="start">
-        <Tooltip open={open} content="Tooltip content">
-          <Text as="span" variant="bodyLg">
-            The tooltip is {String(open)}
-          </Text>
-        </Tooltip>
-        <Button onClick={() => setOpen((prevOpen) => !prevOpen)}>
-          Toggle tooltip
-        </Button>
-      </BlockStack>
+      <Tooltip
+        open={open}
+        onOpen={handleOpen}
+        onClose={handleClose}
+        content="Tooltip content"
+      >
+        <Text as="span" variant="bodyLg">
+          The tooltip is {String(open)}
+        </Text>
+      </Tooltip>
     </Box>
   );
 }

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -43,7 +43,7 @@ export function All() {
 export function Default() {
   return (
     <Box paddingBlockStart="2400">
-      <Tooltip active content="This order has shipping labels.">
+      <Tooltip defaultOpen content="This order has shipping labels.">
         <Text variant="bodyLg" fontWeight="bold" as="span">
           Order #1001
         </Text>
@@ -57,7 +57,7 @@ export function PreferredPosition() {
     <Box paddingBlockStart="2400">
       <InlineStack gap="800">
         <Tooltip
-          active
+          defaultOpen
           content="This content is positioned above the activator"
           preferredPosition="above"
         >
@@ -75,7 +75,7 @@ export function PreferredPosition() {
           </InlineStack>
         </Tooltip>
         <Tooltip
-          active
+          defaultOpen
           content="This content is positioned above the activator"
           preferredPosition="below"
         >
@@ -102,7 +102,7 @@ export function Width() {
     <Box paddingBlockStart="2400">
       <InlineStack gap="800">
         <Tooltip
-          active
+          defaultOpen
           content="This content has the default width and will break into a new line at 200px width"
         >
           <InlineStack gap="100">
@@ -119,7 +119,7 @@ export function Width() {
           </InlineStack>
         </Tooltip>
         <Tooltip
-          active
+          defaultOpen
           content="This content has the wide width and will break into a new line at 275px width"
           width="wide"
         >
@@ -145,7 +145,7 @@ export function Padding() {
   return (
     <Box paddingBlockStart="2400">
       <InlineStack gap="800">
-        <Tooltip active content="This content has default padding">
+        <Tooltip defaultOpen content="This content has default padding">
           <InlineStack gap="100">
             <Text variant="bodyLg" fontWeight="medium" as="span">
               Tooltip with
@@ -160,7 +160,7 @@ export function Padding() {
           </InlineStack>
         </Tooltip>
         <Tooltip
-          active
+          defaultOpen
           content="This content has padding of 4 (space-400 / 16px)"
           padding="400"
         >
@@ -187,7 +187,7 @@ export function BorderRadius() {
     <Box paddingBlockStart="2400">
       <InlineStack gap="800">
         <Tooltip
-          active
+          defaultOpen
           content="This content has the default (radius-100) border radius"
         >
           <InlineStack gap="100">
@@ -204,7 +204,7 @@ export function BorderRadius() {
           </InlineStack>
         </Tooltip>
         <Tooltip
-          active
+          defaultOpen
           content="This content has a border radius of 200 (radius-200)"
           borderRadius="200"
         >
@@ -307,7 +307,7 @@ export function ActivatorAsDiv() {
   return (
     <Box paddingBlockStart="2400">
       <Tooltip
-        active
+        defaultOpen
         content="This tooltip is rendered as a div"
         activatorWrapper="div"
       >
@@ -462,7 +462,7 @@ export function Alignment() {
 export function HasUnderline() {
   return (
     <Card padding="400">
-      <Tooltip active content="This tooltip has an underline" hasUnderline>
+      <Tooltip defaultOpen content="This tooltip has an underline" hasUnderline>
         <Text variant="bodyLg" fontWeight="bold" as="span">
           Order #1001
         </Text>
@@ -577,7 +577,7 @@ export function ActiveStates() {
 export function OneCharacter() {
   return (
     <Box paddingBlockStart="2400">
-      <Tooltip active content="j">
+      <Tooltip defaultOpen content="j">
         <Text variant="bodyLg" fontWeight="bold" as="span">
           Order #1001
         </Text>

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -486,7 +486,7 @@ export function PersistOnClick() {
   );
 }
 
-export function OpenStates() {
+export function WithControlledState() {
   const [open, setOpen] = useState(false);
 
   return (

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -486,6 +486,25 @@ export function PersistOnClick() {
   );
 }
 
+export function OpenStates() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box paddingBlockStart="2400">
+      <BlockStack gap="300" inlineAlign="start">
+        <Tooltip open={open} content="Tooltip content">
+          <Text as="span" variant="bodyLg">
+            The tooltip is {String(open)}
+          </Text>
+        </Tooltip>
+        <Button onClick={() => setOpen((prevOpen) => !prevOpen)}>
+          Toggle tooltip
+        </Button>
+      </BlockStack>
+    </Box>
+  );
+}
+
 export function ActiveStates() {
   const [popoverActive, setPopoverActive] = useState(false);
   const [tooltipActive, setTooltipActive] =

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -23,9 +23,14 @@ export interface TooltipProps {
   children?: React.ReactNode;
   /** The content to display within the tooltip */
   content: React.ReactNode;
-  /** Toggle whether the tooltip is visible. Takes precedence over `active` */
+  /** Toggle whether the tooltip is visible. */
   open?: boolean;
   /** Toggle whether the tooltip is visible initially */
+  defaultOpen?: boolean;
+  /**
+   * Toggle whether the tooltip is visible initially
+   * @deprecated Use `defaultOpen` instead
+   */
   active?: boolean;
   /** Delay in milliseconds while hovering over an element before the tooltip is visible */
   hoverDelay?: number;
@@ -77,6 +82,7 @@ export function Tooltip({
   content,
   dismissOnMouseOut,
   open,
+  defaultOpen: defaultOpenProp,
   active: originalActive,
   hoverDelay,
   preferredPosition = 'above',
@@ -94,14 +100,15 @@ export function Tooltip({
   const borderRadius = borderRadiusProp || '200';
 
   const WrapperComponent: any = activatorWrapper;
+  const defaultOpen = defaultOpenProp ?? originalActive;
   const {
     value: active,
     setTrue: setActiveTrue,
     setFalse: handleBlur,
-  } = useToggle(Boolean(originalActive));
+  } = useToggle(Boolean(defaultOpen));
 
   const {value: persist, toggle: togglePersisting} = useToggle(
-    Boolean(originalActive) && Boolean(persistOnClick),
+    Boolean(defaultOpen) && Boolean(persistOnClick),
   );
 
   const [activatorNode, setActivatorNode] = useState<HTMLElement | null>(null);
@@ -111,14 +118,14 @@ export function Tooltip({
   const id = useId();
   const activatorContainer = useRef<HTMLElement>(null);
   const mouseEntered = useRef(false);
-  const [shouldAnimate, setShouldAnimate] = useState(Boolean(!originalActive));
+  const [shouldAnimate, setShouldAnimate] = useState(Boolean(!defaultOpen));
   const hoverDelayTimeout = useRef<NodeJS.Timeout | null>(null);
   const hoverOutTimeout = useRef<NodeJS.Timeout | null>(null);
 
   const handleFocus = useCallback(() => {
-    if (originalActive !== false) {
-      setActiveTrue();
-    }
+    if (originalActive === false) return;
+
+    setActiveTrue();
   }, [originalActive, setActiveTrue]);
 
   useEffect(() => {

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -23,7 +23,9 @@ export interface TooltipProps {
   children?: React.ReactNode;
   /** The content to display within the tooltip */
   content: React.ReactNode;
-  /** Toggle whether the tooltip is visible */
+  /** Toggle whether the tooltip is visible. Takes precedence over `active` */
+  open?: boolean;
+  /** Toggle whether the tooltip is visible initially */
   active?: boolean;
   /** Delay in milliseconds while hovering over an element before the tooltip is visible */
   hoverDelay?: number;
@@ -74,6 +76,7 @@ export function Tooltip({
   children,
   content,
   dismissOnMouseOut,
+  open,
   active: originalActive,
   hoverDelay,
   preferredPosition = 'above',
@@ -179,7 +182,7 @@ export function Tooltip({
         id={id}
         preferredPosition={preferredPosition}
         activator={activatorNode}
-        active={active}
+        active={open ?? active}
         accessibilityLabel={accessibilityLabel}
         onClose={noop}
         preventInteraction={dismissOnMouseOut}
@@ -187,7 +190,7 @@ export function Tooltip({
         padding={padding}
         borderRadius={borderRadius}
         zIndexOverride={zIndexOverride}
-        instant={!shouldAnimate}
+        instant={open || !shouldAnimate}
       >
         {content}
       </TooltipOverlay>

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -197,7 +197,7 @@ export function Tooltip({
         padding={padding}
         borderRadius={borderRadius}
         zIndexOverride={zIndexOverride}
-        instant={open || !shouldAnimate}
+        instant={!shouldAnimate}
       >
         {content}
       </TooltipOverlay>

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -47,6 +47,50 @@ describe('<Tooltip />', () => {
     );
   });
 
+  it('renders when open is true', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" open>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
+  });
+
+  it('does not render when open is false', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" open={false}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
+      'div',
+    );
+  });
+
+  it('renders when open is true and active is false', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" open active={false}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
+  });
+
+  it('does not render when open is false and active is true', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" open={false} active>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
+      'div',
+    );
+  });
+
   it('does not render when active prop is updated to false', () => {
     const tooltip = mountWithApp(
       <Tooltip content="Inner content" active={undefined}>

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -35,104 +35,94 @@ describe('<Tooltip />', () => {
     expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
   });
 
-  it('does not render when active is false', () => {
-    const tooltipActive = mountWithApp(
-      <Tooltip content="Inner content" active={false}>
-        <Link>link content</Link>
-      </Tooltip>,
-    );
-
-    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
-      'div',
-    );
-  });
-
   it('renders initially when defaultOpen is true', () => {
-    const tooltipActive = mountWithApp(
+    const tooltip = mountWithApp(
       <Tooltip content="Inner content" defaultOpen>
         <Link>link content</Link>
       </Tooltip>,
     );
 
-    expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
+    expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div');
   });
 
-  it('does not render when defaultOpen is false', () => {
-    const tooltipActive = mountWithApp(
+  it('does not render when active is false', () => {
+    const tooltip = mountWithApp(
+      <Tooltip content="Inner content" active={false}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
+  });
+
+  it('does not render initially when defaultOpen is false', () => {
+    const tooltip = mountWithApp(
       <Tooltip content="Inner content" defaultOpen={false}>
         <Link>link content</Link>
       </Tooltip>,
     );
 
-    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
-      'div',
-    );
+    expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
   });
 
   it('renders when open is true', () => {
-    const tooltipActive = mountWithApp(
+    const tooltip = mountWithApp(
       <Tooltip content="Inner content" open>
         <Link>link content</Link>
       </Tooltip>,
     );
 
-    expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
+    expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div');
   });
 
   it('does not render when open is false', () => {
-    const tooltipActive = mountWithApp(
+    const tooltip = mountWithApp(
       <Tooltip content="Inner content" open={false}>
         <Link>link content</Link>
       </Tooltip>,
     );
 
-    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
-      'div',
-    );
+    expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
   });
 
   it('renders when open is true and active is false', () => {
-    const tooltipActive = mountWithApp(
+    const tooltip = mountWithApp(
       <Tooltip content="Inner content" open active={false}>
         <Link>link content</Link>
       </Tooltip>,
     );
 
-    expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
-  });
-
-  it('does not render when open is false and active is true', () => {
-    const tooltipActive = mountWithApp(
-      <Tooltip content="Inner content" open={false} active>
-        <Link>link content</Link>
-      </Tooltip>,
-    );
-
-    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
-      'div',
-    );
+    expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div');
   });
 
   it('renders when open is true and defaultOpen is false', () => {
-    const tooltipActive = mountWithApp(
+    const tooltip = mountWithApp(
       <Tooltip content="Inner content" open defaultOpen={false}>
         <Link>link content</Link>
       </Tooltip>,
     );
 
-    expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
+    expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div');
+  });
+
+  it('does not render when open is false and active is true', () => {
+    const tooltip = mountWithApp(
+      <Tooltip content="Inner content" open={false} active>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
   });
 
   it('does not render when open is false and defaultOpen is true', () => {
-    const tooltipActive = mountWithApp(
+    const tooltip = mountWithApp(
       <Tooltip content="Inner content" open={false} defaultOpen>
         <Link>link content</Link>
       </Tooltip>,
     );
 
-    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
-      'div',
-    );
+    expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
   });
 
   it('does not render when active prop is updated to false', () => {
@@ -149,9 +139,23 @@ describe('<Tooltip />', () => {
     expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
   });
 
+  it('renders when defaultOpen prop is updated to false', () => {
+    const tooltip = mountWithApp(
+      <Tooltip content="Inner content">
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    findWrapperComponent(tooltip)!.trigger('onMouseOver');
+    expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div');
+
+    tooltip.setProps({defaultOpen: false});
+    expect(tooltip.find(TooltipOverlay)).toContainReactComponent('div');
+  });
+
   it('passes preventInteraction to TooltipOverlay when dismissOnMouseOut is true', () => {
     const tooltip = mountWithApp(
-      <Tooltip dismissOnMouseOut content="Inner content" active>
+      <Tooltip dismissOnMouseOut content="Inner content">
         <Link>link content</Link>
       </Tooltip>,
     );
@@ -206,7 +210,7 @@ describe('<Tooltip />', () => {
 
   it('closes itself when escape is pressed on keyup', () => {
     const tooltip = mountWithApp(
-      <Tooltip active content="This order has shipping labels.">
+      <Tooltip defaultOpen content="This order has shipping labels.">
         <div>Order #1001</div>
       </Tooltip>,
     );
@@ -220,11 +224,11 @@ describe('<Tooltip />', () => {
     });
   });
 
-  it('does not call onOpen when initially activated', () => {
+  it('does not call onOpen initially when defaultOpen is true', () => {
     const openSpy = jest.fn();
     const tooltip = mountWithApp(
       <Tooltip
-        active
+        defaultOpen
         content="This order has shipping labels."
         onOpen={openSpy}
       >
@@ -239,11 +243,11 @@ describe('<Tooltip />', () => {
     expect(openSpy).not.toHaveBeenCalled();
   });
 
-  it('calls onClose when initially activated and then closed', () => {
+  it('calls onClose when initially when defaultOpen is true and then closed', () => {
     const closeSpy = jest.fn();
     const tooltip = mountWithApp(
       <Tooltip
-        active
+        defaultOpen
         content="This order has shipping labels."
         onClose={closeSpy}
       >
@@ -304,7 +308,7 @@ describe('<Tooltip />', () => {
     const closeSpy = jest.fn();
 
     const tooltip = mountWithApp(
-      <Tooltip active content="Inner content" onClose={closeSpy}>
+      <Tooltip defaultOpen content="Inner content" onClose={closeSpy}>
         <Link>link content</Link>
       </Tooltip>,
     );
@@ -322,7 +326,7 @@ describe('<Tooltip />', () => {
     const closeSpy = jest.fn();
 
     const tooltip = mountWithApp(
-      <Tooltip active content="Inner content" onClose={closeSpy}>
+      <Tooltip defaultOpen content="Inner content" onClose={closeSpy}>
         <Link>link content</Link>
       </Tooltip>,
     );

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -47,6 +47,28 @@ describe('<Tooltip />', () => {
     );
   });
 
+  it('renders initially when defaultOpen is true', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" defaultOpen>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
+  });
+
+  it('does not render when defaultOpen is false', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" defaultOpen={false}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
+      'div',
+    );
+  });
+
   it('renders when open is true', () => {
     const tooltipActive = mountWithApp(
       <Tooltip content="Inner content" open>
@@ -82,6 +104,28 @@ describe('<Tooltip />', () => {
   it('does not render when open is false and active is true', () => {
     const tooltipActive = mountWithApp(
       <Tooltip content="Inner content" open={false} active>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).not.toContainReactComponent(
+      'div',
+    );
+  });
+
+  it('renders when open is true and defaultOpen is false', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" open defaultOpen={false}>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+
+    expect(tooltipActive.find(TooltipOverlay)).toContainReactComponent('div');
+  });
+
+  it('does not render when open is false and defaultOpen is true', () => {
+    const tooltipActive = mountWithApp(
+      <Tooltip content="Inner content" open={false} defaultOpen>
         <Link>link content</Link>
       </Tooltip>,
     );
@@ -299,7 +343,7 @@ describe('<Tooltip />', () => {
       <Tooltip
         accessibilityLabel={accessibilityLabel}
         content="Inner content"
-        active
+        defaultOpen
       >
         <Link>link content</Link>
       </Tooltip>,
@@ -311,7 +355,7 @@ describe('<Tooltip />', () => {
 
   it("passes 'zIndexOverride' to TooltipOverlay", () => {
     const tooltip = mountWithApp(
-      <Tooltip active content="Inner content" zIndexOverride={100}>
+      <Tooltip defaultOpen content="Inner content" zIndexOverride={100}>
         <Link>link content</Link>
       </Tooltip>,
     );

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -243,7 +243,7 @@ describe('<Tooltip />', () => {
     expect(openSpy).not.toHaveBeenCalled();
   });
 
-  it('calls onClose when initially when defaultOpen is true and then closed', () => {
+  it('calls onClose initially when defaultOpen is true and then closed', () => {
     const closeSpy = jest.fn();
     const tooltip = mountWithApp(
       <Tooltip

--- a/polaris.shopify.com/pages/examples/tooltip-default.tsx
+++ b/polaris.shopify.com/pages/examples/tooltip-default.tsx
@@ -5,7 +5,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function TooltipExample() {
   return (
     <div style={{padding: '75px 0'}}>
-      <Tooltip active content="This order has shipping labels.">
+      <Tooltip defaultOpen content="This order has shipping labels.">
         <Text fontWeight="bold" as="span">
           Order #1001
         </Text>

--- a/polaris.shopify.com/pages/examples/tooltip-with-persistence-on-click.tsx
+++ b/polaris.shopify.com/pages/examples/tooltip-with-persistence-on-click.tsx
@@ -5,7 +5,11 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function TooltipExample() {
   return (
     <div style={{padding: '75px 0'}}>
-      <Tooltip persistOnClick active content="This order has shipping labels.">
+      <Tooltip
+        defaultOpen
+        persistOnClick
+        content="This order has shipping labels."
+      >
         <Text fontWeight="bold" as="span">
           Order #1001
         </Text>

--- a/polaris.shopify.com/pages/examples/tooltip-with-underline.tsx
+++ b/polaris.shopify.com/pages/examples/tooltip-with-underline.tsx
@@ -6,7 +6,11 @@ function TooltipExample() {
   return (
     <div style={{padding: '75px 0'}}>
       <Card padding="400">
-        <Tooltip active content="This tooltip has an underline" hasUnderline>
+        <Tooltip
+          defaultOpen
+          hasUnderline
+          content="This tooltip has an underline"
+        >
           <Text variant="bodyLg" fontWeight="bold" as="span">
             Order #1001
           </Text>


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR introduces a controlled component prop named `open` to the `Tooltip`. This feature is being added to support upcoming Common Actions guidance for Copy to Clipboard buttons.

Currently, the Tooltip provides an `active` prop which only sets the initial open state. Note: The new `open` prop takes precedence over `active`. I suggest we rename `active` to `defaultOpen` in a future major release for consistency with other (un)controlled component patterns (e.g. `<input />`, `value`, and `defaultValue`) and help disambiguate the props.

UPDATE: Per the discussion [here](https://github.com/Shopify/polaris/pull/11714#discussion_r1520359416), we have opt'd to include the proposed `defaultProp` and deprecate the `active` prop as part of this PR e.g.
- Added a new `defaultOpen` prop
- Deprecated the `active` prop
- Special cased the existing `active` prop behavior
- Added new test cases for `defaultOpen`
- Updated existing test cases to use `defaultOpen`
- Added uncontrolled `Tooltip` examples to Storybook
- Updated existing Storybook entries to use `defaultOpen`

Example setting `open={true}` for the duration of the `copied` status timeout:

https://github.com/Shopify/polaris/assets/32409546/2a69ee6c-3b86-40d5-95c7-f6e1707186ce

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
