### PR TITLE
[Option, TextOption] Check for string type before rendering placeholder

### DIFF
--- a/.changeset/eleven-tools-report.md
+++ b/.changeset/eleven-tools-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added check for string type before rendering a placeholder in Option and TextOption

--- a/polaris-react/src/components/Listbox/components/TextOption/TextOption.tsx
+++ b/polaris-react/src/components/Listbox/components/TextOption/TextOption.tsx
@@ -35,7 +35,8 @@ export const TextOption = memo(function TextOption({
     isAction && styles.isAction,
   );
 
-  const placeholder = isAction ? null : <Box width="20px" />;
+  const childIsString = typeof children === 'string';
+  const placeholder = isAction || !childIsString ? null : <Box width="20px" />;
 
   const optionMarkup = (
     <Box width="100%">

--- a/polaris-react/src/components/OptionList/components/Option/Option.tsx
+++ b/polaris-react/src/components/OptionList/components/Option/Option.tsx
@@ -76,6 +76,8 @@ export function Option({
     onFocus(section, index);
   }, [toggleFocused, onFocus, section, index]);
 
+  const labelIsString = typeof label === 'string';
+
   const mediaMarkup = media ? (
     <div className={styles.Media}>{media}</div>
   ) : null;
@@ -98,6 +100,8 @@ export function Option({
     allowMultiple && styles.CheckboxLabel,
     allowMultiple && styles.MultiSelectOption,
   );
+
+  const placeholderMarkup = labelIsString ? <Box width="20px" /> : null;
 
   const optionMarkup = allowMultiple ? (
     <label htmlFor={id} className={multiSelectClassName}>
@@ -131,7 +135,7 @@ export function Option({
           <Icon source={CheckIcon} tone="base" />
         </span>
       ) : (
-        <Box width="20px" />
+        placeholderMarkup
       )}
       <InlineStack
         wrap={false}
@@ -140,8 +144,7 @@ export function Option({
         {mediaMarkup}
         <span
           style={{
-            minWidth:
-              typeof label === 'string' ? `${label.length}ch` : 'initial',
+            minWidth: labelIsString ? `${label.length}ch` : 'initial',
           }}
         >
           {label}


### PR DESCRIPTION
### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
