### PR TITLE
[Common actions] Update Button storybook examples to use `PlusCircleIcon`

### DIFF
--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -17,6 +17,7 @@ import {
 } from '@shopify/polaris';
 import {
   PlusIcon,
+  PlusCircleIcon,
   XSmallIcon,
   ChevronDownIcon,
   EditIcon,
@@ -211,10 +212,10 @@ export function Plain() {
         <Button variant="plain" disabled>
           Label
         </Button>
-        <Button variant="plain" icon={PlusIcon}>
+        <Button variant="plain" icon={PlusCircleIcon}>
           Label
         </Button>
-        <Button variant="plain" disabled icon={PlusIcon}>
+        <Button variant="plain" disabled icon={PlusCircleIcon}>
           Label
         </Button>
         <Button variant="plain" disclosure>
@@ -246,10 +247,10 @@ export function MonochromePlain() {
     <Box padding="400">
       <InlineStack gap="400" blockAlign="center">
         <Button variant="monochromePlain">Default</Button>
-        <Button variant="monochromePlain" icon={PlusIcon}>
+        <Button variant="monochromePlain" icon={PlusCircleIcon}>
           With icon
         </Button>
-        <Button variant="monochromePlain" disabled icon={PlusIcon}>
+        <Button variant="monochromePlain" disabled icon={PlusCircleIcon}>
           Disabled with icon
         </Button>
         <Button variant="monochromePlain" disclosure>
@@ -281,10 +282,10 @@ export function Tertiary() {
           <Button variant="tertiary" disabled>
             Label
           </Button>
-          <Button variant="tertiary" icon={PlusIcon}>
+          <Button variant="tertiary" icon={PlusCircleIcon}>
             Label
           </Button>
-          <Button variant="tertiary" disabled icon={PlusIcon}>
+          <Button variant="tertiary" disabled icon={PlusCircleIcon}>
             Label
           </Button>
           <Button variant="tertiary" disclosure>
@@ -311,10 +312,10 @@ export function Tertiary() {
           <Button variant="tertiary" disabled>
             Label
           </Button>
-          <Button variant="tertiary" icon={PlusIcon}>
+          <Button variant="tertiary" icon={PlusCircleIcon}>
             Label
           </Button>
-          <Button variant="tertiary" disabled icon={PlusIcon}>
+          <Button variant="tertiary" disabled icon={PlusCircleIcon}>
             Label
           </Button>
           <Button variant="tertiary" disclosure>


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/polaris-internal/issues/1518

### WHAT is this pull request doing?

This PR updates the Button storybook examples to follow the [Common Actions guidance](https://polaris.shopify.com/patterns/common-actions/overview).

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
