### PR TITLE
[Image] Add optional `ref` prop type

### DIFF
--- a/polaris-react/src/components/Image/Image.tsx
+++ b/polaris-react/src/components/Image/Image.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, forwardRef} from 'react';
+import type {Ref} from 'react';
 
 interface SourceSet {
   source: string;
@@ -14,6 +15,7 @@ export interface ImageProps extends React.HTMLProps<HTMLImageElement> {
   sourceSet?: SourceSet[];
   onLoad?(): void;
   onError?(): void;
+  ref?: Ref<HTMLImageElement>;
 }
 
 export const Image = forwardRef<HTMLImageElement, ImageProps>(


### PR DESCRIPTION
### WHY are these changes introduced?

Image without optional ref argument was causing type errors.
<img width="1040" alt="11-09-t3waz-qe4ny" src="https://github.com/Shopify/polaris/assets/26749317/82c54744-641f-48d4-bed2-1388c7d3f13f">

### WHAT is this pull request doing?

Explictly adds `ref` as an optional prop type on `ImageProps`

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
