### PR TITLE
Align `RadioButton` styles with mobile

### DIFF
--- a/.changeset/selfish-oranges-listen.md
+++ b/.changeset/selfish-oranges-listen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated `RadioButton` styles to improve mobile consistency

--- a/polaris-react/src/components/RadioButton/RadioButton.module.css
+++ b/polaris-react/src/components/RadioButton/RadioButton.module.css
@@ -1,6 +1,9 @@
 .RadioButton {
   position: relative;
-  margin: var(--p-space-025);
+
+  @media (--p-breakpoints-md-up) {
+    margin: var(--p-space-025);
+  }
 }
 
 /* stylelint-disable selector-max-specificity, selector-max-class, selector-max-combinators -- code is much more readable this way */
@@ -97,13 +100,13 @@
 
 .Backdrop {
   /* stylelint-disable-next-line -- Polaris component custom properties */
-  --pc-icon-size-small: 8px;
+  --pc-icon-size-small: 10px;
 
   /* ::before is the selected dot, ::after the focus-ring */
 
-  @media (--p-breakpoints-md-down) {
+  @media (--p-breakpoints-md-up) {
     /* stylelint-disable-next-line -- Polaris component custom properties */
-    --pc-icon-size-small: 10px;
+    --pc-icon-size-small: 8px;
   }
   position: relative;
   top: 0;
@@ -111,10 +114,14 @@
   display: block;
   width: 100%;
   height: 100%;
-  border: var(--p-border-width-0165) solid var(--p-color-input-border);
+  border: var(--p-border-width-025) solid var(--p-color-input-border);
   border-radius: var(--p-border-radius-full);
   background-color: var(--p-color-input-bg-surface);
   transition: border-color var(--p-motion-duration-100) var(--p-motion-ease-out);
+
+  @media (--p-breakpoints-md-up) {
+    border: var(--p-border-width-0165) solid var(--p-color-input-border);
+  }
 
   &::before {
     content: '';


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1578
Fixes https://github.com/Shopify/mobile/issues/33784

> [!CAUTION] 
> Basing this PR off of https://github.com/Shopify/polaris/pull/11896 (which is also based off https://github.com/Shopify/polaris/pull/11837) and will not merge until that ships. This PR does not include changes from https://github.com/Shopify/polaris/pull/11878 so you will not see the updates to the helper/error text size.

### WHAT is this pull request doing?

- Updates the `border-width` of radio buttons below `breakpoint-md` from `0.66px` ➡️  `1px`
- Updates the size of the radio button below `breakpoint-md` from `18px` ➡️  `20px` (this is done by removing a margin so it will not shift any layouts since it takes up the same amount of space it did before)

| Before | After | 
| -- | -- | 
![Screenshot 2024-05-06 at 3 00 35 PM](https://github.com/Shopify/polaris/assets/21976492/1fa28a87-d4e8-4609-a188-471bc39d3566)|![Screenshot 2024-05-06 at 2 50 02 PM](https://github.com/Shopify/polaris/assets/21976492/ce1cdb1e-8855-4231-a48b-1047aff6caa3)|

> [!TIP] 
> Make sure you have the breakpoint in storybook at `sm` or `xs` to see the changes!

- 📕 [Storybook Before](https://5d559397bae39100201eedc1-wksqjkgeob.chromatic.com/?path=/story/all-components-radiobutton--default&globals=viewport:1)
- 📕 [Storybook After](https://5d559397bae39100201eedc1-fowimyiuxf.chromatic.com/?path=/story/all-components-radiobutton--default&globals=viewport:1)

