### PR TITLE
Ensure pnpm-lock.yml is updated in changeset version PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type-check": "tsc --build",
     "changeset": "changeset",
     "gen-assets": "turbo run gen-assets --filter=polaris.shopify.com",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && pnpm install --lockfile-only",
     "release-packages": "pnpm build:release && changeset publish",
     "new-migration": "pnpm --filter=@shopify/polaris-migrator generate"
   },


### PR DESCRIPTION
See: https://github.com/changesets/changesets/issues/421

Didn't need this before because yarn v1 never stored the dependent's version in the lockfile. `pnpm` does, and so we need to ensure the lockfile is updated immediately after the versions are bumped.

Detailed example:

1. A PR is opened to do a major bump of `@shopify/polaris-tokens`
    - `@shopify/polaris-tokens` is at `8.1.0`
    - `@shopify/polaris` is at `12.12.0`
2. The PR is merged, then Changeset's action runs
    - `pnpm install --frozen-lockfile` succeed (versions haven't been bumped yet)
    - `changesets version` bumps the versions
    - `@shopify/polaris-tokens` is now at `9.0.0`
    - `@shopify/polaris` is now at `12.12.1`
    - _`pnpm-lock.yml` still lists `@shopify/polaris-tokens@8.1.0` as a dep of `@shopify/polaris`_ **🚨 This is the mistake**
    - Changesets commits the version bumps and opens a "Version Packages" PR
3. "Version Packages" PR is opened by Changeset's action
    - CI attempts to run `pnpm install --frozen-lockfile', but it errors ([example](https://github.com/Shopify/polaris/actions/runs/8611499009/job/23598800640#step:7:13))
    - Unable to cut a release

The failure in Step 3 happens because `polaris-react/package.json` asks for `@shopify/polaris-tokens@9.0.0`, but `pnpm-lock.yml` still lists `@shopify/polaris-tokens@8.1.0` as a dep of `@shopify/polaris`.

The fix in this PR alters Step 2 to immediately update the `pnpm-lock.yml` file after Changesets bumps the versions. This updated lockfile will get committed and pushed as part of Step 2. Step 3 will then have a correct lockfile matching the package.json.