### PR TITLE
[EmptyState] Fix layout shift when image is loading with skeleton image

### DIFF
--- a/.changeset/tidy-dryers-stare.md
+++ b/.changeset/tidy-dryers-stare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated `EmptyState` to verify image has loaded before rendering

--- a/.changeset/tidy-dryers-stare.md
+++ b/.changeset/tidy-dryers-stare.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Updated `EmptyState` to verify image has loaded before rendering
+Fixed layout shift on `EmptyState` when image is loading with skeleton image

--- a/polaris-react/src/components/EmptyState/EmptyState.module.css
+++ b/polaris-react/src/components/EmptyState/EmptyState.module.css
@@ -1,9 +1,18 @@
-.Image {
-  opacity: 0;
+.ImageContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.Image-loaded {
-  opacity: 1;
+.Image {
+  opacity: 0;
+  transition: opacity var(--p-motion-duration-150) var(--p-motion-ease);
+  z-index: var(--p-z-index-2);
+
+  &.loaded {
+    opacity: 1;
+  }
 }
 
 .imageContained {
@@ -14,28 +23,32 @@
 }
 
 .SkeletonImageContainer {
-  /* stylelint-disable -- container custom property for size */
+  /* stylelint-disable polaris/conventions/polaris/custom-property-allowed-list -- container custom property for size to prevent layout shift */
   --pc-empty-state-skeleton-image-container-size: 226px;
+  height: var(--pc-empty-state-skeleton-image-container-size);
+  width: var(--pc-empty-state-skeleton-image-container-size);
+  /* stylelint-enable polaris/conventions/polaris/custom-property-allowed-list -- container custom property for size  to prevent layout shift */
   display: flex;
   align-items: center;
   justify-content: center;
-  height: var(--pc-empty-state-skeleton-image-container-size);
-  width: var(--pc-empty-state-skeleton-image-container-size);
-  /* stylelint-enable -- container custom property for size */
 }
 
 .SkeletonImage {
-  /* stylelint-disable -- container custom property for placeholder size */
+  position: absolute;
+  z-index: var(--p-z-index-2);
+  /* stylelint-disable polaris/conventions/polaris/custom-property-allowed-list -- container custom property for placeholder size */
   --pc-empty-state-skeleton-image-size: 145px;
   height: var(--pc-empty-state-skeleton-image-size);
   width: var(--pc-empty-state-skeleton-image-size);
-  /* stylelint-enable -- container custom property for placeholder size */
+  /* stylelint-enable polaris/conventions/polaris/custom-property-allowed-list -- container custom property for placeholder size */
   background-color: var(--p-color-bg-fill-secondary);
   border-radius: var(--p-border-radius-full);
   opacity: 1;
-  visibility: visible;
-  transition: opacity var(--p-motion-duration-159) var(--p-motion-ease),
-    visibility var(--p-motion-duration-150) var(--p-motion-ease);
+  transition: opacity var(--p-motion-duration-500) var(--p-motion-ease);
+
+  &.loaded {
+    opacity: 0;
+  }
 
   @media screen and (-ms-high-contrast: active) {
     background-color: grayText;

--- a/polaris-react/src/components/EmptyState/EmptyState.module.css
+++ b/polaris-react/src/components/EmptyState/EmptyState.module.css
@@ -1,3 +1,7 @@
+.Image {
+  height: 226px;
+}
+
 .imageContained {
   @media (--p-breakpoints-md-up) {
     position: initial;

--- a/polaris-react/src/components/EmptyState/EmptyState.module.css
+++ b/polaris-react/src/components/EmptyState/EmptyState.module.css
@@ -8,7 +8,7 @@
 .Image {
   opacity: 0;
   transition: opacity var(--p-motion-duration-150) var(--p-motion-ease);
-  z-index: var(--p-z-index-2);
+  z-index: var(--p-z-index-1);
 
   &.loaded {
     opacity: 1;
@@ -35,7 +35,7 @@
 
 .SkeletonImage {
   position: absolute;
-  z-index: var(--p-z-index-2);
+  z-index: var(--p-z-index-0);
   /* stylelint-disable polaris/conventions/polaris/custom-property-allowed-list -- container custom property for placeholder size */
   --pc-empty-state-skeleton-image-size: 145px;
   height: var(--pc-empty-state-skeleton-image-size);

--- a/polaris-react/src/components/EmptyState/EmptyState.module.css
+++ b/polaris-react/src/components/EmptyState/EmptyState.module.css
@@ -1,10 +1,37 @@
 .Image {
-  height: 226px;
+  opacity: 0;
+  transition: opacity var(--p-motion-duration-150) var(--p-motion-ease);
+}
+
+.Image-loaded {
+  opacity: 1;
 }
 
 .imageContained {
   @media (--p-breakpoints-md-up) {
     position: initial;
     width: 100%;
+  }
+}
+
+.SkeletonImageContainer {
+  /* stylelint-disable-next-line -- Polaris component custom property */
+  --pc-empty-state-skeleton-image-container-size: 226px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--pc-empty-state-skeleton-image-container-size);
+  width: var(--pc-empty-state-skeleton-image-container-size);
+}
+
+.SkeletonImage {
+  --pc-empty-state-skeleton-image-size: 145px;
+  height: var(--pc-empty-state-skeleton-image-size);
+  width: var(--pc-empty-state-skeleton-image-size);
+  background-color: var(--p-color-bg-fill-tertiary);
+  border-radius: var(--p-border-radius-full);
+
+  @media screen and (-ms-high-contrast: active) {
+    background-color: grayText;
   }
 }

--- a/polaris-react/src/components/EmptyState/EmptyState.module.css
+++ b/polaris-react/src/components/EmptyState/EmptyState.module.css
@@ -26,10 +26,10 @@
 
 .SkeletonImage {
   --pc-empty-state-skeleton-image-size: 145px;
+  background-color: var(--p-color-bg-fill-secondary);
+  border-radius: var(--p-border-radius-full);
   height: var(--pc-empty-state-skeleton-image-size);
   width: var(--pc-empty-state-skeleton-image-size);
-  background-color: var(--p-color-bg-fill-tertiary);
-  border-radius: var(--p-border-radius-full);
 
   @media screen and (-ms-high-contrast: active) {
     background-color: grayText;

--- a/polaris-react/src/components/EmptyState/EmptyState.module.css
+++ b/polaris-react/src/components/EmptyState/EmptyState.module.css
@@ -15,21 +15,24 @@
 }
 
 .SkeletonImageContainer {
-  /* stylelint-disable-next-line -- Polaris component custom property */
+  /* stylelint-disable -- container custom property for size */
   --pc-empty-state-skeleton-image-container-size: 226px;
   display: flex;
   align-items: center;
   justify-content: center;
   height: var(--pc-empty-state-skeleton-image-container-size);
   width: var(--pc-empty-state-skeleton-image-container-size);
+  /* stylelint-enable -- container custom property for size */
 }
 
 .SkeletonImage {
+  /* stylelint-disable -- container custom property for placeholder size */
   --pc-empty-state-skeleton-image-size: 145px;
   background-color: var(--p-color-bg-fill-secondary);
   border-radius: var(--p-border-radius-full);
   height: var(--pc-empty-state-skeleton-image-size);
   width: var(--pc-empty-state-skeleton-image-size);
+  /* stylelint-enable -- container custom property for placeholder size */
 
   @media screen and (-ms-high-contrast: active) {
     background-color: grayText;

--- a/polaris-react/src/components/EmptyState/EmptyState.module.css
+++ b/polaris-react/src/components/EmptyState/EmptyState.module.css
@@ -1,11 +1,9 @@
 .Image {
   opacity: 0;
-  transition: opacity var(--p-motion-duration-150) var(--p-motion-ease-in-out);
 }
 
 .Image-loaded {
   opacity: 1;
-  transition: opacity var(--p-motion-duration-150) var(--p-motion-ease-in-out);
 }
 
 .imageContained {
@@ -29,11 +27,15 @@
 .SkeletonImage {
   /* stylelint-disable -- container custom property for placeholder size */
   --pc-empty-state-skeleton-image-size: 145px;
-  background-color: var(--p-color-bg-fill-secondary);
-  border-radius: var(--p-border-radius-full);
   height: var(--pc-empty-state-skeleton-image-size);
   width: var(--pc-empty-state-skeleton-image-size);
   /* stylelint-enable -- container custom property for placeholder size */
+  background-color: var(--p-color-bg-fill-secondary);
+  border-radius: var(--p-border-radius-full);
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--p-motion-duration-159) var(--p-motion-ease),
+    visibility var(--p-motion-duration-150) var(--p-motion-ease);
 
   @media screen and (-ms-high-contrast: active) {
     background-color: grayText;

--- a/polaris-react/src/components/EmptyState/EmptyState.module.css
+++ b/polaris-react/src/components/EmptyState/EmptyState.module.css
@@ -1,10 +1,11 @@
 .Image {
   opacity: 0;
-  transition: opacity var(--p-motion-duration-150) var(--p-motion-ease);
+  transition: opacity var(--p-motion-duration-150) var(--p-motion-ease-in-out);
 }
 
 .Image-loaded {
   opacity: 1;
+  transition: opacity var(--p-motion-duration-150) var(--p-motion-ease-in-out);
 }
 
 .imageContained {

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 
 import {classNames} from '../../utilities/css';
 import type {ComplexAction} from '../../types';
@@ -46,12 +46,23 @@ export function EmptyState({
   secondaryAction,
   footerContent,
 }: EmptyStateProps) {
+  const [imageLoaded, setImageLoaded] = useState<boolean>(true);
+
+  useEffect(() => {
+    const img: HTMLImageElement = new window.Image(0, 0);
+    img.src = largeImage || image;
+    img.onload = () => {
+      setImageLoaded(true);
+    };
+  }, [largeImage, image]);
+
   const imageContainedClass = classNames(
     styles.Image,
     imageContained && styles.imageContained,
+    imageLoaded && styles['Image-loaded'],
   );
 
-  const imageMarkup = largeImage ? (
+  const loadedImageMarkup = largeImage ? (
     <Image
       alt=""
       role="presentation"
@@ -70,6 +81,14 @@ export function EmptyState({
       alt=""
       source={image}
     />
+  );
+
+  const imageMarkup = imageLoaded ? (
+    loadedImageMarkup
+  ) : (
+    <div className={styles.SkeletonImageContainer}>
+      <div className={styles.SkeletonImage} />
+    </div>
   );
 
   const secondaryActionMarkup = secondaryAction

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 
 import {classNames} from '../../utilities/css';
 import type {ComplexAction} from '../../types';
@@ -46,6 +46,18 @@ export function EmptyState({
   secondaryAction,
   footerContent,
 }: EmptyStateProps) {
+  const [imageLoaded, setImageLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    const img: HTMLImageElement = new window.Image(0, 0);
+    img.src = largeImage || image;
+    img.onload = () => {
+      setImageLoaded(true);
+    };
+  }, [largeImage, image]);
+
+  if (!imageLoaded) return null;
+
   const imageContainedClass = classNames(
     imageContained && styles.imageContained,
   );

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -46,7 +46,7 @@ export function EmptyState({
   secondaryAction,
   footerContent,
 }: EmptyStateProps) {
-  const [imageLoaded, setImageLoaded] = useState<boolean>(true);
+  const [imageLoaded, setImageLoaded] = useState<boolean>(false);
 
   useEffect(() => {
     const img: HTMLImageElement = new window.Image(0, 0);

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
 
 import {classNames} from '../../utilities/css';
 import type {ComplexAction} from '../../types';
@@ -48,18 +48,20 @@ export function EmptyState({
 }: EmptyStateProps) {
   const [imageLoaded, setImageLoaded] = useState<boolean>(false);
 
+  const onImageLoad = useCallback(() => {
+    setImageLoaded(true);
+  }, []);
+
   useEffect(() => {
     const img: HTMLImageElement = new window.Image(0, 0);
     img.src = largeImage || image;
-    img.onload = () => {
-      setImageLoaded(true);
-    };
-  }, [largeImage, image]);
+    img.onload = () => onImageLoad();
+  }, [onImageLoad, largeImage, image]);
 
-  const imageContainedClass = classNames(
+  const imageClassNames = classNames(
     styles.Image,
+    imageLoaded && styles.loaded,
     imageContained && styles.imageContained,
-    imageLoaded && styles['Image-loaded'],
   );
 
   const loadedImageMarkup = largeImage ? (
@@ -67,7 +69,7 @@ export function EmptyState({
       alt=""
       role="presentation"
       source={largeImage}
-      className={imageContainedClass}
+      className={imageClassNames}
       sourceSet={[
         {source: image, descriptor: '568w'},
         {source: largeImage, descriptor: '1136w'},
@@ -76,18 +78,27 @@ export function EmptyState({
     />
   ) : (
     <Image
-      className={imageContainedClass}
-      role="presentation"
       alt=""
+      role="presentation"
+      className={imageClassNames}
       source={image}
     />
   );
 
-  const imageMarkup = imageLoaded ? (
-    loadedImageMarkup
-  ) : (
-    <div className={styles.SkeletonImageContainer}>
-      <div className={styles.SkeletonImage} />
+  const skeletonImageClassNames = classNames(
+    styles.SkeletonImage,
+    imageLoaded && styles.loaded,
+  );
+
+  const imageContainerClassNames = classNames(
+    styles.ImageContainer,
+    !imageLoaded && styles.SkeletonImageContainer,
+  );
+
+  const imageMarkup = (
+    <div className={imageContainerClassNames}>
+      {loadedImageMarkup}
+      <div className={skeletonImageClassNames} />
     </div>
   );
 

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useCallback} from 'react';
+import React, {useState, useCallback} from 'react';
 
 import {classNames} from '../../utilities/css';
 import type {ComplexAction} from '../../types';
@@ -48,15 +48,9 @@ export function EmptyState({
 }: EmptyStateProps) {
   const [imageLoaded, setImageLoaded] = useState<boolean>(false);
 
-  const onImageLoad = useCallback(() => {
+  const handleLoad = useCallback(() => {
     setImageLoaded(true);
   }, []);
-
-  useEffect(() => {
-    const img: HTMLImageElement = new window.Image(0, 0);
-    img.src = largeImage || image;
-    img.onload = () => onImageLoad();
-  }, [onImageLoad, largeImage, image]);
 
   const imageClassNames = classNames(
     styles.Image,
@@ -75,6 +69,7 @@ export function EmptyState({
         {source: largeImage, descriptor: '1136w'},
       ]}
       sizes="(max-width: 568px) 60vw"
+      onLoad={handleLoad}
     />
   ) : (
     <Image
@@ -82,6 +77,7 @@ export function EmptyState({
       role="presentation"
       className={imageClassNames}
       source={image}
+      onLoad={handleLoad}
     />
   );
 

--- a/polaris-react/src/components/EmptyState/EmptyState.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 
 import {classNames} from '../../utilities/css';
 import type {ComplexAction} from '../../types';
@@ -46,19 +46,8 @@ export function EmptyState({
   secondaryAction,
   footerContent,
 }: EmptyStateProps) {
-  const [imageLoaded, setImageLoaded] = useState<boolean>(false);
-
-  useEffect(() => {
-    const img: HTMLImageElement = new window.Image(0, 0);
-    img.src = largeImage || image;
-    img.onload = () => {
-      setImageLoaded(true);
-    };
-  }, [largeImage, image]);
-
-  if (!imageLoaded) return null;
-
   const imageContainedClass = classNames(
+    styles.Image,
     imageContained && styles.imageContained,
   );
 

--- a/polaris-react/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/polaris-react/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -13,6 +13,23 @@ describe('<EmptyState />', () => {
   let imgSrc =
     'https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg';
 
+  it('renders EmptyState with a skeleton image and hidden <Image> when the image is not loaded', () => {
+    const emptyState = mountWithApp(<EmptyState image={imgSrc} />);
+
+    expect(emptyState).toContainReactComponent('div', {
+      className: 'SkeletonImage',
+    });
+    expect(emptyState).toContainReactComponent('div', {
+      className: expect.not.stringContaining('SkeletonImage loaded'),
+    });
+    expect(emptyState).toContainReactComponent(Image, {
+      className: 'Image',
+    });
+    expect(emptyState).toContainReactComponent(Image, {
+      className: expect.not.stringContaining('Image loaded'),
+    });
+  });
+
   describe('action', () => {
     it('renders a button with the action content if action is set', () => {
       const emptyState = mountWithApp(


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [#1545](https://github.com/Shopify/polaris-internal/issues/1545).

Fixes layout shift when image is loading in `EmptyState`.

### WHAT is this pull request doing?
Initially renders a skeleton image with set width/height to prevent layout shift as image asset is loading.
Renders final `<Image>` component with transition to prevent flicker for smoother UX.
  <details>
    <summary>EmptyState — before</summary>
    <img src="https://github.com/Shopify/polaris/assets/26749317/d186b70e-7f59-40cb-b2ad-8487c1f8e276" alt="EmptyState — before">
  </details>
  <details>
    <summary>EmptyState — after</summary>
    <img src="https://github.com/Shopify/polaris/assets/26749317/31ad9f5f-80a9-4d8a-a325-9863458e292e" alt="EmptyState — after">
  </details>

### How to 🎩

[Spin](https://admin.web.fix-empty-state.lo-kim.us.spin.dev/store/shop1/orders)
- Throttle network (open dev console, select `Network` tab, choose either `Fast 3G` or `Slow 3G`)
- Refresh page that renders EmptyState

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
