### PR TITLE
[IndexTable.Row] Revert selectable=false early return, which break on…

### DIFF
--- a/.changeset/real-papayas-tease.md
+++ b/.changeset/real-papayas-tease.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Reverted a change that caused `IndexTable` `onNavigation` not to work when `selectable` is `false`

--- a/polaris-react/src/components/IndexTable/components/Row/Row.tsx
+++ b/polaris-react/src/components/IndexTable/components/Row/Row.tsx
@@ -142,7 +142,7 @@ export const Row = memo(function Row({
         return;
       }
 
-      if (primaryLinkElement.current && !selectMode && selectable) {
+      if (primaryLinkElement.current && !selectMode) {
         isNavigating.current = true;
         const {ctrlKey, metaKey} = event.nativeEvent;
 


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR reverts a change made in #11763, unrelated to the bug fixed, that caused an unintended regression: breaking `onNavigation` behavior for unselectable tables. This needs to ship in a patch asap because it is live in v12.20.0.
