### PR TITLE
[Button] Add support for two right direction icons in disclosure prop.

### DIFF
--- a/.changeset/beige-mugs-retire.md
+++ b/.changeset/beige-mugs-retire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add support for two right direction icons in Button component disclosure prop: ChevronRightIcon and ArrowRightIcon.

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -736,6 +736,32 @@ export function SelectDisclosure() {
   );
 }
 
+export function ChevronRightDisclosure() {
+  return (
+    <div>
+      <Button
+        disclosure="right"
+        onClick={() => console.log('In-context Navigation')}
+      >
+        Next
+      </Button>
+    </div>
+  );
+}
+
+export function ArrowRightDisclosure() {
+  return (
+    <div>
+      <Button
+        disclosure="arrowRight"
+        onClick={() => console.log('Navigation to another context')}
+      >
+        Get started
+      </Button>
+    </div>
+  );
+}
+
 export function Split() {
   const [active, setActive] = React.useState<string | null>(null);
 

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -3,6 +3,8 @@ import {
   SelectIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  ChevronRightIcon,
+  ArrowRightIcon,
 } from '@shopify/polaris-icons';
 
 import {useBreakpoints} from '../../utilities/breakpoints';
@@ -33,7 +35,7 @@ export interface ButtonProps extends BaseButton {
   /** Allows the button to grow to the width of its container */
   fullWidth?: boolean;
   /** Displays the button with a disclosure icon. Defaults to `down` when set to true */
-  disclosure?: 'down' | 'up' | 'select' | boolean;
+  disclosure?: 'down' | 'up' | 'select' | 'right' | 'arrowRight' | boolean;
   /** Removes underline from button text (including on interaction)
    * @deprecated Use a variant instead
    */
@@ -146,15 +148,7 @@ export function Button({
   const disclosureMarkup = disclosure ? (
     <span className={loading ? styles.hidden : styles.Icon}>
       <Icon
-        source={
-          loading
-            ? 'placeholder'
-            : getDisclosureIconSource(
-                disclosure,
-                ChevronUpIcon,
-                ChevronDownIcon,
-              )
-        }
+        source={loading ? 'placeholder' : getDisclosureIconSource(disclosure)}
       />
     </span>
   ) : null;
@@ -260,12 +254,18 @@ function isIconSource(x: any): x is IconSource {
 
 function getDisclosureIconSource(
   disclosure: NonNullable<ButtonProps['disclosure']>,
-  upIcon: IconSource,
-  downIcon: IconSource,
 ) {
-  if (disclosure === 'select') {
-    return SelectIcon;
+  switch (disclosure) {
+    case 'select':
+      return SelectIcon;
+    case 'up':
+      return ChevronUpIcon;
+    case 'right':
+      return ChevronRightIcon;
+    case 'arrowRight':
+      return ArrowRightIcon;
+    case 'down':
+    default:
+      return ChevronDownIcon;
   }
-
-  return disclosure === 'up' ? upIcon : downIcon;
 }

--- a/polaris-react/src/components/Button/tests/Button.test.tsx
+++ b/polaris-react/src/components/Button/tests/Button.test.tsx
@@ -4,6 +4,8 @@ import {
   ChevronUpIcon,
   PlusIcon,
   SelectIcon,
+  ChevronRightIcon,
+  ArrowRightIcon,
 } from '@shopify/polaris-icons';
 import {mountWithApp} from 'tests/utilities';
 
@@ -346,6 +348,18 @@ describe('<Button />', () => {
       const button = mountWithApp(<Button disclosure="up" />);
       const disclosureIcon = button.find(Icon);
       expect(disclosureIcon).toHaveReactProps({source: ChevronUpIcon});
+    });
+
+    it('is facing right if set to "right"', () => {
+      const button = mountWithApp(<Button disclosure="right" />);
+      const disclosureIcon = button.find(Icon);
+      expect(disclosureIcon).toHaveReactProps({source: ChevronRightIcon});
+    });
+
+    it('is arrow right if set to "arrowRight"', () => {
+      const button = mountWithApp(<Button disclosure="arrowRight" />);
+      const disclosureIcon = button.find(Icon);
+      expect(disclosureIcon).toHaveReactProps({source: ArrowRightIcon});
     });
 
     it('is double-arrow if set to "select"', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/web/issues/110696

Reasoning: As part of the signup questionnaire in Admin, we have a temporary [DisclosureIconButton](https://github.com/Shopify/guidance-ui/blob/main/src/components/Questionnaire/components/DisclosureIconButton/DisclosureIconButton.tsx#L26) component  that was created as a forked local version of the Button component, to add support for two right direction icons in the disclosure prop:

<img width="750" alt="23-12-2a83e-16gvr" src="https://github.com/Shopify/web/assets/16692690/20e45f75-b496-48fc-aa70-6269886f93cb">

Having these two icons present in the disclosure prop of the `Button` component directly would allow us to simplify this implementation, by removing the previous temporary `DisclosureIconButton` component and using `Button` component for these Admin use cases.

### WHAT is this pull request doing?

This PR adds supports for two right direction icons in Button component disclosure prop: `ChevronRightIcon` and `ArrowRightIcon`, which are used to indicate in-context navigation or navigation to another context, respectively.

#### Results in Storybook

- Chevron right disclosure:
<img width="400" alt="chevron-right-disclosure" src="https://github.com/Shopify/polaris/assets/16692690/4772c2c2-9141-4dcd-b688-4a63ef62bd8a">

- Arrow right disclosure:
<img width="400" alt="arrow-right-disclosure" src="https://github.com/Shopify/polaris/assets/16692690/ff1b899d-c9b7-4575-b8b1-68b370ab54ce">


### How to 🎩

- All Button component tests should pass.
- Storybook displays two new options for disclosure prop in Button component (see results above).

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
