### PR TITLE
[OptionList] Fix layout shift within popovers

### DIFF
--- a/.changeset/chatty-timers-marry.md
+++ b/.changeset/chatty-timers-marry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed layout shift for option lists within popovers

--- a/polaris-react/src/components/OptionList/components/Option/Option.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/Option.tsx
@@ -141,7 +141,8 @@ export function Option({
         <span
           style={{
             fontWeight: 'var(--p-font-weight-semibold)',
-            minWidth: `${String(label).length ?? undefined}ch`,
+            minWidth:
+              typeof label === 'string' ? `${label.length}ch` : 'initial',
           }}
         >
           <span

--- a/polaris-react/src/components/OptionList/components/Option/Option.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/Option.tsx
@@ -140,19 +140,11 @@ export function Option({
         {mediaMarkup}
         <span
           style={{
-            fontWeight: 'var(--p-font-weight-semibold)',
             minWidth:
               typeof label === 'string' ? `${label.length}ch` : 'initial',
           }}
         >
-          <span
-            style={{
-              fontWeight:
-                select || active ? 'var(--p-font-weight-semibold)' : 'initial',
-            }}
-          >
-            {label}
-          </span>
+          {label}
         </span>
       </InlineStack>
     </button>

--- a/polaris-react/src/components/OptionList/components/Option/Option.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/Option.tsx
@@ -138,7 +138,21 @@ export function Option({
         blockAlign={verticalAlignToBlockAlign(verticalAlign)}
       >
         {mediaMarkup}
-        {label}
+        <span
+          style={{
+            fontWeight: 'var(--p-font-weight-semibold)',
+            minWidth: `${String(label).length ?? undefined}ch`,
+          }}
+        >
+          <span
+            style={{
+              fontWeight:
+                select || active ? 'var(--p-font-weight-semibold)' : 'initial',
+            }}
+          >
+            {label}
+          </span>
+        </span>
       </InlineStack>
     </button>
   );


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris-internal/issues/1517

Open to other ideas on how to fix this but character width is the most performant I can think of

https://github.com/Shopify/polaris/assets/6844391/268bc7c8-48ef-43ba-895f-b647a5a7b8c1

