### PR TITLE
[IndexFilters] Add support for passing zIndexOverride to disclosures

### DIFF
--- a/.changeset/all-humans-cry.md
+++ b/.changeset/all-humans-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added a `disclosureZIndexOverride` prop to `Filters`, `IndexFilters`, and `Tabs` that is passed to `Popover` and `Tooltip` when provided

--- a/.changeset/weak-humans-cry.md
+++ b/.changeset/weak-humans-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added a `disclosureZIndexProp` to `Filters`, `IndexFilters`, and `Tabs` that is passed to `Popover` and `Tooltip` when provided

--- a/.changeset/weak-humans-cry.md
+++ b/.changeset/weak-humans-cry.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris': minor
----
-
-Added a `disclosureZIndexProp` to `Filters`, `IndexFilters`, and `Tabs` that is passed to `Popover` and `Tooltip` when provided

--- a/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/FilterPill.tsx
@@ -25,14 +25,16 @@ export interface FilterPillProps extends FilterInterface {
   selected?: boolean;
   /** Whether the Popover will be initially open or not */
   initialActive: boolean;
+  /** Whether filtering is disabled */
+  disabled?: boolean;
+  /** Override z-index of popovers and tooltips */
+  disclosureZIndexOverride?: number;
+  /** Whether the filter should close when clicking inside another Popover. */
+  closeOnChildOverlayClick?: boolean;
   /** Callback invoked when the filter is removed */
   onRemove?(key: string): void;
   /** Callback invoked when the filter is clicked */
   onClick?(key: string): void;
-  /** Whether filtering is disabled */
-  disabled?: boolean;
-  /** Whether the filter should close when clicking inside another Popover. */
-  closeOnChildOverlayClick?: boolean;
 }
 
 export function FilterPill({
@@ -44,6 +46,7 @@ export function FilterPill({
   hideClearButton,
   selected,
   initialActive,
+  disclosureZIndexOverride,
   closeOnChildOverlayClick,
   onRemove,
   onClick,
@@ -207,6 +210,7 @@ export function FilterPill({
         key={filterKey}
         onClose={handlePopoverClose}
         preferredAlignment="left"
+        zIndexOverride={disclosureZIndexOverride}
         preventCloseOnChildOverlayClick={!closeOnChildOverlayClick}
       >
         <div className={styles.PopoverWrapper}>

--- a/polaris-react/src/components/Filters/components/FilterPill/tests/FilterPill.test.tsx
+++ b/polaris-react/src/components/Filters/components/FilterPill/tests/FilterPill.test.tsx
@@ -157,6 +157,21 @@ describe('<Filters />', () => {
       });
     });
 
+    it('passes the disclosureZIndexOverride to Popover when provided', () => {
+      const disclosureZIndexOverride = 517;
+      const wrapper = mountWithApp(
+        <FilterPill
+          {...defaultProps}
+          disclosureZIndexOverride={disclosureZIndexOverride}
+        />,
+      );
+      const activator = wrapper.find(UnstyledButton);
+      activator?.trigger('onClick');
+      expect(wrapper).toContainReactComponent(Popover, {
+        zIndexOverride: disclosureZIndexOverride,
+      });
+    });
+
     it('invokes the onRemove callback when clicking the clear button inside the Popover', () => {
       const spy = jest.fn();
       const wrapper = mountWithApp(

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -80,6 +80,8 @@ export interface IndexFiltersProps
   onEditStart?: (mode: ActionableIndexFiltersMode) => void;
   /** The current mode of the IndexFilters component. Used to determine which view to show */
   mode: IndexFiltersMode;
+  /** Override z-index of popovers and tooltips */
+  disclosureZIndexOverride?: number;
   /** Callback to set the mode of the IndexFilters component */
   setMode: (mode: IndexFiltersMode) => void;
   /** Will disable all the elements within the IndexFilters component */
@@ -136,6 +138,7 @@ export function IndexFilters({
   loading,
   mode,
   setMode,
+  disclosureZIndexOverride,
   disableStickyMode,
   isFlushWhenSticky = false,
   canCreateNewView = true,
@@ -280,6 +283,7 @@ export function IndexFilters({
         onChangeKey={onSortKeyChange}
         onChangeDirection={onSortDirectionChange}
         disabled={disabled}
+        disclosureZIndexOverride={disclosureZIndexOverride}
       />
     );
   }, [
@@ -289,6 +293,7 @@ export function IndexFilters({
     sortOptions,
     sortSelected,
     disabled,
+    disclosureZIndexOverride,
   ]);
 
   function handleClickEditColumnsButton() {
@@ -398,6 +403,7 @@ export function IndexFilters({
                           disabled={Boolean(
                             mode !== IndexFiltersMode.Default || disabled,
                           )}
+                          disclosureZIndexOverride={disclosureZIndexOverride}
                           canCreateNewView={canCreateNewView}
                           onCreateNewView={onCreateNewView}
                         />
@@ -428,6 +434,9 @@ export function IndexFilters({
                                 ...defaultStyle,
                                 ...transitionStyles[state],
                               }}
+                              disclosureZIndexOverride={
+                                disclosureZIndexOverride
+                              }
                             />
                           )}
                           {editColumnsMarkup}

--- a/polaris-react/src/components/IndexFilters/components/SearchFilterButton/SearchFilterButton.tsx
+++ b/polaris-react/src/components/IndexFilters/components/SearchFilterButton/SearchFilterButton.tsx
@@ -13,6 +13,7 @@ export interface SearchFilterButtonProps {
   label: string;
   disabled?: boolean;
   tooltipContent: string;
+  disclosureZIndexOverride?: number;
   hideFilters?: boolean;
   hideQueryField?: boolean;
   style: CSSProperties;
@@ -23,6 +24,7 @@ export function SearchFilterButton({
   label,
   disabled,
   tooltipContent,
+  disclosureZIndexOverride,
   style,
   hideFilters,
   hideQueryField,
@@ -53,7 +55,12 @@ export function SearchFilterButton({
   );
 
   return (
-    <Tooltip content={content} preferredPosition="above" hoverDelay={400}>
+    <Tooltip
+      content={content}
+      preferredPosition="above"
+      hoverDelay={400}
+      zIndexOverride={disclosureZIndexOverride}
+    >
       {activator}
     </Tooltip>
   );

--- a/polaris-react/src/components/IndexFilters/components/SortButton/SortButton.tsx
+++ b/polaris-react/src/components/IndexFilters/components/SortButton/SortButton.tsx
@@ -20,8 +20,9 @@ export enum SortButtonDirection {
 export interface SortButtonProps {
   choices: SortButtonChoice[];
   selected: ChoiceListProps['selected'];
-  onChange: (selected: string[]) => void;
   disabled?: boolean;
+  disclosureZIndexOverride?: number;
+  onChange: (selected: string[]) => void;
   onChangeKey?: (key: string) => void;
   onChangeDirection?: (direction: string) => void;
 }
@@ -29,8 +30,9 @@ export interface SortButtonProps {
 export function SortButton({
   choices,
   selected,
-  onChange,
   disabled,
+  disclosureZIndexOverride,
+  onChange,
   onChangeKey,
   onChangeDirection,
 }: SortButtonProps) {
@@ -99,6 +101,7 @@ export function SortButton({
       content={i18n.translate('Polaris.IndexFilters.SortButton.tooltip')}
       preferredPosition="above"
       hoverDelay={400}
+      zIndexOverride={disclosureZIndexOverride}
     >
       <Button
         size="slim"
@@ -114,12 +117,13 @@ export function SortButton({
 
   return (
     <Popover
+      fluidContent
       active={active && !disabled}
       activator={sortButton}
       autofocusTarget="first-node"
       onClose={handleClose}
       preferredAlignment="right"
-      fluidContent
+      zIndexOverride={disclosureZIndexOverride}
     >
       <Box
         minWidth="148px"

--- a/polaris-react/src/components/IndexFilters/components/SortButton/tests/SortButton.test.tsx
+++ b/polaris-react/src/components/IndexFilters/components/SortButton/tests/SortButton.test.tsx
@@ -3,6 +3,7 @@ import {mountWithApp} from 'tests/utilities';
 
 import {ChoiceList} from '../../../../ChoiceList';
 import {Popover} from '../../../../Popover';
+import {Tooltip} from '../../../../Tooltip';
 import {UnstyledButton} from '../../../../UnstyledButton';
 import type {SortButtonChoice} from '../../../types';
 import {SortButton} from '..';
@@ -76,6 +77,36 @@ describe('SortButton', () => {
 
     expect(wrapper).toContainReactComponent(Popover, {
       active: false,
+    });
+  });
+
+  it('passes the disclosureZIndexOverride to the popover when provided', () => {
+    const disclosureZIndexOverride = 517;
+    const props: SortButtonProps = {
+      onChange: jest.fn(),
+      choices,
+      selected: ['order-number asc'],
+      disclosureZIndexOverride,
+    };
+    const wrapper = mountWithApp(<SortButton {...props} />);
+
+    expect(wrapper).toContainReactComponent(Popover, {
+      zIndexOverride: disclosureZIndexOverride,
+    });
+  });
+
+  it('passes the disclosureZIndexOverride to the tooltip when provided', () => {
+    const disclosureZIndexOverride = 517;
+    const props: SortButtonProps = {
+      onChange: jest.fn(),
+      choices,
+      selected: ['order-number asc'],
+      disclosureZIndexOverride,
+    };
+    const wrapper = mountWithApp(<SortButton {...props} />);
+
+    expect(wrapper).toContainReactComponent(Tooltip, {
+      zIndexOverride: disclosureZIndexOverride,
     });
   });
 

--- a/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
+++ b/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
@@ -141,11 +141,39 @@ describe('IndexFilters', () => {
     });
   });
 
+  it('passes the disclosureZIndexOverride to the Tabs when provided', () => {
+    const disclosureZIndexOverride = 517;
+    const wrapper = mountWithApp(
+      <IndexFilters
+        {...defaultProps}
+        disclosureZIndexOverride={disclosureZIndexOverride}
+      />,
+    );
+
+    expect(wrapper).toContainReactComponent(Tabs, {
+      disclosureZIndexOverride,
+    });
+  });
+
   it('renders the SearchFilterButton tooltipContent with keyboard shortcut by default', () => {
     const wrapper = mountWithApp(<IndexFilters {...defaultProps} />);
 
     expect(wrapper).toContainReactComponent(SearchFilterButton, {
       tooltipContent: 'Search and filter (F)',
+    });
+  });
+
+  it('passes the disclosureZIndexOverride to the SearchFilterButton when provided', () => {
+    const disclosureZIndexOverride = 517;
+    const wrapper = mountWithApp(
+      <IndexFilters
+        {...defaultProps}
+        disclosureZIndexOverride={disclosureZIndexOverride}
+      />,
+    );
+
+    expect(wrapper).toContainReactComponent(SearchFilterButton, {
+      disclosureZIndexOverride,
     });
   });
 
@@ -161,13 +189,42 @@ describe('IndexFilters', () => {
     expect(defaultProps.onQueryChange).toHaveBeenCalledWith('bar');
   });
 
-  it('onSort gets called correctly', () => {
-    const wrapper = mountWithApp(<IndexFilters {...defaultProps} />);
-    wrapper.act(() => {
-      wrapper.find(SortButton)!.trigger('onChange', ['customer-name asc']);
+  describe('sortOptions', () => {
+    it('does not render the SortButton component when sortOptions is not provided', () => {
+      const wrapper = mountWithApp(
+        <IndexFilters {...defaultProps} sortOptions={undefined} />,
+      );
+
+      expect(wrapper).not.toContainReactComponent(SortButton);
     });
 
-    expect(defaultProps.onSort).toHaveBeenCalledWith(['customer-name asc']);
+    it('renders the SortButton component when sortOptions is provided', () => {
+      const wrapper = mountWithApp(<IndexFilters {...defaultProps} />);
+      expect(wrapper).toContainReactComponent(SortButton);
+    });
+
+    it('passes zIndexOverride to the SortButton component when provided', () => {
+      const disclosureZIndexOverride = 517;
+      const wrapper = mountWithApp(
+        <IndexFilters
+          {...defaultProps}
+          disclosureZIndexOverride={disclosureZIndexOverride}
+        />,
+      );
+
+      expect(wrapper).toContainReactComponent(SortButton, {
+        disclosureZIndexOverride,
+      });
+    });
+
+    it('onSort gets called correctly', () => {
+      const wrapper = mountWithApp(<IndexFilters {...defaultProps} />);
+      wrapper.act(() => {
+        wrapper.find(SortButton)!.trigger('onChange', ['customer-name asc']);
+      });
+
+      expect(defaultProps.onSort).toHaveBeenCalledWith(['customer-name asc']);
+    });
   });
 
   describe('filters', () => {

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -42,18 +42,20 @@ export interface TabsProps {
   selected: number;
   /** Whether the Tabs are disabled or not. */
   disabled?: boolean;
-  /** Optional callback invoked when a Tab becomes selected. */
-  onSelect?: (selectedTabIndex: number) => void;
   /** Whether to show the add new view Tab. */
   canCreateNewView?: boolean;
   /** Label for the new view Tab. Will override the default of "Create new view" */
   newViewAccessibilityLabel?: string;
-  /** Optional callback invoked when a merchant saves a new view from the Modal */
-  onCreateNewView?: (value: string) => Promise<boolean>;
   /** Fit tabs to container */
   fitted?: boolean;
   /** Text to replace disclosures horizontal dots */
   disclosureText?: string;
+  /** Override z-index of popovers and tooltips */
+  disclosureZIndexOverride?: number;
+  /** Optional callback invoked when a Tab becomes selected. */
+  onSelect?: (selectedTabIndex: number) => void;
+  /** Optional callback invoked when a merchant saves a new view from the Modal */
+  onCreateNewView?: (value: string) => Promise<boolean>;
 }
 const CREATE_NEW_VIEW_ID = 'create-new-view';
 
@@ -68,6 +70,7 @@ export const Tabs = ({
   onSelect,
   fitted,
   disclosureText,
+  disclosureZIndexOverride,
 }: TabsProps) => {
   const i18n = useI18n();
   const {mdDown} = useBreakpoints();
@@ -205,17 +208,19 @@ export const Tabs = ({
           onToggleModal={handleToggleModal}
           onTogglePopover={handleTogglePopover}
           viewNames={viewNames}
+          disclosureZIndexOverride={disclosureZIndexOverride}
           ref={index === selected ? selectedTabRef : null}
         />
       );
     },
     [
       disabled,
-      handleTabClick,
       tabs,
       children,
       selected,
       tabToFocus,
+      disclosureZIndexOverride,
+      handleTabClick,
       handleToggleModal,
       handleTogglePopover,
     ],
@@ -578,6 +583,7 @@ export const Tabs = ({
                     active={disclosureActivatorVisible && showDisclosure}
                     onClose={handleClose}
                     autofocusTarget="first-node"
+                    zIndexOverride={disclosureZIndexOverride}
                   >
                     <List
                       focusIndex={hiddenTabs.indexOf(tabToFocus)}
@@ -608,6 +614,7 @@ export const Tabs = ({
                           )}
                           preferredPosition="above"
                           hoverDelay={400}
+                          zIndexOverride={disclosureZIndexOverride}
                         >
                           {newTab}
                         </Tooltip>

--- a/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
@@ -62,6 +62,7 @@ export const Tab = forwardRef(
       onTogglePopover,
       viewNames,
       tabIndexOverride,
+      disclosureZIndexOverride,
       onFocus,
     }: TabPropsWithAddedMethods,
     ref: RefObject<HTMLElement>,
@@ -371,6 +372,7 @@ export const Tab = forwardRef(
             activator={activator}
             autofocusTarget="first-node"
             onClose={togglePopoverActive}
+            zIndexOverride={disclosureZIndexOverride}
           >
             <div className={styles.ActionListWrap}>
               <ActionList actionRole="menuitem" items={formattedActions} />

--- a/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -98,10 +98,25 @@ describe('Tab', () => {
     expect(wrapper.find(UnstyledButton)).toContainReactText(icon);
   });
 
-  it('renders a Popover if selected=true and we have actions', () => {
+  it('renders a Popover if selected=true and has actions', () => {
     const wrapper = mountWithApp(<Tab {...defaultProps} selected />);
 
     expect(wrapper).toContainReactComponent(Popover);
+  });
+
+  it('passes disclosureZIndexOverride to Popover when provided', () => {
+    const disclosureZIndexOverride = 517;
+    const wrapper = mountWithApp(
+      <Tab
+        {...defaultProps}
+        selected
+        disclosureZIndexOverride={disclosureZIndexOverride}
+      />,
+    );
+
+    expect(wrapper).toContainReactComponent(Popover, {
+      zIndexOverride: disclosureZIndexOverride,
+    });
   });
 
   describe('callbacks', () => {

--- a/polaris-react/src/components/Tabs/tests/Tabs.test.tsx
+++ b/polaris-react/src/components/Tabs/tests/Tabs.test.tsx
@@ -4,6 +4,7 @@ import {mountWithApp} from 'tests/utilities';
 import {Icon} from '../../Icon';
 import {Text} from '../../Text';
 import {Popover} from '../../Popover';
+import {Tooltip} from '../../Tooltip';
 import {Tabs} from '..';
 import type {TabProps, TabsProps} from '..';
 import {Tab, Panel, CreateViewModal, TabMeasurer} from '../components';
@@ -453,6 +454,42 @@ describe('Tabs', () => {
       expect(wrapper).toContainReactText(disclosureText);
     });
 
+    it('passes the zIndexOverride through to Popover when provided', () => {
+      const disclosureZIndexOverride = 517;
+      const wrapper = mountWithApp(
+        <Tabs
+          {...mockProps}
+          tabs={mockTabs}
+          disclosureZIndexOverride={disclosureZIndexOverride}
+        />,
+      );
+
+      wrapper.find(TabMeasurer)!.trigger('handleMeasurement', {
+        hiddenTabWidths: [82, 160, 150, 100, 80, 120],
+        containerWidth: 300,
+        disclosureWidth: 0,
+      });
+
+      expect(wrapper.find(Popover)).toHaveReactProps({
+        zIndexOverride: disclosureZIndexOverride,
+      });
+    });
+
+    it('passes the zIndexOverride through to Tab when provided', () => {
+      const disclosureZIndexOverride = 517;
+      const wrapper = mountWithApp(
+        <Tabs
+          {...mockProps}
+          tabs={mockTabs}
+          disclosureZIndexOverride={disclosureZIndexOverride}
+        />,
+      );
+
+      expect(wrapper).toContainReactComponent(Tab, {
+        disclosureZIndexOverride,
+      });
+    });
+
     it('passes preferredPosition below to the Popover', () => {
       const tabs = mountWithApp(<Tabs {...mockProps} tabs={mockTabs} />);
       tabs.find(TabMeasurer)!.trigger('handleMeasurement', {
@@ -586,6 +623,21 @@ describe('Tabs', () => {
       });
       expect(wrapper).toContainReactComponent(Icon, {
         accessibilityLabel: mockProps.newViewAccessibilityLabel,
+      });
+    });
+
+    it('passes the disclosureZIndexOverride to Tooltip when provided', () => {
+      const disclosureZIndexOverride = 517;
+      const wrapper = mountWithApp(
+        <Tabs
+          {...mockProps}
+          canCreateNewView
+          disclosureZIndexOverride={disclosureZIndexOverride}
+        />,
+      );
+
+      expect(wrapper).toContainReactComponent(Tooltip, {
+        zIndexOverride: disclosureZIndexOverride,
       });
     });
 

--- a/polaris-react/src/components/Tabs/types.ts
+++ b/polaris-react/src/components/Tabs/types.ts
@@ -54,6 +54,8 @@ export interface TabProps {
   measuring?: boolean;
   /** Overrides the tabIndex calculated by the Tabs component */
   tabIndexOverride?: 0 | -1;
+  /** Override z-index of popovers and tooltips */
+  disclosureZIndexOverride?: number;
   /** Optional callback invoked when the Tabs component is focused */
   onFocus?(): void;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

`Filters`, `IndexFilters`, and `Tabs` all render `Popovers` and `Tooltips`, which support a `zIndexOverride` when needed by consuming apps. For example, the SettingsModal has a `z-index` of 516, which is higher than `Popover` and `Tooltip`. When rendered in a /settings view, these need to have an increased `z-index` from `--p-z-index-2` (400) to `--p-z-index-9` (517).

### WHAT is this pull request doing?

This PR simply adds support for passing through a `z-index` override to the `Popover` and `Tooltip` components composed by `Filters`, `IndexFilters`, and `Tabs` through a new `disclosureZIndexOverride` prop.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases) (pending)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
