### PR TITLE
[WIP Prototype] Polaris Stepper Prototype

### DIFF
--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -23,6 +23,8 @@ import {
   SearchIcon,
 } from '@shopify/polaris-icons';
 
+import {Stepper} from './components';
+
 export default {
   component: TextField,
 } as ComponentMeta<typeof TextField>;
@@ -281,6 +283,36 @@ export function WithHelpText() {
       onChange={handleTextFieldChange}
       helpText="We’ll use this address if we need to contact you about your account."
       autoComplete="email"
+    />
+  );
+}
+
+export function DefaultStepper() {
+  const [numberValue, setNumberValue] = useState(3);
+
+  const handleValueChange = useCallback((value) => setNumberValue(value), []);
+
+  return (
+    <Stepper
+      label="Stepper"
+      value={numberValue}
+      valueChanged={handleValueChange}
+    />
+  );
+}
+
+export function StepperWithMinMaxValues() {
+  const [numberValue, setNumberValue] = useState(3);
+
+  const handleValueChange = useCallback((value) => setNumberValue(value), []);
+
+  return (
+    <Stepper
+      label="Stepper with min and max values"
+      value={numberValue}
+      minValue={0}
+      maxValue={10}
+      valueChanged={handleValueChange}
     />
   );
 }
@@ -929,6 +961,10 @@ export function All() {
           variant="borderless"
           size="slim"
         />
+      </FormLayout.Group>
+      <FormLayout.Group>
+        {DefaultStepper()}
+        {StepperWithMinMaxValues()}
       </FormLayout.Group>
     </FormLayout>
   );

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -21,8 +21,7 @@ import {Text} from '../Text';
 import {Spinner as LoadingSpinner} from '../Spinner';
 import {useEventListener} from '../../utilities/use-event-listener';
 
-import {Resizer, Spinner} from './components';
-import type {SpinnerProps} from './components';
+import {Resizer} from './components';
 import styles from './TextField.module.css';
 
 type Type =
@@ -272,7 +271,7 @@ export function TextField({
   const suffixRef = useRef<HTMLDivElement>(null);
   const loadingRef = useRef<HTMLDivElement>(null);
   const verticalContentRef = useRef<HTMLDivElement>(null);
-  const buttonPressTimer = useRef<number>();
+  // const buttonPressTimer = useRef<number>();
   const spinnerRef = useRef<HTMLDivElement>(null);
 
   const getInputRef = useCallback(() => {
@@ -444,45 +443,45 @@ export function TextField({
     ],
   );
 
-  const handleSpinnerButtonRelease = useCallback(() => {
-    clearTimeout(buttonPressTimer.current);
-  }, []);
+  // const handleSpinnerButtonRelease = useCallback(() => {
+  //   clearTimeout(buttonPressTimer.current);
+  // }, []);
 
-  const handleSpinnerButtonPress: SpinnerProps['onMouseDown'] = useCallback(
-    (onChange) => {
-      const minInterval = 50;
-      const decrementBy = 10;
-      let interval = 200;
+  // const handleSpinnerButtonPress: SpinnerProps['onMouseDown'] = useCallback(
+  //   (onChange) => {
+  //     const minInterval = 50;
+  //     const decrementBy = 10;
+  //     let interval = 200;
 
-      const onChangeInterval = () => {
-        if (interval > minInterval) interval -= decrementBy;
-        onChange(0);
-        buttonPressTimer.current = window.setTimeout(
-          onChangeInterval,
-          interval,
-        );
-      };
+  //     const onChangeInterval = () => {
+  //       if (interval > minInterval) interval -= decrementBy;
+  //       onChange(0);
+  //       buttonPressTimer.current = window.setTimeout(
+  //         onChangeInterval,
+  //         interval,
+  //       );
+  //     };
 
-      buttonPressTimer.current = window.setTimeout(onChangeInterval, interval);
+  //     buttonPressTimer.current = window.setTimeout(onChangeInterval, interval);
 
-      document.addEventListener('mouseup', handleSpinnerButtonRelease, {
-        once: true,
-      });
-    },
-    [handleSpinnerButtonRelease],
-  );
+  //     document.addEventListener('mouseup', handleSpinnerButtonRelease, {
+  //       once: true,
+  //     });
+  //   },
+  //   [handleSpinnerButtonRelease],
+  // );
 
-  const spinnerMarkup =
-    isNumericType && step !== 0 && !disabled && !readOnly ? (
-      <Spinner
-        onClick={handleClickChild}
-        onChange={handleNumberChange}
-        onMouseDown={handleSpinnerButtonPress}
-        onMouseUp={handleSpinnerButtonRelease}
-        ref={spinnerRef}
-        onBlur={handleOnBlur}
-      />
-    ) : null;
+  // const spinnerMarkup =
+  //   isNumericType && step !== 0 && !disabled && !readOnly ? (
+  //     <Spinner
+  //       onClick={handleClickChild}
+  //       onChange={handleNumberChange}
+  //       onMouseDown={handleSpinnerButtonPress}
+  //       onMouseUp={handleSpinnerButtonRelease}
+  //       ref={spinnerRef}
+  //       onBlur={handleOnBlur}
+  //     />
+  //   ) : null;
 
   const style =
     multiline && height
@@ -678,7 +677,7 @@ export function TextField({
           {characterCountMarkup}
           {loadingMarkup}
           {clearButtonMarkup}
-          {spinnerMarkup}
+          {/* {spinnerMarkup} */}
           {backdropMarkup}
           {resizer}
         </div>

--- a/polaris-react/src/components/TextField/components/Stepper/Stepper.tsx
+++ b/polaris-react/src/components/TextField/components/Stepper/Stepper.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import {MinusIcon, PlusIcon} from '@shopify/polaris-icons';
+
+import {TextField} from '../../TextField';
+import {StepperButton} from './StepperButton';
+import {useStepper} from './useStepper';
+
+interface Props {
+  value: number;
+  label?: string;
+  minValue?: number;
+  maxValue?: number;
+  disabled?: boolean;
+  valueChanged: (newValue: number) => void;
+}
+
+export function Stepper({
+  value,
+  label,
+  minValue,
+  maxValue,
+  valueChanged,
+  disabled,
+}: Props) {
+  const {
+    formattedValue,
+    canDecrement,
+    canIncrement,
+    decrement,
+    increment,
+    handleValueChanged,
+  } = useStepper({
+    value,
+    minValue,
+    maxValue,
+    valueChanged,
+    disabled,
+  });
+
+  const minusButtonMarkup = (
+    <StepperButton
+      disabled={!canDecrement}
+      onPress={decrement}
+      source={MinusIcon}
+    />
+  );
+
+  const plusButtonMarkup = (
+    <StepperButton
+      disabled={!canIncrement}
+      onPress={increment}
+      source={PlusIcon}
+    />
+  );
+  return (
+    <TextField
+      label={label}
+      type="integer"
+      value={formattedValue}
+      onChange={handleValueChanged}
+      autoComplete="off"
+      connectedLeft={minusButtonMarkup}
+      connectedRight={plusButtonMarkup}
+    />
+  );
+}

--- a/polaris-react/src/components/TextField/components/Stepper/StepperButton.tsx
+++ b/polaris-react/src/components/TextField/components/Stepper/StepperButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import type {IconSource} from '../../../..';
+import {Box} from '../../../Box';
+import {Button} from '../../../Button';
+
+interface Props {
+  source: IconSource;
+  disabled: boolean;
+  onPress: () => void;
+}
+
+export function StepperButton({source, disabled, onPress}: Props) {
+  return (
+    <Box padding="300">
+      <Button disabled={disabled} icon={source} onClick={onPress} />
+    </Box>
+  );
+}

--- a/polaris-react/src/components/TextField/components/Stepper/index.ts
+++ b/polaris-react/src/components/TextField/components/Stepper/index.ts
@@ -1,0 +1,1 @@
+export * from './Stepper';

--- a/polaris-react/src/components/TextField/components/Stepper/useStepper.ts
+++ b/polaris-react/src/components/TextField/components/Stepper/useStepper.ts
@@ -1,0 +1,76 @@
+interface Props {
+  value: number | null;
+  minValue?: number;
+  maxValue?: number;
+  valueChanged: (newValue: number) => void;
+  disabled?: boolean;
+}
+
+interface Value {
+  formattedValue: string;
+  canDecrement: boolean;
+  canIncrement: boolean;
+  decrement: () => void;
+  increment: () => void;
+  handleValueChanged: (input: string) => void;
+}
+
+export function useStepper({
+  value,
+  minValue,
+  maxValue,
+  valueChanged,
+  disabled,
+}: Props): Value {
+  const coerceValue = (proposedValue: number) => {
+    const actualMinValue = minValue ?? -Infinity;
+    const actualMaxValue = maxValue ?? Infinity;
+
+    return Math.max(actualMinValue, Math.min(proposedValue, actualMaxValue));
+  };
+
+  const isDisabled = disabled === true || value === null;
+
+  const canDecrement = isDisabled ? false : value > (minValue ?? -Infinity);
+  const canIncrement = isDisabled ? false : value < (maxValue ?? Infinity);
+
+  const handleValueChanged = (input: string) => {
+    const numberInput = Number(input);
+    const coercedNumberInput = coerceValue(numberInput);
+    if (coercedNumberInput !== value) {
+      valueChanged(coercedNumberInput);
+    }
+  };
+
+  const decrement = () => {
+    if (value === null) {
+      return;
+    }
+    const newValue = coerceValue(value - 1);
+    if (newValue !== value) {
+      valueChanged(newValue);
+    }
+  };
+
+  const increment = () => {
+    if (value === null) {
+      return;
+    }
+    const newValue = coerceValue(value + 1);
+    if (newValue !== value) {
+      valueChanged(newValue);
+    }
+  };
+
+  const formattedValue =
+    value === null ? '-' : coerceValue(value).toLocaleString();
+
+  return {
+    formattedValue,
+    canDecrement,
+    canIncrement,
+    decrement,
+    increment,
+    handleValueChanged,
+  };
+}

--- a/polaris-react/src/components/TextField/components/index.ts
+++ b/polaris-react/src/components/TextField/components/index.ts
@@ -1,3 +1,5 @@
 export * from './Resizer';
 
 export * from './Spinner';
+
+export * from './Stepper';


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

**This is a WIP prototype, there are still more work to be done in order to integrate the new stepper into TextField more seamlessly without breaking the consumer end**

- created new Stepper component that renders TextField 
- Took advantage of the existing Connect TextField UI 

Screenshots of Storybook
<img width="628" alt="Screenshot 2024-04-17 at 4 47 11 PM" src="https://github.com/Shopify/polaris/assets/36549039/6bc86188-5978-40f8-83e8-5b06fc1793b0">

<img width="403" alt="Screenshot 2024-04-17 at 4 24 43 PM" src="https://github.com/Shopify/polaris/assets/36549039/74d997f9-ec70-4f08-ac76-f97be737d9b8">

<img width="396" alt="Screenshot 2024-04-17 at 4 24 35 PM" src="https://github.com/Shopify/polaris/assets/36549039/2518c4f7-4ec9-4399-abe5-31a6f879ad62">

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩
Storybook -> [Link](https://5d559397bae39100201eedc1-xiyrgqfmrf.chromatic.com/?path=/story/all-components-textfield--all)  (scroll all the way down)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
