### PR TITLE
[Popover] Remove transition for cover position

### DIFF
--- a/polaris-react/src/components/Popover/Popover.module.css
+++ b/polaris-react/src/components/Popover/Popover.module.css
@@ -21,7 +21,7 @@
 }
 
 .PopoverOverlay-noAnimation {
-  transition: none;
+  transition: opacity var(--p-motion-duration-100) var(--p-motion-ease);
 }
 
 .PopoverOverlay-entering {

--- a/polaris-react/src/components/Popover/Popover.module.css
+++ b/polaris-react/src/components/Popover/Popover.module.css
@@ -20,6 +20,10 @@
   transform: translateY(var(--pc-popover-vertical-motion-offset));
 }
 
+.PopoverOverlay-noAnimation {
+  transition: none;
+}
+
 .PopoverOverlay-entering {
   opacity: 1;
   transform: translateY(0);

--- a/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -144,6 +144,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         styles['PopoverOverlay-open'],
       transitionStatus === TransitionStatus.Exiting &&
         styles['PopoverOverlay-exiting'],
+      preferredPosition === 'cover' && styles['PopoverOverlay-noAnimation'],
     );
 
     return (


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris/pull/11650#issuecomment-1991987509

https://github.com/Shopify/polaris/assets/6844391/60609477-1bf7-4064-b275-f558147b8c7c

