### PR TITLE
[v13] Miniumum required node version updated to v20.10.0

### DIFF
--- a/.changeset/cyan-houses-cross.md
+++ b/.changeset/cyan-houses-cross.md
@@ -1,0 +1,11 @@
+---
+'polaris-for-vscode': major
+'@shopify/polaris-icons': major
+'@shopify/polaris-migrator': major
+'@shopify/polaris': major
+'@shopify/polaris-tokens': major
+'polaris.shopify.com': major
+'@shopify/stylelint-polaris': major
+---
+
+Miniumum required node version updated to v20.10.0

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Each contributor is required to [sign a CLA](https://cla.shopify.com/). This pro
 
 ### Contribution prerequisites
 
-- You have Node installed at v18.12.0+ and Yarn at v1.22.18+
+- You have Node installed at v20.11.1+ and Yarn at v1.22.18+
 
 ### Best practices
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,8 +16,6 @@ jobs:
         node-version: [
             # The minimum required node version for consumers
             '20.10.0',
-            # Make sure it's working on the v21 line (even though it's non-LTS)
-            '21.x',
             # Ensure it's working for the latest versions of node too
             'latest',
           ]

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,7 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.17.0', '18.12.0', '20.11.1']
+        node-version: [
+            # The minimum required node version for consumers
+            '20.10.0',
+            # Make sure it's working on the v21 line (even though it's non-LTS)
+            '21.x',
+            # Ensure it's working for the latest versions of node too
+            'latest',
+          ]
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
@@ -30,7 +37,8 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Setup Node with v${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        id: setup_node
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -43,9 +51,9 @@ jobs:
             **/.turbo
             node_modules/.cache/turbo
             polaris.shopify.com/.next/cache
-          key: ${{ runner.os }}-node${{ matrix.node-version }}-test-v3-${{ github.sha }}
+          key: ${{ runner.os }}-node${{ steps.setup_node.outputs.node-version }}-test-v4-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-node${{ matrix.node-version }}-test-v3-
+            ${{ runner.os }}-node${{ steps.setup_node.outputs.node-version }}-test-v4-
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/documentation/Nodejs support.md
+++ b/documentation/Nodejs support.md
@@ -1,6 +1,6 @@
 # NodeJS support
 
-`@shopify/polaris` supports node's long term suppport (LTS) versions that are in the active or maintenance stages of their [lifecycle](https://nodejs.org/en/about/releases/). We should also ensure support for critical repositories at Shopify like `shopify/web`, 1st party applications and `shopify/cli`.
+`@shopify/polaris` supports node's current [active long term suppport (LTS) versions](https://nodejs.org/en/about/releases/). We should also ensure support for critical repositories at Shopify like `shopify/web`, 1st party applications and `shopify/cli`.
 
 ## Local development
 
@@ -16,26 +16,26 @@ The `package.json` engines. This should match the `.github/workflows/ci.yml` and
 
 ```json
 "engines": {
-  "node": "^16.17.0 || >=18.12.0"
+  "node": ">=20.11.1"
 },
 ```
 
 The GitHub actions `.github/workflows/ci.yml` file. This should match the `package.json` and list all supported versions.
 
 ```yml
-node-version: ['16.17.0', '18.12.0']
+node-version: ['20.11.1']
 ```
 
 The `dev.yml` file which creates a local development environment. This should match the `.nvmrc` file.
 
 ```yml
-version: v18.12.0
+version: v20.11.1
 ```
 
 The `.nvmrc` file for local development. This should match the `dev.yml` file.
 
 ```
-v18.12.0
+v20.11.1
 ```
 
 The `shipit.yml` files. This should point towards the GitHub Actions the packages require to pass before publishing.
@@ -43,13 +43,11 @@ The `shipit.yml` files. This should point towards the GitHub Actions the package
 ```yml
 ci:
   require:
-    - 'Validate with Node v16.17.0'
-    - 'Validate with Node v18.12.0'
+    - 'Validate with Node v20.11.1'
 
 merge:
   require:
-    - 'Validate with Node v16.17.0'
-    - 'Validate with Node v18.12.0'
+    - 'Validate with Node v20.11.1'
 ```
 
 The `rollup.config.mjs` for some monorepo packages. This should match the minimum supported version.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": "^16.17.0 || >=18.12.0"
+    "node": ">=20.10.0"
   },
   "workspaces": {
     "packages": [
@@ -65,7 +65,7 @@
     "@shopify/typescript-configs": "^5.1.0",
     "@size-limit/preset-small-lib": "^5.0.3",
     "@types/jest": "^27.5.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.10.0",
     "babel-loader": "^9.1.2",
     "eslint": "^8.3.0",
     "execa": "^5.0.0",

--- a/polaris-for-vscode/package.json
+++ b/polaris-for-vscode/package.json
@@ -21,7 +21,7 @@
   ],
   "engines": {
     "vscode": "^1.64.0",
-    "node": "^16.17.0 || >=18.12.0"
+    "node": ">=20.10.0"
   },
   "categories": [
     "Other"
@@ -44,7 +44,7 @@
     "vscode-languageserver-textdocument": "^1.0.11"
   },
   "devDependencies": {
-    "@types/node": "16.x",
+    "@types/node": "^20.10.0",
     "@types/vscode": "^1.64.0",
     "globby": "^11.1.0",
     "vsce": "^2.15.0"

--- a/polaris-icons/package.json
+++ b/polaris-icons/package.json
@@ -14,7 +14,7 @@
     }
   },
   "engines": {
-    "node": "^16.17.0 || >=18.12.0"
+    "node": ">=20.10.0"
   },
   "scripts": {
     "build": "rollup -c",

--- a/polaris-migrator/package.json
+++ b/polaris-migrator/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://polaris.shopify.com",
   "repository": "https://github.com/Shopify/polaris",
   "engines": {
-    "node": "^16.17.0 || >=18.12.0"
+    "node": ">=20.10.0"
   },
   "bugs": {
     "url": "https://github.com/Shopify/polaris/issues"

--- a/polaris-react/config/rollup/plugin-styles.js
+++ b/polaris-react/config/rollup/plugin-styles.js
@@ -90,7 +90,7 @@ module.exports.styles = function styles({
     const entrypointBundles = Object.values(bundle).filter(
       (bundleInfo) => bundleInfo.isEntry,
     );
-    const bundleModuleIds = flatMap(entrypointBundles, (bundleInfo) =>
+    const bundleModuleIds = entrypointBundles.flatMap((bundleInfo) =>
       getRecursiveImportOrder(bundleInfo.facadeModuleId, rollup.getModuleInfo),
     );
 
@@ -167,11 +167,6 @@ module.exports.styles = function styles({
     },
   };
 };
-
-// We're still using node 10. Array.flat(fn)/Array.flatMap(fn) are added in v11
-function flatMap(array, fn) {
-  return array.reduce((memo, item) => memo.concat(fn(item)), []);
-}
 
 // An @charset declaration must be at the top of a css file rather than part
 // way through. Because we're combining multiple files we need to make sure

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -120,6 +120,7 @@
     "last 3 safari versions",
     "last 3 chromeandroid versions",
     "last 1 firefoxandroid versions",
-    "ios >= 13.4"
+    "ios >= 13.4",
+    "node 20.10.0"
   ]
 }

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/Shopify/polaris/issues"
   },
   "engines": {
-    "node": "^16.17.0 || >=18.12.0"
+    "node": ">=20.10.0"
   },
   "publishConfig": {
     "access": "public",
@@ -84,7 +84,7 @@
     "@storybook/preview-api": "^7.6.4",
     "@storybook/react": "^7.6.4",
     "@storybook/react-vite": "^7.6.4",
-    "@types/node": "^16.11.11",
+    "@types/node": "^20.10.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-transition-group": "^4.4.2",

--- a/polaris-react/rollup.config.mjs
+++ b/polaris-react/rollup.config.mjs
@@ -69,7 +69,7 @@ function entryFileNames(ext) {
 /** @type {import('rollup').RollupOptions} */
 export default [
   generateConfig({
-    targets: [...pkg.browserslist, 'node 20.10.0'],
+    targets: pkg.browserslist,
     stylesConfig: {
       mode: 'standalone',
       output: 'styles.css',

--- a/polaris-react/rollup.config.mjs
+++ b/polaris-react/rollup.config.mjs
@@ -69,7 +69,7 @@ function entryFileNames(ext) {
 /** @type {import('rollup').RollupOptions} */
 export default [
   generateConfig({
-    targets: [...pkg.browserslist, 'node 16.17.0'],
+    targets: [...pkg.browserslist, 'node 20.10.0'],
     stylesConfig: {
       mode: 'standalone',
       output: 'styles.css',

--- a/polaris-tokens/package.json
+++ b/polaris-tokens/package.json
@@ -6,7 +6,7 @@
   "module": "dist/esm/build/index.mjs",
   "types": "dist/types/build/index.d.ts",
   "engines": {
-    "node": "^16.17.0 || >=18.12.0"
+    "node": ">=20.10.0"
   },
   "exports": {
     ".": {
@@ -49,7 +49,7 @@
     "last 3 chromeandroid versions",
     "last 1 firefoxandroid versions",
     "ios >= 13.4",
-    "node 16.17.0"
+    "node 20.10.0"
   ],
   "files": [
     "dist"

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -3,7 +3,7 @@
   "version": "0.67.3",
   "private": true,
   "engines": {
-    "node": "^16.17.0 || >=18.12.0"
+    "node": ">=20.10.0"
   },
   "scripts": {
     "build": "yarn concurrently \"yarn gen-colors\" \"yarn gen-assets\" \"playroom build\" && next build && cp -r public ./.next/standalone/polaris.shopify.com/ && mkdirp ./.next/standalone/polaris.shopify.com/.next && cp -r .next/static ./.next/standalone/polaris.shopify.com/.next/",

--- a/stylelint-polaris/package.json
+++ b/stylelint-polaris/package.json
@@ -14,7 +14,7 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "engines": {
-    "node": "^16.17.0 || >=18.12.0"
+    "node": ">=20.10.0"
   },
   "files": [
     "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5274,30 +5274,27 @@
     "@types/node" "*"
     form-data "^4.0.0"
 
-"@types/node@*", "@types/node@^18.11.18":
+"@types/node@*":
   version "18.11.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
-
-"@types/node@16.x":
-  version "16.18.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.60.tgz#0b0f4316906f1bd0e03b640363f67bd4e86958bd"
-  integrity sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA==
 
 "@types/node@^12.7.1":
   version "12.20.52"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.52.tgz#2fd2dc6bfa185601b15457398d4ba1ef27f81251"
   integrity sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==
 
-"@types/node@^16.11.11":
-  version "16.18.68"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.68.tgz#3155f64a961b3d8d10246c80657f9a7292e3421a"
-  integrity sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==
-
 "@types/node@^18.0.0":
   version "18.19.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.3.tgz#e4723c4cb385641d61b983f6fe0b716abd5f8fc0"
   integrity sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^20.10.0":
+  version "20.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.4.tgz#af5921bd75ccdf3a3d8b3fa75bf3d3359268cd11"
+  integrity sha512-E+Fa9z3wSQpzgYQdYmme5X3OTuejnnTx88A6p6vkkJosR3KBz+HpE3kqNm98VE6cfLFcISx7zW7MsJkH6KwbTw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -7307,23 +7304,13 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.20.2, browserslist@^4.21.3, browserslist@^4.21.4:
-  version "4.21.5"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
-  integrity sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==
+browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.20.2, browserslist@^4.21.3, browserslist@^4.21.4, browserslist@^4.22.2:
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.0.tgz#8f3acc2bbe73af7213399430890f86c63a5674ab"
+  integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
   dependencies:
-    caniuse-lite "^1.0.30001449"
-    electron-to-chromium "^1.4.284"
-    node-releases "^2.0.8"
-    update-browserslist-db "^1.0.10"
-
-browserslist@^4.22.2:
-  version "4.22.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz#704c4943072bd81ea18997f3bd2180e89c77874b"
-  integrity sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==
-  dependencies:
-    caniuse-lite "^1.0.30001565"
-    electron-to-chromium "^1.4.601"
+    caniuse-lite "^1.0.30001587"
+    electron-to-chromium "^1.4.668"
     node-releases "^2.0.14"
     update-browserslist-db "^1.0.13"
 
@@ -7662,15 +7649,10 @@ caniuse-lite@^1.0.30001406:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz#58da20446ccd0cb1dfebd11d2350c907ee7c2eaa"
   integrity sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==
 
-caniuse-lite@^1.0.30001449:
-  version "1.0.30001449"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz#a8d11f6a814c75c9ce9d851dc53eb1d1dfbcd657"
-  integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
-
-caniuse-lite@^1.0.30001565:
-  version "1.0.30001570"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz#b4e5c1fa786f733ab78fc70f592df6b3f23244ca"
-  integrity sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==
+caniuse-lite@^1.0.30001587:
+  version "1.0.30001605"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz#ca12d7330dd8bcb784557eb9aa64f0037870d9d6"
+  integrity sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -9540,15 +9522,10 @@ ejs@^3.1.8:
   dependencies:
     jake "^10.8.5"
 
-electron-to-chromium@^1.4.284:
-  version "1.4.284"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
-  integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
-
-electron-to-chromium@^1.4.601:
-  version "1.4.613"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.613.tgz#529e4fc65576ecfd055d7d4619fade4fac446af2"
-  integrity sha512-r4x5+FowKG6q+/Wj0W9nidx7QO31BJwmR2uEo+Qh3YLGQ8SbBAFuDFpTxzly/I2gsbrFwBuIjrMp423L3O5U3w==
+electron-to-chromium@^1.4.668:
+  version "1.4.728"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.728.tgz#ac54d9d1b38752b920ec737a48c83dec2bf45ea1"
+  integrity sha512-Ud1v7hJJYIqehlUJGqR6PF1Ek8l80zWwxA6nGxigBsGJ9f9M2fciHyrIiNMerSHSH3p+0/Ia7jIlnDkt41h5cw==
 
 elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
@@ -16302,11 +16279,6 @@ node-releases@^2.0.14:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
-node-releases@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.8.tgz#0f349cdc8fcfa39a92ac0be9bc48b7706292b9ae"
-  integrity sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==
-
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -21842,14 +21814,6 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
-
-update-browserslist-db@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
-  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
-  dependencies:
-    escalade "^3.1.1"
-    picocolors "^1.0.0"
 
 update-browserslist-db@^1.0.13:
   version "1.0.13"


### PR DESCRIPTION
Refs https://github.com/Shopify/polaris-internal/issues/1524

[Node 16 is EOL](https://nodejs.org/en/about/previous-releases), and [Node 18 is in Maintenance Mode](https://nodejs.org/en/about/previous-releases), so we're updating the minimum required Node version to v20.10.0 (the latest supported by `node-releases`/`browserslist` at the time this project started).

## When is node used?

Node is used in 2 contexts:

1. By our consumers when they import, run, and bundle our libraries
2. By us, the Polaris team, while we develop our libraries

These are very different, and have their own configs within our repository...

### 1. Consumer's node version

When a consumer uses one of our libraries, they're importing whatever is in the `build/*` folder. Those assets are generated by our build process (Rollup) which transforms (via babel) whatever version of Javascript we write our code in into a version that's compatible with the [`targets` setting we provide](https://github.com/Shopify/polaris/blob/9c24a465c5e001e148bde335bf6319e924f4b1d6/polaris-react/rollup.config.mjs#L72).

For example, `Array#findLast` was only made available in node v18, so when we write code like:

```javascript
[1, 2, 3, 2, 1].findLast(x => x < 2);
```

The output will be different depending on our Babel config:

```javascript
// with babel config: { targets: 'node 16.0' }
import "core-js/modules/esnext.array.find-last.js";
[1, 2, 3, 2, 1].findLast(x => x < 2);
```

```javascript
// with babel config: { targets: 'node 18.0' }
[1, 2, 3, 2, 1].findLast(x => x < 2);
```

_(try it [here](https://babeljs.io/repl#?browsers=&build=&builtIns=usage&corejs=3.21&spec=false&loose=false&code_lz=NoRgNABATJDMkwiAugOgGYEsB2ATAMgIYDOALgBQAeEAvAHwTUA80AlANxA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=false&targets=Node-16.0&version=7.24.0&externalPlugins=&assumptions=%7B%7D) - set the "Env preset > Node" version to `18.0`)_

The `node 18.0` example above does not include a polyfill for `Array#findLast`, which means if our consumers try to run Polaris in a node environment (eg; during SSR) that doesn't support `Array#findLast`, they will get an error.

The way we let our consumers know what is the minimum version of node they can use is via the `packages.json#engines.node` field. As long as this matches the version specified in `Babel#targets`, any consumer trying to install our library in an unsupported version of Node will receive an error.

This PR updates the minimum required node version of our consumers to `20.10.0`.

### 2. Our node version while developing Polaris

Similarly, the tools we use to develop Polars (Babel, Postcss, etc) may have a minimum node version requirement.

They do it by specifying a `package.json#engines.node` version in their own library. Then when we install their package, if our version of node isn't compatible we'll receive an error.

However, the version of node required to run Babel _has no impact on its ability to transform our code to work on older versions of node_. As long as we tell Babel which version of node to output code for in `targets`, it doesn't matter what our `.nvmrc` file says.

https://github.com/Shopify/polaris/pull/11739 updated the node version for developing with Polaris to `20.11.1`.