### PR TITLE
Bulk Action Button intro animation

### DIFF
--- a/.changeset/thick-walls-kiss.md
+++ b/.changeset/thick-walls-kiss.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated `BulkActionButton` to have a subtle animation when mounting

--- a/polaris-react/src/components/BulkActions/BulkActions.module.css
+++ b/polaris-react/src/components/BulkActions/BulkActions.module.css
@@ -22,6 +22,7 @@
   justify-content: flex-end;
   flex: 1 1 auto;
   gap: var(--p-space-100);
+  perspective: 300px;
 
   > * {
     flex: 0 0 auto;
@@ -54,12 +55,12 @@
 /* stylelint-disable-next-line polaris/motion/at-rule-disallowed-list -- Required for custom animation */
 @keyframes appear {
   from {
-    transform: scale(0.85) translateX(0%);
+    transform: scale(0.85);
     opacity: 0;
   }
 
   to {
-    transform: scale(1) translateX(0);
+    transform: scale(1);
     opacity: 1;
   }
 }

--- a/polaris-react/src/components/BulkActions/BulkActions.module.css
+++ b/polaris-react/src/components/BulkActions/BulkActions.module.css
@@ -66,7 +66,7 @@
 
 .BulkActionButton {
   white-space: nowrap;
-  animation: appear var(--p-motion-duration-250) 1 var(--p-motion-ease-in-out)
+  animation: appear var(--p-motion-duration-200) 1 var(--p-motion-ease-in-out)
     both;
   /* stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list, polaris/motion/declaration-property-unit-disallowed-list -- Required for custom animation */
   animation-delay: var(--pc-bulk-action-button-animation-delay, 0ms);

--- a/polaris-react/src/components/BulkActions/BulkActions.module.css
+++ b/polaris-react/src/components/BulkActions/BulkActions.module.css
@@ -51,8 +51,27 @@
   }
 }
 
+/* stylelint-disable-next-line polaris/motion/at-rule-disallowed-list -- Required for custom animation */
+@keyframes appear {
+  from {
+    transform: scale(0.85) translateX(0%);
+    opacity: 0;
+  }
+
+  to {
+    transform: scale(1) translateX(0);
+    opacity: 1;
+  }
+}
+
 .BulkActionButton {
   white-space: nowrap;
+  animation: appear var(--p-motion-duration-250) 1 var(--p-motion-ease-in-out)
+    both;
+  /* stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list, polaris/motion/declaration-property-unit-disallowed-list -- Required for custom animation */
+  animation-delay: var(--pc-bulk-action-button-animation-delay, 0ms);
+
+  transform-origin: center center;
 
   button {
     display: flex;

--- a/polaris-react/src/components/BulkActions/BulkActions.tsx
+++ b/polaris-react/src/components/BulkActions/BulkActions.tsx
@@ -239,7 +239,7 @@ export const BulkActions = forwardRef(function BulkActions(
 
           return true;
         })
-        .map((action, index) => {
+        .map((action, index, arr) => {
           if (instanceOfMenuGroupDescriptor(action)) {
             return (
               <BulkActionMenu
@@ -249,6 +249,7 @@ export const BulkActions = forwardRef(function BulkActions(
                   actionSections,
                 )}
                 size={buttonSize}
+                animationDelayIndex={arr.length - index}
               />
             );
           }
@@ -258,6 +259,7 @@ export const BulkActions = forwardRef(function BulkActions(
               disabled={disabled}
               {...action}
               size={buttonSize}
+              animationDelayIndex={arr.length - index}
             />
           );
         })

--- a/polaris-react/src/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
+++ b/polaris-react/src/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
@@ -16,6 +16,7 @@ export type BulkActionButtonProps = {
   handleMeasurement?(width: number): void;
   showContentInButton?: boolean;
   size?: Extract<ButtonProps['size'], 'micro' | 'medium'>;
+  animationDelayIndex?: number;
 } & DisableableAction &
   DestructableAction;
 
@@ -32,6 +33,7 @@ export function BulkActionButton({
   indicator,
   showContentInButton,
   size,
+  animationDelayIndex,
 }: BulkActionButtonProps) {
   const bulkActionButton = useRef<HTMLDivElement>(null);
 
@@ -69,7 +71,19 @@ export function BulkActionButton({
   );
 
   return (
-    <div className={styles.BulkActionButton} ref={bulkActionButton}>
+    <div
+      className={styles.BulkActionButton}
+      ref={bulkActionButton}
+      style={
+        animationDelayIndex
+          ? ({
+              '--pc-bulk-action-button-animation-delay': `calc(var(--p-motion-duration-50) * ${
+                animationDelayIndex * 0.75
+              })`,
+            } as React.CSSProperties)
+          : undefined
+      }
+    >
       {isActivatorForMoreActionsPopover ? (
         <Tooltip content={content} preferredPosition="below">
           {buttonMarkup}

--- a/polaris-react/src/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
+++ b/polaris-react/src/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
@@ -78,7 +78,7 @@ export function BulkActionButton({
         animationDelayIndex
           ? ({
               '--pc-bulk-action-button-animation-delay': `calc(var(--p-motion-duration-50) * ${
-                animationDelayIndex * 0.5
+                animationDelayIndex * 0.25
               })`,
             } as React.CSSProperties)
           : undefined

--- a/polaris-react/src/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
+++ b/polaris-react/src/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
@@ -78,7 +78,7 @@ export function BulkActionButton({
         animationDelayIndex
           ? ({
               '--pc-bulk-action-button-animation-delay': `calc(var(--p-motion-duration-50) * ${
-                animationDelayIndex * 0.75
+                animationDelayIndex * 0.5
               })`,
             } as React.CSSProperties)
           : undefined

--- a/polaris-react/src/components/BulkActions/components/BulkActionMenu/BulkActionMenu.tsx
+++ b/polaris-react/src/components/BulkActions/components/BulkActionMenu/BulkActionMenu.tsx
@@ -10,6 +10,7 @@ import type {ButtonProps} from '../../../Button';
 export interface BulkActionsMenuProps extends MenuGroupDescriptor {
   isNewBadgeInBadgeActions: boolean;
   size?: Extract<ButtonProps['size'], 'micro' | 'medium'>;
+  animationDelayIndex?: number;
 }
 
 export function BulkActionMenu({
@@ -17,6 +18,7 @@ export function BulkActionMenu({
   actions,
   isNewBadgeInBadgeActions,
   size,
+  animationDelayIndex,
 }: BulkActionsMenuProps) {
   const {value: isVisible, toggle: toggleMenuVisibility} = useToggle(false);
 
@@ -32,6 +34,7 @@ export function BulkActionMenu({
             content={title}
             indicator={isNewBadgeInBadgeActions}
             size={size}
+            animationDelayIndex={animationDelayIndex}
           />
         }
         onClose={toggleMenuVisibility}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/122215

Adds a subtle animation to the bulk action buttons when they mount, with the aim of increasing discoverability for merchants.

Spin URL: https://admin.web.bulk-action-button-animation.marc-thomas.eu.spin.dev/store/shop1/orders

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
