### PR TITLE
Revert "[IndexTable] Allow row click when onClick is passed in on non-selectable tables"

### DIFF
--- a/polaris-react/src/components/IndexTable/components/Row/Row.tsx
+++ b/polaris-react/src/components/IndexTable/components/Row/Row.tsx
@@ -120,14 +120,13 @@ export const Row = memo(function Row({
     disabled && styles['TableRow-disabled'],
     tone && styles[variationName('tone', tone)],
     !selectable &&
-      !onClick &&
       !primaryLinkElement.current &&
       styles['TableRow-unclickable'],
   );
 
   let handleRowClick;
 
-  if ((!disabled && selectable) || onClick || primaryLinkElement.current) {
+  if ((!disabled && selectable) || primaryLinkElement.current) {
     handleRowClick = (event: React.MouseEvent) => {
       if (rowType === 'subheader') return;
 
@@ -142,7 +141,7 @@ export const Row = memo(function Row({
         return;
       }
 
-      if (primaryLinkElement.current && !selectMode && selectable) {
+      if (primaryLinkElement.current && !selectMode) {
         isNavigating.current = true;
         const {ctrlKey, metaKey} = event.nativeEvent;
 

--- a/polaris-react/src/components/IndexTable/components/Row/tests/Row.test.tsx
+++ b/polaris-react/src/components/IndexTable/components/Row/tests/Row.test.tsx
@@ -444,27 +444,6 @@ describe('<Row />', () => {
     );
   });
 
-  it('fires onClick handler when row has an onclick and is clicked despite no primary link child present and the table not being selectable', () => {
-    const mockOnClick = jest.fn();
-    const row = mountWithTable(
-      <Row {...defaultProps} onClick={mockOnClick}>
-        <th>
-          <a href="/">Child without data-primary-link</a>
-        </th>
-      </Row>,
-      {
-        indexTableProps: {
-          itemCount: 1,
-          selectable: false,
-        },
-      },
-    );
-
-    triggerOnClick(row, 1, defaultEvent);
-
-    expect(mockOnClick).toHaveBeenCalled();
-  });
-
   it('has an undefined tone by default', () => {
     const row = mountWithTable(
       <Row {...defaultProps}>


### PR DESCRIPTION
Reverts Shopify/polaris#11763

Caused this issue https://shopify.slack.com/archives/C4Y8N30KD/p1711057984810169

We should revert this for now so polaris is in a good state, then revert this revert with the fix for the above