### PR TITLE
Add escapeRegex string utility

### DIFF
--- a/polaris-react/src/components/Picker/Picker.tsx
+++ b/polaris-react/src/components/Picker/Picker.tsx
@@ -18,6 +18,7 @@ import type {ListboxProps, OptionProps} from '../Listbox';
 import {Listbox} from '../Listbox';
 import type {IconProps} from '../Icon';
 import {Icon} from '../Icon';
+import {escapeRegex} from '../../utilities/string';
 
 import {Activator, SearchField} from './components';
 import type {ActivatorProps} from './components';
@@ -44,7 +45,8 @@ export interface PickerProps extends Omit<ListboxProps, 'children'> {
 }
 
 const FILTER_REGEX = (value: string) => new RegExp(value, 'i');
-const QUERY_REGEX = (value: string) => new RegExp(`^${value}$`, 'i');
+const QUERY_REGEX = (value: string) =>
+  new RegExp(`^${escapeRegex(value)}$`, 'i');
 
 export function Picker({
   activator,

--- a/polaris-react/src/utilities/string.ts
+++ b/polaris-react/src/utilities/string.ts
@@ -1,0 +1,3 @@
+export function escapeRegex(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
### WHY are these changes introduced?

The picker was exploding when special characters were getting typed into the search field. 

### WHAT is this pull request doing?

Adds a string util to escape special characters. Internal use only so skipping changeset

### How to 🎩

Open the Picker and enter open bracket, square bracket, parenthesis etc.. in the search field: [Storybook](https://5d559397bae39100201eedc1-qccucmxydk.chromatic.com/?path=/story/playground--details-page)