### PR TITLE
Update `Card` and `LegacyCard` mobile styles

### DIFF
--- a/.changeset/angry-avocados-scream.md
+++ b/.changeset/angry-avocados-scream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Removed default `Card` and `LegacyCard` bevel styles below sm breakpoint

--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -1,7 +1,6 @@
 import type {
   BreakpointsAlias,
   ColorBackgroundAlias,
-  BorderRadiusAliasOrScale,
   SpaceScale,
 } from '@shopify/polaris-tokens';
 import React from 'react';
@@ -40,15 +39,15 @@ export const Card = ({
   roundedAbove = 'sm',
 }: CardProps) => {
   const breakpoints = useBreakpoints();
-  const defaultBorderRadius: BorderRadiusAliasOrScale = '300';
-  const hasBorderRadius = Boolean(breakpoints[`${roundedAbove}Up`]);
+  const hasBevel = Boolean(breakpoints[`${roundedAbove}Up`]);
 
   return (
     <WithinContentContext.Provider value>
       <ShadowBevel
         boxShadow="100"
-        borderRadius={hasBorderRadius ? defaultBorderRadius : '0'}
+        borderRadius="300"
         zIndex="32"
+        bevel={hasBevel}
       >
         <Box
           background={background}

--- a/polaris-react/src/components/LegacyCard/LegacyCard.module.css
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.module.css
@@ -1,11 +1,7 @@
 .LegacyCard {
   background-color: var(--p-color-bg-surface);
-  box-shadow: var(--p-shadow-300);
   outline: var(--p-border-width-025) solid transparent;
   overflow: clip;
-
-  @mixin shadow-bevel var(--p-shadow-100), var(--p-border-radius-0), null, '',
-    101;
 
   + .LegacyCard {
     margin-top: var(--p-space-400);
@@ -16,6 +12,7 @@
   }
 
   @media (--p-breakpoints-sm-up) {
+    box-shadow: var(--p-shadow-300);
     border-radius: var(--p-border-radius-200);
 
     @mixin shadow-bevel var(--p-shadow-100), var(--p-border-radius-300), null,


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/polaris-internal/issues/1559
Closes https://github.com/Shopify/mobile/issues/33783

### WHAT is this pull request doing?
Removes `Card` and `LegacyCard` default bevel styles below the `sm` breakpoint. Essentially if card corners aren’t rounded then shadow styles are removed as well. 

Currently the `Card` component toggles `border-radius` at certain breakpoints with the `roundedAbove` prop (and defaults to the `sm` breakpoint). This PR also adds `box-shadow` to these toggled styles.

| Before (below `sm` breakpoint) | After (below `sm` breakpoint) | 
| -- | -- | 
|![Screenshot 2024-04-22 at 11 28 51 AM](https://github.com/Shopify/polaris/assets/21976492/ec0fb20b-8d2f-4353-bc91-8d190d03275a)|![Screenshot 2024-04-22 at 11 28 01 AM](https://github.com/Shopify/polaris/assets/21976492/0b290f3d-20a2-411a-b950-ec05799fa2eb)|

### How to 🎩

- 📕 [`Card` Storybook Before](https://storybook.polaris.shopify.com/?path=/story/all-components-card--default)
- 📕 [`Card` Storybook After](https://5d559397bae39100201eedc1-kchagbotkl.chromatic.com/?path=/story/all-components-card--default)
- 📕 [`LegacyCard` Storybook Before](https://storybook.polaris.shopify.com/?path=/story/all-components-legacycard--default)
- 📕 [`LegacyCard` Storybook After](https://5d559397bae39100201eedc1-kchagbotkl.chromatic.com/?path=/story/all-components-legacycard--default)
