### PR TITLE
Reduce font size of helper, error, and footer text

### DIFF
--- a/.changeset/angry-snakes-camp.md
+++ b/.changeset/angry-snakes-camp.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Reduced text size of helper, error, and footer text

--- a/.changeset/polite-wombats-speak.md
+++ b/.changeset/polite-wombats-speak.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Updated LegacyCard title size to text `headingMg` to match `bodyMd` text size
+Updated LegacyCard title size to text `headingMd` to match `bodyMd` text size

--- a/.changeset/polite-wombats-speak.md
+++ b/.changeset/polite-wombats-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated LegacyCard title size to text `headingMg` to match `bodyMd` text size

--- a/polaris-react/src/components/Autocomplete/components/MappedAction/MappedAction.tsx
+++ b/polaris-react/src/components/Autocomplete/components/MappedAction/MappedAction.tsx
@@ -76,7 +76,7 @@ export function MappedAction({
         {contentText}
       </Text>
       {helpText ? (
-        <Text as="p" variant="bodyMd" tone="subdued">
+        <Text as="p" variant="bodySm" tone="subdued">
           {helpText}
         </Text>
       ) : null}

--- a/polaris-react/src/components/Choice/Choice.tsx
+++ b/polaris-react/src/components/Choice/Choice.tsx
@@ -161,6 +161,7 @@ export function Choice({
     <div className={styles.HelpText} id={helpTextID(id)}>
       <Text
         as="span"
+        variant="bodySm"
         // `undefined` means color: inherit
         // the nearest ancestor with a specified color is .Descriptions in Choice.scss
         tone={disabled ? undefined : 'subdued'}

--- a/polaris-react/src/components/FooterHelp/FooterHelp.tsx
+++ b/polaris-react/src/components/FooterHelp/FooterHelp.tsx
@@ -18,7 +18,7 @@ export function FooterHelp({children, align = 'center'}: FooterHelpProps) {
 
   return (
     <div className={styles.FooterHelp} style={style}>
-      <Text as="p" variant="bodyLg">
+      <Text as="p" variant="bodySm">
         {children}
       </Text>
     </div>

--- a/polaris-react/src/components/FormLayout/components/Group/Group.tsx
+++ b/polaris-react/src/components/FormLayout/components/Group/Group.tsx
@@ -25,8 +25,10 @@ export function Group({children, condensed, title, helpText}: GroupProps) {
   if (helpText) {
     helpTextId = `${id}HelpText`;
     helpTextElement = (
-      <Box id={helpTextId} color="text-secondary">
-        {helpText}
+      <Box id={helpTextId}>
+        <Text as="p" variant="bodySm" tone="subdued">
+          {helpText}
+        </Text>
       </Box>
     );
   }

--- a/polaris-react/src/components/InlineError/InlineError.module.css
+++ b/polaris-react/src/components/InlineError/InlineError.module.css
@@ -2,6 +2,10 @@
   display: flex;
   color: var(--p-color-text-critical);
   fill: var(--p-color-text-critical);
+
+  & > span {
+    margin-top: var(--p-space-050);
+  }
 }
 
 .Icon {

--- a/polaris-react/src/components/InlineError/InlineError.tsx
+++ b/polaris-react/src/components/InlineError/InlineError.tsx
@@ -24,7 +24,7 @@ export function InlineError({message, fieldID}: InlineErrorProps) {
       <div className={styles.Icon}>
         <Icon source={AlertCircleIcon} />
       </div>
-      <Text as="span" variant="bodyMd">
+      <Text as="span" variant="bodySm">
         {message}
       </Text>
     </div>

--- a/polaris-react/src/components/Labelled/Labelled.tsx
+++ b/polaris-react/src/components/Labelled/Labelled.tsx
@@ -66,7 +66,7 @@ export function Labelled({
       id={helpTextID(id)}
       aria-disabled={disabled}
     >
-      <Text as="span" tone="subdued" variant="bodyMd" breakWord>
+      <Text as="span" tone="subdued" variant="bodySm" breakWord>
         {helpText}
       </Text>
     </div>

--- a/polaris-react/src/components/LegacyCard/components/Header/Header.tsx
+++ b/polaris-react/src/components/LegacyCard/components/Header/Header.tsx
@@ -21,7 +21,7 @@ export function Header({children, title, actions}: LegacyCardHeaderProps) {
   const titleMarkup = isValidElement(title) ? (
     title
   ) : (
-    <Text variant="headingSm" as="h2">
+    <Text variant="headingMd" as="h2">
       {title}
     </Text>
   );

--- a/polaris-react/src/components/LegacyFilters/LegacyFilters.tsx
+++ b/polaris-react/src/components/LegacyFilters/LegacyFilters.tsx
@@ -427,7 +427,7 @@ class LegacyFiltersInner extends Component<CombinedProps, State> {
 
     const helpTextMarkup = helpText ? (
       <div id="FiltersHelpText" className={styles.HelpText}>
-        <Text tone="subdued" as="span">
+        <Text tone="subdued" as="span" variant="bodySm">
           {helpText}
         </Text>
       </div>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-internal/issues/1567

The helper, error, and footer text are currently very large on mobile screens. This clashes with the native mobile styles when viewed on webviews.

### WHAT is this pull request doing?

Bumping down the text size of the following components will help bring the text hierarchy closer to mobile.

📸 See [Chromatic](https://shopify.chromatic.com/build?appId=5d559397bae39100201eedc1&number=23375) for all component diffs.
🌀 [Spin link](https://admin.web.card-headers.sam-rose.us.spin.dev/store/shop1)

> [!NOTE]  
> This is changing the text variation from `bodyMd` to `bodySm`. However, Polaris Mobile uses mostly `bodyMd` paired with `bodyXs`. We could consider also using `bodyXs` or perhaps mobile could upshift to `bodySm`.

#### Example screenshot

<img width="440" alt="Screenshot 2024-04-10 at 9 26 02 PM" src="https://github.com/Shopify/polaris/assets/11774595/cd665461-305b-4fb2-a34e-934c6dd05e11">

#### Example of mobile radio input

<img width="792" alt="Screenshot 2024-04-10 at 9 28 21 PM" src="https://github.com/Shopify/polaris/assets/11774595/b8f26f63-6532-4b68-a5e8-17c6cbb864e3">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
