### PR TITLE
Update dev dependency: `postcss-import@^15.1.0` -> `postcss-import@^16.1.0`

### DIFF
--- a/.changeset/lucky-donuts-fetch.md
+++ b/.changeset/lucky-donuts-fetch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Update dev dependency: `postcss-import@^15.1.0` -> `postcss-import@^16.1.0`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,8 +370,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.4.32)
       postcss-import:
-        specifier: '^15.1.0 '
-        version: 15.1.0(postcss@8.4.32)
+        specifier: '^16.1.0 '
+        version: 16.1.0(postcss@8.4.32)
       postcss-loader:
         specifier: ^4.2.0
         version: 4.3.0(postcss@8.4.32)(webpack@5.76.0)
@@ -18595,9 +18595,9 @@ packages:
       postcss: 8.4.32
     dev: true
 
-  /postcss-import@15.1.0(postcss@8.4.32):
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
+  /postcss-import@16.1.0(postcss@8.4.32):
+    resolution: {integrity: sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -100,7 +100,7 @@
     "postcss": "^8.3.1",
     "postcss-custom-media": "^10.0.1",
     "postcss-discard-comments": "^6.0.1",
-    "postcss-import": "^15.1.0 ",
+    "postcss-import": "^16.1.0 ",
     "postcss-loader": "^4.2.0",
     "postcss-mixins": "^9.0.4",
     "postcss-modules": "^4.2.2",


### PR DESCRIPTION
The major change is just dropping old node support: https://github.com/postcss/postcss-import/blob/master/CHANGELOG.md#1600--2024-01-02

I confirmed the generated CSS was the same by running the below script on this branch, then on `main`, and doing a `git diff --no-index ....` (there was no difference):

```sh
if [ -z "$1" ]; then echo "A filename is required:\n> $0 ./postcss-import-15.css"; exit 1; fi;

# Write a temporary postcss config for cssnano to work
cat <<EOF > postcss.config.js
module.exports = {
  plugins: [
    require('cssnano')({
      preset: 'lite',
    }),
  ],
};
EOF

pnpm add --workspace-root cssnano cssnano-preset-lite
pnpm install
pnpm run build --filter="@shopify/polaris" --no-cache --force

cp polaris-react/build/esm/styles.css "$1" # Move out of ignored directories
pnpm prettier -w "$1" # Pre-format to normalize whitespace
pnpm dlx postcss-cli -r --no-map --config="`pwd`" "$1" # cssnano removes more whitespace prettier doesn't
pnpm prettier -w "$1" # Format again to get back into un-minified version
rm postcss.config.js # Clean up temporary files
pnpm remove --workspace-root cssnano cssnano-preset-lite
```