### PR TITLE
[IndexFilters | Tabs] Add `prefix` prop to `IndexFilters` and `readonly` prop to `Tab`.

### DIFF
--- a/.changeset/sixty-eyes-hunt.md
+++ b/.changeset/sixty-eyes-hunt.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Updated `IndexFilters` to allow for a prefix element before the tabs, and support a new `readonly` state for a `Tab`

--- a/polaris-react/src/components/IndexFilters/IndexFilters.module.css
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.module.css
@@ -131,8 +131,13 @@
 }
 
 .ButtonWrap,
-.ActionWrap {
+.ActionWrap,
+.PrefixWrapper {
   button {
     display: flex;
   }
+}
+
+.PrefixWrapper {
+  margin: var(--p-space-025) 0 calc(var(--p-space-025) * -1);
 }

--- a/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
@@ -15,7 +15,9 @@ import {
   IndexFiltersMode,
   ButtonGroup,
   Badge,
+  Box,
 } from '@shopify/polaris';
+import {LayoutColumns2Icon} from '@shopify/polaris-icons';
 
 import type {IndexFiltersProps} from './IndexFilters';
 
@@ -2495,6 +2497,213 @@ export function WithOnlySearchAndSort() {
         setMode={setMode}
         hideFilters
         filteringAccessibilityTooltip="Search (F)"
+      />
+      <IndexTable
+        resourceName={resourceName}
+        itemCount={orders.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {title: 'Order'},
+          {title: 'Date'},
+          {title: 'Customer'},
+          {title: 'Total', alignment: 'end'},
+          {title: 'Payment status'},
+          {title: 'Fulfillment status'},
+        ]}
+      >
+        {rowMarkup}
+      </IndexTable>
+    </Card>
+  );
+}
+
+export function WithReadOnlyAndPrefix() {
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+  const itemStrings = ['All', 'United Kingdom'];
+
+  const tabs: TabProps[] = itemStrings.map((item, index) => ({
+    content: item,
+    index,
+    onAction: () => {},
+    id: `${item}-${index}`,
+    isLocked: index === 0,
+    readonly: index === 1,
+  }));
+  const [selected, setSelected] = useState(0);
+  const sortOptions: IndexFiltersProps['sortOptions'] = [
+    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+  ];
+  const [sortSelected, setSortSelected] = useState(['order asc']);
+  const {mode, setMode} = useSetIndexFiltersMode();
+  const onHandleCancel = () => {};
+
+  const onHandleSave = async () => {
+    await sleep(1);
+    return true;
+  };
+
+  const primaryAction: IndexFiltersProps['primaryAction'] =
+    selected === 0
+      ? {
+          type: 'save-as',
+          onAction: onHandleSave,
+          disabled: false,
+          loading: false,
+        }
+      : {
+          type: 'save',
+          onAction: onHandleSave,
+          disabled: false,
+          loading: false,
+        };
+  const [queryValue, setQueryValue] = useState('');
+
+  const handleFiltersQueryChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+
+  const orders = [
+    {
+      id: '1020',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1020
+        </Text>
+      ),
+      date: 'Jul 20 at 4:34pm',
+      customer: 'Jaydon Stanton',
+      total: '$969.44',
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+    {
+      id: '1019',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1019
+        </Text>
+      ),
+      date: 'Jul 20 at 3:46pm',
+      customer: 'Ruben Westerfelt',
+      total: '$701.19',
+      paymentStatus: <Badge progress="partiallyComplete">Partially paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+    {
+      id: '1018',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1018
+        </Text>
+      ),
+      date: 'Jul 20 at 3.44pm',
+      customer: 'Leo Carder',
+      total: '$798.24',
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+  ];
+  const resourceName = {
+    singular: 'order',
+    plural: 'orders',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(orders);
+
+  const rowMarkup = orders.map(
+    (
+      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+      index,
+    ) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {order}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" variant="bodyMd">
+            {date}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" variant="bodyMd">
+            {customer}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" variant="bodyMd">
+            {paymentStatus}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" variant="bodyMd">
+            {fulfillmentStatus}
+          </Text>
+        </IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <Card padding="0">
+      <IndexFilters
+        sortOptions={sortOptions}
+        sortSelected={sortSelected}
+        queryValue={queryValue}
+        queryPlaceholder="Searching in all"
+        onQueryChange={handleFiltersQueryChange}
+        onQueryClear={() => setQueryValue('')}
+        onSort={setSortSelected}
+        primaryAction={primaryAction}
+        cancelAction={{
+          onAction: onHandleCancel,
+          disabled: false,
+          loading: false,
+        }}
+        tabs={tabs}
+        selected={selected}
+        onSelect={setSelected}
+        canCreateNewView={false}
+        filters={[]}
+        appliedFilters={[]}
+        onClearAll={() => {}}
+        mode={mode}
+        setMode={setMode}
+        hideFilters
+        filteringAccessibilityTooltip="Search (F)"
+        prefix={
+          <Box paddingInlineStart="100">
+            <Button
+              variant="tertiary"
+              icon={LayoutColumns2Icon}
+              accessibilityLabel="Toggle sidebar"
+            />
+          </Box>
+        }
       />
       <IndexTable
         resourceName={resourceName}

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -1,4 +1,5 @@
 import React, {useMemo, useCallback, useRef} from 'react';
+import type {ReactNode} from 'react';
 import {Transition} from 'react-transition-group';
 
 import {useI18n} from '../../utilities/i18n';
@@ -9,6 +10,7 @@ import {useOnValueChange} from '../../utilities/use-on-value-change';
 import {InlineStack} from '../InlineStack';
 import {Spinner} from '../Spinner';
 import {Filters} from '../Filters';
+import {Box} from '../Box';
 import type {FiltersProps} from '../Filters';
 import {Tabs} from '../Tabs';
 import type {TabsProps} from '../Tabs';
@@ -107,6 +109,8 @@ export interface IndexFiltersProps
   showEditColumnsButton?: boolean;
   /** Whether or not to auto-focus the search field when it renders */
   autoFocusSearchField?: boolean;
+  /** A piece of UI to be displayed to the immediate left of the Tabs */
+  prefix?: ReactNode;
 }
 
 export function IndexFilters({
@@ -147,6 +151,7 @@ export function IndexFilters({
   disableKeyboardShortcuts,
   showEditColumnsButton,
   autoFocusSearchField = true,
+  prefix,
 }: IndexFiltersProps) {
   const i18n = useI18n();
   const {mdDown} = useBreakpoints();
@@ -368,15 +373,14 @@ export function IndexFilters({
             <div ref={defaultRef}>
               {mode !== IndexFiltersMode.Filtering ? (
                 <Container>
-                  <InlineStack
-                    align="start"
-                    blockAlign="center"
-                    gap={{
-                      xs: '0',
-                      md: '200',
-                    }}
-                    wrap={false}
-                  >
+                  <InlineStack align="start" blockAlign="center" wrap={false}>
+                    {prefix ? (
+                      <div className={styles.PrefixWrapper}>
+                        <Box padding="200" paddingInlineEnd="0">
+                          {prefix}
+                        </Box>
+                      </div>
+                    ) : null}
                     <div
                       className={classNames(
                         styles.TabsWrapper,

--- a/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
+++ b/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
@@ -12,6 +12,7 @@ import {
   UpdateButtons,
   EditColumnsButton,
 } from '../components';
+import styles from '../IndexFilters.module.css';
 
 describe('IndexFilters', () => {
   const defaultProps: IndexFiltersProps = {
@@ -533,6 +534,30 @@ describe('IndexFilters', () => {
       });
 
       expect(onEditStart).toHaveBeenCalledWith(IndexFiltersMode.EditingColumns);
+    });
+  });
+
+  describe('prefix', () => {
+    it('renders the prefix markup if prop provided', () => {
+      const wrapper = mountWithApp(
+        <IndexFilters {...defaultProps} prefix={<div>Prefix</div>} />,
+      );
+
+      expect(wrapper).toContainReactComponent('div', {
+        className: styles.PrefixWrapper,
+      });
+
+      expect(wrapper).toContainReactComponent('div', {
+        children: 'Prefix',
+      });
+    });
+
+    it('does not render the prefix markup if prop not provided', () => {
+      const wrapper = mountWithApp(<IndexFilters {...defaultProps} />);
+
+      expect(wrapper).not.toContainReactComponent('div', {
+        className: styles.PrefixWrapper,
+      });
     });
   });
 });

--- a/polaris-react/src/components/Tabs/Tabs.module.css
+++ b/polaris-react/src/components/Tabs/Tabs.module.css
@@ -154,6 +154,18 @@
   width: var(--p-space-800);
 }
 
+.Tab-readonly {
+  background: var(--p-color-bg-surface-secondary);
+  border: var(--p-border-width-025) dashed var(--p-color-border);
+  cursor: default;
+
+  &:not([aria-disabled='true']):hover,
+  &:not([aria-disabled='true']):focus,
+  &:not([aria-disabled='true']):active {
+    background: var(--p-color-bg-surface-secondary);
+  }
+}
+
 .fillSpace {
   .TabContainer {
     flex: 1 1 auto;

--- a/polaris-react/src/components/Tabs/Tabs.stories.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.stories.tsx
@@ -15,6 +15,7 @@ export function All() {
       <WithActions />
       <WithBadgeContent />
       <WithCustomDisclosure />
+      <WithReadOnly />
     </BlockStack>
   );
 }
@@ -285,6 +286,38 @@ export function WithCustomDisclosure() {
         onSelect={handleTabChange}
         disclosureText="Extra views"
       >
+        <LegacyCard.Section title={tabs[selected].content}>
+          <Text as="p" variant="bodyMd">
+            Tab {selected} selected
+          </Text>
+        </LegacyCard.Section>
+      </Tabs>
+    </LegacyCard>
+  );
+}
+
+export function WithReadOnly() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = (selectedTabIndex: number) =>
+    setSelected(selectedTabIndex);
+
+  const tabs = [
+    'All',
+    'Unpaid',
+    'Open',
+    'Closed',
+    'Local delivery',
+    'Local pickup',
+  ].map((item, index) => ({
+    content: item,
+    index,
+    id: `${item.split(' ').join('-')}-${index}-with-readonly`,
+    readonly: index === 1,
+  }));
+  return (
+    <LegacyCard>
+      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
         <LegacyCard.Section title={tabs[selected].content}>
           <Text as="p" variant="bodyMd">
             Tab {selected} selected

--- a/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
@@ -63,6 +63,7 @@ export const Tab = forwardRef(
       viewNames,
       tabIndexOverride,
       onFocus,
+      readonly,
     }: TabPropsWithAddedMethods,
     ref: RefObject<HTMLElement>,
   ) => {
@@ -162,7 +163,7 @@ export const Tab = forwardRef(
     }, [actions]);
 
     const handleClick = useCallback(() => {
-      if (disabled) {
+      if (disabled || readonly) {
         return;
       }
       if (selected) {
@@ -170,7 +171,7 @@ export const Tab = forwardRef(
       } else {
         onAction?.();
       }
-    }, [selected, onAction, togglePopoverActive, disabled]);
+    }, [selected, onAction, togglePopoverActive, disabled, readonly]);
 
     const handleModalOpen = (type: TabAction) => {
       setActiveModalType(type);
@@ -261,7 +262,8 @@ export const Tab = forwardRef(
       selected && styles.Underline,
     );
 
-    const urlIfNotDisabledOrSelected = disabled || selected ? undefined : url;
+    const urlIfNotDisabledOrSelected =
+      disabled || selected || readonly ? undefined : url;
 
     const BaseComponent = urlIfNotDisabledOrSelected
       ? UnstyledLink
@@ -273,6 +275,7 @@ export const Tab = forwardRef(
       popoverActive && styles['Tab-popoverActive'],
       selected && styles['Tab-active'],
       selected && actions?.length && styles['Tab-hasActions'],
+      readonly && styles['Tab-readonly'],
     );
 
     const badgeMarkup = badge ? (
@@ -362,7 +365,7 @@ export const Tab = forwardRef(
     ) : null;
 
     const markup =
-      isPlainButton || disabled ? (
+      isPlainButton || disabled || readonly ? (
         activator
       ) : (
         <>

--- a/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -134,6 +134,19 @@ describe('Tab', () => {
       expect(onAction).toHaveBeenCalledTimes(1);
     });
 
+    it('does not fire an onAction callback if readonly', () => {
+      const onAction = jest.fn();
+      const wrapper = mountWithApp(
+        <Tab {...defaultProps} onAction={onAction} readonly />,
+      );
+
+      wrapper.act(() => {
+        wrapper!.find(UnstyledButton)!.trigger('onClick');
+      });
+
+      expect(onAction).toHaveBeenCalledTimes(0);
+    });
+
     describe('ActionList', () => {
       it('renders an ActionList with default props', () => {
         const wrapper = mountWithApp(<Tab {...defaultProps} selected />);

--- a/polaris-react/src/components/Tabs/types.ts
+++ b/polaris-react/src/components/Tabs/types.ts
@@ -56,6 +56,8 @@ export interface TabProps {
   tabIndexOverride?: 0 | -1;
   /** Optional callback invoked when the Tabs component is focused */
   onFocus?(): void;
+  /** If true will be non-interactive with different visual treatment */
+  readonly?: boolean;
 }
 
 export interface TabPropsWithAddedMethods extends TabProps {

--- a/polaris.shopify.com/content/components/selection-and-input/index-filters.mdx
+++ b/polaris.shopify.com/content/components/selection-and-input/index-filters.mdx
@@ -28,6 +28,9 @@ examples:
   - fileName: index-filters-with-no-search-or-filters.tsx
     title: With no search or filters
     description: An IndexFilters component with only view management and sorting.
+  - fileName: index-filters-with-readonly-tab-and-prefix.tsx
+    title: With readonly tab and prefix
+    description: An IndexFilters component configuration used in the Markets index, showing a tab in the readonly state, as well as a prefix button.
 previewImg: /images/components/selection-and-input/index-filters.png
 ---
 

--- a/polaris.shopify.com/pages/examples/index-filters-with-readonly-tab-and-prefix.tsx
+++ b/polaris.shopify.com/pages/examples/index-filters-with-readonly-tab-and-prefix.tsx
@@ -1,0 +1,224 @@
+import {
+  IndexTable,
+  Card,
+  IndexFilters,
+  useSetIndexFiltersMode,
+  useIndexResourceState,
+  Text,
+  Badge,
+  Box,
+  Button,
+} from '@shopify/polaris';
+import type {IndexFiltersProps, TabProps} from '@shopify/polaris';
+import {LayoutColumns2Icon} from '@shopify/polaris-icons';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function IndexFiltersWithReadOnlyAndPrefixExample() {
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+  const itemStrings = ['All', 'United Kingdom'];
+
+  const tabs: TabProps[] = itemStrings.map((item, index) => ({
+    content: item,
+    index,
+    onAction: () => {},
+    id: `${item}-${index}`,
+    isLocked: index === 0,
+    readonly: index === 1,
+  }));
+  const [selected, setSelected] = useState(0);
+  const sortOptions: IndexFiltersProps['sortOptions'] = [
+    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+  ];
+  const [sortSelected, setSortSelected] = useState(['order asc']);
+  const {mode, setMode} = useSetIndexFiltersMode();
+  const onHandleCancel = () => {};
+
+  const onHandleSave = async () => {
+    await sleep(1);
+    return true;
+  };
+
+  const primaryAction: IndexFiltersProps['primaryAction'] =
+    selected === 0
+      ? {
+          type: 'save-as',
+          onAction: onHandleSave,
+          disabled: false,
+          loading: false,
+        }
+      : {
+          type: 'save',
+          onAction: onHandleSave,
+          disabled: false,
+          loading: false,
+        };
+  const [queryValue, setQueryValue] = useState('');
+
+  const handleFiltersQueryChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+
+  const orders = [
+    {
+      id: '1020',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1020
+        </Text>
+      ),
+      date: 'Jul 20 at 4:34pm',
+      customer: 'Jaydon Stanton',
+      total: '$969.44',
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+    {
+      id: '1019',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1019
+        </Text>
+      ),
+      date: 'Jul 20 at 3:46pm',
+      customer: 'Ruben Westerfelt',
+      total: '$701.19',
+      paymentStatus: <Badge progress="partiallyComplete">Partially paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+    {
+      id: '1018',
+      order: (
+        <Text as="span" variant="bodyMd" fontWeight="semibold">
+          #1018
+        </Text>
+      ),
+      date: 'Jul 20 at 3.44pm',
+      customer: 'Leo Carder',
+      total: '$798.24',
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    },
+  ];
+  const resourceName = {
+    singular: 'order',
+    plural: 'orders',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(orders);
+
+  const rowMarkup = orders.map(
+    (
+      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+      index,
+    ) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {order}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" variant="bodyMd">
+            {date}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" variant="bodyMd">
+            {customer}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" alignment="end" numeric>
+            {total}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" variant="bodyMd">
+            {paymentStatus}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>
+          <Text as="span" variant="bodyMd">
+            {fulfillmentStatus}
+          </Text>
+        </IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <Card padding="0">
+      <IndexFilters
+        sortOptions={sortOptions}
+        sortSelected={sortSelected}
+        queryValue={queryValue}
+        queryPlaceholder="Searching in all"
+        onQueryChange={handleFiltersQueryChange}
+        onQueryClear={() => setQueryValue('')}
+        onSort={setSortSelected}
+        primaryAction={primaryAction}
+        cancelAction={{
+          onAction: onHandleCancel,
+          disabled: false,
+          loading: false,
+        }}
+        tabs={tabs}
+        selected={selected}
+        onSelect={setSelected}
+        canCreateNewView={false}
+        filters={[]}
+        appliedFilters={[]}
+        onClearAll={() => {}}
+        mode={mode}
+        setMode={setMode}
+        hideFilters
+        filteringAccessibilityTooltip="Search (F)"
+        prefix={
+          <Box paddingInlineStart="100">
+            <Button
+              variant="tertiary"
+              icon={LayoutColumns2Icon}
+              accessibilityLabel="Toggle sidebar"
+            />
+          </Box>
+        }
+      />
+      <IndexTable
+        resourceName={resourceName}
+        itemCount={orders.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {title: 'Order'},
+          {title: 'Date'},
+          {title: 'Customer'},
+          {title: 'Total', alignment: 'end'},
+          {title: 'Payment status'},
+          {title: 'Fulfillment status'},
+        ]}
+      >
+        {rowMarkup}
+      </IndexTable>
+    </Card>
+  );
+}
+
+export default withPolarisExample(IndexFiltersWithReadOnlyAndPrefixExample);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/123422

The Markets team need some updates to the IndexFilters and Tabs components to support the new UI that they are building.

### WHAT is this pull request doing?

This PR adds a `prefix` prop to the IndexFilters, which will render the ReactNode passed as the prop immediately to the left of the Tabs within the IndexFilters.

It also adds a new `readonly` prop to a `Tab` within the `Tabs` component, which will give the `Tab` a differing visual treatment, and remove any interactivity from the `Tab` itself.

<img width="1155" alt="Screenshot 2024-04-09 at 10 50 35" src="https://github.com/Shopify/polaris/assets/2562596/90be2de4-e2c4-4776-be23-437315c7040d">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
