### PR TITLE
[Prototype] Align `TextField` styles with mobile

### DIFF
--- a/.changeset/sweet-donkeys-shake.md
+++ b/.changeset/sweet-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+Experimenting with TextField styles

--- a/polaris-react/src/components/Label/Label.tsx
+++ b/polaris-react/src/components/Label/Label.tsx
@@ -33,7 +33,7 @@ export function Label({children, id, hidden, requiredIndicator}: LabelProps) {
           requiredIndicator && styles.RequiredIndicator,
         )}
       >
-        <Text as="span" variant="bodyMd">
+        <Text as="span" variant="bodyXs">
           {children}
         </Text>
       </label>

--- a/polaris-react/src/components/Labelled/Labelled.module.css
+++ b/polaris-react/src/components/Labelled/Labelled.module.css
@@ -3,6 +3,10 @@
   @mixin visually-hidden;
 }
 
+.hidden label {
+  display: none;
+}
+
 .disabled > .LabelWrapper {
   color: var(--p-color-text-disabled);
 }
@@ -24,6 +28,12 @@
   justify-content: space-between;
   align-items: baseline;
   margin-bottom: var(--p-space-100);
+  position: absolute;
+  z-index: 100;
+  left: 12px;
+  right: 12px;
+  top: 5px;
+  color: var(--p-color-text-secondary);
 }
 
 .HelpText {
@@ -38,4 +48,5 @@
 
 .Action {
   flex: 0 0 auto;
+  margin-block-start: var(--p-space-100);
 }

--- a/polaris-react/src/components/Labelled/Labelled.tsx
+++ b/polaris-react/src/components/Labelled/Labelled.tsx
@@ -56,7 +56,7 @@ export function Labelled({
 
   const actionMarkup = action ? (
     <div className={styles.Action}>
-      {buttonFrom(action, {variant: 'plain'})}
+      {buttonFrom(action, {variant: 'secondary', fullWidth: true})}
     </div>
   ) : null;
 
@@ -88,15 +88,16 @@ export function Labelled({
       >
         {label}
       </Label>
-
-      {actionMarkup}
     </div>
   ) : null;
 
   return (
     <div className={className}>
-      {labelMarkup}
-      {children}
+      <div style={{position: 'relative'}}>
+        {labelMarkup}
+        {children}
+      </div>
+      {actionMarkup}
       {errorMarkup}
       {helpTextMarkup}
     </div>

--- a/polaris-react/src/components/Select/Select.module.css
+++ b/polaris-react/src/components/Select/Select.module.css
@@ -70,11 +70,19 @@
     var(--p-space-300);
 }
 
+.LabelHidden .SelectedOption,
+.InlineLabel .SelectedOption {
+  padding-block-start: 8px;
+  padding-block-end: 8px;
+}
+
 .SelectedOption {
   flex: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: var(--p-font-size-325);
+  padding-block-start: var(--p-space-400);
 }
 
 .Prefix {
@@ -108,10 +116,6 @@
   opacity: 0;
   appearance: none;
   border: none;
-
-  /* Google chrome on Windows requires padding to be added otherwise <option> has no space */
-  padding: var(--p-space-150) var(--p-space-200) var(--p-space-150)
-    var(--p-space-300);
 }
 
 .Backdrop {
@@ -151,12 +155,14 @@
 }
 
 .Input:focus-visible {
+  border-color: rgba(0, 91, 211, 1);
+
   ~ .Backdrop {
-    border-color: var(--p-color-input-border-active);
+    border-color: rgba(0, 91, 211, 1);
     border-width: var(--p-border-width-025);
     background-color: var(--p-color-input-bg-surface-active);
-    outline: var(--p-border-width-050) solid var(--p-color-border-focus);
-    outline-offset: var(--p-space-025);
+    outline: var(--p-border-width-025) solid rgba(0, 91, 211, 1);
+    /* outline-offset: var(--p-space-025); */
   }
 }
 

--- a/polaris-react/src/components/Select/Select.tsx
+++ b/polaris-react/src/components/Select/Select.tsx
@@ -109,6 +109,8 @@ export function Select({
 
   const className = classNames(
     styles.Select,
+    labelInline && styles.InlineLabel,
+    labelHiddenProp && styles.LabelHidden,
     error && styles.error,
     tone && styles[variationName('tone', tone)],
     disabled && styles.disabled,

--- a/polaris-react/src/components/TextField/TextField.module.css
+++ b/polaris-react/src/components/TextField/TextField.module.css
@@ -46,6 +46,10 @@
       background-color: var(--p-color-input-bg-surface-hover);
     }
   }
+
+  @media (--p-breakpoints-md-up) {
+    /* Non-mobile styles here */
+  }
 }
 
 .multiline {

--- a/polaris-react/src/components/TextField/TextField.module.css
+++ b/polaris-react/src/components/TextField/TextField.module.css
@@ -68,23 +68,42 @@
   color: var(--p-color-text);
 }
 
+.TextField.hasValue .Input,
+.TextField.hasValue .Padded {
+  padding-block-start: 22px;
+  padding-block-end: 6px;
+}
+
+.TextField .Input,
+.TextField .Padded,
+.TextField.labelHidden .Input {
+  padding-block-start: 14px;
+  padding-block-end: 14px;
+}
+
 .focus > .Input,
 .focus > .VerticalContent,
 .focus > .InputAndSuffixWrapper,
 .TextField:focus-within > .Input,
 .Input:focus-visible {
   outline: none;
-
+  border: none;
   /* stylelint-disable-next-line selector-max-class, selector-max-combinators, selector-max-specificity -- outline based on child focus requires complex specificity */
   ~ .Backdrop {
-    border-color: var(--p-color-input-border-active);
+    border-color: rgba(0, 91, 211, 1);
+    /* border-color: var(--p-color-input-border-active); */
+
     border-width: var(--p-border-width-025);
     background-color: var(--p-color-input-bg-surface-active);
 
     /* stylelint-disable-next-line -- remove focus ring mixin */
     @mixin no-focus-ring;
-    outline: var(--p-border-width-050) solid var(--p-color-border-focus);
-    outline-offset: var(--p-space-025);
+    /* outline: var(--p-border-width-050) solid var(--p-color-border-focus);
+    outline-offset: var(--p-space-025); */
+    outline: var(--p-border-width-025) solid rgba(0, 91, 211, 1);
+    /* transition-duration: 0.2s;
+    transition-property: all;
+    transition-timing-function: ease-in-out; */
   }
 }
 
@@ -226,7 +245,7 @@
     min-width: 1em;
     grid-area: 1 / 2;
     padding: 0 var(--p-space-300);
-    font-size: var(--p-font-size-325);
+    font-size: var(--p-font-size-400);
     font-weight: var(--p-font-weight-regular);
     line-height: var(--p-font-line-height-500);
   }

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -1066,3 +1066,18 @@ export function WithLoading() {
     />
   );
 }
+
+export function MobileExploration() {
+  const [value, setValue] = useState('Jaded Pixel');
+
+  const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+  return (
+    <TextField
+      label="Store name"
+      value={value}
+      onChange={handleChange}
+      autoComplete="off"
+    />
+  );
+}

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -309,6 +309,7 @@ export function TextField({
   const className = classNames(
     styles.TextField,
     Boolean(normalizedValue) && styles.hasValue,
+    labelHidden && styles.labelHidden,
     disabled && styles.disabled,
     readOnly && styles.readOnly,
     error && styles.error,
@@ -325,7 +326,11 @@ export function TextField({
 
   const prefixMarkup = prefix ? (
     <div
-      className={classNames(styles.Prefix, iconPrefix && styles.PrefixIcon)}
+      className={classNames(
+        styles.Prefix,
+        iconPrefix && styles.PrefixIcon,
+        styles.Padded,
+      )}
       id={`${id}-Prefix`}
       ref={prefixRef}
     >
@@ -574,7 +579,7 @@ export function TextField({
     role,
     autoFocus,
     value: normalizedValue,
-    placeholder,
+    placeholder: placeholder ?? label,
     style,
     autoComplete,
     className: inputClassName,
@@ -660,18 +665,18 @@ export function TextField({
   );
 
   return (
-    <Labelled
-      label={label}
-      id={id}
-      error={error}
-      action={labelAction}
-      labelHidden={labelHidden}
-      helpText={helpText}
-      requiredIndicator={requiredIndicator}
-      disabled={disabled}
-      readOnly={readOnly}
-    >
-      <Connected left={connectedLeft} right={connectedRight}>
+    <Connected left={connectedLeft} right={connectedRight}>
+      <Labelled
+        label={label}
+        id={id}
+        error={error}
+        action={labelAction}
+        labelHidden={labelHidden || value.length === 0}
+        helpText={helpText}
+        requiredIndicator={requiredIndicator}
+        disabled={disabled}
+        readOnly={readOnly}
+      >
         <div className={className} onClick={handleClick} ref={textFieldRef}>
           {prefixMarkup}
           {inputAndSuffixMarkup}
@@ -682,8 +687,8 @@ export function TextField({
           {backdropMarkup}
           {resizer}
         </div>
-      </Connected>
-    </Labelled>
+      </Labelled>
+    </Connected>
   );
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
> [!WARNING]  
> This PR is not intended to be merged! This is only for exploratory prototyping.

### WHY are these changes introduced?
Fixes https://github.com/Shopify/polaris-internal/issues/1564

### WHAT is this pull request doing?
Creates a new storybook for exploring mobile style alignment. 