### PR TITLE
Use faster object syntax for postcss-mixins

### DIFF
--- a/.changeset/grumpy-chicken-applaud.md
+++ b/.changeset/grumpy-chicken-applaud.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix build performance regression from using postcss-mixins.

--- a/polaris-react/postcss-mixins/items-to-stagger.js
+++ b/polaris-react/postcss-mixins/items-to-stagger.js
@@ -1,16 +1,11 @@
-const postcss = require('postcss');
+const staggerInterval = 50;
 
-module.exports = (mixin) => {
-  const rules = [];
+module.exports = () => {
+  const rules = {};
   for (let i = 1; i <= 12; i++) {
-    const rule = postcss.rule({
-      selector: `&:nth-child(${i})`,
-    });
-    rule.append({
-      prop: 'animation-delay',
-      value: `calc((${i} - 1) * 50ms)`,
-    });
-    rules.push(rule);
+    rules[`&:nth-child(${i})`] = {
+      animationDelay: `${(i - 1) * staggerInterval}ms`,
+    };
   }
-  mixin.replaceWith(rules);
+  return rules;
 };

--- a/polaris-react/postcss-mixins/responsive-grid-cells.js
+++ b/polaris-react/postcss-mixins/responsive-grid-cells.js
@@ -1,35 +1,27 @@
-const postcss = require('postcss');
+function cellColumnEndRules(columns, breakpoint) {
+  const rules = {};
+  for (let column = 1; column <= columns; column++) {
+    rules[`.Cell-${column}-column-${breakpoint}`] = {
+      gridColumnEnd: `span ${column}`,
+    };
+  }
+  return rules;
+}
 
-const breakpoints = ['sm', 'md', 'lg', 'xl'];
-module.exports = (mixin) => {
-  const rules = [];
-  const atRules = [];
-  for (let i = 1; i <= 6; i++) {
-    const rule = postcss.rule({
-      selector: `.Cell-${i}-column-xs`,
-    });
-    rule.append({
-      prop: 'grid-column-end',
-      value: `span ${i}`,
-    });
-    rules.push(rule);
+function wrapInBreakpoint(breakpoints, getRules) {
+  const rules = {};
+  for (const breakpoint of breakpoints) {
+    rules[`@media (--p-breakpoints-${breakpoint}-up)`] = getRules(breakpoint);
   }
-  for (const i of breakpoints) {
-    const atRule = postcss.atRule({
-      name: 'media',
-      params: `(--p-breakpoints-${i}-up)`,
-    });
-    for (let j = 1; j <= (i === 'lg' || i === 'xl' ? 12 : 6); j++) {
-      const rule = postcss.rule({
-        selector: `.Cell-${j}-column-${i}`,
-      });
-      rule.append({
-        prop: 'grid-column-end',
-        value: `span ${j}`,
-      });
-      atRule.append(rule);
-    }
-    atRules.push(atRule);
-  }
-  mixin.replaceWith([].concat(rules, atRules));
-};
+  return rules;
+}
+
+module.exports = () => ({
+  ...cellColumnEndRules(6, 'xs'),
+  ...wrapInBreakpoint(['sm', 'md'], (breakpoint) =>
+    cellColumnEndRules(6, breakpoint),
+  ),
+  ...wrapInBreakpoint(['lg', 'xl'], (breakpoint) =>
+    cellColumnEndRules(12, breakpoint),
+  ),
+});

--- a/polaris-react/postcss-mixins/safe-area-for.js
+++ b/polaris-react/postcss-mixins/safe-area-for.js
@@ -1,5 +1,3 @@
-const postcss = require('postcss');
-
 const {nullish} = require('./utils');
 
 /* Returns a safe-area-inset for iPhone X screen obtrusions.
@@ -10,27 +8,14 @@ const {nullish} = require('./utils');
   If overriding an existing padding / margin that value should be used as
   $spacing
 */
-module.exports = (mixin, property, spacing, area) => {
+module.exports = (_, property, spacing, area) => {
   const spacingValue =
     nullish(spacing) || spacing === 0 || spacing === '0' ? '0px' : spacing;
-  const varDecl = postcss.decl({
-    prop: property,
-    value: spacingValue,
-  });
-  const constantDecl = postcss.decl({
-    prop: property,
-    value: `calc(
-      ${spacingValue} + constant(safe-area-inset-${area})
-    )`,
-  });
-  const envDecl = postcss.decl({
-    prop: property,
-    value: `calc(
-      ${spacingValue} + env(safe-area-inset-${area})
-    )`,
-  });
-
-  // We have to do a manual replace here
-  // Because if we returned an object, declarations with the same property would be deduped.
-  mixin.replaceWith([varDecl, constantDecl, envDecl]);
+  return {
+    [property]: [
+      spacingValue,
+      `calc(${spacingValue} + constant(safe-area-inset-${area}))`,
+      `calc(${spacingValue} + env(safe-area-inset-${area}))`,
+    ],
+  };
 };


### PR DESCRIPTION
There was a performance regression introduced by our non-sass mixins:

Some debugging the [performance flamegraph from 0x](https://github.com/davidmarkclements/0x) shows it's the usage of `postcss` within those mixins trying to generate source maps that's taking a significant amount of time:

<img width="1010" alt="Screenshot 2024-03-20 at 17 00 35" src="https://github.com/Shopify/polaris/assets/612020/d3ecc41f-c680-479b-8b1e-1f4d0b5e5a95">

It was possible to convert the mixins to the simpler object syntax which doesn't suffer from this issue.

### Performance

**tl;dr:** Building `@shopify/polaris` is now 4.4s faster 🎉 

I ran perf benchmarks using this `hyperfine` command:

```
hyperfine --parameter-list branch main,fix-postcss-mixins-perf --setup='git checkout {branch} && . ~/.nvm/nvm.sh && nvm use && yarn --prefer-offline && yarn build --filter="@shopify/polaris"' --prepare="rm -rf polaris-react/build" --runs 5 --warmup 1 '. ~/.nvm/nvm.sh && nvm use && yarn workspace @shopify/polaris build:js'
```

Results

```
Benchmark 1: (branch = main)
  Time (mean ± σ):     15.852 s ±  0.110 s    [User: 19.668 s, System: 4.021 s]
  Range (min … max):   15.743 s … 16.030 s    5 runs

Benchmark 2: (branch = fix-postcss-mixins-perf)
  Time (mean ± σ):     11.419 s ±  0.115 s    [User: 15.215 s, System: 2.943 s]
  Range (min … max):   11.285 s … 11.592 s    5 runs

Summary
  (branch = fix-postcss-mixins-perf) ran 1.39 ± 0.02 times faster than (branch = main)
```

### Validation

I confirmed the generated `.css` file is identical with this script:

```bash
# go.sh
if [ -z "$1" ]; then echo "A filename is required:\n> $0 ./no-sass.css"; exit 1; fi;

# Write a temporary postcss config for cssnano to work
cat <<EOF > postcss.config.js
module.exports = {
  plugins: [
    require('cssnano')({
      preset: 'lite',
    }),
  ],
};
EOF

yarn workspace @shopify/polaris add cssnano-preset-lite
yarn
yarn build --filter="@shopify/polaris"

cp polaris-react/build/esm/styles.css "$1" # Move out of ignored directories
yarn prettier -w "$1" # Pre-format to normalize whitespace
npx postcss-cli --yes postcss-cli -r --no-map --config="`pwd`" "$1" # cssnano removes more whitespace prettier doesn't
yarn prettier -w "$1" # Format again to get back into un-minified version
rm postcss.config.js # Clean up temporary files
yarn workspace @shopify/polaris remove cssnano-preset-lite
```

run like this:

```
git checkout main
./go.sh old.css
git checkout fix-postcss-mixins-perf
./go.sh new.css
git diff --histogram --no-index old.css new.css
```

And the result was: _no change_ 🎉 