### PR TITLE
Add hook that returns disabled value in RowContext

### DIFF
--- a/.changeset/lucky-seahorses-invent.md
+++ b/.changeset/lucky-seahorses-invent.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Add useIndexTableRowDisabled hook
+Added the `useIndexTableRowDisabled` hook

--- a/.changeset/lucky-seahorses-invent.md
+++ b/.changeset/lucky-seahorses-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add useIndexTableRowDisabled hook

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -426,6 +426,7 @@ export {useIndexResourceState} from './utilities/use-index-resource-state';
 export {
   useRowHovered as useIndexTableRowHovered,
   useRowSelected as useIndexTableRowSelected,
+  useRowDisabled as useIndexTableRowDisabled,
   useContainerScroll as useIndexTableContainerScroll,
 } from './utilities/index-table';
 export {

--- a/polaris-react/src/utilities/index-table/hooks.ts
+++ b/polaris-react/src/utilities/index-table/hooks.ts
@@ -12,6 +12,11 @@ export function useRowSelected() {
   return selected;
 }
 
+export function useRowDisabled() {
+  const {disabled} = useContext(RowContext);
+  return disabled;
+}
+
 export function useContainerScroll() {
   const scrolledContainerRef = useContext(ScrollContext);
   return scrolledContainerRef;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

We don't yet expose the `disabled` value for children of the `RowContext.Provider` to consume. 
This is something we discovered we need in the following web [PR](https://github.com/Shopify/web/pull/121521)
See problem outlined in the following [comment](https://github.com/Shopify/web/pull/121521#issuecomment-2003042995). 

We already expose the `hover` and `selected` context values via the [useRowHovered](https://github.com/Shopify/polaris/blob/c3537815a411e3339bd8d681db14e0b8b155ceba/polaris-react/src/utilities/index-table/hooks.ts#L5) and [useRowSelected](https://github.com/Shopify/polaris/blob/c3537815a411e3339bd8d681db14e0b8b155ceba/polaris-react/src/utilities/index-table/hooks.ts#L10) hooks respectively. This aligns with that convention. 

### WHAT is this pull request doing?

Following convention established in the `useRowHovered` and `useRowSelected` hooks to return as small a slice of state as possible, we expose a `useRowDisabled` hook so that context children can access the `disabled` state of the parent Row. (Needed for https://github.com/Shopify/web/pull/121521)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
