### PR TITLE
[Text] Undeprecate `heading2xl` variant

### DIFF
--- a/.changeset/green-laws-crash.md
+++ b/.changeset/green-laws-crash.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/polaris': patch
+'polaris.shopify.com': patch
 ---
 
 Undeprecate `heading2xl` variant in `Text` component

--- a/.changeset/green-laws-crash.md
+++ b/.changeset/green-laws-crash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Undeprecate `heading2xl` variant in `Text` component

--- a/.changeset/green-laws-crash.md
+++ b/.changeset/green-laws-crash.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Undeprecate `heading2xl` variant in `Text` component
+Undeprecated `heading2xl` variant in `Text` component

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -52,7 +52,6 @@ type Tone =
 type TextDecorationLine = 'line-through';
 
 const deprecatedVariants: {[V in Variant]?: Variant} = {
-  heading2xl: 'headingXl',
   heading3xl: 'headingXl',
 };
 export interface TextProps {

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -52,7 +52,7 @@ type Tone =
 type TextDecorationLine = 'line-through';
 
 const deprecatedVariants: {[V in Variant]?: Variant} = {
-  heading3xl: 'headingXl',
+  heading3xl: 'heading2xl',
 };
 export interface TextProps {
   /** Adjust horizontal alignment of text */

--- a/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
+++ b/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
@@ -78,7 +78,7 @@ const componentUnionTypeDeprecations: {
   };
 } = {
   Text: {
-    Variant: ['heading2xl', 'heading3xl'],
+    Variant: ['heading3xl'],
   },
 };
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-internal/issues/1529

### WHAT is this pull request doing?

Undeprecates the `heading2xl` variant since it will be kept in the next major version for mobile purposes. 