### PR TITLE
[IndexTable] Add custom paginated select all text

### DIFF
--- a/.changeset/shaggy-items-smoke.md
+++ b/.changeset/shaggy-items-smoke.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Updated `IndexTable` to support a custom paginated select all text string
+Added the `defaultPaginatedSelectAllText` prop to `IndexTable` to support customizing the label of the checkbox in the header that selects all rows across pages when the table `hasMoreItems`

--- a/.changeset/shaggy-items-smoke.md
+++ b/.changeset/shaggy-items-smoke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated `IndexTable` to support a custom paginated select all text string

--- a/polaris-react/src/components/IndexProvider/IndexProvider.tsx
+++ b/polaris-react/src/components/IndexProvider/IndexProvider.tsx
@@ -19,6 +19,7 @@ export function IndexProvider({
   hasMoreItems,
   condensed,
   selectable: isSelectableIndex = true,
+  defaultPaginatedSelectAllText,
 }: IndexProviderProps) {
   const {
     paginatedSelectAllText,
@@ -32,6 +33,7 @@ export function IndexProvider({
     itemCount,
     hasMoreItems,
     resourceName: passedResourceName,
+    defaultPaginatedSelectAllText,
   });
   const handleSelectionChange = useHandleBulkSelection({onSelectionChange});
 

--- a/polaris-react/src/components/IndexProvider/IndexProvider.tsx
+++ b/polaris-react/src/components/IndexProvider/IndexProvider.tsx
@@ -19,7 +19,7 @@ export function IndexProvider({
   hasMoreItems,
   condensed,
   selectable: isSelectableIndex = true,
-  defaultPaginatedSelectAllText,
+  paginatedSelectAllText: defaultPaginatedSelectAllText,
 }: IndexProviderProps) {
   const {
     paginatedSelectAllText,

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1483,7 +1483,7 @@ export function WithBulkActionsAndSelectionAcrossPages() {
             title: 'Amount spent',
           },
         ]}
-        // defaultPaginatedSelectAllText="Select everything up in here"
+        defaultPaginatedSelectAllText="Select everything in this store"
       >
         {rowMarkup}
       </IndexTable>

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1483,7 +1483,7 @@ export function WithBulkActionsAndSelectionAcrossPages() {
             title: 'Amount spent',
           },
         ]}
-        defaultPaginatedSelectAllText="Select everything in this store"
+        paginatedSelectAllText="Select everything in this store"
       >
         {rowMarkup}
       </IndexTable>

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1483,6 +1483,7 @@ export function WithBulkActionsAndSelectionAcrossPages() {
             title: 'Amount spent',
           },
         ]}
+        // defaultPaginatedSelectAllText="Select everything up in here"
       >
         {rowMarkup}
       </IndexTable>

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -109,7 +109,7 @@ export interface IndexTableBaseProps {
   emptyState?: React.ReactNode;
   sort?: React.ReactNode;
   paginatedSelectAllActionText?: string;
-  defaultPaginatedSelectAllText?: string;
+  paginatedSelectAllText?: string;
   lastColumnSticky?: boolean;
   selectable?: boolean;
   /** List of booleans, which maps to whether sorting is enabled or not for each column. Defaults to false for all columns.  */
@@ -1124,7 +1124,7 @@ export function IndexTable({
   hasMoreItems,
   condensed,
   onSelectionChange,
-  defaultPaginatedSelectAllText,
+  paginatedSelectAllText,
   ...indexTableBaseProps
 }: IndexTableProps) {
   return (
@@ -1138,7 +1138,7 @@ export function IndexTable({
         hasMoreItems={hasMoreItems}
         condensed={condensed}
         onSelectionChange={onSelectionChange}
-        defaultPaginatedSelectAllText={defaultPaginatedSelectAllText}
+        paginatedSelectAllText={paginatedSelectAllText}
       >
         <IndexTableBase {...indexTableBaseProps}>{children}</IndexTableBase>
       </IndexProvider>

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -109,6 +109,7 @@ export interface IndexTableBaseProps {
   emptyState?: React.ReactNode;
   sort?: React.ReactNode;
   paginatedSelectAllActionText?: string;
+  defaultPaginatedSelectAllText?: string;
   lastColumnSticky?: boolean;
   selectable?: boolean;
   /** List of booleans, which maps to whether sorting is enabled or not for each column. Defaults to false for all columns.  */
@@ -177,6 +178,7 @@ function IndexTableBase({
     selectedItemsCount,
     condensed,
   } = useIndexValue();
+
   const handleSelectionChange = useIndexSelectionChange();
   const i18n = useI18n();
 
@@ -1122,6 +1124,7 @@ export function IndexTable({
   hasMoreItems,
   condensed,
   onSelectionChange,
+  defaultPaginatedSelectAllText,
   ...indexTableBaseProps
 }: IndexTableProps) {
   return (
@@ -1135,6 +1138,7 @@ export function IndexTable({
         hasMoreItems={hasMoreItems}
         condensed={condensed}
         onSelectionChange={onSelectionChange}
+        defaultPaginatedSelectAllText={defaultPaginatedSelectAllText}
       >
         <IndexTableBase {...indexTableBaseProps}>{children}</IndexTableBase>
       </IndexProvider>

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -438,7 +438,7 @@ describe('<IndexTable>', () => {
           itemCount={2}
           promotedBulkActions={[{content: 'promoted action'}]}
           onSelectionChange={onSelectionChangeSpy}
-          defaultPaginatedSelectAllText={customString}
+          paginatedSelectAllText={customString}
         >
           {mockTableItems.map(mockRenderRow)}
         </IndexTable>,

--- a/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/polaris-react/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -406,7 +406,7 @@ describe('<IndexTable>', () => {
       );
     });
 
-    it('renders a custom select all string if present', () => {
+    it('renders a custom select all action string if present', () => {
       const onSelectionChangeSpy = jest.fn();
       const customString = 'Foo bar baz';
       const index = mountWithApp(
@@ -419,6 +419,26 @@ describe('<IndexTable>', () => {
           promotedBulkActions={[{content: 'promoted action'}]}
           onSelectionChange={onSelectionChangeSpy}
           paginatedSelectAllActionText={customString}
+        >
+          {mockTableItems.map(mockRenderRow)}
+        </IndexTable>,
+      );
+      expect(index.find(BulkActions)).toContainReactText(customString);
+    });
+
+    it('renders a custom default select all string if present', () => {
+      const onSelectionChangeSpy = jest.fn();
+      const customString = 'Foo bar baz';
+      const index = mountWithApp(
+        <IndexTable
+          {...defaultProps}
+          selectable
+          hasMoreItems
+          selectedItemsCount="All"
+          itemCount={2}
+          promotedBulkActions={[{content: 'promoted action'}]}
+          onSelectionChange={onSelectionChangeSpy}
+          defaultPaginatedSelectAllText={customString}
         >
           {mockTableItems.map(mockRenderRow)}
         </IndexTable>,

--- a/polaris-react/src/utilities/index-provider/hooks.ts
+++ b/polaris-react/src/utilities/index-provider/hooks.ts
@@ -44,6 +44,7 @@ export function useBulkSelectionData({
   itemCount,
   hasMoreItems,
   resourceName: passedResourceName,
+  defaultPaginatedSelectAllText,
 }: BulkSelectionDataOptions) {
   const i18n = useI18n();
 
@@ -90,6 +91,9 @@ export function useBulkSelectionData({
     }
 
     if (selectedItemsCount === SELECT_ALL_ITEMS) {
+      if (defaultPaginatedSelectAllText) {
+        return defaultPaginatedSelectAllText;
+      }
       return i18n.translate('Polaris.IndexProvider.allItemsSelected', {
         itemsLength: itemCount,
         resourceNamePlural: resourceName.plural.toLocaleLowerCase(),

--- a/polaris-react/src/utilities/index-provider/types.ts
+++ b/polaris-react/src/utilities/index-provider/types.ts
@@ -30,7 +30,7 @@ export interface IndexProviderProps {
     selection?: string | Range,
     position?: number,
   ): void;
-  defaultPaginatedSelectAllText?: string;
+  paginatedSelectAllText?: string;
 }
 
 export type HandleSelectionChange = (

--- a/polaris-react/src/utilities/index-provider/types.ts
+++ b/polaris-react/src/utilities/index-provider/types.ts
@@ -30,6 +30,7 @@ export interface IndexProviderProps {
     selection?: string | Range,
     position?: number,
   ): void;
+  defaultPaginatedSelectAllText?: string;
 }
 
 export type HandleSelectionChange = (
@@ -47,6 +48,7 @@ export interface BulkSelectionDataOptions {
     singular: string;
     plural: string;
   };
+  defaultPaginatedSelectAllText?: string;
 }
 
 export interface HandleBulkSelectionOptions {


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses https://github.com/Shopify/web/issues/122239

We need to update the IndexTable to be able to pass a custom `paginatedSelectAllText` string, like we do `paginatedSelectAllActionText` string. The prop added to the `IndexTable` is `defaultPaginatedSelectAllText`.

<img width="1739" alt="Screenshot 2024-04-03 at 10 25 44" src="https://github.com/Shopify/polaris/assets/2562596/d8a92876-6861-4134-af85-c7e065ad8be0">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
