### PR TITLE
Migrate Storybook stories to CSF v3

### DIFF
--- a/.changeset/wild-islands-fry.md
+++ b/.changeset/wild-islands-fry.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris-migrator': patch
+'@shopify/polaris': patch
+---
+
+Migrate Storybook stories to CSF v3

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -148,6 +148,11 @@ module.exports = {
         'polaris-react/playground/*.tsx',
         'polaris-react/src/components/**/*.stories.tsx',
       ],
+      extends: [
+        'plugin:storybook/recommended',
+        'plugin:storybook/csf',
+        'plugin:storybook/csf-strict',
+      ],
       rules: {
         'react/prefer-stateless-function': 'off',
         '@shopify/jsx-no-hardcoded-content': 'off',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/node": "^20.10.0",
     "babel-loader": "^9.1.2",
     "eslint": "^8.3.0",
+    "eslint-plugin-storybook": "^0.8.0",
     "execa": "^5.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       eslint:
         specifier: ^8.3.0
         version: 8.10.0
+      eslint-plugin-storybook:
+        specifier: ^0.8.0
+        version: 0.8.0(eslint@8.10.0)(typescript@4.9.3)
       execa:
         specifier: ^5.0.0
         version: 5.1.1
@@ -6217,6 +6220,12 @@ packages:
       - supports-color
     dev: true
 
+  /@storybook/csf@0.0.1:
+    resolution: {integrity: sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==}
+    dependencies:
+      lodash: 4.17.21
+    dev: true
+
   /@storybook/csf@0.1.2:
     resolution: {integrity: sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==}
     dependencies:
@@ -7285,6 +7294,14 @@ packages:
       '@typescript-eslint/visitor-keys': 5.56.0
     dev: true
 
+  /@typescript-eslint/scope-manager@5.62.0:
+    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+    dev: true
+
   /@typescript-eslint/type-utils@5.56.0(eslint@8.10.0)(typescript@4.9.3):
     resolution: {integrity: sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7310,6 +7327,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@typescript-eslint/types@5.62.0:
+    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
   /@typescript-eslint/typescript-estree@5.56.0(typescript@4.9.3):
     resolution: {integrity: sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7321,6 +7343,27 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/visitor-keys': 5.56.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@4.9.3)
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.3):
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -7351,11 +7394,39 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils@5.62.0(eslint@8.10.0)(typescript@4.9.3):
+    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.3.0(eslint@8.10.0)
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.5.6
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.3)
+      eslint: 8.10.0
+      eslint-scope: 5.1.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys@5.56.0:
     resolution: {integrity: sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.56.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys@5.62.0:
+    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -11454,6 +11525,22 @@ packages:
       eslint: '>=0.8.0'
     dependencies:
       eslint: 8.10.0
+    dev: true
+
+  /eslint-plugin-storybook@0.8.0(eslint@8.10.0)(typescript@4.9.3):
+    resolution: {integrity: sha512-CZeVO5EzmPY7qghO2t64oaFM+8FTaD4uzOEjHKp516exyTKo+skKAL9GI3QALS2BXhyALJjNtwbmr1XinGE8bA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      eslint: '>=6'
+    dependencies:
+      '@storybook/csf': 0.0.1
+      '@typescript-eslint/utils': 5.62.0(eslint@8.10.0)(typescript@4.9.3)
+      eslint: 8.10.0
+      requireindex: 1.2.0
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /eslint-rule-composer@0.3.0:
@@ -20090,6 +20177,11 @@ packages:
 
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+    dev: true
+
+  /requireindex@1.2.0:
+    resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
+    engines: {node: '>=0.10.5'}
     dev: true
 
   /requires-port@1.0.0:

--- a/polaris-migrator/src/migrations/csf-v3/tests/transform.input.tsx
+++ b/polaris-migrator/src/migrations/csf-v3/tests/transform.input.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  foo: 'bar',
+};
+
+export const Blah = () => {
+  return <div>hello</div>;
+};
+
+Blah.parameters = {};
+
+export function App() {
+  return <div>hello</div>;
+}
+
+App.parameters = {};
+
+export const Comp = {
+  render() {
+    return <div>hello</div>;
+  },
+};
+
+Comp.parameters = {};
+
+export const Zip = () => (
+  <div>
+    <p>hello</p>
+  </div>
+);

--- a/polaris-migrator/src/migrations/csf-v3/tests/transform.output.tsx
+++ b/polaris-migrator/src/migrations/csf-v3/tests/transform.output.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  foo: 'bar',
+};
+
+export const Blah = {
+  render: () => {
+    return <div>hello</div>;
+  },
+
+  parameters: {},
+};
+
+export const App = {
+  render() {
+    return <div>hello</div>;
+  },
+
+  parameters: {},
+};
+
+export const Comp = {
+  render() {
+    return <div>hello</div>;
+  },
+};
+
+Comp.parameters = {};
+
+export const Zip = {
+  render: () => (
+    <div>
+      <p>hello</p>
+    </div>
+  ),
+};

--- a/polaris-migrator/src/migrations/csf-v3/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/csf-v3/tests/transform.test.ts
@@ -1,0 +1,11 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'csf-v3';
+const fixtures = ['transform'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+  });
+}

--- a/polaris-migrator/src/migrations/csf-v3/transform.ts
+++ b/polaris-migrator/src/migrations/csf-v3/transform.ts
@@ -1,0 +1,101 @@
+import type {API, FileInfo} from 'jscodeshift';
+
+export default function transformer(file: FileInfo, {jscodeshift: j}: API) {
+  const source = j(file.source);
+
+  source.find(j.ExportNamedDeclaration).replaceWith(({value: node}) => {
+    let id;
+    let storyFn;
+    let isArrowFunction = false;
+
+    if (
+      // export function App() {..}
+      j.match(node, {
+        // @ts-expect-error -- shh
+        declaration: {type: 'FunctionDeclaration'},
+      })
+    ) {
+      // @ts-expect-error -- shh
+      id = node.declaration.id;
+      storyFn = j.functionExpression(
+        null,
+        // @ts-expect-error -- shh
+        node.declaration.params,
+        // @ts-expect-error -- shh
+        node.declaration.body,
+      );
+    } else if (
+      // export const App = () => {..}
+      j.match(node, {
+        declaration: {
+          type: 'VariableDeclaration',
+          // @ts-expect-error -- shh
+          declarations: [{init: {type: 'ArrowFunctionExpression'}}],
+        },
+      })
+    ) {
+      // @ts-expect-error -- shh
+      id = node.declaration?.declarations?.[0]?.id;
+      storyFn = j.arrowFunctionExpression(
+        // @ts-expect-error -- shh
+        node.declaration.declarations[0].init.params,
+        // @ts-expect-error -- shh
+        node.declaration.declarations[0].init.body,
+      );
+      isArrowFunction = true;
+    } else {
+      return node;
+    }
+
+    // App.parameters = {..}, etc
+    const storyData = source.find(j.ExpressionStatement, {
+      expression: {
+        type: 'AssignmentExpression',
+        left: {
+          type: 'MemberExpression',
+          object: {
+            name: id.name,
+          },
+        },
+      },
+    });
+
+    // Convert it into object properties:
+    // parameters: {..}, etc
+    const storyProps = storyData.nodes().map((node) =>
+      j.property(
+        'init',
+        // @ts-expect-error -- shh
+        node.expression.left.property,
+        // @ts-expect-error -- shh
+        node.expression.right,
+      ),
+    );
+
+    // They'll be added to the newly exported object later, so don't need them
+    // anymore
+    storyData.remove();
+
+    // render() { ... }
+    // or
+    // render: () => { ... }
+    const renderProp = j.property('init', j.identifier('render'), storyFn);
+
+    if (!isArrowFunction) {
+      // Use the ES6 shorthand
+      renderProp.method = true;
+    }
+
+    // export const App = { render() { ... }, parameters: { .. } }
+    return j.exportNamedDeclaration(
+      j.variableDeclaration('const', [
+        j.variableDeclarator(
+          id,
+          j.objectExpression([renderProp, ...storyProps]),
+        ),
+      ]),
+    );
+  });
+
+  return source.toSource();
+}

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -51,786 +51,794 @@ import type {DropZoneProps, PageProps} from '../src';
 
 import styles from './DetailsPage.module.css';
 
-export function DetailsPage() {
-  const defaultState = useRef({
-    emailFieldValue: 'dharma@jadedpixel.com',
-    nameFieldValue: 'Jaded Pixel',
-  });
-  const [query, setQuery] = useState('');
-  const skipToContentRef = useRef<HTMLAnchorElement>(null);
-  const [toastActive, setToastActive] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isDirty, setIsDirty] = useState(false);
-  const [searchActive, setSearchActive] = useState(false);
-  const [searchValue, setSearchValue] = useState('');
-  const [userMenuActive, setUserMenuActive] = useState(false);
-  const [mobileNavigationActive, setMobileNavigationActive] = useState(false);
-  const [modalActive, setModalActive] = useState(false);
-  const [navItemActive, setNavItemActive] = useState('products');
-  const initialDescription =
-    'The M60-A represents the benchmark and equilibrium between function and design for us at Rama Works. The gently exaggerated design of the frame is not understated, but rather provocative. Inspiration and evolution from previous models are evident in the beautifully articulated design and the well defined aesthetic, the fingerprint of our ‘Industrial Modern’ designs.';
-  const [previewValue, setPreviewValue] = useState(initialDescription);
-  const [nameFieldValue, setNameFieldValue] = useState(
-    defaultState.current.nameFieldValue,
-  );
-  const [emailFieldValue, setEmailFieldValue] = useState(
-    defaultState.current.emailFieldValue,
-  );
-  const [addedTags, setAddedTags] = useState<
-    {value: string; children: string}[]
-  >([]);
-  const [addedVendors, setAddedVendors] = useState<
-    {value: string; children: string}[]
-  >([]);
+export const DetailsPage = {
+  render() {
+    const defaultState = useRef({
+      emailFieldValue: 'dharma@jadedpixel.com',
+      nameFieldValue: 'Jaded Pixel',
+    });
+    const [query, setQuery] = useState('');
+    const skipToContentRef = useRef<HTMLAnchorElement>(null);
+    const [toastActive, setToastActive] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+    const [searchActive, setSearchActive] = useState(false);
+    const [searchValue, setSearchValue] = useState('');
+    const [userMenuActive, setUserMenuActive] = useState(false);
+    const [mobileNavigationActive, setMobileNavigationActive] = useState(false);
+    const [modalActive, setModalActive] = useState(false);
+    const [navItemActive, setNavItemActive] = useState('products');
+    const initialDescription =
+      'The M60-A represents the benchmark and equilibrium between function and design for us at Rama Works. The gently exaggerated design of the frame is not understated, but rather provocative. Inspiration and evolution from previous models are evident in the beautifully articulated design and the well defined aesthetic, the fingerprint of our ‘Industrial Modern’ designs.';
+    const [previewValue, setPreviewValue] = useState(initialDescription);
+    const [nameFieldValue, setNameFieldValue] = useState(
+      defaultState.current.nameFieldValue,
+    );
+    const [emailFieldValue, setEmailFieldValue] = useState(
+      defaultState.current.emailFieldValue,
+    );
+    const [addedTags, setAddedTags] = useState<
+      {value: string; children: string}[]
+    >([]);
+    const [addedVendors, setAddedVendors] = useState<
+      {value: string; children: string}[]
+    >([]);
 
-  const tags = useMemo(
-    () => [
-      {value: 'Outdoors', children: 'Outdoors'},
-      {value: 'Adventure', children: 'Adventure'},
-      {value: 'Hiking', children: 'Hiking'},
-      {value: 'Camping', children: 'Camping'},
-      {value: 'Backpacking', children: 'Backpacking'},
-      {value: 'Mountaineering', children: 'Mountaineering'},
-      {value: 'Skiing', children: 'Skiing'},
-      {value: 'Snowboarding', children: 'Snowboarding'},
-      ...addedTags,
-    ],
-    [addedTags],
-  );
-
-  const vendors = useMemo(
-    () => [
-      {value: 'The North Face', children: 'The North Face'},
-      {value: 'Patagonia', children: 'Patagonia'},
-      {value: 'Arc’teryx', children: 'Arc’teryx'},
-      {value: 'Marmot', children: 'Marmot'},
-      {value: 'Black Diamond', children: 'Black Diamond'},
-      {value: 'Mountain Hardwear', children: 'Mountain Hardwear'},
-      {value: 'Columbia', children: 'Columbia'},
-      {value: 'Canada Goose', children: 'Canada Goose'},
-      {value: 'Merrell', children: 'Merrell'},
-      {value: 'Salomon', children: 'Salomon'},
-      {value: 'Burton', children: 'Burton'},
-      ...addedVendors,
-    ],
-    [addedVendors],
-  );
-
-  const handleTagSelect = useCallback(
-    (newTag: string) => {
-      if (
-        tags.some((tag) => tag.value === newTag) ||
-        addedTags.some((tag) => tag.value === newTag)
-      ) {
-        return;
-      }
-      setAddedTags((addedTags) => [
+    const tags = useMemo(
+      () => [
+        {value: 'Outdoors', children: 'Outdoors'},
+        {value: 'Adventure', children: 'Adventure'},
+        {value: 'Hiking', children: 'Hiking'},
+        {value: 'Camping', children: 'Camping'},
+        {value: 'Backpacking', children: 'Backpacking'},
+        {value: 'Mountaineering', children: 'Mountaineering'},
+        {value: 'Skiing', children: 'Skiing'},
+        {value: 'Snowboarding', children: 'Snowboarding'},
         ...addedTags,
-        {value: newTag, children: newTag},
-      ]);
-      setQuery('');
-    },
-    [addedTags, tags],
-  );
+      ],
+      [addedTags],
+    );
 
-  const handleVendorSelect = useCallback(
-    (newVendor: string) => {
-      if (
-        vendors.some((vendor) => vendor.value === newVendor) ||
-        addedVendors.some((vendor) => vendor.value === newVendor)
-      ) {
-        return;
-      }
-      setAddedVendors((addedVendors) => [
+    const vendors = useMemo(
+      () => [
+        {value: 'The North Face', children: 'The North Face'},
+        {value: 'Patagonia', children: 'Patagonia'},
+        {value: 'Arc’teryx', children: 'Arc’teryx'},
+        {value: 'Marmot', children: 'Marmot'},
+        {value: 'Black Diamond', children: 'Black Diamond'},
+        {value: 'Mountain Hardwear', children: 'Mountain Hardwear'},
+        {value: 'Columbia', children: 'Columbia'},
+        {value: 'Canada Goose', children: 'Canada Goose'},
+        {value: 'Merrell', children: 'Merrell'},
+        {value: 'Salomon', children: 'Salomon'},
+        {value: 'Burton', children: 'Burton'},
         ...addedVendors,
-        {value: newVendor, children: newVendor},
-      ]);
-      setQuery('');
-    },
-    [addedVendors, vendors],
-  );
+      ],
+      [addedVendors],
+    );
 
-  const [storeName, setStoreName] = useState(
-    defaultState.current.nameFieldValue,
-  );
-  const [supportSubject, setSupportSubject] = useState('');
-  const [supportMessage, setSupportMessage] = useState('');
+    const handleTagSelect = useCallback(
+      (newTag: string) => {
+        if (
+          tags.some((tag) => tag.value === newTag) ||
+          addedTags.some((tag) => tag.value === newTag)
+        ) {
+          return;
+        }
+        setAddedTags((addedTags) => [
+          ...addedTags,
+          {value: newTag, children: newTag},
+        ]);
+        setQuery('');
+      },
+      [addedTags, tags],
+    );
 
-  const handleDiscard = useCallback(() => {
-    setEmailFieldValue(defaultState.current.emailFieldValue);
-    setNameFieldValue(defaultState.current.nameFieldValue);
-    setIsDirty(false);
-  }, []);
-  const handleSave = useCallback(() => {
-    defaultState.current.nameFieldValue = nameFieldValue;
-    defaultState.current.emailFieldValue = emailFieldValue;
+    const handleVendorSelect = useCallback(
+      (newVendor: string) => {
+        if (
+          vendors.some((vendor) => vendor.value === newVendor) ||
+          addedVendors.some((vendor) => vendor.value === newVendor)
+        ) {
+          return;
+        }
+        setAddedVendors((addedVendors) => [
+          ...addedVendors,
+          {value: newVendor, children: newVendor},
+        ]);
+        setQuery('');
+      },
+      [addedVendors, vendors],
+    );
 
-    setIsDirty(false);
-    setToastActive(true);
-    setStoreName(defaultState.current.nameFieldValue);
-  }, [emailFieldValue, nameFieldValue]);
-  const handleSearchResultsDismiss = useCallback(() => {
-    setSearchActive(false);
-    setSearchValue('');
-  }, []);
-  const handleSearchFieldChange = useCallback((value: string) => {
-    setSearchValue(value);
-    setSearchActive(value.length > 0);
-  }, []);
-  const toggleToastActive = useCallback(
-    () => setToastActive((toastActive) => !toastActive),
-    [],
-  );
-  const toggleUserMenuActive = useCallback(
-    () => setUserMenuActive((userMenuActive) => !userMenuActive),
-    [],
-  );
-  const toggleMobileNavigationActive = useCallback(
-    () =>
-      setMobileNavigationActive(
-        (mobileNavigationActive) => !mobileNavigationActive,
-      ),
-    [],
-  );
-  const toggleIsLoading = useCallback(
-    () => setIsLoading((isLoading) => !isLoading),
-    [],
-  );
-  const toggleModalActive = useCallback(
-    () => setModalActive((modalActive) => !modalActive),
-    [],
-  );
+    const [storeName, setStoreName] = useState(
+      defaultState.current.nameFieldValue,
+    );
+    const [supportSubject, setSupportSubject] = useState('');
+    const [supportMessage, setSupportMessage] = useState('');
 
-  const toastMarkup = toastActive ? (
-    <Toast onDismiss={toggleToastActive} content="Changes saved" />
-  ) : null;
+    const handleDiscard = useCallback(() => {
+      setEmailFieldValue(defaultState.current.emailFieldValue);
+      setNameFieldValue(defaultState.current.nameFieldValue);
+      setIsDirty(false);
+    }, []);
+    const handleSave = useCallback(() => {
+      defaultState.current.nameFieldValue = nameFieldValue;
+      defaultState.current.emailFieldValue = emailFieldValue;
 
-  const userMenuActions = [
-    {
-      items: [{content: 'Community forums'}],
-    },
-  ];
+      setIsDirty(false);
+      setToastActive(true);
+      setStoreName(defaultState.current.nameFieldValue);
+    }, [emailFieldValue, nameFieldValue]);
+    const handleSearchResultsDismiss = useCallback(() => {
+      setSearchActive(false);
+      setSearchValue('');
+    }, []);
+    const handleSearchFieldChange = useCallback((value: string) => {
+      setSearchValue(value);
+      setSearchActive(value.length > 0);
+    }, []);
+    const toggleToastActive = useCallback(
+      () => setToastActive((toastActive) => !toastActive),
+      [],
+    );
+    const toggleUserMenuActive = useCallback(
+      () => setUserMenuActive((userMenuActive) => !userMenuActive),
+      [],
+    );
+    const toggleMobileNavigationActive = useCallback(
+      () =>
+        setMobileNavigationActive(
+          (mobileNavigationActive) => !mobileNavigationActive,
+        ),
+      [],
+    );
+    const toggleIsLoading = useCallback(
+      () => setIsLoading((isLoading) => !isLoading),
+      [],
+    );
+    const toggleModalActive = useCallback(
+      () => setModalActive((modalActive) => !modalActive),
+      [],
+    );
 
-  const contextControlMarkup = (
-    <div className={styles.ContextControl}>
-      <svg
-        width="36"
-        height="36"
-        viewBox="0 0 36 36"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M26.8956 8.39159C26.876 8.25021 26.751 8.17175 26.6473 8.16321C26.5443 8.15466 24.5277 8.12436 24.5277 8.12436C24.5277 8.12436 22.8411 6.50548 22.6745 6.3408C22.5079 6.17611 22.1825 6.22583 22.056 6.26312C22.0544 6.26389 21.7392 6.36022 21.2087 6.52257C21.1199 6.23826 20.9895 5.88869 20.8032 5.53757C20.2028 4.40498 19.3233 3.80605 18.2608 3.8045C18.2592 3.8045 18.2584 3.8045 18.2568 3.8045C18.183 3.8045 18.1099 3.81149 18.036 3.8177C18.0046 3.78042 17.9731 3.74391 17.9401 3.70817C17.4772 3.21878 16.8838 2.9803 16.1726 3.00127C14.8004 3.04011 13.4337 4.01968 12.3255 5.75974C11.5459 6.984 10.9525 8.52209 10.7843 9.71295C9.20858 10.1954 8.10673 10.5325 8.08237 10.5403C7.28702 10.7873 7.26187 10.8114 7.15813 11.5524C7.08111 12.1125 5 28.0186 5 28.0186L22.4403 31L29.9992 29.1426C29.9992 29.1426 26.9153 8.53297 26.8956 8.39159ZM20.3356 6.7898C19.934 6.91253 19.4774 7.05236 18.9822 7.20384C18.972 6.51714 18.8895 5.56165 18.5657 4.7359C19.607 4.93088 20.1195 6.09532 20.3356 6.7898ZM18.0698 7.48349C17.1558 7.76315 16.1584 8.06843 15.158 8.3745C15.4393 7.30949 15.973 6.24913 16.6284 5.55388C16.8721 5.29521 17.2131 5.00701 17.6171 4.84232C17.9967 5.62535 18.0792 6.73387 18.0698 7.48349ZM16.2001 3.90393C16.5223 3.89694 16.7935 3.96685 17.0253 4.11755C16.6544 4.30787 16.296 4.58131 15.9596 4.93787C15.088 5.86228 14.42 7.29706 14.1536 8.68134C13.3229 8.93536 12.5102 9.18472 11.762 9.4131C12.2344 7.23414 14.0821 3.96452 16.2001 3.90393Z"
-          fill="#95BF47"
-        />
-        <path
-          d="M26.6482 8.16418C26.5452 8.15564 24.5286 8.12534 24.5286 8.12534C24.5286 8.12534 22.842 6.50646 22.6754 6.34178C22.6133 6.28041 22.5292 6.24856 22.4412 6.23535L22.4419 30.9994L30.0001 29.1428C30.0001 29.1428 26.9162 8.53395 26.8965 8.39257C26.8769 8.25119 26.7511 8.17273 26.6482 8.16418Z"
-          fill="#5E8E3E"
-        />
-        <path
-          d="M18.2512 12.0055L17.3734 15.2518C17.3734 15.2518 16.3941 14.8113 15.2333 14.8836C13.531 14.99 13.5129 16.0511 13.5302 16.3176C13.623 17.7695 17.4873 18.0864 17.7042 21.4873C17.8748 24.1626 16.2684 25.9928 13.9538 26.1373C11.1756 26.3105 9.64624 24.6909 9.64624 24.6909L10.2349 22.2159C10.2349 22.2159 11.7745 23.3641 13.0068 23.2872C13.8116 23.2367 14.0992 22.5896 14.0702 22.132C13.9491 20.2382 10.8023 20.35 10.6035 17.2381C10.4361 14.6195 12.1761 11.9659 16.0153 11.7266C17.4944 11.6326 18.2512 12.0055 18.2512 12.0055Z"
-          fill="white"
-        />
-      </svg>
-      <p className={styles.ShopName}>Spectrally yours</p>
-    </div>
-  );
+    const toastMarkup = toastActive ? (
+      <Toast onDismiss={toggleToastActive} content="Changes saved" />
+    ) : null;
 
-  const contextualSaveBarMarkup = isDirty ? (
-    <ContextualSaveBar
-      message="Unsaved changes"
-      saveAction={{
-        onAction: handleSave,
-      }}
-      discardAction={{
-        onAction: handleDiscard,
-        discardConfirmationModal: true,
-      }}
-      contextControl={contextControlMarkup}
-    />
-  ) : null;
+    const userMenuActions = [
+      {
+        items: [{content: 'Community forums'}],
+      },
+    ];
 
-  const userMenuMarkup = (
-    <TopBar.UserMenu
-      actions={userMenuActions}
-      name="Dharma"
-      detail={storeName}
-      initials="D"
-      open={userMenuActive}
-      onToggle={toggleUserMenuActive}
-      accessibilityLabel="User menu"
-    />
-  );
+    const contextControlMarkup = (
+      <div className={styles.ContextControl}>
+        <svg
+          width="36"
+          height="36"
+          viewBox="0 0 36 36"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M26.8956 8.39159C26.876 8.25021 26.751 8.17175 26.6473 8.16321C26.5443 8.15466 24.5277 8.12436 24.5277 8.12436C24.5277 8.12436 22.8411 6.50548 22.6745 6.3408C22.5079 6.17611 22.1825 6.22583 22.056 6.26312C22.0544 6.26389 21.7392 6.36022 21.2087 6.52257C21.1199 6.23826 20.9895 5.88869 20.8032 5.53757C20.2028 4.40498 19.3233 3.80605 18.2608 3.8045C18.2592 3.8045 18.2584 3.8045 18.2568 3.8045C18.183 3.8045 18.1099 3.81149 18.036 3.8177C18.0046 3.78042 17.9731 3.74391 17.9401 3.70817C17.4772 3.21878 16.8838 2.9803 16.1726 3.00127C14.8004 3.04011 13.4337 4.01968 12.3255 5.75974C11.5459 6.984 10.9525 8.52209 10.7843 9.71295C9.20858 10.1954 8.10673 10.5325 8.08237 10.5403C7.28702 10.7873 7.26187 10.8114 7.15813 11.5524C7.08111 12.1125 5 28.0186 5 28.0186L22.4403 31L29.9992 29.1426C29.9992 29.1426 26.9153 8.53297 26.8956 8.39159ZM20.3356 6.7898C19.934 6.91253 19.4774 7.05236 18.9822 7.20384C18.972 6.51714 18.8895 5.56165 18.5657 4.7359C19.607 4.93088 20.1195 6.09532 20.3356 6.7898ZM18.0698 7.48349C17.1558 7.76315 16.1584 8.06843 15.158 8.3745C15.4393 7.30949 15.973 6.24913 16.6284 5.55388C16.8721 5.29521 17.2131 5.00701 17.6171 4.84232C17.9967 5.62535 18.0792 6.73387 18.0698 7.48349ZM16.2001 3.90393C16.5223 3.89694 16.7935 3.96685 17.0253 4.11755C16.6544 4.30787 16.296 4.58131 15.9596 4.93787C15.088 5.86228 14.42 7.29706 14.1536 8.68134C13.3229 8.93536 12.5102 9.18472 11.762 9.4131C12.2344 7.23414 14.0821 3.96452 16.2001 3.90393Z"
+            fill="#95BF47"
+          />
+          <path
+            d="M26.6482 8.16418C26.5452 8.15564 24.5286 8.12534 24.5286 8.12534C24.5286 8.12534 22.842 6.50646 22.6754 6.34178C22.6133 6.28041 22.5292 6.24856 22.4412 6.23535L22.4419 30.9994L30.0001 29.1428C30.0001 29.1428 26.9162 8.53395 26.8965 8.39257C26.8769 8.25119 26.7511 8.17273 26.6482 8.16418Z"
+            fill="#5E8E3E"
+          />
+          <path
+            d="M18.2512 12.0055L17.3734 15.2518C17.3734 15.2518 16.3941 14.8113 15.2333 14.8836C13.531 14.99 13.5129 16.0511 13.5302 16.3176C13.623 17.7695 17.4873 18.0864 17.7042 21.4873C17.8748 24.1626 16.2684 25.9928 13.9538 26.1373C11.1756 26.3105 9.64624 24.6909 9.64624 24.6909L10.2349 22.2159C10.2349 22.2159 11.7745 23.3641 13.0068 23.2872C13.8116 23.2367 14.0992 22.5896 14.0702 22.132C13.9491 20.2382 10.8023 20.35 10.6035 17.2381C10.4361 14.6195 12.1761 11.9659 16.0153 11.7266C17.4944 11.6326 18.2512 12.0055 18.2512 12.0055Z"
+            fill="white"
+          />
+        </svg>
+        <p className={styles.ShopName}>Spectrally yours</p>
+      </div>
+    );
 
-  const searchResultsMarkup = (
-    <ActionList
-      items={[{content: 'Shopify help center'}, {content: 'Community forums'}]}
-    />
-  );
-
-  const searchFieldMarkup = (
-    <TopBar.SearchField
-      onChange={handleSearchFieldChange}
-      value={searchValue}
-      placeholder="Search"
-    />
-  );
-
-  const topBarMarkup = (
-    <TopBar
-      showNavigationToggle
-      userMenu={userMenuMarkup}
-      searchResultsVisible={searchActive}
-      searchField={searchFieldMarkup}
-      searchResults={searchResultsMarkup}
-      onSearchResultsDismiss={handleSearchResultsDismiss}
-      onNavigationToggle={toggleMobileNavigationActive}
-      contextControl={contextControlMarkup}
-      searchResultsOverlayVisible
-    />
-  );
-  // ---- Navigation ----
-  const navigationMarkup = (
-    <Navigation location="/" contextControl={contextControlMarkup}>
-      <Navigation.Section
-        items={[
-          {
-            label: 'Home',
-            icon: HomeIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('home');
-            },
-            matches: navItemActive === 'home',
-            url: '#',
-          },
-          {
-            label: 'Orders',
-            icon: OrderIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('orders');
-            },
-            matches: navItemActive === 'orders',
-            url: '#',
-            subNavigationItems: [
-              {
-                label: 'All orders',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('all-orders');
-                },
-                matches: navItemActive.includes('orders'),
-                url: '#',
-              },
-              {
-                url: '#',
-                label: 'Drafts',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('drafts');
-                },
-                matches: navItemActive === 'drafts',
-              },
-              {
-                url: '#',
-                label: 'Abandoned checkouts',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('abandoned');
-                },
-                matches: navItemActive === 'abandoned',
-              },
-            ],
-          },
-          {
-            label: 'Products',
-            icon: ProductIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('products');
-            },
-            matches: navItemActive === 'products',
-            url: '#',
-            subNavigationItems: [
-              {
-                label: 'All products',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('all-products');
-                },
-                matches: navItemActive.includes('products'),
-                url: '#',
-              },
-              {
-                url: '#',
-                label: 'Inventory',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('inventory');
-                },
-                matches: navItemActive === 'inventory',
-              },
-              {
-                url: '#',
-                label: 'Transfers',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('transfers');
-                },
-                matches: navItemActive === 'transfers',
-              },
-            ],
-          },
-          {
-            label: 'Customers',
-            icon: PersonIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('customers');
-            },
-            matches: navItemActive === 'customers',
-            url: '#',
-          },
-          {
-            label: 'Analytics',
-            icon: ChartVerticalIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('analytics');
-            },
-            matches: navItemActive === 'analytics',
-            url: '#',
-          },
-          {
-            label: 'Marketing',
-            icon: TargetIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('marketing');
-            },
-            matches: navItemActive === 'marketing',
-            url: '#',
-          },
-          {
-            label: 'Discounts',
-            icon: DiscountIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('discounts');
-            },
-            matches: navItemActive === 'discounts',
-            url: '#',
-          },
-          {
-            label: 'Apps',
-            icon: AppsIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('apps');
-            },
-            matches: navItemActive === 'apps',
-            url: '#',
-          },
-        ]}
-      />
-      <Navigation.Section
-        fill
-        title="Sales channels"
-        action={{
-          icon: PlusCircleIcon,
-          accessibilityLabel: 'Add sales channel',
-          onClick: toggleModalActive,
-          tooltip: {
-            content: 'Add sales channel',
-          },
+    const contextualSaveBarMarkup = isDirty ? (
+      <ContextualSaveBar
+        message="Unsaved changes"
+        saveAction={{
+          onAction: handleSave,
         }}
+        discardAction={{
+          onAction: handleDiscard,
+          discardConfirmationModal: true,
+        }}
+        contextControl={contextControlMarkup}
+      />
+    ) : null;
+
+    const userMenuMarkup = (
+      <TopBar.UserMenu
+        actions={userMenuActions}
+        name="Dharma"
+        detail={storeName}
+        initials="D"
+        open={userMenuActive}
+        onToggle={toggleUserMenuActive}
+        accessibilityLabel="User menu"
+      />
+    );
+
+    const searchResultsMarkup = (
+      <ActionList
         items={[
-          {
-            label: 'Point of sale',
-            icon: posIcon,
-            onClick: () => {
-              toggleIsLoading();
-              setNavItemActive('pos');
+          {content: 'Shopify help center'},
+          {content: 'Community forums'},
+        ]}
+      />
+    );
+
+    const searchFieldMarkup = (
+      <TopBar.SearchField
+        onChange={handleSearchFieldChange}
+        value={searchValue}
+        placeholder="Search"
+      />
+    );
+
+    const topBarMarkup = (
+      <TopBar
+        showNavigationToggle
+        userMenu={userMenuMarkup}
+        searchResultsVisible={searchActive}
+        searchField={searchFieldMarkup}
+        searchResults={searchResultsMarkup}
+        onSearchResultsDismiss={handleSearchResultsDismiss}
+        onNavigationToggle={toggleMobileNavigationActive}
+        contextControl={contextControlMarkup}
+        searchResultsOverlayVisible
+      />
+    );
+    // ---- Navigation ----
+    const navigationMarkup = (
+      <Navigation location="/" contextControl={contextControlMarkup}>
+        <Navigation.Section
+          items={[
+            {
+              label: 'Home',
+              icon: HomeIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('home');
+              },
+              matches: navItemActive === 'home',
+              url: '#',
             },
-            matches: navItemActive === 'pos',
-            url: '#',
-            subNavigationItems: [
-              {
-                label: 'Overview',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('pos');
-                },
-                matches: navItemActive.includes('pos'),
-                url: '#',
+            {
+              label: 'Orders',
+              icon: OrderIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('orders');
               },
-              {
-                url: '#',
-                label: 'Staff',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('pos');
+              matches: navItemActive === 'orders',
+              url: '#',
+              subNavigationItems: [
+                {
+                  label: 'All orders',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('all-orders');
+                  },
+                  matches: navItemActive.includes('orders'),
+                  url: '#',
                 },
-                matches: navItemActive === 'pos',
-              },
-              {
-                url: '#',
-                label: 'Locations',
-                onClick: () => {
-                  toggleIsLoading();
-                  setNavItemActive('pos');
+                {
+                  url: '#',
+                  label: 'Drafts',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('drafts');
+                  },
+                  matches: navItemActive === 'drafts',
                 },
-                matches: navItemActive === 'pos',
-                external: true,
+                {
+                  url: '#',
+                  label: 'Abandoned checkouts',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('abandoned');
+                  },
+                  matches: navItemActive === 'abandoned',
+                },
+              ],
+            },
+            {
+              label: 'Products',
+              icon: ProductIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('products');
               },
+              matches: navItemActive === 'products',
+              url: '#',
+              subNavigationItems: [
+                {
+                  label: 'All products',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('all-products');
+                  },
+                  matches: navItemActive.includes('products'),
+                  url: '#',
+                },
+                {
+                  url: '#',
+                  label: 'Inventory',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('inventory');
+                  },
+                  matches: navItemActive === 'inventory',
+                },
+                {
+                  url: '#',
+                  label: 'Transfers',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('transfers');
+                  },
+                  matches: navItemActive === 'transfers',
+                },
+              ],
+            },
+            {
+              label: 'Customers',
+              icon: PersonIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('customers');
+              },
+              matches: navItemActive === 'customers',
+              url: '#',
+            },
+            {
+              label: 'Analytics',
+              icon: ChartVerticalIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('analytics');
+              },
+              matches: navItemActive === 'analytics',
+              url: '#',
+            },
+            {
+              label: 'Marketing',
+              icon: TargetIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('marketing');
+              },
+              matches: navItemActive === 'marketing',
+              url: '#',
+            },
+            {
+              label: 'Discounts',
+              icon: DiscountIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('discounts');
+              },
+              matches: navItemActive === 'discounts',
+              url: '#',
+            },
+            {
+              label: 'Apps',
+              icon: AppsIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('apps');
+              },
+              matches: navItemActive === 'apps',
+              url: '#',
+            },
+          ]}
+        />
+        <Navigation.Section
+          fill
+          title="Sales channels"
+          action={{
+            icon: PlusCircleIcon,
+            accessibilityLabel: 'Add sales channel',
+            onClick: toggleModalActive,
+            tooltip: {
+              content: 'Add sales channel',
+            },
+          }}
+          items={[
+            {
+              label: 'Point of sale',
+              icon: posIcon,
+              onClick: () => {
+                toggleIsLoading();
+                setNavItemActive('pos');
+              },
+              matches: navItemActive === 'pos',
+              url: '#',
+              subNavigationItems: [
+                {
+                  label: 'Overview',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('pos');
+                  },
+                  matches: navItemActive.includes('pos'),
+                  url: '#',
+                },
+                {
+                  url: '#',
+                  label: 'Staff',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('pos');
+                  },
+                  matches: navItemActive === 'pos',
+                },
+                {
+                  url: '#',
+                  label: 'Locations',
+                  onClick: () => {
+                    toggleIsLoading();
+                    setNavItemActive('pos');
+                  },
+                  matches: navItemActive === 'pos',
+                  external: true,
+                },
+              ],
+            },
+            {
+              label: 'Updog Marketplace',
+              icon: ProductIcon,
+              onClick: () => {},
+              matches: navItemActive === 'pos',
+              url: '#',
+              secondaryAction: {
+                url: '#',
+                accessibilityLabel: 'OLp',
+                icon: ExternalIcon,
+                tooltip: {
+                  content: 'Open Updog Marketplace',
+                },
+              },
+            },
+            {
+              label: 'Radio',
+              icon: WifiIcon,
+              onClick: () => {},
+              matches: navItemActive === 'pos',
+              url: '#',
+              secondaryAction: {
+                url: '#',
+                accessibilityLabel: 'radio',
+                icon: GlobeIcon,
+              },
+            },
+          ]}
+        />
+        <Navigation.Section
+          items={[
+            {
+              icon: SettingsIcon,
+              label: 'Settings',
+              onClick: toggleModalActive,
+            },
+          ]}
+        />
+      </Navigation>
+    );
+
+    const loadingMarkup = isLoading ? <Loading /> : null;
+
+    const skipToContentTarget = (
+      <Text as="span" visuallyHidden>
+        <a
+          href="#SkipToContent"
+          id="SkipToContentTarget"
+          ref={skipToContentRef}
+          tabIndex={-1}
+        >
+          Page content
+        </a>
+      </Text>
+    );
+
+    const [title, setTitle] = useState(
+      "The North Face Ventrix Active Trail Hybrid Hoodie - Men's",
+    );
+    const [descriptionValue, setDescriptionValue] =
+      useState(initialDescription);
+    const [selected, setSelected] = useState('today');
+
+    const options = [
+      {label: 'Keyboard', value: 'keyboard'},
+      {label: 'Accessories', value: 'accessories'},
+      {label: 'Last 7 days', value: 'lastWeek'},
+    ];
+
+    const handleChange = useCallback((newValue: string) => {
+      setDescriptionValue(newValue);
+      setPreviewValue(newValue);
+    }, []);
+
+    const actions1: PageProps['secondaryActions'] = [
+      {
+        content: 'Duplicate',
+        onAction: () => console.log('duplicate'),
+      },
+      {
+        content: 'Print',
+        onAction: () => console.log('print'),
+      },
+    ];
+    const actions2: PageProps['secondaryActions'] = [
+      {
+        content: 'Print',
+        onAction: () => console.log('print'),
+      },
+    ];
+
+    const [actions, setActions] =
+      useState<PageProps['secondaryActions']>(actions1);
+
+    const toggleActions = () => {
+      if (Array.isArray(actions) && actions.length === 2) {
+        setActions(actions2);
+      } else {
+        setActions(actions1);
+      }
+    };
+
+    // ---- Dropzone ----
+    const [files, setFiles] = useState<File[]>([]);
+
+    const handleDropZoneDrop = useCallback<
+      NonNullable<DropZoneProps['onDrop']>
+    >(
+      (_dropFiles, acceptedFiles, _rejectedFiles) =>
+        setFiles((files) => [...files, ...acceptedFiles]),
+      [],
+    );
+
+    const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+
+    const fileUpload = !files.length && <DropZone.FileUpload />;
+    const uploadedFiles = files.length > 0 && (
+      <LegacyStack vertical>
+        {files.map((file, index) => (
+          <LegacyStack alignment="center" key={index}>
+            <Thumbnail
+              size="small"
+              alt={file.name}
+              source={
+                validImageTypes.indexOf(file.type) > 0
+                  ? URL.createObjectURL(file)
+                  : 'https://cdn.shopify.com/s/files/1/0757/9955/files/New_Post.png?12678548500147524304'
+              }
+            />
+            <div>
+              {file.name}{' '}
+              <Text as="p" variant="bodySm">
+                {file.size} bytes
+              </Text>
+            </div>
+          </LegacyStack>
+        ))}
+      </LegacyStack>
+    );
+
+    // ---- Page markup ----
+    const actualPageMarkup = (
+      <Page
+        fullWidth
+        backAction={{content: 'Products', url: '/products/31'}}
+        title={title}
+        titleMetadata={<Badge tone="success">Success badge</Badge>}
+        primaryAction={{
+          content: 'Save this page',
+          onAction: () => console.log('save'),
+        }}
+        additionalMetadata="Created May 8, 2020 at 7:31 am from Developer Tools (via import)"
+        secondaryActions={
+          Array.isArray(actions) && [
+            ...actions,
+            {
+              content: 'View',
+              onAction: () => {
+                console.log(previewValue);
+              },
+            },
+          ]
+        }
+        actionGroups={[
+          {
+            title: 'Promote',
+            actions: [
+              {content: 'Promote', onAction: () => console.log('promote')},
             ],
           },
           {
-            label: 'Updog Marketplace',
-            icon: ProductIcon,
-            onClick: () => {},
-            matches: navItemActive === 'pos',
-            url: '#',
-            secondaryAction: {
-              url: '#',
-              accessibilityLabel: 'OLp',
-              icon: ExternalIcon,
-              tooltip: {
-                content: 'Open Updog Marketplace',
+            title: 'More actions',
+            actions: [
+              {
+                content: 'Embed on a website',
+                onAction: () => console.log('embed'),
               },
-            },
-          },
-          {
-            label: 'Radio',
-            icon: WifiIcon,
-            onClick: () => {},
-            matches: navItemActive === 'pos',
-            url: '#',
-            secondaryAction: {
-              url: '#',
-              accessibilityLabel: 'radio',
-              icon: GlobeIcon,
-            },
+              {
+                content: 'Toggle page actions',
+                onAction: toggleActions,
+              },
+            ],
           },
         ]}
-      />
-      <Navigation.Section
-        items={[
-          {
-            icon: SettingsIcon,
-            label: 'Settings',
-            onClick: toggleModalActive,
-          },
-        ]}
-      />
-    </Navigation>
-  );
-
-  const loadingMarkup = isLoading ? <Loading /> : null;
-
-  const skipToContentTarget = (
-    <Text as="span" visuallyHidden>
-      <a
-        href="#SkipToContent"
-        id="SkipToContentTarget"
-        ref={skipToContentRef}
-        tabIndex={-1}
+        pagination={{
+          hasPrevious: true,
+          hasNext: true,
+        }}
       >
-        Page content
-      </a>
-    </Text>
-  );
-
-  const [title, setTitle] = useState(
-    "The North Face Ventrix Active Trail Hybrid Hoodie - Men's",
-  );
-  const [descriptionValue, setDescriptionValue] = useState(initialDescription);
-  const [selected, setSelected] = useState('today');
-
-  const options = [
-    {label: 'Keyboard', value: 'keyboard'},
-    {label: 'Accessories', value: 'accessories'},
-    {label: 'Last 7 days', value: 'lastWeek'},
-  ];
-
-  const handleChange = useCallback((newValue: string) => {
-    setDescriptionValue(newValue);
-    setPreviewValue(newValue);
-  }, []);
-
-  const actions1: PageProps['secondaryActions'] = [
-    {
-      content: 'Duplicate',
-      onAction: () => console.log('duplicate'),
-    },
-    {
-      content: 'Print',
-      onAction: () => console.log('print'),
-    },
-  ];
-  const actions2: PageProps['secondaryActions'] = [
-    {
-      content: 'Print',
-      onAction: () => console.log('print'),
-    },
-  ];
-
-  const [actions, setActions] =
-    useState<PageProps['secondaryActions']>(actions1);
-
-  const toggleActions = () => {
-    if (Array.isArray(actions) && actions.length === 2) {
-      setActions(actions2);
-    } else {
-      setActions(actions1);
-    }
-  };
-
-  // ---- Dropzone ----
-  const [files, setFiles] = useState<File[]>([]);
-
-  const handleDropZoneDrop = useCallback<NonNullable<DropZoneProps['onDrop']>>(
-    (_dropFiles, acceptedFiles, _rejectedFiles) =>
-      setFiles((files) => [...files, ...acceptedFiles]),
-    [],
-  );
-
-  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
-
-  const fileUpload = !files.length && <DropZone.FileUpload />;
-  const uploadedFiles = files.length > 0 && (
-    <LegacyStack vertical>
-      {files.map((file, index) => (
-        <LegacyStack alignment="center" key={index}>
-          <Thumbnail
-            size="small"
-            alt={file.name}
-            source={
-              validImageTypes.indexOf(file.type) > 0
-                ? URL.createObjectURL(file)
-                : 'https://cdn.shopify.com/s/files/1/0757/9955/files/New_Post.png?12678548500147524304'
-            }
-          />
-          <div>
-            {file.name}{' '}
-            <Text as="p" variant="bodySm">
-              {file.size} bytes
-            </Text>
-          </div>
-        </LegacyStack>
-      ))}
-    </LegacyStack>
-  );
-
-  // ---- Page markup ----
-  const actualPageMarkup = (
-    <Page
-      fullWidth
-      backAction={{content: 'Products', url: '/products/31'}}
-      title={title}
-      titleMetadata={<Badge tone="success">Success badge</Badge>}
-      primaryAction={{
-        content: 'Save this page',
-        onAction: () => console.log('save'),
-      }}
-      additionalMetadata="Created May 8, 2020 at 7:31 am from Developer Tools (via import)"
-      secondaryActions={
-        Array.isArray(actions) && [
-          ...actions,
-          {
-            content: 'View',
-            onAction: () => {
-              console.log(previewValue);
-            },
-          },
-        ]
-      }
-      actionGroups={[
-        {
-          title: 'Promote',
-          actions: [
-            {content: 'Promote', onAction: () => console.log('promote')},
-          ],
-        },
-        {
-          title: 'More actions',
-          actions: [
-            {
-              content: 'Embed on a website',
-              onAction: () => console.log('embed'),
-            },
-            {
-              content: 'Toggle page actions',
-              onAction: toggleActions,
-            },
-          ],
-        },
-      ]}
-      pagination={{
-        hasPrevious: true,
-        hasNext: true,
-      }}
-    >
-      <Layout>
-        {skipToContentTarget}
-        <Layout.Section>
-          <LegacyCard sectioned>
-            <FormLayout>
-              <TextField
-                label="Title"
-                value={title}
-                onChange={(title) => {
-                  setTitle(title);
-                  setIsDirty(true);
-                }}
-                autoComplete="off"
-              />
-              <TextField
-                label="Description"
-                value={descriptionValue}
-                onChange={handleChange}
-                autoComplete="off"
-                multiline
-              />
-            </FormLayout>
-          </LegacyCard>
-          <LegacyCard title="Media" sectioned>
-            <DropZone onDrop={handleDropZoneDrop}>
-              {uploadedFiles}
-              {fileUpload}
-            </DropZone>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard title="Organization">
-            <LegacyCard.Section>
-              <BlockStack gap="200">
-                <Select
-                  label="Product type"
-                  options={options}
-                  onChange={setSelected}
-                  value={selected}
+        <Layout>
+          {skipToContentTarget}
+          <Layout.Section>
+            <LegacyCard sectioned>
+              <FormLayout>
+                <TextField
+                  label="Title"
+                  value={title}
+                  onChange={(title) => {
+                    setTitle(title);
+                    setIsDirty(true);
+                  }}
+                  autoComplete="off"
                 />
-
-                <AlphaPicker
-                  allowMultiple
-                  activator={{
-                    label: 'Tags',
-                    placeholder: 'None selected',
-                  }}
-                  searchField={{
-                    label: 'Search tags',
-                    placeholder: 'Search or add new tags',
-                    value: query,
-                    onChange: (value) => setQuery(value),
-                  }}
-                  options={tags}
-                  onSelect={handleTagSelect}
-                  addAction={{
-                    value: query,
-                    children: `Add ${query}`,
-                  }}
+                <TextField
+                  label="Description"
+                  value={descriptionValue}
+                  onChange={handleChange}
+                  autoComplete="off"
+                  multiline
                 />
+              </FormLayout>
+            </LegacyCard>
+            <LegacyCard title="Media" sectioned>
+              <DropZone onDrop={handleDropZoneDrop}>
+                {uploadedFiles}
+                {fileUpload}
+              </DropZone>
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard title="Organization">
+              <LegacyCard.Section>
+                <BlockStack gap="200">
+                  <Select
+                    label="Product type"
+                    options={options}
+                    onChange={setSelected}
+                    value={selected}
+                  />
 
-                <AlphaPicker
-                  activator={{
-                    label: 'Vendor',
-                    placeholder: 'None selected',
-                  }}
-                  searchField={{
-                    label: 'Search vendors',
-                    placeholder: 'Search or add new vendor',
-                    value: query,
-                    onChange: (value) => setQuery(value),
-                  }}
-                  options={vendors}
-                  onSelect={handleVendorSelect}
-                  addAction={{
-                    value: query,
-                    children: `Add ${query}`,
-                  }}
-                />
-              </BlockStack>
-            </LegacyCard.Section>
-            <LegacyCard.Section title="Collections" />
-            <LegacyCard.Section title="Tags" />
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </Page>
-  );
+                  <AlphaPicker
+                    allowMultiple
+                    activator={{
+                      label: 'Tags',
+                      placeholder: 'None selected',
+                    }}
+                    searchField={{
+                      label: 'Search tags',
+                      placeholder: 'Search or add new tags',
+                      value: query,
+                      onChange: (value) => setQuery(value),
+                    }}
+                    options={tags}
+                    onSelect={handleTagSelect}
+                    addAction={{
+                      value: query,
+                      children: `Add ${query}`,
+                    }}
+                  />
 
-  // ---- Loading ----
-  const loadingPageMarkup = (
-    <SkeletonPage>
-      <Layout>
-        <Layout.Section>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
-              <SkeletonBodyText lines={9} />
-            </TextContainer>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </SkeletonPage>
-  );
+                  <AlphaPicker
+                    activator={{
+                      label: 'Vendor',
+                      placeholder: 'None selected',
+                    }}
+                    searchField={{
+                      label: 'Search vendors',
+                      placeholder: 'Search or add new vendor',
+                      value: query,
+                      onChange: (value) => setQuery(value),
+                    }}
+                    options={vendors}
+                    onSelect={handleVendorSelect}
+                    addAction={{
+                      value: query,
+                      children: `Add ${query}`,
+                    }}
+                  />
+                </BlockStack>
+              </LegacyCard.Section>
+              <LegacyCard.Section title="Collections" />
+              <LegacyCard.Section title="Tags" />
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </Page>
+    );
 
-  const pageMarkup = isLoading ? loadingPageMarkup : actualPageMarkup;
+    // ---- Loading ----
+    const loadingPageMarkup = (
+      <SkeletonPage>
+        <Layout>
+          <Layout.Section>
+            <LegacyCard sectioned>
+              <TextContainer>
+                <SkeletonDisplayText size="small" />
+                <SkeletonBodyText lines={9} />
+              </TextContainer>
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </SkeletonPage>
+    );
 
-  // ---- Modal ----
-  const modalMarkup = (
-    <Modal
-      open={modalActive}
-      onClose={toggleModalActive}
-      title="Contact support"
-      primaryAction={{
-        content: 'Send',
-        onAction: toggleModalActive,
-      }}
-    >
-      <Modal.Section>
-        <FormLayout>
-          <TextField
-            label="Subject"
-            value={supportSubject}
-            onChange={setSupportSubject}
-            autoComplete="off"
-          />
-          <TextField
-            label="Message"
-            value={supportMessage}
-            onChange={setSupportMessage}
-            autoComplete="off"
-            multiline
-          />
-        </FormLayout>
-      </Modal.Section>
-    </Modal>
-  );
+    const pageMarkup = isLoading ? loadingPageMarkup : actualPageMarkup;
 
-  return (
-    <Frame
-      topBar={topBarMarkup}
-      navigation={navigationMarkup}
-      showMobileNavigation={mobileNavigationActive}
-      onNavigationDismiss={toggleMobileNavigationActive}
-      skipToContentTarget={skipToContentRef}
-    >
-      {contextualSaveBarMarkup}
-      {loadingMarkup}
-      {pageMarkup}
-      {toastMarkup}
-      {modalMarkup}
-      <FooterHelp>
-        Learn more about{' '}
-        <Link url="https://help.shopify.com/manual/orders/fulfill-orders">
-          fulfilling orders
-        </Link>
-      </FooterHelp>
-    </Frame>
-  );
-}
+    // ---- Modal ----
+    const modalMarkup = (
+      <Modal
+        open={modalActive}
+        onClose={toggleModalActive}
+        title="Contact support"
+        primaryAction={{
+          content: 'Send',
+          onAction: toggleModalActive,
+        }}
+      >
+        <Modal.Section>
+          <FormLayout>
+            <TextField
+              label="Subject"
+              value={supportSubject}
+              onChange={setSupportSubject}
+              autoComplete="off"
+            />
+            <TextField
+              label="Message"
+              value={supportMessage}
+              onChange={setSupportMessage}
+              autoComplete="off"
+              multiline
+            />
+          </FormLayout>
+        </Modal.Section>
+      </Modal>
+    );
+
+    return (
+      <Frame
+        topBar={topBarMarkup}
+        navigation={navigationMarkup}
+        showMobileNavigation={mobileNavigationActive}
+        onNavigationDismiss={toggleMobileNavigationActive}
+        skipToContentTarget={skipToContentRef}
+      >
+        {contextualSaveBarMarkup}
+        {loadingMarkup}
+        {pageMarkup}
+        {toastMarkup}
+        {modalMarkup}
+        <FooterHelp>
+          Learn more about{' '}
+          <Link url="https://help.shopify.com/manual/orders/fulfill-orders">
+            fulfilling orders
+          </Link>
+        </FooterHelp>
+      </Frame>
+    );
+  },
+};
 
 const posIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 20"><path d="M8.717 9.46l.77-2.26s-.52-.29-1.57-.29c-2.71 0-4.06 1.8-4.06 3.66 0 2.21 2.22 2.27 2.22 3.61 0 .33-.23.77-.8.77-.87 0-1.9-.88-1.9-.88l-.53 1.73s1.01 1.21 2.97 1.21c1.64 0 2.85-1.22 2.85-3.12 0-2.42-2.7-2.81-2.7-3.85 0-.18.06-.93 1.26-.93.82 0 1.49.35 1.49.35zm-2.34-5.62c-.51.14-.88.57-.94 1.09-.04.42.2.85.7.81s.9-.51 1-.97c.11-.49-.18-1.04-.76-.93zm1.35-2.7c-.32 0-.72.55-.84 1.36l1.6-.39c-.19-.64-.53-.97-.76-.97zm1.93.9c.32.09.62.29.81.58l1.62 2.13c.16.23.196.458.18.78l-.23 4.84-.33 6.68-.1 1.96c0 .13-.01.26-.03.38-.09.49-.51.67-.97.59l-8.65-1.62c-.51-.09-1.07-.15-1.57-.29-.6-.17-.34-1.1-.28-1.55l.36-2.78.82-6.23c.03-.21.05-.42.08-.63.05-.28.17-.55.34-.78l1.68-2.39c.18-.28.47-.48.8-.55l1.21-.3.3-.07c.09-1.58.94-2.79 2.04-2.79.9 0 1.65.86 1.92 2.04zM12 2l3.875 2.616c.168.157.276.37.31.598l1.77 13.008c.05.195 0 .4-.135.55-.13.15-.33.226-.527.2l-3.61-.37.066-1.36.33-6.864.25-5.208c.01-.182-.05-.36-.164-.503L12 2z"/></svg>`;

--- a/polaris-react/playground/KitchenSink.tsx
+++ b/polaris-react/playground/KitchenSink.tsx
@@ -23,37 +23,39 @@ Object.entries(modules).forEach(
   },
 );
 
-export function KitchenSink() {
-  return Object.entries(stories)
-    .filter(
-      ([id]) =>
-        ![
-          'Modal',
-          'ContextualSaveBar',
-          'TopBar',
-          'Sheet',
-          'Frame',
-          'Loading',
-          'AppProvider',
-        ].includes(id.split(':')[0]),
-    )
-    .map(([id, Story]) => {
-      return (
-        <div key={id}>
-          <RenderPerformanceProfiler
-            id={id.replace('All Components/', '')}
-            kind={id}
-            printToDOM
-          >
-            <Story />
-          </RenderPerformanceProfiler>
-          <hr
-            style={{
-              border: 'none',
-              margin: 10,
-            }}
-          />
-        </div>
-      );
-    });
-}
+export const KitchenSink = {
+  render() {
+    return Object.entries(stories)
+      .filter(
+        ([id]) =>
+          ![
+            'Modal',
+            'ContextualSaveBar',
+            'TopBar',
+            'Sheet',
+            'Frame',
+            'Loading',
+            'AppProvider',
+          ].includes(id.split(':')[0]),
+      )
+      .map(([id, Story]) => {
+        return (
+          <div key={id}>
+            <RenderPerformanceProfiler
+              id={id.replace('All Components/', '')}
+              kind={id}
+              printToDOM
+            >
+              <Story />
+            </RenderPerformanceProfiler>
+            <hr
+              style={{
+                border: 'none',
+                margin: 10,
+              }}
+            />
+          </div>
+        );
+      });
+  },
+};

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import {Page} from '../src';
 
-export function Playground() {
-  return (
-    <Page title="Playground">
-      {/* Add the code you want to test in here */}
-    </Page>
-  );
-}
+export const Playground = {
+  render() {
+    return (
+      <Page title="Playground">
+        {/* Add the code you want to test in here */}
+      </Page>
+    );
+  },
+};

--- a/polaris-react/playground/stories.tsx
+++ b/polaris-react/playground/stories.tsx
@@ -2,8 +2,8 @@ import {Playground} from './Playground';
 import {KitchenSink} from './KitchenSink';
 import {DetailsPage} from './DetailsPage';
 
-// eslint-disable-next-line import/no-anonymous-default-export
 export default {
+  // eslint-disable-next-line storybook/no-title-property-in-meta
   title: 'Playground',
   parameters: {
     layout: 'fullscreen',

--- a/polaris-react/src/components/AccountConnection/AccountConnection.stories.tsx
+++ b/polaris-react/src/components/AccountConnection/AccountConnection.stories.tsx
@@ -1,87 +1,95 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {AccountConnection, Box, Link, Text, BlockStack} from '@shopify/polaris';
 
 export default {
   component: AccountConnection,
-} as ComponentMeta<typeof AccountConnection>;
+} as Meta<typeof AccountConnection>;
 
-export function All() {
-  return (
-    <>
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          Default
-        </Text>
-        <Default />
-        <Box paddingBlockEnd="300" />
-      </BlockStack>
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With account connected
-        </Text>
-        <WithAccountConnected />
-        <Box paddingBlockEnd="300" />
-      </BlockStack>
-    </>
-  );
-}
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <>
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            Default
+          </Text>
+          <Default.render />
+          <Box paddingBlockEnd="300" />
+        </BlockStack>
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With account connected
+          </Text>
+          <WithAccountConnected.render />
+          <Box paddingBlockEnd="300" />
+        </BlockStack>
+      </>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function Default() {
-  const [connected, setConnected] = useState(false);
-  const accountName = connected ? 'Olive Eight' : '';
+export const Default = {
+  render() {
+    const [connected, setConnected] = useState(false);
+    const accountName = connected ? 'Olive Eight' : '';
 
-  const handleAction = useCallback(() => {
-    setConnected((connected) => !connected);
-  }, []);
+    const handleAction = useCallback(() => {
+      setConnected((connected) => !connected);
+    }, []);
 
-  const buttonText = connected ? 'Disconnect' : 'Connect';
-  const details = connected ? 'Account connected' : 'No account connected';
+    const buttonText = connected ? 'Disconnect' : 'Connect';
+    const details = connected ? 'Account connected' : 'No account connected';
 
-  const terms = connected ? null : (
-    <Text as="p" variant="bodyMd">
-      By clicking Connect, you agree to accept Sample App’s{' '}
-      <Link url="Example App">terms and conditions</Link>. You’ll pay a
-      commission rate of 15% on sales made through Sample App.
-    </Text>
-  );
+    const terms = connected ? null : (
+      <Text as="p" variant="bodyMd">
+        By clicking Connect, you agree to accept Sample App’s{' '}
+        <Link url="Example App">terms and conditions</Link>. You’ll pay a
+        commission rate of 15% on sales made through Sample App.
+      </Text>
+    );
 
-  return (
-    <AccountConnection
-      accountName={accountName}
-      connected={connected}
-      title="Example App"
-      action={{
-        content: buttonText,
-        onAction: handleAction,
-      }}
-      details={details}
-      termsOfService={terms}
-    />
-  );
-}
+    return (
+      <AccountConnection
+        accountName={accountName}
+        connected={connected}
+        title="Example App"
+        action={{
+          content: buttonText,
+          onAction: handleAction,
+        }}
+        details={details}
+        termsOfService={terms}
+      />
+    );
+  },
+};
 
-export function WithAccountConnected() {
-  const [connected, setConnected] = useState(true);
-  const accountName = connected ? 'Olive Eight' : '';
+export const WithAccountConnected = {
+  render() {
+    const [connected, setConnected] = useState(true);
+    const accountName = connected ? 'Olive Eight' : '';
 
-  const handleAction = useCallback(() => {
-    setConnected((connected) => !connected);
-  }, []);
+    const handleAction = useCallback(() => {
+      setConnected((connected) => !connected);
+    }, []);
 
-  const buttonText = connected ? 'Disconnect' : 'Connect';
-  const details = connected ? 'Account connected' : 'No account connected';
+    const buttonText = connected ? 'Disconnect' : 'Connect';
+    const details = connected ? 'Account connected' : 'No account connected';
 
-  return (
-    <AccountConnection
-      accountName={accountName}
-      connected={connected}
-      title="Example App"
-      action={{
-        content: buttonText,
-        onAction: handleAction,
-      }}
-      details={details}
-    />
-  );
-}
+    return (
+      <AccountConnection
+        accountName={accountName}
+        connected={connected}
+        title="Example App"
+        action={{
+          content: buttonText,
+          onAction: handleAction,
+        }}
+        details={details}
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/ActionList/ActionList.stories.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   ActionList,
   Avatar,
@@ -23,389 +23,411 @@ import {
 
 export default {
   component: ActionList,
-} as ComponentMeta<typeof ActionList>;
+} as Meta<typeof ActionList>;
 
-export function All() {
-  return (
-    <BlockStack gap="1600">
-      <InAPopover />
-      <WithIconsOrImage />
-      <WithAnIconAndASuffix />
-      <WithSections />
-      <WithSectionsNoTitles />
-      <WithDestructiveItem />
-      <WithHelpText />
-      <WithAPrefixAndASuffix />
-    </BlockStack>
-  );
-}
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="1600">
+        <InAPopover.render />
+        <WithIconsOrImage.render />
+        <WithAnIconAndASuffix.render />
+        <WithSections.render />
+        <WithSectionsNoTitles.render />
+        <WithDestructiveItem.render />
+        <WithHelpText.render />
+        <WithAPrefixAndASuffix.render />
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function InAPopover() {
-  const [active, setActive] = useState(true);
+export const InAPopover = {
+  render() {
+    const [active, setActive] = useState(true);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const handleImportedAction = useCallback(
-    () => console.log('Imported action'),
-    [],
-  );
+    const handleImportedAction = useCallback(
+      () => console.log('Imported action'),
+      [],
+    );
 
-  const handleExportedAction = useCallback(
-    () => console.log('Exported action'),
-    [],
-  );
+    const handleExportedAction = useCallback(
+      () => console.log('Exported action'),
+      [],
+    );
 
-  const activator = (
-    <Button onClick={toggleActive} disclosure>
-      More actions
-    </Button>
-  );
+    const activator = (
+      <Button onClick={toggleActive} disclosure>
+        More actions
+      </Button>
+    );
 
-  return (
-    <div style={{height: '250px'}}>
-      <Popover
-        active={active}
-        activator={activator}
-        autofocusTarget="first-node"
-        onClose={toggleActive}
-      >
-        <ActionList
-          actionRole="menuitem"
-          items={[
-            {
-              content: 'Import file',
-              onAction: handleImportedAction,
-            },
-            {
-              content: 'Export file',
-              onAction: handleExportedAction,
-            },
-          ]}
-        />
-      </Popover>
-    </div>
-  );
-}
-
-export function WithIconsOrImage() {
-  const [active, setActive] = useState(true);
-
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
-
-  const activator = (
-    <Button onClick={toggleActive} disclosure>
-      More actions
-    </Button>
-  );
-
-  return (
-    <div style={{height: '200px'}}>
-      <Popover
-        active={active}
-        activator={activator}
-        autofocusTarget="first-node"
-        onClose={toggleActive}
-      >
-        <ActionList
-          actionRole="menuitem"
-          items={[
-            {content: 'Duplicate', icon: DuplicateIcon},
-            {content: 'Archive', icon: ArchiveIcon},
-          ]}
-        />
-      </Popover>
-    </div>
-  );
-}
-
-export function WithAnIconAndASuffix() {
-  const [active, setActive] = useState(true);
-
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
-
-  const activator = (
-    <Button onClick={toggleActive} disclosure>
-      More actions
-    </Button>
-  );
-
-  return (
-    <div style={{height: '200px'}}>
-      <Popover
-        active={active}
-        activator={activator}
-        autofocusTarget="first-node"
-        onClose={toggleActive}
-      >
-        <div style={{width: '200px'}}>
+    return (
+      <div style={{height: '250px'}}>
+        <Popover
+          active={active}
+          activator={activator}
+          autofocusTarget="first-node"
+          onClose={toggleActive}
+        >
           <ActionList
             actionRole="menuitem"
             items={[
               {
-                active: true,
                 content: 'Import file',
-                icon: ImportIcon,
-                suffix: <Icon source={CheckSmallIcon} />,
-              },
-              {content: 'Export file', icon: ExportIcon},
-              {
-                content: 'Manage your blog articles',
-                icon: ImportIcon,
-                suffix: <Icon source={CheckSmallIcon} />,
+                onAction: handleImportedAction,
               },
               {
-                content: `Manage uploaded images`,
-                icon: ImportIcon,
-                suffix: <Icon source={CheckSmallIcon} />,
-                truncate: true,
-              },
-              {
-                disabled: true,
-                content: 'Disable file',
-                icon: ImportIcon,
-                suffix: <Icon source={CheckSmallIcon} />,
+                content: 'Export file',
+                onAction: handleExportedAction,
               },
             ]}
           />
-        </div>
-      </Popover>
-    </div>
-  );
-}
+        </Popover>
+      </div>
+    );
+  },
+};
 
-export function WithSections() {
-  const [active, setActive] = useState(true);
+export const WithIconsOrImage = {
+  render() {
+    const [active, setActive] = useState(true);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const activator = (
-    <Button onClick={toggleActive} disclosure>
-      More actions
-    </Button>
-  );
+    const activator = (
+      <Button onClick={toggleActive} disclosure>
+        More actions
+      </Button>
+    );
 
-  return (
-    <div style={{height: '250px'}}>
-      <Popover
-        active={active}
-        activator={activator}
-        autofocusTarget="first-node"
-        onClose={toggleActive}
-      >
-        <ActionList
-          actionRole="menuitem"
-          sections={[
-            {
-              title: 'File options',
-              items: [
-                {content: 'Import file', icon: ImportIcon},
-                {content: 'Export file', icon: ExportIcon},
-              ],
-            },
-            {
-              title: 'Bulk actions',
-              items: [
-                {content: 'Edit', icon: EditIcon},
-                {content: 'Delete', icon: DeleteIcon, destructive: true},
-              ],
-            },
-            {
-              title: 'More options',
-              items: [
-                {
-                  content:
-                    'Manage several customers at once with a CSV file import',
-                  icon: PersonIcon,
-                  truncate: true,
-                },
-              ],
-            },
-          ]}
-        />
-      </Popover>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '200px'}}>
+        <Popover
+          active={active}
+          activator={activator}
+          autofocusTarget="first-node"
+          onClose={toggleActive}
+        >
+          <ActionList
+            actionRole="menuitem"
+            items={[
+              {content: 'Duplicate', icon: DuplicateIcon},
+              {content: 'Archive', icon: ArchiveIcon},
+            ]}
+          />
+        </Popover>
+      </div>
+    );
+  },
+};
 
-export function WithSectionsNoTitles() {
-  const [active, setActive] = useState(true);
+export const WithAnIconAndASuffix = {
+  render() {
+    const [active, setActive] = useState(true);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const activator = (
-    <Button onClick={toggleActive} disclosure>
-      More actions
-    </Button>
-  );
+    const activator = (
+      <Button onClick={toggleActive} disclosure>
+        More actions
+      </Button>
+    );
 
-  return (
-    <div style={{height: '250px'}}>
-      <Popover
-        active={active}
-        activator={activator}
-        autofocusTarget="first-node"
-        onClose={toggleActive}
-      >
-        <ActionList
-          actionRole="menuitem"
-          sections={[
-            {
-              items: [
-                {content: 'Import file', icon: ImportIcon},
-                {content: 'Export file', icon: ExportIcon},
-              ],
-            },
-            {
-              items: [
-                {content: 'Edit', icon: EditIcon},
-                {content: 'Delete', icon: DeleteIcon, destructive: true},
-              ],
-            },
-          ]}
-        />
-      </Popover>
-    </div>
-  );
-}
-
-export function WithDestructiveItem() {
-  const [active, setActive] = useState(true);
-
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
-
-  const activator = (
-    <Button onClick={toggleActive} disclosure>
-      More actions
-    </Button>
-  );
-
-  return (
-    <div style={{height: '250px'}}>
-      <Popover
-        active={active}
-        activator={activator}
-        autofocusTarget="first-node"
-        onClose={toggleActive}
-      >
-        <ActionList
-          actionRole="menuitem"
-          sections={[
-            {
-              title: 'File options',
-              items: [
+    return (
+      <div style={{height: '200px'}}>
+        <Popover
+          active={active}
+          activator={activator}
+          autofocusTarget="first-node"
+          onClose={toggleActive}
+        >
+          <div style={{width: '200px'}}>
+            <ActionList
+              actionRole="menuitem"
+              items={[
                 {
                   active: true,
                   content: 'Import file',
                   icon: ImportIcon,
+                  suffix: <Icon source={CheckSmallIcon} />,
                 },
                 {content: 'Export file', icon: ExportIcon},
                 {
-                  destructive: true,
-                  content: 'Delete file',
-                  icon: DeleteIcon,
-                },
-              ],
-            },
-          ]}
-        />
-      </Popover>
-    </div>
-  );
-}
-
-export function WithHelpText() {
-  const [active, setActive] = useState(true);
-
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
-
-  const activator = (
-    <Button onClick={toggleActive} disclosure>
-      More actions
-    </Button>
-  );
-
-  return (
-    <div style={{height: '250px'}}>
-      <Popover
-        active={active}
-        activator={activator}
-        autofocusTarget="first-node"
-        onClose={toggleActive}
-      >
-        <ActionList
-          actionRole="menuitem"
-          sections={[
-            {
-              items: [
-                {
-                  content: 'Blog posts',
-                  helpText: 'Manage your blog articles',
-                },
-                {
-                  content: 'Blogs',
-                  helpText: 'Manage blogs published to your Online Store',
-                },
-                {
-                  active: true,
-                  content: 'Active blogs',
-                  helpText: 'This is helpful text',
+                  content: 'Manage your blog articles',
                   icon: ImportIcon,
                   suffix: <Icon source={CheckSmallIcon} />,
+                },
+                {
+                  content: `Manage uploaded images`,
+                  icon: ImportIcon,
+                  suffix: <Icon source={CheckSmallIcon} />,
+                  truncate: true,
                 },
                 {
                   disabled: true,
-                  content: 'Disabled blogs',
-                  helpText: 'This is also helpful text',
+                  content: 'Disable file',
                   icon: ImportIcon,
                   suffix: <Icon source={CheckSmallIcon} />,
                 },
-              ],
+              ]}
+            />
+          </div>
+        </Popover>
+      </div>
+    );
+  },
+};
+
+export const WithSections = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+    const activator = (
+      <Button onClick={toggleActive} disclosure>
+        More actions
+      </Button>
+    );
+
+    return (
+      <div style={{height: '250px'}}>
+        <Popover
+          active={active}
+          activator={activator}
+          autofocusTarget="first-node"
+          onClose={toggleActive}
+        >
+          <ActionList
+            actionRole="menuitem"
+            sections={[
+              {
+                title: 'File options',
+                items: [
+                  {content: 'Import file', icon: ImportIcon},
+                  {content: 'Export file', icon: ExportIcon},
+                ],
+              },
+              {
+                title: 'Bulk actions',
+                items: [
+                  {content: 'Edit', icon: EditIcon},
+                  {content: 'Delete', icon: DeleteIcon, destructive: true},
+                ],
+              },
+              {
+                title: 'More options',
+                items: [
+                  {
+                    content:
+                      'Manage several customers at once with a CSV file import',
+                    icon: PersonIcon,
+                    truncate: true,
+                  },
+                ],
+              },
+            ]}
+          />
+        </Popover>
+      </div>
+    );
+  },
+};
+
+export const WithSectionsNoTitles = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+    const activator = (
+      <Button onClick={toggleActive} disclosure>
+        More actions
+      </Button>
+    );
+
+    return (
+      <div style={{height: '250px'}}>
+        <Popover
+          active={active}
+          activator={activator}
+          autofocusTarget="first-node"
+          onClose={toggleActive}
+        >
+          <ActionList
+            actionRole="menuitem"
+            sections={[
+              {
+                items: [
+                  {content: 'Import file', icon: ImportIcon},
+                  {content: 'Export file', icon: ExportIcon},
+                ],
+              },
+              {
+                items: [
+                  {content: 'Edit', icon: EditIcon},
+                  {content: 'Delete', icon: DeleteIcon, destructive: true},
+                ],
+              },
+            ]}
+          />
+        </Popover>
+      </div>
+    );
+  },
+};
+
+export const WithDestructiveItem = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+    const activator = (
+      <Button onClick={toggleActive} disclosure>
+        More actions
+      </Button>
+    );
+
+    return (
+      <div style={{height: '250px'}}>
+        <Popover
+          active={active}
+          activator={activator}
+          autofocusTarget="first-node"
+          onClose={toggleActive}
+        >
+          <ActionList
+            actionRole="menuitem"
+            sections={[
+              {
+                title: 'File options',
+                items: [
+                  {
+                    active: true,
+                    content: 'Import file',
+                    icon: ImportIcon,
+                  },
+                  {content: 'Export file', icon: ExportIcon},
+                  {
+                    destructive: true,
+                    content: 'Delete file',
+                    icon: DeleteIcon,
+                  },
+                ],
+              },
+            ]}
+          />
+        </Popover>
+      </div>
+    );
+  },
+};
+
+export const WithHelpText = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+    const activator = (
+      <Button onClick={toggleActive} disclosure>
+        More actions
+      </Button>
+    );
+
+    return (
+      <div style={{height: '250px'}}>
+        <Popover
+          active={active}
+          activator={activator}
+          autofocusTarget="first-node"
+          onClose={toggleActive}
+        >
+          <ActionList
+            actionRole="menuitem"
+            sections={[
+              {
+                items: [
+                  {
+                    content: 'Blog posts',
+                    helpText: 'Manage your blog articles',
+                  },
+                  {
+                    content: 'Blogs',
+                    helpText: 'Manage blogs published to your Online Store',
+                  },
+                  {
+                    active: true,
+                    content: 'Active blogs',
+                    helpText: 'This is helpful text',
+                    icon: ImportIcon,
+                    suffix: <Icon source={CheckSmallIcon} />,
+                  },
+                  {
+                    disabled: true,
+                    content: 'Disabled blogs',
+                    helpText: 'This is also helpful text',
+                    icon: ImportIcon,
+                    suffix: <Icon source={CheckSmallIcon} />,
+                  },
+                ],
+              },
+            ]}
+          />
+        </Popover>
+      </div>
+    );
+  },
+};
+
+export const WithAPrefixAndASuffix = {
+  render() {
+    return (
+      <div style={{height: '250px', maxWidth: '350px'}}>
+        <ActionList
+          actionRole="menuitem"
+          items={[
+            {
+              content: 'Go here',
+              prefix: (
+                <Thumbnail
+                  source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                  size="small"
+                  alt="Black leather pet collar"
+                />
+              ),
+              suffix: <Icon source={ChevronRightIcon} />,
+            },
+            {
+              content: 'Or there',
+              prefix: <Avatar customer name="Farrah" size="sm" />,
+              suffix: <Icon source={ChevronRightIcon} />,
             },
           ]}
         />
-      </Popover>
-    </div>
-  );
-}
+      </div>
+    );
+  },
+};
 
-export function WithAPrefixAndASuffix() {
-  return (
-    <div style={{height: '250px', maxWidth: '350px'}}>
-      <ActionList
-        actionRole="menuitem"
-        items={[
-          {
-            content: 'Go here',
-            prefix: (
-              <Thumbnail
-                source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                size="small"
-                alt="Black leather pet collar"
-              />
-            ),
-            suffix: <Icon source={ChevronRightIcon} />,
-          },
-          {
-            content: 'Or there',
-            prefix: <Avatar customer name="Farrah" size="sm" />,
-            suffix: <Icon source={ChevronRightIcon} />,
-          },
-        ]}
-      />
-    </div>
-  );
-}
-
-export function WithFiltering() {
-  return (
-    <div style={{height: '250px', maxWidth: '350px'}}>
-      <ActionList
-        actionRole="menuitem"
-        allowFiltering
-        items={Array.from({length: 8}).map((_, index) => ({
-          content: `Item #${index + 1}`,
-        }))}
-      />
-    </div>
-  );
-}
+export const WithFiltering = {
+  render() {
+    return (
+      <div style={{height: '250px', maxWidth: '350px'}}>
+        <ActionList
+          actionRole="menuitem"
+          allowFiltering
+          items={Array.from({length: 8}).map((_, index) => ({
+            content: `Item #${index + 1}`,
+          }))}
+        />
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/AppProvider/AppProvider.stories.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   AppProvider,
   Avatar,
@@ -13,153 +13,159 @@ export default {
   component: AppProvider,
   args: {omitAppProvider: true},
   parameters: {layout: 'fullscreen'},
-} as ComponentMeta<typeof AppProvider>;
+} as Meta<typeof AppProvider>;
 
-export function Default(_, context) {
-  return (
-    <AppProvider
-      i18n={{
-        Polaris: {
-          ResourceList: {
-            sortingLabel: 'Sort by',
-            defaultItemSingular: 'item',
-            defaultItemPlural: 'items',
-            showing: 'Showing {itemsCount} {resource}',
-            Item: {
-              viewItem: 'View details for {itemName}',
-            },
-          },
-          Common: {
-            checkbox: 'checkbox',
-          },
-        },
-      }}
-    >
-      <Page>
-        <LegacyCard>
-          <ResourceList
-            showHeader
-            items={[
-              {
-                id: 341,
-                url: '#',
-                name: 'Mae Jemison',
-                location: 'Decatur, USA',
-              },
-              {
-                id: 256,
-                url: '#',
-                name: 'Ellen Ochoa',
-                location: 'Los Angeles, USA',
-              },
-            ]}
-            renderItem={(item) => {
-              const {id, url, name, location} = item;
-              const media = <Avatar customer size="md" name={name} />;
-
-              return (
-                <ResourceList.Item id={id} url={url} media={media}>
-                  <Text as="h3" variant="bodyMd" fontWeight="bold">
-                    {name}
-                  </Text>
-                  <Text as="p" variant="bodyMd">
-                    {location}
-                  </Text>
-                </ResourceList.Item>
-              );
-            }}
-          />
-        </LegacyCard>
-      </Page>
-    </AppProvider>
-  );
-}
-
-export function WithI18n() {
-  return (
-    <AppProvider
-      i18n={{
-        Polaris: {
-          Common: {
-            checkbox: 'case à cocher',
-          },
-          ResourceList: {
-            sortingLabel: 'Trier par',
-            showing: '{itemsCount} {resource} affichés',
-            defaultItemPlural: 'articles',
-            defaultItemSingular: 'article',
-            Item: {
-              viewItem: "Afficher les détails de l'{itemName}",
-            },
-          },
-        },
-      }}
-    >
-      <Page>
-        <LegacyCard>
-          <ResourceList
-            showHeader
-            items={[
-              {
-                id: 341,
-                url: '#',
-                name: 'Mae Jemison',
-                location: 'Decatur, USA',
-              },
-              {
-                id: 256,
-                url: '#',
-                name: 'Ellen Ochoa',
-                location: 'Los Angeles, USA',
-              },
-            ]}
-            renderItem={(item) => {
-              const {id, url, name, location} = item;
-              const media = <Avatar customer size="md" name={name} />;
-
-              return (
-                <ResourceList.Item id={id} url={url} media={media}>
-                  <Text as="h3" fontWeight="bold" variant="bodyMd">
-                    {name}
-                  </Text>
-                  <Text as="p" variant="bodyMd">
-                    {location}
-                  </Text>
-                </ResourceList.Item>
-              );
-            }}
-          />
-        </LegacyCard>
-      </Page>
-    </AppProvider>
-  );
-}
-
-export function WithLinkComponent(_, context) {
-  // We can do this because the AppProviderDecorator wraps all Stories, even AppProvider.stories.tsx
-  const CustomLinkComponent = ({children, url, ...rest}) => {
+export const Default = {
+  render(_, context) {
     return (
-      <a
-        href={url}
-        onClick={() => console.log('Custom link clicked')}
-        {...rest}
+      <AppProvider
+        i18n={{
+          Polaris: {
+            ResourceList: {
+              sortingLabel: 'Sort by',
+              defaultItemSingular: 'item',
+              defaultItemPlural: 'items',
+              showing: 'Showing {itemsCount} {resource}',
+              Item: {
+                viewItem: 'View details for {itemName}',
+              },
+            },
+            Common: {
+              checkbox: 'checkbox',
+            },
+          },
+        }}
       >
-        {children}
-      </a>
-    );
-  };
+        <Page>
+          <LegacyCard>
+            <ResourceList
+              showHeader
+              items={[
+                {
+                  id: 341,
+                  url: '#',
+                  name: 'Mae Jemison',
+                  location: 'Decatur, USA',
+                },
+                {
+                  id: 256,
+                  url: '#',
+                  name: 'Ellen Ochoa',
+                  location: 'Los Angeles, USA',
+                },
+              ]}
+              renderItem={(item) => {
+                const {id, url, name, location} = item;
+                const media = <Avatar customer size="md" name={name} />;
 
-  return (
-    <AppProvider linkComponent={CustomLinkComponent} i18n={{}}>
-      <Page
-        backAction={{content: 'Products', url: '#'}}
-        title="Jar With Lock-Lid"
-        primaryAction={{content: 'Save', disabled: true}}
+                return (
+                  <ResourceList.Item id={id} url={url} media={media}>
+                    <Text as="h3" variant="bodyMd" fontWeight="bold">
+                      {name}
+                    </Text>
+                    <Text as="p" variant="bodyMd">
+                      {location}
+                    </Text>
+                  </ResourceList.Item>
+                );
+              }}
+            />
+          </LegacyCard>
+        </Page>
+      </AppProvider>
+    );
+  },
+};
+
+export const WithI18n = {
+  render() {
+    return (
+      <AppProvider
+        i18n={{
+          Polaris: {
+            Common: {
+              checkbox: 'case à cocher',
+            },
+            ResourceList: {
+              sortingLabel: 'Trier par',
+              showing: '{itemsCount} {resource} affichés',
+              defaultItemPlural: 'articles',
+              defaultItemSingular: 'article',
+              Item: {
+                viewItem: "Afficher les détails de l'{itemName}",
+              },
+            },
+          },
+        }}
       >
-        <Text as="p" variant="bodyMd">
-          Page content
-        </Text>
-      </Page>
-    </AppProvider>
-  );
-}
+        <Page>
+          <LegacyCard>
+            <ResourceList
+              showHeader
+              items={[
+                {
+                  id: 341,
+                  url: '#',
+                  name: 'Mae Jemison',
+                  location: 'Decatur, USA',
+                },
+                {
+                  id: 256,
+                  url: '#',
+                  name: 'Ellen Ochoa',
+                  location: 'Los Angeles, USA',
+                },
+              ]}
+              renderItem={(item) => {
+                const {id, url, name, location} = item;
+                const media = <Avatar customer size="md" name={name} />;
+
+                return (
+                  <ResourceList.Item id={id} url={url} media={media}>
+                    <Text as="h3" fontWeight="bold" variant="bodyMd">
+                      {name}
+                    </Text>
+                    <Text as="p" variant="bodyMd">
+                      {location}
+                    </Text>
+                  </ResourceList.Item>
+                );
+              }}
+            />
+          </LegacyCard>
+        </Page>
+      </AppProvider>
+    );
+  },
+};
+
+export const WithLinkComponent = {
+  render(_, context) {
+    // We can do this because the AppProviderDecorator wraps all Stories, even AppProvider.stories.tsx
+    const CustomLinkComponent = ({children, url, ...rest}) => {
+      return (
+        <a
+          href={url}
+          onClick={() => console.log('Custom link clicked')}
+          {...rest}
+        >
+          {children}
+        </a>
+      );
+    };
+
+    return (
+      <AppProvider linkComponent={CustomLinkComponent} i18n={{}}>
+        <Page
+          backAction={{content: 'Products', url: '#'}}
+          title="Jar With Lock-Lid"
+          primaryAction={{content: 'Save', disabled: true}}
+        >
+          <Text as="p" variant="bodyMd">
+            Page content
+          </Text>
+        </Page>
+      </AppProvider>
+    );
+  },
+};

--- a/polaris-react/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/polaris-react/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Autocomplete,
   Icon,
@@ -11,137 +11,448 @@ import {PlusCircleIcon, DeleteIcon, SearchIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Autocomplete,
-} as ComponentMeta<typeof Autocomplete>;
+} as Meta<typeof Autocomplete>;
 
-export function Default() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
+export const Default = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
 
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
 
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
-      }
+        if (value === '') {
+          setOptions(deselectedOptions);
+          return;
+        }
 
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = deselectedOptions.filter((option) =>
-        option.label.match(filterRegex),
-      );
-      setOptions(resultOptions);
-    },
-    [deselectedOptions],
-  );
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = deselectedOptions.filter((option) =>
+          option.label.match(filterRegex),
+        );
+        setOptions(resultOptions);
+      },
+      [deselectedOptions],
+    );
 
-  const updateSelection = useCallback(
-    (selected) => {
-      const selectedValue = selected.map((selectedItem) => {
-        const matchedOption = options.find((option) => {
-          return option.value.match(selectedItem);
+    const updateSelection = useCallback(
+      (selected) => {
+        const selectedValue = selected.map((selectedItem) => {
+          const matchedOption = options.find((option) => {
+            return option.value.match(selectedItem);
+          });
+          return matchedOption && matchedOption.label;
         });
-        return matchedOption && matchedOption.label;
-      });
 
-      setSelectedOptions(selected);
-      setInputValue(selectedValue[0]);
-    },
-    [options],
-  );
+        setSelectedOptions(selected);
+        setInputValue(selectedValue[0]);
+      },
+      [options],
+    );
 
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      prefix={<Icon source={SearchIcon} tone="base" />}
-      placeholder="Search"
-    />
-  );
-
-  return (
-    <div style={{height: '225px'}}>
-      <Autocomplete
-        options={options}
-        selected={selectedOptions}
-        onSelect={updateSelection}
-        textField={textField}
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        prefix={<Icon source={SearchIcon} tone="base" />}
+        placeholder="Search"
       />
-    </div>
-  );
-}
+    );
 
-export function WithMultipleTags() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-  const [selectedOptions, setSelectedOptions] = useState(['rustic']);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
+    return (
+      <div style={{height: '225px'}}>
+        <Autocomplete
+          options={options}
+          selected={selectedOptions}
+          onSelect={updateSelection}
+          textField={textField}
+        />
+      </div>
+    );
+  },
+};
 
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
+export const WithMultipleTags = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+    const [selectedOptions, setSelectedOptions] = useState(['rustic']);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
 
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (value === '') {
+          setOptions(deselectedOptions);
+          return;
+        }
+
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = deselectedOptions.filter((option) =>
+          option.label.match(filterRegex),
+        );
+        let endIndex = resultOptions.length - 1;
+        if (resultOptions.length === 0) {
+          endIndex = 0;
+        }
+        setOptions(resultOptions);
+      },
+      [deselectedOptions],
+    );
+
+    const handleSelect = useCallback(
+      (selected) => {
+        setSelectedOptions(selected);
+        updateText('');
+      },
+      [updateText],
+    );
+
+    const removeTag = useCallback(
+      (tag) => (event) => {
+        event.stopPropagation();
+        const options = [...selectedOptions];
+        options.splice(options.indexOf(tag), 1);
+        setSelectedOptions(options);
+      },
+      [selectedOptions],
+    );
+
+    const verticalContentMarkup =
+      selectedOptions.length > 0 ? (
+        <LegacyStack spacing="extraTight" alignment="center">
+          {selectedOptions.map((option) => {
+            let tagLabel = '';
+            tagLabel = option.replace('_', ' ');
+            tagLabel = titleCase(tagLabel);
+            return (
+              <Tag key={`option${option}`} onRemove={removeTag(option)}>
+                {tagLabel}
+              </Tag>
+            );
+          })}
+        </LegacyStack>
+      ) : null;
+
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        placeholder="Vintage, cotton, summer"
+        verticalContent={verticalContentMarkup}
+      />
+    );
+
+    return (
+      <div style={{height: '325px'}}>
+        <Autocomplete
+          allowMultiple
+          options={options}
+          selected={selectedOptions}
+          textField={textField}
+          onSelect={handleSelect}
+          listTitle="Suggested Tags"
+        />
+      </div>
+    );
+
+    function titleCase(string) {
+      return string
+        .toLowerCase()
+        .split(' ')
+        .map((word) => word.replace(word[0], word[0].toUpperCase()))
+        .join('');
+    }
+  },
+};
+
+export const WithMultipleSections = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {
+          title: 'Frequently used',
+          options: [
+            {value: 'ups', label: 'UPS'},
+            {value: 'usps', label: 'USPS'},
+          ],
+        },
+        {
+          title: 'All carriers',
+          options: [
+            {value: 'dhl', label: 'DHL Express'},
+            {value: 'canada_post', label: 'Canada Post'},
+          ],
+        },
+      ],
+      [],
+    );
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (value === '') {
+          setOptions(deselectedOptions);
+          return;
+        }
+
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = [];
+
+        deselectedOptions.forEach((opt) => {
+          const lol = opt.options.filter((option) =>
+            option.label.match(filterRegex),
+          );
+
+          resultOptions.push({
+            title: opt.title,
+            options: lol,
+          });
+        });
+
+        setOptions(resultOptions);
+      },
+      [deselectedOptions],
+    );
+
+    const updateSelection = useCallback(
+      ([selected]) => {
+        let selectedValue;
+
+        options.forEach(({options: opt}) => {
+          if (selectedValue) {
+            return;
+          }
+
+          const matchedOption = opt.find((option) =>
+            option.value.match(selected),
+          );
+
+          if (matchedOption) {
+            selectedValue = matchedOption.label;
+          }
+        });
+
+        setSelectedOptions([selected]);
+        setInputValue(String(selectedValue) ? String(selectedValue) : '');
+      },
+      [options],
+    );
+
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        prefix={<Icon source={SearchIcon} tone="base" />}
+        placeholder="Search"
+      />
+    );
+
+    return (
+      <div style={{height: '225px'}}>
+        <Autocomplete
+          textField={textField}
+          selected={selectedOptions}
+          options={options}
+          onSelect={updateSelection}
+        />
+      </div>
+    );
+  },
+};
+
+export const WithLoading = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+    const [loading, setLoading] = useState(false);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (!loading) {
+          setLoading(true);
+        }
+
+        setTimeout(() => {
+          if (value === '') {
+            setOptions(deselectedOptions);
+            setLoading(false);
+            return;
+          }
+          const filterRegex = new RegExp(value, 'i');
+          const resultOptions = deselectedOptions.filter((option) =>
+            option.label.match(filterRegex),
+          );
+          setOptions(resultOptions);
+          setLoading(false);
+        }, 300);
+      },
+      [deselectedOptions, loading],
+    );
+
+    const updateSelection = useCallback(
+      (selected) => {
+        const selectedText = selected.map((selectedItem) => {
+          const matchedOption = options.find((option) => {
+            return option.value.match(selectedItem);
+          });
+          return matchedOption && matchedOption.label;
+        });
+        setSelectedOptions(selected);
+        setInputValue(selectedText[0]);
+      },
+      [options],
+    );
+
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        prefix={<Icon source={SearchIcon} tone="base" />}
+        placeholder="Search"
+      />
+    );
+
+    return (
+      <div style={{height: '225px'}}>
+        <Autocomplete
+          options={options}
+          selected={selectedOptions}
+          onSelect={updateSelection}
+          loading={loading}
+          textField={textField}
+        />
+      </div>
+    );
+  },
+};
+
+export const WithLazyLoading = {
+  render() {
+    const paginationInterval = 25;
+    const deselectedOptions = Array.from(Array(100)).map((_, index) => ({
+      value: `rustic ${index + 1}`,
+      label: `Rustic ${index + 1}`,
+    }));
+
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+    const [isLoading, setIsLoading] = useState(false);
+    const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
+    const [visibleOptionIndex, setVisibleOptionIndex] =
+      useState(paginationInterval);
+
+    const handleLoadMoreResults = useCallback(() => {
+      if (willLoadMoreResults) {
+        setIsLoading(true);
+
+        setTimeout(() => {
+          const remainingOptionCount = options.length - visibleOptionIndex;
+          const nextVisibleOptionIndex =
+            remainingOptionCount >= paginationInterval
+              ? visibleOptionIndex + paginationInterval
+              : visibleOptionIndex + remainingOptionCount;
+
+          setIsLoading(false);
+          setVisibleOptionIndex(nextVisibleOptionIndex);
+
+          if (remainingOptionCount <= paginationInterval) {
+            setWillLoadMoreResults(false);
+          }
+        }, 1000);
       }
+    }, [willLoadMoreResults, visibleOptionIndex, options.length]);
 
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = deselectedOptions.filter((option) =>
-        option.label.match(filterRegex),
-      );
-      let endIndex = resultOptions.length - 1;
-      if (resultOptions.length === 0) {
-        endIndex = 0;
-      }
-      setOptions(resultOptions);
-    },
-    [deselectedOptions],
-  );
+    const removeTag = useCallback(
+      (tag) => () => {
+        const options = [...selectedOptions];
+        options.splice(options.indexOf(tag), 1);
+        setSelectedOptions(options);
+      },
+      [selectedOptions],
+    );
 
-  const handleSelect = useCallback(
-    (selected) => {
-      setSelectedOptions(selected);
-      updateText('');
-    },
-    [updateText],
-  );
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
 
-  const removeTag = useCallback(
-    (tag) => (event) => {
-      event.stopPropagation();
-      const options = [...selectedOptions];
-      options.splice(options.indexOf(tag), 1);
-      setSelectedOptions(options);
-    },
-    [selectedOptions],
-  );
+        if (value === '') {
+          setOptions(deselectedOptions);
+          return;
+        }
 
-  const verticalContentMarkup =
-    selectedOptions.length > 0 ? (
-      <LegacyStack spacing="extraTight" alignment="center">
-        {selectedOptions.map((option) => {
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = deselectedOptions.filter((option) =>
+          option.label.match(filterRegex),
+        );
+
+        let endIndex = resultOptions.length - 1;
+        if (resultOptions.length === 0) {
+          endIndex = 0;
+        }
+        setOptions(resultOptions);
+        setInputValue;
+      },
+      [deselectedOptions],
+    );
+
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        placeholder="Vintage, cotton, summer"
+      />
+    );
+
+    const hasSelectedOptions = selectedOptions.length > 0;
+
+    const tagsMarkup = hasSelectedOptions
+      ? selectedOptions.map((option) => {
           let tagLabel = '';
           tagLabel = option.replace('_', ' ');
           tagLabel = titleCase(tagLabel);
@@ -150,703 +461,410 @@ export function WithMultipleTags() {
               {tagLabel}
             </Tag>
           );
-        })}
-      </LegacyStack>
+        })
+      : null;
+    const optionList = options.slice(0, visibleOptionIndex);
+    const selectedTagMarkup = hasSelectedOptions ? (
+      <LegacyStack spacing="extraTight">{tagsMarkup}</LegacyStack>
     ) : null;
 
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      placeholder="Vintage, cotton, summer"
-      verticalContent={verticalContentMarkup}
-    />
-  );
+    return (
+      <LegacyStack vertical>
+        {selectedTagMarkup}
+        <Autocomplete
+          allowMultiple
+          options={optionList}
+          selected={selectedOptions}
+          textField={textField}
+          onSelect={setSelectedOptions}
+          listTitle="Suggested Tags"
+          loading={isLoading}
+          onLoadMoreResults={handleLoadMoreResults}
+          willLoadMoreResults={willLoadMoreResults}
+        />
+      </LegacyStack>
+    );
 
-  return (
-    <div style={{height: '325px'}}>
-      <Autocomplete
-        allowMultiple
-        options={options}
-        selected={selectedOptions}
-        textField={textField}
-        onSelect={handleSelect}
-        listTitle="Suggested Tags"
-      />
-    </div>
-  );
-
-  function titleCase(string) {
-    return string
-      .toLowerCase()
-      .split(' ')
-      .map((word) => word.replace(word[0], word[0].toUpperCase()))
-      .join('');
-  }
-}
-
-export function WithMultipleSections() {
-  const deselectedOptions = useMemo(
-    () => [
-      {
-        title: 'Frequently used',
-        options: [
-          {value: 'ups', label: 'UPS'},
-          {value: 'usps', label: 'USPS'},
-        ],
-      },
-      {
-        title: 'All carriers',
-        options: [
-          {value: 'dhl', label: 'DHL Express'},
-          {value: 'canada_post', label: 'Canada Post'},
-        ],
-      },
-    ],
-    [],
-  );
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
-      }
-
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = [];
-
-      deselectedOptions.forEach((opt) => {
-        const lol = opt.options.filter((option) =>
-          option.label.match(filterRegex),
-        );
-
-        resultOptions.push({
-          title: opt.title,
-          options: lol,
-        });
-      });
-
-      setOptions(resultOptions);
-    },
-    [deselectedOptions],
-  );
-
-  const updateSelection = useCallback(
-    ([selected]) => {
-      let selectedValue;
-
-      options.forEach(({options: opt}) => {
-        if (selectedValue) {
-          return;
-        }
-
-        const matchedOption = opt.find((option) =>
-          option.value.match(selected),
-        );
-
-        if (matchedOption) {
-          selectedValue = matchedOption.label;
-        }
-      });
-
-      setSelectedOptions([selected]);
-      setInputValue(String(selectedValue) ? String(selectedValue) : '');
-    },
-    [options],
-  );
-
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      prefix={<Icon source={SearchIcon} tone="base" />}
-      placeholder="Search"
-    />
-  );
-
-  return (
-    <div style={{height: '225px'}}>
-      <Autocomplete
-        textField={textField}
-        selected={selectedOptions}
-        options={options}
-        onSelect={updateSelection}
-      />
-    </div>
-  );
-}
-
-export function WithLoading() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-  const [loading, setLoading] = useState(false);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (!loading) {
-        setLoading(true);
-      }
-
-      setTimeout(() => {
-        if (value === '') {
-          setOptions(deselectedOptions);
-          setLoading(false);
-          return;
-        }
-        const filterRegex = new RegExp(value, 'i');
-        const resultOptions = deselectedOptions.filter((option) =>
-          option.label.match(filterRegex),
-        );
-        setOptions(resultOptions);
-        setLoading(false);
-      }, 300);
-    },
-    [deselectedOptions, loading],
-  );
-
-  const updateSelection = useCallback(
-    (selected) => {
-      const selectedText = selected.map((selectedItem) => {
-        const matchedOption = options.find((option) => {
-          return option.value.match(selectedItem);
-        });
-        return matchedOption && matchedOption.label;
-      });
-      setSelectedOptions(selected);
-      setInputValue(selectedText[0]);
-    },
-    [options],
-  );
-
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      prefix={<Icon source={SearchIcon} tone="base" />}
-      placeholder="Search"
-    />
-  );
-
-  return (
-    <div style={{height: '225px'}}>
-      <Autocomplete
-        options={options}
-        selected={selectedOptions}
-        onSelect={updateSelection}
-        loading={loading}
-        textField={textField}
-      />
-    </div>
-  );
-}
-
-export function WithLazyLoading() {
-  const paginationInterval = 25;
-  const deselectedOptions = Array.from(Array(100)).map((_, index) => ({
-    value: `rustic ${index + 1}`,
-    label: `Rustic ${index + 1}`,
-  }));
-
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-  const [isLoading, setIsLoading] = useState(false);
-  const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
-  const [visibleOptionIndex, setVisibleOptionIndex] =
-    useState(paginationInterval);
-
-  const handleLoadMoreResults = useCallback(() => {
-    if (willLoadMoreResults) {
-      setIsLoading(true);
-
-      setTimeout(() => {
-        const remainingOptionCount = options.length - visibleOptionIndex;
-        const nextVisibleOptionIndex =
-          remainingOptionCount >= paginationInterval
-            ? visibleOptionIndex + paginationInterval
-            : visibleOptionIndex + remainingOptionCount;
-
-        setIsLoading(false);
-        setVisibleOptionIndex(nextVisibleOptionIndex);
-
-        if (remainingOptionCount <= paginationInterval) {
-          setWillLoadMoreResults(false);
-        }
-      }, 1000);
+    function titleCase(string) {
+      return string
+        .toLowerCase()
+        .split(' ')
+        .map((word) => {
+          return word.replace(word[0], word[0].toUpperCase());
+        })
+        .join(' ');
     }
-  }, [willLoadMoreResults, visibleOptionIndex, options.length]);
+  },
+};
 
-  const removeTag = useCallback(
-    (tag) => () => {
-      const options = [...selectedOptions];
-      options.splice(options.indexOf(tag), 1);
-      setSelectedOptions(options);
-    },
-    [selectedOptions],
-  );
+export const WithEmptyState = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+    const [loading, setLoading] = useState(false);
 
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
 
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
-      }
-
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = deselectedOptions.filter((option) =>
-        option.label.match(filterRegex),
-      );
-
-      let endIndex = resultOptions.length - 1;
-      if (resultOptions.length === 0) {
-        endIndex = 0;
-      }
-      setOptions(resultOptions);
-      setInputValue;
-    },
-    [deselectedOptions],
-  );
-
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      placeholder="Vintage, cotton, summer"
-    />
-  );
-
-  const hasSelectedOptions = selectedOptions.length > 0;
-
-  const tagsMarkup = hasSelectedOptions
-    ? selectedOptions.map((option) => {
-        let tagLabel = '';
-        tagLabel = option.replace('_', ' ');
-        tagLabel = titleCase(tagLabel);
-        return (
-          <Tag key={`option${option}`} onRemove={removeTag(option)}>
-            {tagLabel}
-          </Tag>
-        );
-      })
-    : null;
-  const optionList = options.slice(0, visibleOptionIndex);
-  const selectedTagMarkup = hasSelectedOptions ? (
-    <LegacyStack spacing="extraTight">{tagsMarkup}</LegacyStack>
-  ) : null;
-
-  return (
-    <LegacyStack vertical>
-      {selectedTagMarkup}
-      <Autocomplete
-        allowMultiple
-        options={optionList}
-        selected={selectedOptions}
-        textField={textField}
-        onSelect={setSelectedOptions}
-        listTitle="Suggested Tags"
-        loading={isLoading}
-        onLoadMoreResults={handleLoadMoreResults}
-        willLoadMoreResults={willLoadMoreResults}
-      />
-    </LegacyStack>
-  );
-
-  function titleCase(string) {
-    return string
-      .toLowerCase()
-      .split(' ')
-      .map((word) => {
-        return word.replace(word[0], word[0].toUpperCase());
-      })
-      .join(' ');
-  }
-}
-
-export function WithEmptyState() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-  const [loading, setLoading] = useState(false);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (!loading) {
-        setLoading(true);
-      }
-
-      setTimeout(() => {
-        if (value === '') {
-          setOptions(deselectedOptions);
-          setLoading(false);
-          return;
+        if (!loading) {
+          setLoading(true);
         }
-        const filterRegex = new RegExp(value, 'i');
-        const resultOptions = deselectedOptions.filter((option) =>
-          option.label.match(filterRegex),
-        );
-        setOptions(resultOptions);
-        setLoading(false);
-      }, 300);
-    },
-    [deselectedOptions, loading],
-  );
 
-  const updateSelection = useCallback(
-    (selected) => {
-      const selectedText = selected.map((selectedItem) => {
-        const matchedOption = options.find((option) => {
-          return option.value.match(selectedItem);
+        setTimeout(() => {
+          if (value === '') {
+            setOptions(deselectedOptions);
+            setLoading(false);
+            return;
+          }
+          const filterRegex = new RegExp(value, 'i');
+          const resultOptions = deselectedOptions.filter((option) =>
+            option.label.match(filterRegex),
+          );
+          setOptions(resultOptions);
+          setLoading(false);
+        }, 300);
+      },
+      [deselectedOptions, loading],
+    );
+
+    const updateSelection = useCallback(
+      (selected) => {
+        const selectedText = selected.map((selectedItem) => {
+          const matchedOption = options.find((option) => {
+            return option.value.match(selectedItem);
+          });
+          return matchedOption && matchedOption.label;
         });
-        return matchedOption && matchedOption.label;
-      });
-      setSelectedOptions(selected);
-      setInputValue(selectedText[0]);
-    },
-    [options],
-  );
+        setSelectedOptions(selected);
+        setInputValue(selectedText[0]);
+      },
+      [options],
+    );
 
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      prefix={<Icon source={SearchIcon} tone="base" />}
-      placeholder="Search"
-    />
-  );
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        prefix={<Icon source={SearchIcon} tone="base" />}
+        placeholder="Search"
+      />
+    );
 
-  const emptyState = (
-    <>
-      <Icon source={SearchIcon} />
-      <div style={{textAlign: 'center'}}>
-        <TextContainer>Could not find any results</TextContainer>
+    const emptyState = (
+      <>
+        <Icon source={SearchIcon} />
+        <div style={{textAlign: 'center'}}>
+          <TextContainer>Could not find any results</TextContainer>
+        </div>
+      </>
+    );
+
+    return (
+      <div style={{height: '225px'}}>
+        <Autocomplete
+          options={options}
+          selected={selectedOptions}
+          onSelect={updateSelection}
+          emptyState={emptyState}
+          loading={loading}
+          textField={textField}
+        />
       </div>
-    </>
-  );
+    );
+  },
+};
 
-  return (
-    <div style={{height: '225px'}}>
-      <Autocomplete
-        options={options}
-        selected={selectedOptions}
-        onSelect={updateSelection}
-        emptyState={emptyState}
-        loading={loading}
-        textField={textField}
-      />
-    </div>
-  );
-}
+export const WithAction = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+    const [loading, setLoading] = useState(false);
 
-export function WithAction() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-  const [loading, setLoading] = useState(false);
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
 
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (!loading) {
-        setLoading(true);
-      }
-
-      setTimeout(() => {
-        if (value === '') {
-          setOptions(deselectedOptions);
-          setLoading(false);
-          return;
+        if (!loading) {
+          setLoading(true);
         }
-        const filterRegex = new RegExp(value, 'i');
-        const resultOptions = options.filter((option) =>
-          option.label.match(filterRegex),
-        );
-        setOptions(resultOptions);
-        setLoading(false);
-      }, 300);
-    },
-    [deselectedOptions, loading, options],
-  );
 
-  const updateSelection = useCallback(
-    (selected) => {
-      const selectedText = selected.map((selectedItem) => {
-        const matchedOption = options.find((option) => {
-          return option.value.match(selectedItem);
-        });
-        return matchedOption && matchedOption.label;
-      });
-      setSelectedOptions(selected);
-      setInputValue(selectedText[0]);
-    },
-    [options],
-  );
-
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      prefix={<Icon source={SearchIcon} />}
-      placeholder="Search"
-    />
-  );
-
-  return (
-    <div style={{height: '225px'}}>
-      <Autocomplete
-        actionBefore={{
-          accessibilityLabel: 'Action label',
-          badge: {
-            status: 'new',
-            content: 'New!',
-          },
-          content: 'Action with long name',
-          ellipsis: true,
-          helpText: 'Help text',
-          icon: PlusCircleIcon,
-          onAction: () => {
-            console.log('actionBefore clicked!');
-          },
-        }}
-        options={options}
-        selected={selectedOptions}
-        onSelect={updateSelection}
-        listTitle="Suggested tags"
-        loading={loading}
-        textField={textField}
-      />
-    </div>
-  );
-}
-
-export function WithWrappingAction() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-  const [loading, setLoading] = useState(false);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (!loading) {
-        setLoading(true);
-      }
-
-      setTimeout(() => {
-        if (value === '') {
-          setOptions(deselectedOptions);
+        setTimeout(() => {
+          if (value === '') {
+            setOptions(deselectedOptions);
+            setLoading(false);
+            return;
+          }
+          const filterRegex = new RegExp(value, 'i');
+          const resultOptions = options.filter((option) =>
+            option.label.match(filterRegex),
+          );
+          setOptions(resultOptions);
           setLoading(false);
-          return;
-        }
-        const filterRegex = new RegExp(value, 'i');
-        const resultOptions = options.filter((option) =>
-          option.label.match(filterRegex),
-        );
-        setOptions(resultOptions);
-        setLoading(false);
-      }, 300);
-    },
-    [deselectedOptions, loading, options],
-  );
+        }, 300);
+      },
+      [deselectedOptions, loading, options],
+    );
 
-  const updateSelection = useCallback(
-    (selected) => {
-      const selectedText = selected.map((selectedItem) => {
-        const matchedOption = options.find((option) => {
-          return option.value.match(selectedItem);
+    const updateSelection = useCallback(
+      (selected) => {
+        const selectedText = selected.map((selectedItem) => {
+          const matchedOption = options.find((option) => {
+            return option.value.match(selectedItem);
+          });
+          return matchedOption && matchedOption.label;
         });
-        return matchedOption && matchedOption.label;
-      });
-      setSelectedOptions(selected);
-      setInputValue(selectedText[0]);
-    },
-    [options],
-  );
+        setSelectedOptions(selected);
+        setInputValue(selectedText[0]);
+      },
+      [options],
+    );
 
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      prefix={<Icon source={SearchIcon} />}
-      placeholder="Search"
-    />
-  );
-
-  return (
-    <div style={{height: '225px'}}>
-      <Autocomplete
-        actionBefore={{
-          accessibilityLabel: 'Action label',
-          badge: {
-            status: 'new',
-            content: 'New!',
-          },
-          content:
-            'Action with long name that will need to wrap on small display in order to have a nice display',
-          ellipsis: true,
-          helpText: 'Help text',
-          icon: PlusCircleIcon,
-          wrapOverflow: true,
-          onAction: () => {
-            console.log('actionBefore clicked!');
-          },
-        }}
-        options={options}
-        selected={selectedOptions}
-        onSelect={updateSelection}
-        listTitle="Suggested tags"
-        loading={loading}
-        textField={textField}
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        prefix={<Icon source={SearchIcon} />}
+        placeholder="Search"
       />
-    </div>
-  );
-}
+    );
 
-export function WithDestructiveAction() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-  const [loading, setLoading] = useState(false);
+    return (
+      <div style={{height: '225px'}}>
+        <Autocomplete
+          actionBefore={{
+            accessibilityLabel: 'Action label',
+            badge: {
+              status: 'new',
+              content: 'New!',
+            },
+            content: 'Action with long name',
+            ellipsis: true,
+            helpText: 'Help text',
+            icon: PlusCircleIcon,
+            onAction: () => {
+              console.log('actionBefore clicked!');
+            },
+          }}
+          options={options}
+          selected={selectedOptions}
+          onSelect={updateSelection}
+          listTitle="Suggested tags"
+          loading={loading}
+          textField={textField}
+        />
+      </div>
+    );
+  },
+};
 
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
+export const WithWrappingAction = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+    const [loading, setLoading] = useState(false);
 
-      if (!loading) {
-        setLoading(true);
-      }
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
 
-      setTimeout(() => {
-        if (value === '') {
-          setOptions(deselectedOptions);
+        if (!loading) {
+          setLoading(true);
+        }
+
+        setTimeout(() => {
+          if (value === '') {
+            setOptions(deselectedOptions);
+            setLoading(false);
+            return;
+          }
+          const filterRegex = new RegExp(value, 'i');
+          const resultOptions = options.filter((option) =>
+            option.label.match(filterRegex),
+          );
+          setOptions(resultOptions);
           setLoading(false);
-          return;
-        }
-        const filterRegex = new RegExp(value, 'i');
-        const resultOptions = options.filter((option) =>
-          option.label.match(filterRegex),
-        );
-        setOptions(resultOptions);
-        setLoading(false);
-      }, 300);
-    },
-    [deselectedOptions, loading, options],
-  );
+        }, 300);
+      },
+      [deselectedOptions, loading, options],
+    );
 
-  const updateSelection = useCallback(
-    (selected) => {
-      const selectedText = selected.map((selectedItem) => {
-        const matchedOption = options.find((option) => {
-          return option.value.match(selectedItem);
+    const updateSelection = useCallback(
+      (selected) => {
+        const selectedText = selected.map((selectedItem) => {
+          const matchedOption = options.find((option) => {
+            return option.value.match(selectedItem);
+          });
+          return matchedOption && matchedOption.label;
         });
-        return matchedOption && matchedOption.label;
-      });
-      setSelectedOptions(selected);
-      setInputValue(selectedText[0]);
-    },
-    [options],
-  );
+        setSelectedOptions(selected);
+        setInputValue(selectedText[0]);
+      },
+      [options],
+    );
 
-  const textField = (
-    <Autocomplete.TextField
-      onChange={updateText}
-      label="Tags"
-      value={inputValue}
-      prefix={<Icon source={SearchIcon} />}
-      placeholder="Search"
-    />
-  );
-
-  return (
-    <div style={{height: '225px'}}>
-      <Autocomplete
-        actionBefore={{
-          accessibilityLabel: 'Destructive action label',
-          content: 'Destructive action',
-          destructive: true,
-          icon: DeleteIcon,
-          onAction: () => {
-            console.log('actionBefore clicked!');
-          },
-        }}
-        options={options}
-        selected={selectedOptions}
-        onSelect={updateSelection}
-        listTitle="Suggested tags"
-        loading={loading}
-        textField={textField}
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        prefix={<Icon source={SearchIcon} />}
+        placeholder="Search"
       />
-    </div>
-  );
-}
+    );
+
+    return (
+      <div style={{height: '225px'}}>
+        <Autocomplete
+          actionBefore={{
+            accessibilityLabel: 'Action label',
+            badge: {
+              status: 'new',
+              content: 'New!',
+            },
+            content:
+              'Action with long name that will need to wrap on small display in order to have a nice display',
+            ellipsis: true,
+            helpText: 'Help text',
+            icon: PlusCircleIcon,
+            wrapOverflow: true,
+            onAction: () => {
+              console.log('actionBefore clicked!');
+            },
+          }}
+          options={options}
+          selected={selectedOptions}
+          onSelect={updateSelection}
+          listTitle="Suggested tags"
+          loading={loading}
+          textField={textField}
+        />
+      </div>
+    );
+  },
+};
+
+export const WithDestructiveAction = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+    const [loading, setLoading] = useState(false);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (!loading) {
+          setLoading(true);
+        }
+
+        setTimeout(() => {
+          if (value === '') {
+            setOptions(deselectedOptions);
+            setLoading(false);
+            return;
+          }
+          const filterRegex = new RegExp(value, 'i');
+          const resultOptions = options.filter((option) =>
+            option.label.match(filterRegex),
+          );
+          setOptions(resultOptions);
+          setLoading(false);
+        }, 300);
+      },
+      [deselectedOptions, loading, options],
+    );
+
+    const updateSelection = useCallback(
+      (selected) => {
+        const selectedText = selected.map((selectedItem) => {
+          const matchedOption = options.find((option) => {
+            return option.value.match(selectedItem);
+          });
+          return matchedOption && matchedOption.label;
+        });
+        setSelectedOptions(selected);
+        setInputValue(selectedText[0]);
+      },
+      [options],
+    );
+
+    const textField = (
+      <Autocomplete.TextField
+        onChange={updateText}
+        label="Tags"
+        value={inputValue}
+        prefix={<Icon source={SearchIcon} />}
+        placeholder="Search"
+      />
+    );
+
+    return (
+      <div style={{height: '225px'}}>
+        <Autocomplete
+          actionBefore={{
+            accessibilityLabel: 'Destructive action label',
+            content: 'Destructive action',
+            destructive: true,
+            icon: DeleteIcon,
+            onAction: () => {
+              console.log('actionBefore clicked!');
+            },
+          }}
+          options={options}
+          selected={selectedOptions}
+          onSelect={updateSelection}
+          listTitle="Suggested tags"
+          loading={loading}
+          textField={textField}
+        />
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/Avatar/Avatar.stories.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import type {AvatarProps} from '@shopify/polaris';
 import {
   ActionList,
@@ -18,7 +18,7 @@ import type {STYLE_CLASSES} from './Avatar';
 
 export default {
   component: Avatar,
-} as ComponentMeta<typeof Avatar>;
+} as Meta<typeof Avatar>;
 
 const sizes: NonNullable<AvatarProps['size']>[] = [
   'xl',
@@ -62,162 +62,178 @@ const styleInitialsLongEntries = Object.entries(styleInitialsLong) as Entries<
   typeof styleInitialsLong
 >;
 
-export function All() {
-  return (
-    <BlockStack gap="400">
-      <Box paddingBlockEnd="200">
-        <BlockStack gap="300">
-          <BlockStack gap="200">
-            <Text as="h2" variant="headingSm">
-              Default
-            </Text>
-            <InlineStack gap="200" blockAlign="center">
-              {sizes.map((size) => (
-                <Avatar key={size} size={size} />
-              ))}
-            </InlineStack>
-          </BlockStack>
-          <BlockStack gap="200">
-            <Text as="h2" variant="headingSm">
-              With customer
-            </Text>
-            <InlineStack gap="200" blockAlign="center">
-              {sizes.map((size) => (
-                <Avatar customer key={size} size={size} />
-              ))}
-            </InlineStack>
-          </BlockStack>
-          <BlockStack gap="200">
-            <Text as="h2" variant="headingSm">
-              With image
-            </Text>
-            <InlineStack gap="200" blockAlign="center">
-              <Image />
-            </InlineStack>
-          </BlockStack>
-          <BlockStack gap="200">
-            <Text as="h2" variant="headingSm">
-              With icon (all styles)
-            </Text>
-            <IconColorsSizes />
-          </BlockStack>
-          <BlockStack gap="200">
-            <Text as="h2" variant="headingSm">
-              With default initials (all styles)
-            </Text>
-            <InitialsColorsSizes />
-          </BlockStack>
-          <BlockStack gap="200">
-            <Text as="h2" variant="headingSm">
-              With long initials (all styles)
-            </Text>
-            <InitialsLong />
-          </BlockStack>
-          <BlockStack gap="200">
-            <Text as="h2" variant="headingSm">
-              With long and wide initials
-            </Text>
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="400">
+        <Box paddingBlockEnd="200">
+          <BlockStack gap="300">
             <BlockStack gap="200">
+              <Text as="h2" variant="headingSm">
+                Default
+              </Text>
               <InlineStack gap="200" blockAlign="center">
                 {sizes.map((size) => (
-                  <Avatar key={size} size={size} initials="WWW" />
+                  <Avatar key={size} size={size} />
                 ))}
               </InlineStack>
             </BlockStack>
+            <BlockStack gap="200">
+              <Text as="h2" variant="headingSm">
+                With customer
+              </Text>
+              <InlineStack gap="200" blockAlign="center">
+                {sizes.map((size) => (
+                  <Avatar customer key={size} size={size} />
+                ))}
+              </InlineStack>
+            </BlockStack>
+            <BlockStack gap="200">
+              <Text as="h2" variant="headingSm">
+                With image
+              </Text>
+              <InlineStack gap="200" blockAlign="center">
+                <Image.render />
+              </InlineStack>
+            </BlockStack>
+            <BlockStack gap="200">
+              <Text as="h2" variant="headingSm">
+                With icon (all styles)
+              </Text>
+              <IconColorsSizes.render />
+            </BlockStack>
+            <BlockStack gap="200">
+              <Text as="h2" variant="headingSm">
+                With default initials (all styles)
+              </Text>
+              <InitialsColorsSizes.render />
+            </BlockStack>
+            <BlockStack gap="200">
+              <Text as="h2" variant="headingSm">
+                With long initials (all styles)
+              </Text>
+              <InitialsLong.render />
+            </BlockStack>
+            <BlockStack gap="200">
+              <Text as="h2" variant="headingSm">
+                With long and wide initials
+              </Text>
+              <BlockStack gap="200">
+                <InlineStack gap="200" blockAlign="center">
+                  {sizes.map((size) => (
+                    <Avatar key={size} size={size} initials="WWW" />
+                  ))}
+                </InlineStack>
+              </BlockStack>
+            </BlockStack>
           </BlockStack>
-        </BlockStack>
-      </Box>
-    </BlockStack>
-  );
-}
+        </Box>
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function Default() {
-  return <Avatar />;
-}
+export const Default = {
+  render() {
+    return <Avatar />;
+  },
+};
 
-export function IconColorsSizes() {
-  return (
-    <BlockStack gap="200">
-      {styleInitialsDefaultEntries.map(([style, initials]) => (
-        <InlineStack key={style} gap="200" blockAlign="center">
-          {sizes.map((size) => (
-            <Avatar key={size} name={initials} size={size} />
-          ))}
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-}
+export const IconColorsSizes = {
+  render() {
+    return (
+      <BlockStack gap="200">
+        {styleInitialsDefaultEntries.map(([style, initials]) => (
+          <InlineStack key={style} gap="200" blockAlign="center">
+            {sizes.map((size) => (
+              <Avatar key={size} name={initials} size={size} />
+            ))}
+          </InlineStack>
+        ))}
+      </BlockStack>
+    );
+  },
+};
 
-export function InitialsColorsSizes() {
-  return (
-    <BlockStack gap="200">
-      {styleInitialsDefaultEntries.map(([style, initials]) => (
-        <InlineStack key={style} gap="200" blockAlign="center">
-          {sizes.map((size) => (
-            <Avatar key={size} initials={initials} size={size} />
-          ))}
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-}
+export const InitialsColorsSizes = {
+  render() {
+    return (
+      <BlockStack gap="200">
+        {styleInitialsDefaultEntries.map(([style, initials]) => (
+          <InlineStack key={style} gap="200" blockAlign="center">
+            {sizes.map((size) => (
+              <Avatar key={size} initials={initials} size={size} />
+            ))}
+          </InlineStack>
+        ))}
+      </BlockStack>
+    );
+  },
+};
 
-export function InitialsLong() {
-  return (
-    <BlockStack gap="200">
-      {styleInitialsLongEntries.map(([style, initialsLong]) => (
-        <InlineStack key={style} gap="200" blockAlign="center">
-          {sizes.map((size) => (
-            <Avatar key={size} initials={initialsLong} size={size} />
-          ))}
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-}
+export const InitialsLong = {
+  render() {
+    return (
+      <BlockStack gap="200">
+        {styleInitialsLongEntries.map(([style, initialsLong]) => (
+          <InlineStack key={style} gap="200" blockAlign="center">
+            {sizes.map((size) => (
+              <Avatar key={size} initials={initialsLong} size={size} />
+            ))}
+          </InlineStack>
+        ))}
+      </BlockStack>
+    );
+  },
+};
 
-export function ExtraSmallInContext() {
-  const [active, setActive] = useState(true);
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
-  const activator = (
-    <Button onClick={toggleActive} disclosure>
-      Manage staff
-    </Button>
-  );
+export const ExtraSmallInContext = {
+  render() {
+    const [active, setActive] = useState(true);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const activator = (
+      <Button onClick={toggleActive} disclosure>
+        Manage staff
+      </Button>
+    );
 
-  return (
-    <div style={{height: '144px'}}>
-      <Popover active={active} activator={activator} onClose={toggleActive}>
-        <ActionList
-          items={[
-            {
-              content: 'Chet Baker',
-              prefix: <Avatar customer size="xs" name="Chet Baker" />,
-            },
-            {
-              content: 'Farrah Fawcett',
-              prefix: <Avatar customer size="xs" name="Farrah Fawcett" />,
-            },
-          ]}
-        />
-      </Popover>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '144px'}}>
+        <Popover active={active} activator={activator} onClose={toggleActive}>
+          <ActionList
+            items={[
+              {
+                content: 'Chet Baker',
+                prefix: <Avatar customer size="xs" name="Chet Baker" />,
+              },
+              {
+                content: 'Farrah Fawcett',
+                prefix: <Avatar customer size="xs" name="Farrah Fawcett" />,
+              },
+            ]}
+          />
+        </Popover>
+      </div>
+    );
+  },
+};
 
-export function Image() {
-  return (
-    <InlineStack gap="200" blockAlign="center">
-      {sizes.map((size) => (
-        <Avatar
-          key={size}
-          size={size}
-          initials="WWW"
-          name="Image"
-          source="https://burst.shopifycdn.com/photos/woman-dressed-in-pale-colors.jpg"
-        />
-      ))}
-    </InlineStack>
-  );
-}
+export const Image = {
+  render() {
+    return (
+      <InlineStack gap="200" blockAlign="center">
+        {sizes.map((size) => (
+          <Avatar
+            key={size}
+            size={size}
+            initials="WWW"
+            name="Image"
+            source="https://burst.shopifycdn.com/photos/woman-dressed-in-pale-colors.jpg"
+          />
+        ))}
+      </InlineStack>
+    );
+  },
+};

--- a/polaris-react/src/components/Badge/Badge.stories.tsx
+++ b/polaris-react/src/components/Badge/Badge.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import type {BadgeProps} from '@shopify/polaris';
 import {
   Badge,
@@ -14,71 +14,95 @@ import type {Entries} from '../../types';
 
 export default {
   component: Badge,
-} as ComponentMeta<typeof Badge>;
+} as Meta<typeof Badge>;
 
-export function Default() {
-  return <Badge>Fulfilled</Badge>;
-}
+export const Default = {
+  render() {
+    return <Badge>Fulfilled</Badge>;
+  },
+};
 
-export function Informational() {
-  return <Badge tone="info">Draft</Badge>;
-}
+export const Informational = {
+  render() {
+    return <Badge tone="info">Draft</Badge>;
+  },
+};
 
-export function Success() {
-  return <Badge tone="success">Active</Badge>;
-}
+export const Success = {
+  render() {
+    return <Badge tone="success">Active</Badge>;
+  },
+};
 
-export function Attention() {
-  return <Badge tone="attention">Open</Badge>;
-}
+export const Attention = {
+  render() {
+    return <Badge tone="attention">Open</Badge>;
+  },
+};
 
-export function Warning() {
-  return <Badge tone="warning">On hold</Badge>;
-}
+export const Warning = {
+  render() {
+    return <Badge tone="warning">On hold</Badge>;
+  },
+};
 
-export function Critical() {
-  return <Badge tone="critical">Action required</Badge>;
-}
+export const Critical = {
+  render() {
+    return <Badge tone="critical">Action required</Badge>;
+  },
+};
 
-export function New() {
-  return <Badge tone="new">Fulfilled</Badge>;
-}
+export const New = {
+  render() {
+    return <Badge tone="new">Fulfilled</Badge>;
+  },
+};
 
-export function Magic() {
-  return <Badge tone="magic">Magic</Badge>;
-}
+export const Magic = {
+  render() {
+    return <Badge tone="magic">Magic</Badge>;
+  },
+};
 
-export function Incomplete() {
-  return (
-    <Badge progress="incomplete" tone="attention">
-      Unfulfilled
-    </Badge>
-  );
-}
+export const Incomplete = {
+  render() {
+    return (
+      <Badge progress="incomplete" tone="attention">
+        Unfulfilled
+      </Badge>
+    );
+  },
+};
 
-export function PartiallyComplete() {
-  return (
-    <Badge progress="partiallyComplete" tone="warning">
-      Partially fulfilled
-    </Badge>
-  );
-}
+export const PartiallyComplete = {
+  render() {
+    return (
+      <Badge progress="partiallyComplete" tone="warning">
+        Partially fulfilled
+      </Badge>
+    );
+  },
+};
 
-export function Complete() {
-  return <Badge progress="complete">Fulfilled</Badge>;
-}
+export const Complete = {
+  render() {
+    return <Badge progress="complete">Fulfilled</Badge>;
+  },
+};
 
-export function WithToneAndProgressLabelOverride() {
-  return (
-    <Badge
-      tone="success"
-      progress="complete"
-      toneAndProgressLabelOverride="Tone: Published. Your online store is visible."
-    >
-      Published
-    </Badge>
-  );
-}
+export const WithToneAndProgressLabelOverride = {
+  render() {
+    return (
+      <Badge
+        tone="success"
+        progress="complete"
+        toneAndProgressLabelOverride="Tone: Published. Your online store is visible."
+      >
+        Published
+      </Badge>
+    );
+  },
+};
 
 const TempIcon = () => (
   <svg viewBox="0 0 20 20">
@@ -134,62 +158,25 @@ const sizes: {
 
 const sizeEntries = Object.entries(sizes) as Entries<typeof sizes>;
 
-export function All() {
-  return (
-    <LegacyCard sectioned>
-      {sizeEntries.map(([size, sizeLabel]) => (
-        <Box key={size} paddingBlockEnd="200">
-          <BlockStack gap="300">
-            <Text as="h2" variant="headingXl">
-              Size: {sizeLabel}
-            </Text>
-            <BlockStack gap="200">
-              <Text as="h2" variant="headingSm">
-                Tone only
+export const All = {
+  render() {
+    return (
+      <LegacyCard sectioned>
+        {sizeEntries.map(([size, sizeLabel]) => (
+          <Box key={size} paddingBlockEnd="200">
+            <BlockStack gap="300">
+              <Text as="h2" variant="headingXl">
+                Size: {sizeLabel}
               </Text>
-              <InlineStack gap="200">
-                {toneEntries.map(([tone, toneLabel]) => (
-                  <Badge
-                    key={tone}
-                    size={size}
-                    tone={tone === 'default' ? undefined : tone}
-                  >
-                    {toneLabel}
-                  </Badge>
-                ))}
-              </InlineStack>
-            </BlockStack>
-            <BlockStack gap="200">
-              <Text as="h2" variant="headingSm">
-                Tone with progress
-              </Text>
-              {progressEntries.map(([progress]) => (
-                <InlineStack key={progress} gap="200">
-                  {toneEntries.map(([tone, toneLabel]) => (
-                    <Badge
-                      key={tone}
-                      size={size}
-                      progress={progress}
-                      tone={tone === 'default' ? undefined : tone}
-                    >
-                      {toneLabel}
-                    </Badge>
-                  ))}
-                </InlineStack>
-              ))}
-            </BlockStack>
-            {/* Remove `size` condition when micro icons are available */}
-            {size === 'large' && (
               <BlockStack gap="200">
                 <Text as="h2" variant="headingSm">
-                  Tone with icon
+                  Tone only
                 </Text>
                 <InlineStack gap="200">
                   {toneEntries.map(([tone, toneLabel]) => (
                     <Badge
                       key={tone}
                       size={size}
-                      icon={TempIcon}
                       tone={tone === 'default' ? undefined : tone}
                     >
                       {toneLabel}
@@ -197,26 +184,65 @@ export function All() {
                   ))}
                 </InlineStack>
               </BlockStack>
-            )}
-            {/* TODO: Re-enable the following examples when designs are available (see https://github.com/Shopify/polaris-internal/issues/1411) */}
-            {/* <BlockStack gap="200">
-              <Text as="h2" variant="headingSm">
-                Tone with icon only
-              </Text>
-              <InlineStack gap="200">
-                {toneEntries.map(([tone]) => (
-                  <Badge
-                    key={tone}
-                    size={size}
-                    icon={TempIcon}
-                    tone={tone === 'default' ? undefined : tone}
-                  />
+              <BlockStack gap="200">
+                <Text as="h2" variant="headingSm">
+                  Tone with progress
+                </Text>
+                {progressEntries.map(([progress]) => (
+                  <InlineStack key={progress} gap="200">
+                    {toneEntries.map(([tone, toneLabel]) => (
+                      <Badge
+                        key={tone}
+                        size={size}
+                        progress={progress}
+                        tone={tone === 'default' ? undefined : tone}
+                      >
+                        {toneLabel}
+                      </Badge>
+                    ))}
+                  </InlineStack>
                 ))}
-              </InlineStack>
-            </BlockStack> */}
-          </BlockStack>
-        </Box>
-      ))}
-    </LegacyCard>
-  );
-}
+              </BlockStack>
+              {/* Remove `size` condition when micro icons are available */}
+              {size === 'large' && (
+                <BlockStack gap="200">
+                  <Text as="h2" variant="headingSm">
+                    Tone with icon
+                  </Text>
+                  <InlineStack gap="200">
+                    {toneEntries.map(([tone, toneLabel]) => (
+                      <Badge
+                        key={tone}
+                        size={size}
+                        icon={TempIcon}
+                        tone={tone === 'default' ? undefined : tone}
+                      >
+                        {toneLabel}
+                      </Badge>
+                    ))}
+                  </InlineStack>
+                </BlockStack>
+              )}
+              {/* TODO: Re-enable the following examples when designs are available (see https://github.com/Shopify/polaris-internal/issues/1411) */}
+              {/* <BlockStack gap="200">
+                <Text as="h2" variant="headingSm">
+                  Tone with icon only
+                </Text>
+                <InlineStack gap="200">
+                  {toneEntries.map(([tone]) => (
+                    <Badge
+                      key={tone}
+                      size={size}
+                      icon={TempIcon}
+                      tone={tone === 'default' ? undefined : tone}
+                    />
+                  ))}
+                </InlineStack>
+              </BlockStack> */}
+            </BlockStack>
+          </Box>
+        ))}
+      </LegacyCard>
+    );
+  },
+};

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-children-prop */
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   BlockStack,
   Banner,
@@ -18,383 +18,327 @@ import {DiscountIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Banner,
-} as ComponentMeta<typeof Banner>;
+} as Meta<typeof Banner>;
 
-export function Default() {
-  return (
-    <Banner title="Order archived" onDismiss={() => {}}>
-      <Text as="p" variant="bodyMd">
-        This order was archived on March 7, 2017 at 3:12pm EDT.
-      </Text>
-    </Banner>
-  );
-}
-
-export function Dismissible() {
-  return (
-    <Banner onDismiss={() => {}}>
-      <Text as="p" variant="bodyMd">
-        Use your finance report to get detailed information about your business.{' '}
-        <Link url="">Let us know what you think</Link>
-      </Text>
-    </Banner>
-  );
-}
-
-export function WithFooterCallToAction() {
-  return (
-    <Banner
-      title="Some of your product variants are missing weights"
-      tone="warning"
-      action={{content: 'Edit variant weights', url: ''}}
-      secondaryAction={{content: 'Learn more', url: ''}}
-      onDismiss={() => {}}
-    >
-      <Text as="p" variant="bodyMd">
-        Add weights to show accurate rates at checkout and when buying shipping
-        labels in Shopify.
-      </Text>
-    </Banner>
-  );
-}
-
-export function Informational() {
-  return (
-    <Banner
-      title="USPS has updated their rates"
-      action={{content: 'Update rates', url: ''}}
-      secondaryAction={{content: 'Learn more'}}
-      tone="info"
-      onDismiss={() => {}}
-    >
-      <Text as="p" variant="bodyMd">
-        Make sure you know how these changes affect your store.
-      </Text>
-    </Banner>
-  );
-}
-
-export function Success() {
-  return (
-    <Banner
-      title="Your shipping label is ready to print."
-      tone="success"
-      action={{content: 'Print label'}}
-      onDismiss={() => {}}
-    />
-  );
-}
-
-export function Warning() {
-  return (
-    <Banner
-      title="Before you can purchase a shipping label, this change needs to be made:"
-      action={{content: 'Edit address'}}
-      tone="warning"
-    >
-      <List>
-        <List.Item>
-          The name of the city you’re shipping to has characters that aren’t
-          allowed. City name can only include spaces and hyphens.
-        </List.Item>
-      </List>
-    </Banner>
-  );
-}
-
-export function Critical() {
-  return (
-    <Banner
-      title="High risk of fraud detected"
-      action={{content: 'Review risk analysis'}}
-      tone="critical"
-    >
-      <Text as="p" variant="bodyMd">
-        Before fulfilling this order or capturing payment, please{' '}
-        <Link url="">review the Risk Analysis</Link> and determine if this order
-        is fraudulent.
-      </Text>
-    </Banner>
-  );
-}
-
-export function InAModal() {
-  const [active, setActive] = useState(false);
-
-  const handleChange = useCallback(() => setActive(!active), [active]);
-
-  return (
-    <div style={{height: '500px'}}>
-      <Button onClick={handleChange}>Open</Button>
-      <Modal
-        open={active}
-        onClose={handleChange}
-        title="Reach more shoppers with Instagram product tags"
-        primaryAction={{
-          content: 'Add Instagram',
-          onAction: handleChange,
-        }}
-        secondaryActions={[
-          {
-            content: 'Learn more',
-            onAction: handleChange,
-          },
-        ]}
-      >
-        <Modal.Section>
-          <TextContainer>
-            <Banner action={{content: 'Connect account'}} tone="warning">
-              <Text as="p" variant="bodyMd">
-                Connect your instagram account to your shop before proceeding.
-              </Text>
-            </Banner>
-            <Text as="p" variant="bodyMd">
-              Use Instagram posts to share your products with millions of
-              people. Let shoppers buy from your store without leaving
-              Instagram.
-            </Text>
-          </TextContainer>
-        </Modal.Section>
-      </Modal>
-    </div>
-  );
-}
-
-export function WithFocus() {
-  const banner = useRef();
-
-  useEffect(() => banner.current.focus(), []);
-
-  return (
-    <Banner
-      title="High risk of fraud detected"
-      onDismiss={() => {}}
-      tone="critical"
-      ref={banner}
-    >
-      <Text as="p" variant="bodyMd">
-        Before fulfilling this order or capturing payment, please review the
-        fraud analysis and determine if this order is fraudulent
-      </Text>
-    </Banner>
-  );
-}
-
-export function InACard() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="300">
-        <Text as="h2" variant="headingMd">
-          Online store dashboard
-        </Text>
-        <Banner onDismiss={() => {}}>
-          <Text as="p">
-            Use your finance report to get detailed information about your
-            business. <Link url="">Let us know what you think</Link>
-          </Text>
-        </Banner>
-        <Text as="p">View a summary of your online store’s performance.</Text>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function InALegacyCard() {
-  return (
-    <LegacyCard title="Online store dashboard" sectioned>
-      <TextContainer>
-        <Banner onDismiss={() => {}}>
-          <Text as="p" variant="bodyMd">
-            Use your finance report to get detailed information about your
-            business. <Link url="">Let us know what you think</Link>
-          </Text>
-        </Banner>
-
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance.
-        </Text>
-      </TextContainer>
-    </LegacyCard>
-  );
-}
-
-export function WithEndJustifiedContent() {
-  return (
-    <Banner tone="critical">
-      <BlockStack gap="100">
-        <InlineStack gap="400" align="space-between">
-          <Text variant="headingMd" fontWeight="semibold" as="h3">
-            Deployment failed in 5min
-          </Text>
-          <Link external url="https://example.com">
-            Logs
-          </Link>
-        </InlineStack>
+export const Default = {
+  render() {
+    return (
+      <Banner title="Order archived" onDismiss={() => {}}>
         <Text as="p" variant="bodyMd">
           This order was archived on March 7, 2017 at 3:12pm EDT.
         </Text>
-      </BlockStack>
-    </Banner>
-  );
-}
+      </Banner>
+    );
+  },
+};
 
-export function HideIcon() {
-  return (
-    <LegacyCard title="Edit customer" sectioned>
-      <Banner tone="warning" hideIcon>
-        <Text as="p" fontWeight="semibold">
-          Changing the phone number for this customer will unsubscribe them from
-          SMS marketing text messages until they provide consent.
+export const Dismissible = {
+  render() {
+    return (
+      <Banner onDismiss={() => {}}>
+        <Text as="p" variant="bodyMd">
+          Use your finance report to get detailed information about your
+          business. <Link url="">Let us know what you think</Link>
         </Text>
       </Banner>
-    </LegacyCard>
-  );
-}
+    );
+  },
+};
 
-export function CustomIcon() {
-  return (
-    <Banner
-      tone="info"
-      icon={DiscountIcon}
-      title="Choose a plan and your discount will be applied at checkout."
-    />
-  );
-}
-
-export function All() {
-  return (
-    <BlockStack gap="300">
-      <Text as="h2" variant="headingMd">
-        With dismiss and actions
-      </Text>
-      <AllBanners
+export const WithFooterCallToAction = {
+  render() {
+    return (
+      <Banner
+        title="Some of your product variants are missing weights"
+        tone="warning"
+        action={{content: 'Edit variant weights', url: ''}}
+        secondaryAction={{content: 'Learn more', url: ''}}
         onDismiss={() => {}}
-        action={{content: 'Primary action'}}
-        secondaryAction={{content: 'Secondary action'}}
+      >
+        <Text as="p" variant="bodyMd">
+          Add weights to show accurate rates at checkout and when buying
+          shipping labels in Shopify.
+        </Text>
+      </Banner>
+    );
+  },
+};
+
+export const Informational = {
+  render() {
+    return (
+      <Banner
+        title="USPS has updated their rates"
+        action={{content: 'Update rates', url: ''}}
+        secondaryAction={{content: 'Learn more'}}
+        tone="info"
+        onDismiss={() => {}}
+      >
+        <Text as="p" variant="bodyMd">
+          Make sure you know how these changes affect your store.
+        </Text>
+      </Banner>
+    );
+  },
+};
+
+export const Success = {
+  render() {
+    return (
+      <Banner
+        title="Your shipping label is ready to print."
+        tone="success"
+        action={{content: 'Print label'}}
+        onDismiss={() => {}}
       />
-      <Text as="h2" variant="headingMd">
-        Default by status
-      </Text>
-      <AllBanners />
-      <Text as="h2" variant="headingMd">
-        No title
-      </Text>
-      <AllBanners
-        title={undefined}
+    );
+  },
+};
+
+export const Warning = {
+  render() {
+    return (
+      <Banner
+        title="Before you can purchase a shipping label, this change needs to be made:"
+        action={{content: 'Edit address'}}
+        tone="warning"
+      >
+        <List>
+          <List.Item>
+            The name of the city you’re shipping to has characters that aren’t
+            allowed. City name can only include spaces and hyphens.
+          </List.Item>
+        </List>
+      </Banner>
+    );
+  },
+};
+
+export const Critical = {
+  render() {
+    return (
+      <Banner
+        title="High risk of fraud detected"
+        action={{content: 'Review risk analysis'}}
+        tone="critical"
+      >
+        <Text as="p" variant="bodyMd">
+          Before fulfilling this order or capturing payment, please{' '}
+          <Link url="">review the Risk Analysis</Link> and determine if this
+          order is fraudulent.
+        </Text>
+      </Banner>
+    );
+  },
+};
+
+export const InAModal = {
+  render() {
+    const [active, setActive] = useState(false);
+
+    const handleChange = useCallback(() => setActive(!active), [active]);
+
+    return (
+      <div style={{height: '500px'}}>
+        <Button onClick={handleChange}>Open</Button>
+        <Modal
+          open={active}
+          onClose={handleChange}
+          title="Reach more shoppers with Instagram product tags"
+          primaryAction={{
+            content: 'Add Instagram',
+            onAction: handleChange,
+          }}
+          secondaryActions={[
+            {
+              content: 'Learn more',
+              onAction: handleChange,
+            },
+          ]}
+        >
+          <Modal.Section>
+            <TextContainer>
+              <Banner action={{content: 'Connect account'}} tone="warning">
+                <Text as="p" variant="bodyMd">
+                  Connect your instagram account to your shop before proceeding.
+                </Text>
+              </Banner>
+              <Text as="p" variant="bodyMd">
+                Use Instagram posts to share your products with millions of
+                people. Let shoppers buy from your store without leaving
+                Instagram.
+              </Text>
+            </TextContainer>
+          </Modal.Section>
+        </Modal>
+      </div>
+    );
+  },
+};
+
+export const WithFocus = {
+  render() {
+    const banner = useRef();
+
+    useEffect(() => banner.current.focus(), []);
+
+    return (
+      <Banner
+        title="High risk of fraud detected"
         onDismiss={() => {}}
-        children={
-          <Text as="p">
+        tone="critical"
+        ref={banner}
+      >
+        <Text as="p" variant="bodyMd">
+          Before fulfilling this order or capturing payment, please review the
+          fraud analysis and determine if this order is fraudulent
+        </Text>
+      </Banner>
+    );
+  },
+};
+
+export const InACard = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="300">
+          <Text as="h2" variant="headingMd">
+            Online store dashboard
+          </Text>
+          <Banner onDismiss={() => {}}>
+            <Text as="p">
+              Use your finance report to get detailed information about your
+              business. <Link url="">Let us know what you think</Link>
+            </Text>
+          </Banner>
+          <Text as="p">View a summary of your online store’s performance.</Text>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const InALegacyCard = {
+  render() {
+    return (
+      <LegacyCard title="Online store dashboard" sectioned>
+        <TextContainer>
+          <Banner onDismiss={() => {}}>
+            <Text as="p" variant="bodyMd">
+              Use your finance report to get detailed information about your
+              business. <Link url="">Let us know what you think</Link>
+            </Text>
+          </Banner>
+
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </TextContainer>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithEndJustifiedContent = {
+  render() {
+    return (
+      <Banner tone="critical">
+        <BlockStack gap="100">
+          <InlineStack gap="400" align="space-between">
+            <Text variant="headingMd" fontWeight="semibold" as="h3">
+              Deployment failed in 5min
+            </Text>
+            <Link external url="https://example.com">
+              Logs
+            </Link>
+          </InlineStack>
+          <Text as="p" variant="bodyMd">
+            This order was archived on March 7, 2017 at 3:12pm EDT.
+          </Text>
+        </BlockStack>
+      </Banner>
+    );
+  },
+};
+
+export const HideIcon = {
+  render() {
+    return (
+      <LegacyCard title="Edit customer" sectioned>
+        <Banner tone="warning" hideIcon>
+          <Text as="p" fontWeight="semibold">
             Changing the phone number for this customer will unsubscribe them
             from SMS marketing text messages until they provide consent.
           </Text>
-        }
+        </Banner>
+      </LegacyCard>
+    );
+  },
+};
+
+export const CustomIcon = {
+  render() {
+    return (
+      <Banner
+        tone="info"
+        icon={DiscountIcon}
+        title="Choose a plan and your discount will be applied at checkout."
       />
-      <Text as="h2" variant="headingMd">
-        No title with actions
-      </Text>
-      <AllBanners
-        title={undefined}
-        action={{content: 'Primary action'}}
-        secondaryAction={{content: 'Secondary action'}}
-        children={
-          <Text as="p">
-            Changing the phone number for this customer will unsubscribe them
-            from SMS marketing text messages until they provide consent.
-          </Text>
-        }
-      />
-      <Text as="h2" variant="headingMd">
-        No title with hidden icon
-      </Text>
-      <AllBanners
-        title={undefined}
-        hideIcon
-        onDismiss={() => {}}
-        children={
-          <>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
-          </>
-        }
-      />
-      <Text as="h2" variant="headingMd">
-        Only title
-      </Text>
-      <AllBanners children={undefined} onDismiss={() => {}} />
-      <Text as="h2" variant="headingMd">
-        Hide icon
-      </Text>
-      <AllBanners hideIcon onDismiss={() => {}} />
-      <Text as="h2" variant="headingMd">
-        Custom icon
-      </Text>
-      <AllBanners icon={DiscountIcon} onDismiss={() => {}} />
-      <Text as="h2" variant="headingMd">
-        With links
-      </Text>
-      <AllBanners
-        onDismiss={() => {}}
-        children={
-          <>
-            Text with <Link url="">monochrome link</Link>.
-          </>
-        }
-      />
-      <Text as="h2" variant="headingMd">
-        In card
-      </Text>
-      <LegacyCard sectioned>
-        <AllBanners />
-      </LegacyCard>
-      <Text as="h2" variant="headingMd">
-        In card with dismiss
-      </Text>
-      <LegacyCard sectioned>
-        <AllBanners onDismiss={() => {}} />
-      </LegacyCard>
-      <Text as="h2" variant="headingMd">
-        In card no title
-      </Text>
-      <LegacyCard sectioned>
-        <AllBanners title={undefined} onDismiss={() => {}} />
-      </LegacyCard>
-      <Text as="h2" variant="headingMd">
-        In card no icon
-      </Text>
-      <LegacyCard sectioned>
-        <AllBanners hideIcon onDismiss={() => {}} />
-      </LegacyCard>
-      <Text as="h2" variant="headingMd">
-        In card custom icon
-      </Text>
-      <LegacyCard sectioned>
-        <AllBanners icon={DiscountIcon} onDismiss={() => {}} />
-      </LegacyCard>
-      <Text as="h2" variant="headingMd">
-        In card with links
-      </Text>
-      <LegacyCard sectioned>
+    );
+  },
+};
+
+export const All = {
+  render() {
+    return (
+      <BlockStack gap="300">
+        <Text as="h2" variant="headingMd">
+          With dismiss and actions
+        </Text>
         <AllBanners
+          onDismiss={() => {}}
+          action={{content: 'Primary action'}}
+          secondaryAction={{content: 'Secondary action'}}
+        />
+        <Text as="h2" variant="headingMd">
+          Default by status
+        </Text>
+        <AllBanners />
+        <Text as="h2" variant="headingMd">
+          No title
+        </Text>
+        <AllBanners
+          title={undefined}
           onDismiss={() => {}}
           children={
-            <>
-              Text with <Link url="">monochrome link</Link>.
-            </>
+            <Text as="p">
+              Changing the phone number for this customer will unsubscribe them
+              from SMS marketing text messages until they provide consent.
+            </Text>
           }
         />
-      </LegacyCard>
-      <Text as="h2" variant="headingMd">
-        In card with long text
-      </Text>
-      <LegacyCard sectioned>
+        <Text as="h2" variant="headingMd">
+          No title with actions
+        </Text>
         <AllBanners
-          onDismiss={() => {}}
           title={undefined}
+          action={{content: 'Primary action'}}
+          secondaryAction={{content: 'Secondary action'}}
+          children={
+            <Text as="p">
+              Changing the phone number for this customer will unsubscribe them
+              from SMS marketing text messages until they provide consent.
+            </Text>
+          }
+        />
+        <Text as="h2" variant="headingMd">
+          No title with hidden icon
+        </Text>
+        <AllBanners
+          title={undefined}
+          hideIcon
+          onDismiss={() => {}}
           children={
             <>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -407,10 +351,96 @@ export function All() {
             </>
           }
         />
-      </LegacyCard>
-    </BlockStack>
-  );
-}
+        <Text as="h2" variant="headingMd">
+          Only title
+        </Text>
+        <AllBanners children={undefined} onDismiss={() => {}} />
+        <Text as="h2" variant="headingMd">
+          Hide icon
+        </Text>
+        <AllBanners hideIcon onDismiss={() => {}} />
+        <Text as="h2" variant="headingMd">
+          Custom icon
+        </Text>
+        <AllBanners icon={DiscountIcon} onDismiss={() => {}} />
+        <Text as="h2" variant="headingMd">
+          With links
+        </Text>
+        <AllBanners
+          onDismiss={() => {}}
+          children={
+            <>
+              Text with <Link url="">monochrome link</Link>.
+            </>
+          }
+        />
+        <Text as="h2" variant="headingMd">
+          In card
+        </Text>
+        <LegacyCard sectioned>
+          <AllBanners />
+        </LegacyCard>
+        <Text as="h2" variant="headingMd">
+          In card with dismiss
+        </Text>
+        <LegacyCard sectioned>
+          <AllBanners onDismiss={() => {}} />
+        </LegacyCard>
+        <Text as="h2" variant="headingMd">
+          In card no title
+        </Text>
+        <LegacyCard sectioned>
+          <AllBanners title={undefined} onDismiss={() => {}} />
+        </LegacyCard>
+        <Text as="h2" variant="headingMd">
+          In card no icon
+        </Text>
+        <LegacyCard sectioned>
+          <AllBanners hideIcon onDismiss={() => {}} />
+        </LegacyCard>
+        <Text as="h2" variant="headingMd">
+          In card custom icon
+        </Text>
+        <LegacyCard sectioned>
+          <AllBanners icon={DiscountIcon} onDismiss={() => {}} />
+        </LegacyCard>
+        <Text as="h2" variant="headingMd">
+          In card with links
+        </Text>
+        <LegacyCard sectioned>
+          <AllBanners
+            onDismiss={() => {}}
+            children={
+              <>
+                Text with <Link url="">monochrome link</Link>.
+              </>
+            }
+          />
+        </LegacyCard>
+        <Text as="h2" variant="headingMd">
+          In card with long text
+        </Text>
+        <LegacyCard sectioned>
+          <AllBanners
+            onDismiss={() => {}}
+            title={undefined}
+            children={
+              <>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+                in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+                nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+                sunt in culpa qui officia deserunt mollit anim id est laborum.
+              </>
+            }
+          />
+        </LegacyCard>
+      </BlockStack>
+    );
+  },
+};
 
 function AllBanners(props) {
   return (

--- a/polaris-react/src/components/Bleed/Bleed.stories.tsx
+++ b/polaris-react/src/components/Bleed/Bleed.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Card, Bleed, Box, Divider, LegacyStack, Text} from '@shopify/polaris';
 
 export default {
   component: Bleed,
-} as ComponentMeta<typeof Bleed>;
+} as Meta<typeof Bleed>;
 
 const styles = {
   background: 'var(--p-color-bg-inverse)',
@@ -13,143 +13,155 @@ const styles = {
   height: 'var(--p-space-1200)',
 };
 
-export function Default() {
-  return (
-    <Card>
-      <Box paddingBlockEnd="500">
-        <Text as="p" variant="bodySm">
-          Section 01
+export const Default = {
+  render() {
+    return (
+      <Card>
+        <Box paddingBlockEnd="500">
+          <Text as="p" variant="bodySm">
+            Section 01
+          </Text>
+        </Box>
+        <Bleed>
+          <Divider />
+        </Bleed>
+        <Box paddingBlockStart="500">
+          <Text as="p" variant="bodySm">
+            Section 02
+          </Text>
+        </Box>
+      </Card>
+    );
+  },
+};
+
+export const WithVerticalDirection = {
+  render() {
+    return (
+      <Box
+        background="bg-surface"
+        padding="400"
+        borderColor="border-secondary"
+        borderWidth="025"
+      >
+        <Bleed marginBlock="600">
+          <div style={styles} />
+        </Bleed>
+      </Box>
+    );
+  },
+};
+
+export const WithHorizontalDirection = {
+  render() {
+    return (
+      <Box
+        background="bg-surface"
+        padding="400"
+        borderColor="border-secondary"
+        borderWidth="025"
+      >
+        <Bleed marginInline="600">
+          <div style={styles} />
+        </Bleed>
+      </Box>
+    );
+  },
+};
+
+export const WithSpecificDirection = {
+  render() {
+    return (
+      <LegacyStack vertical>
+        <Text as="p" variant="bodyMd">
+          Block Start
         </Text>
-      </Box>
-      <Bleed>
-        <Divider />
-      </Bleed>
-      <Box paddingBlockStart="500">
-        <Text as="p" variant="bodySm">
-          Section 02
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderColor="border-secondary"
+          borderWidth="025"
+        >
+          <Bleed marginInline="400" marginBlockStart="600">
+            <div style={styles} />
+          </Bleed>
+        </Box>
+        <Text as="p" variant="bodyMd">
+          Block End
         </Text>
-      </Box>
-    </Card>
-  );
-}
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderColor="border-secondary"
+          borderWidth="025"
+        >
+          <Bleed marginInline="400" marginBlockEnd="600">
+            <div style={styles} />
+          </Bleed>
+        </Box>
+        <Text as="p" variant="bodyMd">
+          Inline Start
+        </Text>
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderColor="border-secondary"
+          borderWidth="025"
+        >
+          <Bleed marginInline="0" marginInlineStart="600">
+            <div style={styles} />
+          </Bleed>
+        </Box>
+        <Text as="p" variant="bodyMd">
+          Inline End
+        </Text>
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderColor="border-secondary"
+          borderWidth="025"
+        >
+          <Bleed marginInline="0" marginInlineEnd="600">
+            <div style={styles} />
+          </Bleed>
+        </Box>
+      </LegacyStack>
+    );
+  },
+};
 
-export function WithVerticalDirection() {
-  return (
-    <Box
-      background="bg-surface"
-      padding="400"
-      borderColor="border-secondary"
-      borderWidth="025"
-    >
-      <Bleed marginBlock="600">
-        <div style={styles} />
-      </Bleed>
-    </Box>
-  );
-}
-
-export function WithHorizontalDirection() {
-  return (
-    <Box
-      background="bg-surface"
-      padding="400"
-      borderColor="border-secondary"
-      borderWidth="025"
-    >
-      <Bleed marginInline="600">
-        <div style={styles} />
-      </Bleed>
-    </Box>
-  );
-}
-
-export function WithSpecificDirection() {
-  return (
-    <LegacyStack vertical>
-      <Text as="p" variant="bodyMd">
-        Block Start
-      </Text>
+export const WithAllDirection = {
+  render() {
+    return (
       <Box
         background="bg-surface"
         padding="400"
         borderColor="border-secondary"
         borderWidth="025"
       >
-        <Bleed marginInline="400" marginBlockStart="600">
+        <Bleed marginInline="600" marginBlock="600">
           <div style={styles} />
         </Bleed>
       </Box>
-      <Text as="p" variant="bodyMd">
-        Block End
-      </Text>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderColor="border-secondary"
-        borderWidth="025"
-      >
-        <Bleed marginInline="400" marginBlockEnd="600">
-          <div style={styles} />
-        </Bleed>
-      </Box>
-      <Text as="p" variant="bodyMd">
-        Inline Start
-      </Text>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderColor="border-secondary"
-        borderWidth="025"
-      >
-        <Bleed marginInline="0" marginInlineStart="600">
-          <div style={styles} />
-        </Bleed>
-      </Box>
-      <Text as="p" variant="bodyMd">
-        Inline End
-      </Text>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderColor="border-secondary"
-        borderWidth="025"
-      >
-        <Bleed marginInline="0" marginInlineEnd="600">
-          <div style={styles} />
-        </Bleed>
-      </Box>
-    </LegacyStack>
-  );
-}
+    );
+  },
+};
 
-export function WithAllDirection() {
-  return (
-    <Box
-      background="bg-surface"
-      padding="400"
-      borderColor="border-secondary"
-      borderWidth="025"
-    >
-      <Bleed marginInline="600" marginBlock="600">
-        <div style={styles} />
-      </Bleed>
-    </Box>
-  );
-}
-
-export function WithResponsiveHorizontalDirection() {
-  return (
-    <Box
-      background="bg-surface"
-      padding={{xs: '100', sm: '200', md: '300', lg: '400', xl: '500'}}
-      borderColor="border-secondary"
-      borderWidth="025"
-    >
-      <Bleed
-        marginInline={{xs: '100', sm: '200', md: '300', lg: '400', xl: '500'}}
+export const WithResponsiveHorizontalDirection = {
+  render() {
+    return (
+      <Box
+        background="bg-surface"
+        padding={{xs: '100', sm: '200', md: '300', lg: '400', xl: '500'}}
+        borderColor="border-secondary"
+        borderWidth="025"
       >
-        <div style={styles} />
-      </Bleed>
-    </Box>
-  );
-}
+        <Bleed
+          marginInline={{xs: '100', sm: '200', md: '300', lg: '400', xl: '500'}}
+        >
+          <div style={styles} />
+        </Bleed>
+      </Box>
+    );
+  },
+};

--- a/polaris-react/src/components/BlockStack/BlockStack.stories.tsx
+++ b/polaris-react/src/components/BlockStack/BlockStack.stories.tsx
@@ -1,63 +1,15 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Box, BlockStack} from '@shopify/polaris';
 
 export default {
   component: BlockStack,
-} as ComponentMeta<typeof BlockStack>;
+} as Meta<typeof BlockStack>;
 
-export function Default() {
-  return (
-    <BlockStack>
-      <Box background="bg-surface" padding="100">
-        01
-      </Box>
-      <Box background="bg-surface" padding="100">
-        02
-      </Box>
-      <Box background="bg-surface" padding="100">
-        03
-      </Box>
-    </BlockStack>
-  );
-}
-
-export function WithGap() {
-  return (
-    <BlockStack gap="800">
-      <Box background="bg-surface" padding="100">
-        01
-      </Box>
-      <Box background="bg-surface" padding="100">
-        02
-      </Box>
-      <Box background="bg-surface" padding="100">
-        03
-      </Box>
-    </BlockStack>
-  );
-}
-
-export function WithResponsiveGap() {
-  return (
-    <BlockStack gap={{xs: '400', md: '1000'}}>
-      <Box background="bg-surface" padding="100">
-        01
-      </Box>
-      <Box background="bg-surface" padding="100">
-        02
-      </Box>
-      <Box background="bg-surface" padding="100">
-        03
-      </Box>
-    </BlockStack>
-  );
-}
-
-export function WithAlignStart() {
-  return (
-    <div style={{display: 'flex', height: '250px'}}>
-      <BlockStack gap="400" align="start">
+export const Default = {
+  render() {
+    return (
+      <BlockStack>
         <Box background="bg-surface" padding="100">
           01
         </Box>
@@ -68,14 +20,14 @@ export function WithAlignStart() {
           03
         </Box>
       </BlockStack>
-    </div>
-  );
-}
+    );
+  },
+};
 
-export function WithAlignCenter() {
-  return (
-    <div style={{display: 'flex', height: '250px'}}>
-      <BlockStack gap="400" align="center">
+export const WithGap = {
+  render() {
+    return (
+      <BlockStack gap="800">
         <Box background="bg-surface" padding="100">
           01
         </Box>
@@ -86,14 +38,14 @@ export function WithAlignCenter() {
           03
         </Box>
       </BlockStack>
-    </div>
-  );
-}
+    );
+  },
+};
 
-export function WithAlignEnd() {
-  return (
-    <div style={{display: 'flex', height: '250px'}}>
-      <BlockStack gap="400" align="end">
+export const WithResponsiveGap = {
+  render() {
+    return (
+      <BlockStack gap={{xs: '400', md: '1000'}}>
         <Box background="bg-surface" padding="100">
           01
         </Box>
@@ -104,14 +56,134 @@ export function WithAlignEnd() {
           03
         </Box>
       </BlockStack>
-    </div>
-  );
-}
+    );
+  },
+};
 
-export function WithAlignSpaceAround() {
-  return (
-    <div style={{display: 'flex', height: '250px'}}>
-      <BlockStack gap="400" align="space-around">
+export const WithAlignStart = {
+  render() {
+    return (
+      <div style={{display: 'flex', height: '250px'}}>
+        <BlockStack gap="400" align="start">
+          <Box background="bg-surface" padding="100">
+            01
+          </Box>
+          <Box background="bg-surface" padding="100">
+            02
+          </Box>
+          <Box background="bg-surface" padding="100">
+            03
+          </Box>
+        </BlockStack>
+      </div>
+    );
+  },
+};
+
+export const WithAlignCenter = {
+  render() {
+    return (
+      <div style={{display: 'flex', height: '250px'}}>
+        <BlockStack gap="400" align="center">
+          <Box background="bg-surface" padding="100">
+            01
+          </Box>
+          <Box background="bg-surface" padding="100">
+            02
+          </Box>
+          <Box background="bg-surface" padding="100">
+            03
+          </Box>
+        </BlockStack>
+      </div>
+    );
+  },
+};
+
+export const WithAlignEnd = {
+  render() {
+    return (
+      <div style={{display: 'flex', height: '250px'}}>
+        <BlockStack gap="400" align="end">
+          <Box background="bg-surface" padding="100">
+            01
+          </Box>
+          <Box background="bg-surface" padding="100">
+            02
+          </Box>
+          <Box background="bg-surface" padding="100">
+            03
+          </Box>
+        </BlockStack>
+      </div>
+    );
+  },
+};
+
+export const WithAlignSpaceAround = {
+  render() {
+    return (
+      <div style={{display: 'flex', height: '250px'}}>
+        <BlockStack gap="400" align="space-around">
+          <Box background="bg-surface" padding="100">
+            01
+          </Box>
+          <Box background="bg-surface" padding="100">
+            02
+          </Box>
+          <Box background="bg-surface" padding="100">
+            03
+          </Box>
+        </BlockStack>
+      </div>
+    );
+  },
+};
+
+export const WithAlignSpaceBetween = {
+  render() {
+    return (
+      <div style={{display: 'flex', height: '250px'}}>
+        <BlockStack gap="400" align="space-between">
+          <Box background="bg-surface" padding="100">
+            01
+          </Box>
+          <Box background="bg-surface" padding="100">
+            02
+          </Box>
+          <Box background="bg-surface" padding="100">
+            03
+          </Box>
+        </BlockStack>
+      </div>
+    );
+  },
+};
+
+export const WithAlignSpaceEvenly = {
+  render() {
+    return (
+      <div style={{display: 'flex', height: '250px'}}>
+        <BlockStack gap="400" align="space-evenly">
+          <Box background="bg-surface" padding="100">
+            01
+          </Box>
+          <Box background="bg-surface" padding="100">
+            02
+          </Box>
+          <Box background="bg-surface" padding="100">
+            03
+          </Box>
+        </BlockStack>
+      </div>
+    );
+  },
+};
+
+export const WithInlineAlignStart = {
+  render() {
+    return (
+      <BlockStack gap="400" inlineAlign="start">
         <Box background="bg-surface" padding="100">
           01
         </Box>
@@ -122,14 +194,14 @@ export function WithAlignSpaceAround() {
           03
         </Box>
       </BlockStack>
-    </div>
-  );
-}
+    );
+  },
+};
 
-export function WithAlignSpaceBetween() {
-  return (
-    <div style={{display: 'flex', height: '250px'}}>
-      <BlockStack gap="400" align="space-between">
+export const WithInlineAlignCenter = {
+  render() {
+    return (
+      <BlockStack gap="400" inlineAlign="center">
         <Box background="bg-surface" padding="100">
           01
         </Box>
@@ -140,14 +212,14 @@ export function WithAlignSpaceBetween() {
           03
         </Box>
       </BlockStack>
-    </div>
-  );
-}
+    );
+  },
+};
 
-export function WithAlignSpaceEvenly() {
-  return (
-    <div style={{display: 'flex', height: '250px'}}>
-      <BlockStack gap="400" align="space-evenly">
+export const WithInlineAlignEnd = {
+  render() {
+    return (
+      <BlockStack gap="400" inlineAlign="end">
         <Box background="bg-surface" padding="100">
           01
         </Box>
@@ -158,54 +230,6 @@ export function WithAlignSpaceEvenly() {
           03
         </Box>
       </BlockStack>
-    </div>
-  );
-}
-
-export function WithInlineAlignStart() {
-  return (
-    <BlockStack gap="400" inlineAlign="start">
-      <Box background="bg-surface" padding="100">
-        01
-      </Box>
-      <Box background="bg-surface" padding="100">
-        02
-      </Box>
-      <Box background="bg-surface" padding="100">
-        03
-      </Box>
-    </BlockStack>
-  );
-}
-
-export function WithInlineAlignCenter() {
-  return (
-    <BlockStack gap="400" inlineAlign="center">
-      <Box background="bg-surface" padding="100">
-        01
-      </Box>
-      <Box background="bg-surface" padding="100">
-        02
-      </Box>
-      <Box background="bg-surface" padding="100">
-        03
-      </Box>
-    </BlockStack>
-  );
-}
-
-export function WithInlineAlignEnd() {
-  return (
-    <BlockStack gap="400" inlineAlign="end">
-      <Box background="bg-surface" padding="100">
-        01
-      </Box>
-      <Box background="bg-surface" padding="100">
-        02
-      </Box>
-      <Box background="bg-surface" padding="100">
-        03
-      </Box>
-    </BlockStack>
-  );
-}
+    );
+  },
+};

--- a/polaris-react/src/components/Box/Box.stories.tsx
+++ b/polaris-react/src/components/Box/Box.stories.tsx
@@ -1,255 +1,267 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {BlockStack, Text, Box, Icon} from '@shopify/polaris';
 import {PaintBrushFlatIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Box,
-} as ComponentMeta<typeof Box>;
+} as Meta<typeof Box>;
 
-export function Default() {
-  return (
-    <Box>
-      <Icon source={PaintBrushFlatIcon} tone="base" />
-    </Box>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <Box>
+        <Icon source={PaintBrushFlatIcon} tone="base" />
+      </Box>
+    );
+  },
+};
 
-export function WithBorders() {
-  return (
-    <BlockStack gap="400">
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderWidth="025"
-        borderColor="border"
-      >
-        <Text as="p">1px solid border</Text>
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderWidth="025"
-        borderStyle="dashed"
-        borderColor="border-secondary"
-      >
-        <Text as="p">1px dashed border</Text>
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderWidth="050"
-        borderColor="border-info"
-      >
-        <Text as="p">2px solid blue</Text>
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderWidth="100"
-        borderColor="border-caution"
-      >
-        <Text as="p">4px solid yellow</Text>
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderBlockStartWidth="100"
-        borderColor="border-critical"
-      >
-        <Text as="p">border-block-start: 4px solid red</Text>
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderWidth="100"
-        borderBlockStartWidth="025"
-        borderColor="border-critical"
-      >
-        <Text as="p">border-width: 4px solid red</Text>
-        <Text as="p">border-block-start: 1px solid red</Text>
+export const WithBorders = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderWidth="025"
+          borderColor="border"
+        >
+          <Text as="p">1px solid border</Text>
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderWidth="025"
+          borderStyle="dashed"
+          borderColor="border-secondary"
+        >
+          <Text as="p">1px dashed border</Text>
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderWidth="050"
+          borderColor="border-info"
+        >
+          <Text as="p">2px solid blue</Text>
+        </Box>
         <Box
           background="bg-surface"
           padding="400"
           borderWidth="100"
           borderColor="border-caution"
         >
-          <Text as="p">border-width: 4px solid yellow</Text>
-          <Text as="p" fontWeight="semibold">
-            Note: border-block-start will not inherit from the parent Box
-            component
-          </Text>
+          <Text as="p">4px solid yellow</Text>
         </Box>
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        borderWidth="100"
-        borderColor="transparent"
-      >
-        <Text as="p">4px solid transparent</Text>
-      </Box>
-    </BlockStack>
-  );
-}
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderBlockStartWidth="100"
+          borderColor="border-critical"
+        >
+          <Text as="p">border-block-start: 4px solid red</Text>
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderWidth="100"
+          borderBlockStartWidth="025"
+          borderColor="border-critical"
+        >
+          <Text as="p">border-width: 4px solid red</Text>
+          <Text as="p">border-block-start: 1px solid red</Text>
+          <Box
+            background="bg-surface"
+            padding="400"
+            borderWidth="100"
+            borderColor="border-caution"
+          >
+            <Text as="p">border-width: 4px solid yellow</Text>
+            <Text as="p" fontWeight="semibold">
+              Note: border-block-start will not inherit from the parent Box
+              component
+            </Text>
+          </Box>
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="400"
+          borderWidth="100"
+          borderColor="transparent"
+        >
+          <Text as="p">4px solid transparent</Text>
+        </Box>
+      </BlockStack>
+    );
+  },
+};
 
-export function WithOutline() {
-  return (
-    <BlockStack gap="400">
-      <Box
-        background="bg-surface"
-        padding="400"
-        outlineWidth="025"
-        outlineColor="border"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        outlineWidth="025"
-        outlineStyle="dashed"
-        outlineColor="border-secondary"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        outlineWidth="050"
-        outlineColor="border-info"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="400"
-        outlineWidth="100"
-        outlineColor="border-caution"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-    </BlockStack>
-  );
-}
+export const WithOutline = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <Box
+          background="bg-surface"
+          padding="400"
+          outlineWidth="025"
+          outlineColor="border"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="400"
+          outlineWidth="025"
+          outlineStyle="dashed"
+          outlineColor="border-secondary"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="400"
+          outlineWidth="050"
+          outlineColor="border-info"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="400"
+          outlineWidth="100"
+          outlineColor="border-caution"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+      </BlockStack>
+    );
+  },
+};
 
-export function WithBorderRadius() {
-  return (
-    <Box background="bg-surface" padding="400" borderRadius="200">
-      <Icon source={PaintBrushFlatIcon} tone="info" />
-    </Box>
-  );
-}
+export const WithBorderRadius = {
+  render() {
+    return (
+      <Box background="bg-surface" padding="400" borderRadius="200">
+        <Icon source={PaintBrushFlatIcon} tone="info" />
+      </Box>
+    );
+  },
+};
 
-export function WithPadding() {
-  return (
-    <BlockStack gap="400">
-      <Box
-        background="bg-surface"
-        padding="100"
-        borderWidth="050"
-        borderColor="border-info"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        paddingBlock="400"
-        borderWidth="050"
-        borderColor="border-info"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        paddingBlockStart="400"
-        borderWidth="050"
-        borderColor="border-info"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        paddingBlockEnd="400"
-        borderWidth="050"
-        borderColor="border-info"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        paddingInline="400"
-        borderWidth="050"
-        borderColor="border-info"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        paddingInlineStart="400"
-        borderWidth="050"
-        borderColor="border-info"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        paddingInlineEnd="400"
-        borderWidth="050"
-        borderColor="border-info"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-    </BlockStack>
-  );
-}
+export const WithPadding = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <Box
+          background="bg-surface"
+          padding="100"
+          borderWidth="050"
+          borderColor="border-info"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          paddingBlock="400"
+          borderWidth="050"
+          borderColor="border-info"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          paddingBlockStart="400"
+          borderWidth="050"
+          borderColor="border-info"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          paddingBlockEnd="400"
+          borderWidth="050"
+          borderColor="border-info"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          paddingInline="400"
+          borderWidth="050"
+          borderColor="border-info"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          paddingInlineStart="400"
+          borderWidth="050"
+          borderColor="border-info"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          paddingInlineEnd="400"
+          borderWidth="050"
+          borderColor="border-info"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+      </BlockStack>
+    );
+  },
+};
 
-export function WithResponsivePadding() {
-  return (
-    <BlockStack gap="400">
-      <Box
-        background="bg-surface"
-        padding={{xs: '200', sm: '800'}}
-        borderWidth="025"
-        borderColor="border"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="200"
-        paddingBlockStart={{xs: '400', sm: '1000'}}
-        borderWidth="025"
-        borderColor="border"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="200"
-        paddingBlockEnd={{xs: '400', sm: '1000'}}
-        borderWidth="025"
-        borderColor="border"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        padding="200"
-        paddingInlineStart={{xs: '400', sm: '1000'}}
-        borderWidth="025"
-        borderColor="border"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-      <Box
-        background="bg-surface"
-        paddingInlineEnd={{xs: '400', sm: '1000'}}
-        borderWidth="025"
-        borderColor="border"
-      >
-        <Icon source={PaintBrushFlatIcon} tone="base" />
-      </Box>
-    </BlockStack>
-  );
-}
+export const WithResponsivePadding = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <Box
+          background="bg-surface"
+          padding={{xs: '200', sm: '800'}}
+          borderWidth="025"
+          borderColor="border"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="200"
+          paddingBlockStart={{xs: '400', sm: '1000'}}
+          borderWidth="025"
+          borderColor="border"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="200"
+          paddingBlockEnd={{xs: '400', sm: '1000'}}
+          borderWidth="025"
+          borderColor="border"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          padding="200"
+          paddingInlineStart={{xs: '400', sm: '1000'}}
+          borderWidth="025"
+          borderColor="border"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+        <Box
+          background="bg-surface"
+          paddingInlineEnd={{xs: '400', sm: '1000'}}
+          borderWidth="025"
+          borderColor="border"
+        >
+          <Icon source={PaintBrushFlatIcon} tone="base" />
+        </Box>
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/BulkActions/BulkActions.stories.tsx
+++ b/polaris-react/src/components/BulkActions/BulkActions.stories.tsx
@@ -1,137 +1,141 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {DeleteIcon} from '@shopify/polaris-icons';
 
 import {BulkActions} from './BulkActions';
 
 export default {
   component: BulkActions,
-} as ComponentMeta<typeof BulkActions>;
+} as Meta<typeof BulkActions>;
 
-export function Default() {
-  const promotedActions = [
-    {
-      content: 'Capture payments',
-      onAction: () => console.log('Todo: implement payment capture'),
-    },
-    {
-      title: 'Edit customers',
-      actions: [
-        {
-          content: 'Add customers',
-          onAction: () => console.log('Todo: implement adding customers'),
-        },
-        {
-          icon: DeleteIcon,
-          destructive: true,
-          content: 'Delete customers',
-          onAction: () => console.log('Todo: implement deleting customers'),
-        },
-      ],
-    },
-    {
-      title: 'Export',
-      actions: [
-        {
-          content: 'Export as PDF',
-          onAction: () => console.log('Todo: implement PDF exporting'),
-        },
-        {
-          content: 'Export as CSV',
-          onAction: () => console.log('Todo: implement CSV exporting'),
-        },
-      ],
-    },
-  ];
-  const actions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-  return (
-    <BulkActions
-      selectMode
-      onToggleAll={() => console.log('toggling all')}
-      accessibilityLabel="Select all items"
-      selected={false}
-      promotedActions={promotedActions}
-      actions={actions}
-    />
-  );
-}
+export const Default = {
+  render() {
+    const promotedActions = [
+      {
+        content: 'Capture payments',
+        onAction: () => console.log('Todo: implement payment capture'),
+      },
+      {
+        title: 'Edit customers',
+        actions: [
+          {
+            content: 'Add customers',
+            onAction: () => console.log('Todo: implement adding customers'),
+          },
+          {
+            icon: DeleteIcon,
+            destructive: true,
+            content: 'Delete customers',
+            onAction: () => console.log('Todo: implement deleting customers'),
+          },
+        ],
+      },
+      {
+        title: 'Export',
+        actions: [
+          {
+            content: 'Export as PDF',
+            onAction: () => console.log('Todo: implement PDF exporting'),
+          },
+          {
+            content: 'Export as CSV',
+            onAction: () => console.log('Todo: implement CSV exporting'),
+          },
+        ],
+      },
+    ];
+    const actions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+    return (
+      <BulkActions
+        selectMode
+        onToggleAll={() => console.log('toggling all')}
+        accessibilityLabel="Select all items"
+        selected={false}
+        promotedActions={promotedActions}
+        actions={actions}
+      />
+    );
+  },
+};
 
-export function WithDeprecatedProps() {
-  const promotedActions = [
-    {
-      content: 'Capture payments',
-      onAction: () => console.log('Todo: implement payment capture'),
-    },
-    {
-      title: 'Edit customers',
-      actions: [
-        {
-          content: 'Add customers',
-          onAction: () => console.log('Todo: implement adding customers'),
-        },
-        {
-          icon: DeleteIcon,
-          destructive: true,
-          content: 'Delete customers',
-          onAction: () => console.log('Todo: implement deleting customers'),
-        },
-      ],
-    },
-    {
-      title: 'Export',
-      actions: [
-        {
-          content: 'Export as PDF',
-          onAction: () => console.log('Todo: implement PDF exporting'),
-        },
-        {
-          content: 'Export as CSV',
-          onAction: () => console.log('Todo: implement CSV exporting'),
-        },
-      ],
-    },
-  ];
-  const actions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-  return (
-    <BulkActions
-      selectMode
-      onToggleAll={() => console.log('toggling all')}
-      accessibilityLabel="Select all items"
-      selected={false}
-      promotedActions={promotedActions}
-      actions={actions}
-      isSticky
-      width={500}
-    />
-  );
-}
+export const WithDeprecatedProps = {
+  render() {
+    const promotedActions = [
+      {
+        content: 'Capture payments',
+        onAction: () => console.log('Todo: implement payment capture'),
+      },
+      {
+        title: 'Edit customers',
+        actions: [
+          {
+            content: 'Add customers',
+            onAction: () => console.log('Todo: implement adding customers'),
+          },
+          {
+            icon: DeleteIcon,
+            destructive: true,
+            content: 'Delete customers',
+            onAction: () => console.log('Todo: implement deleting customers'),
+          },
+        ],
+      },
+      {
+        title: 'Export',
+        actions: [
+          {
+            content: 'Export as PDF',
+            onAction: () => console.log('Todo: implement PDF exporting'),
+          },
+          {
+            content: 'Export as CSV',
+            onAction: () => console.log('Todo: implement CSV exporting'),
+          },
+        ],
+      },
+    ];
+    const actions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+    return (
+      <BulkActions
+        selectMode
+        onToggleAll={() => console.log('toggling all')}
+        accessibilityLabel="Select all items"
+        selected={false}
+        promotedActions={promotedActions}
+        actions={actions}
+        isSticky
+        width={500}
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useRef, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import type {TextProps} from '@shopify/polaris';
 import {
   useCopyToClipboard,
@@ -32,862 +32,928 @@ import {
 
 export default {
   component: Button,
-} as ComponentMeta<typeof Button>;
+} as Meta<typeof Button>;
 
-export function All() {
-  const textProps: Pick<TextProps, 'as' | 'fontWeight'> = {
-    as: 'span',
-    fontWeight: 'bold',
-  };
-  return (
-    <BlockStack gap="400">
-      <Text {...textProps}>Default</Text>
-      <Default />
-      <Text {...textProps}>Critical</Text>
-      <Critical />
-      <Text {...textProps}>Primary</Text>
-      <Primary />
-      <Text {...textProps}>Primary success</Text>
-      <PrimarySuccess />
-      <Text {...textProps}>Primary critical</Text>
-      <PrimaryCritical />
-      <Text {...textProps}>Tertiary</Text>
-      <Tertiary />
-      <Text {...textProps}>Tertiary critical</Text>
-      <TertiaryCritical />
-      <Text {...textProps}>Plain</Text>
-      <Plain />
-      <Text {...textProps}>Plain Critical</Text>
-      <PlainCritical />
-      <Text {...textProps}>Monochrome Plain</Text>
-      <MonochromePlain />
-      <Text {...textProps}>Micro</Text>
-      <Micro />
-      <Text {...textProps}>Slim</Text>
-      <Slim />
-      <Text {...textProps}>Large</Text>
-      <Large />
-      <Text {...textProps}>Full width</Text>
-      <FullWidth />
-      <Text {...textProps}>Text aligned</Text>
-      <TextAligned />
-      <Text {...textProps}>Pressed</Text>
-      <Pressed />
-      <Text {...textProps}>Disclosure</Text>
-      <PlainDisclosure />
-      <Text {...textProps}>Right aligned disclosure</Text>
-      <RightAlignedDisclosure />
-      <Text {...textProps}>Select disclosure</Text>
-      <SelectDisclosure />
-      <Text {...textProps}>Split</Text>
-      <Split />
-      <Text {...textProps}>Disabled state</Text>
-      <DisabledState />
-      <Text {...textProps}>Loading state</Text>
-      <LoadingState />
-    </BlockStack>
-  );
-}
+export const All = {
+  render() {
+    const textProps: Pick<TextProps, 'as' | 'fontWeight'> = {
+      as: 'span',
+      fontWeight: 'bold',
+    };
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="400">
+        <Text {...textProps}>Default</Text>
+        <Default.render />
+        <Text {...textProps}>Critical</Text>
+        <Critical.render />
+        <Text {...textProps}>Primary</Text>
+        <Primary.render />
+        <Text {...textProps}>Primary success</Text>
+        <PrimarySuccess.render />
+        <Text {...textProps}>Primary critical</Text>
+        <PrimaryCritical.render />
+        <Text {...textProps}>Tertiary</Text>
+        <Tertiary.render />
+        <Text {...textProps}>Tertiary critical</Text>
+        <TertiaryCritical.render />
+        <Text {...textProps}>Plain</Text>
+        <Plain.render />
+        <Text {...textProps}>Plain Critical</Text>
+        <PlainCritical.render />
+        <Text {...textProps}>Monochrome Plain</Text>
+        <MonochromePlain.render />
+        <Text {...textProps}>Micro</Text>
+        <Micro.render />
+        <Text {...textProps}>Slim</Text>
+        <Slim.render />
+        <Text {...textProps}>Large</Text>
+        <Large.render />
+        <Text {...textProps}>Full width</Text>
+        <FullWidth.render />
+        <Text {...textProps}>Text aligned</Text>
+        <TextAligned.render />
+        <Text {...textProps}>Pressed</Text>
+        <Pressed.render />
+        <Text {...textProps}>Disclosure</Text>
+        <PlainDisclosure.render />
+        <Text {...textProps}>Right aligned disclosure</Text>
+        <RightAlignedDisclosure.render />
+        <Text {...textProps}>Select disclosure</Text>
+        <SelectDisclosure.render />
+        <Text {...textProps}>Split</Text>
+        <Split.render />
+        <Text {...textProps}>Disabled state</Text>
+        <DisabledState.render />
+        <Text {...textProps}>Loading state</Text>
+        <LoadingState.render />
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function Default() {
-  return (
-    <>
+export const Default = {
+  render() {
+    return (
+      <>
+        <Box padding="400">
+          <InlineStack gap="400" blockAlign="end">
+            <Button>Label</Button>
+            <Button disabled>Label</Button>
+            <Button icon={PlusIcon}>Label</Button>
+            <Button disabled icon={PlusIcon}>
+              Label
+            </Button>
+            <Button disclosure>Label</Button>
+            <Button
+              icon={XSmallIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              icon={EditIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
+        </Box>
+        <Card>
+          <InlineStack gap="400" blockAlign="end">
+            <Button>Label</Button>
+            <Button disabled>Label</Button>
+            <Button icon={PlusIcon}>Label</Button>
+            <Button disabled icon={PlusIcon}>
+              Label
+            </Button>
+            <Button disclosure>Label</Button>
+            <Button
+              icon={XSmallIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              icon={EditIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
+        </Card>
+      </>
+    );
+  },
+};
+
+export const Critical = {
+  render() {
+    return (
+      <>
+        <Box padding="400">
+          <InlineStack gap="400" blockAlign="end">
+            <Button tone="critical">Label</Button>
+            <Button tone="critical" disabled>
+              Label
+            </Button>
+            <Button tone="critical" icon={DeleteIcon}>
+              Label
+            </Button>
+            <Button tone="critical" disabled icon={DeleteIcon}>
+              Label
+            </Button>
+            <Button tone="critical" disclosure>
+              Label
+            </Button>
+            <Button
+              tone="critical"
+              icon={DeleteIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              tone="critical"
+              icon={DeleteIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
+        </Box>
+        <Card>
+          <InlineStack gap="400" blockAlign="end">
+            <Button tone="critical">Label</Button>
+            <Button tone="critical" disabled>
+              Label
+            </Button>
+            <Button tone="critical" icon={DeleteIcon}>
+              Label
+            </Button>
+            <Button tone="critical" disabled icon={DeleteIcon}>
+              Label
+            </Button>
+            <Button tone="critical" disclosure>
+              Label
+            </Button>
+            <Button
+              tone="critical"
+              icon={DeleteIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              tone="critical"
+              disabled
+              icon={DeleteIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
+        </Card>
+      </>
+    );
+  },
+};
+
+export const Plain = {
+  render() {
+    return (
       <Box padding="400">
         <InlineStack gap="400" blockAlign="end">
-          <Button>Label</Button>
-          <Button disabled>Label</Button>
-          <Button icon={PlusIcon}>Label</Button>
-          <Button disabled icon={PlusIcon}>
+          <Button variant="plain">Label</Button>
+          <Button variant="plain" disabled>
             Label
           </Button>
-          <Button disclosure>Label</Button>
+          <Button variant="plain" icon={PlusCircleIcon}>
+            Label
+          </Button>
+          <Button variant="plain" disabled icon={PlusCircleIcon}>
+            Label
+          </Button>
+          <Button variant="plain" disclosure>
+            Label
+          </Button>
+          <Button variant="plain" disclosure disabled>
+            Label
+          </Button>
           <Button
+            variant="plain"
             icon={XSmallIcon}
             onClick={() => {}}
             accessibilityLabel="Dismiss"
           />
           <Button
+            variant="plain"
             disabled
-            icon={EditIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Box>
-      <Card>
-        <InlineStack gap="400" blockAlign="end">
-          <Button>Label</Button>
-          <Button disabled>Label</Button>
-          <Button icon={PlusIcon}>Label</Button>
-          <Button disabled icon={PlusIcon}>
-            Label
-          </Button>
-          <Button disclosure>Label</Button>
-          <Button
             icon={XSmallIcon}
             onClick={() => {}}
             accessibilityLabel="Dismiss"
           />
-          <Button
-            disabled
-            icon={EditIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Card>
-    </>
-  );
-}
-
-export function Critical() {
-  return (
-    <>
-      <Box padding="400">
-        <InlineStack gap="400" blockAlign="end">
-          <Button tone="critical">Label</Button>
-          <Button tone="critical" disabled>
-            Label
-          </Button>
-          <Button tone="critical" icon={DeleteIcon}>
-            Label
-          </Button>
-          <Button tone="critical" disabled icon={DeleteIcon}>
-            Label
-          </Button>
-          <Button tone="critical" disclosure>
-            Label
-          </Button>
-          <Button
-            tone="critical"
-            icon={DeleteIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            disabled
-            tone="critical"
-            icon={DeleteIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
         </InlineStack>
       </Box>
-      <Card>
-        <InlineStack gap="400" blockAlign="end">
-          <Button tone="critical">Label</Button>
-          <Button tone="critical" disabled>
-            Label
-          </Button>
-          <Button tone="critical" icon={DeleteIcon}>
-            Label
-          </Button>
-          <Button tone="critical" disabled icon={DeleteIcon}>
-            Label
-          </Button>
-          <Button tone="critical" disclosure>
-            Label
-          </Button>
-          <Button
-            tone="critical"
-            icon={DeleteIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            tone="critical"
-            disabled
-            icon={DeleteIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Card>
-    </>
-  );
-}
+    );
+  },
+};
 
-export function Plain() {
-  return (
-    <Box padding="400">
-      <InlineStack gap="400" blockAlign="end">
-        <Button variant="plain">Label</Button>
-        <Button variant="plain" disabled>
-          Label
-        </Button>
-        <Button variant="plain" icon={PlusCircleIcon}>
-          Label
-        </Button>
-        <Button variant="plain" disabled icon={PlusCircleIcon}>
-          Label
-        </Button>
-        <Button variant="plain" disclosure>
-          Label
-        </Button>
-        <Button variant="plain" disclosure disabled>
-          Label
-        </Button>
-        <Button
-          variant="plain"
-          icon={XSmallIcon}
-          onClick={() => {}}
-          accessibilityLabel="Dismiss"
-        />
-        <Button
-          variant="plain"
-          disabled
-          icon={XSmallIcon}
-          onClick={() => {}}
-          accessibilityLabel="Dismiss"
-        />
-      </InlineStack>
-    </Box>
-  );
-}
-
-export function MonochromePlain() {
-  return (
-    <Box padding="400">
-      <InlineStack gap="400" blockAlign="center">
-        <Button variant="monochromePlain">Default</Button>
-        <Button variant="monochromePlain" icon={PlusCircleIcon}>
-          With icon
-        </Button>
-        <Button variant="monochromePlain" disabled icon={PlusCircleIcon}>
-          Disabled with icon
-        </Button>
-        <Button variant="monochromePlain" disclosure>
-          Disclosure
-        </Button>
-        <Box color="text-success">
+export const MonochromePlain = {
+  render() {
+    return (
+      <Box padding="400">
+        <InlineStack gap="400" blockAlign="center">
+          <Button variant="monochromePlain">Default</Button>
+          <Button variant="monochromePlain" icon={PlusCircleIcon}>
+            With icon
+          </Button>
+          <Button variant="monochromePlain" disabled icon={PlusCircleIcon}>
+            Disabled with icon
+          </Button>
           <Button variant="monochromePlain" disclosure>
-            Inherited color
+            Disclosure
           </Button>
+          <Box color="text-success">
+            <Button variant="monochromePlain" disclosure>
+              Inherited color
+            </Button>
+          </Box>
+          <Box color="text-magic">
+            <Button
+              variant="monochromePlain"
+              icon={MagicIcon}
+              accessibilityLabel="Apply suggestion"
+            />
+          </Box>
+        </InlineStack>
+      </Box>
+    );
+  },
+};
+
+export const Tertiary = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <Box padding="400">
+          <InlineStack gap="400" blockAlign="end">
+            <Button variant="tertiary">Label</Button>
+            <Button variant="tertiary" disabled>
+              Label
+            </Button>
+            <Button variant="tertiary" icon={PlusCircleIcon}>
+              Label
+            </Button>
+            <Button variant="tertiary" disabled icon={PlusCircleIcon}>
+              Label
+            </Button>
+            <Button variant="tertiary" disclosure>
+              Label
+            </Button>
+            <Button
+              variant="tertiary"
+              icon={XSmallIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              variant="tertiary"
+              icon={EditIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
         </Box>
-        <Box color="text-magic">
-          <Button
-            variant="monochromePlain"
-            icon={MagicIcon}
-            accessibilityLabel="Apply suggestion"
-          />
+        <Card>
+          <InlineStack gap="400" blockAlign="end">
+            <Button variant="tertiary">Label</Button>
+            <Button variant="tertiary" disabled>
+              Label
+            </Button>
+            <Button variant="tertiary" icon={PlusCircleIcon}>
+              Label
+            </Button>
+            <Button variant="tertiary" disabled icon={PlusCircleIcon}>
+              Label
+            </Button>
+            <Button variant="tertiary" disclosure>
+              Label
+            </Button>
+            <Button
+              variant="tertiary"
+              icon={XSmallIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              variant="tertiary"
+              icon={EditIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
+        </Card>
+      </BlockStack>
+    );
+  },
+};
+
+export const TertiaryCritical = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <Box padding="400">
+          <InlineStack gap="400" blockAlign="end">
+            <Button variant="tertiary" tone="critical">
+              Label
+            </Button>
+            <Button variant="tertiary" tone="critical" disabled>
+              Label
+            </Button>
+            <Button variant="tertiary" tone="critical" icon={DeleteIcon}>
+              Label
+            </Button>
+            <Button
+              variant="tertiary"
+              tone="critical"
+              disabled
+              icon={DeleteIcon}
+            >
+              Label
+            </Button>
+            <Button variant="tertiary" tone="critical" disclosure>
+              Label
+            </Button>
+            <Button
+              variant="tertiary"
+              tone="critical"
+              icon={DeleteIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              variant="tertiary"
+              tone="critical"
+              icon={DeleteIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
         </Box>
-      </InlineStack>
-    </Box>
-  );
-}
+        <Card>
+          <InlineStack gap="400" blockAlign="end">
+            <Button variant="tertiary" tone="critical">
+              Label
+            </Button>
+            <Button variant="tertiary" tone="critical" disabled>
+              Label
+            </Button>
+            <Button variant="tertiary" tone="critical" icon={DeleteIcon}>
+              Label
+            </Button>
+            <Button
+              variant="tertiary"
+              tone="critical"
+              disabled
+              icon={DeleteIcon}
+            >
+              Label
+            </Button>
+            <Button variant="tertiary" tone="critical" disclosure>
+              Label
+            </Button>
+            <Button
+              variant="tertiary"
+              tone="critical"
+              icon={DeleteIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              variant="tertiary"
+              tone="critical"
+              icon={DeleteIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
+        </Card>
+      </BlockStack>
+    );
+  },
+};
 
-export function Tertiary() {
-  return (
-    <BlockStack gap="400">
-      <Box padding="400">
-        <InlineStack gap="400" blockAlign="end">
-          <Button variant="tertiary">Label</Button>
-          <Button variant="tertiary" disabled>
-            Label
-          </Button>
-          <Button variant="tertiary" icon={PlusCircleIcon}>
-            Label
-          </Button>
-          <Button variant="tertiary" disabled icon={PlusCircleIcon}>
-            Label
-          </Button>
-          <Button variant="tertiary" disclosure>
-            Label
-          </Button>
-          <Button
-            variant="tertiary"
-            icon={XSmallIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            disabled
-            variant="tertiary"
-            icon={EditIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Box>
-      <Card>
-        <InlineStack gap="400" blockAlign="end">
-          <Button variant="tertiary">Label</Button>
-          <Button variant="tertiary" disabled>
-            Label
-          </Button>
-          <Button variant="tertiary" icon={PlusCircleIcon}>
-            Label
-          </Button>
-          <Button variant="tertiary" disabled icon={PlusCircleIcon}>
-            Label
-          </Button>
-          <Button variant="tertiary" disclosure>
-            Label
-          </Button>
-          <Button
-            variant="tertiary"
-            icon={XSmallIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            disabled
-            variant="tertiary"
-            icon={EditIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Card>
-    </BlockStack>
-  );
-}
-
-export function TertiaryCritical() {
-  return (
-    <BlockStack gap="400">
-      <Box padding="400">
-        <InlineStack gap="400" blockAlign="end">
-          <Button variant="tertiary" tone="critical">
-            Label
-          </Button>
-          <Button variant="tertiary" tone="critical" disabled>
-            Label
-          </Button>
-          <Button variant="tertiary" tone="critical" icon={DeleteIcon}>
-            Label
-          </Button>
-          <Button variant="tertiary" tone="critical" disabled icon={DeleteIcon}>
-            Label
-          </Button>
-          <Button variant="tertiary" tone="critical" disclosure>
-            Label
-          </Button>
-          <Button
-            variant="tertiary"
-            tone="critical"
-            icon={DeleteIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            disabled
-            variant="tertiary"
-            tone="critical"
-            icon={DeleteIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Box>
-      <Card>
-        <InlineStack gap="400" blockAlign="end">
-          <Button variant="tertiary" tone="critical">
-            Label
-          </Button>
-          <Button variant="tertiary" tone="critical" disabled>
-            Label
-          </Button>
-          <Button variant="tertiary" tone="critical" icon={DeleteIcon}>
-            Label
-          </Button>
-          <Button variant="tertiary" tone="critical" disabled icon={DeleteIcon}>
-            Label
-          </Button>
-          <Button variant="tertiary" tone="critical" disclosure>
-            Label
-          </Button>
-          <Button
-            variant="tertiary"
-            tone="critical"
-            icon={DeleteIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            disabled
-            variant="tertiary"
-            tone="critical"
-            icon={DeleteIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Card>
-    </BlockStack>
-  );
-}
-
-export function PlainCritical() {
-  return (
-    <InlineStack gap="400" blockAlign="end">
-      <Button variant="plain" tone="critical">
-        Label
-      </Button>
-      <Button variant="plain" tone="critical" disabled>
-        Label
-      </Button>
-      <Button variant="plain" tone="critical" icon={DeleteIcon}>
-        Label
-      </Button>
-      <Button variant="plain" tone="critical" disabled icon={DeleteIcon}>
-        Label
-      </Button>
-      <Button variant="plain" tone="critical" disclosure>
-        Label
-      </Button>
-      <Button variant="plain" tone="critical" disclosure disabled>
-        Label
-      </Button>
-      <Button
-        variant="plain"
-        tone="critical"
-        icon={DeleteIcon}
-        onClick={() => {}}
-        accessibilityLabel="Dismiss"
-      />
-      <Button
-        variant="plain"
-        tone="critical"
-        disabled
-        icon={DeleteIcon}
-        onClick={() => {}}
-        accessibilityLabel="Dismiss"
-      />
-    </InlineStack>
-  );
-}
-
-export function Primary() {
-  return (
-    <BlockStack gap="400">
-      <Box padding="400">
-        <InlineStack gap="400" blockAlign="end">
-          <Button variant="primary">Label</Button>
-          <Button variant="primary" disabled>
-            Label
-          </Button>
-          <Button variant="primary" icon={PlusIcon}>
-            Label
-          </Button>
-          <Button variant="primary" disabled icon={PlusIcon}>
-            Label
-          </Button>
-          <Button variant="primary" disclosure>
-            Label
-          </Button>
-          <Button
-            variant="primary"
-            icon={XSmallIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            disabled
-            variant="primary"
-            icon={EditIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Box>
-      <Card>
-        <InlineStack gap="400" blockAlign="end">
-          <Button variant="primary">Label</Button>
-          <Button variant="primary" disabled>
-            Label
-          </Button>
-          <Button variant="primary" icon={PlusIcon}>
-            Label
-          </Button>
-          <Button variant="primary" disabled icon={PlusIcon}>
-            Label
-          </Button>
-          <Button variant="primary" disclosure>
-            Label
-          </Button>
-          <Button
-            variant="primary"
-            icon={XSmallIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-          <Button
-            disabled
-            variant="primary"
-            icon={EditIcon}
-            onClick={() => {}}
-            accessibilityLabel="Dismiss"
-          />
-        </InlineStack>
-      </Card>
-    </BlockStack>
-  );
-}
-
-export function PrimarySuccess() {
-  return (
-    <Box padding="400">
+export const PlainCritical = {
+  render() {
+    return (
       <InlineStack gap="400" blockAlign="end">
-        <Button variant="primary" tone="success">
+        <Button variant="plain" tone="critical">
           Label
         </Button>
-        <Button variant="primary" tone="success" disabled>
+        <Button variant="plain" tone="critical" disabled>
           Label
         </Button>
-        <Button variant="primary" tone="success" icon={PlusIcon}>
+        <Button variant="plain" tone="critical" icon={DeleteIcon}>
           Label
         </Button>
-        <Button variant="primary" tone="success" disabled icon={PlusIcon}>
+        <Button variant="plain" tone="critical" disabled icon={DeleteIcon}>
           Label
         </Button>
-        <Button variant="primary" tone="success" disclosure>
+        <Button variant="plain" tone="critical" disclosure>
           Label
         </Button>
-        <Button
-          variant="primary"
-          tone="success"
-          icon={XSmallIcon}
-          onClick={() => {}}
-          accessibilityLabel="Dismiss"
-        />
-        <Button
-          disabled
-          variant="primary"
-          tone="success"
-          icon={EditIcon}
-          onClick={() => {}}
-          accessibilityLabel="Dismiss"
-        />
-      </InlineStack>
-    </Box>
-  );
-}
-
-export function PrimaryCritical() {
-  return (
-    <Box padding="400">
-      <InlineStack gap="400" blockAlign="end">
-        <Button variant="primary" tone="critical">
-          Label
-        </Button>
-        <Button variant="primary" tone="critical" disabled>
-          Label
-        </Button>
-        <Button variant="primary" tone="critical" icon={DeleteIcon}>
-          Label
-        </Button>
-        <Button variant="primary" tone="critical" disabled icon={DeleteIcon}>
-          Label
-        </Button>
-        <Button variant="primary" tone="critical" disclosure>
+        <Button variant="plain" tone="critical" disclosure disabled>
           Label
         </Button>
         <Button
-          variant="primary"
+          variant="plain"
           tone="critical"
           icon={DeleteIcon}
           onClick={() => {}}
           accessibilityLabel="Dismiss"
         />
         <Button
-          disabled
-          variant="primary"
+          variant="plain"
           tone="critical"
+          disabled
           icon={DeleteIcon}
           onClick={() => {}}
           accessibilityLabel="Dismiss"
         />
       </InlineStack>
-    </Box>
-  );
-}
+    );
+  },
+};
 
-export function Micro() {
-  return (
-    <InlineStack gap="400">
-      <Button size="micro">Label</Button>
-      <Button variant="primary" size="micro">
-        Label
-      </Button>
-      <Button tone="critical" size="micro">
-        Label
-      </Button>
-      <Button variant="plain" size="micro">
-        Label
-      </Button>
-      <Button size="micro" accessibilityLabel="Edit" icon={EditIcon} />
-    </InlineStack>
-  );
-}
+export const Primary = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <Box padding="400">
+          <InlineStack gap="400" blockAlign="end">
+            <Button variant="primary">Label</Button>
+            <Button variant="primary" disabled>
+              Label
+            </Button>
+            <Button variant="primary" icon={PlusIcon}>
+              Label
+            </Button>
+            <Button variant="primary" disabled icon={PlusIcon}>
+              Label
+            </Button>
+            <Button variant="primary" disclosure>
+              Label
+            </Button>
+            <Button
+              variant="primary"
+              icon={XSmallIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              variant="primary"
+              icon={EditIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
+        </Box>
+        <Card>
+          <InlineStack gap="400" blockAlign="end">
+            <Button variant="primary">Label</Button>
+            <Button variant="primary" disabled>
+              Label
+            </Button>
+            <Button variant="primary" icon={PlusIcon}>
+              Label
+            </Button>
+            <Button variant="primary" disabled icon={PlusIcon}>
+              Label
+            </Button>
+            <Button variant="primary" disclosure>
+              Label
+            </Button>
+            <Button
+              variant="primary"
+              icon={XSmallIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+            <Button
+              disabled
+              variant="primary"
+              icon={EditIcon}
+              onClick={() => {}}
+              accessibilityLabel="Dismiss"
+            />
+          </InlineStack>
+        </Card>
+      </BlockStack>
+    );
+  },
+};
 
-export function Slim() {
-  return (
-    <InlineStack gap="400">
-      <Button size="slim">Label</Button>
-      <Button variant="primary" size="slim">
-        Label
-      </Button>
-      <Button tone="critical" size="slim">
-        Label
-      </Button>
-      <Button variant="plain" size="slim">
-        Label
-      </Button>
-      <Button size="slim" accessibilityLabel="Edit" icon={EditIcon} />
-    </InlineStack>
-  );
-}
+export const PrimarySuccess = {
+  render() {
+    return (
+      <Box padding="400">
+        <InlineStack gap="400" blockAlign="end">
+          <Button variant="primary" tone="success">
+            Label
+          </Button>
+          <Button variant="primary" tone="success" disabled>
+            Label
+          </Button>
+          <Button variant="primary" tone="success" icon={PlusIcon}>
+            Label
+          </Button>
+          <Button variant="primary" tone="success" disabled icon={PlusIcon}>
+            Label
+          </Button>
+          <Button variant="primary" tone="success" disclosure>
+            Label
+          </Button>
+          <Button
+            variant="primary"
+            tone="success"
+            icon={XSmallIcon}
+            onClick={() => {}}
+            accessibilityLabel="Dismiss"
+          />
+          <Button
+            disabled
+            variant="primary"
+            tone="success"
+            icon={EditIcon}
+            onClick={() => {}}
+            accessibilityLabel="Dismiss"
+          />
+        </InlineStack>
+      </Box>
+    );
+  },
+};
 
-export function Large() {
-  return (
-    <InlineStack gap="400">
-      <Button size="large">Label</Button>
-      <Button size="large" variant="primary">
-        Label
-      </Button>
-      <Button size="large" tone="critical">
-        Label
-      </Button>
-      <Button size="large" variant="plain">
-        Label
-      </Button>
-      <Button size="large" accessibilityLabel="Edit" icon={EditIcon} />
-    </InlineStack>
-  );
-}
+export const PrimaryCritical = {
+  render() {
+    return (
+      <Box padding="400">
+        <InlineStack gap="400" blockAlign="end">
+          <Button variant="primary" tone="critical">
+            Label
+          </Button>
+          <Button variant="primary" tone="critical" disabled>
+            Label
+          </Button>
+          <Button variant="primary" tone="critical" icon={DeleteIcon}>
+            Label
+          </Button>
+          <Button variant="primary" tone="critical" disabled icon={DeleteIcon}>
+            Label
+          </Button>
+          <Button variant="primary" tone="critical" disclosure>
+            Label
+          </Button>
+          <Button
+            variant="primary"
+            tone="critical"
+            icon={DeleteIcon}
+            onClick={() => {}}
+            accessibilityLabel="Dismiss"
+          />
+          <Button
+            disabled
+            variant="primary"
+            tone="critical"
+            icon={DeleteIcon}
+            onClick={() => {}}
+            accessibilityLabel="Dismiss"
+          />
+        </InlineStack>
+      </Box>
+    );
+  },
+};
 
-export function FullWidth() {
-  return <Button fullWidth>Add customer</Button>;
-}
+export const Micro = {
+  render() {
+    return (
+      <InlineStack gap="400">
+        <Button size="micro">Label</Button>
+        <Button variant="primary" size="micro">
+          Label
+        </Button>
+        <Button tone="critical" size="micro">
+          Label
+        </Button>
+        <Button variant="plain" size="micro">
+          Label
+        </Button>
+        <Button size="micro" accessibilityLabel="Edit" icon={EditIcon} />
+      </InlineStack>
+    );
+  },
+};
 
-export function TextAligned() {
-  return (
-    <Box maxWidth="200px">
-      <Button variant="plain" textAlign="right">
-        This is a really long string of text that overflows onto the next line.
-      </Button>
-    </Box>
-  );
-}
+export const Slim = {
+  render() {
+    return (
+      <InlineStack gap="400">
+        <Button size="slim">Label</Button>
+        <Button variant="primary" size="slim">
+          Label
+        </Button>
+        <Button tone="critical" size="slim">
+          Label
+        </Button>
+        <Button variant="plain" size="slim">
+          Label
+        </Button>
+        <Button size="slim" accessibilityLabel="Edit" icon={EditIcon} />
+      </InlineStack>
+    );
+  },
+};
 
-export function Pressed() {
-  const [isFirstButtonActive, setIsFirstButtonActive] = useState(true);
+export const Large = {
+  render() {
+    return (
+      <InlineStack gap="400">
+        <Button size="large">Label</Button>
+        <Button size="large" variant="primary">
+          Label
+        </Button>
+        <Button size="large" tone="critical">
+          Label
+        </Button>
+        <Button size="large" variant="plain">
+          Label
+        </Button>
+        <Button size="large" accessibilityLabel="Edit" icon={EditIcon} />
+      </InlineStack>
+    );
+  },
+};
 
-  const handleFirstButtonClick = useCallback(() => {
-    if (isFirstButtonActive) return;
-    setIsFirstButtonActive(true);
-  }, [isFirstButtonActive]);
+export const FullWidth = {
+  render() {
+    return <Button fullWidth>Add customer</Button>;
+  },
+};
 
-  const handleSecondButtonClick = useCallback(() => {
-    if (!isFirstButtonActive) return;
-    setIsFirstButtonActive(false);
-  }, [isFirstButtonActive]);
+export const TextAligned = {
+  render() {
+    return (
+      <Box maxWidth="200px">
+        <Button variant="plain" textAlign="right">
+          This is a really long string of text that overflows onto the next
+          line.
+        </Button>
+      </Box>
+    );
+  },
+};
 
-  return (
-    <ButtonGroup variant="segmented">
-      <Button pressed={isFirstButtonActive} onClick={handleFirstButtonClick}>
-        First button
-      </Button>
-      <Button pressed={!isFirstButtonActive} onClick={handleSecondButtonClick}>
-        Second button
-      </Button>
-    </ButtonGroup>
-  );
-}
+export const Pressed = {
+  render() {
+    const [isFirstButtonActive, setIsFirstButtonActive] = useState(true);
 
-export function PlainDisclosure() {
-  const [expanded, setExpanded] = useState(false);
+    const handleFirstButtonClick = useCallback(() => {
+      if (isFirstButtonActive) return;
+      setIsFirstButtonActive(true);
+    }, [isFirstButtonActive]);
 
-  return (
-    <Button
-      variant="plain"
-      disclosure={expanded ? 'up' : 'down'}
-      onClick={() => {
-        setExpanded(!expanded);
-      }}
-    >
-      {expanded ? 'Show less' : 'Show more'}
-    </Button>
-  );
-}
+    const handleSecondButtonClick = useCallback(() => {
+      if (!isFirstButtonActive) return;
+      setIsFirstButtonActive(false);
+    }, [isFirstButtonActive]);
 
-export function RightAlignedDisclosure() {
-  const [expanded, setExpanded] = useState(false);
+    return (
+      <ButtonGroup variant="segmented">
+        <Button pressed={isFirstButtonActive} onClick={handleFirstButtonClick}>
+          First button
+        </Button>
+        <Button
+          pressed={!isFirstButtonActive}
+          onClick={handleSecondButtonClick}
+        >
+          Second button
+        </Button>
+      </ButtonGroup>
+    );
+  },
+};
 
-  return (
-    <div style={{width: '200px'}}>
+export const PlainDisclosure = {
+  render() {
+    const [expanded, setExpanded] = useState(false);
+
+    return (
       <Button
-        fullWidth
-        textAlign="left"
+        variant="plain"
         disclosure={expanded ? 'up' : 'down'}
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => {
+          setExpanded(!expanded);
+        }}
       >
         {expanded ? 'Show less' : 'Show more'}
       </Button>
-    </div>
-  );
-}
+    );
+  },
+};
 
-export function SelectDisclosure() {
-  return (
-    <div>
-      <Button disclosure="select" onClick={() => console.log('Open Popover')}>
-        Select options
-      </Button>
-    </div>
-  );
-}
+export const RightAlignedDisclosure = {
+  render() {
+    const [expanded, setExpanded] = useState(false);
 
-export function Split() {
-  const [active, setActive] = React.useState<string | null>(null);
+    return (
+      <div style={{width: '200px'}}>
+        <Button
+          fullWidth
+          textAlign="left"
+          disclosure={expanded ? 'up' : 'down'}
+          onClick={() => setExpanded(!expanded)}
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </Button>
+      </div>
+    );
+  },
+};
 
-  const toggleActive = (id: string) => () => {
-    setActive((activeId) => (activeId !== id ? id : null));
-  };
-  return (
-    <div>
-      <InlineStack gap="400">
-        <ButtonGroup variant="segmented">
-          <Button variant="primary">Save</Button>
+export const SelectDisclosure = {
+  render() {
+    return (
+      <div>
+        <Button disclosure="select" onClick={() => console.log('Open Popover')}>
+          Select options
+        </Button>
+      </div>
+    );
+  },
+};
 
-          <Popover
-            active={active === 'popover1'}
-            preferredAlignment="right"
-            activator={
-              <Button
-                variant="primary"
-                onClick={toggleActive('popover1')}
-                icon={ChevronDownIcon}
-                accessibilityLabel="Other save actions"
+export const Split = {
+  render() {
+    const [active, setActive] = React.useState<string | null>(null);
+
+    const toggleActive = (id: string) => () => {
+      setActive((activeId) => (activeId !== id ? id : null));
+    };
+    return (
+      <div>
+        <InlineStack gap="400">
+          <ButtonGroup variant="segmented">
+            <Button variant="primary">Save</Button>
+
+            <Popover
+              active={active === 'popover1'}
+              preferredAlignment="right"
+              activator={
+                <Button
+                  variant="primary"
+                  onClick={toggleActive('popover1')}
+                  icon={ChevronDownIcon}
+                  accessibilityLabel="Other save actions"
+                />
+              }
+              autofocusTarget="first-node"
+              onClose={toggleActive('popover1')}
+            >
+              <ActionList
+                actionRole="menuitem"
+                items={[{content: 'Save as draft'}]}
               />
-            }
-            autofocusTarget="first-node"
-            onClose={toggleActive('popover1')}
-          >
-            <ActionList
-              actionRole="menuitem"
-              items={[{content: 'Save as draft'}]}
-            />
-          </Popover>
-        </ButtonGroup>
+            </Popover>
+          </ButtonGroup>
 
-        <ButtonGroup variant="segmented">
-          <Button>Save</Button>
+          <ButtonGroup variant="segmented">
+            <Button>Save</Button>
 
-          <Popover
-            active={active === 'popover2'}
-            preferredAlignment="right"
-            activator={
-              <Button
-                onClick={toggleActive('popover2')}
-                icon={ChevronDownIcon}
-                accessibilityLabel="Other save actions"
+            <Popover
+              active={active === 'popover2'}
+              preferredAlignment="right"
+              activator={
+                <Button
+                  onClick={toggleActive('popover2')}
+                  icon={ChevronDownIcon}
+                  accessibilityLabel="Other save actions"
+                />
+              }
+              autofocusTarget="first-node"
+              onClose={toggleActive('popover2')}
+            >
+              <ActionList
+                actionRole="menuitem"
+                items={[{content: 'Save as draft'}]}
               />
-            }
-            autofocusTarget="first-node"
-            onClose={toggleActive('popover2')}
-          >
-            <ActionList
-              actionRole="menuitem"
-              items={[{content: 'Save as draft'}]}
-            />
-          </Popover>
-        </ButtonGroup>
-      </InlineStack>
-    </div>
-  );
-}
+            </Popover>
+          </ButtonGroup>
+        </InlineStack>
+      </div>
+    );
+  },
+};
 
-export function DisabledState() {
-  return (
-    <ButtonGroup>
-      <Button disabled>Buy shipping label</Button>
-      <Button variant="primary" disabled>
-        Buy shipping label
-      </Button>
-      <Button tone="critical" disabled>
-        Buy shipping label
-      </Button>
-      <span style={{color: '#bf0711'}}>
+export const DisabledState = {
+  render() {
+    return (
+      <ButtonGroup>
         <Button disabled>Buy shipping label</Button>
-      </span>
-      <Button variant="plain" disabled>
-        Buy shipping label
-      </Button>
-      <Button variant="plain" tone="critical" disabled>
-        Buy shipping label
-      </Button>
-      {/* Visual check to ensure the button color is not inherited from the parent */}
-      <Box color="text-critical">
-        <Button variant="monochromePlain" disabled icon={XSmallIcon}>
+        <Button variant="primary" disabled>
           Buy shipping label
         </Button>
-      </Box>
-    </ButtonGroup>
-  );
-}
+        <Button tone="critical" disabled>
+          Buy shipping label
+        </Button>
+        <span style={{color: '#bf0711'}}>
+          <Button disabled>Buy shipping label</Button>
+        </span>
+        <Button variant="plain" disabled>
+          Buy shipping label
+        </Button>
+        <Button variant="plain" tone="critical" disabled>
+          Buy shipping label
+        </Button>
+        {/* Visual check to ensure the button color is not inherited from the parent */}
+        <Box color="text-critical">
+          <Button variant="monochromePlain" disabled icon={XSmallIcon}>
+            Buy shipping label
+          </Button>
+        </Box>
+      </ButtonGroup>
+    );
+  },
+};
 
-export function LoadingState() {
-  return (
-    <InlineStack gap="400">
-      <Button loading>Save product</Button>
-      <Button variant="primary" loading>
-        Save product
-      </Button>
-      <Button variant="plain" loading>
-        Save product
-      </Button>
-    </InlineStack>
-  );
-}
+export const LoadingState = {
+  render() {
+    return (
+      <InlineStack gap="400">
+        <Button loading>Save product</Button>
+        <Button variant="primary" loading>
+          Save product
+        </Button>
+        <Button variant="plain" loading>
+          Save product
+        </Button>
+      </InlineStack>
+    );
+  },
+};
 
-export function CopyToClipboard() {
-  const [copy, status] = useCopyToClipboard({
-    defaultValue: 'hello@example.com',
-  });
+export const CopyToClipboard = {
+  render() {
+    const [copy, status] = useCopyToClipboard({
+      defaultValue: 'hello@example.com',
+    });
 
-  const ref = useRef(null);
-  const isFocusedIn = useFocusIn(ref);
-  const isHovered = useHover(ref);
-  const isMouseDevice = useMediaQuery('mouse');
-  const isMouseHovered = isMouseDevice ? isHovered : true;
+    const ref = useRef(null);
+    const isFocusedIn = useFocusIn(ref);
+    const isHovered = useHover(ref);
+    const isMouseDevice = useMediaQuery('mouse');
+    const isMouseHovered = isMouseDevice ? isHovered : true;
 
-  return (
-    <div style={{maxWidth: 300, paddingTop: 100}}>
-      <Card>
-        <div ref={ref}>
-          <InlineStack align="space-between" gap="200" blockAlign="center">
-            <Link removeUnderline>hello@example.com</Link>
-            <div
-              style={{
-                opacity:
-                  isMouseHovered || isFocusedIn || status === 'copied' ? 1 : 0,
-                transition:
-                  isMouseHovered || isFocusedIn
-                    ? 'var(--p-motion-duration-100) var(--p-motion-ease) opacity'
-                    : 'none',
-              }}
-            >
-              <Tooltip
-                dismissOnMouseOut
-                hoverDelay={500}
-                preferredPosition="above"
-                content="Copy"
-                active={status === 'copied' ? false : undefined}
-                activatorWrapper="div"
+    return (
+      <div style={{maxWidth: 300, paddingTop: 100}}>
+        <Card>
+          <div ref={ref}>
+            <InlineStack align="space-between" gap="200" blockAlign="center">
+              <Link removeUnderline>hello@example.com</Link>
+              <div
+                style={{
+                  opacity:
+                    isMouseHovered || isFocusedIn || status === 'copied'
+                      ? 1
+                      : 0,
+                  transition:
+                    isMouseHovered || isFocusedIn
+                      ? 'var(--p-motion-duration-100) var(--p-motion-ease) opacity'
+                      : 'none',
+                }}
               >
-                <Button
-                  variant="tertiary"
-                  accessibilityLabel="Copy email address"
-                  onClick={copy}
-                  icon={status === 'copied' ? CheckIcon : ClipboardIcon}
-                />
-              </Tooltip>
-            </div>
-          </InlineStack>
-        </div>
-      </Card>
-    </div>
-  );
-}
+                <Tooltip
+                  dismissOnMouseOut
+                  hoverDelay={500}
+                  preferredPosition="above"
+                  content="Copy"
+                  active={status === 'copied' ? false : undefined}
+                  activatorWrapper="div"
+                >
+                  <Button
+                    variant="tertiary"
+                    accessibilityLabel="Copy email address"
+                    onClick={copy}
+                    icon={status === 'copied' ? CheckIcon : ClipboardIcon}
+                  />
+                </Tooltip>
+              </div>
+            </InlineStack>
+          </div>
+        </Card>
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,196 +1,206 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Button, ButtonGroup, Icon, BlockStack, Text} from '@shopify/polaris';
 import {DeleteIcon} from '@shopify/polaris-icons';
 
 export default {
   component: ButtonGroup,
-} as ComponentMeta<typeof ButtonGroup>;
+} as Meta<typeof ButtonGroup>;
 
-export function Default() {
-  return (
-    <ButtonGroup>
-      <Button>Cancel</Button>
-      <Button variant="primary">Save</Button>
-    </ButtonGroup>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <ButtonGroup>
+        <Button>Cancel</Button>
+        <Button variant="primary">Save</Button>
+      </ButtonGroup>
+    );
+  },
+};
 
-export function WithSegmentedButtons() {
-  const [activeButtonIndex, setActiveButtonIndex] = useState(0);
+export const WithSegmentedButtons = {
+  render() {
+    const [activeButtonIndex, setActiveButtonIndex] = useState(0);
 
-  const handleButtonClick = useCallback(
-    (index: number) => {
-      if (activeButtonIndex === index) return;
-      setActiveButtonIndex(index);
-    },
-    [activeButtonIndex],
-  );
-  return (
-    <div>
-      <ButtonGroup variant="segmented">
-        <Button size="slim">Bold</Button>
-        <Button size="slim" pressed>
-          Italic
-        </Button>
-        <Button size="slim">Underline</Button>
-        <Button
-          size="slim"
-          tone="critical"
-          icon={<Icon source={DeleteIcon} />}
-          accessibilityLabel="Delete"
-        />
-      </ButtonGroup>
-      <br />
-      <ButtonGroup variant="segmented">
-        <Button
-          pressed={activeButtonIndex === 0}
-          onClick={() => handleButtonClick(0)}
-        >
-          Mercury
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 1}
-          onClick={() => handleButtonClick(1)}
-        >
-          Venus
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 2}
-          onClick={() => handleButtonClick(2)}
-        >
-          Earth
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 3}
-          onClick={() => handleButtonClick(3)}
-        >
-          Mars
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 4}
-          onClick={() => handleButtonClick(4)}
-        >
-          Jupiter
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 5}
-          onClick={() => handleButtonClick(5)}
-        >
-          Saturn
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 6}
-          onClick={() => handleButtonClick(6)}
-        >
-          Uranus
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 7}
-          onClick={() => handleButtonClick(7)}
-        >
-          Neptune
-        </Button>
-      </ButtonGroup>
-      <br />
-      <ButtonGroup variant="segmented" fullWidth>
-        <Button
-          pressed={activeButtonIndex === 8}
-          onClick={() => handleButtonClick(8)}
-        >
-          Bold
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 9}
-          onClick={() => handleButtonClick(9)}
-        >
-          Italic
-        </Button>
-        <Button
-          pressed={activeButtonIndex === 10}
-          onClick={() => handleButtonClick(10)}
-        >
-          Underline
-        </Button>
-      </ButtonGroup>
-    </div>
-  );
-}
-
-export function OutlineWithSegmentedButtons() {
-  return (
-    <ButtonGroup variant="segmented">
-      <Button>Bold</Button>
-      <Button>Italic</Button>
-      <Button>Underline</Button>
-    </ButtonGroup>
-  );
-}
-
-export function WithAllGaps() {
-  return (
-    <BlockStack gap="400">
-      <ButtonGroup gap="extraTight" connectedTop>
-        <Button>Bold</Button>
-        <Button>Italic</Button>
-        <Button>Underline</Button>
-      </ButtonGroup>
-      <ButtonGroup gap="tight">
-        <Button>Bold</Button>
-        <Button>Italic</Button>
-        <Button>Underline</Button>
-      </ButtonGroup>
-      <ButtonGroup gap="loose">
-        <Button>Bold</Button>
-        <Button>Italic</Button>
-        <Button>Underline</Button>
-      </ButtonGroup>
-    </BlockStack>
-  );
-}
-
-export function NoWrapButtons() {
-  return (
-    <>
-      <Text as="p" variant="bodyMd">
-        Default
-      </Text>
-      <div
-        style={{
-          width: '300px',
-          border: '2px solid blue',
-          padding: '10px',
-          overflowX: 'scroll',
-        }}
-      >
-        <ButtonGroup>
-          <Button>Fifth</Button>
-          <Button>Fourth</Button>
-          <Button>Third</Button>
-          <Button>Second</Button>
-          <Button variant="primary">First</Button>
+    const handleButtonClick = useCallback(
+      (index: number) => {
+        if (activeButtonIndex === index) return;
+        setActiveButtonIndex(index);
+      },
+      [activeButtonIndex],
+    );
+    return (
+      <div>
+        <ButtonGroup variant="segmented">
+          <Button size="slim">Bold</Button>
+          <Button size="slim" pressed>
+            Italic
+          </Button>
+          <Button size="slim">Underline</Button>
+          <Button
+            size="slim"
+            tone="critical"
+            icon={<Icon source={DeleteIcon} />}
+            accessibilityLabel="Delete"
+          />
+        </ButtonGroup>
+        <br />
+        <ButtonGroup variant="segmented">
+          <Button
+            pressed={activeButtonIndex === 0}
+            onClick={() => handleButtonClick(0)}
+          >
+            Mercury
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 1}
+            onClick={() => handleButtonClick(1)}
+          >
+            Venus
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 2}
+            onClick={() => handleButtonClick(2)}
+          >
+            Earth
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 3}
+            onClick={() => handleButtonClick(3)}
+          >
+            Mars
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 4}
+            onClick={() => handleButtonClick(4)}
+          >
+            Jupiter
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 5}
+            onClick={() => handleButtonClick(5)}
+          >
+            Saturn
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 6}
+            onClick={() => handleButtonClick(6)}
+          >
+            Uranus
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 7}
+            onClick={() => handleButtonClick(7)}
+          >
+            Neptune
+          </Button>
+        </ButtonGroup>
+        <br />
+        <ButtonGroup variant="segmented" fullWidth>
+          <Button
+            pressed={activeButtonIndex === 8}
+            onClick={() => handleButtonClick(8)}
+          >
+            Bold
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 9}
+            onClick={() => handleButtonClick(9)}
+          >
+            Italic
+          </Button>
+          <Button
+            pressed={activeButtonIndex === 10}
+            onClick={() => handleButtonClick(10)}
+          >
+            Underline
+          </Button>
         </ButtonGroup>
       </div>
-      <br />
-      <Text as="p" variant="bodyMd">
-        With noWrap
-      </Text>
-      <div
-        style={{
-          width: '300px',
-          border: '2px solid blue',
-          padding: '10px',
-          overflowX: 'scroll',
-        }}
-      >
-        <ButtonGroup noWrap>
-          <Button>Fifth</Button>
-          <Button>Fourth</Button>
-          <Button>Third</Button>
-          <Button>Second</Button>
-          <Button variant="primary">First</Button>
+    );
+  },
+};
+
+export const OutlineWithSegmentedButtons = {
+  render() {
+    return (
+      <ButtonGroup variant="segmented">
+        <Button>Bold</Button>
+        <Button>Italic</Button>
+        <Button>Underline</Button>
+      </ButtonGroup>
+    );
+  },
+};
+
+export const WithAllGaps = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <ButtonGroup gap="extraTight" connectedTop>
+          <Button>Bold</Button>
+          <Button>Italic</Button>
+          <Button>Underline</Button>
         </ButtonGroup>
-      </div>
-    </>
-  );
-}
+        <ButtonGroup gap="tight">
+          <Button>Bold</Button>
+          <Button>Italic</Button>
+          <Button>Underline</Button>
+        </ButtonGroup>
+        <ButtonGroup gap="loose">
+          <Button>Bold</Button>
+          <Button>Italic</Button>
+          <Button>Underline</Button>
+        </ButtonGroup>
+      </BlockStack>
+    );
+  },
+};
+
+export const NoWrapButtons = {
+  render() {
+    return (
+      <>
+        <Text as="p" variant="bodyMd">
+          Default
+        </Text>
+        <div
+          style={{
+            width: '300px',
+            border: '2px solid blue',
+            padding: '10px',
+            overflowX: 'scroll',
+          }}
+        >
+          <ButtonGroup>
+            <Button>Fifth</Button>
+            <Button>Fourth</Button>
+            <Button>Third</Button>
+            <Button>Second</Button>
+            <Button variant="primary">First</Button>
+          </ButtonGroup>
+        </div>
+        <br />
+        <Text as="p" variant="bodyMd">
+          With noWrap
+        </Text>
+        <div
+          style={{
+            width: '300px',
+            border: '2px solid blue',
+            padding: '10px',
+            overflowX: 'scroll',
+          }}
+        >
+          <ButtonGroup noWrap>
+            <Button>Fifth</Button>
+            <Button>Fourth</Button>
+            <Button>Third</Button>
+            <Button>Second</Button>
+            <Button variant="primary">First</Button>
+          </ButtonGroup>
+        </div>
+      </>
+    );
+  },
+};

--- a/polaris-react/src/components/CalloutCard/CalloutCard.stories.tsx
+++ b/polaris-react/src/components/CalloutCard/CalloutCard.stories.tsx
@@ -7,92 +7,102 @@ export default {
   component: CalloutCard,
 } as Meta<typeof CalloutCard>;
 
-export function Default() {
-  return (
-    <CalloutCard
-      title="Customize the style of your checkout"
-      illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
-      primaryAction={{
-        content: 'Customize checkout',
-        url: 'https://www.shopify.com',
-      }}
-    >
-      <Text as="p" variant="bodyMd">
-        Upload your store’s logo, change colors and fonts, and more.
-      </Text>
-    </CalloutCard>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <CalloutCard
+        title="Customize the style of your checkout"
+        illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
+        primaryAction={{
+          content: 'Customize checkout',
+          url: 'https://www.shopify.com',
+        }}
+      >
+        <Text as="p" variant="bodyMd">
+          Upload your store’s logo, change colors and fonts, and more.
+        </Text>
+      </CalloutCard>
+    );
+  },
+};
 
-export function WithSecondaryAction() {
-  return (
-    <CalloutCard
-      title="Customize the style of your checkout"
-      illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
-      primaryAction={{content: 'Customize checkout'}}
-      secondaryAction={{content: 'Learn more about customizing checkout'}}
-    >
-      <Text as="p" variant="bodyMd">
-        Upload your store’s logo, change colors and fonts, and more.
-      </Text>
-    </CalloutCard>
-  );
-}
+export const WithSecondaryAction = {
+  render() {
+    return (
+      <CalloutCard
+        title="Customize the style of your checkout"
+        illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
+        primaryAction={{content: 'Customize checkout'}}
+        secondaryAction={{content: 'Learn more about customizing checkout'}}
+      >
+        <Text as="p" variant="bodyMd">
+          Upload your store’s logo, change colors and fonts, and more.
+        </Text>
+      </CalloutCard>
+    );
+  },
+};
 
-export function Dismissable() {
-  return (
-    <CalloutCard
-      title="Customize the style of your checkout"
-      illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
-      primaryAction={{content: 'Customize checkout'}}
-      onDismiss={() => {}}
-    >
-      <Text as="p" variant="bodyMd">
-        Upload your store’s logo, change colors and fonts, and more.
-      </Text>
-    </CalloutCard>
-  );
-}
+export const Dismissable = {
+  render() {
+    return (
+      <CalloutCard
+        title="Customize the style of your checkout"
+        illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
+        primaryAction={{content: 'Customize checkout'}}
+        onDismiss={() => {}}
+      >
+        <Text as="p" variant="bodyMd">
+          Upload your store’s logo, change colors and fonts, and more.
+        </Text>
+      </CalloutCard>
+    );
+  },
+};
 
-export function WithCustomTitle() {
-  const customTitle = (
-    <>
-      <span>Customize the style of your checkout </span>
-      <Badge tone="new">New</Badge>
-    </>
-  );
+export const WithCustomTitle = {
+  render() {
+    const customTitle = (
+      <>
+        <span>Customize the style of your checkout </span>
+        <Badge tone="new">New</Badge>
+      </>
+    );
 
-  return (
-    <CalloutCard
-      title={customTitle}
-      illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
-      primaryAction={{content: 'Customize checkout'}}
-    >
-      <Text as="p" variant="bodyMd">
-        Upload your store’s logo, change colors and fonts, and more.
-      </Text>
-    </CalloutCard>
-  );
-}
+    return (
+      <CalloutCard
+        title={customTitle}
+        illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
+        primaryAction={{content: 'Customize checkout'}}
+      >
+        <Text as="p" variant="bodyMd">
+          Upload your store’s logo, change colors and fonts, and more.
+        </Text>
+      </CalloutCard>
+    );
+  },
+};
 
-export function WithIconableActions() {
-  return (
-    <CalloutCard
-      title="Tell us how we're doing"
-      illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
-      primaryAction={{
-        content: 'Good',
-        icon: SmileyHappyIcon,
-      }}
-      secondaryAction={{
-        content: 'Bad',
-        icon: SmileySadIcon,
-        variant: 'secondary',
-      }}
-    >
-      <Text as="p" variant="bodyMd">
-        How do you like our app?
-      </Text>
-    </CalloutCard>
-  );
-}
+export const WithIconableActions = {
+  render() {
+    return (
+      <CalloutCard
+        title="Tell us how we're doing"
+        illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
+        primaryAction={{
+          content: 'Good',
+          icon: SmileyHappyIcon,
+        }}
+        secondaryAction={{
+          content: 'Bad',
+          icon: SmileySadIcon,
+          variant: 'secondary',
+        }}
+      >
+        <Text as="p" variant="bodyMd">
+          How do you like our app?
+        </Text>
+      </CalloutCard>
+    );
+  },
+};

--- a/polaris-react/src/components/Card/Card.stories.tsx
+++ b/polaris-react/src/components/Card/Card.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   ActionList,
   BlockStack,
@@ -26,739 +26,783 @@ import {
 
 export default {
   component: Card,
-} as ComponentMeta<typeof Card>;
+} as Meta<typeof Card>;
 
-export function Default() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Online store dashboard
-        </Text>
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance.
-        </Text>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithResponsiveBorderRadius() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Online store dashboard
-        </Text>
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance.
-        </Text>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithResponsivePadding() {
-  return (
-    <Card padding={{xs: '500', sm: '600', md: '800'}} roundedAbove="sm">
-      <BlockStack gap={{xs: '400', sm: '500'}}>
-        <Text as="h2" variant="headingSm">
-          Online store dashboard
-        </Text>
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance.
-        </Text>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithSubdued() {
-  return (
-    <Card background="bg-surface-secondary" roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Online store dashboard
-        </Text>
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance.
-        </Text>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithSubduedForSecondaryContent() {
-  return (
-    <Card background="bg-surface-secondary" roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h3" variant="headingSm" fontWeight="medium">
-          Deactivated staff accounts
-        </Text>
-        <List>
-          <List.Item>Felix Crafford</List.Item>
-          <List.Item>Ezequiel Manno</List.Item>
-        </List>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithSection() {
-  return (
-    <Card roundedAbove="sm">
-      <Text as="h2" variant="headingSm">
-        Online store dashboard
-      </Text>
-      <Box paddingBlockStart="200">
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance.
-        </Text>
-      </Box>
-    </Card>
-  );
-}
-
-export function WithSubduedSection() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Staff accounts
-        </Text>
-        <Box paddingBlockEnd="200">
-          <List>
-            <List.Item>Felix Crafford</List.Item>
-            <List.Item>Ezequiel Manno</List.Item>
-          </List>
-        </Box>
-      </BlockStack>
-      <Bleed marginBlockEnd="400" marginInline="400">
-        <Box background="bg-surface-secondary" padding="400">
-          <BlockStack gap="200">
-            <Text as="h3" variant="headingSm" fontWeight="medium">
-              Deactivated staff accounts
-            </Text>
-            <List>
-              <List.Item>Felix Crafford</List.Item>
-              <List.Item>Ezequiel Manno</List.Item>
-            </List>
-          </BlockStack>
-        </Box>
-      </Bleed>
-    </Card>
-  );
-}
-
-export function WithMultipleSections() {
-  return (
-    <Card roundedAbove="sm">
-      <Text as="h2" variant="headingSm">
-        Online store dashboard
-      </Text>
-      <Box paddingBlock="200">
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance.
-        </Text>
-      </Box>
-      <Box paddingBlockStart="200">
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance, including sales,
-          visitors, top products, and referrals.
-        </Text>
-      </Box>
-    </Card>
-  );
-}
-
-export function WithMultipleTitledSections() {
-  return (
-    <Card roundedAbove="sm">
-      <Text as="h2" variant="headingSm">
-        Online store dashboard
-      </Text>
-      <Box paddingBlock="200">
+export const Default = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
         <BlockStack gap="200">
-          <Text as="h3" variant="headingSm" fontWeight="medium">
-            Reports
+          <Text as="h2" variant="headingSm">
+            Online store dashboard
           </Text>
           <Text as="p" variant="bodyMd">
             View a summary of your online store’s performance.
           </Text>
         </BlockStack>
-      </Box>
-      <Box paddingBlockStart="200">
+      </Card>
+    );
+  },
+};
+
+export const WithResponsiveBorderRadius = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Online store dashboard
+          </Text>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithResponsivePadding = {
+  render() {
+    return (
+      <Card padding={{xs: '500', sm: '600', md: '800'}} roundedAbove="sm">
+        <BlockStack gap={{xs: '400', sm: '500'}}>
+          <Text as="h2" variant="headingSm">
+            Online store dashboard
+          </Text>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithSubdued = {
+  render() {
+    return (
+      <Card background="bg-surface-secondary" roundedAbove="sm">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Online store dashboard
+          </Text>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithSubduedForSecondaryContent = {
+  render() {
+    return (
+      <Card background="bg-surface-secondary" roundedAbove="sm">
         <BlockStack gap="200">
           <Text as="h3" variant="headingSm" fontWeight="medium">
-            Summary
+            Deactivated staff accounts
           </Text>
+          <List>
+            <List.Item>Felix Crafford</List.Item>
+            <List.Item>Ezequiel Manno</List.Item>
+          </List>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithSection = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <Text as="h2" variant="headingSm">
+          Online store dashboard
+        </Text>
+        <Box paddingBlockStart="200">
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </Box>
+      </Card>
+    );
+  },
+};
+
+export const WithSubduedSection = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Staff accounts
+          </Text>
+          <Box paddingBlockEnd="200">
+            <List>
+              <List.Item>Felix Crafford</List.Item>
+              <List.Item>Ezequiel Manno</List.Item>
+            </List>
+          </Box>
+        </BlockStack>
+        <Bleed marginBlockEnd="400" marginInline="400">
+          <Box background="bg-surface-secondary" padding="400">
+            <BlockStack gap="200">
+              <Text as="h3" variant="headingSm" fontWeight="medium">
+                Deactivated staff accounts
+              </Text>
+              <List>
+                <List.Item>Felix Crafford</List.Item>
+                <List.Item>Ezequiel Manno</List.Item>
+              </List>
+            </BlockStack>
+          </Box>
+        </Bleed>
+      </Card>
+    );
+  },
+};
+
+export const WithMultipleSections = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <Text as="h2" variant="headingSm">
+          Online store dashboard
+        </Text>
+        <Box paddingBlock="200">
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </Box>
+        <Box paddingBlockStart="200">
           <Text as="p" variant="bodyMd">
             View a summary of your online store’s performance, including sales,
             visitors, top products, and referrals.
           </Text>
-        </BlockStack>
-      </Box>
-    </Card>
-  );
-}
+        </Box>
+      </Card>
+    );
+  },
+};
 
-export function WithSubsection() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="400">
-        <BlockStack gap="200">
-          <Text as="h2" variant="headingSm">
-            Customer
-          </Text>
-          <Text as="p" variant="bodyMd">
-            John Smith
-          </Text>
-        </BlockStack>
-        <div>
+export const WithMultipleTitledSections = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <Text as="h2" variant="headingSm">
+          Online store dashboard
+        </Text>
+        <Box paddingBlock="200">
           <BlockStack gap="200">
             <Text as="h3" variant="headingSm" fontWeight="medium">
-              Addresses
+              Reports
             </Text>
-            <div>
-              <Text as="p" variant="bodyMd">
-                123 First St
-              </Text>
-              <Text as="p" variant="bodyMd">
-                Somewhere
-              </Text>
-              <Text as="p" variant="bodyMd">
-                The Universe
-              </Text>
-            </div>
-            <div>
-              <Text as="p" variant="bodyMd">
-                123 Second St
-              </Text>
-              <Text as="p" variant="bodyMd">
-                Somewhere
-              </Text>
-              <Text as="p" variant="bodyMd">
-                The Universe
-              </Text>
-            </div>
+            <Text as="p" variant="bodyMd">
+              View a summary of your online store’s performance.
+            </Text>
           </BlockStack>
-        </div>
-        <div>
-          <Text as="p" variant="bodyMd">
-            A single subsection without a sibling has no visual appearance
-          </Text>
-        </div>
-      </BlockStack>
-    </Card>
-  );
-}
+        </Box>
+        <Box paddingBlockStart="200">
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Summary
+            </Text>
+            <Text as="p" variant="bodyMd">
+              View a summary of your online store’s performance, including
+              sales, visitors, top products, and referrals.
+            </Text>
+          </BlockStack>
+        </Box>
+      </Card>
+    );
+  },
+};
 
-export function WithFlushedSection() {
-  return (
-    <Card roundedAbove="sm">
-      <Bleed marginInline="400" marginBlockStart="400">
-        <Image
-          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
-          alt="a sheet with purple and orange stripes"
-        />
-      </Bleed>
-      <Box paddingBlockStart="400">
-        <Text as="p" variant="bodyMd">
-          You can use sales reports to see information about your customers’
-          orders based on criteria such as sales over time, by channel, or by
-          staff.
-        </Text>
-      </Box>
-    </Card>
-  );
-}
+export const WithSubsection = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="400">
+          <BlockStack gap="200">
+            <Text as="h2" variant="headingSm">
+              Customer
+            </Text>
+            <Text as="p" variant="bodyMd">
+              John Smith
+            </Text>
+          </BlockStack>
+          <div>
+            <BlockStack gap="200">
+              <Text as="h3" variant="headingSm" fontWeight="medium">
+                Addresses
+              </Text>
+              <div>
+                <Text as="p" variant="bodyMd">
+                  123 First St
+                </Text>
+                <Text as="p" variant="bodyMd">
+                  Somewhere
+                </Text>
+                <Text as="p" variant="bodyMd">
+                  The Universe
+                </Text>
+              </div>
+              <div>
+                <Text as="p" variant="bodyMd">
+                  123 Second St
+                </Text>
+                <Text as="p" variant="bodyMd">
+                  Somewhere
+                </Text>
+                <Text as="p" variant="bodyMd">
+                  The Universe
+                </Text>
+              </div>
+            </BlockStack>
+          </div>
+          <div>
+            <Text as="p" variant="bodyMd">
+              A single subsection without a sibling has no visual appearance
+            </Text>
+          </div>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
 
-export function WithFlushedSectionAndSubduedSection() {
-  return (
-    <Card roundedAbove="sm">
-      <Bleed marginInline="400" marginBlock="400">
-        <Image
-          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
-          alt="a sheet with purple and orange stripes"
-        />
-        <Box background="bg-surface-secondary" padding="400">
+export const WithFlushedSection = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <Bleed marginInline="400" marginBlockStart="400">
+          <Image
+            source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+            alt="a sheet with purple and orange stripes"
+          />
+        </Bleed>
+        <Box paddingBlockStart="400">
           <Text as="p" variant="bodyMd">
             You can use sales reports to see information about your customers’
             orders based on criteria such as sales over time, by channel, or by
             staff.
           </Text>
         </Box>
-      </Bleed>
-    </Card>
-  );
-}
+      </Card>
+    );
+  },
+};
 
-export function WithSectionsAndActions() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="400">
-        <BlockStack gap="200">
-          <Text as="h2" variant="headingSm">
-            Customer
-          </Text>
-          <Text as="p" variant="bodyMd">
-            John Smith
-          </Text>
-        </BlockStack>
-        <BlockStack gap="200">
-          <InlineGrid columns="1fr auto">
-            <Text as="h3" variant="headingSm" fontWeight="medium">
-              Contact Information
+export const WithFlushedSectionAndSubduedSection = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <Bleed marginInline="400" marginBlock="400">
+          <Image
+            source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+            alt="a sheet with purple and orange stripes"
+          />
+          <Box background="bg-surface-secondary" padding="400">
+            <Text as="p" variant="bodyMd">
+              You can use sales reports to see information about your customers’
+              orders based on criteria such as sales over time, by channel, or
+              by staff.
             </Text>
-            <Button
-              icon={EditIcon}
-              variant="tertiary"
-              onClick={() => {}}
-              accessibilityLabel="Edit"
-            />
-          </InlineGrid>
-          <Text as="p" variant="bodyMd">
-            john.smith@example.com
-          </Text>
-        </BlockStack>
-      </BlockStack>
-    </Card>
-  );
-}
+          </Box>
+        </Bleed>
+      </Card>
+    );
+  },
+};
 
-export function WithSectionsAndCriticalAction() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="400">
-        <BlockStack gap="200">
-          <Text as="h2" variant="headingSm">
-            Customer
-          </Text>
-          <Text as="p" variant="bodyMd">
-            John Smith
-          </Text>
-        </BlockStack>
-        <BlockStack gap="200">
-          <InlineGrid columns="1fr auto">
-            <Text as="h3" variant="headingSm" fontWeight="medium">
-              Contact Information
+export const WithSectionsAndActions = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="400">
+          <BlockStack gap="200">
+            <Text as="h2" variant="headingSm">
+              Customer
             </Text>
-            <ButtonGroup>
-              <Button
-                icon={DeleteIcon}
-                variant="tertiary"
-                tone="critical"
-                onClick={() => {}}
-                accessibilityLabel="Delete"
-              />
+            <Text as="p" variant="bodyMd">
+              John Smith
+            </Text>
+          </BlockStack>
+          <BlockStack gap="200">
+            <InlineGrid columns="1fr auto">
+              <Text as="h3" variant="headingSm" fontWeight="medium">
+                Contact Information
+              </Text>
               <Button
                 icon={EditIcon}
                 variant="tertiary"
                 onClick={() => {}}
                 accessibilityLabel="Edit"
               />
+            </InlineGrid>
+            <Text as="p" variant="bodyMd">
+              john.smith@example.com
+            </Text>
+          </BlockStack>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithSectionsAndCriticalAction = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="400">
+          <BlockStack gap="200">
+            <Text as="h2" variant="headingSm">
+              Customer
+            </Text>
+            <Text as="p" variant="bodyMd">
+              John Smith
+            </Text>
+          </BlockStack>
+          <BlockStack gap="200">
+            <InlineGrid columns="1fr auto">
+              <Text as="h3" variant="headingSm" fontWeight="medium">
+                Contact Information
+              </Text>
+              <ButtonGroup>
+                <Button
+                  icon={DeleteIcon}
+                  variant="tertiary"
+                  tone="critical"
+                  onClick={() => {}}
+                  accessibilityLabel="Delete"
+                />
+                <Button
+                  icon={EditIcon}
+                  variant="tertiary"
+                  onClick={() => {}}
+                  accessibilityLabel="Edit"
+                />
+              </ButtonGroup>
+            </InlineGrid>
+            <Text as="p" variant="bodyMd">
+              john.smith@example.com
+            </Text>
+          </BlockStack>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithSeparateHeader = {
+  render() {
+    const [actionActive, toggleAction] = useState(false);
+
+    const handleToggleAction = () => {
+      toggleAction(!actionActive);
+    };
+
+    const items = [{content: 'Member'}, {content: 'Admin'}];
+
+    const disclosureButtonActivator = (
+      <Button variant="plain" disclosure onClick={handleToggleAction}>
+        Add account
+      </Button>
+    );
+
+    const disclosureButton = (
+      <Popover
+        active={actionActive}
+        activator={disclosureButtonActivator}
+        onClose={handleToggleAction}
+      >
+        <ActionList items={items} />
+      </Popover>
+    );
+
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="200">
+          <InlineGrid columns="1fr auto">
+            <Text as="h2" variant="headingSm">
+              Staff accounts
+            </Text>
+            <ButtonGroup>
+              <Button
+                variant="plain"
+                onClick={() => {}}
+                accessibilityLabel="Preview"
+              >
+                Preview
+              </Button>
+              {disclosureButton}
             </ButtonGroup>
           </InlineGrid>
-          <Text as="p" variant="bodyMd">
-            john.smith@example.com
-          </Text>
-        </BlockStack>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithSeparateHeader() {
-  const [actionActive, toggleAction] = useState(false);
-
-  const handleToggleAction = () => {
-    toggleAction(!actionActive);
-  };
-
-  const items = [{content: 'Member'}, {content: 'Admin'}];
-
-  const disclosureButtonActivator = (
-    <Button variant="plain" disclosure onClick={handleToggleAction}>
-      Add account
-    </Button>
-  );
-
-  const disclosureButton = (
-    <Popover
-      active={actionActive}
-      activator={disclosureButtonActivator}
-      onClose={handleToggleAction}
-    >
-      <ActionList items={items} />
-    </Popover>
-  );
-
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <InlineGrid columns="1fr auto">
-          <Text as="h2" variant="headingSm">
-            Staff accounts
-          </Text>
-          <ButtonGroup>
-            <Button
-              variant="plain"
-              onClick={() => {}}
-              accessibilityLabel="Preview"
-            >
-              Preview
-            </Button>
-            {disclosureButton}
-          </ButtonGroup>
-        </InlineGrid>
-        <List>
-          <List.Item>Felix Crafford</List.Item>
-          <List.Item>Ezequiel Manno</List.Item>
-        </List>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithHeaderActions() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <InlineGrid columns="1fr auto">
-          <Text as="h2" variant="headingSm">
-            Variants
-          </Text>
-          <Button
-            icon={PlusIcon}
-            onClick={() => {}}
-            accessibilityLabel="Add variant"
-          >
-            Add variant
-          </Button>
-        </InlineGrid>
-        <Text as="p" variant="bodyMd">
-          Add variants if this product comes in multiple versions, like
-          different sizes or colors.
-        </Text>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithFooterActions() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Shipment 1234
-        </Text>
-        <BlockStack gap="200">
-          <Text as="h3" variant="headingSm" fontWeight="medium">
-            Items
-          </Text>
           <List>
-            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
-            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+            <List.Item>Felix Crafford</List.Item>
+            <List.Item>Ezequiel Manno</List.Item>
           </List>
         </BlockStack>
-        <InlineStack align="end">
-          <ButtonGroup>
-            <Button onClick={() => {}} accessibilityLabel="Fulfill items">
-              Fulfill items
-            </Button>
+      </Card>
+    );
+  },
+};
+
+export const WithHeaderActions = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="200">
+          <InlineGrid columns="1fr auto">
+            <Text as="h2" variant="headingSm">
+              Variants
+            </Text>
             <Button
               icon={PlusIcon}
-              variant="primary"
               onClick={() => {}}
-              accessibilityLabel="Create shipping label"
+              accessibilityLabel="Add variant"
             >
-              Create shipping label
+              Add variant
             </Button>
-          </ButtonGroup>
-        </InlineStack>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithMultipleFooterActions() {
-  const [actionActive, toggleAction] = useState(false);
-
-  const handleToggleAction = () => {
-    toggleAction(!actionActive);
-  };
-
-  const items = [
-    {content: 'Cancel shipment', destructive: true},
-    {content: 'Add another shipment', disabled: true},
-  ];
-
-  const disclosureButtonActivator = (
-    <Button disclosure accessibilityLabel="More" onClick={handleToggleAction}>
-      More
-    </Button>
-  );
-
-  const disclosureButton = (
-    <Popover
-      active={actionActive}
-      activator={disclosureButtonActivator}
-      onClose={handleToggleAction}
-    >
-      <ActionList items={items} />
-    </Popover>
-  );
-
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Shipment 1234
-        </Text>
-        <BlockStack gap="200">
-          <Text as="h3" variant="headingSm" fontWeight="medium">
-            Items
+          </InlineGrid>
+          <Text as="p" variant="bodyMd">
+            Add variants if this product comes in multiple versions, like
+            different sizes or colors.
           </Text>
-          <List>
-            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
-            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
-          </List>
         </BlockStack>
-        <InlineStack align="end">
-          <ButtonGroup>
-            {disclosureButton}
-            <Button
-              variant="primary"
-              onClick={() => {}}
-              accessibilityLabel="Add tracking number"
-            >
-              Add tracking number
-            </Button>
-          </ButtonGroup>
-        </InlineStack>
-      </BlockStack>
-    </Card>
-  );
-}
+      </Card>
+    );
+  },
+};
 
-export function WithCustomFooterActions() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="500">
+export const WithFooterActions = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
         <BlockStack gap="200">
           <Text as="h2" variant="headingSm">
-            Secure your account with 2-step authentication
+            Shipment 1234
           </Text>
-          <Text as="p" variant="bodyMd">
-            Two-step authentication adds an extra layer of security when logging
-            in to your account. A special code will be required each time you
-            log in, ensuring only you can access your account.
-          </Text>
-        </BlockStack>
-        <InlineStack align="end">
-          <ButtonGroup>
-            <Button
-              onClick={() => {}}
-              accessibilityLabel="Enable two-step authentication"
-            >
-              Enable two-step authentication
-            </Button>
-            <Button variant="plain">Learn more</Button>
-          </ButtonGroup>
-        </InlineStack>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithCriticalFooterActions() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Shipment 1234
-        </Text>
-        <BlockStack gap="200">
-          <Text as="h3" variant="headingSm" fontWeight="medium">
-            Items
-          </Text>
-          <List>
-            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
-            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
-          </List>
-        </BlockStack>
-        <InlineStack align="end">
-          <ButtonGroup>
-            <Button
-              variant="secondary"
-              tone="critical"
-              onClick={() => {}}
-              accessibilityLabel="Cancel shipment"
-            >
-              Cancel shipment
-            </Button>
-            <Button
-              variant="primary"
-              onClick={() => {}}
-              accessibilityLabel="Add tracking number"
-            >
-              Add tracking number
-            </Button>
-          </ButtonGroup>
-        </InlineStack>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithCustomReactNodeTitle() {
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingSm">
-          Products
-        </Text>
-        <BlockStack inlineAlign="start">
-          <InlineStack gap="400">
-            <Icon source={ProductIcon} />
-            <Text as="h3" variant="headingSm">
-              New Products
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Items
             </Text>
-          </InlineStack>
-        </BlockStack>
-        <List>
-          <List.Item>Socks</List.Item>
-          <List.Item>Super Shoes</List.Item>
-        </List>
-      </BlockStack>
-    </Card>
-  );
-}
-
-export function WithAllElements() {
-  const [actionActive, toggleAction] = useState(false);
-
-  const handleToggleAction = () => {
-    toggleAction(!actionActive);
-  };
-
-  const items = [{content: 'Gross Sales'}, {content: 'Net Sales'}];
-
-  const disclosureButtonActivator = (
-    <Button variant="plain" disclosure onClick={handleToggleAction}>
-      View Sales
-    </Button>
-  );
-
-  const disclosureButton = (
-    <Popover
-      active={actionActive}
-      activator={disclosureButtonActivator}
-      onClose={handleToggleAction}
-    >
-      <ActionList items={items} />
-    </Popover>
-  );
-
-  const salesMarkup = (
-    <div>
-      <ResourceList
-        resourceName={{singular: 'sale', plural: 'sales'}}
-        items={[
-          {
-            sales: 'Orders',
-            amount: 'USD$0.00',
-            url: '#',
-          },
-          {
-            sales: 'Returns',
-            amount: '-USD$250.00',
-            url: '#',
-          },
-        ]}
-        renderItem={(item) => {
-          const {sales, amount, url} = item;
-          return (
-            <ResourceList.Item
-              id={sales}
-              url={url}
-              accessibilityLabel={`View Sales for ${sales}`}
-            >
-              <InlineStack align="space-between">
-                <div>{sales}</div>
-                <div>{amount}</div>
-              </InlineStack>
-            </ResourceList.Item>
-          );
-        }}
-      />
-    </div>
-  );
-
-  return (
-    <Card roundedAbove="sm">
-      <BlockStack gap="200">
-        <InlineGrid columns="1fr auto">
-          <Text as="h2" variant="headingSm">
-            Sales
-          </Text>
-          <ButtonGroup>
-            <Button variant="plain">Total Sales</Button>
-            {disclosureButton}
-          </ButtonGroup>
-        </InlineGrid>
-        <BlockStack gap="400">
-          <Text as="p" variant="bodyMd">
-            You can use sales reports to see information about your customers’
-            orders based on criteria such as sales over time, by channel, or by
-            staff.
-          </Text>
-          <Text as="h3" variant="headingSm" fontWeight="medium">
-            Total Sales Breakdown
-          </Text>
-        </BlockStack>
-        {salesMarkup}
-        <Bleed marginInline="400">
-          <Box
-            background="bg-surface-secondary"
-            paddingBlock="300"
-            paddingInline="400"
-          >
-            <BlockStack gap="200">
-              <Text as="h3" variant="headingSm" fontWeight="medium">
-                Deactivated reports
-              </Text>
-              <List>
-                <List.Item>Payouts</List.Item>
-                <List.Item>Total Sales By Channel</List.Item>
-              </List>
-            </BlockStack>
-          </Box>
-        </Bleed>
-        <BlockStack gap="200">
-          <Text as="h3" variant="headingSm" fontWeight="medium">
-            Note
-          </Text>
-          <Text as="p" variant="bodyMd">
-            The sales reports are available only if your store is on the Shopify
-            plan or higher.
-          </Text>
+            <List>
+              <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+              <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+            </List>
+          </BlockStack>
           <InlineStack align="end">
             <ButtonGroup>
-              <Button onClick={() => {}} accessibilityLabel="Dismiss">
-                Dismiss
+              <Button onClick={() => {}} accessibilityLabel="Fulfill items">
+                Fulfill items
+              </Button>
+              <Button
+                icon={PlusIcon}
+                variant="primary"
+                onClick={() => {}}
+                accessibilityLabel="Create shipping label"
+              >
+                Create shipping label
+              </Button>
+            </ButtonGroup>
+          </InlineStack>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithMultipleFooterActions = {
+  render() {
+    const [actionActive, toggleAction] = useState(false);
+
+    const handleToggleAction = () => {
+      toggleAction(!actionActive);
+    };
+
+    const items = [
+      {content: 'Cancel shipment', destructive: true},
+      {content: 'Add another shipment', disabled: true},
+    ];
+
+    const disclosureButtonActivator = (
+      <Button disclosure accessibilityLabel="More" onClick={handleToggleAction}>
+        More
+      </Button>
+    );
+
+    const disclosureButton = (
+      <Popover
+        active={actionActive}
+        activator={disclosureButtonActivator}
+        onClose={handleToggleAction}
+      >
+        <ActionList items={items} />
+      </Popover>
+    );
+
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Shipment 1234
+          </Text>
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Items
+            </Text>
+            <List>
+              <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+              <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+            </List>
+          </BlockStack>
+          <InlineStack align="end">
+            <ButtonGroup>
+              {disclosureButton}
+              <Button
+                variant="primary"
+                onClick={() => {}}
+                accessibilityLabel="Add tracking number"
+              >
+                Add tracking number
+              </Button>
+            </ButtonGroup>
+          </InlineStack>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithCustomFooterActions = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="500">
+          <BlockStack gap="200">
+            <Text as="h2" variant="headingSm">
+              Secure your account with 2-step authentication
+            </Text>
+            <Text as="p" variant="bodyMd">
+              Two-step authentication adds an extra layer of security when
+              logging in to your account. A special code will be required each
+              time you log in, ensuring only you can access your account.
+            </Text>
+          </BlockStack>
+          <InlineStack align="end">
+            <ButtonGroup>
+              <Button
+                onClick={() => {}}
+                accessibilityLabel="Enable two-step authentication"
+              >
+                Enable two-step authentication
+              </Button>
+              <Button variant="plain">Learn more</Button>
+            </ButtonGroup>
+          </InlineStack>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithCriticalFooterActions = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Shipment 1234
+          </Text>
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Items
+            </Text>
+            <List>
+              <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+              <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+            </List>
+          </BlockStack>
+          <InlineStack align="end">
+            <ButtonGroup>
+              <Button
+                variant="secondary"
+                tone="critical"
+                onClick={() => {}}
+                accessibilityLabel="Cancel shipment"
+              >
+                Cancel shipment
               </Button>
               <Button
                 variant="primary"
                 onClick={() => {}}
-                accessibilityLabel="Export Report"
+                accessibilityLabel="Add tracking number"
               >
-                Export Report
+                Add tracking number
               </Button>
             </ButtonGroup>
           </InlineStack>
         </BlockStack>
-      </BlockStack>
-    </Card>
-  );
-}
+      </Card>
+    );
+  },
+};
+
+export const WithCustomReactNodeTitle = {
+  render() {
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Products
+          </Text>
+          <BlockStack inlineAlign="start">
+            <InlineStack gap="400">
+              <Icon source={ProductIcon} />
+              <Text as="h3" variant="headingSm">
+                New Products
+              </Text>
+            </InlineStack>
+          </BlockStack>
+          <List>
+            <List.Item>Socks</List.Item>
+            <List.Item>Super Shoes</List.Item>
+          </List>
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithAllElements = {
+  render() {
+    const [actionActive, toggleAction] = useState(false);
+
+    const handleToggleAction = () => {
+      toggleAction(!actionActive);
+    };
+
+    const items = [{content: 'Gross Sales'}, {content: 'Net Sales'}];
+
+    const disclosureButtonActivator = (
+      <Button variant="plain" disclosure onClick={handleToggleAction}>
+        View Sales
+      </Button>
+    );
+
+    const disclosureButton = (
+      <Popover
+        active={actionActive}
+        activator={disclosureButtonActivator}
+        onClose={handleToggleAction}
+      >
+        <ActionList items={items} />
+      </Popover>
+    );
+
+    const salesMarkup = (
+      <div>
+        <ResourceList
+          resourceName={{singular: 'sale', plural: 'sales'}}
+          items={[
+            {
+              sales: 'Orders',
+              amount: 'USD$0.00',
+              url: '#',
+            },
+            {
+              sales: 'Returns',
+              amount: '-USD$250.00',
+              url: '#',
+            },
+          ]}
+          renderItem={(item) => {
+            const {sales, amount, url} = item;
+            return (
+              <ResourceList.Item
+                id={sales}
+                url={url}
+                accessibilityLabel={`View Sales for ${sales}`}
+              >
+                <InlineStack align="space-between">
+                  <div>{sales}</div>
+                  <div>{amount}</div>
+                </InlineStack>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </div>
+    );
+
+    return (
+      <Card roundedAbove="sm">
+        <BlockStack gap="200">
+          <InlineGrid columns="1fr auto">
+            <Text as="h2" variant="headingSm">
+              Sales
+            </Text>
+            <ButtonGroup>
+              <Button variant="plain">Total Sales</Button>
+              {disclosureButton}
+            </ButtonGroup>
+          </InlineGrid>
+          <BlockStack gap="400">
+            <Text as="p" variant="bodyMd">
+              You can use sales reports to see information about your customers’
+              orders based on criteria such as sales over time, by channel, or
+              by staff.
+            </Text>
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Total Sales Breakdown
+            </Text>
+          </BlockStack>
+          {salesMarkup}
+          <Bleed marginInline="400">
+            <Box
+              background="bg-surface-secondary"
+              paddingBlock="300"
+              paddingInline="400"
+            >
+              <BlockStack gap="200">
+                <Text as="h3" variant="headingSm" fontWeight="medium">
+                  Deactivated reports
+                </Text>
+                <List>
+                  <List.Item>Payouts</List.Item>
+                  <List.Item>Total Sales By Channel</List.Item>
+                </List>
+              </BlockStack>
+            </Box>
+          </Bleed>
+          <BlockStack gap="200">
+            <Text as="h3" variant="headingSm" fontWeight="medium">
+              Note
+            </Text>
+            <Text as="p" variant="bodyMd">
+              The sales reports are available only if your store is on the
+              Shopify plan or higher.
+            </Text>
+            <InlineStack align="end">
+              <ButtonGroup>
+                <Button onClick={() => {}} accessibilityLabel="Dismiss">
+                  Dismiss
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={() => {}}
+                  accessibilityLabel="Export Report"
+                >
+                  Export Report
+                </Button>
+              </ButtonGroup>
+            </InlineStack>
+          </BlockStack>
+        </BlockStack>
+      </Card>
+    );
+  },
+};

--- a/polaris-react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/polaris-react/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,153 +1,177 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Checkbox, InlineStack, BlockStack, Card} from '@shopify/polaris';
 
 export default {
   component: Checkbox,
-} as ComponentMeta<typeof Checkbox>;
+} as Meta<typeof Checkbox>;
 
 type CheckboxState = boolean | 'indeterminate';
 
-export function Default() {
-  const [checked, setChecked] = useState<CheckboxState>(false);
-  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+export const Default = {
+  render() {
+    const [checked, setChecked] = useState<CheckboxState>(false);
+    const handleChange = useCallback(
+      (newChecked) => setChecked(newChecked),
+      [],
+    );
 
-  return (
-    <Checkbox
-      label="Basic checkbox"
-      checked={checked}
-      onChange={handleChange}
-    />
-  );
-}
-
-export function Indeterminate() {
-  const [checked, setChecked] = useState<CheckboxState>('indeterminate');
-  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
-
-  return (
-    <Checkbox
-      label="Basic checkbox"
-      checked={checked}
-      onChange={handleChange}
-    />
-  );
-}
-
-export function DisabledStates() {
-  const handleChange = () => {
-    console.error('This should never be fired');
-  };
-
-  return (
-    <InlineStack gap="200">
+    return (
       <Checkbox
-        label="Disabled unchecked checkbox"
-        disabled
+        label="Basic checkbox"
+        checked={checked}
         onChange={handleChange}
       />
+    );
+  },
+};
+
+export const Indeterminate = {
+  render() {
+    const [checked, setChecked] = useState<CheckboxState>('indeterminate');
+    const handleChange = useCallback(
+      (newChecked) => setChecked(newChecked),
+      [],
+    );
+
+    return (
       <Checkbox
-        label="Disabled checked checkbox"
-        checked
-        disabled
+        label="Basic checkbox"
+        checked={checked}
         onChange={handleChange}
       />
-      <Checkbox
-        label="Disabled indeterminate checkbox"
-        checked="indeterminate"
-        disabled
-        onChange={handleChange}
-      />
-    </InlineStack>
-  );
-}
+    );
+  },
+};
 
-export function Error() {
-  const [checked, setChecked] = useState<CheckboxState>('indeterminate');
-  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
+export const DisabledStates = {
+  render() {
+    const handleChange = () => {
+      console.error('This should never be fired');
+    };
 
-  return (
-    <Checkbox
-      label="Basic checkbox"
-      helpText="Some help text"
-      error="Something went wrong"
-      checked={checked}
-      onChange={handleChange}
-    />
-  );
-}
-
-export function Magic() {
-  const [checked, setChecked] = useState<CheckboxState>();
-  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);
-
-  return (
-    <Checkbox
-      label="Magic checkbox"
-      checked={checked}
-      onChange={handleChange}
-      tone="magic"
-    />
-  );
-}
-
-export function WithBleedAndFill() {
-  const [checked1, setChecked1] = useState<CheckboxState>(false);
-  const [checked2, setChecked2] = useState<CheckboxState>(false);
-  const [checked3, setChecked3] = useState<CheckboxState>(false);
-  const [checked4, setChecked4] = useState<CheckboxState>(false);
-  const handleChange1 = useCallback(
-    (newChecked) => setChecked1(newChecked),
-    [],
-  );
-  const handleChange2 = useCallback(
-    (newChecked) => setChecked2(newChecked),
-    [],
-  );
-  const handleChange3 = useCallback(
-    (newChecked) => setChecked3(newChecked),
-    [],
-  );
-  const handleChange4 = useCallback(
-    (newChecked) => setChecked4(newChecked),
-    [],
-  );
-  return (
-    <BlockStack gap="600">
-      <Card padding="400">
+    return (
+      <InlineStack gap="200">
         <Checkbox
-          label="No bleed"
-          checked={checked1}
-          onChange={handleChange1}
+          label="Disabled unchecked checkbox"
+          disabled
+          onChange={handleChange}
         />
-      </Card>
-      <Card padding="400">
         <Checkbox
-          label="Bleed increase hit size"
-          bleed="400"
-          checked={checked2}
-          onChange={handleChange2}
+          label="Disabled checked checkbox"
+          checked
+          disabled
+          onChange={handleChange}
         />
-      </Card>
-      <Card padding="400">
-        <div style={{height: '100px'}}>
+        <Checkbox
+          label="Disabled indeterminate checkbox"
+          checked="indeterminate"
+          disabled
+          onChange={handleChange}
+        />
+      </InlineStack>
+    );
+  },
+};
+
+export const Error = {
+  render() {
+    const [checked, setChecked] = useState<CheckboxState>('indeterminate');
+    const handleChange = useCallback(
+      (newChecked) => setChecked(newChecked),
+      [],
+    );
+
+    return (
+      <Checkbox
+        label="Basic checkbox"
+        helpText="Some help text"
+        error="Something went wrong"
+        checked={checked}
+        onChange={handleChange}
+      />
+    );
+  },
+};
+
+export const Magic = {
+  render() {
+    const [checked, setChecked] = useState<CheckboxState>();
+    const handleChange = useCallback(
+      (newChecked) => setChecked(newChecked),
+      [],
+    );
+
+    return (
+      <Checkbox
+        label="Magic checkbox"
+        checked={checked}
+        onChange={handleChange}
+        tone="magic"
+      />
+    );
+  },
+};
+
+export const WithBleedAndFill = {
+  render() {
+    const [checked1, setChecked1] = useState<CheckboxState>(false);
+    const [checked2, setChecked2] = useState<CheckboxState>(false);
+    const [checked3, setChecked3] = useState<CheckboxState>(false);
+    const [checked4, setChecked4] = useState<CheckboxState>(false);
+    const handleChange1 = useCallback(
+      (newChecked) => setChecked1(newChecked),
+      [],
+    );
+    const handleChange2 = useCallback(
+      (newChecked) => setChecked2(newChecked),
+      [],
+    );
+    const handleChange3 = useCallback(
+      (newChecked) => setChecked3(newChecked),
+      [],
+    );
+    const handleChange4 = useCallback(
+      (newChecked) => setChecked4(newChecked),
+      [],
+    );
+    return (
+      <BlockStack gap="600">
+        <Card padding="400">
           <Checkbox
-            label="Fill to full width/height + bleed"
-            bleed="400"
-            fill
-            checked={checked3}
-            onChange={handleChange3}
+            label="No bleed"
+            checked={checked1}
+            onChange={handleChange1}
           />
-        </div>
-      </Card>
-      <Card padding={{xs: '400', lg: '600'}}>
-        <Checkbox
-          label="Supports responsive sizes"
-          bleed={{xs: '400', lg: '600'}}
-          checked={checked4}
-          onChange={handleChange4}
-        />
-      </Card>
-    </BlockStack>
-  );
-}
+        </Card>
+        <Card padding="400">
+          <Checkbox
+            label="Bleed increase hit size"
+            bleed="400"
+            checked={checked2}
+            onChange={handleChange2}
+          />
+        </Card>
+        <Card padding="400">
+          <div style={{height: '100px'}}>
+            <Checkbox
+              label="Fill to full width/height + bleed"
+              bleed="400"
+              fill
+              checked={checked3}
+              onChange={handleChange3}
+            />
+          </div>
+        </Card>
+        <Card padding={{xs: '400', lg: '600'}}>
+          <Checkbox
+            label="Supports responsive sizes"
+            bleed={{xs: '400', lg: '600'}}
+            checked={checked4}
+            onChange={handleChange4}
+          />
+        </Card>
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/polaris-react/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -1,188 +1,156 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {ChoiceList, TextField} from '@shopify/polaris';
 
 export default {
   component: ChoiceList,
-} as ComponentMeta<typeof ChoiceList>;
+} as Meta<typeof ChoiceList>;
 
-export function Default() {
-  const [selected, setSelected] = useState(['hidden']);
+export const Default = {
+  render() {
+    const [selected, setSelected] = useState(['hidden']);
 
-  const handleChange = useCallback((value) => setSelected(value), []);
+    const handleChange = useCallback((value) => setSelected(value), []);
 
-  return (
-    <ChoiceList
-      title="Company name"
-      choices={[
-        {label: 'Hidden', value: 'hidden'},
-        {label: 'Optional', value: 'optional'},
-        {label: 'Required', value: 'required'},
-      ]}
-      selected={selected}
-      onChange={handleChange}
-    />
-  );
-}
-
-export function WithError() {
-  const [selected, setSelected] = useState(['hidden']);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
-
-  return (
-    <ChoiceList
-      title="Company name"
-      choices={[
-        {label: 'Hidden', value: 'hidden', describedByError: true},
-        {label: 'Optional', value: 'optional'},
-        {label: 'Required', value: 'required'},
-      ]}
-      selected={selected}
-      onChange={handleChange}
-      error="Company name cannot be hidden at this time"
-    />
-  );
-}
-
-export function Magic() {
-  const [selected, setSelected] = useState(['hidden']);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
-
-  return (
-    <ChoiceList
-      title="Company name"
-      choices={[
-        {label: 'Hidden', value: 'hidden'},
-        {label: 'Optional', value: 'optional'},
-        {label: 'Required', value: 'required'},
-      ]}
-      selected={selected}
-      onChange={handleChange}
-      tone="magic"
-    />
-  );
-}
-
-export function WithMultiChoice() {
-  const [selected, setSelected] = useState(['hidden']);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
-
-  return (
-    <ChoiceList
-      allowMultiple
-      title="While the customer is checking out"
-      choices={[
-        {
-          label: 'Use the shipping address as the billing address by default',
-          value: 'shipping',
-          helpText:
-            'Reduces the number of fields required to check out. The billing address can still be edited.',
-        },
-        {
-          label: 'Require a confirmation step',
-          value: 'confirmation',
-          helpText:
-            'Customers must review their order details before purchasing.',
-        },
-      ]}
-      selected={selected}
-      onChange={handleChange}
-    />
-  );
-}
-
-export function MagicWithMultiChoice() {
-  const [selected, setSelected] = useState(['hidden']);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
-
-  return (
-    <ChoiceList
-      allowMultiple
-      title="While the customer is checking out"
-      choices={[
-        {
-          label: 'Use the shipping address as the billing address by default',
-          value: 'shipping',
-          helpText:
-            'Reduces the number of fields required to check out. The billing address can still be edited.',
-        },
-        {
-          label: 'Require a confirmation step',
-          value: 'confirmation',
-          helpText:
-            'Customers must review their order details before purchasing.',
-        },
-      ]}
-      selected={selected}
-      onChange={handleChange}
-      tone="magic"
-    />
-  );
-}
-
-export function WithChildrenContent() {
-  const [selected, setSelected] = useState(['none']);
-  const [textFieldValue, setTextFieldValue] = useState('');
-
-  const handleChoiceListChange = useCallback((value) => setSelected(value), []);
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  const renderChildren = useCallback(
-    () => (
-      <TextField
-        label="Minimum Quantity"
-        labelHidden
-        onChange={handleTextFieldChange}
-        value={textFieldValue}
-        autoComplete="off"
+    return (
+      <ChoiceList
+        title="Company name"
+        choices={[
+          {label: 'Hidden', value: 'hidden'},
+          {label: 'Optional', value: 'optional'},
+          {label: 'Required', value: 'required'},
+        ]}
+        selected={selected}
+        onChange={handleChange}
       />
-    ),
-    [handleTextFieldChange, textFieldValue],
-  );
+    );
+  },
+};
 
-  return (
-    <ChoiceList
-      title="Discount minimum requirements"
-      choices={[
-        {label: 'None', value: 'none'},
-        {
-          label: 'Minimum purchase',
-          value: 'minimum_purchase',
-          renderChildren,
-        },
-        {
-          label: 'Minimum quantity',
-          value: 'minimum_quantity',
-        },
-      ]}
-      selected={selected}
-      onChange={handleChoiceListChange}
-    />
-  );
-}
+export const WithError = {
+  render() {
+    const [selected, setSelected] = useState(['hidden']);
 
-export function WithDynamicChildrenContent() {
-  const [selected, setSelected] = useState(['none']);
-  const [textFieldValue, setTextFieldValue] = useState('');
+    const handleChange = useCallback((value) => setSelected(value), []);
 
-  const handleChoiceListChange = useCallback((value) => setSelected(value), []);
+    return (
+      <ChoiceList
+        title="Company name"
+        choices={[
+          {label: 'Hidden', value: 'hidden', describedByError: true},
+          {label: 'Optional', value: 'optional'},
+          {label: 'Required', value: 'required'},
+        ]}
+        selected={selected}
+        onChange={handleChange}
+        error="Company name cannot be hidden at this time"
+      />
+    );
+  },
+};
 
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
+export const Magic = {
+  render() {
+    const [selected, setSelected] = useState(['hidden']);
 
-  const renderChildren = useCallback(
-    (isSelected) =>
-      isSelected && (
+    const handleChange = useCallback((value) => setSelected(value), []);
+
+    return (
+      <ChoiceList
+        title="Company name"
+        choices={[
+          {label: 'Hidden', value: 'hidden'},
+          {label: 'Optional', value: 'optional'},
+          {label: 'Required', value: 'required'},
+        ]}
+        selected={selected}
+        onChange={handleChange}
+        tone="magic"
+      />
+    );
+  },
+};
+
+export const WithMultiChoice = {
+  render() {
+    const [selected, setSelected] = useState(['hidden']);
+
+    const handleChange = useCallback((value) => setSelected(value), []);
+
+    return (
+      <ChoiceList
+        allowMultiple
+        title="While the customer is checking out"
+        choices={[
+          {
+            label: 'Use the shipping address as the billing address by default',
+            value: 'shipping',
+            helpText:
+              'Reduces the number of fields required to check out. The billing address can still be edited.',
+          },
+          {
+            label: 'Require a confirmation step',
+            value: 'confirmation',
+            helpText:
+              'Customers must review their order details before purchasing.',
+          },
+        ]}
+        selected={selected}
+        onChange={handleChange}
+      />
+    );
+  },
+};
+
+export const MagicWithMultiChoice = {
+  render() {
+    const [selected, setSelected] = useState(['hidden']);
+
+    const handleChange = useCallback((value) => setSelected(value), []);
+
+    return (
+      <ChoiceList
+        allowMultiple
+        title="While the customer is checking out"
+        choices={[
+          {
+            label: 'Use the shipping address as the billing address by default',
+            value: 'shipping',
+            helpText:
+              'Reduces the number of fields required to check out. The billing address can still be edited.',
+          },
+          {
+            label: 'Require a confirmation step',
+            value: 'confirmation',
+            helpText:
+              'Customers must review their order details before purchasing.',
+          },
+        ]}
+        selected={selected}
+        onChange={handleChange}
+        tone="magic"
+      />
+    );
+  },
+};
+
+export const WithChildrenContent = {
+  render() {
+    const [selected, setSelected] = useState(['none']);
+    const [textFieldValue, setTextFieldValue] = useState('');
+
+    const handleChoiceListChange = useCallback(
+      (value) => setSelected(value),
+      [],
+    );
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    const renderChildren = useCallback(
+      () => (
         <TextField
           label="Minimum Quantity"
           labelHidden
@@ -191,11 +159,10 @@ export function WithDynamicChildrenContent() {
           autoComplete="off"
         />
       ),
-    [handleTextFieldChange, textFieldValue],
-  );
+      [handleTextFieldChange, textFieldValue],
+    );
 
-  return (
-    <div style={{height: '150px'}}>
+    return (
       <ChoiceList
         title="Discount minimum requirements"
         choices={[
@@ -208,12 +175,65 @@ export function WithDynamicChildrenContent() {
           {
             label: 'Minimum quantity',
             value: 'minimum_quantity',
-            renderChildren,
           },
         ]}
         selected={selected}
         onChange={handleChoiceListChange}
       />
-    </div>
-  );
-}
+    );
+  },
+};
+
+export const WithDynamicChildrenContent = {
+  render() {
+    const [selected, setSelected] = useState(['none']);
+    const [textFieldValue, setTextFieldValue] = useState('');
+
+    const handleChoiceListChange = useCallback(
+      (value) => setSelected(value),
+      [],
+    );
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    const renderChildren = useCallback(
+      (isSelected) =>
+        isSelected && (
+          <TextField
+            label="Minimum Quantity"
+            labelHidden
+            onChange={handleTextFieldChange}
+            value={textFieldValue}
+            autoComplete="off"
+          />
+        ),
+      [handleTextFieldChange, textFieldValue],
+    );
+
+    return (
+      <div style={{height: '150px'}}>
+        <ChoiceList
+          title="Discount minimum requirements"
+          choices={[
+            {label: 'None', value: 'none'},
+            {
+              label: 'Minimum purchase',
+              value: 'minimum_purchase',
+              renderChildren,
+            },
+            {
+              label: 'Minimum quantity',
+              value: 'minimum_quantity',
+              renderChildren,
+            },
+          ]}
+          selected={selected}
+          onChange={handleChoiceListChange}
+        />
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/Collapsible/Collapsible.stories.tsx
+++ b/polaris-react/src/components/Collapsible/Collapsible.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Button,
   LegacyCard,
@@ -12,44 +12,46 @@ import {
 
 export default {
   component: Collapsible,
-} as ComponentMeta<typeof Collapsible>;
+} as Meta<typeof Collapsible>;
 
-export function Default() {
-  const [open, setOpen] = useState(true);
+export const Default = {
+  render() {
+    const [open, setOpen] = useState(true);
 
-  const handleToggle = useCallback(() => setOpen((open) => !open), []);
+    const handleToggle = useCallback(() => setOpen((open) => !open), []);
 
-  return (
-    <div style={{height: '200px'}}>
-      <LegacyCard sectioned>
-        <LegacyStack vertical>
-          <Button
-            onClick={handleToggle}
-            ariaExpanded={open}
-            ariaControls="basic-collapsible"
-          >
-            Toggle
-          </Button>
-          <Collapsible
-            open={open}
-            id="basic-collapsible"
-            transition={{
-              duration: 'var(--p-motion-duration-150)',
-              timingFunction: 'var(--p-motion-ease-in-out)',
-            }}
-            expandOnPrint
-          >
-            <TextContainer>
-              <Text as="p" variant="bodyMd">
-                Your mailing list lets you contact customers or visitors who
-                have shown an interest in your store. Reach out to them with
-                exclusive offers or updates about your products.
-              </Text>
-              <Link url="#">Test link</Link>
-            </TextContainer>
-          </Collapsible>
-        </LegacyStack>
-      </LegacyCard>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '200px'}}>
+        <LegacyCard sectioned>
+          <LegacyStack vertical>
+            <Button
+              onClick={handleToggle}
+              ariaExpanded={open}
+              ariaControls="basic-collapsible"
+            >
+              Toggle
+            </Button>
+            <Collapsible
+              open={open}
+              id="basic-collapsible"
+              transition={{
+                duration: 'var(--p-motion-duration-150)',
+                timingFunction: 'var(--p-motion-ease-in-out)',
+              }}
+              expandOnPrint
+            >
+              <TextContainer>
+                <Text as="p" variant="bodyMd">
+                  Your mailing list lets you contact customers or visitors who
+                  have shown an interest in your store. Reach out to them with
+                  exclusive offers or updates about your products.
+                </Text>
+                <Link url="#">Test link</Link>
+              </TextContainer>
+            </Collapsible>
+          </LegacyStack>
+        </LegacyCard>
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   ColorPicker,
   TextField,
@@ -10,97 +10,108 @@ import {
 
 export default {
   component: ColorPicker,
-} as ComponentMeta<typeof ColorPicker>;
+} as Meta<typeof ColorPicker>;
 
-export function Default() {
-  const [color, setColor] = useState({
-    hue: 120,
-    brightness: 1,
-    saturation: 1,
-  });
+export const Default = {
+  render() {
+    const [color, setColor] = useState({
+      hue: 120,
+      brightness: 1,
+      saturation: 1,
+    });
 
-  return <ColorPicker onChange={setColor} color={color} />;
-}
+    return <ColorPicker onChange={setColor} color={color} />;
+  },
+};
 
-export function WithTransparentValue() {
-  const [color, setColor] = useState({
-    hue: 300,
-    brightness: 1,
-    saturation: 0.7,
-    alpha: 0.7,
-  });
+export const WithTransparentValue = {
+  render() {
+    const [color, setColor] = useState({
+      hue: 300,
+      brightness: 1,
+      saturation: 0.7,
+      alpha: 0.7,
+    });
 
-  return <ColorPicker onChange={setColor} color={color} allowAlpha />;
-}
+    return <ColorPicker onChange={setColor} color={color} allowAlpha />;
+  },
+};
 
-export function WithTransparentValueFullWidth() {
-  const [color, setColor] = useState({
-    hue: 300,
-    brightness: 1,
-    saturation: 0.7,
-    alpha: 0.7,
-  });
+export const WithTransparentValueFullWidth = {
+  render() {
+    const [color, setColor] = useState({
+      hue: 300,
+      brightness: 1,
+      saturation: 0.7,
+      alpha: 0.7,
+    });
 
-  return <ColorPicker fullWidth onChange={setColor} color={color} allowAlpha />;
-}
+    return (
+      <ColorPicker fullWidth onChange={setColor} color={color} allowAlpha />
+    );
+  },
+};
 
-export function WithHexTextField() {
-  const [color, setColor] = useState({
-    hue: 300,
-    saturation: 0.7,
-    brightness: 1,
-  });
+export const WithHexTextField = {
+  render() {
+    const [color, setColor] = useState({
+      hue: 300,
+      saturation: 0.7,
+      brightness: 1,
+    });
 
-  const [hex, setHex] = useState(hsbToHex(color));
+    const [hex, setHex] = useState(hsbToHex(color));
 
-  const handleBlur = useCallback(() => {
-    setColor(rgbToHsb(hexToRgb(hex)));
-  }, [hex]);
+    const handleBlur = useCallback(() => {
+      setColor(rgbToHsb(hexToRgb(hex)));
+    }, [hex]);
 
-  useEffect(() => {
-    setHex(hsbToHex(color));
-  }, [color]);
+    useEffect(() => {
+      setHex(hsbToHex(color));
+    }, [color]);
 
-  const styles = {
-    Wrapper: {
-      display: 'grid',
-      gap: 'var(--p-space-200)',
-      gridTemplateColumns: 'auto 1fr',
-      maxWidth: 'fit-content',
-    },
-    Picker: {
-      gridColumn: '1 / 3',
-    },
-    Tile: {
-      minHeight: 'calc(100% - 0.125rem)',
-      aspectRatio: '1 / 1',
-      borderRadius: 'var(--p-border-radius-100)',
-      border: 'var(--p-border-width-025) solid var(--p-color-border-secondary)',
-      backgroundColor: hsbToHex(color),
-    },
-    TextField: {
-      maxWidth: 'fit-content',
-    },
-  };
+    const styles = {
+      Wrapper: {
+        display: 'grid',
+        gap: 'var(--p-space-200)',
+        gridTemplateColumns: 'auto 1fr',
+        maxWidth: 'fit-content',
+      },
+      Picker: {
+        gridColumn: '1 / 3',
+      },
+      Tile: {
+        minHeight: 'calc(100% - 0.125rem)',
+        aspectRatio: '1 / 1',
+        borderRadius: 'var(--p-border-radius-100)',
+        border:
+          'var(--p-border-width-025) solid var(--p-color-border-secondary)',
+        backgroundColor: hsbToHex(color),
+      },
+      TextField: {
+        maxWidth: 'fit-content',
+      },
+    };
 
-  return (
-    <div style={styles.Wrapper}>
-      <div style={styles.Picker}>
-        <ColorPicker onChange={setColor} color={color} />
+    return (
+      <div style={styles.Wrapper}>
+        <div style={styles.Picker}>
+          <ColorPicker onChange={setColor} color={color} />
+        </div>
+
+        <div style={styles.Tile} />
+
+        <div style={styles.TextField}>
+          <TextField
+            label=""
+            prefix="#"
+            value={hex.replace('#', '')}
+            onChange={setHex}
+            onBlur={handleBlur}
+            autoComplete="off"
+          />
+        </div>
       </div>
-
-      <div style={styles.Tile} />
-
-      <div style={styles.TextField}>
-        <TextField
-          label=""
-          prefix="#"
-          value={hex.replace('#', '')}
-          onChange={setHex}
-          onBlur={handleBlur}
-          autoComplete="off"
-        />
-      </div>
-    </div>
-  );
-}
+    );
+  },
+};

--- a/polaris-react/src/components/Combobox/Combobox.stories.tsx
+++ b/polaris-react/src/components/Combobox/Combobox.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Combobox,
   EmptySearchResult,
@@ -14,770 +14,790 @@ import {SearchIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Combobox,
-} as ComponentMeta<typeof Combobox>;
+} as Meta<typeof Combobox>;
+
+export const Default = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+
+    const [selectedOption, setSelectedOption] = useState();
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
 
-export function Default() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-
-  const [selectedOption, setSelectedOption] = useState();
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
-      }
-
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = deselectedOptions.filter((option) =>
-        option.label.match(filterRegex),
-      );
-      setOptions(resultOptions);
-    },
-    [deselectedOptions],
-  );
-
-  const updateSelection = useCallback(
-    (selected) => {
-      const matchedOption = options.find((option) => {
-        return option.value.match(selected);
-      });
-
-      setSelectedOption(selected);
-      setInputValue((matchedOption && matchedOption.label) || '');
-    },
-    [options],
-  );
-
-  const optionsMarkup =
-    options.length > 0
-      ? options.map((option) => {
-          const {label, value} = option;
-
-          return (
-            <Listbox.Option
-              key={`${value}`}
-              value={value}
-              selected={selectedOption === value}
-              accessibilityLabel={label}
-            >
-              {label}
-            </Listbox.Option>
-          );
-        })
-      : null;
-
-  return (
-    <div style={{height: '225px'}}>
-      <Combobox
-        activator={
-          <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
-            onChange={updateText}
-            label="Search tags"
-            labelHidden
-            value={inputValue}
-            placeholder="Search tags"
-          />
-        }
-      >
-        {options.length > 0 ? (
-          <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
-        ) : null}
-      </Combobox>
-    </div>
-  );
-}
-
-export function WithChildrenBasedOnInput() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-
-  const [selectedOption, setSelectedOption] = useState();
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
-      }
-
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = deselectedOptions.filter((option) =>
-        option.label.match(filterRegex),
-      );
-      setOptions(resultOptions);
-    },
-    [deselectedOptions],
-  );
-
-  const updateSelection = useCallback(
-    (selected) => {
-      const matchedOption = options.find((option) => {
-        return option.value.match(selected);
-      });
-
-      setSelectedOption(selected);
-      setInputValue((matchedOption && matchedOption.label) || '');
-    },
-    [options],
-  );
-
-  const optionsMarkup =
-    options.length > 0
-      ? options.map((option) => {
-          const {label, value} = option;
-
-          return (
-            <Listbox.Option
-              key={`${value}`}
-              value={value}
-              selected={selectedOption === value}
-              accessibilityLabel={label}
-            >
-              {label}
-            </Listbox.Option>
-          );
-        })
-      : null;
-
-  return (
-    <div style={{height: '225px'}}>
-      <Combobox
-        activator={
-          <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
-            onChange={updateText}
-            label="Search tags"
-            labelHidden
-            value={inputValue}
-            placeholder="Search tags"
-          />
-        }
-      >
-        {inputValue.length > 0 && options.length > 0 ? (
-          <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
-        ) : null}
-      </Combobox>
-    </div>
-  );
-}
-
-export function WithManualSelection() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-
-  const [selectedOption, setSelectedOption] = useState();
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
-      }
-
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = deselectedOptions.filter((option) =>
-        option.label.match(filterRegex),
-      );
-      setOptions(resultOptions);
-    },
-    [deselectedOptions],
-  );
-
-  const updateSelection = useCallback(
-    (selected) => {
-      const matchedOption = options.find((option) => {
-        return option.value.match(selected);
-      });
-
-      setSelectedOption(selected);
-      setInputValue((matchedOption && matchedOption.label) || '');
-    },
-    [options],
-  );
-
-  const optionsMarkup =
-    options.length > 0
-      ? options.map((option) => {
-          const {label, value} = option;
-
-          return (
-            <Listbox.Option
-              key={`${value}`}
-              value={value}
-              selected={selectedOption === value}
-              accessibilityLabel={label}
-            >
-              {label}
-            </Listbox.Option>
-          );
-        })
-      : null;
-
-  return (
-    <div style={{height: '225px'}}>
-      <Combobox
-        activator={
-          <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
-            onChange={updateText}
-            label="Search tags"
-            labelHidden
-            value={inputValue}
-            placeholder="Search tags"
-          />
-        }
-      >
-        {options.length > 0 ? (
-          <Listbox autoSelection="NONE" onSelect={updateSelection}>
-            {optionsMarkup}
-          </Listbox>
-        ) : null}
-      </Combobox>
-    </div>
-  );
-}
-
-export function WithMultiSelect() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
-      }
-
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = deselectedOptions.filter((option) =>
-        option.label.match(filterRegex),
-      );
-      setOptions(resultOptions);
-    },
-    [deselectedOptions],
-  );
-
-  const updateSelection = useCallback(
-    (selected) => {
-      if (selectedOptions.includes(selected)) {
-        setSelectedOptions(
-          selectedOptions.filter((option) => option !== selected),
-        );
-      } else {
-        setSelectedOptions([...selectedOptions, selected]);
-      }
-
-      const matchedOption = options.find((option) => {
-        return option.value.match(selected);
-      });
-
-      updateText('');
-    },
-    [options, selectedOptions, updateText],
-  );
-
-  const removeTag = useCallback(
-    (tag) => () => {
-      const options = [...selectedOptions];
-      options.splice(options.indexOf(tag), 1);
-      setSelectedOptions(options);
-    },
-    [selectedOptions],
-  );
-
-  const tagsMarkup = selectedOptions.map((option) => (
-    <Tag key={`option-${option}`} onRemove={removeTag(option)}>
-      {option}
-    </Tag>
-  ));
-
-  const optionsMarkup =
-    options.length > 0
-      ? options.map((option) => {
-          const {label, value} = option;
-
-          return (
-            <Listbox.Option
-              key={`${value}`}
-              value={value}
-              selected={selectedOptions.includes(value)}
-              accessibilityLabel={label}
-            >
-              {label}
-            </Listbox.Option>
-          );
-        })
-      : null;
-
-  return (
-    <div style={{height: '225px'}}>
-      <Combobox
-        allowMultiple
-        activator={
-          <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
-            onChange={updateText}
-            label="Search tags"
-            labelHidden
-            value={inputValue}
-            placeholder="Search tags"
-          />
-        }
-      >
-        {optionsMarkup ? (
-          <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
-        ) : null}
-      </Combobox>
-      <TextContainer>
-        <LegacyStack>{tagsMarkup}</LegacyStack>
-      </TextContainer>
-    </div>
-  );
-}
-
-export function WithMultiSelectAndManualSelection() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-
-  const [selectedOptions, setSelectedOptions] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (value === '') {
-        setOptions(deselectedOptions);
-        return;
-      }
-
-      const filterRegex = new RegExp(value, 'i');
-      const resultOptions = deselectedOptions.filter((option) =>
-        option.label.match(filterRegex),
-      );
-      setOptions(resultOptions);
-    },
-    [deselectedOptions],
-  );
-
-  const updateSelection = useCallback(
-    (selected) => {
-      if (selectedOptions.includes(selected)) {
-        setSelectedOptions(
-          selectedOptions.filter((option) => option !== selected),
-        );
-      } else {
-        setSelectedOptions([...selectedOptions, selected]);
-      }
-
-      const matchedOption = options.find((option) => {
-        return option.value.match(selected);
-      });
-
-      updateText('');
-    },
-    [options, selectedOptions, updateText],
-  );
-
-  const removeTag = useCallback(
-    (tag) => () => {
-      const options = [...selectedOptions];
-      options.splice(options.indexOf(tag), 1);
-      setSelectedOptions(options);
-    },
-    [selectedOptions],
-  );
-
-  const tagsMarkup = selectedOptions.map((option) => (
-    <Tag key={`option-${option}`} onRemove={removeTag(option)}>
-      {option}
-    </Tag>
-  ));
-
-  const optionsMarkup =
-    options.length > 0
-      ? options.map((option) => {
-          const {label, value} = option;
-
-          return (
-            <Listbox.Option
-              key={`${value}`}
-              value={value}
-              selected={selectedOptions.includes(value)}
-              accessibilityLabel={label}
-            >
-              {label}
-            </Listbox.Option>
-          );
-        })
-      : null;
-
-  return (
-    <div style={{height: '225px'}}>
-      <Combobox
-        allowMultiple
-        activator={
-          <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
-            onChange={updateText}
-            label="Search tags"
-            labelHidden
-            value={inputValue}
-            placeholder="Search tags"
-          />
-        }
-      >
-        {optionsMarkup ? (
-          <Listbox autoSelection="NONE" onSelect={updateSelection}>
-            {optionsMarkup}
-          </Listbox>
-        ) : null}
-      </Combobox>
-      <TextContainer>
-        <LegacyStack>{tagsMarkup}</LegacyStack>
-      </TextContainer>
-    </div>
-  );
-}
-
-export function WithMultiSelectAndVerticalContent() {
-  const [selectedTags, setSelectedTags] = useState(['Rustic']);
-  const [value, setValue] = useState('');
-  const [suggestion, setSuggestion] = useState('');
-
-  const handleActiveOptionChange = useCallback(
-    (activeOption) => {
-      const activeOptionIsAction = activeOption === value;
-
-      if (!activeOptionIsAction && !selectedTags.includes(activeOption)) {
-        setSuggestion(activeOption);
-      } else {
-        setSuggestion('');
-      }
-    },
-    [value, selectedTags],
-  );
-  const updateSelection = useCallback(
-    (selected) => {
-      const nextSelectedTags = new Set([...selectedTags]);
-
-      if (nextSelectedTags.has(selected)) {
-        nextSelectedTags.delete(selected);
-      } else {
-        nextSelectedTags.add(selected);
-      }
-      setSelectedTags([...nextSelectedTags]);
-      setValue('');
-      setSuggestion('');
-    },
-    [selectedTags],
-  );
-
-  const removeTag = useCallback(
-    (tag) => () => {
-      updateSelection(tag);
-    },
-    [updateSelection],
-  );
-
-  const getAllTags = useCallback(() => {
-    const savedTags = ['Rustic', 'Antique', 'Vinyl', 'Vintage', 'Refurbished'];
-    return [...new Set([...savedTags, ...selectedTags].sort())];
-  }, [selectedTags]);
-
-  const formatOptionText = useCallback(
-    (option) => {
-      const trimValue = value.trim().toLocaleLowerCase();
-      const matchIndex = option.toLocaleLowerCase().indexOf(trimValue);
-
-      if (!value || matchIndex === -1) return option;
-
-      const start = option.slice(0, matchIndex);
-      const highlight = option.slice(
-        matchIndex,
-        `${matchIndex}${trimValue.length}`,
-      );
-      const end = option.slice(
-        `${matchIndex}${trimValue.length}`,
-        option.length,
-      );
-
-      return (
-        <Text as="p" variant="bodyMd">
-          {start}
-          <Text fontWeight="bold" as="span">
-            {highlight}
-          </Text>
-          {end}
-        </Text>
-      );
-    },
-    [value],
-  );
-
-  const options = useMemo(() => {
-    let list;
-    const allTags = getAllTags();
-    const filterRegex = new RegExp(value, 'i');
-
-    if (value) {
-      list = allTags.filter((tag) => tag.match(filterRegex));
-    } else {
-      list = allTags;
-    }
-
-    return [...list];
-  }, [value, getAllTags]);
-
-  const verticalContentMarkup =
-    selectedTags.length > 0 ? (
-      <LegacyStack spacing="extraTight" alignment="center">
-        {selectedTags.map((tag) => (
-          <Tag key={`option-${tag}`} onRemove={removeTag(tag)}>
-            {tag}
-          </Tag>
-        ))}
-      </LegacyStack>
-    ) : null;
-
-  const optionMarkup =
-    options.length > 0
-      ? options.map((option) => {
-          return (
-            <Listbox.Option
-              key={option}
-              value={option}
-              selected={selectedTags.includes(option)}
-              accessibilityLabel={option}
-            >
-              <Listbox.TextOption selected={selectedTags.includes(option)}>
-                {formatOptionText(option)}
-              </Listbox.TextOption>
-            </Listbox.Option>
-          );
-        })
-      : null;
-
-  const noResults = value && !getAllTags().includes(value);
-
-  const actionMarkup = noResults ? (
-    <Listbox.Action value={value}>{`Add "${value}"`}</Listbox.Action>
-  ) : null;
-
-  const emptyStateMarkup = optionMarkup ? null : (
-    <EmptySearchResult
-      title=""
-      description={`No tags found matching "${value}"`}
-    />
-  );
-
-  const listboxMarkup =
-    optionMarkup || actionMarkup || emptyStateMarkup ? (
-      <Listbox
-        autoSelection="FIRST"
-        onSelect={updateSelection}
-        onActiveOptionChange={handleActiveOptionChange}
-      >
-        {actionMarkup}
-        {optionMarkup}
-      </Listbox>
-    ) : null;
-
-  return (
-    <div style={{height: '225px'}}>
-      <Combobox
-        allowMultiple
-        activator={
-          <Combobox.TextField
-            autoComplete="off"
-            label="Search tags"
-            labelHidden
-            value={value}
-            suggestion={suggestion}
-            placeholder="Search tags"
-            verticalContent={verticalContentMarkup}
-            onChange={setValue}
-          />
-        }
-      >
-        {listboxMarkup}
-      </Combobox>
-    </div>
-  );
-}
-
-export function WithLoading() {
-  const deselectedOptions = useMemo(
-    () => [
-      {value: 'rustic', label: 'Rustic'},
-      {value: 'antique', label: 'Antique'},
-      {value: 'vinyl', label: 'Vinyl'},
-      {value: 'vintage', label: 'Vintage'},
-      {value: 'refurbished', label: 'Refurbished'},
-    ],
-    [],
-  );
-
-  const [selectedOption, setSelectedOption] = useState();
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState(deselectedOptions);
-  const [loading, setLoading] = useState(false);
-
-  const updateText = useCallback(
-    (value) => {
-      setInputValue(value);
-
-      if (!loading) {
-        setLoading(true);
-      }
-
-      setTimeout(() => {
         if (value === '') {
           setOptions(deselectedOptions);
-          setLoading(false);
           return;
         }
+
         const filterRegex = new RegExp(value, 'i');
-        const resultOptions = options.filter((option) =>
+        const resultOptions = deselectedOptions.filter((option) =>
           option.label.match(filterRegex),
         );
         setOptions(resultOptions);
-        setLoading(false);
-      }, 400);
-    },
-    [deselectedOptions, loading, options],
-  );
+      },
+      [deselectedOptions],
+    );
 
-  const updateSelection = useCallback(
-    (selected) => {
-      const matchedOption = options.find((option) => {
-        return option.value.match(selected);
-      });
+    const updateSelection = useCallback(
+      (selected) => {
+        const matchedOption = options.find((option) => {
+          return option.value.match(selected);
+        });
 
-      setSelectedOption(selected);
-      setInputValue((matchedOption && matchedOption.label) || '');
-    },
-    [options],
-  );
+        setSelectedOption(selected);
+        setInputValue((matchedOption && matchedOption.label) || '');
+      },
+      [options],
+    );
 
-  const optionsMarkup =
-    options.length > 0 && !loading
-      ? options.map((option) => {
-          const {label, value} = option;
+    const optionsMarkup =
+      options.length > 0
+        ? options.map((option) => {
+            const {label, value} = option;
 
-          return (
-            <Listbox.Option
-              key={`${value}`}
-              value={value}
-              selected={selectedOption === value}
-              accessibilityLabel={label}
-            >
-              {label}
-            </Listbox.Option>
+            return (
+              <Listbox.Option
+                key={`${value}`}
+                value={value}
+                selected={selectedOption === value}
+                accessibilityLabel={label}
+              >
+                {label}
+              </Listbox.Option>
+            );
+          })
+        : null;
+
+    return (
+      <div style={{height: '225px'}}>
+        <Combobox
+          activator={
+            <Combobox.TextField
+              prefix={<Icon source={SearchIcon} />}
+              onChange={updateText}
+              label="Search tags"
+              labelHidden
+              value={inputValue}
+              placeholder="Search tags"
+            />
+          }
+        >
+          {options.length > 0 ? (
+            <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
+          ) : null}
+        </Combobox>
+      </div>
+    );
+  },
+};
+
+export const WithChildrenBasedOnInput = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+
+    const [selectedOption, setSelectedOption] = useState();
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (value === '') {
+          setOptions(deselectedOptions);
+          return;
+        }
+
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = deselectedOptions.filter((option) =>
+          option.label.match(filterRegex),
+        );
+        setOptions(resultOptions);
+      },
+      [deselectedOptions],
+    );
+
+    const updateSelection = useCallback(
+      (selected) => {
+        const matchedOption = options.find((option) => {
+          return option.value.match(selected);
+        });
+
+        setSelectedOption(selected);
+        setInputValue((matchedOption && matchedOption.label) || '');
+      },
+      [options],
+    );
+
+    const optionsMarkup =
+      options.length > 0
+        ? options.map((option) => {
+            const {label, value} = option;
+
+            return (
+              <Listbox.Option
+                key={`${value}`}
+                value={value}
+                selected={selectedOption === value}
+                accessibilityLabel={label}
+              >
+                {label}
+              </Listbox.Option>
+            );
+          })
+        : null;
+
+    return (
+      <div style={{height: '225px'}}>
+        <Combobox
+          activator={
+            <Combobox.TextField
+              prefix={<Icon source={SearchIcon} />}
+              onChange={updateText}
+              label="Search tags"
+              labelHidden
+              value={inputValue}
+              placeholder="Search tags"
+            />
+          }
+        >
+          {inputValue.length > 0 && options.length > 0 ? (
+            <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
+          ) : null}
+        </Combobox>
+      </div>
+    );
+  },
+};
+
+export const WithManualSelection = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+
+    const [selectedOption, setSelectedOption] = useState();
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (value === '') {
+          setOptions(deselectedOptions);
+          return;
+        }
+
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = deselectedOptions.filter((option) =>
+          option.label.match(filterRegex),
+        );
+        setOptions(resultOptions);
+      },
+      [deselectedOptions],
+    );
+
+    const updateSelection = useCallback(
+      (selected) => {
+        const matchedOption = options.find((option) => {
+          return option.value.match(selected);
+        });
+
+        setSelectedOption(selected);
+        setInputValue((matchedOption && matchedOption.label) || '');
+      },
+      [options],
+    );
+
+    const optionsMarkup =
+      options.length > 0
+        ? options.map((option) => {
+            const {label, value} = option;
+
+            return (
+              <Listbox.Option
+                key={`${value}`}
+                value={value}
+                selected={selectedOption === value}
+                accessibilityLabel={label}
+              >
+                {label}
+              </Listbox.Option>
+            );
+          })
+        : null;
+
+    return (
+      <div style={{height: '225px'}}>
+        <Combobox
+          activator={
+            <Combobox.TextField
+              prefix={<Icon source={SearchIcon} />}
+              onChange={updateText}
+              label="Search tags"
+              labelHidden
+              value={inputValue}
+              placeholder="Search tags"
+            />
+          }
+        >
+          {options.length > 0 ? (
+            <Listbox autoSelection="NONE" onSelect={updateSelection}>
+              {optionsMarkup}
+            </Listbox>
+          ) : null}
+        </Combobox>
+      </div>
+    );
+  },
+};
+
+export const WithMultiSelect = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (value === '') {
+          setOptions(deselectedOptions);
+          return;
+        }
+
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = deselectedOptions.filter((option) =>
+          option.label.match(filterRegex),
+        );
+        setOptions(resultOptions);
+      },
+      [deselectedOptions],
+    );
+
+    const updateSelection = useCallback(
+      (selected) => {
+        if (selectedOptions.includes(selected)) {
+          setSelectedOptions(
+            selectedOptions.filter((option) => option !== selected),
           );
-        })
-      : null;
+        } else {
+          setSelectedOptions([...selectedOptions, selected]);
+        }
 
-  const loadingMarkup = loading ? (
-    <div
-      style={{
-        height: '220px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <Listbox.Loading />
-    </div>
-  ) : null;
+        const matchedOption = options.find((option) => {
+          return option.value.match(selected);
+        });
 
-  const listboxMarkup =
-    optionsMarkup || loadingMarkup ? (
-      <Listbox onSelect={updateSelection}>
-        {optionsMarkup}
-        {loadingMarkup}
-      </Listbox>
+        updateText('');
+      },
+      [options, selectedOptions, updateText],
+    );
+
+    const removeTag = useCallback(
+      (tag) => () => {
+        const options = [...selectedOptions];
+        options.splice(options.indexOf(tag), 1);
+        setSelectedOptions(options);
+      },
+      [selectedOptions],
+    );
+
+    const tagsMarkup = selectedOptions.map((option) => (
+      <Tag key={`option-${option}`} onRemove={removeTag(option)}>
+        {option}
+      </Tag>
+    ));
+
+    const optionsMarkup =
+      options.length > 0
+        ? options.map((option) => {
+            const {label, value} = option;
+
+            return (
+              <Listbox.Option
+                key={`${value}`}
+                value={value}
+                selected={selectedOptions.includes(value)}
+                accessibilityLabel={label}
+              >
+                {label}
+              </Listbox.Option>
+            );
+          })
+        : null;
+
+    return (
+      <div style={{height: '225px'}}>
+        <Combobox
+          allowMultiple
+          activator={
+            <Combobox.TextField
+              prefix={<Icon source={SearchIcon} />}
+              onChange={updateText}
+              label="Search tags"
+              labelHidden
+              value={inputValue}
+              placeholder="Search tags"
+            />
+          }
+        >
+          {optionsMarkup ? (
+            <Listbox onSelect={updateSelection}>{optionsMarkup}</Listbox>
+          ) : null}
+        </Combobox>
+        <TextContainer>
+          <LegacyStack>{tagsMarkup}</LegacyStack>
+        </TextContainer>
+      </div>
+    );
+  },
+};
+
+export const WithMultiSelectAndManualSelection = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+
+    const [selectedOptions, setSelectedOptions] = useState([]);
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (value === '') {
+          setOptions(deselectedOptions);
+          return;
+        }
+
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = deselectedOptions.filter((option) =>
+          option.label.match(filterRegex),
+        );
+        setOptions(resultOptions);
+      },
+      [deselectedOptions],
+    );
+
+    const updateSelection = useCallback(
+      (selected) => {
+        if (selectedOptions.includes(selected)) {
+          setSelectedOptions(
+            selectedOptions.filter((option) => option !== selected),
+          );
+        } else {
+          setSelectedOptions([...selectedOptions, selected]);
+        }
+
+        const matchedOption = options.find((option) => {
+          return option.value.match(selected);
+        });
+
+        updateText('');
+      },
+      [options, selectedOptions, updateText],
+    );
+
+    const removeTag = useCallback(
+      (tag) => () => {
+        const options = [...selectedOptions];
+        options.splice(options.indexOf(tag), 1);
+        setSelectedOptions(options);
+      },
+      [selectedOptions],
+    );
+
+    const tagsMarkup = selectedOptions.map((option) => (
+      <Tag key={`option-${option}`} onRemove={removeTag(option)}>
+        {option}
+      </Tag>
+    ));
+
+    const optionsMarkup =
+      options.length > 0
+        ? options.map((option) => {
+            const {label, value} = option;
+
+            return (
+              <Listbox.Option
+                key={`${value}`}
+                value={value}
+                selected={selectedOptions.includes(value)}
+                accessibilityLabel={label}
+              >
+                {label}
+              </Listbox.Option>
+            );
+          })
+        : null;
+
+    return (
+      <div style={{height: '225px'}}>
+        <Combobox
+          allowMultiple
+          activator={
+            <Combobox.TextField
+              prefix={<Icon source={SearchIcon} />}
+              onChange={updateText}
+              label="Search tags"
+              labelHidden
+              value={inputValue}
+              placeholder="Search tags"
+            />
+          }
+        >
+          {optionsMarkup ? (
+            <Listbox autoSelection="NONE" onSelect={updateSelection}>
+              {optionsMarkup}
+            </Listbox>
+          ) : null}
+        </Combobox>
+        <TextContainer>
+          <LegacyStack>{tagsMarkup}</LegacyStack>
+        </TextContainer>
+      </div>
+    );
+  },
+};
+
+export const WithMultiSelectAndVerticalContent = {
+  render() {
+    const [selectedTags, setSelectedTags] = useState(['Rustic']);
+    const [value, setValue] = useState('');
+    const [suggestion, setSuggestion] = useState('');
+
+    const handleActiveOptionChange = useCallback(
+      (activeOption) => {
+        const activeOptionIsAction = activeOption === value;
+
+        if (!activeOptionIsAction && !selectedTags.includes(activeOption)) {
+          setSuggestion(activeOption);
+        } else {
+          setSuggestion('');
+        }
+      },
+      [value, selectedTags],
+    );
+    const updateSelection = useCallback(
+      (selected) => {
+        const nextSelectedTags = new Set([...selectedTags]);
+
+        if (nextSelectedTags.has(selected)) {
+          nextSelectedTags.delete(selected);
+        } else {
+          nextSelectedTags.add(selected);
+        }
+        setSelectedTags([...nextSelectedTags]);
+        setValue('');
+        setSuggestion('');
+      },
+      [selectedTags],
+    );
+
+    const removeTag = useCallback(
+      (tag) => () => {
+        updateSelection(tag);
+      },
+      [updateSelection],
+    );
+
+    const getAllTags = useCallback(() => {
+      const savedTags = [
+        'Rustic',
+        'Antique',
+        'Vinyl',
+        'Vintage',
+        'Refurbished',
+      ];
+      return [...new Set([...savedTags, ...selectedTags].sort())];
+    }, [selectedTags]);
+
+    const formatOptionText = useCallback(
+      (option) => {
+        const trimValue = value.trim().toLocaleLowerCase();
+        const matchIndex = option.toLocaleLowerCase().indexOf(trimValue);
+
+        if (!value || matchIndex === -1) return option;
+
+        const start = option.slice(0, matchIndex);
+        const highlight = option.slice(
+          matchIndex,
+          `${matchIndex}${trimValue.length}`,
+        );
+        const end = option.slice(
+          `${matchIndex}${trimValue.length}`,
+          option.length,
+        );
+
+        return (
+          <Text as="p" variant="bodyMd">
+            {start}
+            <Text fontWeight="bold" as="span">
+              {highlight}
+            </Text>
+            {end}
+          </Text>
+        );
+      },
+      [value],
+    );
+
+    const options = useMemo(() => {
+      let list;
+      const allTags = getAllTags();
+      const filterRegex = new RegExp(value, 'i');
+
+      if (value) {
+        list = allTags.filter((tag) => tag.match(filterRegex));
+      } else {
+        list = allTags;
+      }
+
+      return [...list];
+    }, [value, getAllTags]);
+
+    const verticalContentMarkup =
+      selectedTags.length > 0 ? (
+        <LegacyStack spacing="extraTight" alignment="center">
+          {selectedTags.map((tag) => (
+            <Tag key={`option-${tag}`} onRemove={removeTag(tag)}>
+              {tag}
+            </Tag>
+          ))}
+        </LegacyStack>
+      ) : null;
+
+    const optionMarkup =
+      options.length > 0
+        ? options.map((option) => {
+            return (
+              <Listbox.Option
+                key={option}
+                value={option}
+                selected={selectedTags.includes(option)}
+                accessibilityLabel={option}
+              >
+                <Listbox.TextOption selected={selectedTags.includes(option)}>
+                  {formatOptionText(option)}
+                </Listbox.TextOption>
+              </Listbox.Option>
+            );
+          })
+        : null;
+
+    const noResults = value && !getAllTags().includes(value);
+
+    const actionMarkup = noResults ? (
+      <Listbox.Action value={value}>{`Add "${value}"`}</Listbox.Action>
     ) : null;
 
-  return (
-    <div style={{height: '225px'}}>
-      <Combobox
-        height="220px"
-        activator={
-          <Combobox.TextField
-            prefix={<Icon source={SearchIcon} />}
-            onChange={updateText}
-            label="Search tags"
-            labelHidden
-            value={inputValue}
-            placeholder="Search tags"
-          />
+    const emptyStateMarkup = optionMarkup ? null : (
+      <EmptySearchResult
+        title=""
+        description={`No tags found matching "${value}"`}
+      />
+    );
+
+    const listboxMarkup =
+      optionMarkup || actionMarkup || emptyStateMarkup ? (
+        <Listbox
+          autoSelection="FIRST"
+          onSelect={updateSelection}
+          onActiveOptionChange={handleActiveOptionChange}
+        >
+          {actionMarkup}
+          {optionMarkup}
+        </Listbox>
+      ) : null;
+
+    return (
+      <div style={{height: '225px'}}>
+        <Combobox
+          allowMultiple
+          activator={
+            <Combobox.TextField
+              autoComplete="off"
+              label="Search tags"
+              labelHidden
+              value={value}
+              suggestion={suggestion}
+              placeholder="Search tags"
+              verticalContent={verticalContentMarkup}
+              onChange={setValue}
+            />
+          }
+        >
+          {listboxMarkup}
+        </Combobox>
+      </div>
+    );
+  },
+};
+
+export const WithLoading = {
+  render() {
+    const deselectedOptions = useMemo(
+      () => [
+        {value: 'rustic', label: 'Rustic'},
+        {value: 'antique', label: 'Antique'},
+        {value: 'vinyl', label: 'Vinyl'},
+        {value: 'vintage', label: 'Vintage'},
+        {value: 'refurbished', label: 'Refurbished'},
+      ],
+      [],
+    );
+
+    const [selectedOption, setSelectedOption] = useState();
+    const [inputValue, setInputValue] = useState('');
+    const [options, setOptions] = useState(deselectedOptions);
+    const [loading, setLoading] = useState(false);
+
+    const updateText = useCallback(
+      (value) => {
+        setInputValue(value);
+
+        if (!loading) {
+          setLoading(true);
         }
+
+        setTimeout(() => {
+          if (value === '') {
+            setOptions(deselectedOptions);
+            setLoading(false);
+            return;
+          }
+          const filterRegex = new RegExp(value, 'i');
+          const resultOptions = options.filter((option) =>
+            option.label.match(filterRegex),
+          );
+          setOptions(resultOptions);
+          setLoading(false);
+        }, 400);
+      },
+      [deselectedOptions, loading, options],
+    );
+
+    const updateSelection = useCallback(
+      (selected) => {
+        const matchedOption = options.find((option) => {
+          return option.value.match(selected);
+        });
+
+        setSelectedOption(selected);
+        setInputValue((matchedOption && matchedOption.label) || '');
+      },
+      [options],
+    );
+
+    const optionsMarkup =
+      options.length > 0 && !loading
+        ? options.map((option) => {
+            const {label, value} = option;
+
+            return (
+              <Listbox.Option
+                key={`${value}`}
+                value={value}
+                selected={selectedOption === value}
+                accessibilityLabel={label}
+              >
+                {label}
+              </Listbox.Option>
+            );
+          })
+        : null;
+
+    const loadingMarkup = loading ? (
+      <div
+        style={{
+          height: '220px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
       >
-        {listboxMarkup}
-      </Combobox>
-    </div>
-  );
-}
+        <Listbox.Loading />
+      </div>
+    ) : null;
+
+    const listboxMarkup =
+      optionsMarkup || loadingMarkup ? (
+        <Listbox onSelect={updateSelection}>
+          {optionsMarkup}
+          {loadingMarkup}
+        </Listbox>
+      ) : null;
+
+    return (
+      <div style={{height: '225px'}}>
+        <Combobox
+          height="220px"
+          activator={
+            <Combobox.TextField
+              prefix={<Icon source={SearchIcon} />}
+              onChange={updateText}
+              label="Search tags"
+              labelHidden
+              value={inputValue}
+              placeholder="Search tags"
+            />
+          }
+        >
+          {listboxMarkup}
+        </Combobox>
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/ContextualSaveBar/ContextualSaveBar.stories.tsx
+++ b/polaris-react/src/components/ContextualSaveBar/ContextualSaveBar.stories.tsx
@@ -1,112 +1,120 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {ContextualSaveBar, Frame} from '@shopify/polaris';
 
 export default {
   component: ContextualSaveBar,
   parameters: {layout: 'fullscreen'},
-} as ComponentMeta<typeof ContextualSaveBar>;
+} as Meta<typeof ContextualSaveBar>;
 
-export function Default() {
-  return (
-    <div style={{height: '250px'}}>
-      <Frame
-        logo={{
-          width: 86,
-          contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
-        }}
-      >
-        <ContextualSaveBar
-          message="Unsaved changes"
-          saveAction={{
-            onAction: () => console.log('add form submit logic'),
-            loading: false,
-            disabled: false,
+export const Default = {
+  render() {
+    return (
+      <div style={{height: '250px'}}>
+        <Frame
+          logo={{
+            width: 86,
+            contextualSaveBarSource:
+              'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
           }}
-          discardAction={{
-            onAction: () => console.log('add clear form logic'),
-          }}
-        />
-      </Frame>
-    </div>
-  );
-}
+        >
+          <ContextualSaveBar
+            message="Unsaved changes"
+            saveAction={{
+              onAction: () => console.log('add form submit logic'),
+              loading: false,
+              disabled: false,
+            }}
+            discardAction={{
+              onAction: () => console.log('add clear form logic'),
+            }}
+          />
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function Disabled() {
-  return (
-    <div style={{height: '250px'}}>
-      <Frame
-        logo={{
-          width: 86,
-          contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
-        }}
-      >
-        <ContextualSaveBar
-          message="Unsaved changes"
-          saveAction={{
-            onAction: () => console.log('add form submit logic'),
-            loading: false,
-            disabled: true,
+export const Disabled = {
+  render() {
+    return (
+      <div style={{height: '250px'}}>
+        <Frame
+          logo={{
+            width: 86,
+            contextualSaveBarSource:
+              'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
           }}
-          discardAction={{
-            onAction: () => console.log('add clear form logic'),
-          }}
-        />
-      </Frame>
-    </div>
-  );
-}
+        >
+          <ContextualSaveBar
+            message="Unsaved changes"
+            saveAction={{
+              onAction: () => console.log('add form submit logic'),
+              loading: false,
+              disabled: true,
+            }}
+            discardAction={{
+              onAction: () => console.log('add clear form logic'),
+            }}
+          />
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function WithFlushContents() {
-  return (
-    <div style={{height: '250px'}}>
-      <Frame
-        logo={{
-          width: 86,
-          contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
-        }}
-      >
-        <ContextualSaveBar
-          alignContentFlush
-          message="Unsaved changes"
-          saveAction={{
-            onAction: () => console.log('add form submit logic'),
+export const WithFlushContents = {
+  render() {
+    return (
+      <div style={{height: '250px'}}>
+        <Frame
+          logo={{
+            width: 86,
+            contextualSaveBarSource:
+              'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
           }}
-          discardAction={{
-            onAction: () => console.log('add clear form logic'),
-          }}
-        />
-      </Frame>
-    </div>
-  );
-}
+        >
+          <ContextualSaveBar
+            alignContentFlush
+            message="Unsaved changes"
+            saveAction={{
+              onAction: () => console.log('add form submit logic'),
+            }}
+            discardAction={{
+              onAction: () => console.log('add clear form logic'),
+            }}
+          />
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function WithFullWidth() {
-  return (
-    <div style={{height: '250px'}}>
-      <Frame
-        logo={{
-          width: 86,
-          contextualSaveBarSource:
-            'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
-        }}
-      >
-        <ContextualSaveBar
-          fullWidth
-          message="Unsaved changes"
-          saveAction={{
-            onAction: () => console.log('add form submit logic'),
-            loading: false,
-            disabled: false,
+export const WithFullWidth = {
+  render() {
+    return (
+      <div style={{height: '250px'}}>
+        <Frame
+          logo={{
+            width: 86,
+            contextualSaveBarSource:
+              'https://cdn.shopify.com/s/files/1/2376/3301/files/Shopify_Secondary_Inverted.png',
           }}
-          discardAction={{
-            onAction: () => console.log('add clear form logic'),
-          }}
-        />
-      </Frame>
-    </div>
-  );
-}
+        >
+          <ContextualSaveBar
+            fullWidth
+            message="Unsaved changes"
+            saveAction={{
+              onAction: () => console.log('add form submit logic'),
+              loading: false,
+              disabled: false,
+            }}
+            discardAction={{
+              onAction: () => console.log('add clear form logic'),
+            }}
+          />
+        </Frame>
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/DataTable/DataTable.stories.tsx
+++ b/polaris-react/src/components/DataTable/DataTable.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {LegacyCard, DataTable, Link, Page} from '@shopify/polaris';
 
 export default {
@@ -11,7 +11,7 @@ export default {
       },
     },
   },
-} as ComponentMeta<typeof DataTable>;
+} as Meta<typeof DataTable>;
 
 function sortCurrency(rows, index, direction) {
   return [...rows].sort((rowA, rowB) => {
@@ -22,898 +22,928 @@ function sortCurrency(rows, index, direction) {
   });
 }
 
-export function Default() {
-  const rows = [
-    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-    [
-      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+export const Default = {
+  render() {
+    const rows = [
+      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+      [
+        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function Sortable() {
-  const [sortedRows, setSortedRows] = useState<any[]>();
+export const Sortable = {
+  render() {
+    const [sortedRows, setSortedRows] = useState<any[]>();
 
-  const initiallySortedRows = [
-    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-    [
-      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
-  const rows = sortedRows ? sortedRows : initiallySortedRows;
+    const initiallySortedRows = [
+      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+      [
+        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
+    const rows = sortedRows ? sortedRows : initiallySortedRows;
 
-  const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
-    [rows],
-  );
+    const handleSort = useCallback(
+      (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
+      [rows],
+    );
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-          sortable={[false, true, false, false, true]}
-          defaultSortDirection="descending"
-          initialSortColumnIndex={4}
-          onSort={handleSort}
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+            sortable={[false, true, false, false, true]}
+            defaultSortDirection="descending"
+            initialSortColumnIndex={4}
+            onSort={handleSort}
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithFooter() {
-  const rows = [
-    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-    [
-      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+export const WithFooter = {
+  render() {
+    const rows = [
+      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+      [
+        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-          footerContent={`Showing ${rows.length} of ${rows.length} results`}
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+            footerContent={`Showing ${rows.length} of ${rows.length} results`}
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithCustomTotalsHeading() {
-  const rows = [
-    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-    [
-      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+export const WithCustomTotalsHeading = {
+  render() {
+    const rows = [
+      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+      [
+        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          showTotalsInFooter
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', '', '$155,830.00']}
-          totalsName={{
-            singular: 'Total net sales',
-            plural: 'Total net sales',
-          }}
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            showTotalsInFooter
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', '', '$155,830.00']}
+            totalsName={{
+              singular: 'Total net sales',
+              plural: 'Total net sales',
+            }}
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithTotalsInFooter() {
-  const rows = [
-    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-    [
-      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+export const WithTotalsInFooter = {
+  render() {
+    const rows = [
+      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+      [
+        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-          showTotalsInFooter
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+            showTotalsInFooter
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithRowHeadingLinks() {
-  const rows = [
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$122,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+export const WithRowHeadingLinks = {
+  render() {
+    const rows = [
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$122,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={['Product', 'Price', 'SKU Number', 'Quantity', 'Net sales']}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithAllOfItsElements() {
-  const [sortedRows, setSortedRows] = useState<any[]>();
+export const WithAllOfItsElements = {
+  render() {
+    const [sortedRows, setSortedRows] = useState<any[]>();
 
-  const initiallySortedRows = [
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$121,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+    const initiallySortedRows = [
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$121,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  const rows = sortedRows ? sortedRows : initiallySortedRows;
-  const handleSort = useCallback(
-    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
-    [rows],
-  );
+    const rows = sortedRows ? sortedRows : initiallySortedRows;
+    const handleSort = useCallback(
+      (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
+      [rows],
+    );
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-          sortable={[false, true, false, false, true]}
-          defaultSortDirection="descending"
-          initialSortColumnIndex={4}
-          onSort={handleSort}
-          footerContent={`Showing ${rows.length} of ${rows.length} results`}
-          stickyHeader
-          fixedFirstColumns={1}
-          truncate
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+            sortable={[false, true, false, false, true]}
+            defaultSortDirection="descending"
+            initialSortColumnIndex={4}
+            onSort={handleSort}
+            footerContent={`Showing ${rows.length} of ${rows.length} results`}
+            stickyHeader
+            fixedFirstColumns={1}
+            truncate
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithColumnSpanning() {
-  const rows = [
-    [
-      'Sep 19, 2010, 1:02 pm NDT',
-      '#1234',
-      'Adjustment',
-      '$1.00',
-      '$1.00',
-      '$1.00',
-      '$1.00',
-      '$1.00',
-    ],
-    // eslint-disable-next-line react/jsx-key
-    [<LegacyCard>Hello</LegacyCard>],
-    [
-      'Sep 19, 2010, 1:02 pm NDT',
-      '#1234',
-      'Adjustment',
-      '$1.00',
-      '$1.00',
-      '$1.00',
-      '$1.00',
-      '$1.00',
-    ],
-  ];
+export const WithColumnSpanning = {
+  render() {
+    const rows = [
+      [
+        'Sep 19, 2010, 1:02 pm NDT',
+        '#1234',
+        'Adjustment',
+        '$1.00',
+        '$1.00',
+        '$1.00',
+        '$1.00',
+        '$1.00',
+      ],
+      // eslint-disable-next-line react/jsx-key
+      [<LegacyCard>Hello</LegacyCard>],
+      [
+        'Sep 19, 2010, 1:02 pm NDT',
+        '#1234',
+        'Adjustment',
+        '$1.00',
+        '$1.00',
+        '$1.00',
+        '$1.00',
+        '$1.00',
+      ],
+    ];
 
-  return (
-    <Page title="Payouts">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'transactionDate',
-            'reference',
-            'type',
-            'amount',
-            'fee',
-            'net',
-            'gross',
-            'number',
-          ]}
-          rows={rows}
-          verticalAlign="middle"
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Payouts">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'transactionDate',
+              'reference',
+              'type',
+              'amount',
+              'fee',
+              'net',
+              'gross',
+              'number',
+            ]}
+            rows={rows}
+            verticalAlign="middle"
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithFixedColumns() {
-  const rows = [
-    [
-      'Emerald Silk Gown',
-      'Formalwear',
-      "Jill's formal",
-      10,
-      '$875.00',
-      124689,
-      140,
-      '$426.00',
-      '$122,500.00',
-    ],
-    [
-      'Mauve Cashmere Scarf',
-      'Accessories',
-      "Jack's Accessories",
-      253,
-      '$230.00',
-      124533,
-      83,
-      '$620.00',
-      '$19,090.00',
-    ],
-    [
-      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-      'Ensembles',
-      'Avocado Fashions',
-      23,
-      '$445.00',
-      124518,
-      32,
-      '$353.00',
-      '$14,240.00',
-    ],
-    [
-      'Socks',
-      'Essentials',
-      'Avocado Fashions',
-      465,
-      '$4.00',
-      124518,
-      32,
-      '$3.00',
-      '$140.00',
-    ],
-  ];
+export const WithFixedColumns = {
+  render() {
+    const rows = [
+      [
+        'Emerald Silk Gown',
+        'Formalwear',
+        "Jill's formal",
+        10,
+        '$875.00',
+        124689,
+        140,
+        '$426.00',
+        '$122,500.00',
+      ],
+      [
+        'Mauve Cashmere Scarf',
+        'Accessories',
+        "Jack's Accessories",
+        253,
+        '$230.00',
+        124533,
+        83,
+        '$620.00',
+        '$19,090.00',
+      ],
+      [
+        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+        'Ensembles',
+        'Avocado Fashions',
+        23,
+        '$445.00',
+        124518,
+        32,
+        '$353.00',
+        '$14,240.00',
+      ],
+      [
+        'Socks',
+        'Essentials',
+        'Avocado Fashions',
+        465,
+        '$4.00',
+        124518,
+        32,
+        '$3.00',
+        '$140.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'text',
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Category',
-            'Vendor',
-            'Orders',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Shipping',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', '', '', '', 255, '$1399', '$155,830.00']}
-          initialSortColumnIndex={4}
-          stickyHeader
-          fixedFirstColumns={3}
-          truncate
-          showTotalsInFooter
-          footerContent={`Showing ${rows.length} of ${rows.length} results`}
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'text',
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Category',
+              'Vendor',
+              'Orders',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Shipping',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', '', '', '', 255, '$1399', '$155,830.00']}
+            initialSortColumnIndex={4}
+            stickyHeader
+            fixedFirstColumns={3}
+            truncate
+            showTotalsInFooter
+            footerContent={`Showing ${rows.length} of ${rows.length} results`}
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithIncreasedDensityAndZebraStriping() {
-  const rows = [
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$121,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+export const WithIncreasedDensityAndZebraStriping = {
+  render() {
+    const rows = [
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$121,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-          defaultSortDirection="descending"
-          initialSortColumnIndex={4}
-          footerContent={`Showing ${rows.length} of ${rows.length} results`}
-          hasZebraStripingOnData
-          increasedTableDensity
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+            defaultSortDirection="descending"
+            initialSortColumnIndex={4}
+            footerContent={`Showing ${rows.length} of ${rows.length} results`}
+            hasZebraStripingOnData
+            increasedTableDensity
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithStickyHeaderEnabled() {
-  const rows = [
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$121,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$121,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$121,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$121,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$121,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="emerald-silk-gown"
-      >
-        Emerald Silk Gown
-      </Link>,
-      '$875.00',
-      124689,
-      140,
-      '$121,500.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="mauve-cashmere-scarf"
-      >
-        Mauve Cashmere Scarf
-      </Link>,
-      '$230.00',
-      124533,
-      83,
-      '$19,090.00',
-    ],
-    [
-      <Link
-        removeUnderline
-        url="https://www.example.com"
-        key="navy-merino-wool"
-      >
-        Navy Merino Wool Blazer with khaki chinos and yellow belt
-      </Link>,
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+export const WithStickyHeaderEnabled = {
+  render() {
+    const rows = [
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$121,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$121,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$121,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$121,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$121,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="emerald-silk-gown"
+        >
+          Emerald Silk Gown
+        </Link>,
+        '$875.00',
+        124689,
+        140,
+        '$121,500.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="mauve-cashmere-scarf"
+        >
+          Mauve Cashmere Scarf
+        </Link>,
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        <Link
+          removeUnderline
+          url="https://www.example.com"
+          key="navy-merino-wool"
+        >
+          Navy Merino Wool Blazer with khaki chinos and yellow belt
+        </Link>,
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-          defaultSortDirection="descending"
-          initialSortColumnIndex={4}
-          footerContent={`Showing ${rows.length} of ${rows.length} results`}
-          hasZebraStripingOnData
-          increasedTableDensity
-          stickyHeader
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+            defaultSortDirection="descending"
+            initialSortColumnIndex={4}
+            footerContent={`Showing ${rows.length} of ${rows.length} results`}
+            hasZebraStripingOnData
+            increasedTableDensity
+            stickyHeader
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithPagination() {
-  const rows = [
-    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-    [
-      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-      '$445.00',
-      124518,
-      32,
-      '$14,240.00',
-    ],
-  ];
+export const WithPagination = {
+  render() {
+    const rows = [
+      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+      [
+        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
 
-  return (
-    <Page title="Sales by product">
-      <LegacyCard>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={rows}
-          totals={['', '', '', 255, '$155,830.00']}
-          pagination={{
-            hasNext: true,
-            onNext: () => {},
-          }}
-        />
-      </LegacyCard>
-    </Page>
-  );
-}
+    return (
+      <Page title="Sales by product">
+        <LegacyCard>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+            pagination={{
+              hasNext: true,
+              onNext: () => {},
+            }}
+          />
+        </LegacyCard>
+      </Page>
+    );
+  },
+};

--- a/polaris-react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/polaris-react/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Box, Card, DatePicker, BlockStack} from '@shopify/polaris';
 
 export default {
@@ -7,167 +7,181 @@ export default {
   parameters: {
     chromatic: {delay: 300},
   },
-} as ComponentMeta<typeof DatePicker>;
+} as Meta<typeof DatePicker>;
 
-export function All() {
-  return (
-    <BlockStack gap="400">
-      <Box maxWidth="290px">
-        <Card>
-          <Default />
-        </Card>
-      </Box>
-      <Box maxWidth="556px">
-        <Card>
-          <Ranged />
-        </Card>
-      </Box>
-      <Box maxWidth="556px">
-        <Card>
-          <MultiMonthRanged />
-        </Card>
-      </Box>
-      <Box maxWidth="290px">
-        <Card>
-          <WithDisabledDateRanges />
-        </Card>
-      </Box>
-      <Box maxWidth="290px">
-        <Card>
-          <WithSpecificDisabledDates />
-        </Card>
-      </Box>
-    </BlockStack>
-  );
-}
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="400">
+        <Box maxWidth="290px">
+          <Card>
+            <Default.render />
+          </Card>
+        </Box>
+        <Box maxWidth="556px">
+          <Card>
+            <Ranged.render />
+          </Card>
+        </Box>
+        <Box maxWidth="556px">
+          <Card>
+            <MultiMonthRanged.render />
+          </Card>
+        </Box>
+        <Box maxWidth="290px">
+          <Card>
+            <WithDisabledDateRanges.render />
+          </Card>
+        </Box>
+        <Box maxWidth="290px">
+          <Card>
+            <WithSpecificDisabledDates.render />
+          </Card>
+        </Box>
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function Default() {
-  const [{month, year}, setDate] = useState({month: 1, year: 2018});
-  const [selectedDates, setSelectedDates] = useState({
-    start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
-    end: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
-  });
+export const Default = {
+  render() {
+    const [{month, year}, setDate] = useState({month: 1, year: 2018});
+    const [selectedDates, setSelectedDates] = useState({
+      start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
+      end: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
+    });
 
-  const handleMonthChange = useCallback(
-    (month, year) => setDate({month, year}),
-    [],
-  );
+    const handleMonthChange = useCallback(
+      (month, year) => setDate({month, year}),
+      [],
+    );
 
-  return (
-    <DatePicker
-      month={month}
-      year={year}
-      onChange={setSelectedDates}
-      onMonthChange={handleMonthChange}
-      selected={selectedDates}
-    />
-  );
-}
+    return (
+      <DatePicker
+        month={month}
+        year={year}
+        onChange={setSelectedDates}
+        onMonthChange={handleMonthChange}
+        selected={selectedDates}
+      />
+    );
+  },
+};
 
-export function Ranged() {
-  const [{month, year}, setDate] = useState({month: 1, year: 2018});
-  const [selectedDates, setSelectedDates] = useState({
-    start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
-    end: new Date('Sat Feb 10 2018 00:00:00 GMT-0500 (EST)'),
-  });
+export const Ranged = {
+  render() {
+    const [{month, year}, setDate] = useState({month: 1, year: 2018});
+    const [selectedDates, setSelectedDates] = useState({
+      start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
+      end: new Date('Sat Feb 10 2018 00:00:00 GMT-0500 (EST)'),
+    });
 
-  const handleMonthChange = useCallback(
-    (month, year) => setDate({month, year}),
-    [],
-  );
+    const handleMonthChange = useCallback(
+      (month, year) => setDate({month, year}),
+      [],
+    );
 
-  return (
-    <DatePicker
-      month={month}
-      year={year}
-      onChange={setSelectedDates}
-      onMonthChange={handleMonthChange}
-      selected={selectedDates}
-      allowRange
-    />
-  );
-}
+    return (
+      <DatePicker
+        month={month}
+        year={year}
+        onChange={setSelectedDates}
+        onMonthChange={handleMonthChange}
+        selected={selectedDates}
+        allowRange
+      />
+    );
+  },
+};
 
-export function MultiMonthRanged() {
-  const [{month, year}, setDate] = useState({month: 1, year: 2018});
-  const [selectedDates, setSelectedDates] = useState({
-    start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
-    end: new Date('Mon Mar 12 2018 00:00:00 GMT-0500 (EST)'),
-  });
+export const MultiMonthRanged = {
+  render() {
+    const [{month, year}, setDate] = useState({month: 1, year: 2018});
+    const [selectedDates, setSelectedDates] = useState({
+      start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
+      end: new Date('Mon Mar 12 2018 00:00:00 GMT-0500 (EST)'),
+    });
 
-  const handleMonthChange = useCallback(
-    (month, year) => setDate({month, year}),
-    [],
-  );
+    const handleMonthChange = useCallback(
+      (month, year) => setDate({month, year}),
+      [],
+    );
 
-  return (
-    <DatePicker
-      month={month}
-      year={year}
-      onChange={setSelectedDates}
-      onMonthChange={handleMonthChange}
-      selected={selectedDates}
-      multiMonth
-      allowRange
-    />
-  );
-}
+    return (
+      <DatePicker
+        month={month}
+        year={year}
+        onChange={setSelectedDates}
+        onMonthChange={handleMonthChange}
+        selected={selectedDates}
+        multiMonth
+        allowRange
+      />
+    );
+  },
+};
 
-export function WithDisabledDateRanges() {
-  const [{month, year}, setDate] = useState({month: 1, year: 2018});
-  const [selectedDates, setSelectedDates] = useState({
-    start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
-    end: new Date('Sat Feb 10 2018 00:00:00 GMT-0500 (EST)'),
-  });
+export const WithDisabledDateRanges = {
+  render() {
+    const [{month, year}, setDate] = useState({month: 1, year: 2018});
+    const [selectedDates, setSelectedDates] = useState({
+      start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
+      end: new Date('Sat Feb 10 2018 00:00:00 GMT-0500 (EST)'),
+    });
 
-  const handleMonthChange = useCallback(
-    (month, year) => setDate({month, year}),
-    [],
-  );
+    const handleMonthChange = useCallback(
+      (month, year) => setDate({month, year}),
+      [],
+    );
 
-  return (
-    <DatePicker
-      month={month}
-      year={year}
-      onChange={setSelectedDates}
-      onMonthChange={handleMonthChange}
-      selected={selectedDates}
-      disableDatesBefore={new Date('Sat Feb 03 2018 00:00:00 GMT-0500 (EST)')}
-      disableDatesAfter={new Date('Sun Feb 18 2018 00:00:00 GMT-0500 (EST)')}
-      allowRange
-    />
-  );
-}
+    return (
+      <DatePicker
+        month={month}
+        year={year}
+        onChange={setSelectedDates}
+        onMonthChange={handleMonthChange}
+        selected={selectedDates}
+        disableDatesBefore={new Date('Sat Feb 03 2018 00:00:00 GMT-0500 (EST)')}
+        disableDatesAfter={new Date('Sun Feb 18 2018 00:00:00 GMT-0500 (EST)')}
+        allowRange
+      />
+    );
+  },
+};
 
-export function WithSpecificDisabledDates() {
-  const [{month, year}, setDate] = useState({month: 1, year: 2018});
-  const [selectedDates, setSelectedDates] = useState(
-    new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
-  );
+export const WithSpecificDisabledDates = {
+  render() {
+    const [{month, year}, setDate] = useState({month: 1, year: 2018});
+    const [selectedDates, setSelectedDates] = useState(
+      new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
+    );
 
-  const handleMonthChange = useCallback(
-    (month, year) => setDate({month, year}),
-    [],
-  );
+    const handleMonthChange = useCallback(
+      (month, year) => setDate({month, year}),
+      [],
+    );
 
-  const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  const disableSpecificDates = [
-    new Date('Mon Feb 12 2018 00:00:00 GMT-0500 (EST)'),
-    new Date('Sat Feb 10 2018 00:00:00 GMT-0500 (EST)'),
-    new Date('Wed Feb 21 2018 00:00:00 GMT-0500 (EST)'),
-  ];
+    const disableSpecificDates = [
+      new Date('Mon Feb 12 2018 00:00:00 GMT-0500 (EST)'),
+      new Date('Sat Feb 10 2018 00:00:00 GMT-0500 (EST)'),
+      new Date('Wed Feb 21 2018 00:00:00 GMT-0500 (EST)'),
+    ];
 
-  return (
-    <DatePicker
-      month={month}
-      year={year}
-      onChange={setSelectedDates}
-      onMonthChange={handleMonthChange}
-      selected={selectedDates}
-      disableDatesBefore={new Date('Sat Feb 03 2018 00:00:00 GMT-0500 (EST)')}
-      disableDatesAfter={new Date('Sun Feb 25 2018 00:00:00 GMT-0500 (EST)')}
-      disableSpecificDates={disableSpecificDates}
-    />
-  );
-}
+    return (
+      <DatePicker
+        month={month}
+        year={year}
+        onChange={setSelectedDates}
+        onMonthChange={handleMonthChange}
+        selected={selectedDates}
+        disableDatesBefore={new Date('Sat Feb 03 2018 00:00:00 GMT-0500 (EST)')}
+        disableDatesAfter={new Date('Sun Feb 25 2018 00:00:00 GMT-0500 (EST)')}
+        disableSpecificDates={disableSpecificDates}
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/polaris-react/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -1,56 +1,60 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {DescriptionList} from '@shopify/polaris';
 
 export default {
   component: DescriptionList,
-} as ComponentMeta<typeof DescriptionList>;
+} as Meta<typeof DescriptionList>;
 
-export function Default() {
-  return (
-    <DescriptionList
-      items={[
-        {
-          term: 'Logistics',
-          description:
-            'The management of products or other resources as they travel between a point of origin and a destination.',
-        },
-        {
-          term: 'Sole proprietorship',
-          description:
-            'A business structure where a single individual both owns and runs the company.',
-        },
-        {
-          term: 'Discount code',
-          description:
-            'A series of numbers and/or letters that an online shopper may enter at checkout to get a discount or special offer.',
-        },
-      ]}
-    />
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <DescriptionList
+        items={[
+          {
+            term: 'Logistics',
+            description:
+              'The management of products or other resources as they travel between a point of origin and a destination.',
+          },
+          {
+            term: 'Sole proprietorship',
+            description:
+              'A business structure where a single individual both owns and runs the company.',
+          },
+          {
+            term: 'Discount code',
+            description:
+              'A series of numbers and/or letters that an online shopper may enter at checkout to get a discount or special offer.',
+          },
+        ]}
+      />
+    );
+  },
+};
 
-export function Tight() {
-  return (
-    <DescriptionList
-      gap="tight"
-      items={[
-        {
-          term: 'Logistics',
-          description:
-            'The management of products or other resources as they travel between a point of origin and a destination.',
-        },
-        {
-          term: 'Sole proprietorship',
-          description:
-            'A business structure where a single individual both owns and runs the company.',
-        },
-        {
-          term: 'Discount code',
-          description:
-            'A series of numbers and/or letters that an online shopper may enter at checkout to get a discount or special offer.',
-        },
-      ]}
-    />
-  );
-}
+export const Tight = {
+  render() {
+    return (
+      <DescriptionList
+        gap="tight"
+        items={[
+          {
+            term: 'Logistics',
+            description:
+              'The management of products or other resources as they travel between a point of origin and a destination.',
+          },
+          {
+            term: 'Sole proprietorship',
+            description:
+              'A business structure where a single individual both owns and runs the company.',
+          },
+          {
+            term: 'Discount code',
+            description:
+              'A series of numbers and/or letters that an online shopper may enter at checkout to get a discount or special offer.',
+          },
+        ]}
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/Divider/Divider.stories.tsx
+++ b/polaris-react/src/components/Divider/Divider.stories.tsx
@@ -1,34 +1,38 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {BlockStack, Divider, Text} from '@shopify/polaris';
 
 export default {
   component: Divider,
-} as ComponentMeta<typeof Divider>;
+} as Meta<typeof Divider>;
 
-export function Default() {
-  return <Divider />;
-}
+export const Default = {
+  render() {
+    return <Divider />;
+  },
+};
 
-export function WithBorderStyles() {
-  return (
-    <BlockStack gap="500">
-      <Text as="h1" variant="headingSm">
-        Default
-      </Text>
-      <Divider />
-      <Text as="h1" variant="headingSm">
-        Border
-      </Text>
-      <Divider borderColor="border" />
-      <Text as="h1" variant="headingSm">
-        Border inverse
-      </Text>
-      <Divider borderColor="border-inverse" />
-      <Text as="h1" variant="headingSm">
-        Transparent
-      </Text>
-      <Divider borderColor="transparent" />
-    </BlockStack>
-  );
-}
+export const WithBorderStyles = {
+  render() {
+    return (
+      <BlockStack gap="500">
+        <Text as="h1" variant="headingSm">
+          Default
+        </Text>
+        <Divider />
+        <Text as="h1" variant="headingSm">
+          Border
+        </Text>
+        <Divider borderColor="border" />
+        <Text as="h1" variant="headingSm">
+          Border inverse
+        </Text>
+        <Divider borderColor="border-inverse" />
+        <Text as="h1" variant="headingSm">
+          Transparent
+        </Text>
+        <Divider borderColor="transparent" />
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/DropZone/DropZone.stories.tsx
+++ b/polaris-react/src/components/DropZone/DropZone.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Banner,
   Text,
@@ -15,33 +15,89 @@ import {NoteIcon} from '@shopify/polaris-icons';
 
 export default {
   component: DropZone,
-} as ComponentMeta<typeof DropZone>;
+} as Meta<typeof DropZone>;
 
-export function Default() {
-  const [files, setFiles] = useState([]);
+export const Default = {
+  render() {
+    const [files, setFiles] = useState([]);
 
-  const handleDropZoneDrop = useCallback(
-    (_dropFiles, acceptedFiles, _rejectedFiles) =>
-      setFiles((files) => [...files, ...acceptedFiles]),
-    [],
-  );
+    const handleDropZoneDrop = useCallback(
+      (_dropFiles, acceptedFiles, _rejectedFiles) =>
+        setFiles((files) => [...files, ...acceptedFiles]),
+      [],
+    );
 
-  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+    const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
 
-  const fileUpload = !files.length && <DropZone.FileUpload />;
-  const uploadedFiles = files.length > 0 && (
-    <div style={{padding: '0'}}>
+    const fileUpload = !files.length && <DropZone.FileUpload />;
+    const uploadedFiles = files.length > 0 && (
+      <div style={{padding: '0'}}>
+        <BlockStack gap="400">
+          {files.map((file, index) => (
+            <InlineStack gap="400" align="center" key={index}>
+              <Thumbnail
+                size="small"
+                alt={file.name}
+                source={
+                  validImageTypes.includes(file.type)
+                    ? window.URL.createObjectURL(file)
+                    : NoteIcon
+                }
+              />
+              <div>
+                {file.name}{' '}
+                <Text variant="bodySm" as="p">
+                  {file.size} bytes
+                </Text>
+              </div>
+            </InlineStack>
+          ))}
+        </BlockStack>
+      </div>
+    );
+
+    return (
+      <DropZone onDrop={handleDropZoneDrop}>
+        {uploadedFiles}
+        {fileUpload}
+      </DropZone>
+    );
+  },
+};
+
+export const WithALabel = {
+  render() {
+    return (
+      <DropZone label="Theme files">
+        <DropZone.FileUpload />
+      </DropZone>
+    );
+  },
+};
+
+export const WithImageFileUpload = {
+  render() {
+    const [files, setFiles] = useState([]);
+    const [rejectedFiles, setRejectedFiles] = useState([]);
+    const hasError = rejectedFiles.length > 0;
+
+    const handleDrop = useCallback(
+      (_droppedFiles, acceptedFiles, rejectedFiles) => {
+        setFiles((files) => [...files, ...acceptedFiles]);
+        setRejectedFiles(rejectedFiles);
+      },
+      [],
+    );
+
+    const fileUpload = !files.length && <DropZone.FileUpload />;
+    const uploadedFiles = files.length > 0 && (
       <BlockStack gap="400">
         {files.map((file, index) => (
           <InlineStack gap="400" align="center" key={index}>
             <Thumbnail
               size="small"
               alt={file.name}
-              source={
-                validImageTypes.includes(file.type)
-                  ? window.URL.createObjectURL(file)
-                  : NoteIcon
-              }
+              source={window.URL.createObjectURL(file)}
             />
             <div>
               {file.name}{' '}
@@ -52,501 +108,90 @@ export function Default() {
           </InlineStack>
         ))}
       </BlockStack>
-    </div>
-  );
+    );
 
-  return (
-    <DropZone onDrop={handleDropZoneDrop}>
-      {uploadedFiles}
-      {fileUpload}
-    </DropZone>
-  );
-}
-
-export function WithALabel() {
-  return (
-    <DropZone label="Theme files">
-      <DropZone.FileUpload />
-    </DropZone>
-  );
-}
-
-export function WithImageFileUpload() {
-  const [files, setFiles] = useState([]);
-  const [rejectedFiles, setRejectedFiles] = useState([]);
-  const hasError = rejectedFiles.length > 0;
-
-  const handleDrop = useCallback(
-    (_droppedFiles, acceptedFiles, rejectedFiles) => {
-      setFiles((files) => [...files, ...acceptedFiles]);
-      setRejectedFiles(rejectedFiles);
-    },
-    [],
-  );
-
-  const fileUpload = !files.length && <DropZone.FileUpload />;
-  const uploadedFiles = files.length > 0 && (
-    <BlockStack gap="400">
-      {files.map((file, index) => (
-        <InlineStack gap="400" align="center" key={index}>
-          <Thumbnail
-            size="small"
-            alt={file.name}
-            source={window.URL.createObjectURL(file)}
-          />
-          <div>
-            {file.name}{' '}
-            <Text variant="bodySm" as="p">
-              {file.size} bytes
-            </Text>
-          </div>
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-
-  const errorMessage = hasError && (
-    <Banner
-      title="The following images couldn’t be uploaded:"
-      status="critical"
-    >
-      <List type="bullet">
-        {rejectedFiles.map((file, index) => (
-          <List.Item key={index}>
-            {`"${file.name}" is not supported. File type must be .gif, .jpg, .png or .svg.`}
-          </List.Item>
-        ))}
-      </List>
-    </Banner>
-  );
-
-  return (
-    <BlockStack gap="400">
-      {errorMessage}
-      <DropZone accept="image/*" type="image" onDrop={handleDrop}>
-        {uploadedFiles}
-        {fileUpload}
-      </DropZone>
-    </BlockStack>
-  );
-}
-
-export function WithSingleFileUpload() {
-  const [file, setFile] = useState();
-
-  const handleDropZoneDrop = useCallback(
-    (_dropFiles, acceptedFiles, _rejectedFiles) =>
-      setFile((file) => acceptedFiles[0]),
-    [],
-  );
-
-  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
-
-  const fileUpload = !file && <DropZone.FileUpload />;
-  const uploadedFile = file && (
-    <InlineStack gap="400">
-      <Thumbnail
-        size="small"
-        alt={file.name}
-        source={
-          validImageTypes.includes(file.type)
-            ? window.URL.createObjectURL(file)
-            : NoteIcon
-        }
-      />
-      <div>
-        {file.name}{' '}
-        <Text variant="bodySm" as="p">
-          {file.size} bytes
-        </Text>
-      </div>
-    </InlineStack>
-  );
-
-  return (
-    <DropZone allowMultiple={false} onDrop={handleDropZoneDrop}>
-      {uploadedFile}
-      {fileUpload}
-    </DropZone>
-  );
-}
-
-export function WithDropOnPage() {
-  const [files, setFiles] = useState([]);
-
-  const handleDropZoneDrop = useCallback(
-    (dropFiles, _acceptedFiles, _rejectedFiles) =>
-      setFiles((files) => [...files, ...dropFiles]),
-    [],
-  );
-
-  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
-
-  const uploadedFiles = files.length > 0 && (
-    <BlockStack gap="400">
-      {files.map((file, index) => (
-        <InlineStack gap="400" align="center" key={index}>
-          <Thumbnail
-            size="small"
-            alt={file.name}
-            source={
-              validImageTypes.includes(file.type)
-                ? window.URL.createObjectURL(file)
-                : NoteIcon
-            }
-          />
-          <div>
-            {file.name}{' '}
-            <Text variant="bodySm" as="p">
-              {file.size} bytes
-            </Text>
-          </div>
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-
-  const uploadMessage = !uploadedFiles && <DropZone.FileUpload />;
-
-  return (
-    <Page
-      backAction={{content: 'Products'}}
-      title="Jar With Lock-Lid"
-      primaryAction={{content: 'Save', disabled: true}}
-      secondaryActions={[
-        {content: 'Duplicate'},
-        {content: 'View on your store'},
-      ]}
-      pagination={{
-        hasPrevious: true,
-        hasNext: true,
-      }}
-    >
-      <DropZone dropOnPage onDrop={handleDropZoneDrop}>
-        {uploadedFiles}
-        {uploadMessage}
-      </DropZone>
-    </Page>
-  );
-}
-
-export function AcceptsOnlySVGFiles() {
-  const [files, setFiles] = useState([]);
-  const [rejectedFiles, setRejectedFiles] = useState([]);
-  const hasError = rejectedFiles.length > 0;
-
-  const handleDropZoneDrop = useCallback(
-    (_dropFiles, acceptedFiles, rejectedFiles) => {
-      setFiles((files) => [...files, ...acceptedFiles]);
-      setRejectedFiles(rejectedFiles);
-    },
-    [],
-  );
-
-  const uploadedFiles = files.length > 0 && (
-    <BlockStack gap="400">
-      {files.map((file, index) => (
-        <InlineStack gap="400" align="center" key={index}>
-          <Thumbnail
-            size="small"
-            alt={file.name}
-            source={window.URL.createObjectURL(file)}
-          />
-          <div>
-            {file.name}{' '}
-            <Text variant="bodySm" as="p">
-              {file.size} bytes
-            </Text>
-          </div>
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-
-  const errorMessage = hasError && (
-    <Banner
-      title="The following images couldn’t be uploaded:"
-      status="critical"
-    >
-      <List type="bullet">
-        {rejectedFiles.map((file, index) => (
-          <List.Item key={index}>
-            {`"${file.name}" is not supported. File type must be .svg.`}
-          </List.Item>
-        ))}
-      </List>
-    </Banner>
-  );
-
-  return (
-    <BlockStack gap="400">
-      {errorMessage}
-      <DropZone
-        accept="image/svg+xml"
-        type="image"
-        errorOverlayText="File type must be .svg"
-        onDrop={handleDropZoneDrop}
+    const errorMessage = hasError && (
+      <Banner
+        title="The following images couldn’t be uploaded:"
+        status="critical"
       >
-        {uploadedFiles}
-      </DropZone>
-    </BlockStack>
-  );
-}
+        <List type="bullet">
+          {rejectedFiles.map((file, index) => (
+            <List.Item key={index}>
+              {`"${file.name}" is not supported. File type must be .gif, .jpg, .png or .svg.`}
+            </List.Item>
+          ))}
+        </List>
+      </Banner>
+    );
 
-export function Nested() {
-  const [files, setFiles] = useState([]);
-
-  const handleDrop = useCallback((dropFiles) => {
-    setFiles((files) => [...files, dropFiles]);
-  }, []);
-
-  const handleDropZoneClick = useCallback(() => {}, []);
-
-  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
-
-  const fileUpload = !files.length && <DropZone.FileUpload />;
-  const uploadedFiles = files.length > 0 && (
-    <BlockStack gap="400">
-      {files.map((file, index) => (
-        <InlineStack gap="400" align="center" key={index}>
-          <Thumbnail
-            size="small"
-            alt={file.name}
-            source={
-              validImageTypes.includes(file.type)
-                ? window.URL.createObjectURL(file)
-                : NoteIcon
-            }
-          />
-          <div>
-            {file.name}{' '}
-            <Text variant="bodySm" as="p">
-              {file.size} bytes
-            </Text>
-          </div>
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-
-  return (
-    <DropZone outline={false} onDrop={handleDrop}>
-      <LegacyCard sectioned>
-        <DropZone onClick={handleDropZoneClick}>
+    return (
+      <BlockStack gap="400">
+        {errorMessage}
+        <DropZone accept="image/*" type="image" onDrop={handleDrop}>
           {uploadedFiles}
           {fileUpload}
         </DropZone>
-      </LegacyCard>
-    </DropZone>
-  );
-}
+      </BlockStack>
+    );
+  },
+};
 
-export function MediumSized() {
-  return (
-    <BlockStack gap="400">
-      <BlockStack gap="200">
+export const WithSingleFileUpload = {
+  render() {
+    const [file, setFile] = useState();
+
+    const handleDropZoneDrop = useCallback(
+      (_dropFiles, acceptedFiles, _rejectedFiles) =>
+        setFile((file) => acceptedFiles[0]),
+      [],
+    );
+
+    const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+
+    const fileUpload = !file && <DropZone.FileUpload />;
+    const uploadedFile = file && (
+      <InlineStack gap="400">
+        <Thumbnail
+          size="small"
+          alt={file.name}
+          source={
+            validImageTypes.includes(file.type)
+              ? window.URL.createObjectURL(file)
+              : NoteIcon
+          }
+        />
         <div>
-          <Text as="h2" variant="headingMd">
-            Medium sized Drop zone
+          {file.name}{' '}
+          <Text variant="bodySm" as="p">
+            {file.size} bytes
           </Text>
         </div>
-        <div style={{width: 114, height: 114}}>
-          <DropZone>
-            <DropZone.FileUpload />
-          </DropZone>
-        </div>
-      </BlockStack>
-      <BlockStack gap="200">
-        <div>
-          <Text as="h2" variant="headingMd">
-            Medium sized Drop zone with label and hint
-          </Text>
-        </div>
-        <div style={{width: 140, height: 114}}>
-          <DropZone label="Field label">
-            <DropZone.FileUpload actionHint="Accepts .gif" />
-          </DropZone>
-        </div>
-      </BlockStack>
-    </BlockStack>
-  );
-}
+      </InlineStack>
+    );
 
-export function SmallSized() {
-  return (
-    <BlockStack gap="400">
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingMd">
-          Small sized Drop zone (40px)
-        </Text>
-
-        <div style={{width: 40, height: 40}}>
-          <DropZone>
-            <DropZone.FileUpload />
-          </DropZone>
-        </div>
-      </BlockStack>
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingMd">
-          Small sized Drop zone without outline
-        </Text>
-
-        <div style={{width: 40, height: 40}}>
-          <DropZone outline={false}>
-            <DropZone.FileUpload />
-          </DropZone>
-        </div>
-      </BlockStack>
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingMd">
-          Small sized Drop zone with error
-        </Text>
-        <Text as="p">Drag file in to see error state</Text>
-
-        <div style={{width: 40, height: 40}}>
-          <DropZone error>
-            <DropZone.FileUpload />
-          </DropZone>
-        </div>
-      </BlockStack>
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingMd">
-          Small sized Drop zone with disabled state
-        </Text>
-
-        <div style={{width: 40, height: 40}}>
-          <DropZone disabled>
-            <DropZone.FileUpload />
-          </DropZone>
-        </div>
-      </BlockStack>
-    </BlockStack>
-  );
-}
-
-export function WithCustomFileUploadText() {
-  const [files, setFiles] = useState([]);
-
-  const handleDropZoneDrop = useCallback(
-    (_dropFiles, acceptedFiles, _rejectedFiles) =>
-      setFiles((files) => [...files, ...acceptedFiles]),
-    [],
-  );
-
-  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
-
-  const fileUpload = !files.length && (
-    <DropZone.FileUpload actionHint="Accepts .gif, .jpg, and .png" />
-  );
-
-  const uploadedFiles = files.length > 0 && (
-    <BlockStack gap="400">
-      {files.map((file, index) => (
-        <InlineStack gap="400" align="center" key={index}>
-          <Thumbnail
-            size="small"
-            alt={file.name}
-            source={
-              validImageTypes.includes(file.type)
-                ? window.URL.createObjectURL(file)
-                : NoteIcon
-            }
-          />
-          <div>
-            {file.name}{' '}
-            <Text variant="bodySm" as="p">
-              {file.size} bytes
-            </Text>
-          </div>
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-
-  return (
-    <DropZone onDrop={handleDropZoneDrop} variableHeight>
-      {uploadedFiles}
-      {fileUpload}
-    </DropZone>
-  );
-}
-
-export function WithCustomFileDialogTrigger() {
-  const [files, setFiles] = useState([]);
-  const [openFileDialog, setOpenFileDialog] = useState(false);
-
-  const handleDropZoneDrop = useCallback(
-    (dropFiles, _acceptedFiles, _rejectedFiles) =>
-      setFiles((files) => [...files, ...dropFiles]),
-    [],
-  );
-  const toggleOpenFileDialog = useCallback(
-    () => setOpenFileDialog((openFileDialog) => !openFileDialog),
-    [],
-  );
-
-  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
-
-  const uploadedFiles = files.length > 0 && (
-    <BlockStack gap="400">
-      {files.map((file, index) => (
-        <InlineStack gap="400" align="center" key={index}>
-          <Thumbnail
-            size="small"
-            alt={file.name}
-            source={
-              validImageTypes.includes(file.type)
-                ? window.URL.createObjectURL(file)
-                : NoteIcon
-            }
-          />
-          <div>
-            {file.name}{' '}
-            <Text variant="bodySm" as="p">
-              {file.size} bytes
-            </Text>
-          </div>
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-
-  return (
-    <LegacyCard
-      sectioned
-      title="Product Images"
-      actions={[
-        {
-          content: 'Upload Image',
-          onAction: toggleOpenFileDialog,
-        },
-      ]}
-    >
-      <DropZone
-        openFileDialog={openFileDialog}
-        onDrop={handleDropZoneDrop}
-        onFileDialogClose={toggleOpenFileDialog}
-      >
-        {uploadedFiles}
+    return (
+      <DropZone allowMultiple={false} onDrop={handleDropZoneDrop}>
+        {uploadedFile}
+        {fileUpload}
       </DropZone>
-    </LegacyCard>
-  );
-}
+    );
+  },
+};
 
-export function Error() {
-  const [files, setFiles] = useState([]);
+export const WithDropOnPage = {
+  render() {
+    const [files, setFiles] = useState([]);
 
-  const handleDropZoneDrop = useCallback(
-    (_dropFiles, acceptedFiles, _rejectedFiles) =>
-      setFiles((files) => [...files, ...acceptedFiles]),
-    [],
-  );
+    const handleDropZoneDrop = useCallback(
+      (dropFiles, _acceptedFiles, _rejectedFiles) =>
+        setFiles((files) => [...files, ...dropFiles]),
+      [],
+    );
 
-  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+    const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
 
-  const fileUpload = !files.length && <DropZone.FileUpload />;
-  const uploadedFiles = files.length > 0 && (
-    <div style={{padding: '0'}}>
+    const uploadedFiles = files.length > 0 && (
       <BlockStack gap="400">
         {files.map((file, index) => (
           <InlineStack gap="400" align="center" key={index}>
@@ -568,34 +213,415 @@ export function Error() {
           </InlineStack>
         ))}
       </BlockStack>
-    </div>
-  );
+    );
 
-  return (
-    <BlockStack gap="200">
-      <div>
-        <Text as="h2" variant="headingMd">
-          Drop zone with error
-        </Text>
-        <Text as="p">Drag file in to see error state</Text>
-      </div>
-      <DropZone error onDrop={handleDropZoneDrop}>
+    const uploadMessage = !uploadedFiles && <DropZone.FileUpload />;
+
+    return (
+      <Page
+        backAction={{content: 'Products'}}
+        title="Jar With Lock-Lid"
+        primaryAction={{content: 'Save', disabled: true}}
+        secondaryActions={[
+          {content: 'Duplicate'},
+          {content: 'View on your store'},
+        ]}
+        pagination={{
+          hasPrevious: true,
+          hasNext: true,
+        }}
+      >
+        <DropZone dropOnPage onDrop={handleDropZoneDrop}>
+          {uploadedFiles}
+          {uploadMessage}
+        </DropZone>
+      </Page>
+    );
+  },
+};
+
+export const AcceptsOnlySVGFiles = {
+  render() {
+    const [files, setFiles] = useState([]);
+    const [rejectedFiles, setRejectedFiles] = useState([]);
+    const hasError = rejectedFiles.length > 0;
+
+    const handleDropZoneDrop = useCallback(
+      (_dropFiles, acceptedFiles, rejectedFiles) => {
+        setFiles((files) => [...files, ...acceptedFiles]);
+        setRejectedFiles(rejectedFiles);
+      },
+      [],
+    );
+
+    const uploadedFiles = files.length > 0 && (
+      <BlockStack gap="400">
+        {files.map((file, index) => (
+          <InlineStack gap="400" align="center" key={index}>
+            <Thumbnail
+              size="small"
+              alt={file.name}
+              source={window.URL.createObjectURL(file)}
+            />
+            <div>
+              {file.name}{' '}
+              <Text variant="bodySm" as="p">
+                {file.size} bytes
+              </Text>
+            </div>
+          </InlineStack>
+        ))}
+      </BlockStack>
+    );
+
+    const errorMessage = hasError && (
+      <Banner
+        title="The following images couldn’t be uploaded:"
+        status="critical"
+      >
+        <List type="bullet">
+          {rejectedFiles.map((file, index) => (
+            <List.Item key={index}>
+              {`"${file.name}" is not supported. File type must be .svg.`}
+            </List.Item>
+          ))}
+        </List>
+      </Banner>
+    );
+
+    return (
+      <BlockStack gap="400">
+        {errorMessage}
+        <DropZone
+          accept="image/svg+xml"
+          type="image"
+          errorOverlayText="File type must be .svg"
+          onDrop={handleDropZoneDrop}
+        >
+          {uploadedFiles}
+        </DropZone>
+      </BlockStack>
+    );
+  },
+};
+
+export const Nested = {
+  render() {
+    const [files, setFiles] = useState([]);
+
+    const handleDrop = useCallback((dropFiles) => {
+      setFiles((files) => [...files, dropFiles]);
+    }, []);
+
+    const handleDropZoneClick = useCallback(() => {}, []);
+
+    const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+
+    const fileUpload = !files.length && <DropZone.FileUpload />;
+    const uploadedFiles = files.length > 0 && (
+      <BlockStack gap="400">
+        {files.map((file, index) => (
+          <InlineStack gap="400" align="center" key={index}>
+            <Thumbnail
+              size="small"
+              alt={file.name}
+              source={
+                validImageTypes.includes(file.type)
+                  ? window.URL.createObjectURL(file)
+                  : NoteIcon
+              }
+            />
+            <div>
+              {file.name}{' '}
+              <Text variant="bodySm" as="p">
+                {file.size} bytes
+              </Text>
+            </div>
+          </InlineStack>
+        ))}
+      </BlockStack>
+    );
+
+    return (
+      <DropZone outline={false} onDrop={handleDrop}>
+        <LegacyCard sectioned>
+          <DropZone onClick={handleDropZoneClick}>
+            {uploadedFiles}
+            {fileUpload}
+          </DropZone>
+        </LegacyCard>
+      </DropZone>
+    );
+  },
+};
+
+export const MediumSized = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <div>
+            <Text as="h2" variant="headingMd">
+              Medium sized Drop zone
+            </Text>
+          </div>
+          <div style={{width: 114, height: 114}}>
+            <DropZone>
+              <DropZone.FileUpload />
+            </DropZone>
+          </div>
+        </BlockStack>
+        <BlockStack gap="200">
+          <div>
+            <Text as="h2" variant="headingMd">
+              Medium sized Drop zone with label and hint
+            </Text>
+          </div>
+          <div style={{width: 140, height: 114}}>
+            <DropZone label="Field label">
+              <DropZone.FileUpload actionHint="Accepts .gif" />
+            </DropZone>
+          </div>
+        </BlockStack>
+      </BlockStack>
+    );
+  },
+};
+
+export const SmallSized = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingMd">
+            Small sized Drop zone (40px)
+          </Text>
+
+          <div style={{width: 40, height: 40}}>
+            <DropZone>
+              <DropZone.FileUpload />
+            </DropZone>
+          </div>
+        </BlockStack>
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingMd">
+            Small sized Drop zone without outline
+          </Text>
+
+          <div style={{width: 40, height: 40}}>
+            <DropZone outline={false}>
+              <DropZone.FileUpload />
+            </DropZone>
+          </div>
+        </BlockStack>
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingMd">
+            Small sized Drop zone with error
+          </Text>
+          <Text as="p">Drag file in to see error state</Text>
+
+          <div style={{width: 40, height: 40}}>
+            <DropZone error>
+              <DropZone.FileUpload />
+            </DropZone>
+          </div>
+        </BlockStack>
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingMd">
+            Small sized Drop zone with disabled state
+          </Text>
+
+          <div style={{width: 40, height: 40}}>
+            <DropZone disabled>
+              <DropZone.FileUpload />
+            </DropZone>
+          </div>
+        </BlockStack>
+      </BlockStack>
+    );
+  },
+};
+
+export const WithCustomFileUploadText = {
+  render() {
+    const [files, setFiles] = useState([]);
+
+    const handleDropZoneDrop = useCallback(
+      (_dropFiles, acceptedFiles, _rejectedFiles) =>
+        setFiles((files) => [...files, ...acceptedFiles]),
+      [],
+    );
+
+    const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+
+    const fileUpload = !files.length && (
+      <DropZone.FileUpload actionHint="Accepts .gif, .jpg, and .png" />
+    );
+
+    const uploadedFiles = files.length > 0 && (
+      <BlockStack gap="400">
+        {files.map((file, index) => (
+          <InlineStack gap="400" align="center" key={index}>
+            <Thumbnail
+              size="small"
+              alt={file.name}
+              source={
+                validImageTypes.includes(file.type)
+                  ? window.URL.createObjectURL(file)
+                  : NoteIcon
+              }
+            />
+            <div>
+              {file.name}{' '}
+              <Text variant="bodySm" as="p">
+                {file.size} bytes
+              </Text>
+            </div>
+          </InlineStack>
+        ))}
+      </BlockStack>
+    );
+
+    return (
+      <DropZone onDrop={handleDropZoneDrop} variableHeight>
         {uploadedFiles}
         {fileUpload}
       </DropZone>
-    </BlockStack>
-  );
-}
+    );
+  },
+};
 
-export function Disabled() {
-  const handleDropZoneDrop = () => {
-    // eslint-disable-next-line no-alert
-    alert("this shouldn't be called");
-  };
+export const WithCustomFileDialogTrigger = {
+  render() {
+    const [files, setFiles] = useState([]);
+    const [openFileDialog, setOpenFileDialog] = useState(false);
 
-  return (
-    <DropZone disabled onDrop={handleDropZoneDrop}>
-      <DropZone.FileUpload />
-    </DropZone>
-  );
-}
+    const handleDropZoneDrop = useCallback(
+      (dropFiles, _acceptedFiles, _rejectedFiles) =>
+        setFiles((files) => [...files, ...dropFiles]),
+      [],
+    );
+    const toggleOpenFileDialog = useCallback(
+      () => setOpenFileDialog((openFileDialog) => !openFileDialog),
+      [],
+    );
+
+    const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+
+    const uploadedFiles = files.length > 0 && (
+      <BlockStack gap="400">
+        {files.map((file, index) => (
+          <InlineStack gap="400" align="center" key={index}>
+            <Thumbnail
+              size="small"
+              alt={file.name}
+              source={
+                validImageTypes.includes(file.type)
+                  ? window.URL.createObjectURL(file)
+                  : NoteIcon
+              }
+            />
+            <div>
+              {file.name}{' '}
+              <Text variant="bodySm" as="p">
+                {file.size} bytes
+              </Text>
+            </div>
+          </InlineStack>
+        ))}
+      </BlockStack>
+    );
+
+    return (
+      <LegacyCard
+        sectioned
+        title="Product Images"
+        actions={[
+          {
+            content: 'Upload Image',
+            onAction: toggleOpenFileDialog,
+          },
+        ]}
+      >
+        <DropZone
+          openFileDialog={openFileDialog}
+          onDrop={handleDropZoneDrop}
+          onFileDialogClose={toggleOpenFileDialog}
+        >
+          {uploadedFiles}
+        </DropZone>
+      </LegacyCard>
+    );
+  },
+};
+
+export const Error = {
+  render() {
+    const [files, setFiles] = useState([]);
+
+    const handleDropZoneDrop = useCallback(
+      (_dropFiles, acceptedFiles, _rejectedFiles) =>
+        setFiles((files) => [...files, ...acceptedFiles]),
+      [],
+    );
+
+    const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+
+    const fileUpload = !files.length && <DropZone.FileUpload />;
+    const uploadedFiles = files.length > 0 && (
+      <div style={{padding: '0'}}>
+        <BlockStack gap="400">
+          {files.map((file, index) => (
+            <InlineStack gap="400" align="center" key={index}>
+              <Thumbnail
+                size="small"
+                alt={file.name}
+                source={
+                  validImageTypes.includes(file.type)
+                    ? window.URL.createObjectURL(file)
+                    : NoteIcon
+                }
+              />
+              <div>
+                {file.name}{' '}
+                <Text variant="bodySm" as="p">
+                  {file.size} bytes
+                </Text>
+              </div>
+            </InlineStack>
+          ))}
+        </BlockStack>
+      </div>
+    );
+
+    return (
+      <BlockStack gap="200">
+        <div>
+          <Text as="h2" variant="headingMd">
+            Drop zone with error
+          </Text>
+          <Text as="p">Drag file in to see error state</Text>
+        </div>
+        <DropZone error onDrop={handleDropZoneDrop}>
+          {uploadedFiles}
+          {fileUpload}
+        </DropZone>
+      </BlockStack>
+    );
+  },
+};
+
+export const Disabled = {
+  render() {
+    const handleDropZoneDrop = () => {
+      // eslint-disable-next-line no-alert
+      alert("this shouldn't be called");
+    };
+
+    return (
+      <DropZone disabled onDrop={handleDropZoneDrop}>
+        <DropZone.FileUpload />
+      </DropZone>
+    );
+  },
+};

--- a/polaris-react/src/components/EmptyState/EmptyState.stories.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,94 +1,102 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {LegacyCard, EmptyState, Link, Text} from '@shopify/polaris';
 
 export default {
   component: EmptyState,
-} as ComponentMeta<typeof EmptyState>;
+} as Meta<typeof EmptyState>;
 
-export function Default() {
-  return (
-    <LegacyCard sectioned>
-      <EmptyState
-        heading="Manage your inventory transfers"
-        action={{content: 'Add transfer'}}
-        secondaryAction={{
-          content: 'Learn more',
-          url: 'https://help.shopify.com',
-        }}
-        image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
-      >
-        <Text as="p" variant="bodyMd">
-          Track and receive your incoming inventory from suppliers.
-        </Text>
-      </EmptyState>
-    </LegacyCard>
-  );
-}
-
-export function WithSubduedFooterContext() {
-  return (
-    <LegacyCard sectioned>
-      <EmptyState
-        heading="Manage your inventory transfers"
-        action={{content: 'Add transfer'}}
-        secondaryAction={{
-          content: 'Learn more',
-          url: 'https://help.shopify.com',
-        }}
-        footerContent={
+export const Default = {
+  render() {
+    return (
+      <LegacyCard sectioned>
+        <EmptyState
+          heading="Manage your inventory transfers"
+          action={{content: 'Add transfer'}}
+          secondaryAction={{
+            content: 'Learn more',
+            url: 'https://help.shopify.com',
+          }}
+          image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
+        >
           <Text as="p" variant="bodyMd">
-            If you don’t want to add a transfer, you can import your inventory
-            from{' '}
-            <Link monochrome url="/settings">
-              settings
-            </Link>
-            .
+            Track and receive your incoming inventory from suppliers.
           </Text>
-        }
+        </EmptyState>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSubduedFooterContext = {
+  render() {
+    return (
+      <LegacyCard sectioned>
+        <EmptyState
+          heading="Manage your inventory transfers"
+          action={{content: 'Add transfer'}}
+          secondaryAction={{
+            content: 'Learn more',
+            url: 'https://help.shopify.com',
+          }}
+          footerContent={
+            <Text as="p" variant="bodyMd">
+              If you don’t want to add a transfer, you can import your inventory
+              from{' '}
+              <Link monochrome url="/settings">
+                settings
+              </Link>
+              .
+            </Text>
+          }
+          image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
+        >
+          <Text as="p" variant="bodyMd">
+            Track and receive your incoming inventory from suppliers.
+          </Text>
+        </EmptyState>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithFullWidthLayout = {
+  render() {
+    return (
+      <LegacyCard sectioned>
+        <EmptyState
+          heading="Upload a file to get started"
+          action={{content: 'Upload files'}}
+          image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
+          fullWidth
+        >
+          <Text as="p" variant="bodyMd">
+            You can use the Files section to upload images, videos, and other
+            documents. This example shows the content with a centered layout and
+            full width.
+          </Text>
+        </EmptyState>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithoutContentContainer = {
+  render() {
+    return (
+      <EmptyState
+        heading="Manage your inventory transfers"
+        action={{content: 'Add transfer'}}
+        secondaryAction={{
+          content: 'Learn more',
+          url: 'https://help.shopify.com',
+        }}
         image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
       >
         <Text as="p" variant="bodyMd">
           Track and receive your incoming inventory from suppliers.
         </Text>
       </EmptyState>
-    </LegacyCard>
-  );
-}
-
-export function WithFullWidthLayout() {
-  return (
-    <LegacyCard sectioned>
-      <EmptyState
-        heading="Upload a file to get started"
-        action={{content: 'Upload files'}}
-        image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
-        fullWidth
-      >
-        <Text as="p" variant="bodyMd">
-          You can use the Files section to upload images, videos, and other
-          documents. This example shows the content with a centered layout and
-          full width.
-        </Text>
-      </EmptyState>
-    </LegacyCard>
-  );
-}
-
-export function WithoutContentContainer() {
-  return (
-    <EmptyState
-      heading="Manage your inventory transfers"
-      action={{content: 'Add transfer'}}
-      secondaryAction={{
-        content: 'Learn more',
-        url: 'https://help.shopify.com',
-      }}
-      image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
-    >
-      <Text as="p" variant="bodyMd">
-        Track and receive your incoming inventory from suppliers.
-      </Text>
-    </EmptyState>
-  );
-}
+    );
+  },
+};

--- a/polaris-react/src/components/ExceptionList/ExceptionList.stories.tsx
+++ b/polaris-react/src/components/ExceptionList/ExceptionList.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {ExceptionList} from '@shopify/polaris';
 import {
   NoteIcon,
@@ -9,63 +9,65 @@ import {
 
 export default {
   component: ExceptionList,
-} as ComponentMeta<typeof ExceptionList>;
+} as Meta<typeof ExceptionList>;
 
-export function All() {
-  return (
-    <ExceptionList
-      items={[
-        {
-          title: 'Order #1001',
-          description:
-            'This customer is awesome. Make sure to treat them right!',
-        },
-        {
-          title: 'Order #1002',
-          status: 'warning',
-          description:
-            'This customer is awesome. Make sure to treat them right!',
-        },
-        {
-          title: 'Order #1003',
-          status: 'critical',
-          description:
-            'This customer is awesome. Make sure to treat them right!',
-        },
-        {
-          title: 'Truncated Order #1004',
-          truncate: true,
-          description:
-            'This customer is awesome. Make sure to treat them right! Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-        },
-        {
-          title: 'Order #1005',
-          icon: NoteIcon,
-          description:
-            'This customer is awesome. Make sure to treat them right!',
-        },
-        {
-          title: 'Order #1002',
-          icon: AlertTriangleIcon,
-          status: 'warning',
-          description:
-            'This customer is awesome. Make sure to treat them right!',
-        },
-        {
-          title: 'Order #1003',
-          icon: AlertCircleIcon,
-          status: 'critical',
-          description:
-            'This customer is awesome. Make sure to treat them right!',
-        },
-        {
-          title: 'Truncated Order #1004',
-          icon: NoteIcon,
-          truncate: true,
-          description:
-            'This customer is awesome. Make sure to treat them right! Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-        },
-      ]}
-    />
-  );
-}
+export const All = {
+  render() {
+    return (
+      <ExceptionList
+        items={[
+          {
+            title: 'Order #1001',
+            description:
+              'This customer is awesome. Make sure to treat them right!',
+          },
+          {
+            title: 'Order #1002',
+            status: 'warning',
+            description:
+              'This customer is awesome. Make sure to treat them right!',
+          },
+          {
+            title: 'Order #1003',
+            status: 'critical',
+            description:
+              'This customer is awesome. Make sure to treat them right!',
+          },
+          {
+            title: 'Truncated Order #1004',
+            truncate: true,
+            description:
+              'This customer is awesome. Make sure to treat them right! Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+          },
+          {
+            title: 'Order #1005',
+            icon: NoteIcon,
+            description:
+              'This customer is awesome. Make sure to treat them right!',
+          },
+          {
+            title: 'Order #1002',
+            icon: AlertTriangleIcon,
+            status: 'warning',
+            description:
+              'This customer is awesome. Make sure to treat them right!',
+          },
+          {
+            title: 'Order #1003',
+            icon: AlertCircleIcon,
+            status: 'critical',
+            description:
+              'This customer is awesome. Make sure to treat them right!',
+          },
+          {
+            title: 'Truncated Order #1004',
+            icon: NoteIcon,
+            truncate: true,
+            description:
+              'This customer is awesome. Make sure to treat them right! Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+          },
+        ]}
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/Filters/Filters.stories.tsx
+++ b/polaris-react/src/components/Filters/Filters.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import type {FiltersProps} from '@shopify/polaris';
 import {
   Avatar,
@@ -27,2019 +27,2048 @@ export default {
       },
     },
   },
-} as ComponentMeta<typeof Filters>;
+} as Meta<typeof Filters>;
 
-export function WithAResourceList() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
+export const WithAResourceList = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
 
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-      pinned: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-      pinned: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters: FiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-            />
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithADataTable() {
-  const [availability, setAvailability] = useState(null);
-  const [productType, setProductType] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleAvailabilityChange = useCallback(
-    (value) => setAvailability(value),
-    [],
-  );
-  const handleProductTypeChange = useCallback(
-    (value) => setProductType(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAvailabilityRemove = useCallback(() => setAvailability(null), []);
-  const handleProductTypeRemove = useCallback(() => setProductType(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAvailabilityRemove();
-    handleProductTypeRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAvailabilityRemove,
-    handleQueryValueRemove,
-    handleProductTypeRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'availability',
-      label: 'Availability',
-      filter: (
-        <ChoiceList
-          title="Availability"
-          titleHidden
-          choices={[
-            {label: 'Online Store', value: 'Online Store'},
-            {label: 'Point of Sale', value: 'Point of Sale'},
-            {label: 'Buy Button', value: 'Buy Button'},
-          ]}
-          selected={availability || []}
-          onChange={handleAvailabilityChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'productType',
-      label: 'Product type',
-      filter: (
-        <ChoiceList
-          title="Product type"
-          titleHidden
-          choices={[
-            {label: 'T-Shirt', value: 'T-Shirt'},
-            {label: 'Accessory', value: 'Accessory'},
-            {label: 'Gift card', value: 'Gift card'},
-          ]}
-          selected={productType || []}
-          onChange={handleProductTypeChange}
-          allowMultiple
-        />
-      ),
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters: FiltersProps['appliedFilters'] = [];
-  if (!isEmpty(availability)) {
-    const key = 'availability';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, availability),
-      onRemove: handleAvailabilityRemove,
-    });
-  }
-  if (!isEmpty(productType)) {
-    const key = 'productType';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, productType),
-      onRemove: handleProductTypeRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <Filters
-          queryValue={queryValue}
-          queryPlaceholder="Searching in all"
-          filters={filters}
-          appliedFilters={appliedFilters}
-          onQueryChange={handleFiltersQueryChange}
-          onQueryClear={handleQueryValueRemove}
-          onClearAll={handleFiltersClearAll}
-        />
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={[
-            ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-            ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-            [
-              'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-              '$445.00',
-              124518,
-              32,
-              '$14,240.00',
-            ],
-          ]}
-          totals={['', '', '', 255, '$155,830.00']}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'availability':
-        return value.map((val) => `Available on ${val}`).join(', ');
-      case 'productType':
-        return value.join(', ');
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithChildrenContent() {
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleQueryValueChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleClearAll}
-            >
-              <div style={{paddingLeft: '8px'}}>
-                <Button
-                  onClick={() => console.log('New filter saved')}
-                  size="micro"
-                  variant="tertiary"
-                >
-                  Save
-                </Button>
-              </div>
-            </Filters>
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithChildrenContentAndUnsavedChanges() {
-  const emptyFilterState: {
-    query: {
-      label: string;
-      value: '';
-    };
-    accountStatus: {
-      label: string;
-      value: string[];
-    };
-    moneySpent: {
-      label: string;
-      value: [number, number];
-    };
-    taggedWith: {
-      label: string;
-      value: '';
-    };
-  } = {
-    query: {
-      label: 'Search',
-      value: '',
-    },
-    accountStatus: {
-      label: 'Account status',
-      value: [],
-    },
-    moneySpent: {
-      label: 'Money spent',
-      value: [0, 0],
-    },
-    taggedWith: {
-      label: 'Tagged with',
-      value: '',
-    },
-  };
-
-  const [queryValue, setQueryValue] = useState('');
-  const [taggedWith, setTaggedWith] = useState('');
-  const [moneySpent, setMoneySpent] = useState<[number, number]>([0, 0]);
-  const [accountStatus, setAccountStatus] = useState<string[]>(['enabled']);
-  const [savedFilterState, setSavedFilterState] = useState<
-    Map<
-      string,
-      {
-        label: string;
-        value: string | string[] | number | [number, number];
-      }
-    >
-  >(new Map(Object.entries(emptyFilterState)));
-
-  const handleFilterChange =
-    (key: string) => (value: string | string[] | number | [number, number]) => {
-      if (key === 'taggedWith') setTaggedWith(value as string);
-      if (key === 'moneySpent') setMoneySpent(value as [number, number]);
-      if (key === 'accountStatus') setAccountStatus(value as string[]);
-    };
-
-  const handleFilterRemove = (key: string) => {
-    if (key === 'taggedWith') {
-      setTaggedWith(emptyFilterState.taggedWith.value);
-    } else if (key === 'moneySpent') {
-      setMoneySpent(emptyFilterState.moneySpent.value);
-    } else if (key === 'accountStatus') {
-      setAccountStatus(emptyFilterState.accountStatus.value);
-    }
-  };
-
-  const handleFiltersQueryChange = (value: string) => setQueryValue(value);
-
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-
-  const handleFiltersClearAll = () => {
-    Object.entries(emptyFilterState).forEach(([key]) =>
-      handleFilterRemove(key),
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
     );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
 
-    handleQueryValueRemove();
-  };
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+        pinned: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+        pinned: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
 
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      value: accountStatus,
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus}
-          onChange={handleFilterChange('accountStatus')}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-      pinned: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      value: taggedWith,
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleFilterChange('taggedWith')}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-      pinned: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      value: moneySpent,
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleFilterChange('moneySpent')}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters: FiltersProps['appliedFilters'] = [];
-
-  filters.forEach(({key, label, value}) => {
-    if (!isEmpty(value)) {
+    const appliedFilters: FiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
       appliedFilters.push({
         key,
-        label: `${label}: ${humanReadableValue(key, value)}`,
-        unsavedChanges: !isUnchanged(key, value),
-        onRemove: () => handleFilterRemove(key),
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
       });
     }
-  });
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
 
-  const handleSaveFilters = () => {
-    const nextSavedFilterState = new Map(savedFilterState);
-    appliedFilters.forEach(({key, unsavedChanges}) => {
-      const savedFilter = nextSavedFilterState.get(key);
-      const value = filters.find((filter) => filter.key === key)?.value;
-      console.log(`Saving filter: ${key}, ${value}`, savedFilter);
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+              />
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
 
-      if (value && unsavedChanges && savedFilter) {
-        savedFilter.value = value;
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithADataTable = {
+  render() {
+    const [availability, setAvailability] = useState(null);
+    const [productType, setProductType] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleAvailabilityChange = useCallback(
+      (value) => setAvailability(value),
+      [],
+    );
+    const handleProductTypeChange = useCallback(
+      (value) => setProductType(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAvailabilityRemove = useCallback(
+      () => setAvailability(null),
+      [],
+    );
+    const handleProductTypeRemove = useCallback(() => setProductType(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAvailabilityRemove();
+      handleProductTypeRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAvailabilityRemove,
+      handleQueryValueRemove,
+      handleProductTypeRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'availability',
+        label: 'Availability',
+        filter: (
+          <ChoiceList
+            title="Availability"
+            titleHidden
+            choices={[
+              {label: 'Online Store', value: 'Online Store'},
+              {label: 'Point of Sale', value: 'Point of Sale'},
+              {label: 'Buy Button', value: 'Buy Button'},
+            ]}
+            selected={availability || []}
+            onChange={handleAvailabilityChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'productType',
+        label: 'Product type',
+        filter: (
+          <ChoiceList
+            title="Product type"
+            titleHidden
+            choices={[
+              {label: 'T-Shirt', value: 'T-Shirt'},
+              {label: 'Accessory', value: 'Accessory'},
+              {label: 'Gift card', value: 'Gift card'},
+            ]}
+            selected={productType || []}
+            onChange={handleProductTypeChange}
+            allowMultiple
+          />
+        ),
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters: FiltersProps['appliedFilters'] = [];
+    if (!isEmpty(availability)) {
+      const key = 'availability';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, availability),
+        onRemove: handleAvailabilityRemove,
+      });
+    }
+    if (!isEmpty(productType)) {
+      const key = 'productType';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, productType),
+        onRemove: handleProductTypeRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <Filters
+            queryValue={queryValue}
+            queryPlaceholder="Searching in all"
+            filters={filters}
+            appliedFilters={appliedFilters}
+            onQueryChange={handleFiltersQueryChange}
+            onQueryClear={handleQueryValueRemove}
+            onClearAll={handleFiltersClearAll}
+          />
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={[
+              ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+              ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+              [
+                'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+                '$445.00',
+                124518,
+                32,
+                '$14,240.00',
+              ],
+            ]}
+            totals={['', '', '', 255, '$155,830.00']}
+          />
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'availability':
+          return value.map((val) => `Available on ${val}`).join(', ');
+        case 'productType':
+          return value.join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithChildrenContent = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleQueryValueChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleClearAll}
+              >
+                <div style={{paddingLeft: '8px'}}>
+                  <Button
+                    onClick={() => console.log('New filter saved')}
+                    size="micro"
+                    variant="tertiary"
+                  >
+                    Save
+                  </Button>
+                </div>
+              </Filters>
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithChildrenContentAndUnsavedChanges = {
+  render() {
+    const emptyFilterState: {
+      query: {
+        label: string;
+        value: '';
+      };
+      accountStatus: {
+        label: string;
+        value: string[];
+      };
+      moneySpent: {
+        label: string;
+        value: [number, number];
+      };
+      taggedWith: {
+        label: string;
+        value: '';
+      };
+    } = {
+      query: {
+        label: 'Search',
+        value: '',
+      },
+      accountStatus: {
+        label: 'Account status',
+        value: [],
+      },
+      moneySpent: {
+        label: 'Money spent',
+        value: [0, 0],
+      },
+      taggedWith: {
+        label: 'Tagged with',
+        value: '',
+      },
+    };
+
+    const [queryValue, setQueryValue] = useState('');
+    const [taggedWith, setTaggedWith] = useState('');
+    const [moneySpent, setMoneySpent] = useState<[number, number]>([0, 0]);
+    const [accountStatus, setAccountStatus] = useState<string[]>(['enabled']);
+    const [savedFilterState, setSavedFilterState] = useState<
+      Map<
+        string,
+        {
+          label: string;
+          value: string | string[] | number | [number, number];
+        }
+      >
+    >(new Map(Object.entries(emptyFilterState)));
+
+    const handleFilterChange =
+      (key: string) =>
+      (value: string | string[] | number | [number, number]) => {
+        if (key === 'taggedWith') setTaggedWith(value as string);
+        if (key === 'moneySpent') setMoneySpent(value as [number, number]);
+        if (key === 'accountStatus') setAccountStatus(value as string[]);
+      };
+
+    const handleFilterRemove = (key: string) => {
+      if (key === 'taggedWith') {
+        setTaggedWith(emptyFilterState.taggedWith.value);
+      } else if (key === 'moneySpent') {
+        setMoneySpent(emptyFilterState.moneySpent.value);
+      } else if (key === 'accountStatus') {
+        setAccountStatus(emptyFilterState.accountStatus.value);
+      }
+    };
+
+    const handleFiltersQueryChange = (value: string) => setQueryValue(value);
+
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+
+    const handleFiltersClearAll = () => {
+      Object.entries(emptyFilterState).forEach(([key]) =>
+        handleFilterRemove(key),
+      );
+
+      handleQueryValueRemove();
+    };
+
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        value: accountStatus,
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus}
+            onChange={handleFilterChange('accountStatus')}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+        pinned: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        value: taggedWith,
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleFilterChange('taggedWith')}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+        pinned: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        value: moneySpent,
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleFilterChange('moneySpent')}
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters: FiltersProps['appliedFilters'] = [];
+
+    filters.forEach(({key, label, value}) => {
+      if (!isEmpty(value)) {
+        appliedFilters.push({
+          key,
+          label: `${label}: ${humanReadableValue(key, value)}`,
+          unsavedChanges: !isUnchanged(key, value),
+          onRemove: () => handleFilterRemove(key),
+        });
       }
     });
 
-    setSavedFilterState(nextSavedFilterState);
-  };
+    const handleSaveFilters = () => {
+      const nextSavedFilterState = new Map(savedFilterState);
+      appliedFilters.forEach(({key, unsavedChanges}) => {
+        const savedFilter = nextSavedFilterState.get(key);
+        const value = filters.find((filter) => filter.key === key)?.value;
+        console.log(`Saving filter: ${key}, ${value}`, savedFilter);
 
-  const disableAction = appliedFilters.every(
-    ({unsavedChanges}) => !unsavedChanges,
-  );
+        if (value && unsavedChanges && savedFilter) {
+          savedFilter.value = value;
+        }
+      });
 
-  return (
-    <div style={{height: '568px'}}>
-      <Card roundedAbove="sm" padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-            >
-              <Box paddingInlineStart="200">
-                <Button
-                  disabled={disableAction}
-                  onClick={handleSaveFilters}
-                  size="micro"
-                  variant="tertiary"
-                >
-                  Save
-                </Button>
-              </Box>
-            </Filters>
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = (
-              <Avatar
-                initials={name
-                  .split(' ')
-                  .map((nm) => nm.substring(0, 1))
-                  .join('')}
-                size="md"
-                name={name}
-              />
-            );
+      setSavedFilterState(nextSavedFilterState);
+    };
 
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
+    const disableAction = appliedFilters.every(
+      ({unsavedChanges}) => !unsavedChanges,
+    );
+
+    return (
+      <div style={{height: '568px'}}>
+        <Card roundedAbove="sm" padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
               >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
+                <Box paddingInlineStart="200">
+                  <Button
+                    disabled={disableAction}
+                    onClick={handleSaveFilters}
+                    size="micro"
+                    variant="tertiary"
+                  >
+                    Save
+                  </Button>
+                </Box>
+              </Filters>
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = (
+                <Avatar
+                  initials={name
+                    .split(' ')
+                    .map((nm) => nm.substring(0, 1))
+                    .join('')}
+                  size="md"
+                  name={name}
+                />
+              );
 
-  function humanReadableValue(
-    key: string,
-    value: string | string[] | number | [number, number],
-  ): string {
-    if (isEmpty(value)) return '';
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
 
-    switch (key) {
-      case 'moneySpent': {
-        const [min, max] = value as [number, number];
-        if (min === 0 && max === 0) return '';
-        if (min === 0) return `up to $${max}`;
-        if (max === 0) return `more than $${min}`;
-        return `between $${min} and $${max}`;
-      }
-      case 'taggedWith': {
-        const tags = (value as string).trim().split(',');
-        if (tags.length === 1) return ` ${tags[0]}`;
-        else if (tags.length === 2) return `${tags[0]} and ${tags[1]}`;
-        return tags
-          .map((tag, index) => {
-            return index !== tags.length - 1 ? tag : `and ${tag}`;
-          })
-          .join(', ');
-      }
-      case 'accountStatus': {
-        const statuses = value as string[];
-        if (statuses.length === 1) {
-          return statuses[0];
-        } else if (statuses.length === 2) {
-          return `${statuses[0]} or ${statuses[1]}`;
-        } else {
-          return statuses
-            .map((status, index) => {
-              return index !== statuses.length - 1 ? status : `or ${status}`;
+    function humanReadableValue(
+      key: string,
+      value: string | string[] | number | [number, number],
+    ): string {
+      if (isEmpty(value)) return '';
+
+      switch (key) {
+        case 'moneySpent': {
+          const [min, max] = value as [number, number];
+          if (min === 0 && max === 0) return '';
+          if (min === 0) return `up to $${max}`;
+          if (max === 0) return `more than $${min}`;
+          return `between $${min} and $${max}`;
+        }
+        case 'taggedWith': {
+          const tags = (value as string).trim().split(',');
+          if (tags.length === 1) return ` ${tags[0]}`;
+          else if (tags.length === 2) return `${tags[0]} and ${tags[1]}`;
+          return tags
+            .map((tag, index) => {
+              return index !== tags.length - 1 ? tag : `and ${tag}`;
             })
             .join(', ');
         }
+        case 'accountStatus': {
+          const statuses = value as string[];
+          if (statuses.length === 1) {
+            return statuses[0];
+          } else if (statuses.length === 2) {
+            return `${statuses[0]} or ${statuses[1]}`;
+          } else {
+            return statuses
+              .map((status, index) => {
+                return index !== statuses.length - 1 ? status : `or ${status}`;
+              })
+              .join(', ');
+          }
+        }
+        default:
+          return '';
       }
-      default:
-        return '';
     }
-  }
 
-  function isEmpty(value: string | string[] | number | [number, number]) {
-    if (Array.isArray(value)) {
-      return value.length === 0 || value[1] === 0;
-    } else {
-      return value === '' || value === 0 || value == null;
+    function isEmpty(value: string | string[] | number | [number, number]) {
+      if (Array.isArray(value)) {
+        return value.length === 0 || value[1] === 0;
+      } else {
+        return value === '' || value === 0 || value == null;
+      }
     }
-  }
 
-  function isUnchanged(
-    key: string,
-    value: string | string[] | number | [number, number],
-  ) {
-    if (key === 'taggedWith') {
-      return value === savedFilterState.get(key)?.value;
-    } else if (key === 'moneySpent') {
-      const [min, max] = value as [number, number];
-      const savedMoneySpent = savedFilterState.get(key)?.value as [
-        number,
-        number,
-      ];
+    function isUnchanged(
+      key: string,
+      value: string | string[] | number | [number, number],
+    ) {
+      if (key === 'taggedWith') {
+        return value === savedFilterState.get(key)?.value;
+      } else if (key === 'moneySpent') {
+        const [min, max] = value as [number, number];
+        const savedMoneySpent = savedFilterState.get(key)?.value as [
+          number,
+          number,
+        ];
 
-      return min === savedMoneySpent?.[0] && max === savedMoneySpent?.[1];
-    } else if (key === 'accountStatus') {
-      const savedAccountStatus =
-        (savedFilterState.get(key)?.value as string[]) || [];
-      return (
-        Array.isArray(value) &&
-        value.every(
-          (val) =>
-            typeof val === 'string' &&
-            savedAccountStatus?.includes(val as string),
-        )
-      );
+        return min === savedMoneySpent?.[0] && max === savedMoneySpent?.[1];
+      } else if (key === 'accountStatus') {
+        const savedAccountStatus =
+          (savedFilterState.get(key)?.value as string[]) || [];
+        return (
+          Array.isArray(value) &&
+          value.every(
+            (val) =>
+              typeof val === 'string' &&
+              savedAccountStatus?.includes(val as string),
+          )
+        );
+      }
     }
-  }
-}
+  },
+};
 
-export function Disabled() {
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
+export const Disabled = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
 
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
 
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
 
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
 
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
 
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleQueryValueChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleClearAll}
-              disabled
-            >
-              <div style={{paddingLeft: '8px'}}>
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleQueryValueChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleClearAll}
+                disabled
+              >
+                <div style={{paddingLeft: '8px'}}>
+                  <Button
+                    disabled
+                    size="micro"
+                    variant="tertiary"
+                    onClick={() => console.log('New filter saved')}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </Filters>
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const SomeDisabled = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState('');
+    const [vendor, setVendor] = useState('');
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleVendorChange = useCallback((value) => setVendor(value), []);
+
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleVendorRemove = useCallback(() => setVendor(''), []);
+
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+      handleVendorRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove, handleVendorRemove]);
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'vendor',
+        label: 'Vendor',
+        filter: (
+          <TextField
+            label="Vendor"
+            value={vendor}
+            onChange={handleVendorChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+        disabled: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleQueryValueChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleClearAll}
+              >
+                <div style={{paddingLeft: '8px'}}>
+                  <Button
+                    disabled
+                    size="micro"
+                    variant="tertiary"
+                    onClick={() => console.log('New filter saved')}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </Filters>
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithQueryFieldHidden = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters: FiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+                hideQueryField
+              >
                 <Button
-                  disabled
+                  onClick={() => console.log('New filter saved')}
                   size="micro"
                   variant="tertiary"
-                  onClick={() => console.log('New filter saved')}
                 >
                   Save
                 </Button>
-              </div>
-            </Filters>
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
+              </Filters>
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
 
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function SomeDisabled() {
-  const [taggedWith, setTaggedWith] = useState('');
-  const [vendor, setVendor] = useState('');
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleVendorChange = useCallback((value) => setVendor(value), []);
-
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleVendorRemove = useCallback(() => setVendor(''), []);
-
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-    handleVendorRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove, handleVendorRemove]);
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'vendor',
-      label: 'Vendor',
-      filter: (
-        <TextField
-          label="Vendor"
-          value={vendor}
-          onChange={handleVendorChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-      disabled: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleQueryValueChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleClearAll}
-            >
-              <div style={{paddingLeft: '8px'}}>
-                <Button
-                  disabled
-                  size="micro"
-                  variant="tertiary"
-                  onClick={() => console.log('New filter saved')}
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
                 >
-                  Save
-                </Button>
-              </div>
-            </Filters>
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
 
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
     }
-  }
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
     }
-  }
-}
+  },
+};
 
-export function WithQueryFieldHidden() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
+export const WithQueryFieldDisabled = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
 
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
 
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
 
-  const appliedFilters: FiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-              hideQueryField
-            >
-              <Button
-                onClick={() => console.log('New filter saved')}
-                size="micro"
-                variant="tertiary"
-              >
-                Save
-              </Button>
-            </Filters>
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
+    const appliedFilters: FiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
     }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
     }
-  }
-}
-
-export function WithQueryFieldDisabled() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters: FiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-              disableQueryField
-            />
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
     }
-  }
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+                disableQueryField
+              />
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
     }
-  }
-}
 
-export function WithAdditionalFilterSections() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [accountId, setAccountId] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleAccountIdChange = useCallback((value) => setAccountId(value), []);
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleAccountIdRemove = useCallback(() => setAccountId(null), []);
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleAccountIdRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleAccountIdRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith || ''}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-    },
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      section: 'Account filters',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-    },
-    {
-      key: 'accountId',
-      label: 'Account ID',
-      section: 'Account filters',
-      filter: (
-        <TextField
-          label="Account ID"
-          value={accountId || ''}
-          onChange={handleAccountIdChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      section: 'Money filters',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters: FiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(accountId)) {
-    const key = 'accountId';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountId),
-      onRemove: handleAccountIdRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue || ''}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-            />
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      case 'accountId':
-        return `Account id: ${value}`;
-      default:
-        return value;
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
     }
-  }
+  },
+};
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+export const WithAdditionalFilterSections = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [accountId, setAccountId] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleAccountIdChange = useCallback(
+      (value) => setAccountId(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleAccountIdRemove = useCallback(() => setAccountId(null), []);
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleAccountIdRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleAccountIdRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith || ''}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+      },
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        section: 'Account filters',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+      },
+      {
+        key: 'accountId',
+        label: 'Account ID',
+        section: 'Account filters',
+        filter: (
+          <TextField
+            label="Account ID"
+            value={accountId || ''}
+            onChange={handleAccountIdChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        section: 'Money filters',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters: FiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
     }
-  }
-}
-
-export function WithFilterBarHidden() {
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove]);
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={[]}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-              hideFilters
-            />
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-}
-
-export function WithAllFiltersPinned() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-      pinned: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-      pinned: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-      shortcut: true,
-      pinned: true,
-    },
-  ];
-
-  const appliedFilters: FiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <LegacyCard>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              queryPlaceholder="Searching in all"
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-            />
-          }
-          flushFilters
-          items={[
-            {
-              id: '341',
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: '256',
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
+    if (!isEmpty(accountId)) {
+      const key = 'accountId';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountId),
+        onRemove: handleAccountIdRemove,
+      });
     }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
     }
-  }
-}
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue || ''}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+              />
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        case 'accountId':
+          return `Account id: ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithFilterBarHidden = {
+  render() {
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove]);
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={[]}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+                hideFilters
+              />
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
+  },
+};
+
+export const WithAllFiltersPinned = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+        pinned: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+        pinned: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+        shortcut: true,
+        pinned: true,
+      },
+    ];
+
+    const appliedFilters: FiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <div style={{height: '568px'}}>
+        <LegacyCard>
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <Filters
+                queryValue={queryValue}
+                queryPlaceholder="Searching in all"
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+              />
+            }
+            flushFilters
+            items={[
+              {
+                id: '341',
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: '256',
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};

--- a/polaris-react/src/components/FooterHelp/FooterHelp.stories.tsx
+++ b/polaris-react/src/components/FooterHelp/FooterHelp.stories.tsx
@@ -6,35 +6,41 @@ export default {
   component: FooterHelp,
 } as Meta<typeof FooterHelp>;
 
-export function Default() {
-  return (
-    <FooterHelp>
-      Learn more about{' '}
-      <Link url="https://help.shopify.com/manual/orders/fulfill-orders">
-        fulfilling orders
-      </Link>
-    </FooterHelp>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <FooterHelp>
+        Learn more about{' '}
+        <Link url="https://help.shopify.com/manual/orders/fulfill-orders">
+          fulfilling orders
+        </Link>
+      </FooterHelp>
+    );
+  },
+};
 
-export function LeftAligned() {
-  return (
-    <FooterHelp align="start">
-      Learn more about{' '}
-      <Link url="https://help.shopify.com/manual/orders/fulfill-orders">
-        fulfilling orders
-      </Link>
-    </FooterHelp>
-  );
-}
+export const LeftAligned = {
+  render() {
+    return (
+      <FooterHelp align="start">
+        Learn more about{' '}
+        <Link url="https://help.shopify.com/manual/orders/fulfill-orders">
+          fulfilling orders
+        </Link>
+      </FooterHelp>
+    );
+  },
+};
 
-export function RightAligned() {
-  return (
-    <FooterHelp align="end">
-      Learn more about{' '}
-      <Link url="https://help.shopify.com/manual/orders/fulfill-orders">
-        fulfilling orders
-      </Link>
-    </FooterHelp>
-  );
-}
+export const RightAligned = {
+  render() {
+    return (
+      <FooterHelp align="end">
+        Learn more about{' '}
+        <Link url="https://help.shopify.com/manual/orders/fulfill-orders">
+          fulfilling orders
+        </Link>
+      </FooterHelp>
+    );
+  },
+};

--- a/polaris-react/src/components/Form/Form.stories.tsx
+++ b/polaris-react/src/components/Form/Form.stories.tsx
@@ -1,76 +1,80 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Button, Checkbox, Form, FormLayout, TextField} from '@shopify/polaris';
 
 export default {
   component: Form,
-} as ComponentMeta<typeof Form>;
+} as Meta<typeof Form>;
 
-export function CustomOnSubmit() {
-  const [newsletter, setNewsletter] = useState(false);
-  const [email, setEmail] = useState('');
+export const CustomOnSubmit = {
+  render() {
+    const [newsletter, setNewsletter] = useState(false);
+    const [email, setEmail] = useState('');
 
-  const handleSubmit = useCallback((_event) => {
-    setEmail('');
-    setNewsletter(false);
-  }, []);
+    const handleSubmit = useCallback((_event) => {
+      setEmail('');
+      setNewsletter(false);
+    }, []);
 
-  const handleNewsLetterChange = useCallback(
-    (value) => setNewsletter(value),
-    [],
-  );
+    const handleNewsLetterChange = useCallback(
+      (value) => setNewsletter(value),
+      [],
+    );
 
-  const handleEmailChange = useCallback((value) => setEmail(value), []);
+    const handleEmailChange = useCallback((value) => setEmail(value), []);
 
-  return (
-    <Form onSubmit={handleSubmit}>
-      <FormLayout>
-        <Checkbox
-          label="Sign up for the Polaris newsletter"
-          checked={newsletter}
-          onChange={handleNewsLetterChange}
-        />
+    return (
+      <Form onSubmit={handleSubmit}>
+        <FormLayout>
+          <Checkbox
+            label="Sign up for the Polaris newsletter"
+            checked={newsletter}
+            onChange={handleNewsLetterChange}
+          />
 
-        <TextField
-          value={email}
-          onChange={handleEmailChange}
-          label="Email"
-          type="email"
-          autoComplete="email"
-          helpText={
-            <span>
-              We’ll use this email address to inform you on future changes to
-              Polaris.
-            </span>
-          }
-        />
+          <TextField
+            value={email}
+            onChange={handleEmailChange}
+            label="Email"
+            type="email"
+            autoComplete="email"
+            helpText={
+              <span>
+                We’ll use this email address to inform you on future changes to
+                Polaris.
+              </span>
+            }
+          />
 
-        <Button submit>Submit</Button>
-      </FormLayout>
-    </Form>
-  );
-}
+          <Button submit>Submit</Button>
+        </FormLayout>
+      </Form>
+    );
+  },
+};
 
-export function WithoutNativeValidation() {
-  const [url, setUrl] = useState('');
+export const WithoutNativeValidation = {
+  render() {
+    const [url, setUrl] = useState('');
 
-  const handleSubmit = useCallback((_event) => setUrl(''), []);
+    const handleSubmit = useCallback((_event) => setUrl(''), []);
 
-  const handleUrlChange = useCallback((value) => setUrl(value), []);
+    const handleUrlChange = useCallback((value) => setUrl(value), []);
 
-  return (
-    <Form noValidate onSubmit={handleSubmit}>
-      <FormLayout>
-        <TextField
-          value={url}
-          onChange={handleUrlChange}
-          label="App URL"
-          type="url"
-          autoComplete="off"
-        />
+    return (
+      <Form noValidate onSubmit={handleSubmit}>
+        <FormLayout>
+          <TextField
+            value={url}
+            onChange={handleUrlChange}
+            label="App URL"
+            type="url"
+            autoComplete="off"
+          />
 
-        <Button submit>Submit</Button>
-      </FormLayout>
-    </Form>
-  );
-}
+          <Button submit>Submit</Button>
+        </FormLayout>
+      </Form>
+    );
+  },
+};

--- a/polaris-react/src/components/FormLayout/FormLayout.stories.tsx
+++ b/polaris-react/src/components/FormLayout/FormLayout.stories.tsx
@@ -1,84 +1,122 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Card, FormLayout, TextField, Text, BlockStack} from '@shopify/polaris';
 
 export default {
   component: FormLayout,
-} as ComponentMeta<typeof FormLayout>;
+} as Meta<typeof FormLayout>;
 
-export function Default() {
-  return (
-    <FormLayout>
-      <TextField label="Store name" onChange={() => {}} autoComplete="off" />
-      <TextField
-        type="email"
-        label="Account email"
-        onChange={() => {}}
-        autoComplete="email"
-      />
-    </FormLayout>
-  );
-}
-
-export function FieldGroup() {
-  return (
-    <FormLayout>
-      <FormLayout.Group>
+export const Default = {
+  render() {
+    return (
+      <FormLayout>
+        <TextField label="Store name" onChange={() => {}} autoComplete="off" />
         <TextField
-          type="number"
-          label="Minimum order"
+          type="email"
+          label="Account email"
           onChange={() => {}}
-          autoComplete="off"
+          autoComplete="email"
         />
-        <TextField
-          type="number"
-          label="Maximum order"
-          onChange={() => {}}
-          autoComplete="off"
-        />
-      </FormLayout.Group>
-    </FormLayout>
-  );
-}
+      </FormLayout>
+    );
+  },
+};
 
-export function CondensedFieldGroup() {
-  return (
-    <FormLayout>
-      <FormLayout.Group condensed>
-        <TextField label="Input 1" onChange={() => {}} autoComplete="off" />
-        <TextField label="Input 2" onChange={() => {}} autoComplete="off" />
-        <TextField label="Input 3" onChange={() => {}} autoComplete="off" />
-        <TextField label="Input 4" onChange={() => {}} autoComplete="off" />
-      </FormLayout.Group>
-    </FormLayout>
-  );
-}
+export const FieldGroup = {
+  render() {
+    return (
+      <FormLayout>
+        <FormLayout.Group>
+          <TextField
+            type="number"
+            label="Minimum order"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            type="number"
+            label="Maximum order"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+        </FormLayout.Group>
+      </FormLayout>
+    );
+  },
+};
 
-export function All() {
-  return (
-    <BlockStack gap="500">
-      <Card roundedAbove="sm">
-        <BlockStack gap="400">
-          <Text as="h2" variant="headingSm">
-            Card title
-          </Text>
+export const CondensedFieldGroup = {
+  render() {
+    return (
+      <FormLayout>
+        <FormLayout.Group condensed>
+          <TextField label="Input 1" onChange={() => {}} autoComplete="off" />
+          <TextField label="Input 2" onChange={() => {}} autoComplete="off" />
+          <TextField label="Input 3" onChange={() => {}} autoComplete="off" />
+          <TextField label="Input 4" onChange={() => {}} autoComplete="off" />
+        </FormLayout.Group>
+      </FormLayout>
+    );
+  },
+};
+
+export const All = {
+  render() {
+    return (
+      <BlockStack gap="500">
+        <Card roundedAbove="sm">
+          <BlockStack gap="400">
+            <Text as="h2" variant="headingSm">
+              Card title
+            </Text>
+            <FormLayout>
+              <FormLayout.Group
+                title="Default group 1"
+                helpText="Form group help text"
+              >
+                <TextField
+                  label="Input 1"
+                  onChange={() => {}}
+                  autoComplete="off"
+                />
+                <TextField
+                  label="Input 2"
+                  onChange={() => {}}
+                  autoComplete="off"
+                />
+              </FormLayout.Group>
+              <FormLayout.Group title="Default group 2">
+                <TextField
+                  label="Input 1"
+                  onChange={() => {}}
+                  autoComplete="off"
+                />
+                <TextField
+                  label="Input 2"
+                  onChange={() => {}}
+                  autoComplete="off"
+                />
+                <TextField
+                  label="Input 3"
+                  onChange={() => {}}
+                  autoComplete="off"
+                />
+                <TextField
+                  label="Input 4"
+                  onChange={() => {}}
+                  autoComplete="off"
+                />
+              </FormLayout.Group>
+            </FormLayout>
+          </BlockStack>
+        </Card>
+        <Card roundedAbove="sm">
           <FormLayout>
             <FormLayout.Group
-              title="Default group 1"
+              condensed
+              title="Condensed group"
               helpText="Form group help text"
             >
-              <TextField
-                label="Input 1"
-                onChange={() => {}}
-                autoComplete="off"
-              />
-              <TextField
-                label="Input 2"
-                onChange={() => {}}
-                autoComplete="off"
-              />
-            </FormLayout.Group>
-            <FormLayout.Group title="Default group 2">
               <TextField
                 label="Input 1"
                 onChange={() => {}}
@@ -94,43 +132,25 @@ export function All() {
                 onChange={() => {}}
                 autoComplete="off"
               />
+            </FormLayout.Group>
+          </FormLayout>
+        </Card>
+        <Card roundedAbove="sm">
+          <FormLayout>
+            <FormLayout.Group
+              title="Form group title"
+              helpText="Form group help text"
+            >
               <TextField
-                label="Input 4"
+                label="Field label"
                 onChange={() => {}}
                 autoComplete="off"
+                helpText="Field help text"
               />
             </FormLayout.Group>
           </FormLayout>
-        </BlockStack>
-      </Card>
-      <Card roundedAbove="sm">
-        <FormLayout>
-          <FormLayout.Group
-            condensed
-            title="Condensed group"
-            helpText="Form group help text"
-          >
-            <TextField label="Input 1" onChange={() => {}} autoComplete="off" />
-            <TextField label="Input 2" onChange={() => {}} autoComplete="off" />
-            <TextField label="Input 3" onChange={() => {}} autoComplete="off" />
-          </FormLayout.Group>
-        </FormLayout>
-      </Card>
-      <Card roundedAbove="sm">
-        <FormLayout>
-          <FormLayout.Group
-            title="Form group title"
-            helpText="Form group help text"
-          >
-            <TextField
-              label="Field label"
-              onChange={() => {}}
-              autoComplete="off"
-              helpText="Field help text"
-            />
-          </FormLayout.Group>
-        </FormLayout>
-      </Card>
-    </BlockStack>
-  );
-}
+        </Card>
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/Frame/Frame.stories.tsx
+++ b/polaris-react/src/components/Frame/Frame.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useRef, useState} from 'react';
-import type {Args, ComponentMeta} from '@storybook/react';
+import type {Args, Meta} from '@storybook/react';
 import {
   ActionList,
   AppProvider,
@@ -32,7 +32,7 @@ export default {
   component: Frame,
   args: {omitAppProvider: true},
   parameters: {layout: 'fullscreen'},
-} as ComponentMeta<typeof Frame>;
+} as Meta<typeof Frame>;
 
 export const InAnApplication = {
   render: (_args: Args) => <InAnApplicationComponent />,

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.stories.tsx
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Badge,
   Button,
@@ -14,113 +14,121 @@ import {useBreakpoints} from '../../utilities/breakpoints';
 export default {
   component: FullscreenBar,
   parameters: {layout: 'fullscreen'},
-} as ComponentMeta<typeof FullscreenBar>;
+} as Meta<typeof FullscreenBar>;
 
-export function All() {
-  return (
-    <>
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With children
-        </Text>
-        <WithChildren />
-      </BlockStack>
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <>
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With children
+          </Text>
+          <WithChildren.render />
+        </BlockStack>
 
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          No children
-        </Text>
-        <NoChildren />
-      </BlockStack>
-    </>
-  );
-}
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            No children
+          </Text>
+          <NoChildren.render />
+        </BlockStack>
+      </>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function WithChildren() {
-  const [isFullscreen, setFullscreen] = useState(true);
-  const breakpoints = useBreakpoints();
+export const WithChildren = {
+  render() {
+    const [isFullscreen, setFullscreen] = useState(true);
+    const breakpoints = useBreakpoints();
 
-  const handleActionClick = useCallback(() => {
-    setFullscreen(false);
-  }, []);
+    const handleActionClick = useCallback(() => {
+      setFullscreen(false);
+    }, []);
 
-  const titleContentMarkup = breakpoints.mdUp ? (
-    <Text as="p" variant="headingMd">
-      Join our email list
-    </Text>
-  ) : null;
+    const titleContentMarkup = breakpoints.mdUp ? (
+      <Text as="p" variant="headingMd">
+        Join our email list
+      </Text>
+    ) : null;
 
-  const titleMarkup = (
-    <div
-      style={{
-        marginLeft: 'var(--p-space-200)',
-        marginRight: 'var(--p-space-400)',
-        flexGrow: 1,
-      }}
-    >
-      {titleContentMarkup}
-    </div>
-  );
-
-  const fullscreenBarMarkup = (
-    <FullscreenBar onAction={handleActionClick}>
+    const titleMarkup = (
       <div
         style={{
-          display: 'flex',
+          marginLeft: 'var(--p-space-200)',
+          marginRight: 'var(--p-space-400)',
           flexGrow: 1,
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          paddingLeft: '1rem',
-          paddingRight: '1rem',
         }}
       >
-        <Badge tone="info">Draft</Badge>
-        {titleMarkup}
-        <ButtonGroup>
-          <Button onClick={() => {}}>Secondary Action</Button>
-          <Button variant="primary" onClick={() => {}}>
-            Primary Action
-          </Button>
-        </ButtonGroup>
+        {titleContentMarkup}
       </div>
-    </FullscreenBar>
-  );
+    );
 
-  return (
-    <div style={{height: '250px'}}>
-      {isFullscreen && fullscreenBarMarkup}
-      <div style={{padding: '1rem'}}>
-        {!isFullscreen && (
-          <Button onClick={() => setFullscreen(true)}>Go Fullscreen</Button>
-        )}
-        <Text as="p" variant="headingLg">
-          Page content
-        </Text>
+    const fullscreenBarMarkup = (
+      <FullscreenBar onAction={handleActionClick}>
+        <div
+          style={{
+            display: 'flex',
+            flexGrow: 1,
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            paddingLeft: '1rem',
+            paddingRight: '1rem',
+          }}
+        >
+          <Badge tone="info">Draft</Badge>
+          {titleMarkup}
+          <ButtonGroup>
+            <Button onClick={() => {}}>Secondary Action</Button>
+            <Button variant="primary" onClick={() => {}}>
+              Primary Action
+            </Button>
+          </ButtonGroup>
+        </div>
+      </FullscreenBar>
+    );
+
+    return (
+      <div style={{height: '250px'}}>
+        {isFullscreen && fullscreenBarMarkup}
+        <div style={{padding: '1rem'}}>
+          {!isFullscreen && (
+            <Button onClick={() => setFullscreen(true)}>Go Fullscreen</Button>
+          )}
+          <Text as="p" variant="headingLg">
+            Page content
+          </Text>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+};
 
-export function NoChildren() {
-  const [isFullscreen, setFullscreen] = useState(true);
+export const NoChildren = {
+  render() {
+    const [isFullscreen, setFullscreen] = useState(true);
 
-  const handleActionClick = useCallback(() => {
-    setFullscreen(false);
-  }, []);
+    const handleActionClick = useCallback(() => {
+      setFullscreen(false);
+    }, []);
 
-  const fullscreenBarMarkup = <FullscreenBar onAction={handleActionClick} />;
+    const fullscreenBarMarkup = <FullscreenBar onAction={handleActionClick} />;
 
-  return (
-    <div style={{height: '250px'}}>
-      {isFullscreen && fullscreenBarMarkup}
-      <div style={{padding: '1rem'}}>
-        {!isFullscreen && (
-          <Button onClick={() => setFullscreen(true)}>Go Fullscreen</Button>
-        )}
-        <Text as="p" variant="headingLg">
-          Page content
-        </Text>
+    return (
+      <div style={{height: '250px'}}>
+        {isFullscreen && fullscreenBarMarkup}
+        <div style={{padding: '1rem'}}>
+          {!isFullscreen && (
+            <Button onClick={() => setFullscreen(true)}>Go Fullscreen</Button>
+          )}
+          <Text as="p" variant="headingLg">
+            Page content
+          </Text>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+};

--- a/polaris-react/src/components/Grid/Grid.stories.tsx
+++ b/polaris-react/src/components/Grid/Grid.stories.tsx
@@ -1,130 +1,138 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {LegacyCard, Grid, Page, Text} from '@shopify/polaris';
 
 export default {
   component: Grid,
-} as ComponentMeta<typeof Grid>;
+} as Meta<typeof Grid>;
 
-export function TwoColumn() {
-  return (
-    <Page fullWidth>
-      <Grid>
-        <Grid.Cell columnSpan={{xs: 6, sm: 3, md: 3, lg: 6, xl: 6}}>
-          <LegacyCard title="Sales" sectioned>
-            <Text as="p" variant="bodyMd">
-              View a summary of your online store’s sales.
-            </Text>
-          </LegacyCard>
-        </Grid.Cell>
-        <Grid.Cell columnSpan={{xs: 6, sm: 3, md: 3, lg: 6, xl: 6}}>
-          <LegacyCard title="Orders" sectioned>
-            <Text as="p" variant="bodyMd">
-              View a summary of your online store’s orders.
-            </Text>
-          </LegacyCard>
-        </Grid.Cell>
-      </Grid>
-    </Page>
-  );
-}
-
-export function TwoThirdsAndOneThirdColumn() {
-  return (
-    <Page fullWidth>
-      <Grid columns={{sm: 3}}>
-        <Grid.Cell columnSpan={{xs: 6, sm: 4, md: 4, lg: 8, xl: 8}}>
-          <LegacyCard title="Sales" sectioned>
-            <Text as="p" variant="bodyMd">
-              View a summary of your online store’s sales.
-            </Text>
-          </LegacyCard>
-        </Grid.Cell>
-        <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <LegacyCard title="Orders" sectioned>
-            <Text as="p" variant="bodyMd">
-              View a summary of your online store’s orders.
-            </Text>
-          </LegacyCard>
-        </Grid.Cell>
-      </Grid>
-    </Page>
-  );
-}
-
-export function ThreeOneThirdColumn() {
-  return (
-    <Page fullWidth>
-      <Grid>
-        <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <LegacyCard title="Sales" sectioned>
-            <Text as="p" variant="bodyMd">
-              View a summary of your online store’s sales.
-            </Text>
-          </LegacyCard>
-        </Grid.Cell>
-        <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <LegacyCard title="Orders" sectioned>
-            <Text as="p" variant="bodyMd">
-              View a summary of your online store’s orders.
-            </Text>
-          </LegacyCard>
-        </Grid.Cell>
-        <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
-          <LegacyCard title="Orders" sectioned>
-            <Text as="p" variant="bodyMd">
-              View a summary of your online store’s orders.
-            </Text>
-          </LegacyCard>
-        </Grid.Cell>
-      </Grid>
-    </Page>
-  );
-}
-
-export function CustomLayout() {
-  return (
-    <Page fullWidth>
-      <LegacyCard sectioned>
-        <Grid
-          columns={{xs: 1, sm: 4, md: 4, lg: 6, xl: 6}}
-          areas={{
-            xs: ['product', 'sales', 'orders'],
-            sm: [
-              'product product product product',
-              'sales sales orders orders',
-            ],
-            md: ['sales product product orders'],
-            lg: ['product product product product sales orders'],
-            xl: ['product product sales sales orders orders'],
-          }}
-        >
-          <Grid.Cell area="product">
-            <div
-              style={{
-                height: '60px',
-                background: 'var(--p-color-text-info)',
-              }}
-            />
+export const TwoColumn = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Grid>
+          <Grid.Cell columnSpan={{xs: 6, sm: 3, md: 3, lg: 6, xl: 6}}>
+            <LegacyCard title="Sales" sectioned>
+              <Text as="p" variant="bodyMd">
+                View a summary of your online store’s sales.
+              </Text>
+            </LegacyCard>
           </Grid.Cell>
-          <Grid.Cell area="sales">
-            <div
-              style={{
-                height: '60px',
-                background: 'var(--p-color-text-info)',
-              }}
-            />
-          </Grid.Cell>
-          <Grid.Cell area="orders">
-            <div
-              style={{
-                height: '60px',
-                background: 'var(--p-color-text-info)',
-              }}
-            />
+          <Grid.Cell columnSpan={{xs: 6, sm: 3, md: 3, lg: 6, xl: 6}}>
+            <LegacyCard title="Orders" sectioned>
+              <Text as="p" variant="bodyMd">
+                View a summary of your online store’s orders.
+              </Text>
+            </LegacyCard>
           </Grid.Cell>
         </Grid>
-      </LegacyCard>
-    </Page>
-  );
-}
+      </Page>
+    );
+  },
+};
+
+export const TwoThirdsAndOneThirdColumn = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Grid columns={{sm: 3}}>
+          <Grid.Cell columnSpan={{xs: 6, sm: 4, md: 4, lg: 8, xl: 8}}>
+            <LegacyCard title="Sales" sectioned>
+              <Text as="p" variant="bodyMd">
+                View a summary of your online store’s sales.
+              </Text>
+            </LegacyCard>
+          </Grid.Cell>
+          <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
+            <LegacyCard title="Orders" sectioned>
+              <Text as="p" variant="bodyMd">
+                View a summary of your online store’s orders.
+              </Text>
+            </LegacyCard>
+          </Grid.Cell>
+        </Grid>
+      </Page>
+    );
+  },
+};
+
+export const ThreeOneThirdColumn = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Grid>
+          <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
+            <LegacyCard title="Sales" sectioned>
+              <Text as="p" variant="bodyMd">
+                View a summary of your online store’s sales.
+              </Text>
+            </LegacyCard>
+          </Grid.Cell>
+          <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
+            <LegacyCard title="Orders" sectioned>
+              <Text as="p" variant="bodyMd">
+                View a summary of your online store’s orders.
+              </Text>
+            </LegacyCard>
+          </Grid.Cell>
+          <Grid.Cell columnSpan={{xs: 6, sm: 2, md: 2, lg: 4, xl: 4}}>
+            <LegacyCard title="Orders" sectioned>
+              <Text as="p" variant="bodyMd">
+                View a summary of your online store’s orders.
+              </Text>
+            </LegacyCard>
+          </Grid.Cell>
+        </Grid>
+      </Page>
+    );
+  },
+};
+
+export const CustomLayout = {
+  render() {
+    return (
+      <Page fullWidth>
+        <LegacyCard sectioned>
+          <Grid
+            columns={{xs: 1, sm: 4, md: 4, lg: 6, xl: 6}}
+            areas={{
+              xs: ['product', 'sales', 'orders'],
+              sm: [
+                'product product product product',
+                'sales sales orders orders',
+              ],
+              md: ['sales product product orders'],
+              lg: ['product product product product sales orders'],
+              xl: ['product product sales sales orders orders'],
+            }}
+          >
+            <Grid.Cell area="product">
+              <div
+                style={{
+                  height: '60px',
+                  background: 'var(--p-color-text-info)',
+                }}
+              />
+            </Grid.Cell>
+            <Grid.Cell area="sales">
+              <div
+                style={{
+                  height: '60px',
+                  background: 'var(--p-color-text-info)',
+                }}
+              />
+            </Grid.Cell>
+            <Grid.Cell area="orders">
+              <div
+                style={{
+                  height: '60px',
+                  background: 'var(--p-color-text-info)',
+                }}
+              />
+            </Grid.Cell>
+          </Grid>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};

--- a/polaris-react/src/components/Icon/Icon.stories.tsx
+++ b/polaris-react/src/components/Icon/Icon.stories.tsx
@@ -1,171 +1,187 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Icon, Text, BlockStack, InlineStack} from '@shopify/polaris';
 import * as polarisIcons from '@shopify/polaris-icons';
 import iconMetadata from '@shopify/polaris-icons/metadata';
 
 export default {
   component: Icon,
-} as ComponentMeta<typeof Icon>;
+} as Meta<typeof Icon>;
 
 interface Icons {
   [key: string]: any;
 }
 const icons: Icons = polarisIcons;
 
-export function Default() {
-  return <Icon source={icons.PlusCircleIcon} />;
-}
+export const Default = {
+  render() {
+    return <Icon source={icons.PlusCircleIcon} />;
+  },
+};
 
-export function Colored() {
-  return (
-    <BlockStack gap="200">
-      <Text as="p" variant="bodyMd" alignment="center">
-        Base tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="base" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Subdued tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="subdued" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Primary tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="primary" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Info tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="info" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Success tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="success" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Caution tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="caution" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Warning tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="warning" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Critical tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="critical" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Emphasis tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="emphasis" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Magic tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="magic" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Text Primary tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="textPrimary" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Text Caution tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="textCaution" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Text Warning tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="textWarning" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Text Critical tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="textCritical" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Text Info tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="textInfo" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Text Success tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="textSuccess" />
-      <Text as="p" variant="bodyMd" alignment="center">
-        Text Magic tone
-      </Text>
-      <Icon source={icons.PlusCircleIcon} tone="textMagic" />
-    </BlockStack>
-  );
-}
-
-export function WithToneInherit() {
-  return (
-    <BlockStack gap="200">
-      <Text as="p" tone="caution" variant="bodyMd" alignment="center">
-        Caution tone
-        <Icon source={icons.PlusCircleIcon} tone="inherit" />
-      </Text>
-      <Text as="p" tone="critical" variant="bodyMd" alignment="center">
-        Critical tone
-        <Icon source={icons.PlusCircleIcon} tone="inherit" />
-      </Text>
-      <Text as="p" tone="magic" variant="bodyMd" alignment="center">
-        Magic tone
-        <Icon source={icons.PlusCircleIcon} tone="inherit" />
-      </Text>
-      <Text as="p" tone="magic-subdued" variant="bodyMd" alignment="center">
-        Magic subdued tone
-        <Icon source={icons.PlusCircleIcon} tone="inherit" />
-      </Text>
-      <Text as="p" tone="subdued" variant="bodyMd" alignment="center">
-        Subdued tone
-        <Icon source={icons.PlusCircleIcon} tone="inherit" />
-      </Text>
-      <Text as="p" tone="success" variant="bodyMd" alignment="center">
-        Success tone
-        <Icon source={icons.PlusCircleIcon} tone="inherit" />
-      </Text>
-      <Text as="p" tone="text-inverse" variant="bodyMd" alignment="center">
-        Text inverse tone
-        <Icon source={icons.PlusCircleIcon} tone="inherit" />
-      </Text>
-    </BlockStack>
-  );
-}
-
-export function WithPlaceholder() {
-  return <Icon source="placeholder" />;
-}
-
-export function WithExternalIcon() {
-  return (
-    <Icon source="%3Csvg%20viewBox%3D%220%200%2020%2020%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M2.5%203.75a.75.75%200%200%201%20.75-.75h1.612a1.75%201.75%200%200%201%201.732%201.5h9.656a.75.75%200%200%201%20.748.808l-.358%204.653a2.75%202.75%200%200%201-2.742%202.539h-6.351l.093.78a.25.25%200%200%200%20.248.22h6.362a.75.75%200%200%201%200%201.5h-6.362a1.75%201.75%200%200%201-1.738-1.543l-1.04-8.737a.25.25%200%200%200-.248-.22h-1.612a.75.75%200%200%201-.75-.75Zm6.708%202.458a.625.625%200%200%200%200%20.884l1.408%201.408-1.408%201.408a.625.625%200%201%200%20.884.884l1.408-1.408%201.408%201.408a.625.625%200%201%200%20.884-.884l-1.408-1.408%201.408-1.408a.625.625%200%200%200-.884-.884l-1.408%201.408-1.408-1.408a.625.625%200%200%200-.884%200Z%22%20fill%3D%22%235C5F62%22%2F%3E%3Cpath%20d%3D%22M10%2017a1%201%200%201%201-2%200%201%201%200%200%201%202%200Z%22%20fill%3D%22%235C5F62%22%2F%3E%3Cpath%20d%3D%22M14%2018a1%201%200%201%200%200-2%201%201%200%200%200%200%202Z%22%20fill%3D%22%235C5F62%22%2F%3E%3C%2Fsvg%3E" />
-  );
-}
-
-export function WithCustomSVG() {
-  return (
-    <Icon source="<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'><path d='M10.707 17.707l5-5a.999.999 0 1 0-1.414-1.414L11 14.586V3a1 1 0 1 0-2 0v11.586l-3.293-3.293a.999.999 0 1 0-1.414 1.414l5 5a.999.999 0 0 0 1.414 0' /></svg>" />
-  );
-}
-
-export function WithCustomSVGAndColor() {
-  const iconContent = () => {
+export const Colored = {
+  render() {
     return (
-      <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="10" cy="10" r="10" fill="rebeccapurple" />
-        <circle cx="10" cy="10" r="6" fill="currentColor" />
-        <circle cx="10" cy="10" r="3" />
-      </svg>
+      <BlockStack gap="200">
+        <Text as="p" variant="bodyMd" alignment="center">
+          Base tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="base" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Subdued tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="subdued" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Primary tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="primary" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Info tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="info" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Success tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="success" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Caution tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="caution" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Warning tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="warning" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Critical tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="critical" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Emphasis tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="emphasis" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Magic tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="magic" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Text Primary tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="textPrimary" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Text Caution tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="textCaution" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Text Warning tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="textWarning" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Text Critical tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="textCritical" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Text Info tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="textInfo" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Text Success tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="textSuccess" />
+        <Text as="p" variant="bodyMd" alignment="center">
+          Text Magic tone
+        </Text>
+        <Icon source={icons.PlusCircleIcon} tone="textMagic" />
+      </BlockStack>
     );
-  };
+  },
+};
 
-  return <Icon source={iconContent} tone="warning" />;
-}
+export const WithToneInherit = {
+  render() {
+    return (
+      <BlockStack gap="200">
+        <Text as="p" tone="caution" variant="bodyMd" alignment="center">
+          Caution tone
+          <Icon source={icons.PlusCircleIcon} tone="inherit" />
+        </Text>
+        <Text as="p" tone="critical" variant="bodyMd" alignment="center">
+          Critical tone
+          <Icon source={icons.PlusCircleIcon} tone="inherit" />
+        </Text>
+        <Text as="p" tone="magic" variant="bodyMd" alignment="center">
+          Magic tone
+          <Icon source={icons.PlusCircleIcon} tone="inherit" />
+        </Text>
+        <Text as="p" tone="magic-subdued" variant="bodyMd" alignment="center">
+          Magic subdued tone
+          <Icon source={icons.PlusCircleIcon} tone="inherit" />
+        </Text>
+        <Text as="p" tone="subdued" variant="bodyMd" alignment="center">
+          Subdued tone
+          <Icon source={icons.PlusCircleIcon} tone="inherit" />
+        </Text>
+        <Text as="p" tone="success" variant="bodyMd" alignment="center">
+          Success tone
+          <Icon source={icons.PlusCircleIcon} tone="inherit" />
+        </Text>
+        <Text as="p" tone="text-inverse" variant="bodyMd" alignment="center">
+          Text inverse tone
+          <Icon source={icons.PlusCircleIcon} tone="inherit" />
+        </Text>
+      </BlockStack>
+    );
+  },
+};
 
-export function PolarisIconsLibrary() {
-  return (
-    <BlockStack gap="100" inlineAlign="start">
-      {Object.keys(iconMetadata).map((icon) => (
-        <InlineStack key={icon} gap="200">
-          <Icon source={polarisIcons[icon]} />
-          <Text as="span">{icon}</Text>
-        </InlineStack>
-      ))}
-    </BlockStack>
-  );
-}
+export const WithPlaceholder = {
+  render() {
+    return <Icon source="placeholder" />;
+  },
+};
+
+export const WithExternalIcon = {
+  render() {
+    return (
+      <Icon source="%3Csvg%20viewBox%3D%220%200%2020%2020%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M2.5%203.75a.75.75%200%200%201%20.75-.75h1.612a1.75%201.75%200%200%201%201.732%201.5h9.656a.75.75%200%200%201%20.748.808l-.358%204.653a2.75%202.75%200%200%201-2.742%202.539h-6.351l.093.78a.25.25%200%200%200%20.248.22h6.362a.75.75%200%200%201%200%201.5h-6.362a1.75%201.75%200%200%201-1.738-1.543l-1.04-8.737a.25.25%200%200%200-.248-.22h-1.612a.75.75%200%200%201-.75-.75Zm6.708%202.458a.625.625%200%200%200%200%20.884l1.408%201.408-1.408%201.408a.625.625%200%201%200%20.884.884l1.408-1.408%201.408%201.408a.625.625%200%201%200%20.884-.884l-1.408-1.408%201.408-1.408a.625.625%200%200%200-.884-.884l-1.408%201.408-1.408-1.408a.625.625%200%200%200-.884%200Z%22%20fill%3D%22%235C5F62%22%2F%3E%3Cpath%20d%3D%22M10%2017a1%201%200%201%201-2%200%201%201%200%200%201%202%200Z%22%20fill%3D%22%235C5F62%22%2F%3E%3Cpath%20d%3D%22M14%2018a1%201%200%201%200%200-2%201%201%200%200%200%200%202Z%22%20fill%3D%22%235C5F62%22%2F%3E%3C%2Fsvg%3E" />
+    );
+  },
+};
+
+export const WithCustomSVG = {
+  render() {
+    return (
+      <Icon source="<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'><path d='M10.707 17.707l5-5a.999.999 0 1 0-1.414-1.414L11 14.586V3a1 1 0 1 0-2 0v11.586l-3.293-3.293a.999.999 0 1 0-1.414 1.414l5 5a.999.999 0 0 0 1.414 0' /></svg>" />
+    );
+  },
+};
+
+export const WithCustomSVGAndColor = {
+  render() {
+    const iconContent = () => {
+      return (
+        <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="10" cy="10" r="10" fill="rebeccapurple" />
+          <circle cx="10" cy="10" r="6" fill="currentColor" />
+          <circle cx="10" cy="10" r="3" />
+        </svg>
+      );
+    };
+
+    return <Icon source={iconContent} tone="warning" />;
+  },
+};
+
+export const PolarisIconsLibrary = {
+  render() {
+    return (
+      <BlockStack gap="100" inlineAlign="start">
+        {Object.keys(iconMetadata).map((icon) => (
+          <InlineStack key={icon} gap="200">
+            <Icon source={polarisIcons[icon]} />
+            <Text as="span">{icon}</Text>
+          </InlineStack>
+        ))}
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback, useEffect} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import type {TabProps} from '@shopify/polaris';
 import {
   ChoiceList,
@@ -30,7 +30,7 @@ export default {
       },
     },
   },
-} as ComponentMeta<typeof IndexFilters>;
+} as Meta<typeof IndexFilters>;
 
 function Table() {
   const customers = [
@@ -419,2101 +419,2134 @@ function BasicExample(
   }
 }
 
-export function Default() {
-  return <BasicExample />;
-}
+export const Default = {
+  render() {
+    return <BasicExample />;
+  },
+};
 
-export function WithFilteringByDefault() {
-  return <BasicExample withFilteringByDefault />;
-}
+export const WithFilteringByDefault = {
+  render() {
+    return <BasicExample withFilteringByDefault />;
+  },
+};
 
-export function WithEditColumsButton() {
-  return <BasicExample showEditColumnsButton />;
-}
+export const WithEditColumsButton = {
+  render() {
+    return <BasicExample showEditColumnsButton />;
+  },
+};
 
-export function WithoutKeyboardShortcuts() {
-  return <BasicExample disableKeyboardShortcuts />;
-}
+export const WithoutKeyboardShortcuts = {
+  render() {
+    return <BasicExample disableKeyboardShortcuts />;
+  },
+};
 
-export function WithLoading() {
-  return <BasicExample loading />;
-}
+export const WithLoading = {
+  render() {
+    return <BasicExample loading />;
+  },
+};
 
-export function WithPinnedFilters() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const [itemStrings, setItemStrings] = useState([
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ]);
-  const deleteView = (index: number) => {
-    const newItemStrings = [...itemStrings];
-    newItemStrings.splice(index, 1);
-    setItemStrings(newItemStrings);
-    setSelected(0);
-  };
+export const WithPinnedFilters = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const [itemStrings, setItemStrings] = useState([
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ]);
+    const deleteView = (index: number) => {
+      const newItemStrings = [...itemStrings];
+      newItemStrings.splice(index, 1);
+      setItemStrings(newItemStrings);
+      setSelected(0);
+    };
 
-  const duplicateView = async (name: string) => {
-    setItemStrings([...itemStrings, name]);
-    setSelected(itemStrings.length);
-    await sleep(1);
-    return true;
-  };
+    const duplicateView = async (name: string) => {
+      setItemStrings([...itemStrings, name]);
+      setSelected(itemStrings.length);
+      await sleep(1);
+      return true;
+    };
 
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
-    content: item,
-    index,
-    onAction: () => {},
-    id: `${item}-${index}`,
-    isLocked: index === 0,
-    actions:
-      index === 0
-        ? []
-        : [
-            {
-              type: 'rename',
-              onAction: () => {},
-              onPrimaryAction: async (value: string) => {
-                const newItemsStrings = tabs.map((item, idx) => {
-                  if (idx === index) {
-                    return value;
-                  }
-                  return item.content;
-                });
-                await sleep(1);
-                setItemStrings(newItemsStrings);
-                return true;
+    const tabs: TabProps[] = itemStrings.map((item, index) => ({
+      content: item,
+      index,
+      onAction: () => {},
+      id: `${item}-${index}`,
+      isLocked: index === 0,
+      actions:
+        index === 0
+          ? []
+          : [
+              {
+                type: 'rename',
+                onAction: () => {},
+                onPrimaryAction: async (value: string) => {
+                  const newItemsStrings = tabs.map((item, idx) => {
+                    if (idx === index) {
+                      return value;
+                    }
+                    return item.content;
+                  });
+                  await sleep(1);
+                  setItemStrings(newItemsStrings);
+                  return true;
+                },
               },
-            },
-            {
-              type: 'duplicate',
-              onPrimaryAction: async (name) => {
-                await sleep(1);
-                duplicateView(name);
-                return true;
+              {
+                type: 'duplicate',
+                onPrimaryAction: async (name) => {
+                  await sleep(1);
+                  duplicateView(name);
+                  return true;
+                },
               },
-            },
-            {
-              type: 'edit',
-            },
-            {
-              type: 'delete',
-              onPrimaryAction: async (id: string) => {
-                await sleep(1);
-                deleteView(index);
-                return true;
+              {
+                type: 'edit',
               },
-            },
-          ],
-  }));
-  const [selected, setSelected] = useState(0);
-  const onCreateNewView = async (value: string) => {
-    await sleep(500);
-    setItemStrings([...itemStrings, value]);
-    setSelected(itemStrings.length);
-    return true;
-  };
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
-    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
-    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
-    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
-    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
-    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
-    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
-    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
-  ];
-  const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode();
-  const onHandleCancel = () => {};
+              {
+                type: 'delete',
+                onPrimaryAction: async (id: string) => {
+                  await sleep(1);
+                  deleteView(index);
+                  return true;
+                },
+              },
+            ],
+    }));
+    const [selected, setSelected] = useState(0);
+    const onCreateNewView = async (value: string) => {
+      await sleep(500);
+      setItemStrings([...itemStrings, value]);
+      setSelected(itemStrings.length);
+      return true;
+    };
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+      {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+      {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+      {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+      {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+      {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+      {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+      {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+    ];
+    const [sortSelected, setSortSelected] = useState(['order asc']);
+    const {mode, setMode} = useSetIndexFiltersMode();
+    const onHandleCancel = () => {};
 
-  const onHandleSave = async () => {
-    await sleep(1);
-    return true;
-  };
+    const onHandleSave = async () => {
+      await sleep(1);
+      return true;
+    };
 
-  const primaryAction: IndexFiltersProps['primaryAction'] =
-    selected === 0
-      ? {
-          type: 'save-as',
-          onAction: onCreateNewView,
-          disabled: false,
-          loading: false,
-        }
-      : {
-          type: 'save',
-          onAction: onHandleSave,
-          disabled: false,
-          loading: false,
-        };
-  const [accountStatus, setAccountStatus] = useState<string[] | null>(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
+    const primaryAction: IndexFiltersProps['primaryAction'] =
+      selected === 0
+        ? {
+            type: 'save-as',
+            onAction: onCreateNewView,
+            disabled: false,
+            loading: false,
+          }
+        : {
+            type: 'save',
+            onAction: onHandleSave,
+            disabled: false,
+            loading: false,
+          };
+    const [accountStatus, setAccountStatus] = useState<string[] | null>(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
 
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
 
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      pinned: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      pinned: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        pinned: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        pinned: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
 
-  const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <Card padding="0">
-      <IndexFilters
-        sortOptions={sortOptions}
-        sortSelected={sortSelected}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        onQueryChange={handleFiltersQueryChange}
-        onQueryClear={() => setQueryValue('')}
-        onSort={setSortSelected}
-        primaryAction={primaryAction}
-        cancelAction={{
-          onAction: onHandleCancel,
-          disabled: false,
-          loading: false,
-        }}
-        tabs={tabs}
-        selected={selected}
-        onSelect={setSelected}
-        canCreateNewView
-        onCreateNewView={onCreateNewView}
-        filters={filters}
-        appliedFilters={appliedFilters}
-        onClearAll={handleFiltersClearAll}
-        mode={mode}
-        setMode={setMode}
-      />
-      <Table />
-    </Card>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
+    const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
     }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
     }
-  }
-}
-
-export function WithPrefilledFilters() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const [itemStrings, setItemStrings] = useState([
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ]);
-  const deleteView = (index: number) => {
-    const newItemStrings = [...itemStrings];
-    newItemStrings.splice(index, 1);
-    setItemStrings(newItemStrings);
-    setSelected(0);
-  };
-
-  const duplicateView = async (name: string) => {
-    setItemStrings([...itemStrings, name]);
-    setSelected(itemStrings.length);
-    await sleep(1);
-    return true;
-  };
-
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
-    content: item,
-    index,
-    onAction: () => {},
-    id: `${item}-${index}`,
-    isLocked: index === 0,
-    actions:
-      index === 0
-        ? []
-        : [
-            {
-              type: 'rename',
-              onAction: () => {},
-              onPrimaryAction: async (value: string) => {
-                const newItemsStrings = tabs.map((item, idx) => {
-                  if (idx === index) {
-                    return value;
-                  }
-                  return item.content;
-                });
-                await sleep(1);
-                setItemStrings(newItemsStrings);
-                return true;
-              },
-            },
-            {
-              type: 'duplicate',
-              onPrimaryAction: async (name) => {
-                await sleep(1);
-                duplicateView(name);
-                return true;
-              },
-            },
-            {
-              type: 'edit',
-            },
-            {
-              type: 'delete',
-              onPrimaryAction: async (id: string) => {
-                await sleep(1);
-                deleteView(index);
-                return true;
-              },
-            },
-          ],
-  }));
-  const [selected, setSelected] = useState(0);
-  const onCreateNewView = async (value: string) => {
-    await sleep(500);
-    setItemStrings([...itemStrings, value]);
-    setSelected(itemStrings.length);
-    return true;
-  };
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
-    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
-    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
-    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
-    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
-    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
-    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
-    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
-  ];
-  const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode();
-  const onHandleCancel = () => {};
-
-  const onHandleSave = async () => {
-    await sleep(1);
-    return true;
-  };
-
-  const primaryAction: IndexFiltersProps['primaryAction'] =
-    selected === 0
-      ? {
-          type: 'save-as',
-          onAction: onCreateNewView,
-          disabled: false,
-          loading: false,
-        }
-      : {
-          type: 'save',
-          onAction: onHandleSave,
-          disabled: false,
-          loading: false,
-        };
-  const [accountStatus, setAccountStatus] = useState<string[] | null>([
-    'enabled',
-  ]);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('Returning customer');
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <Card padding="0">
-      <IndexFilters
-        sortOptions={sortOptions}
-        sortSelected={sortSelected}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        onQueryChange={handleFiltersQueryChange}
-        onQueryClear={() => setQueryValue('')}
-        onSort={setSortSelected}
-        primaryAction={primaryAction}
-        cancelAction={{
-          onAction: onHandleCancel,
-          disabled: false,
-          loading: false,
-        }}
-        tabs={tabs}
-        selected={selected}
-        onSelect={setSelected}
-        canCreateNewView
-        onCreateNewView={onCreateNewView}
-        filters={filters}
-        appliedFilters={appliedFilters}
-        onClearAll={handleFiltersClearAll}
-        mode={mode}
-        setMode={setMode}
-      />
-      <Table />
-    </Card>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
     }
-  }
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    return (
+      <Card padding="0">
+        <IndexFilters
+          sortOptions={sortOptions}
+          sortSelected={sortSelected}
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          onQueryChange={handleFiltersQueryChange}
+          onQueryClear={() => setQueryValue('')}
+          onSort={setSortSelected}
+          primaryAction={primaryAction}
+          cancelAction={{
+            onAction: onHandleCancel,
+            disabled: false,
+            loading: false,
+          }}
+          tabs={tabs}
+          selected={selected}
+          onSelect={setSelected}
+          canCreateNewView
+          onCreateNewView={onCreateNewView}
+          filters={filters}
+          appliedFilters={appliedFilters}
+          onClearAll={handleFiltersClearAll}
+          mode={mode}
+          setMode={setMode}
+        />
+        <Table />
+      </Card>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
     }
-  }
-}
 
-export function WithHiddenFilter() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const [itemStrings, setItemStrings] = useState([
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ]);
-  const deleteView = (index: number) => {
-    const newItemStrings = [...itemStrings];
-    newItemStrings.splice(index, 1);
-    setItemStrings(newItemStrings);
-    setSelected(0);
-  };
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
 
-  const duplicateView = async (name: string) => {
-    setItemStrings([...itemStrings, name]);
-    setSelected(itemStrings.length);
-    await sleep(1);
-    return true;
-  };
+export const WithPrefilledFilters = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const [itemStrings, setItemStrings] = useState([
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ]);
+    const deleteView = (index: number) => {
+      const newItemStrings = [...itemStrings];
+      newItemStrings.splice(index, 1);
+      setItemStrings(newItemStrings);
+      setSelected(0);
+    };
 
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
-    content: item,
-    index,
-    onAction: () => {},
-    id: `${item}-${index}`,
-    isLocked: index === 0,
-    actions:
-      index === 0
-        ? []
-        : [
-            {
-              type: 'rename',
-              onAction: () => {},
-              onPrimaryAction: async (value: string) => {
-                const newItemsStrings = tabs.map((item, idx) => {
-                  if (idx === index) {
-                    return value;
-                  }
-                  return item.content;
-                });
-                await sleep(1);
-                setItemStrings(newItemsStrings);
-                return true;
+    const duplicateView = async (name: string) => {
+      setItemStrings([...itemStrings, name]);
+      setSelected(itemStrings.length);
+      await sleep(1);
+      return true;
+    };
+
+    const tabs: TabProps[] = itemStrings.map((item, index) => ({
+      content: item,
+      index,
+      onAction: () => {},
+      id: `${item}-${index}`,
+      isLocked: index === 0,
+      actions:
+        index === 0
+          ? []
+          : [
+              {
+                type: 'rename',
+                onAction: () => {},
+                onPrimaryAction: async (value: string) => {
+                  const newItemsStrings = tabs.map((item, idx) => {
+                    if (idx === index) {
+                      return value;
+                    }
+                    return item.content;
+                  });
+                  await sleep(1);
+                  setItemStrings(newItemsStrings);
+                  return true;
+                },
               },
-            },
-            {
-              type: 'duplicate',
-              onPrimaryAction: async (name) => {
-                await sleep(1);
-                duplicateView(name);
-                return true;
+              {
+                type: 'duplicate',
+                onPrimaryAction: async (name) => {
+                  await sleep(1);
+                  duplicateView(name);
+                  return true;
+                },
               },
-            },
-            {
-              type: 'edit',
-            },
-            {
-              type: 'delete',
-              onPrimaryAction: async (id: string) => {
-                await sleep(1);
-                deleteView(index);
-                return true;
+              {
+                type: 'edit',
               },
-            },
-          ],
-  }));
-  const [selected, setSelected] = useState(0);
-  const onCreateNewView = async (value: string) => {
-    await sleep(500);
-    setItemStrings([...itemStrings, value]);
-    setSelected(itemStrings.length);
-    return true;
-  };
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
-    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
-    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
-    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
-    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
-    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
-    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
-    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
-  ];
-  const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode(IndexFiltersMode.Filtering);
-  const onHandleCancel = () => {};
+              {
+                type: 'delete',
+                onPrimaryAction: async (id: string) => {
+                  await sleep(1);
+                  deleteView(index);
+                  return true;
+                },
+              },
+            ],
+    }));
+    const [selected, setSelected] = useState(0);
+    const onCreateNewView = async (value: string) => {
+      await sleep(500);
+      setItemStrings([...itemStrings, value]);
+      setSelected(itemStrings.length);
+      return true;
+    };
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+      {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+      {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+      {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+      {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+      {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+      {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+      {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+    ];
+    const [sortSelected, setSortSelected] = useState(['order asc']);
+    const {mode, setMode} = useSetIndexFiltersMode();
+    const onHandleCancel = () => {};
 
-  const onHandleSave = async () => {
-    await sleep(1);
-    return true;
-  };
+    const onHandleSave = async () => {
+      await sleep(1);
+      return true;
+    };
 
-  const primaryAction: IndexFiltersProps['primaryAction'] =
-    selected === 0
-      ? {
-          type: 'save-as',
-          onAction: onCreateNewView,
-          disabled: false,
-          loading: false,
-        }
-      : {
-          type: 'save',
-          onAction: onHandleSave,
-          disabled: false,
-          loading: false,
-        };
-  const [accountStatus, setAccountStatus] = useState<string[] | null>([
-    'enabled',
-  ]);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('Returning customer');
-  const [queryValue, setQueryValue] = useState('');
+    const primaryAction: IndexFiltersProps['primaryAction'] =
+      selected === 0
+        ? {
+            type: 'save-as',
+            onAction: onCreateNewView,
+            disabled: false,
+            loading: false,
+          }
+        : {
+            type: 'save',
+            onAction: onHandleSave,
+            disabled: false,
+            loading: false,
+          };
+    const [accountStatus, setAccountStatus] = useState<string[] | null>([
+      'enabled',
+    ]);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('Returning customer');
+    const [queryValue, setQueryValue] = useState('');
 
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
 
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <Card padding="0">
+        <IndexFilters
+          sortOptions={sortOptions}
+          sortSelected={sortSelected}
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          onQueryChange={handleFiltersQueryChange}
+          onQueryClear={() => setQueryValue('')}
+          onSort={setSortSelected}
+          primaryAction={primaryAction}
+          cancelAction={{
+            onAction: onHandleCancel,
+            disabled: false,
+            loading: false,
+          }}
+          tabs={tabs}
+          selected={selected}
+          onSelect={setSelected}
+          canCreateNewView
+          onCreateNewView={onCreateNewView}
+          filters={filters}
+          appliedFilters={appliedFilters}
+          onClearAll={handleFiltersClearAll}
+          mode={mode}
+          setMode={setMode}
         />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-    {
+        <Table />
+      </Card>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithHiddenFilter = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const [itemStrings, setItemStrings] = useState([
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ]);
+    const deleteView = (index: number) => {
+      const newItemStrings = [...itemStrings];
+      newItemStrings.splice(index, 1);
+      setItemStrings(newItemStrings);
+      setSelected(0);
+    };
+
+    const duplicateView = async (name: string) => {
+      setItemStrings([...itemStrings, name]);
+      setSelected(itemStrings.length);
+      await sleep(1);
+      return true;
+    };
+
+    const tabs: TabProps[] = itemStrings.map((item, index) => ({
+      content: item,
+      index,
+      onAction: () => {},
+      id: `${item}-${index}`,
+      isLocked: index === 0,
+      actions:
+        index === 0
+          ? []
+          : [
+              {
+                type: 'rename',
+                onAction: () => {},
+                onPrimaryAction: async (value: string) => {
+                  const newItemsStrings = tabs.map((item, idx) => {
+                    if (idx === index) {
+                      return value;
+                    }
+                    return item.content;
+                  });
+                  await sleep(1);
+                  setItemStrings(newItemsStrings);
+                  return true;
+                },
+              },
+              {
+                type: 'duplicate',
+                onPrimaryAction: async (name) => {
+                  await sleep(1);
+                  duplicateView(name);
+                  return true;
+                },
+              },
+              {
+                type: 'edit',
+              },
+              {
+                type: 'delete',
+                onPrimaryAction: async (id: string) => {
+                  await sleep(1);
+                  deleteView(index);
+                  return true;
+                },
+              },
+            ],
+    }));
+    const [selected, setSelected] = useState(0);
+    const onCreateNewView = async (value: string) => {
+      await sleep(500);
+      setItemStrings([...itemStrings, value]);
+      setSelected(itemStrings.length);
+      return true;
+    };
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+      {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+      {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+      {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+      {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+      {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+      {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+      {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+    ];
+    const [sortSelected, setSortSelected] = useState(['order asc']);
+    const {mode, setMode} = useSetIndexFiltersMode(IndexFiltersMode.Filtering);
+    const onHandleCancel = () => {};
+
+    const onHandleSave = async () => {
+      await sleep(1);
+      return true;
+    };
+
+    const primaryAction: IndexFiltersProps['primaryAction'] =
+      selected === 0
+        ? {
+            type: 'save-as',
+            onAction: onCreateNewView,
+            disabled: false,
+            loading: false,
+          }
+        : {
+            type: 'save',
+            onAction: onHandleSave,
+            disabled: false,
+            loading: false,
+          };
+    const [accountStatus, setAccountStatus] = useState<string[] | null>([
+      'enabled',
+    ]);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('Returning customer');
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+      {
+        key: 'hiddenFilter',
+        label: 'Filter not accessible from the dropdown',
+        hidden: true,
+        filter: null,
+      },
+    ];
+
+    const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    appliedFilters.push({
       key: 'hiddenFilter',
       label: 'Filter not accessible from the dropdown',
-      hidden: true,
-      filter: null,
-    },
-  ];
-
-  const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
       onRemove: handleTaggedWithRemove,
     });
-  }
 
-  appliedFilters.push({
-    key: 'hiddenFilter',
-    label: 'Filter not accessible from the dropdown',
-    onRemove: handleTaggedWithRemove,
-  });
+    return (
+      <Card padding="0">
+        <IndexFilters
+          sortOptions={sortOptions}
+          sortSelected={sortSelected}
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          onQueryChange={handleFiltersQueryChange}
+          onQueryClear={() => setQueryValue('')}
+          onSort={setSortSelected}
+          primaryAction={primaryAction}
+          cancelAction={{
+            onAction: onHandleCancel,
+            disabled: false,
+            loading: false,
+          }}
+          tabs={tabs}
+          selected={selected}
+          onSelect={setSelected}
+          canCreateNewView
+          onCreateNewView={onCreateNewView}
+          filters={filters}
+          appliedFilters={appliedFilters}
+          onClearAll={handleFiltersClearAll}
+          mode={mode}
+          setMode={setMode}
+        />
+        <Table />
+      </Card>
+    );
 
-  return (
-    <Card padding="0">
-      <IndexFilters
-        sortOptions={sortOptions}
-        sortSelected={sortSelected}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        onQueryChange={handleFiltersQueryChange}
-        onQueryClear={() => setQueryValue('')}
-        onSort={setSortSelected}
-        primaryAction={primaryAction}
-        cancelAction={{
-          onAction: onHandleCancel,
-          disabled: false,
-          loading: false,
-        }}
-        tabs={tabs}
-        selected={selected}
-        onSelect={setSelected}
-        canCreateNewView
-        onCreateNewView={onCreateNewView}
-        filters={filters}
-        appliedFilters={appliedFilters}
-        onClearAll={handleFiltersClearAll}
-        mode={mode}
-        setMode={setMode}
-      />
-      <Table />
-    </Card>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
     }
-  }
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
     }
-  }
-}
+  },
+};
 
-export function WithAsyncData() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const [loadData, setLoadData] = useState(false);
-  const [addAsyncFilter, setAddAsyncFilter] = useState(false);
-  const [itemStrings, setItemStrings] = useState([
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ]);
-  const deleteView = (index: number) => {
-    const newItemStrings = [...itemStrings];
-    newItemStrings.splice(index, 1);
-    setItemStrings(newItemStrings);
-    setSelected(0);
-  };
+export const WithAsyncData = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const [loadData, setLoadData] = useState(false);
+    const [addAsyncFilter, setAddAsyncFilter] = useState(false);
+    const [itemStrings, setItemStrings] = useState([
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ]);
+    const deleteView = (index: number) => {
+      const newItemStrings = [...itemStrings];
+      newItemStrings.splice(index, 1);
+      setItemStrings(newItemStrings);
+      setSelected(0);
+    };
 
-  const duplicateView = async (name: string) => {
-    setItemStrings([...itemStrings, name]);
-    setSelected(itemStrings.length);
-    await sleep(1);
-    return true;
-  };
+    const duplicateView = async (name: string) => {
+      setItemStrings([...itemStrings, name]);
+      setSelected(itemStrings.length);
+      await sleep(1);
+      return true;
+    };
 
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
-    content: item,
-    index,
-    onAction: () => {},
-    id: `${item}-${index}`,
-    isLocked: index === 0,
-    actions:
-      index === 0
-        ? []
-        : [
-            {
-              type: 'rename',
-              onAction: () => {},
-              onPrimaryAction: async (value: string) => {
-                const newItemsStrings = tabs.map((item, idx) => {
-                  if (idx === index) {
-                    return value;
-                  }
-                  return item.content;
-                });
-                await sleep(1);
-                setItemStrings(newItemsStrings);
-                return true;
-              },
-            },
-            {
-              type: 'duplicate',
-              onPrimaryAction: async (name) => {
-                await sleep(1);
-                duplicateView(name);
-                return true;
-              },
-            },
-            {
-              type: 'edit',
-            },
-            {
-              type: 'delete',
-              onPrimaryAction: async (id: string) => {
-                await sleep(1);
-                deleteView(index);
-                return true;
-              },
-            },
-          ],
-  }));
-  const [selected, setSelected] = useState(0);
-  const onCreateNewView = async (value: string) => {
-    await sleep(500);
-    setItemStrings([...itemStrings, value]);
-    setSelected(itemStrings.length);
-    return true;
-  };
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
-    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
-    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
-    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
-    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
-    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
-    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
-    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
-  ];
-  const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode(IndexFiltersMode.Filtering);
-  const onHandleCancel = () => {};
-
-  const onHandleSave = async () => {
-    await sleep(1);
-    return true;
-  };
-
-  const primaryAction: IndexFiltersProps['primaryAction'] =
-    selected === 0
-      ? {
-          type: 'save-as',
-          onAction: onCreateNewView,
-          disabled: false,
-          loading: false,
-        }
-      : {
-          type: 'save',
-          onAction: onHandleSave,
-          disabled: false,
-          loading: false,
-        };
-  const [accountStatus, setAccountStatus] = useState<string[] | null>([
-    'enabled',
-  ]);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('Returning customer');
-  const [deliveryMethod, setDeliveryMethod] = useState<string[] | null>([
-    'local_pick_up',
-    'local_delivery',
-  ]);
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleDeliveryMethodChange = useCallback(
-    (value) => setDeliveryMethod(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleDeliveryMethodRemove = useCallback(
-    () => setDeliveryMethod(null),
-    [],
-  );
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleDeliveryMethodRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-    handleDeliveryMethodRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  if (addAsyncFilter) {
-    filters.push({
-      key: 'delivery_method',
-      label: 'Delivery method',
-      filter: (
-        <ChoiceList
-          title="Delivery method"
-          titleHidden
-          choices={[
-            {label: 'Local pick up', value: 'local_pick_up'},
-            {label: 'Local delivery', value: 'local_delivery'},
-            {label: 'National delivery', value: 'national_delivery'},
-            {label: 'International delivery', value: 'international_delivery'},
-          ]}
-          selected={deliveryMethod || []}
-          onChange={handleDeliveryMethodChange}
-          allowMultiple
-        />
-      ),
-    });
-  }
-
-  const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-  if (!isEmpty(deliveryMethod)) {
-    const key = 'delivery_method';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, deliveryMethod),
-      onRemove: handleDeliveryMethodRemove,
-    });
-  }
-
-  return (
-    <Card padding="0">
-      <IndexFilters
-        sortOptions={sortOptions}
-        sortSelected={sortSelected}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        onQueryChange={handleFiltersQueryChange}
-        onQueryClear={() => setQueryValue('')}
-        onSort={setSortSelected}
-        primaryAction={primaryAction}
-        cancelAction={{
-          onAction: onHandleCancel,
-          disabled: false,
-          loading: false,
-        }}
-        tabs={tabs}
-        selected={selected}
-        onSelect={setSelected}
-        canCreateNewView
-        onCreateNewView={onCreateNewView}
-        filters={loadData ? filters : []}
-        appliedFilters={loadData ? appliedFilters : []}
-        onClearAll={handleFiltersClearAll}
-        mode={mode}
-        setMode={setMode}
-      />
-      <Table />
-      <div style={{padding: '1rem'}}>
-        <ButtonGroup>
-          <Button
-            size="micro"
-            variant="primary"
-            onClick={() => setLoadData(true)}
-          >
-            Load filter data
-          </Button>
-          <Button
-            size="micro"
-            variant="primary"
-            onClick={() => setAddAsyncFilter(true)}
-          >
-            Add async filter
-          </Button>
-        </ButtonGroup>
-      </div>
-    </Card>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      case 'delivery_method':
-        return `Delivery method: ${value.join(', ')}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function Disabled() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const [itemStrings, setItemStrings] = useState([
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ]);
-  const deleteView = (index: number) => {
-    const newItemStrings = [...itemStrings];
-    newItemStrings.splice(index, 1);
-    setItemStrings(newItemStrings);
-    setSelected(0);
-  };
-
-  const duplicateView = async (name: string) => {
-    setItemStrings([...itemStrings, name]);
-    setSelected(itemStrings.length);
-    await sleep(1);
-    return true;
-  };
-
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
-    content: item,
-    index,
-    onAction: () => {},
-    id: `${item}-${index}`,
-    isLocked: index === 0,
-    actions:
-      index === 0
-        ? []
-        : [
-            {
-              type: 'rename',
-              onAction: () => {},
-              onPrimaryAction: async (value: string) => {
-                const newItemsStrings = tabs.map((item, idx) => {
-                  if (idx === index) {
-                    return value;
-                  }
-                  return item.content;
-                });
-                await sleep(1);
-                setItemStrings(newItemsStrings);
-                return true;
-              },
-            },
-            {
-              type: 'duplicate',
-              onPrimaryAction: async (name) => {
-                await sleep(1);
-                duplicateView(name);
-                return true;
-              },
-            },
-            {
-              type: 'edit',
-            },
-            {
-              type: 'delete',
-              onPrimaryAction: async (id: string) => {
-                await sleep(1);
-                deleteView(index);
-                return true;
-              },
-            },
-          ],
-  }));
-  const [selected, setSelected] = useState(0);
-  const onCreateNewView = async (value: string) => {
-    await sleep(500);
-    setItemStrings([...itemStrings, value]);
-    setSelected(itemStrings.length);
-    return true;
-  };
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
-    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
-    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
-    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
-    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
-    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
-    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
-    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
-  ];
-  const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode();
-  const onHandleCancel = () => {};
-
-  const onHandleSave = async () => {
-    await sleep(1);
-    return true;
-  };
-
-  const primaryAction: IndexFiltersProps['primaryAction'] =
-    selected === 0
-      ? {
-          type: 'save-as',
-          onAction: onCreateNewView,
-          disabled: false,
-          loading: false,
-        }
-      : {
-          type: 'save',
-          onAction: onHandleSave,
-          disabled: false,
-          loading: false,
-        };
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState('');
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <Card padding="0">
-      <IndexFilters
-        sortOptions={sortOptions}
-        sortSelected={sortSelected}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        onQueryChange={handleFiltersQueryChange}
-        onQueryClear={() => setQueryValue('')}
-        onSort={setSortSelected}
-        primaryAction={primaryAction}
-        cancelAction={{
-          onAction: onHandleCancel,
-          disabled: false,
-          loading: false,
-        }}
-        tabs={tabs}
-        selected={selected}
-        onSelect={setSelected}
-        canCreateNewView
-        onCreateNewView={onCreateNewView}
-        filters={filters}
-        appliedFilters={appliedFilters}
-        onClearAll={handleFiltersClearAll}
-        mode={mode}
-        setMode={setMode}
-        disabled
-        showEditColumnsButton
-      />
-      <Table />
-    </Card>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithQueryFieldAndFiltersHidden() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const [itemStrings, setItemStrings] = useState([
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ]);
-  const deleteView = (index: number) => {
-    const newItemStrings = [...itemStrings];
-    newItemStrings.splice(index, 1);
-    setItemStrings(newItemStrings);
-    setSelected(0);
-  };
-
-  const duplicateView = async (name: string) => {
-    setItemStrings([...itemStrings, name]);
-    setSelected(itemStrings.length);
-    await sleep(1);
-    return true;
-  };
-
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
-    content: item,
-    index,
-    onAction: () => {},
-    id: `${item}-${index}`,
-    isLocked: index === 0,
-    actions:
-      index === 0
-        ? []
-        : [
-            {
-              type: 'rename',
-              onAction: () => {},
-              onPrimaryAction: async (value: string) => {
-                const newItemsStrings = tabs.map((item, idx) => {
-                  if (idx === index) {
-                    return value;
-                  }
-                  return item.content;
-                });
-                await sleep(1);
-                setItemStrings(newItemsStrings);
-                return true;
-              },
-            },
-            {
-              type: 'duplicate',
-              onPrimaryAction: async (name) => {
-                await sleep(1);
-                duplicateView(name);
-                return true;
-              },
-            },
-            {
-              type: 'edit',
-            },
-            {
-              type: 'delete',
-              onPrimaryAction: async (id: string) => {
-                await sleep(1);
-                deleteView(index);
-                return true;
-              },
-            },
-          ],
-  }));
-  const [selected, setSelected] = useState(0);
-  const onCreateNewView = async (value: string) => {
-    await sleep(500);
-    setItemStrings([...itemStrings, value]);
-    setSelected(itemStrings.length);
-    return true;
-  };
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
-    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
-    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
-    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
-    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
-    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
-    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
-    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
-  ];
-  const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode();
-  const onHandleCancel = () => {};
-
-  const onHandleSave = async () => {
-    await sleep(1);
-    return true;
-  };
-
-  const primaryAction: IndexFiltersProps['primaryAction'] =
-    selected === 0
-      ? {
-          type: 'save-as',
-          onAction: onCreateNewView,
-          disabled: false,
-          loading: false,
-        }
-      : {
-          type: 'save',
-          onAction: onHandleSave,
-          disabled: false,
-          loading: false,
-        };
-
-  return (
-    <Card padding="0">
-      <IndexFilters
-        sortOptions={sortOptions}
-        sortSelected={sortSelected}
-        queryValue=""
-        queryPlaceholder="Searching in all"
-        onQueryChange={() => {}}
-        onQueryClear={() => {}}
-        onSort={setSortSelected}
-        primaryAction={primaryAction}
-        cancelAction={{
-          onAction: onHandleCancel,
-          disabled: false,
-          loading: false,
-        }}
-        tabs={tabs}
-        selected={selected}
-        onSelect={setSelected}
-        canCreateNewView
-        onCreateNewView={onCreateNewView}
-        filters={[]}
-        onClearAll={() => {}}
-        mode={mode}
-        setMode={setMode}
-        hideQueryField
-        hideFilters
-      />
-      <Table />
-    </Card>
-  );
-}
-
-export function WithNoFilters() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const [itemStrings, setItemStrings] = useState([
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ]);
-  const deleteView = (index: number) => {
-    const newItemStrings = [...itemStrings];
-    newItemStrings.splice(index, 1);
-    setItemStrings(newItemStrings);
-    setSelected(0);
-  };
-
-  const duplicateView = async (name: string) => {
-    setItemStrings([...itemStrings, name]);
-    setSelected(itemStrings.length);
-    await sleep(1);
-    return true;
-  };
-
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
-    content: item,
-    index,
-    onAction: () => {},
-    id: `${item}-${index}`,
-    isLocked: index === 0,
-    actions:
-      index === 0
-        ? []
-        : [
-            {
-              type: 'rename',
-              onAction: () => {},
-              onPrimaryAction: async (value: string): Promise<boolean> => {
-                const newItemsStrings = tabs.map((item, idx) => {
-                  if (idx === index) {
-                    return value;
-                  }
-                  return item.content;
-                });
-                await sleep(1);
-                setItemStrings(newItemsStrings);
-                return true;
-              },
-            },
-            {
-              type: 'duplicate',
-              onPrimaryAction: async (value: string): Promise<boolean> => {
-                await sleep(1);
-                duplicateView(value);
-                return true;
-              },
-            },
-            {
-              type: 'edit',
-            },
-            {
-              type: 'delete',
-              onPrimaryAction: async () => {
-                await sleep(1);
-                deleteView(index);
-                return true;
-              },
-            },
-          ],
-  }));
-  const [selected, setSelected] = useState(0);
-  const onCreateNewView = async (value: string) => {
-    await sleep(500);
-    setItemStrings([...itemStrings, value]);
-    setSelected(itemStrings.length);
-    return true;
-  };
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
-    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
-    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
-    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
-    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
-    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
-    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
-    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
-  ];
-  const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode();
-  const onHandleCancel = () => {};
-
-  const onHandleSave = async () => {
-    await sleep(1);
-    return true;
-  };
-
-  const primaryAction: IndexFiltersProps['primaryAction'] =
-    selected === 0
-      ? {
-          type: 'save-as',
-          onAction: onCreateNewView,
-          disabled: false,
-          loading: false,
-        }
-      : {
-          type: 'save',
-          onAction: onHandleSave,
-          disabled: false,
-          loading: false,
-        };
-  const [queryValue, setQueryValue] = useState('');
-
-  const handleFiltersQueryChange = useCallback(
-    (value: string) => setQueryValue(value),
-    [],
-  );
-
-  const orders = [
-    {
-      id: '1020',
-      order: (
-        <Text as="span" variant="bodyMd" fontWeight="semibold">
-          #1020
-        </Text>
-      ),
-      date: 'Jul 20 at 4:34pm',
-      customer: 'Jaydon Stanton',
-      total: '$969.44',
-      paymentStatus: <Badge progress="complete">Paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-    {
-      id: '1019',
-      order: (
-        <Text as="span" variant="bodyMd" fontWeight="semibold">
-          #1019
-        </Text>
-      ),
-      date: 'Jul 20 at 3:46pm',
-      customer: 'Ruben Westerfelt',
-      total: '$701.19',
-      paymentStatus: <Badge progress="partiallyComplete">Partially paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-    {
-      id: '1018',
-      order: (
-        <Text as="span" variant="bodyMd" fontWeight="semibold">
-          #1018
-        </Text>
-      ),
-      date: 'Jul 20 at 3.44pm',
-      customer: 'Leo Carder',
-      total: '$798.24',
-      paymentStatus: <Badge progress="complete">Paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-  ];
-  const resourceName = {
-    singular: 'order',
-    plural: 'orders',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(orders);
-
-  const rowMarkup = orders.map(
-    (
-      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+    const tabs: TabProps[] = itemStrings.map((item, index) => ({
+      content: item,
       index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text variant="bodyMd" fontWeight="bold" as="span">
-            {order}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" variant="bodyMd">
-            {date}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" variant="bodyMd">
-            {customer}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric>
-            {total}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" variant="bodyMd">
-            {paymentStatus}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" variant="bodyMd">
-            {fulfillmentStatus}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
+      onAction: () => {},
+      id: `${item}-${index}`,
+      isLocked: index === 0,
+      actions:
+        index === 0
+          ? []
+          : [
+              {
+                type: 'rename',
+                onAction: () => {},
+                onPrimaryAction: async (value: string) => {
+                  const newItemsStrings = tabs.map((item, idx) => {
+                    if (idx === index) {
+                      return value;
+                    }
+                    return item.content;
+                  });
+                  await sleep(1);
+                  setItemStrings(newItemsStrings);
+                  return true;
+                },
+              },
+              {
+                type: 'duplicate',
+                onPrimaryAction: async (name) => {
+                  await sleep(1);
+                  duplicateView(name);
+                  return true;
+                },
+              },
+              {
+                type: 'edit',
+              },
+              {
+                type: 'delete',
+                onPrimaryAction: async (id: string) => {
+                  await sleep(1);
+                  deleteView(index);
+                  return true;
+                },
+              },
+            ],
+    }));
+    const [selected, setSelected] = useState(0);
+    const onCreateNewView = async (value: string) => {
+      await sleep(500);
+      setItemStrings([...itemStrings, value]);
+      setSelected(itemStrings.length);
+      return true;
+    };
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+      {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+      {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+      {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+      {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+      {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+      {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+      {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+    ];
+    const [sortSelected, setSortSelected] = useState(['order asc']);
+    const {mode, setMode} = useSetIndexFiltersMode(IndexFiltersMode.Filtering);
+    const onHandleCancel = () => {};
 
-  return (
-    <Card padding="0">
-      <IndexFilters
-        sortOptions={sortOptions}
-        sortSelected={sortSelected}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        onQueryChange={handleFiltersQueryChange}
-        onQueryClear={() => setQueryValue('')}
-        onSort={setSortSelected}
-        primaryAction={primaryAction}
-        cancelAction={{
-          onAction: onHandleCancel,
-          disabled: false,
-          loading: false,
-        }}
-        tabs={tabs}
-        selected={selected}
-        onSelect={setSelected}
-        canCreateNewView
-        onCreateNewView={onCreateNewView}
-        filters={[]}
-        appliedFilters={[]}
-        onClearAll={() => {}}
-        mode={mode}
-        setMode={setMode}
-        hideFilters
-        filteringAccessibilityTooltip="Search (F)"
-      />
-      <IndexTable
-        resourceName={resourceName}
-        itemCount={orders.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Order'},
-          {title: 'Date'},
-          {title: 'Customer'},
-          {title: 'Total', alignment: 'end'},
-          {title: 'Payment status'},
-          {title: 'Fulfillment status'},
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </Card>
-  );
-}
+    const onHandleSave = async () => {
+      await sleep(1);
+      return true;
+    };
 
-export function WithOnlySearchAndSort() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
-    {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
-    {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
-    {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
-    {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
-    {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
-    {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
-    {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
-  ];
-  const [sortSelected, setSortSelected] = useState(['order asc']);
-  const {mode, setMode} = useSetIndexFiltersMode(IndexFiltersMode.Filtering);
-  const onHandleCancel = () => {};
+    const primaryAction: IndexFiltersProps['primaryAction'] =
+      selected === 0
+        ? {
+            type: 'save-as',
+            onAction: onCreateNewView,
+            disabled: false,
+            loading: false,
+          }
+        : {
+            type: 'save',
+            onAction: onHandleSave,
+            disabled: false,
+            loading: false,
+          };
+    const [accountStatus, setAccountStatus] = useState<string[] | null>([
+      'enabled',
+    ]);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('Returning customer');
+    const [deliveryMethod, setDeliveryMethod] = useState<string[] | null>([
+      'local_pick_up',
+      'local_delivery',
+    ]);
+    const [queryValue, setQueryValue] = useState('');
 
-  const onHandleSave = async () => {
-    await sleep(1);
-    return true;
-  };
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleDeliveryMethodChange = useCallback(
+      (value) => setDeliveryMethod(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleDeliveryMethodRemove = useCallback(
+      () => setDeliveryMethod(null),
+      [],
+    );
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleDeliveryMethodRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+      handleDeliveryMethodRemove,
+    ]);
 
-  const [queryValue, setQueryValue] = useState('');
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
 
-  const handleFiltersQueryChange = useCallback(
-    (value: string) => setQueryValue(value),
-    [],
-  );
+    if (addAsyncFilter) {
+      filters.push({
+        key: 'delivery_method',
+        label: 'Delivery method',
+        filter: (
+          <ChoiceList
+            title="Delivery method"
+            titleHidden
+            choices={[
+              {label: 'Local pick up', value: 'local_pick_up'},
+              {label: 'Local delivery', value: 'local_delivery'},
+              {label: 'National delivery', value: 'national_delivery'},
+              {
+                label: 'International delivery',
+                value: 'international_delivery',
+              },
+            ]}
+            selected={deliveryMethod || []}
+            onChange={handleDeliveryMethodChange}
+            allowMultiple
+          />
+        ),
+      });
+    }
 
-  const orders = [
-    {
-      id: '1020',
-      order: (
-        <Text as="span" variant="bodyMd" fontWeight="semibold">
-          #1020
-        </Text>
-      ),
-      date: 'Jul 20 at 4:34pm',
-      customer: 'Jaydon Stanton',
-      total: '$969.44',
-      paymentStatus: <Badge progress="complete">Paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-    {
-      id: '1019',
-      order: (
-        <Text as="span" variant="bodyMd" fontWeight="semibold">
-          #1019
-        </Text>
-      ),
-      date: 'Jul 20 at 3:46pm',
-      customer: 'Ruben Westerfelt',
-      total: '$701.19',
-      paymentStatus: <Badge progress="partiallyComplete">Partially paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-    {
-      id: '1018',
-      order: (
-        <Text as="span" variant="bodyMd" fontWeight="semibold">
-          #1018
-        </Text>
-      ),
-      date: 'Jul 20 at 3.44pm',
-      customer: 'Leo Carder',
-      total: '$798.24',
-      paymentStatus: <Badge progress="complete">Paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-  ];
-  const resourceName = {
-    singular: 'order',
-    plural: 'orders',
-  };
+    const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+    if (!isEmpty(deliveryMethod)) {
+      const key = 'delivery_method';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, deliveryMethod),
+        onRemove: handleDeliveryMethodRemove,
+      });
+    }
 
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(orders);
+    return (
+      <Card padding="0">
+        <IndexFilters
+          sortOptions={sortOptions}
+          sortSelected={sortSelected}
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          onQueryChange={handleFiltersQueryChange}
+          onQueryClear={() => setQueryValue('')}
+          onSort={setSortSelected}
+          primaryAction={primaryAction}
+          cancelAction={{
+            onAction: onHandleCancel,
+            disabled: false,
+            loading: false,
+          }}
+          tabs={tabs}
+          selected={selected}
+          onSelect={setSelected}
+          canCreateNewView
+          onCreateNewView={onCreateNewView}
+          filters={loadData ? filters : []}
+          appliedFilters={loadData ? appliedFilters : []}
+          onClearAll={handleFiltersClearAll}
+          mode={mode}
+          setMode={setMode}
+        />
+        <Table />
+        <div style={{padding: '1rem'}}>
+          <ButtonGroup>
+            <Button
+              size="micro"
+              variant="primary"
+              onClick={() => setLoadData(true)}
+            >
+              Load filter data
+            </Button>
+            <Button
+              size="micro"
+              variant="primary"
+              onClick={() => setAddAsyncFilter(true)}
+            >
+              Add async filter
+            </Button>
+          </ButtonGroup>
+        </div>
+      </Card>
+    );
 
-  const rowMarkup = orders.map(
-    (
-      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        case 'delivery_method':
+          return `Delivery method: ${value.join(', ')}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const Disabled = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const [itemStrings, setItemStrings] = useState([
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ]);
+    const deleteView = (index: number) => {
+      const newItemStrings = [...itemStrings];
+      newItemStrings.splice(index, 1);
+      setItemStrings(newItemStrings);
+      setSelected(0);
+    };
+
+    const duplicateView = async (name: string) => {
+      setItemStrings([...itemStrings, name]);
+      setSelected(itemStrings.length);
+      await sleep(1);
+      return true;
+    };
+
+    const tabs: TabProps[] = itemStrings.map((item, index) => ({
+      content: item,
       index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text variant="bodyMd" fontWeight="bold" as="span">
-            {order}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" variant="bodyMd">
-            {date}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" variant="bodyMd">
-            {customer}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric>
-            {total}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" variant="bodyMd">
-            {paymentStatus}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" variant="bodyMd">
-            {fulfillmentStatus}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
+      onAction: () => {},
+      id: `${item}-${index}`,
+      isLocked: index === 0,
+      actions:
+        index === 0
+          ? []
+          : [
+              {
+                type: 'rename',
+                onAction: () => {},
+                onPrimaryAction: async (value: string) => {
+                  const newItemsStrings = tabs.map((item, idx) => {
+                    if (idx === index) {
+                      return value;
+                    }
+                    return item.content;
+                  });
+                  await sleep(1);
+                  setItemStrings(newItemsStrings);
+                  return true;
+                },
+              },
+              {
+                type: 'duplicate',
+                onPrimaryAction: async (name) => {
+                  await sleep(1);
+                  duplicateView(name);
+                  return true;
+                },
+              },
+              {
+                type: 'edit',
+              },
+              {
+                type: 'delete',
+                onPrimaryAction: async (id: string) => {
+                  await sleep(1);
+                  deleteView(index);
+                  return true;
+                },
+              },
+            ],
+    }));
+    const [selected, setSelected] = useState(0);
+    const onCreateNewView = async (value: string) => {
+      await sleep(500);
+      setItemStrings([...itemStrings, value]);
+      setSelected(itemStrings.length);
+      return true;
+    };
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+      {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+      {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+      {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+      {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+      {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+      {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+      {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+    ];
+    const [sortSelected, setSortSelected] = useState(['order asc']);
+    const {mode, setMode} = useSetIndexFiltersMode();
+    const onHandleCancel = () => {};
 
-  return (
-    <Card padding="0">
-      <IndexFilters
-        sortOptions={sortOptions}
-        sortSelected={sortSelected}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        onQueryChange={handleFiltersQueryChange}
-        onQueryClear={() => setQueryValue('')}
-        onSort={setSortSelected}
-        autoFocusSearchField={false}
-        tabs={[]}
-        filters={[]}
-        appliedFilters={[]}
-        onClearAll={() => {}}
-        mode={mode}
-        setMode={setMode}
-        hideFilters
-        filteringAccessibilityTooltip="Search (F)"
-      />
-      <IndexTable
-        resourceName={resourceName}
-        itemCount={orders.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Order'},
-          {title: 'Date'},
-          {title: 'Customer'},
-          {title: 'Total', alignment: 'end'},
-          {title: 'Payment status'},
-          {title: 'Fulfillment status'},
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </Card>
-  );
-}
+    const onHandleSave = async () => {
+      await sleep(1);
+      return true;
+    };
+
+    const primaryAction: IndexFiltersProps['primaryAction'] =
+      selected === 0
+        ? {
+            type: 'save-as',
+            onAction: onCreateNewView,
+            disabled: false,
+            loading: false,
+          }
+        : {
+            type: 'save',
+            onAction: onHandleSave,
+            disabled: false,
+            loading: false,
+          };
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState('');
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters: IndexFiltersProps['appliedFilters'] = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <Card padding="0">
+        <IndexFilters
+          sortOptions={sortOptions}
+          sortSelected={sortSelected}
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          onQueryChange={handleFiltersQueryChange}
+          onQueryClear={() => setQueryValue('')}
+          onSort={setSortSelected}
+          primaryAction={primaryAction}
+          cancelAction={{
+            onAction: onHandleCancel,
+            disabled: false,
+            loading: false,
+          }}
+          tabs={tabs}
+          selected={selected}
+          onSelect={setSelected}
+          canCreateNewView
+          onCreateNewView={onCreateNewView}
+          filters={filters}
+          appliedFilters={appliedFilters}
+          onClearAll={handleFiltersClearAll}
+          mode={mode}
+          setMode={setMode}
+          disabled
+          showEditColumnsButton
+        />
+        <Table />
+      </Card>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithQueryFieldAndFiltersHidden = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const [itemStrings, setItemStrings] = useState([
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ]);
+    const deleteView = (index: number) => {
+      const newItemStrings = [...itemStrings];
+      newItemStrings.splice(index, 1);
+      setItemStrings(newItemStrings);
+      setSelected(0);
+    };
+
+    const duplicateView = async (name: string) => {
+      setItemStrings([...itemStrings, name]);
+      setSelected(itemStrings.length);
+      await sleep(1);
+      return true;
+    };
+
+    const tabs: TabProps[] = itemStrings.map((item, index) => ({
+      content: item,
+      index,
+      onAction: () => {},
+      id: `${item}-${index}`,
+      isLocked: index === 0,
+      actions:
+        index === 0
+          ? []
+          : [
+              {
+                type: 'rename',
+                onAction: () => {},
+                onPrimaryAction: async (value: string) => {
+                  const newItemsStrings = tabs.map((item, idx) => {
+                    if (idx === index) {
+                      return value;
+                    }
+                    return item.content;
+                  });
+                  await sleep(1);
+                  setItemStrings(newItemsStrings);
+                  return true;
+                },
+              },
+              {
+                type: 'duplicate',
+                onPrimaryAction: async (name) => {
+                  await sleep(1);
+                  duplicateView(name);
+                  return true;
+                },
+              },
+              {
+                type: 'edit',
+              },
+              {
+                type: 'delete',
+                onPrimaryAction: async (id: string) => {
+                  await sleep(1);
+                  deleteView(index);
+                  return true;
+                },
+              },
+            ],
+    }));
+    const [selected, setSelected] = useState(0);
+    const onCreateNewView = async (value: string) => {
+      await sleep(500);
+      setItemStrings([...itemStrings, value]);
+      setSelected(itemStrings.length);
+      return true;
+    };
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+      {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+      {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+      {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+      {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+      {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+      {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+      {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+    ];
+    const [sortSelected, setSortSelected] = useState(['order asc']);
+    const {mode, setMode} = useSetIndexFiltersMode();
+    const onHandleCancel = () => {};
+
+    const onHandleSave = async () => {
+      await sleep(1);
+      return true;
+    };
+
+    const primaryAction: IndexFiltersProps['primaryAction'] =
+      selected === 0
+        ? {
+            type: 'save-as',
+            onAction: onCreateNewView,
+            disabled: false,
+            loading: false,
+          }
+        : {
+            type: 'save',
+            onAction: onHandleSave,
+            disabled: false,
+            loading: false,
+          };
+
+    return (
+      <Card padding="0">
+        <IndexFilters
+          sortOptions={sortOptions}
+          sortSelected={sortSelected}
+          queryValue=""
+          queryPlaceholder="Searching in all"
+          onQueryChange={() => {}}
+          onQueryClear={() => {}}
+          onSort={setSortSelected}
+          primaryAction={primaryAction}
+          cancelAction={{
+            onAction: onHandleCancel,
+            disabled: false,
+            loading: false,
+          }}
+          tabs={tabs}
+          selected={selected}
+          onSelect={setSelected}
+          canCreateNewView
+          onCreateNewView={onCreateNewView}
+          filters={[]}
+          onClearAll={() => {}}
+          mode={mode}
+          setMode={setMode}
+          hideQueryField
+          hideFilters
+        />
+        <Table />
+      </Card>
+    );
+  },
+};
+
+export const WithNoFilters = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const [itemStrings, setItemStrings] = useState([
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ]);
+    const deleteView = (index: number) => {
+      const newItemStrings = [...itemStrings];
+      newItemStrings.splice(index, 1);
+      setItemStrings(newItemStrings);
+      setSelected(0);
+    };
+
+    const duplicateView = async (name: string) => {
+      setItemStrings([...itemStrings, name]);
+      setSelected(itemStrings.length);
+      await sleep(1);
+      return true;
+    };
+
+    const tabs: TabProps[] = itemStrings.map((item, index) => ({
+      content: item,
+      index,
+      onAction: () => {},
+      id: `${item}-${index}`,
+      isLocked: index === 0,
+      actions:
+        index === 0
+          ? []
+          : [
+              {
+                type: 'rename',
+                onAction: () => {},
+                onPrimaryAction: async (value: string): Promise<boolean> => {
+                  const newItemsStrings = tabs.map((item, idx) => {
+                    if (idx === index) {
+                      return value;
+                    }
+                    return item.content;
+                  });
+                  await sleep(1);
+                  setItemStrings(newItemsStrings);
+                  return true;
+                },
+              },
+              {
+                type: 'duplicate',
+                onPrimaryAction: async (value: string): Promise<boolean> => {
+                  await sleep(1);
+                  duplicateView(value);
+                  return true;
+                },
+              },
+              {
+                type: 'edit',
+              },
+              {
+                type: 'delete',
+                onPrimaryAction: async () => {
+                  await sleep(1);
+                  deleteView(index);
+                  return true;
+                },
+              },
+            ],
+    }));
+    const [selected, setSelected] = useState(0);
+    const onCreateNewView = async (value: string) => {
+      await sleep(500);
+      setItemStrings([...itemStrings, value]);
+      setSelected(itemStrings.length);
+      return true;
+    };
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+      {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+      {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+      {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+      {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+      {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+      {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+      {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+    ];
+    const [sortSelected, setSortSelected] = useState(['order asc']);
+    const {mode, setMode} = useSetIndexFiltersMode();
+    const onHandleCancel = () => {};
+
+    const onHandleSave = async () => {
+      await sleep(1);
+      return true;
+    };
+
+    const primaryAction: IndexFiltersProps['primaryAction'] =
+      selected === 0
+        ? {
+            type: 'save-as',
+            onAction: onCreateNewView,
+            disabled: false,
+            loading: false,
+          }
+        : {
+            type: 'save',
+            onAction: onHandleSave,
+            disabled: false,
+            loading: false,
+          };
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleFiltersQueryChange = useCallback(
+      (value: string) => setQueryValue(value),
+      [],
+    );
+
+    const orders = [
+      {
+        id: '1020',
+        order: (
+          <Text as="span" variant="bodyMd" fontWeight="semibold">
+            #1020
+          </Text>
+        ),
+        date: 'Jul 20 at 4:34pm',
+        customer: 'Jaydon Stanton',
+        total: '$969.44',
+        paymentStatus: <Badge progress="complete">Paid</Badge>,
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+      {
+        id: '1019',
+        order: (
+          <Text as="span" variant="bodyMd" fontWeight="semibold">
+            #1019
+          </Text>
+        ),
+        date: 'Jul 20 at 3:46pm',
+        customer: 'Ruben Westerfelt',
+        total: '$701.19',
+        paymentStatus: (
+          <Badge progress="partiallyComplete">Partially paid</Badge>
+        ),
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+      {
+        id: '1018',
+        order: (
+          <Text as="span" variant="bodyMd" fontWeight="semibold">
+            #1018
+          </Text>
+        ),
+        date: 'Jul 20 at 3.44pm',
+        customer: 'Leo Carder',
+        total: '$798.24',
+        paymentStatus: <Badge progress="complete">Paid</Badge>,
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+    ];
+    const resourceName = {
+      singular: 'order',
+      plural: 'orders',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(orders);
+
+    const rowMarkup = orders.map(
+      (
+        {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {order}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" variant="bodyMd">
+              {date}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" variant="bodyMd">
+              {customer}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric>
+              {total}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" variant="bodyMd">
+              {paymentStatus}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" variant="bodyMd">
+              {fulfillmentStatus}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <Card padding="0">
+        <IndexFilters
+          sortOptions={sortOptions}
+          sortSelected={sortSelected}
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          onQueryChange={handleFiltersQueryChange}
+          onQueryClear={() => setQueryValue('')}
+          onSort={setSortSelected}
+          primaryAction={primaryAction}
+          cancelAction={{
+            onAction: onHandleCancel,
+            disabled: false,
+            loading: false,
+          }}
+          tabs={tabs}
+          selected={selected}
+          onSelect={setSelected}
+          canCreateNewView
+          onCreateNewView={onCreateNewView}
+          filters={[]}
+          appliedFilters={[]}
+          onClearAll={() => {}}
+          mode={mode}
+          setMode={setMode}
+          hideFilters
+          filteringAccessibilityTooltip="Search (F)"
+        />
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={orders.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Order'},
+            {title: 'Date'},
+            {title: 'Customer'},
+            {title: 'Total', alignment: 'end'},
+            {title: 'Payment status'},
+            {title: 'Fulfillment status'},
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </Card>
+    );
+  },
+};
+
+export const WithOnlySearchAndSort = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Order', value: 'order asc', directionLabel: 'Ascending'},
+      {label: 'Order', value: 'order desc', directionLabel: 'Descending'},
+      {label: 'Customer', value: 'customer asc', directionLabel: 'A-Z'},
+      {label: 'Customer', value: 'customer desc', directionLabel: 'Z-A'},
+      {label: 'Date', value: 'date asc', directionLabel: 'A-Z'},
+      {label: 'Date', value: 'date desc', directionLabel: 'Z-A'},
+      {label: 'Total', value: 'total asc', directionLabel: 'Ascending'},
+      {label: 'Total', value: 'total desc', directionLabel: 'Descending'},
+    ];
+    const [sortSelected, setSortSelected] = useState(['order asc']);
+    const {mode, setMode} = useSetIndexFiltersMode(IndexFiltersMode.Filtering);
+    const onHandleCancel = () => {};
+
+    const onHandleSave = async () => {
+      await sleep(1);
+      return true;
+    };
+
+    const [queryValue, setQueryValue] = useState('');
+
+    const handleFiltersQueryChange = useCallback(
+      (value: string) => setQueryValue(value),
+      [],
+    );
+
+    const orders = [
+      {
+        id: '1020',
+        order: (
+          <Text as="span" variant="bodyMd" fontWeight="semibold">
+            #1020
+          </Text>
+        ),
+        date: 'Jul 20 at 4:34pm',
+        customer: 'Jaydon Stanton',
+        total: '$969.44',
+        paymentStatus: <Badge progress="complete">Paid</Badge>,
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+      {
+        id: '1019',
+        order: (
+          <Text as="span" variant="bodyMd" fontWeight="semibold">
+            #1019
+          </Text>
+        ),
+        date: 'Jul 20 at 3:46pm',
+        customer: 'Ruben Westerfelt',
+        total: '$701.19',
+        paymentStatus: (
+          <Badge progress="partiallyComplete">Partially paid</Badge>
+        ),
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+      {
+        id: '1018',
+        order: (
+          <Text as="span" variant="bodyMd" fontWeight="semibold">
+            #1018
+          </Text>
+        ),
+        date: 'Jul 20 at 3.44pm',
+        customer: 'Leo Carder',
+        total: '$798.24',
+        paymentStatus: <Badge progress="complete">Paid</Badge>,
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+    ];
+    const resourceName = {
+      singular: 'order',
+      plural: 'orders',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(orders);
+
+    const rowMarkup = orders.map(
+      (
+        {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {order}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" variant="bodyMd">
+              {date}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" variant="bodyMd">
+              {customer}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric>
+              {total}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" variant="bodyMd">
+              {paymentStatus}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" variant="bodyMd">
+              {fulfillmentStatus}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <Card padding="0">
+        <IndexFilters
+          sortOptions={sortOptions}
+          sortSelected={sortSelected}
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          onQueryChange={handleFiltersQueryChange}
+          onQueryClear={() => setQueryValue('')}
+          onSort={setSortSelected}
+          autoFocusSearchField={false}
+          tabs={[]}
+          filters={[]}
+          appliedFilters={[]}
+          onClearAll={() => {}}
+          mode={mode}
+          setMode={setMode}
+          hideFilters
+          filteringAccessibilityTooltip="Search (F)"
+        />
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={orders.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Order'},
+            {title: 'Date'},
+            {title: 'Customer'},
+            {title: 'Total', alignment: 'end'},
+            {title: 'Payment status'},
+            {title: 'Fulfillment status'},
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </Card>
+    );
+  },
+};

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -1,5 +1,5 @@
 import React, {Fragment, useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import type {
   IndexFiltersProps,
   IndexTableProps,
@@ -38,4695 +38,1757 @@ import {IndexTable} from './IndexTable';
 
 export default {
   component: IndexTable,
-} as ComponentMeta<typeof IndexTable>;
+} as Meta<typeof IndexTable>;
 
-export function Default() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" variant="bodyMd" numeric>
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" variant="bodyMd" numeric>
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function Condensed() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-        condensed
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function Flush() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell flush>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell flush>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell flush>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell flush>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name', flush: true},
-          {title: 'Location', flush: true},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            flush: true,
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            flush: true,
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function SmallScreen() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <div style={{padding: '12px 16px'}}>
-          <Text fontWeight="bold" as="p">
-            {name}
-          </Text>
-          <Text as="p" variant="bodyMd">
-            <Text variant="bodyMd" as="span">
-              {location}
-            </Text>
-          </Text>
-          <Text as="p" alignment="end" numeric>
-            {orders}
-          </Text>
-          <Text as="p" alignment="end" numeric>
-            {amountSpent}
-          </Text>
-        </div>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <div style={{width: '430px'}}>
-      <LegacyCard>
-        <IndexTable
-          resourceName={resourceName}
-          itemCount={customers.length}
-          selectedItemsCount={
-            allResourcesSelected ? 'All' : selectedResources.length
-          }
-          onSelectionChange={handleSelectionChange}
-          condensed
-          headings={[
-            {title: 'Name'},
-            {title: 'Location'},
-            {
-              alignment: 'end',
-              id: 'order-count',
-              title: 'Order count',
-            },
-            {
-              alignment: 'end',
-              id: 'amount-spent',
-              title: 'Amount spent',
-            },
-          ]}
-        >
-          {rowMarkup}
-        </IndexTable>
-      </LegacyCard>
-    </div>
-  );
-}
-
-export function SmallScreenLoading() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <div style={{padding: '12px 16px'}}>
-          <Text fontWeight="bold" as="p">
-            {name}
-          </Text>
-          <Text as="p" variant="bodyMd">
-            <Text variant="bodyMd" as="span">
-              {location}
-            </Text>
-          </Text>
-          <Text as="p" alignment="end" numeric>
-            {orders}
-          </Text>
-          <Text as="p" alignment="end" numeric>
-            {amountSpent}
-          </Text>
-        </div>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <div style={{width: '430px'}}>
-      <LegacyCard>
-        <IndexTable
-          resourceName={resourceName}
-          itemCount={customers.length}
-          selectedItemsCount={
-            allResourcesSelected ? 'All' : selectedResources.length
-          }
-          onSelectionChange={handleSelectionChange}
-          condensed
-          headings={[
-            {title: 'Name'},
-            {title: 'Location'},
-            {
-              alignment: 'end',
-              id: 'order-count',
-              title: 'Order count',
-            },
-            {
-              alignment: 'end',
-              id: 'amount-spent',
-              title: 'Amount spent',
-            },
-          ]}
-          loading
-        >
-          {rowMarkup}
-        </IndexTable>
-      </LegacyCard>
-    </div>
-  );
-}
-
-export function WithDisabledRows() {
-  const customers = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      disabled: false,
-    },
-    {
-      id: '2561',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      disabled: true,
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const selectableCustomers = customers.filter(
-    (customer) => !customer.disabled,
-  );
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(selectableCustomers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent, disabled}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-        disabled={disabled}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={selectableCustomers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithSubduedRows() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-        tone={index === 1 || index === 2 ? 'subdued' : undefined}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithEmptyState() {
-  const customers = [];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const emptyStateMarkup = (
-    <EmptySearchResult
-      title="No customers yet"
-      description="Try changing the filters or search term"
-      withIllustration
-    />
-  );
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        emptyState={emptyStateMarkup}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithBulkActions() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-  ];
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        bulkActions={bulkActions}
-        promotedBulkActions={promotedBulkActions}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithSelectionAndNoBulkActions() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        hasMoreItems
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithMultiplePromotedBulkActions() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const promotedBulkActions = [
-    {
-      content: 'Capture payments',
-      onAction: () => console.log('Todo: implement payment capture'),
-    },
-    {
-      title: 'Edit customers',
-      actions: [
-        {
-          content: 'Add customers',
-          onAction: () => console.log('Todo: implement adding customers'),
-        },
-        {
-          icon: DeleteIcon,
-          destructive: true,
-          content: 'Delete customers',
-          onAction: () => console.log('Todo: implement deleting customers'),
-        },
-      ],
-    },
-    {
-      title: 'Export',
-      actions: [
-        {
-          content: 'Export as PDF',
-          onAction: () => console.log('Todo: implement PDF exporting'),
-        },
-        {
-          content: 'Export as CSV',
-          onAction: () => console.log('Todo: implement CSV exporting'),
-        },
-      ],
-    },
-  ];
-  const bulkActions = [
-    {
-      title: 'Import',
-      items: [
-        {
-          content: 'Import from PDF',
-          onAction: () => console.log('Todo: implement PDF importing'),
-        },
-        {
-          content: 'Import from CSV',
-          onAction: () => console.log('Todo: implement CSV importing'),
-        },
-      ],
-    },
-    {
-      title: 'Customers',
-      items: [
-        {
-          content: 'Add customers',
-          onAction: () => console.log('Todo: implement Adding customers'),
-        },
-        {
-          content: 'Edit customers',
-          onAction: () => console.log('Todo: implement Editing customers'),
-        },
-        {
-          icon: DeleteIcon,
-          destructive: true,
-          content: 'Delete customers',
-          onAction: () => console.log('Todo: implement Deleting customers'),
-        },
-      ],
-    },
-  ];
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        bulkActions={bulkActions}
-        promotedBulkActions={promotedBulkActions}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithBulkActionsAndSelectionAcrossPages() {
-  const customers = Array.from({length: 50}, (_, num) => {
-    return {
-      id: `${num}`,
-      url: '#',
-      name: `Mae Jemison ${num}`,
-      location: 'Truth or Consequences, New Mexico, United States of America',
-      orders: 20,
-      amountSpent: '$24,00',
+export const Default = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
     };
-  });
 
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
 
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const promotedBulkActions = [
-    {
-      content: 'Rename customers',
-      onAction: () => console.log('Todo: implement bulk rename'),
-    },
-    {
-      title: 'Edit customers',
-      actions: [
-        {
-          content: 'Add customers',
-          onAction: () => console.log('Todo: implement adding customers'),
-        },
-        {
-          icon: DeleteIcon,
-          destructive: true,
-          content: 'Delete customers',
-          onAction: () => console.log('Todo: implement deleting customers'),
-        },
-      ],
-    },
-    {
-      title: 'Export',
-      actions: [
-        {
-          content: 'Export as PDF',
-          onAction: () => console.log('Todo: implement PDF exporting'),
-        },
-        {
-          content: 'Export as CSV',
-          onAction: () => console.log('Todo: implement CSV exporting'),
-        },
-      ],
-    },
-  ];
-  const bulkActions = [
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      title: 'Bulk action section',
-      items: [
-        {
-          content: 'Edit data',
-        },
-        {
-          content: 'Manage data',
-        },
-        {
-          icon: DeleteIcon,
-          destructive: true,
-          content: 'Delete data',
-        },
-      ],
-    },
-    {
-      content: 'Edit prices',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-    {
-      content: 'Edit quantities',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-    {
-      content: 'Edit SKUs',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-    {
-      content: 'Edit barcodes',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        hasMoreItems
-        bulkActions={bulkActions}
-        promotedBulkActions={promotedBulkActions}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-        paginatedSelectAllText="Select everything in this store"
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithLoadingState() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        loading
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithFiltering() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-  const [taggedWith, setTaggedWith] = useState('VIP');
-  const [queryValue, setQueryValue] = useState('');
-  const [sortValue, setSortValue] = useState(['today asc']);
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-  const handleSortChange = useCallback((value) => setSortValue(value), []);
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Date', value: 'today asc', directionLabel: 'Ascending'},
-    {label: 'Date', value: 'today desc', directionLabel: 'Descending'},
-  ];
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  const tabs = [
-    {
-      id: 'all',
-      content: 'All customers',
-    },
-  ];
-
-  const {mode, setMode} = useSetIndexFiltersMode();
-
-  const cancelAction = {
-    onAction: () => {},
-  };
-
-  async function emptyPromise() {
-    const prom = Promise.resolve();
-    return prom.then(() => {
-      return true;
-    });
-  }
-
-  const primaryAction: IndexFiltersProps['primaryAction'] = {
-    onAction: emptyPromise,
-    type: 'save-as',
-  };
-
-  return (
-    <LegacyCard>
-      <IndexFilters
-        tabs={tabs}
-        selected={0}
-        onSelect={() => {}}
-        onCreateNewView={emptyPromise}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        filters={filters}
-        appliedFilters={appliedFilters}
-        onQueryChange={setQueryValue}
-        onQueryClear={handleQueryValueRemove}
-        onClearAll={handleClearAll}
-        sortOptions={sortOptions}
-        sortSelected={sortValue}
-        onSort={handleSortChange}
-        mode={mode}
-        setMode={setMode}
-        cancelAction={cancelAction}
-        primaryAction={primaryAction}
-      />
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithRowStatus() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Astronaut',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Baker',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      status: 'subdued',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Candlestick maker',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      status: 'success',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Rice Cooker',
-      location: 'Los Angeles, USA',
-      orders: 40,
-      amountSpent: '$40',
-      status: 'critical',
-    },
-    {
-      id: '3414',
-      url: '#',
-      name: 'Volleyball Player',
-      location: 'Delaware, USA',
-      orders: 50,
-      amountSpent: '$80',
-      status: 'warning',
-    },
-  ];
-
-  const customersForNestedRows = [
-    {
-      id: '34101',
-      url: '#',
-      name: 'Astronaut',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '34111',
-      url: '#',
-      name: 'Baker',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      status: 'subdued',
-    },
-    {
-      id: '34121',
-      url: '#',
-      name: 'Candlestick maker',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      status: 'success',
-    },
-    {
-      id: '34131',
-      url: '#',
-      name: 'Rice Cooker',
-      location: 'Los Angeles, USA',
-      orders: 40,
-      amountSpent: '$40',
-      status: 'critical',
-    },
-    {
-      id: '34141',
-      url: '#',
-      name: 'Volleyball Player',
-      location: 'Delaware, USA',
-      orders: 50,
-      amountSpent: '$80',
-      status: 'warning',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent, status}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-        tone={status as IndexTableRowProps['tone']}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <code>{status}</code>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  const rowMarkupNested = customersForNestedRows.map(
-    ({id, name, location, orders, amountSpent, status}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-        tone={status as IndexTableRowProps['tone']}
-        rowType={index > 0 ? 'child' : 'subheader'}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <code>{status}</code>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Tone'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-        {rowMarkupNested}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithStickyLastColumn() {
-  const customers = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      channel: 'Point of Sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-    },
-    {
-      id: '2561',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      channel: 'Online Store',
-      paymentStatus: 'Paid',
-      fulfillmentStatus: 'Unfulfilled',
-    },
-    {
-      id: '2562',
-      url: '#',
-      name: 'Helen Troy',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$975',
-      lastOrderDate: 'May 31, 2023',
-      status: 'success',
-    },
-    {
-      id: '4102',
-      url: '#',
-      name: 'Colm Dillane',
-      location: 'New York, USA',
-      orders: 27,
-      amountSpent: '$2885',
-      lastOrderDate: 'May 31, 2023',
-      status: 'critical',
-    },
-    {
-      id: '2564',
-      url: '#',
-      name: 'Al Chemist',
-      location: 'New York, USA',
-      orders: 19,
-      amountSpent: '$1,209',
-      lastOrderDate: 'April 4, 2023',
-      disabled: true,
-      status: 'warning',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Larry June',
-      location: 'San Francisco, USA',
-      orders: 22,
-      amountSpent: '$1,400',
-      lastOrderDate: 'March 19, 2023',
-      status: 'subdued',
-    },
-  ];
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    (
-      {
-        id,
-        name,
-        location,
-        orders,
-        amountSpent,
-        status,
-        channel,
-        paymentStatus,
-        fulfillmentStatus,
-      },
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-        tone={status as IndexTableRowProps['tone']}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{channel}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <Card padding="0">
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-          {title: 'Channel'},
-          {title: 'Payment status'},
-          {title: 'Fulfillment status'},
-        ]}
-        lastColumnSticky
-      >
-        {rowMarkup}
-      </IndexTable>
-    </Card>
-  );
-}
-
-export function WithRowNavigationLink() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, url, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Link
-            dataPrimaryLink
-            url={url}
-            onClick={() => console.log(`Clicked ${name}`)}
-          >
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
             <Text fontWeight="bold" as="span" variant="bodyMd">
               {name}
             </Text>
-          </Link>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" variant="bodyMd" numeric>
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" variant="bodyMd" numeric>
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
 
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
+    return (
+      <LegacyCard>
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithClickableButtonColumn() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
+export const Condensed = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
 
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
 
-  const rowMarkup = customers.map(
-    ({id, url, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Link
-            dataPrimaryLink
-            url={url}
-            onClick={() => console.log(`Clicked ${name}`)}
-          >
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
             <Text fontWeight="bold" as="span" variant="bodyMd">
               {name}
             </Text>
-          </Link>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithoutCheckboxes() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row id={id} key={id} position={index}>
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            hidden: false,
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-        selectable={false}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithTonesWithoutCheckboxes() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-      status: 'success',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-      status: 'critical',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-      status: 'warning',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      status: 'subdued',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent, status}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        position={index}
-        tone={status as IndexTableRowProps['tone']}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            hidden: false,
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-        selectable={false}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithAllOfItsElements() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-  const [taggedWith, setTaggedWith] = useState('VIP');
-  const [queryValue, setQueryValue] = useState('');
-  const [sortValue, setSortValue] = useState(['today asc']);
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-  const handleSortChange = useCallback((value) => setSortValue(value), []);
-
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Date', value: 'today asc', directionLabel: 'Ascending'},
-    {label: 'Date', value: 'today desc', directionLabel: 'Descending'},
-  ];
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  const tabs = [
-    {
-      id: 'all',
-      content: 'All customers',
-    },
-  ];
-
-  const {mode, setMode} = useSetIndexFiltersMode();
-
-  const cancelAction = {
-    onAction: () => {},
-  };
-
-  async function emptyPromise() {
-    const prom = Promise.resolve();
-    return prom.then(() => {
-      return true;
-    });
-  }
-
-  const primaryAction: IndexFiltersProps['primaryAction'] = {
-    onAction: emptyPromise,
-    type: 'save-as',
-  };
-
-  return (
-    <LegacyCard>
-      <IndexFilters
-        tabs={tabs}
-        selected={0}
-        onSelect={() => {}}
-        onCreateNewView={emptyPromise}
-        queryValue={queryValue}
-        queryPlaceholder="Searching in all"
-        filters={filters}
-        appliedFilters={appliedFilters}
-        onQueryChange={setQueryValue}
-        onQueryClear={handleQueryValueRemove}
-        onClearAll={handleClearAll}
-        sortOptions={sortOptions}
-        sortSelected={sortValue}
-        onSort={handleSortChange}
-        mode={mode}
-        setMode={setMode}
-        cancelAction={cancelAction}
-        primaryAction={primaryAction}
-      />
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        hasMoreItems
-        bulkActions={bulkActions}
-        promotedBulkActions={promotedBulkActions}
-        lastColumnSticky
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            hidden: false,
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithSortableHeadings() {
-  const [sortIndex, setSortIndex] = useState(0);
-  const [sortDirection, setSortDirection] =
-    useState<IndexTableProps['sortDirection']>('descending');
-
-  const sortToggleLabels = {
-    0: {ascending: 'A-Z', descending: 'Z-A'},
-    1: {ascending: 'Ascending', descending: 'Descending'},
-    2: {ascending: 'Newest', descending: 'Oldest'},
-    3: {ascending: 'Ascending', descending: 'Ascending'},
-    4: {ascending: 'A-Z', descending: 'Z-A'},
-    5: {ascending: 'A-Z', descending: 'Z-A'},
-    6: {ascending: 'A-Z', descending: 'Z-A'},
-    7: {ascending: 'A-Z', descending: 'Z-A'},
-  };
-
-  const initialRows = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      date: '2022-02-04',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Paid',
-      notes: '',
-    },
-    {
-      id: '2561',
-      url: '#',
-      date: '2022-01-19',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Not paid',
-      notes: 'This customer lives on the 3rd floor',
-    },
-    {
-      id: '1245',
-      url: '#',
-      date: '2021-12-12',
-      name: 'Anne-Marie Johnson',
-      location: 'Portland, USA',
-      orders: 10,
-      amountSpent: '$250',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Not paid',
-      notes: '',
-    },
-    {
-      id: '8741',
-      url: '#',
-      date: '2022-05-11',
-      name: 'Bradley Stevens',
-      location: 'Hialeah, USA',
-      orders: 5,
-      amountSpent: '$26',
-      fulfillmentStatus: 'Unfulfilled',
-      paymentStatus: 'Not paid',
-      notes: 'This customer has requested fragile delivery',
-    },
-  ];
-  const [sortedRows, setSortedRows] = useState(
-    sortRows(initialRows, sortIndex, sortDirection),
-  );
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const rows = sortedRows ?? initialRows;
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows);
-
-  function handleClickSortHeading(index, direction) {
-    setSortIndex(index);
-    setSortDirection(direction);
-    const newSortedRows = sortRows(rows, index, direction);
-    setSortedRows(newSortedRows);
-  }
-
-  function sortRows(localRows, index, direction) {
-    return [...localRows].sort((rowA, rowB) => {
-      const key = index === 0 ? 'name' : 'location';
-      if (rowA[key] < rowB[key]) {
-        return direction === 'descending' ? -1 : 1;
-      }
-      if (rowA[key] > rowB[key]) {
-        return direction === 'descending' ? 1 : -1;
-      }
-      return 0;
-    });
-  }
-
-  const rowMarkup = rows.map(
-    (
-      {
-        id,
-        name,
-        date,
-        location,
-        orders,
-        amountSpent,
-        fulfillmentStatus,
-        paymentStatus,
-        notes,
-      },
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{date}</IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{notes}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={rows.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Date', defaultSortDirection: 'ascending'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-
-          {title: 'Location'},
-          {title: 'Fulfillment status'},
-          {title: 'Payment status'},
-          {title: 'Notes'},
-        ]}
-        sortable={[true, true, false, true, true, false, false]}
-        sortDirection={sortDirection}
-        sortColumnIndex={sortIndex}
-        onSort={handleClickSortHeading}
-        sortToggleLabels={sortToggleLabels}
-        lastColumnSticky
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithSortableHeadingsLastElementAlignmentEnd() {
-  const [sortIndex, setSortIndex] = useState(0);
-  const [sortDirection, setSortDirection] =
-    useState<IndexTableProps['sortDirection']>('descending');
-
-  const sortToggleLabels = {
-    0: {ascending: 'A-Z', descending: 'Z-A'},
-    1: {ascending: 'Ascending', descending: 'Descending'},
-    2: {ascending: 'Newest', descending: 'Oldest'},
-    3: {ascending: 'Ascending', descending: 'Ascending'},
-    4: {ascending: 'A-Z', descending: 'Z-A'},
-    5: {ascending: 'A-Z', descending: 'Z-A'},
-    6: {ascending: 'A-Z', descending: 'Z-A'},
-    7: {ascending: 'A-Z', descending: 'Z-A'},
-  };
-
-  const initialRows = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      date: '2022-02-04',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Paid',
-      notes: '',
-    },
-    {
-      id: '2561',
-      url: '#',
-      date: '2022-01-19',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Not paid',
-      notes: 'This customer lives on the 3rd floor',
-    },
-    {
-      id: '1245',
-      url: '#',
-      date: '2021-12-12',
-      name: 'Anne-Marie Johnson',
-      location: 'Portland, USA',
-      orders: 10,
-      amountSpent: '$250',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Not paid',
-      notes: '',
-    },
-    {
-      id: '8741',
-      url: '#',
-      date: '2022-05-11',
-      name: 'Bradley Stevens',
-      location: 'Hialeah, USA',
-      orders: 5,
-      amountSpent: '$26',
-      fulfillmentStatus: 'Unfulfilled',
-      paymentStatus: 'Not paid',
-      notes: 'This customer has requested fragile delivery',
-    },
-  ];
-  const [sortedRows, setSortedRows] = useState(
-    sortRows(initialRows, sortIndex, sortDirection),
-  );
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const rows = sortedRows ?? initialRows;
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows);
-
-  function handleClickSortHeading(index, direction) {
-    setSortIndex(index);
-    setSortDirection(direction);
-    const newSortedRows = sortRows(rows, index, direction);
-    setSortedRows(newSortedRows);
-  }
-
-  function sortRows(localRows, index, direction) {
-    return [...localRows].sort((rowA, rowB) => {
-      const key = index === 0 ? 'name' : 'location';
-      if (rowA[key] < rowB[key]) {
-        return direction === 'descending' ? -1 : 1;
-      }
-      if (rowA[key] > rowB[key]) {
-        return direction === 'descending' ? 1 : -1;
-      }
-      return 0;
-    });
-  }
-
-  const rowMarkup = rows.map(
-    (
-      {
-        id,
-        name,
-        date,
-        location,
-        orders,
-        amountSpent,
-        fulfillmentStatus,
-        paymentStatus,
-        notes,
-      },
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{date}</IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{notes}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={rows.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Date', defaultSortDirection: 'ascending'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-
-          {title: 'Location'},
-          {title: 'Fulfillment status'},
-          {title: 'Payment status'},
-          {title: 'Notes', alignment: 'end'},
-        ]}
-        sortable={[true, true, false, true, true, false, false, true]}
-        sortDirection={sortDirection}
-        sortColumnIndex={sortIndex}
-        onSort={handleClickSortHeading}
-        sortToggleLabels={sortToggleLabels}
-        lastColumnSticky
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithSortableCustomHeadings() {
-  const [sortIndex, setSortIndex] = useState(0);
-  const [sortDirection, setSortDirection] =
-    useState<IndexTableProps['sortDirection']>('descending');
-
-  const sortToggleLabels = {
-    0: {ascending: 'A-Z', descending: 'Z-A'},
-    1: {ascending: 'Ascending', descending: 'Descending'},
-    2: {ascending: 'Newest', descending: 'Oldest'},
-    3: {ascending: 'Ascending', descending: 'Ascending'},
-    4: {ascending: 'A-Z', descending: 'Z-A'},
-    5: {ascending: 'A-Z', descending: 'Z-A'},
-    6: {ascending: 'A-Z', descending: 'Z-A'},
-    7: {ascending: 'A-Z', descending: 'Z-A'},
-  };
-
-  const initialRows = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      date: '2022-02-04',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Paid',
-      notes: '',
-    },
-    {
-      id: '2561',
-      url: '#',
-      date: '2022-01-19',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Not paid',
-      notes: 'This customer lives on the 3rd floor',
-    },
-    {
-      id: '1245',
-      url: '#',
-      date: '2021-12-12',
-      name: 'Anne-Marie Johnson',
-      location: 'Portland, USA',
-      orders: 10,
-      amountSpent: '$250',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Not paid',
-      notes: '',
-    },
-    {
-      id: '8741',
-      url: '#',
-      date: '2022-05-11',
-      name: 'Bradley Stevens',
-      location: 'Hialeah, USA',
-      orders: 5,
-      amountSpent: '$26',
-      fulfillmentStatus: 'Unfulfilled',
-      paymentStatus: 'Not paid',
-      notes: 'This customer has requested fragile delivery',
-    },
-  ];
-  const [sortedRows, setSortedRows] = useState(
-    sortRows(initialRows, sortIndex, sortDirection),
-  );
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const rows = sortedRows ?? initialRows;
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows);
-
-  function handleClickSortHeading(index, direction) {
-    setSortIndex(index);
-    setSortDirection(direction);
-    const newSortedRows = sortRows(rows, index, direction);
-    setSortedRows(newSortedRows);
-  }
-
-  function sortRows(localRows, index, direction) {
-    return [...localRows].sort((rowA, rowB) => {
-      const key = index === 0 ? 'name' : 'location';
-      if (rowA[key] < rowB[key]) {
-        return direction === 'descending' ? -1 : 1;
-      }
-      if (rowA[key] > rowB[key]) {
-        return direction === 'descending' ? 1 : -1;
-      }
-      return 0;
-    });
-  }
-
-  const rowMarkup = rows.map(
-    (
-      {
-        id,
-        name,
-        date,
-        location,
-        orders,
-        amountSpent,
-        fulfillmentStatus,
-        paymentStatus,
-        notes,
-      },
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{date}</IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{notes}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={rows.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {
-            title: 'Name',
-            tooltipContent: 'I am a wide tooltip describing the Name column',
-            tooltipWidth: 'wide',
-          },
-          {title: 'Date', tooltipContent: 'I am the Date tooltip'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            title: 'Amount spent',
-            tooltipContent:
-              'I am a wide Amount spent tooltip that stays when clicked',
-            tooltipWidth: 'wide',
-          },
-          {title: 'Location'},
-          {title: 'Fulfillment status'},
-          {title: 'Payment status'},
-          {title: 'Notes'},
-        ]}
-        sortable={[true, true, false, true, true, false, false]}
-        sortDirection={sortDirection}
-        sortColumnIndex={sortIndex}
-        onSort={handleClickSortHeading}
-        sortToggleLabels={sortToggleLabels}
-        lastColumnSticky
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithHeadingWithPaddingBlockEnd() {
-  const [sortIndex, setSortIndex] = useState(0);
-  const [sortDirection, setSortDirection] =
-    useState<IndexTableProps['sortDirection']>('descending');
-
-  const sortToggleLabels = {
-    0: {ascending: 'A-Z', descending: 'Z-A'},
-    1: {ascending: 'Ascending', descending: 'Descending'},
-    2: {ascending: 'Newest', descending: 'Oldest'},
-    3: {ascending: 'Ascending', descending: 'Ascending'},
-    4: {ascending: 'A-Z', descending: 'Z-A'},
-    5: {ascending: 'A-Z', descending: 'Z-A'},
-    6: {ascending: 'A-Z', descending: 'Z-A'},
-    7: {ascending: 'A-Z', descending: 'Z-A'},
-  };
-
-  const initialRows = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      date: '2022-02-04',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Paid',
-      notes: '',
-    },
-    {
-      id: '2561',
-      url: '#',
-      date: '2022-01-19',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Not paid',
-      notes: 'This customer lives on the 3rd floor',
-    },
-    {
-      id: '1245',
-      url: '#',
-      date: '2021-12-12',
-      name: 'Anne-Marie Johnson',
-      location: 'Portland, USA',
-      orders: 10,
-      amountSpent: '$250',
-      fulfillmentStatus: 'Fulfilled',
-      paymentStatus: 'Not paid',
-      notes: '',
-    },
-    {
-      id: '8741',
-      url: '#',
-      date: '2022-05-11',
-      name: 'Bradley Stevens',
-      location: 'Hialeah, USA',
-      orders: 5,
-      amountSpent: '$26',
-      fulfillmentStatus: 'Unfulfilled',
-      paymentStatus: 'Not paid',
-      notes: 'This customer has requested fragile delivery',
-    },
-  ];
-  const [sortedRows, setSortedRows] = useState(
-    sortRows(initialRows, sortIndex, sortDirection),
-  );
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const rows = sortedRows ?? initialRows;
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows);
-
-  function handleClickSortHeading(index, direction) {
-    setSortIndex(index);
-    setSortDirection(direction);
-    const newSortedRows = sortRows(rows, index, direction);
-    setSortedRows(newSortedRows);
-  }
-
-  function sortRows(localRows, index, direction) {
-    return [...localRows].sort((rowA, rowB) => {
-      const key = index === 0 ? 'name' : 'location';
-      if (rowA[key] < rowB[key]) {
-        return direction === 'descending' ? -1 : 1;
-      }
-      if (rowA[key] > rowB[key]) {
-        return direction === 'descending' ? 1 : -1;
-      }
-      return 0;
-    });
-  }
-
-  const rowMarkup = rows.map(
-    (
-      {
-        id,
-        name,
-        date,
-        location,
-        orders,
-        amountSpent,
-        fulfillmentStatus,
-        paymentStatus,
-        notes,
-      },
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{date}</IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Box paddingInlineEnd="600">
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
             <Text as="span" alignment="end" numeric variant="bodyMd">
               {amountSpent}
             </Text>
-          </Box>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{notes}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={rows.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {
-            title: 'Name',
-            tooltipContent: 'I am a wide tooltip describing the Name column',
-            tooltipWidth: 'wide',
-          },
-          {title: 'Date', tooltipContent: 'I am the Date tooltip'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            title: 'Amount spent',
-            tooltipContent:
-              'I am a wide Amount spent tooltip that stays when clicked',
-            tooltipWidth: 'wide',
-            paddingBlockEnd: '600',
-          },
-          {title: 'Location'},
-          {title: 'Fulfillment status'},
-          {title: 'Payment status'},
-          {title: 'Notes'},
-        ]}
-        sortable={[true, true, false, true, true, false, false]}
-        sortDirection={sortDirection}
-        sortColumnIndex={sortIndex}
-        onSort={handleClickSortHeading}
-        sortToggleLabels={sortToggleLabels}
-        lastColumnSticky
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithCustomTooltips() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {
-            title: 'Name',
-            tooltipContent:
-              'I am a wide tooltip describing the Name column and I also stay when clicked',
-            tooltipWidth: 'wide',
-            tooltipPersistsOnClick: true,
-          },
-          {
-            title: 'Location',
-          },
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithHeadingTooltips() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location', tooltipContent: 'Strictly within the US'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-            new: true,
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithZebraStriping() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-
-  const customersForNestedRows = [
-    {
-      id: '34101',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '34111',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '34121',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '34131',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '25631',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-  const nestedRowMarkup = customersForNestedRows.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-        rowType={index > 0 ? 'child' : 'subheader'}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-        hasZebraStriping
-      >
-        {rowMarkup}
-        {nestedRowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithZebraStripingCondensed() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-        hasZebraStriping
-        condensed
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithZebraStripingAndRowStatus() {
-  const customers = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      status: 'success',
-    },
-    {
-      id: '2561',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      status: 'subdued',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent, status}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-        tone={status as IndexTableRowProps['tone']}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithZebraStripingAndStickyLastColumn() {
-  const customers = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-      channel: 'Point of Sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-    },
-    {
-      id: '2561',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-      channel: 'Online Store',
-      paymentStatus: 'Paid',
-      fulfillmentStatus: 'Unfulfilled',
-    },
-    {
-      id: '2562',
-      url: '#',
-      name: 'Helen Troy',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$975',
-      lastOrderDate: 'May 31, 2023',
-    },
-    {
-      id: '4102',
-      url: '#',
-      name: 'Colm Dillane',
-      location: 'New York, USA',
-      orders: 27,
-      amountSpent: '$2885',
-      lastOrderDate: 'May 31, 2023',
-    },
-    {
-      id: '2564',
-      url: '#',
-      name: 'Al Chemist',
-      location: 'New York, USA',
-      orders: 19,
-      amountSpent: '$1,209',
-      lastOrderDate: 'April 4, 2023',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Larry June',
-      location: 'San Francisco, USA',
-      orders: 22,
-      amountSpent: '$1,400',
-      lastOrderDate: 'March 19, 2023',
-    },
-  ];
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    (
-      {
-        id,
-        name,
-        location,
-        orders,
-        amountSpent,
-        channel,
-        paymentStatus,
-        fulfillmentStatus,
-      },
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{channel}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-          {title: 'Channel'},
-          {title: 'Payment status'},
-          {title: 'Fulfillment status'},
-        ]}
-        lastColumnSticky
-        hasZebraStriping
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithZebraStripingAndWithoutCheckboxes() {
-  const customers = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '2561',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row id={id} key={id} position={index}>
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            hidden: false,
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-        selectable={false}
-        hasZebraStriping
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function SmallScreenWithAllOfItsElements() {
-  const customers = [
-    {
-      id: '3410',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$2,400',
-    },
-    {
-      id: '3411',
-      url: '#',
-      name: 'Joe Jemison',
-      location: 'Sydney, AU',
-      orders: 20,
-      amountSpent: '$1,400',
-    },
-    {
-      id: '3412',
-      url: '#',
-      name: 'Sam Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$400',
-    },
-    {
-      id: '3413',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$4,300',
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$140',
-    },
-  ];
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-  const [taggedWith, setTaggedWith] = useState('VIP');
-  const [queryValue, setQueryValue] = useState('');
-  const [sortValue, setSortValue] = useState(['today asc']);
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-  const handleSortChange = useCallback((value) => setSortValue(value), []);
-
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
+          </IndexTable.Cell>
+        </IndexTable.Row>
       ),
-      shortcut: true,
-    },
-  ];
+    );
 
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
+    return (
+      <LegacyCard>
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+          condensed
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
 
-  const sortOptions: IndexFiltersProps['sortOptions'] = [
-    {label: 'Date', value: 'today asc', directionLabel: 'Ascending'},
-    {label: 'Date', value: 'today desc', directionLabel: 'Descending'},
-  ];
+export const Flush = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
 
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <div style={{padding: '.75rem 1rem'}}>
-          <Text fontWeight="bold" as="p">
-            {name}
-          </Text>
-          <Text as="p" variant="bodyMd">
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell flush>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell flush>
             <Text variant="bodyMd" as="span">
               {location}
             </Text>
-          </Text>
-          <Text as="p" alignment="end" numeric>
-            {orders}
-          </Text>
-          <Text as="p" alignment="end" numeric>
-            {amountSpent}
-          </Text>
-        </div>
-      </IndexTable.Row>
-    ),
-  );
+          </IndexTable.Cell>
+          <IndexTable.Cell flush>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell flush>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
 
-  const tabs = [
-    {
-      id: 'all',
-      content: 'All customers',
-    },
-  ];
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name', flush: true},
+            {title: 'Location', flush: true},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              flush: true,
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              flush: true,
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
 
-  const {mode, setMode} = useSetIndexFiltersMode();
+export const SmallScreen = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
 
-  const cancelAction = {
-    onAction: () => {},
-  };
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
 
-  async function emptyPromise() {
-    const prom = Promise.resolve();
-    return prom.then(() => {
-      return true;
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <div style={{padding: '12px 16px'}}>
+            <Text fontWeight="bold" as="p">
+              {name}
+            </Text>
+            <Text as="p" variant="bodyMd">
+              <Text variant="bodyMd" as="span">
+                {location}
+              </Text>
+            </Text>
+            <Text as="p" alignment="end" numeric>
+              {orders}
+            </Text>
+            <Text as="p" alignment="end" numeric>
+              {amountSpent}
+            </Text>
+          </div>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <div style={{width: '430px'}}>
+        <LegacyCard>
+          <IndexTable
+            resourceName={resourceName}
+            itemCount={customers.length}
+            selectedItemsCount={
+              allResourcesSelected ? 'All' : selectedResources.length
+            }
+            onSelectionChange={handleSelectionChange}
+            condensed
+            headings={[
+              {title: 'Name'},
+              {title: 'Location'},
+              {
+                alignment: 'end',
+                id: 'order-count',
+                title: 'Order count',
+              },
+              {
+                alignment: 'end',
+                id: 'amount-spent',
+                title: 'Amount spent',
+              },
+            ]}
+          >
+            {rowMarkup}
+          </IndexTable>
+        </LegacyCard>
+      </div>
+    );
+  },
+};
+
+export const SmallScreenLoading = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <div style={{padding: '12px 16px'}}>
+            <Text fontWeight="bold" as="p">
+              {name}
+            </Text>
+            <Text as="p" variant="bodyMd">
+              <Text variant="bodyMd" as="span">
+                {location}
+              </Text>
+            </Text>
+            <Text as="p" alignment="end" numeric>
+              {orders}
+            </Text>
+            <Text as="p" alignment="end" numeric>
+              {amountSpent}
+            </Text>
+          </div>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <div style={{width: '430px'}}>
+        <LegacyCard>
+          <IndexTable
+            resourceName={resourceName}
+            itemCount={customers.length}
+            selectedItemsCount={
+              allResourcesSelected ? 'All' : selectedResources.length
+            }
+            onSelectionChange={handleSelectionChange}
+            condensed
+            headings={[
+              {title: 'Name'},
+              {title: 'Location'},
+              {
+                alignment: 'end',
+                id: 'order-count',
+                title: 'Order count',
+              },
+              {
+                alignment: 'end',
+                id: 'amount-spent',
+                title: 'Amount spent',
+              },
+            ]}
+            loading
+          >
+            {rowMarkup}
+          </IndexTable>
+        </LegacyCard>
+      </div>
+    );
+  },
+};
+
+export const WithDisabledRows = {
+  render() {
+    const customers = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        disabled: false,
+      },
+      {
+        id: '2561',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        disabled: true,
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const selectableCustomers = customers.filter(
+      (customer) => !customer.disabled,
+    );
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(selectableCustomers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent, disabled}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+          disabled={disabled}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={selectableCustomers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSubduedRows = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+          tone={index === 1 || index === 2 ? 'subdued' : undefined}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithEmptyState = {
+  render() {
+    const customers = [];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const emptyStateMarkup = (
+      <EmptySearchResult
+        title="No customers yet"
+        description="Try changing the filters or search term"
+        withIllustration
+      />
+    );
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          emptyState={emptyStateMarkup}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithBulkActions = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+    ];
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          bulkActions={bulkActions}
+          promotedBulkActions={promotedBulkActions}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSelectionAndNoBulkActions = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          hasMoreItems
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithMultiplePromotedBulkActions = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const promotedBulkActions = [
+      {
+        content: 'Capture payments',
+        onAction: () => console.log('Todo: implement payment capture'),
+      },
+      {
+        title: 'Edit customers',
+        actions: [
+          {
+            content: 'Add customers',
+            onAction: () => console.log('Todo: implement adding customers'),
+          },
+          {
+            icon: DeleteIcon,
+            destructive: true,
+            content: 'Delete customers',
+            onAction: () => console.log('Todo: implement deleting customers'),
+          },
+        ],
+      },
+      {
+        title: 'Export',
+        actions: [
+          {
+            content: 'Export as PDF',
+            onAction: () => console.log('Todo: implement PDF exporting'),
+          },
+          {
+            content: 'Export as CSV',
+            onAction: () => console.log('Todo: implement CSV exporting'),
+          },
+        ],
+      },
+    ];
+    const bulkActions = [
+      {
+        title: 'Import',
+        items: [
+          {
+            content: 'Import from PDF',
+            onAction: () => console.log('Todo: implement PDF importing'),
+          },
+          {
+            content: 'Import from CSV',
+            onAction: () => console.log('Todo: implement CSV importing'),
+          },
+        ],
+      },
+      {
+        title: 'Customers',
+        items: [
+          {
+            content: 'Add customers',
+            onAction: () => console.log('Todo: implement Adding customers'),
+          },
+          {
+            content: 'Edit customers',
+            onAction: () => console.log('Todo: implement Editing customers'),
+          },
+          {
+            icon: DeleteIcon,
+            destructive: true,
+            content: 'Delete customers',
+            onAction: () => console.log('Todo: implement Deleting customers'),
+          },
+        ],
+      },
+    ];
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          bulkActions={bulkActions}
+          promotedBulkActions={promotedBulkActions}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithBulkActionsAndSelectionAcrossPages = {
+  render() {
+    const customers = Array.from({length: 50}, (_, num) => {
+      return {
+        id: `${num}`,
+        url: '#',
+        name: `Mae Jemison ${num}`,
+        location: 'Truth or Consequences, New Mexico, United States of America',
+        orders: 20,
+        amountSpent: '$24,00',
+      };
     });
-  }
 
-  const primaryAction: IndexFiltersProps['primaryAction'] = {
-    onAction: emptyPromise,
-    type: 'save-as',
-  };
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
 
-  return (
-    <div style={{width: '430px'}}>
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const promotedBulkActions = [
+      {
+        content: 'Rename customers',
+        onAction: () => console.log('Todo: implement bulk rename'),
+      },
+      {
+        title: 'Edit customers',
+        actions: [
+          {
+            content: 'Add customers',
+            onAction: () => console.log('Todo: implement adding customers'),
+          },
+          {
+            icon: DeleteIcon,
+            destructive: true,
+            content: 'Delete customers',
+            onAction: () => console.log('Todo: implement deleting customers'),
+          },
+        ],
+      },
+      {
+        title: 'Export',
+        actions: [
+          {
+            content: 'Export as PDF',
+            onAction: () => console.log('Todo: implement PDF exporting'),
+          },
+          {
+            content: 'Export as CSV',
+            onAction: () => console.log('Todo: implement CSV exporting'),
+          },
+        ],
+      },
+    ];
+    const bulkActions = [
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        title: 'Bulk action section',
+        items: [
+          {
+            content: 'Edit data',
+          },
+          {
+            content: 'Manage data',
+          },
+          {
+            icon: DeleteIcon,
+            destructive: true,
+            content: 'Delete data',
+          },
+        ],
+      },
+      {
+        content: 'Edit prices',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+      {
+        content: 'Edit quantities',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+      {
+        content: 'Edit SKUs',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+      {
+        content: 'Edit barcodes',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          hasMoreItems
+          bulkActions={bulkActions}
+          promotedBulkActions={promotedBulkActions}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+          paginatedSelectAllText="Select everything in this store"
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithLoadingState = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          loading
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithFiltering = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+    const [taggedWith, setTaggedWith] = useState('VIP');
+    const [queryValue, setQueryValue] = useState('');
+    const [sortValue, setSortValue] = useState(['today asc']);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+    const handleSortChange = useCallback((value) => setSortValue(value), []);
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Date', value: 'today asc', directionLabel: 'Ascending'},
+      {label: 'Date', value: 'today desc', directionLabel: 'Descending'},
+    ];
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    const tabs = [
+      {
+        id: 'all',
+        content: 'All customers',
+      },
+    ];
+
+    const {mode, setMode} = useSetIndexFiltersMode();
+
+    const cancelAction = {
+      onAction: () => {},
+    };
+
+    async function emptyPromise() {
+      const prom = Promise.resolve();
+      return prom.then(() => {
+        return true;
+      });
+    }
+
+    const primaryAction: IndexFiltersProps['primaryAction'] = {
+      onAction: emptyPromise,
+      type: 'save-as',
+    };
+
+    return (
       <LegacyCard>
         <IndexFilters
           tabs={tabs}
@@ -4749,16 +1811,13 @@ export function SmallScreenWithAllOfItsElements() {
           primaryAction={primaryAction}
         />
         <IndexTable
+          condensed={useBreakpoints().smDown}
           resourceName={resourceName}
           itemCount={customers.length}
           selectedItemsCount={
             allResourcesSelected ? 'All' : selectedResources.length
           }
           onSelectionChange={handleSelectionChange}
-          hasMoreItems
-          condensed
-          bulkActions={bulkActions}
-          promotedBulkActions={promotedBulkActions}
           headings={[
             {title: 'Name'},
             {title: 'Location'},
@@ -4777,411 +1836,3590 @@ export function SmallScreenWithAllOfItsElements() {
           {rowMarkup}
         </IndexTable>
       </LegacyCard>
-    </div>
-  );
+    );
 
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithSubHeaders() {
-  const rows = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 11,
-      amountSpent: '$2,400',
-      lastOrderDate: 'May 31, 2023',
-    },
-    {
-      id: '2562',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$975',
-      lastOrderDate: 'May 31, 2023',
-    },
-    {
-      id: '4102',
-      url: '#',
-      name: 'Colm Dillane',
-      location: 'New York, USA',
-      orders: 27,
-      amountSpent: '$2885',
-      lastOrderDate: 'May 31, 2023',
-    },
-    {
-      id: '2564',
-      url: '#',
-      name: 'Al Chemist',
-      location: 'New York, USA',
-      orders: 19,
-      amountSpent: '$1,209',
-      lastOrderDate: 'April 4, 2023',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Larry June',
-      location: 'San Francisco, USA',
-      orders: 22,
-      amountSpent: '$1,400',
-      lastOrderDate: 'March 19, 2023',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Name', id: 'column-header--name'},
-    {title: 'Location', id: 'column-header--location'},
-    {
-      alignment: 'end',
-      id: 'column-header--order-count',
-      title: 'Order count',
-    },
-    {
-      alignment: 'end',
-      hidden: false,
-      id: 'column-header--amount-spent',
-      title: 'Amount spent',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, customer) => {
-      const groupVal = customer[groupKey];
-      if (!groups[groupVal]) {
-        position += 1;
-
-        groups[groupVal] = {
-          position,
-          customers: [],
-          id: resolveId(groupVal),
-        };
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
       }
-
-      groups[groupVal].customers.push({
-        ...customer,
-        position: position + 1,
-      });
-
-      position += 1;
-      return groups;
-    }, {});
-
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const orders = groupRowsBy(
-    'lastOrderDate',
-    (date) => `last-order-date--${date.replace(',', '').split(' ').join('-')}`,
-  );
-
-  const rowMarkup = Object.keys(orders).map((orderDate, index) => {
-    const {customers, position, id: subheaderId} = orders[orderDate];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someCustomersSelected = customers.some(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    const allCustomersSelected = customers.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allCustomersSelected) {
-      selected = true;
-    } else if (someCustomersSelected) {
-      selected = 'indeterminate';
     }
 
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === customers[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === customers[customers.length - 1].id,
-      ),
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithRowStatus = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Astronaut',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Baker',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        status: 'subdued',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Candlestick maker',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        status: 'success',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Rice Cooker',
+        location: 'Los Angeles, USA',
+        orders: 40,
+        amountSpent: '$40',
+        status: 'critical',
+      },
+      {
+        id: '3414',
+        url: '#',
+        name: 'Volleyball Player',
+        location: 'Delaware, USA',
+        orders: 50,
+        amountSpent: '$80',
+        status: 'warning',
+      },
     ];
 
-    const disabled = customers.every(({disabled}) => disabled);
+    const customersForNestedRows = [
+      {
+        id: '34101',
+        url: '#',
+        name: 'Astronaut',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '34111',
+        url: '#',
+        name: 'Baker',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        status: 'subdued',
+      },
+      {
+        id: '34121',
+        url: '#',
+        name: 'Candlestick maker',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        status: 'success',
+      },
+      {
+        id: '34131',
+        url: '#',
+        name: 'Rice Cooker',
+        location: 'Los Angeles, USA',
+        orders: 40,
+        amountSpent: '$40',
+        status: 'critical',
+      },
+      {
+        id: '34141',
+        url: '#',
+        name: 'Volleyball Player',
+        location: 'Delaware, USA',
+        orders: 50,
+        amountSpent: '$80',
+        status: 'warning',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent, status}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+          tone={status as IndexTableRowProps['tone']}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <code>{status}</code>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    const rowMarkupNested = customersForNestedRows.map(
+      ({id, name, location, orders, amountSpent, status}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+          tone={status as IndexTableRowProps['tone']}
+          rowType={index > 0 ? 'child' : 'subheader'}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <code>{status}</code>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Tone'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+          {rowMarkupNested}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithStickyLastColumn = {
+  render() {
+    const customers = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        channel: 'Point of Sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+      },
+      {
+        id: '2561',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        channel: 'Online Store',
+        paymentStatus: 'Paid',
+        fulfillmentStatus: 'Unfulfilled',
+      },
+      {
+        id: '2562',
+        url: '#',
+        name: 'Helen Troy',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$975',
+        lastOrderDate: 'May 31, 2023',
+        status: 'success',
+      },
+      {
+        id: '4102',
+        url: '#',
+        name: 'Colm Dillane',
+        location: 'New York, USA',
+        orders: 27,
+        amountSpent: '$2885',
+        lastOrderDate: 'May 31, 2023',
+        status: 'critical',
+      },
+      {
+        id: '2564',
+        url: '#',
+        name: 'Al Chemist',
+        location: 'New York, USA',
+        orders: 19,
+        amountSpent: '$1,209',
+        lastOrderDate: 'April 4, 2023',
+        disabled: true,
+        status: 'warning',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Larry June',
+        location: 'San Francisco, USA',
+        orders: 22,
+        amountSpent: '$1,400',
+        lastOrderDate: 'March 19, 2023',
+        status: 'subdued',
+      },
+    ];
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      (
+        {
+          id,
+          name,
+          location,
+          orders,
+          amountSpent,
+          status,
+          channel,
+          paymentStatus,
+          fulfillmentStatus,
+        },
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+          tone={status as IndexTableRowProps['tone']}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{channel}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
 
     return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          rowType="subheader"
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all customers whose last order was placed on ${orderDate}`}
+      <Card padding="0">
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+            {title: 'Channel'},
+            {title: 'Payment status'},
+            {title: 'Fulfillment status'},
+          ]}
+          lastColumnSticky
         >
-          <IndexTable.Cell scope="col" as="th" id={subheaderId}>
-            {`Last order placed: ${orderDate}`}
-          </IndexTable.Cell>
-          <IndexTable.Cell as="th" />
-          <IndexTable.Cell as="th" />
-          <IndexTable.Cell as="th" />
-        </IndexTable.Row>
-        {customers.map(
-          (
-            {id, name, location, orders, amountSpent, position, disabled},
-            rowIndex,
-          ) => {
-            return (
-              <IndexTable.Row
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell
-                  as="th"
-                  scope="row"
-                  headers={`${columnHeadings[0].id} ${subheaderId}`}
-                >
-                  <Text variant="bodyMd" fontWeight="semibold" as="span">
-                    {name}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text variant="bodyMd" as="span">
-                    {location}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {orders}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {amountSpent}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
+          {rowMarkup}
+        </IndexTable>
+      </Card>
     );
-  });
+  },
+};
 
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithPagination() {
-  const customers = Array.from({length: 50}, (_, num) => {
-    return {
-      id: `${num}`,
-      url: '#',
-      name: `Mae Jemison ${num}`,
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$24,00',
-    };
-  });
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    ({id, name, location, orders, amountSpent}, index) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        resourceName={resourceName}
-        itemCount={customers.length}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        onSelectionChange={handleSelectionChange}
-        headings={[
-          {title: 'Name'},
-          {title: 'Location'},
-          {
-            alignment: 'end',
-            id: 'order-count',
-            title: 'Order count',
-          },
-          {
-            alignment: 'end',
-            id: 'amount-spent',
-            title: 'Amount spent',
-          },
-        ]}
-        pagination={{
-          hasNext: true,
-          onNext: () => {},
-        }}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithStickyScrollBar() {
-  const customers = Array.from({length: 50}, (_, num) => {
-    return {
-      id: `${num}`,
-      url: '#',
-      name: `Mae Jemison ${num}`,
-      location: 'Truth or Consequences, United States of America',
-      orders: 20,
-      amountSpent: '$24,00',
-      channel: 'Point of sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-      tags: 'No tags applied',
-    };
-  });
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const rowMarkup = customers.map(
-    (
+export const WithRowNavigationLink = {
+  render() {
+    const customers = [
       {
-        id,
-        name,
-        location,
-        orders,
-        amountSpent,
-        channel,
-        paymentStatus,
-        fulfillmentStatus,
-        tags,
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
       },
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{channel}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{tags}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
 
-  return (
-    <Box paddingBlockEnd="400">
-      <BlockStack gap="200">
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, url, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Link
+              dataPrimaryLink
+              url={url}
+              onClick={() => console.log(`Clicked ${name}`)}
+            >
+              <Text fontWeight="bold" as="span" variant="bodyMd">
+                {name}
+              </Text>
+            </Link>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithClickableButtonColumn = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, url, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Link
+              dataPrimaryLink
+              url={url}
+              onClick={() => console.log(`Clicked ${name}`)}
+            >
+              <Text fontWeight="bold" as="span" variant="bodyMd">
+                {name}
+              </Text>
+            </Link>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithoutCheckboxes = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row id={id} key={id} position={index}>
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              hidden: false,
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+          selectable={false}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithTonesWithoutCheckboxes = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+        status: 'success',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+        status: 'critical',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+        status: 'warning',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        status: 'subdued',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent, status}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          position={index}
+          tone={status as IndexTableRowProps['tone']}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              hidden: false,
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+          selectable={false}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithAllOfItsElements = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+    const [taggedWith, setTaggedWith] = useState('VIP');
+    const [queryValue, setQueryValue] = useState('');
+    const [sortValue, setSortValue] = useState(['today asc']);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+    const handleSortChange = useCallback((value) => setSortValue(value), []);
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Date', value: 'today asc', directionLabel: 'Ascending'},
+      {label: 'Date', value: 'today desc', directionLabel: 'Descending'},
+    ];
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    const tabs = [
+      {
+        id: 'all',
+        content: 'All customers',
+      },
+    ];
+
+    const {mode, setMode} = useSetIndexFiltersMode();
+
+    const cancelAction = {
+      onAction: () => {},
+    };
+
+    async function emptyPromise() {
+      const prom = Promise.resolve();
+      return prom.then(() => {
+        return true;
+      });
+    }
+
+    const primaryAction: IndexFiltersProps['primaryAction'] = {
+      onAction: emptyPromise,
+      type: 'save-as',
+    };
+
+    return (
+      <LegacyCard>
+        <IndexFilters
+          tabs={tabs}
+          selected={0}
+          onSelect={() => {}}
+          onCreateNewView={emptyPromise}
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          filters={filters}
+          appliedFilters={appliedFilters}
+          onQueryChange={setQueryValue}
+          onQueryClear={handleQueryValueRemove}
+          onClearAll={handleClearAll}
+          sortOptions={sortOptions}
+          sortSelected={sortValue}
+          onSort={handleSortChange}
+          mode={mode}
+          setMode={setMode}
+          cancelAction={cancelAction}
+          primaryAction={primaryAction}
+        />
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          hasMoreItems
+          bulkActions={bulkActions}
+          promotedBulkActions={promotedBulkActions}
+          lastColumnSticky
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              hidden: false,
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithSortableHeadings = {
+  render() {
+    const [sortIndex, setSortIndex] = useState(0);
+    const [sortDirection, setSortDirection] =
+      useState<IndexTableProps['sortDirection']>('descending');
+
+    const sortToggleLabels = {
+      0: {ascending: 'A-Z', descending: 'Z-A'},
+      1: {ascending: 'Ascending', descending: 'Descending'},
+      2: {ascending: 'Newest', descending: 'Oldest'},
+      3: {ascending: 'Ascending', descending: 'Ascending'},
+      4: {ascending: 'A-Z', descending: 'Z-A'},
+      5: {ascending: 'A-Z', descending: 'Z-A'},
+      6: {ascending: 'A-Z', descending: 'Z-A'},
+      7: {ascending: 'A-Z', descending: 'Z-A'},
+    };
+
+    const initialRows = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        date: '2022-02-04',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Paid',
+        notes: '',
+      },
+      {
+        id: '2561',
+        url: '#',
+        date: '2022-01-19',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Not paid',
+        notes: 'This customer lives on the 3rd floor',
+      },
+      {
+        id: '1245',
+        url: '#',
+        date: '2021-12-12',
+        name: 'Anne-Marie Johnson',
+        location: 'Portland, USA',
+        orders: 10,
+        amountSpent: '$250',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Not paid',
+        notes: '',
+      },
+      {
+        id: '8741',
+        url: '#',
+        date: '2022-05-11',
+        name: 'Bradley Stevens',
+        location: 'Hialeah, USA',
+        orders: 5,
+        amountSpent: '$26',
+        fulfillmentStatus: 'Unfulfilled',
+        paymentStatus: 'Not paid',
+        notes: 'This customer has requested fragile delivery',
+      },
+    ];
+    const [sortedRows, setSortedRows] = useState(
+      sortRows(initialRows, sortIndex, sortDirection),
+    );
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const rows = sortedRows ?? initialRows;
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows);
+
+    function handleClickSortHeading(index, direction) {
+      setSortIndex(index);
+      setSortDirection(direction);
+      const newSortedRows = sortRows(rows, index, direction);
+      setSortedRows(newSortedRows);
+    }
+
+    function sortRows(localRows, index, direction) {
+      return [...localRows].sort((rowA, rowB) => {
+        const key = index === 0 ? 'name' : 'location';
+        if (rowA[key] < rowB[key]) {
+          return direction === 'descending' ? -1 : 1;
+        }
+        if (rowA[key] > rowB[key]) {
+          return direction === 'descending' ? 1 : -1;
+        }
+        return 0;
+      });
+    }
+
+    const rowMarkup = rows.map(
+      (
+        {
+          id,
+          name,
+          date,
+          location,
+          orders,
+          amountSpent,
+          fulfillmentStatus,
+          paymentStatus,
+          notes,
+        },
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{date}</IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{notes}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={rows.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Date', defaultSortDirection: 'ascending'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+
+            {title: 'Location'},
+            {title: 'Fulfillment status'},
+            {title: 'Payment status'},
+            {title: 'Notes'},
+          ]}
+          sortable={[true, true, false, true, true, false, false]}
+          sortDirection={sortDirection}
+          sortColumnIndex={sortIndex}
+          onSort={handleClickSortHeading}
+          sortToggleLabels={sortToggleLabels}
+          lastColumnSticky
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSortableHeadingsLastElementAlignmentEnd = {
+  render() {
+    const [sortIndex, setSortIndex] = useState(0);
+    const [sortDirection, setSortDirection] =
+      useState<IndexTableProps['sortDirection']>('descending');
+
+    const sortToggleLabels = {
+      0: {ascending: 'A-Z', descending: 'Z-A'},
+      1: {ascending: 'Ascending', descending: 'Descending'},
+      2: {ascending: 'Newest', descending: 'Oldest'},
+      3: {ascending: 'Ascending', descending: 'Ascending'},
+      4: {ascending: 'A-Z', descending: 'Z-A'},
+      5: {ascending: 'A-Z', descending: 'Z-A'},
+      6: {ascending: 'A-Z', descending: 'Z-A'},
+      7: {ascending: 'A-Z', descending: 'Z-A'},
+    };
+
+    const initialRows = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        date: '2022-02-04',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Paid',
+        notes: '',
+      },
+      {
+        id: '2561',
+        url: '#',
+        date: '2022-01-19',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Not paid',
+        notes: 'This customer lives on the 3rd floor',
+      },
+      {
+        id: '1245',
+        url: '#',
+        date: '2021-12-12',
+        name: 'Anne-Marie Johnson',
+        location: 'Portland, USA',
+        orders: 10,
+        amountSpent: '$250',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Not paid',
+        notes: '',
+      },
+      {
+        id: '8741',
+        url: '#',
+        date: '2022-05-11',
+        name: 'Bradley Stevens',
+        location: 'Hialeah, USA',
+        orders: 5,
+        amountSpent: '$26',
+        fulfillmentStatus: 'Unfulfilled',
+        paymentStatus: 'Not paid',
+        notes: 'This customer has requested fragile delivery',
+      },
+    ];
+    const [sortedRows, setSortedRows] = useState(
+      sortRows(initialRows, sortIndex, sortDirection),
+    );
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const rows = sortedRows ?? initialRows;
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows);
+
+    function handleClickSortHeading(index, direction) {
+      setSortIndex(index);
+      setSortDirection(direction);
+      const newSortedRows = sortRows(rows, index, direction);
+      setSortedRows(newSortedRows);
+    }
+
+    function sortRows(localRows, index, direction) {
+      return [...localRows].sort((rowA, rowB) => {
+        const key = index === 0 ? 'name' : 'location';
+        if (rowA[key] < rowB[key]) {
+          return direction === 'descending' ? -1 : 1;
+        }
+        if (rowA[key] > rowB[key]) {
+          return direction === 'descending' ? 1 : -1;
+        }
+        return 0;
+      });
+    }
+
+    const rowMarkup = rows.map(
+      (
+        {
+          id,
+          name,
+          date,
+          location,
+          orders,
+          amountSpent,
+          fulfillmentStatus,
+          paymentStatus,
+          notes,
+        },
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{date}</IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{notes}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={rows.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Date', defaultSortDirection: 'ascending'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+
+            {title: 'Location'},
+            {title: 'Fulfillment status'},
+            {title: 'Payment status'},
+            {title: 'Notes', alignment: 'end'},
+          ]}
+          sortable={[true, true, false, true, true, false, false, true]}
+          sortDirection={sortDirection}
+          sortColumnIndex={sortIndex}
+          onSort={handleClickSortHeading}
+          sortToggleLabels={sortToggleLabels}
+          lastColumnSticky
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSortableCustomHeadings = {
+  render() {
+    const [sortIndex, setSortIndex] = useState(0);
+    const [sortDirection, setSortDirection] =
+      useState<IndexTableProps['sortDirection']>('descending');
+
+    const sortToggleLabels = {
+      0: {ascending: 'A-Z', descending: 'Z-A'},
+      1: {ascending: 'Ascending', descending: 'Descending'},
+      2: {ascending: 'Newest', descending: 'Oldest'},
+      3: {ascending: 'Ascending', descending: 'Ascending'},
+      4: {ascending: 'A-Z', descending: 'Z-A'},
+      5: {ascending: 'A-Z', descending: 'Z-A'},
+      6: {ascending: 'A-Z', descending: 'Z-A'},
+      7: {ascending: 'A-Z', descending: 'Z-A'},
+    };
+
+    const initialRows = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        date: '2022-02-04',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Paid',
+        notes: '',
+      },
+      {
+        id: '2561',
+        url: '#',
+        date: '2022-01-19',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Not paid',
+        notes: 'This customer lives on the 3rd floor',
+      },
+      {
+        id: '1245',
+        url: '#',
+        date: '2021-12-12',
+        name: 'Anne-Marie Johnson',
+        location: 'Portland, USA',
+        orders: 10,
+        amountSpent: '$250',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Not paid',
+        notes: '',
+      },
+      {
+        id: '8741',
+        url: '#',
+        date: '2022-05-11',
+        name: 'Bradley Stevens',
+        location: 'Hialeah, USA',
+        orders: 5,
+        amountSpent: '$26',
+        fulfillmentStatus: 'Unfulfilled',
+        paymentStatus: 'Not paid',
+        notes: 'This customer has requested fragile delivery',
+      },
+    ];
+    const [sortedRows, setSortedRows] = useState(
+      sortRows(initialRows, sortIndex, sortDirection),
+    );
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const rows = sortedRows ?? initialRows;
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows);
+
+    function handleClickSortHeading(index, direction) {
+      setSortIndex(index);
+      setSortDirection(direction);
+      const newSortedRows = sortRows(rows, index, direction);
+      setSortedRows(newSortedRows);
+    }
+
+    function sortRows(localRows, index, direction) {
+      return [...localRows].sort((rowA, rowB) => {
+        const key = index === 0 ? 'name' : 'location';
+        if (rowA[key] < rowB[key]) {
+          return direction === 'descending' ? -1 : 1;
+        }
+        if (rowA[key] > rowB[key]) {
+          return direction === 'descending' ? 1 : -1;
+        }
+        return 0;
+      });
+    }
+
+    const rowMarkup = rows.map(
+      (
+        {
+          id,
+          name,
+          date,
+          location,
+          orders,
+          amountSpent,
+          fulfillmentStatus,
+          paymentStatus,
+          notes,
+        },
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{date}</IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{notes}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={rows.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {
+              title: 'Name',
+              tooltipContent: 'I am a wide tooltip describing the Name column',
+              tooltipWidth: 'wide',
+            },
+            {title: 'Date', tooltipContent: 'I am the Date tooltip'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              title: 'Amount spent',
+              tooltipContent:
+                'I am a wide Amount spent tooltip that stays when clicked',
+              tooltipWidth: 'wide',
+            },
+            {title: 'Location'},
+            {title: 'Fulfillment status'},
+            {title: 'Payment status'},
+            {title: 'Notes'},
+          ]}
+          sortable={[true, true, false, true, true, false, false]}
+          sortDirection={sortDirection}
+          sortColumnIndex={sortIndex}
+          onSort={handleClickSortHeading}
+          sortToggleLabels={sortToggleLabels}
+          lastColumnSticky
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithHeadingWithPaddingBlockEnd = {
+  render() {
+    const [sortIndex, setSortIndex] = useState(0);
+    const [sortDirection, setSortDirection] =
+      useState<IndexTableProps['sortDirection']>('descending');
+
+    const sortToggleLabels = {
+      0: {ascending: 'A-Z', descending: 'Z-A'},
+      1: {ascending: 'Ascending', descending: 'Descending'},
+      2: {ascending: 'Newest', descending: 'Oldest'},
+      3: {ascending: 'Ascending', descending: 'Ascending'},
+      4: {ascending: 'A-Z', descending: 'Z-A'},
+      5: {ascending: 'A-Z', descending: 'Z-A'},
+      6: {ascending: 'A-Z', descending: 'Z-A'},
+      7: {ascending: 'A-Z', descending: 'Z-A'},
+    };
+
+    const initialRows = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        date: '2022-02-04',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Paid',
+        notes: '',
+      },
+      {
+        id: '2561',
+        url: '#',
+        date: '2022-01-19',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Not paid',
+        notes: 'This customer lives on the 3rd floor',
+      },
+      {
+        id: '1245',
+        url: '#',
+        date: '2021-12-12',
+        name: 'Anne-Marie Johnson',
+        location: 'Portland, USA',
+        orders: 10,
+        amountSpent: '$250',
+        fulfillmentStatus: 'Fulfilled',
+        paymentStatus: 'Not paid',
+        notes: '',
+      },
+      {
+        id: '8741',
+        url: '#',
+        date: '2022-05-11',
+        name: 'Bradley Stevens',
+        location: 'Hialeah, USA',
+        orders: 5,
+        amountSpent: '$26',
+        fulfillmentStatus: 'Unfulfilled',
+        paymentStatus: 'Not paid',
+        notes: 'This customer has requested fragile delivery',
+      },
+    ];
+    const [sortedRows, setSortedRows] = useState(
+      sortRows(initialRows, sortIndex, sortDirection),
+    );
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const rows = sortedRows ?? initialRows;
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows);
+
+    function handleClickSortHeading(index, direction) {
+      setSortIndex(index);
+      setSortDirection(direction);
+      const newSortedRows = sortRows(rows, index, direction);
+      setSortedRows(newSortedRows);
+    }
+
+    function sortRows(localRows, index, direction) {
+      return [...localRows].sort((rowA, rowB) => {
+        const key = index === 0 ? 'name' : 'location';
+        if (rowA[key] < rowB[key]) {
+          return direction === 'descending' ? -1 : 1;
+        }
+        if (rowA[key] > rowB[key]) {
+          return direction === 'descending' ? 1 : -1;
+        }
+        return 0;
+      });
+    }
+
+    const rowMarkup = rows.map(
+      (
+        {
+          id,
+          name,
+          date,
+          location,
+          orders,
+          amountSpent,
+          fulfillmentStatus,
+          paymentStatus,
+          notes,
+        },
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{date}</IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Box paddingInlineEnd="600">
+              <Text as="span" alignment="end" numeric variant="bodyMd">
+                {amountSpent}
+              </Text>
+            </Box>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{notes}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={rows.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {
+              title: 'Name',
+              tooltipContent: 'I am a wide tooltip describing the Name column',
+              tooltipWidth: 'wide',
+            },
+            {title: 'Date', tooltipContent: 'I am the Date tooltip'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              title: 'Amount spent',
+              tooltipContent:
+                'I am a wide Amount spent tooltip that stays when clicked',
+              tooltipWidth: 'wide',
+              paddingBlockEnd: '600',
+            },
+            {title: 'Location'},
+            {title: 'Fulfillment status'},
+            {title: 'Payment status'},
+            {title: 'Notes'},
+          ]}
+          sortable={[true, true, false, true, true, false, false]}
+          sortDirection={sortDirection}
+          sortColumnIndex={sortIndex}
+          onSort={handleClickSortHeading}
+          sortToggleLabels={sortToggleLabels}
+          lastColumnSticky
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithCustomTooltips = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {
+              title: 'Name',
+              tooltipContent:
+                'I am a wide tooltip describing the Name column and I also stay when clicked',
+              tooltipWidth: 'wide',
+              tooltipPersistsOnClick: true,
+            },
+            {
+              title: 'Location',
+            },
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithHeadingTooltips = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location', tooltipContent: 'Strictly within the US'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+              new: true,
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithZebraStriping = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+
+    const customersForNestedRows = [
+      {
+        id: '34101',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '34111',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '34121',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '34131',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '25631',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+    const nestedRowMarkup = customersForNestedRows.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+          rowType={index > 0 ? 'child' : 'subheader'}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+          hasZebraStriping
+        >
+          {rowMarkup}
+          {nestedRowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithZebraStripingCondensed = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+          hasZebraStriping
+          condensed
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithZebraStripingAndRowStatus = {
+  render() {
+    const customers = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        status: 'success',
+      },
+      {
+        id: '2561',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        status: 'subdued',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent, status}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+          tone={status as IndexTableRowProps['tone']}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithZebraStripingAndStickyLastColumn = {
+  render() {
+    const customers = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+        channel: 'Point of Sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+      },
+      {
+        id: '2561',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+        channel: 'Online Store',
+        paymentStatus: 'Paid',
+        fulfillmentStatus: 'Unfulfilled',
+      },
+      {
+        id: '2562',
+        url: '#',
+        name: 'Helen Troy',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$975',
+        lastOrderDate: 'May 31, 2023',
+      },
+      {
+        id: '4102',
+        url: '#',
+        name: 'Colm Dillane',
+        location: 'New York, USA',
+        orders: 27,
+        amountSpent: '$2885',
+        lastOrderDate: 'May 31, 2023',
+      },
+      {
+        id: '2564',
+        url: '#',
+        name: 'Al Chemist',
+        location: 'New York, USA',
+        orders: 19,
+        amountSpent: '$1,209',
+        lastOrderDate: 'April 4, 2023',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Larry June',
+        location: 'San Francisco, USA',
+        orders: 22,
+        amountSpent: '$1,400',
+        lastOrderDate: 'March 19, 2023',
+      },
+    ];
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      (
+        {
+          id,
+          name,
+          location,
+          orders,
+          amountSpent,
+          channel,
+          paymentStatus,
+          fulfillmentStatus,
+        },
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{channel}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+            {title: 'Channel'},
+            {title: 'Payment status'},
+            {title: 'Fulfillment status'},
+          ]}
+          lastColumnSticky
+          hasZebraStriping
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithZebraStripingAndWithoutCheckboxes = {
+  render() {
+    const customers = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '2561',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row id={id} key={id} position={index}>
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              hidden: false,
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+          selectable={false}
+          hasZebraStriping
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const SmallScreenWithAllOfItsElements = {
+  render() {
+    const customers = [
+      {
+        id: '3410',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$2,400',
+      },
+      {
+        id: '3411',
+        url: '#',
+        name: 'Joe Jemison',
+        location: 'Sydney, AU',
+        orders: 20,
+        amountSpent: '$1,400',
+      },
+      {
+        id: '3412',
+        url: '#',
+        name: 'Sam Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$400',
+      },
+      {
+        id: '3413',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$4,300',
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$140',
+      },
+    ];
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+    const [taggedWith, setTaggedWith] = useState('VIP');
+    const [queryValue, setQueryValue] = useState('');
+    const [sortValue, setSortValue] = useState(['today asc']);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+    const handleSortChange = useCallback((value) => setSortValue(value), []);
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    const sortOptions: IndexFiltersProps['sortOptions'] = [
+      {label: 'Date', value: 'today asc', directionLabel: 'Ascending'},
+      {label: 'Date', value: 'today desc', directionLabel: 'Descending'},
+    ];
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <div style={{padding: '.75rem 1rem'}}>
+            <Text fontWeight="bold" as="p">
+              {name}
+            </Text>
+            <Text as="p" variant="bodyMd">
+              <Text variant="bodyMd" as="span">
+                {location}
+              </Text>
+            </Text>
+            <Text as="p" alignment="end" numeric>
+              {orders}
+            </Text>
+            <Text as="p" alignment="end" numeric>
+              {amountSpent}
+            </Text>
+          </div>
+        </IndexTable.Row>
+      ),
+    );
+
+    const tabs = [
+      {
+        id: 'all',
+        content: 'All customers',
+      },
+    ];
+
+    const {mode, setMode} = useSetIndexFiltersMode();
+
+    const cancelAction = {
+      onAction: () => {},
+    };
+
+    async function emptyPromise() {
+      const prom = Promise.resolve();
+      return prom.then(() => {
+        return true;
+      });
+    }
+
+    const primaryAction: IndexFiltersProps['primaryAction'] = {
+      onAction: emptyPromise,
+      type: 'save-as',
+    };
+
+    return (
+      <div style={{width: '430px'}}>
         <LegacyCard>
+          <IndexFilters
+            tabs={tabs}
+            selected={0}
+            onSelect={() => {}}
+            onCreateNewView={emptyPromise}
+            queryValue={queryValue}
+            queryPlaceholder="Searching in all"
+            filters={filters}
+            appliedFilters={appliedFilters}
+            onQueryChange={setQueryValue}
+            onQueryClear={handleQueryValueRemove}
+            onClearAll={handleClearAll}
+            sortOptions={sortOptions}
+            sortSelected={sortValue}
+            onSort={handleSortChange}
+            mode={mode}
+            setMode={setMode}
+            cancelAction={cancelAction}
+            primaryAction={primaryAction}
+          />
           <IndexTable
             resourceName={resourceName}
             itemCount={customers.length}
             selectedItemsCount={
               allResourcesSelected ? 'All' : selectedResources.length
             }
+            onSelectionChange={handleSelectionChange}
+            hasMoreItems
+            condensed
+            bulkActions={bulkActions}
+            promotedBulkActions={promotedBulkActions}
+            headings={[
+              {title: 'Name'},
+              {title: 'Location'},
+              {
+                alignment: 'end',
+                id: 'order-count',
+                title: 'Order count',
+              },
+              {
+                alignment: 'end',
+                id: 'amount-spent',
+                title: 'Amount spent',
+              },
+            ]}
+          >
+            {rowMarkup}
+          </IndexTable>
+        </LegacyCard>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithSubHeaders = {
+  render() {
+    const rows = [
+      {
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 11,
+        amountSpent: '$2,400',
+        lastOrderDate: 'May 31, 2023',
+      },
+      {
+        id: '2562',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$975',
+        lastOrderDate: 'May 31, 2023',
+      },
+      {
+        id: '4102',
+        url: '#',
+        name: 'Colm Dillane',
+        location: 'New York, USA',
+        orders: 27,
+        amountSpent: '$2885',
+        lastOrderDate: 'May 31, 2023',
+      },
+      {
+        id: '2564',
+        url: '#',
+        name: 'Al Chemist',
+        location: 'New York, USA',
+        orders: 19,
+        amountSpent: '$1,209',
+        lastOrderDate: 'April 4, 2023',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Larry June',
+        location: 'San Francisco, USA',
+        orders: 22,
+        amountSpent: '$1,400',
+        lastOrderDate: 'March 19, 2023',
+      },
+    ];
+
+    const columnHeadings = [
+      {title: 'Name', id: 'column-header--name'},
+      {title: 'Location', id: 'column-header--location'},
+      {
+        alignment: 'end',
+        id: 'column-header--order-count',
+        title: 'Order count',
+      },
+      {
+        alignment: 'end',
+        hidden: false,
+        id: 'column-header--amount-spent',
+        title: 'Amount spent',
+      },
+    ];
+
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, customer) => {
+        const groupVal = customer[groupKey];
+        if (!groups[groupVal]) {
+          position += 1;
+
+          groups[groupVal] = {
+            position,
+            customers: [],
+            id: resolveId(groupVal),
+          };
+        }
+
+        groups[groupVal].customers.push({
+          ...customer,
+          position: position + 1,
+        });
+
+        position += 1;
+        return groups;
+      }, {});
+
+      return groups;
+    };
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
+
+    const orders = groupRowsBy(
+      'lastOrderDate',
+      (date) =>
+        `last-order-date--${date.replace(',', '').split(' ').join('-')}`,
+    );
+
+    const rowMarkup = Object.keys(orders).map((orderDate, index) => {
+      const {customers, position, id: subheaderId} = orders[orderDate];
+      let selected: IndexTableRowProps['selected'] = false;
+
+      const someCustomersSelected = customers.some(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      const allCustomersSelected = customers.every(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      if (allCustomersSelected) {
+        selected = true;
+      } else if (someCustomersSelected) {
+        selected = 'indeterminate';
+      }
+
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === customers[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === customers[customers.length - 1].id,
+        ),
+      ];
+
+      const disabled = customers.every(({disabled}) => disabled);
+
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            rowType="subheader"
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all customers whose last order was placed on ${orderDate}`}
+          >
+            <IndexTable.Cell scope="col" as="th" id={subheaderId}>
+              {`Last order placed: ${orderDate}`}
+            </IndexTable.Cell>
+            <IndexTable.Cell as="th" />
+            <IndexTable.Cell as="th" />
+            <IndexTable.Cell as="th" />
+          </IndexTable.Row>
+          {customers.map(
+            (
+              {id, name, location, orders, amountSpent, position, disabled},
+              rowIndex,
+            ) => {
+              return (
+                <IndexTable.Row
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
+                >
+                  <IndexTable.Cell
+                    as="th"
+                    scope="row"
+                    headers={`${columnHeadings[0].id} ${subheaderId}`}
+                  >
+                    <Text variant="bodyMd" fontWeight="semibold" as="span">
+                      {name}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text variant="bodyMd" as="span">
+                      {location}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {orders}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {amountSpent}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          onSelectionChange={handleSelectionChange}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithPagination = {
+  render() {
+    const customers = Array.from({length: 50}, (_, num) => {
+      return {
+        id: `${num}`,
+        url: '#',
+        name: `Mae Jemison ${num}`,
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$24,00',
+      };
+    });
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      ({id, name, location, orders, amountSpent}, index) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {
+              alignment: 'end',
+              id: 'order-count',
+              title: 'Order count',
+            },
+            {
+              alignment: 'end',
+              id: 'amount-spent',
+              title: 'Amount spent',
+            },
+          ]}
+          pagination={{
+            hasNext: true,
+            onNext: () => {},
+          }}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithStickyScrollBar = {
+  render() {
+    const customers = Array.from({length: 50}, (_, num) => {
+      return {
+        id: `${num}`,
+        url: '#',
+        name: `Mae Jemison ${num}`,
+        location: 'Truth or Consequences, United States of America',
+        orders: 20,
+        amountSpent: '$24,00',
+        channel: 'Point of sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+        tags: 'No tags applied',
+      };
+    });
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const rowMarkup = customers.map(
+      (
+        {
+          id,
+          name,
+          location,
+          orders,
+          amountSpent,
+          channel,
+          paymentStatus,
+          fulfillmentStatus,
+          tags,
+        },
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{channel}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{tags}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <Box paddingBlockEnd="400">
+        <BlockStack gap="200">
+          <LegacyCard>
+            <IndexTable
+              resourceName={resourceName}
+              itemCount={customers.length}
+              selectedItemsCount={
+                allResourcesSelected ? 'All' : selectedResources.length
+              }
+              onSelectionChange={handleSelectionChange}
+              headings={[
+                {title: 'Name'},
+                {title: 'Location'},
+                {
+                  alignment: 'end',
+                  id: 'order-count',
+                  title: 'Order count',
+                },
+                {
+                  alignment: 'end',
+                  id: 'amount-spent',
+                  title: 'Amount spent',
+                },
+                {title: 'Channel'},
+                {title: 'Payment status'},
+                {title: 'Fulfillment status'},
+                {title: 'Tags'},
+              ]}
+            >
+              {rowMarkup}
+            </IndexTable>
+          </LegacyCard>
+        </BlockStack>
+      </Box>
+    );
+  },
+};
+
+export const WithPaginationAndBulkActions = {
+  render() {
+    const customers = Array.from({length: 50}, (_, num) => {
+      return {
+        id: `${num}`,
+        url: '#',
+        name: `Mae Jemison ${num}`,
+        location: 'Truth or Consequences, United States of America',
+        orders: 20,
+        amountSpent: '$24,00',
+        channel: 'Point of sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+        tags: 'No tags applied',
+      };
+    });
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(customers);
+
+    const promotedBulkActions = [
+      {
+        content: 'Capture payments',
+        onAction: () => console.log('Todo: implement payment capture'),
+      },
+      {
+        title: 'Edit customers',
+        actions: [
+          {
+            content: 'Add customers',
+            onAction: () => console.log('Todo: implement adding customers'),
+          },
+          {
+            icon: DeleteIcon,
+            destructive: true,
+            content: 'Delete customers',
+            onAction: () => console.log('Todo: implement deleting customers'),
+          },
+        ],
+      },
+      {
+        title: 'Export',
+        actions: [
+          {
+            content: 'Export as PDF',
+            onAction: () => console.log('Todo: implement PDF exporting'),
+          },
+          {
+            content: 'Export as CSV',
+            onAction: () => console.log('Todo: implement CSV exporting'),
+          },
+        ],
+      },
+    ];
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    const rowMarkup = customers.map(
+      (
+        {
+          id,
+          name,
+          location,
+          orders,
+          amountSpent,
+          channel,
+          paymentStatus,
+          fulfillmentStatus,
+          tags,
+        },
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text fontWeight="bold" as="span" variant="bodyMd">
+              {name}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" as="span">
+              {location}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {orders}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {amountSpent}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{channel}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{tags}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <Box paddingBlockEnd="400">
+        <Card padding="0">
+          <IndexTable
+            condensed={useBreakpoints().smDown}
+            resourceName={resourceName}
+            itemCount={customers.length}
+            selectedItemsCount={
+              allResourcesSelected ? 'All' : selectedResources.length
+            }
+            bulkActions={bulkActions}
+            promotedBulkActions={promotedBulkActions}
             onSelectionChange={handleSelectionChange}
             headings={[
               {title: 'Name'},
@@ -5201,2002 +5439,1956 @@ export function WithStickyScrollBar() {
               {title: 'Fulfillment status'},
               {title: 'Tags'},
             ]}
+            pagination={{
+              hasNext: true,
+              onNext: () => {},
+            }}
           >
             {rowMarkup}
           </IndexTable>
-        </LegacyCard>
-      </BlockStack>
-    </Box>
-  );
-}
+        </Card>
+      </Box>
+    );
+  },
+};
 
-export function WithPaginationAndBulkActions() {
-  const customers = Array.from({length: 50}, (_, num) => {
-    return {
-      id: `${num}`,
-      url: '#',
-      name: `Mae Jemison ${num}`,
-      location: 'Truth or Consequences, United States of America',
-      orders: 20,
-      amountSpent: '$24,00',
-      channel: 'Point of sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-      tags: 'No tags applied',
-    };
-  });
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(customers);
-
-  const promotedBulkActions = [
-    {
-      content: 'Capture payments',
-      onAction: () => console.log('Todo: implement payment capture'),
-    },
-    {
-      title: 'Edit customers',
-      actions: [
-        {
-          content: 'Add customers',
-          onAction: () => console.log('Todo: implement adding customers'),
-        },
-        {
-          icon: DeleteIcon,
-          destructive: true,
-          content: 'Delete customers',
-          onAction: () => console.log('Todo: implement deleting customers'),
-        },
-      ],
-    },
-    {
-      title: 'Export',
-      actions: [
-        {
-          content: 'Export as PDF',
-          onAction: () => console.log('Todo: implement PDF exporting'),
-        },
-        {
-          content: 'Export as CSV',
-          onAction: () => console.log('Todo: implement CSV exporting'),
-        },
-      ],
-    },
-  ];
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  const rowMarkup = customers.map(
-    (
+export const WithSubHeadersNonSelectable = {
+  render() {
+    const rows = [
       {
-        id,
-        name,
-        location,
-        orders,
-        amountSpent,
-        channel,
-        paymentStatus,
-        fulfillmentStatus,
-        tags,
+        id: '3411',
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 11,
+        amountSpent: '$2,400',
+        lastOrderDate: 'May 31, 2023',
       },
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text fontWeight="bold" as="span" variant="bodyMd">
-            {name}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" as="span">
-            {location}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {orders}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {amountSpent}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{channel}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{tags}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
+      {
+        id: '2562',
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        orders: 30,
+        amountSpent: '$975',
+        lastOrderDate: 'May 31, 2023',
+      },
+      {
+        id: '4102',
+        url: '#',
+        name: 'Colm Dillane',
+        location: 'New York, USA',
+        orders: 27,
+        amountSpent: '$2885',
+        lastOrderDate: 'May 31, 2023',
+      },
+      {
+        id: '2564',
+        url: '#',
+        name: 'Al Chemist',
+        location: 'New York, USA',
+        orders: 19,
+        amountSpent: '$1,209',
+        lastOrderDate: 'April 4, 2023',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        url: '#',
+        name: 'Larry June',
+        location: 'San Francisco, USA',
+        orders: 22,
+        amountSpent: '$1,400',
+        lastOrderDate: 'March 19, 2023',
+      },
+    ];
 
-  return (
-    <Box paddingBlockEnd="400">
-      <Card padding="0">
+    const columnHeadings = [
+      {title: 'Name', id: 'column-header--name'},
+      {title: 'Location', id: 'column-header--location'},
+      {
+        alignment: 'end',
+        id: 'column-header--order-count',
+        title: 'Order count',
+      },
+      {
+        alignment: 'end',
+        hidden: false,
+        id: 'column-header--amount-spent',
+        title: 'Amount spent',
+      },
+    ];
+
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, customer) => {
+        const groupVal = customer[groupKey];
+        if (!groups[groupVal]) {
+          position += 1;
+
+          groups[groupVal] = {
+            position,
+            customers: [],
+            id: resolveId(groupVal),
+          };
+        }
+
+        groups[groupVal].customers.push({
+          ...customer,
+          position: position + 1,
+        });
+
+        position += 1;
+        return groups;
+      }, {});
+
+      return groups;
+    };
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
+
+    const orders = groupRowsBy(
+      'lastOrderDate',
+      (date) =>
+        `last-order-date--${date.replace(',', '').split(' ').join('-')}`,
+    );
+
+    const rowMarkup = Object.keys(orders).map((orderDate, index) => {
+      const {customers, position, id: subheaderId} = orders[orderDate];
+      let selected: IndexTableRowProps['selected'] = false;
+
+      const someCustomersSelected = customers.some(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      const allCustomersSelected = customers.every(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      if (allCustomersSelected) {
+        selected = true;
+      } else if (someCustomersSelected) {
+        selected = 'indeterminate';
+      }
+
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === customers[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === customers[customers.length - 1].id,
+        ),
+      ];
+
+      const disabled = customers.every(({disabled}) => disabled);
+
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            rowType="subheader"
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all customers whose last order was placed on ${orderDate}`}
+          >
+            <IndexTable.Cell scope="col" as="th" id={subheaderId}>
+              {`Last order placed: ${orderDate}`}
+            </IndexTable.Cell>
+            <IndexTable.Cell as="th" />
+            <IndexTable.Cell as="th" />
+            <IndexTable.Cell as="th" />
+          </IndexTable.Row>
+          {customers.map(
+            (
+              {id, name, location, orders, amountSpent, position, disabled},
+              rowIndex,
+            ) => {
+              return (
+                <IndexTable.Row
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
+                >
+                  <IndexTable.Cell
+                    as="th"
+                    scope="row"
+                    headers={`${columnHeadings[0].id} ${subheaderId}`}
+                  >
+                    <Text variant="bodyMd" fontWeight="semibold" as="span">
+                      {name}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text variant="bodyMd" as="span">
+                      {location}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {orders}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {amountSpent}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
+
+    return (
+      <LegacyCard>
         <IndexTable
           condensed={useBreakpoints().smDown}
-          resourceName={resourceName}
-          itemCount={customers.length}
+          onSelectionChange={handleSelectionChange}
           selectedItemsCount={
             allResourcesSelected ? 'All' : selectedResources.length
           }
-          bulkActions={bulkActions}
-          promotedBulkActions={promotedBulkActions}
-          onSelectionChange={handleSelectionChange}
-          headings={[
-            {title: 'Name'},
-            {title: 'Location'},
-            {
-              alignment: 'end',
-              id: 'order-count',
-              title: 'Order count',
-            },
-            {
-              alignment: 'end',
-              id: 'amount-spent',
-              title: 'Amount spent',
-            },
-            {title: 'Channel'},
-            {title: 'Payment status'},
-            {title: 'Fulfillment status'},
-            {title: 'Tags'},
-          ]}
-          pagination={{
-            hasNext: true,
-            onNext: () => {},
-          }}
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
+          selectable={false}
         >
           {rowMarkup}
         </IndexTable>
-      </Card>
-    </Box>
-  );
-}
-
-export function WithSubHeadersNonSelectable() {
-  const rows = [
-    {
-      id: '3411',
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 11,
-      amountSpent: '$2,400',
-      lastOrderDate: 'May 31, 2023',
-    },
-    {
-      id: '2562',
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      orders: 30,
-      amountSpent: '$975',
-      lastOrderDate: 'May 31, 2023',
-    },
-    {
-      id: '4102',
-      url: '#',
-      name: 'Colm Dillane',
-      location: 'New York, USA',
-      orders: 27,
-      amountSpent: '$2885',
-      lastOrderDate: 'May 31, 2023',
-    },
-    {
-      id: '2564',
-      url: '#',
-      name: 'Al Chemist',
-      location: 'New York, USA',
-      orders: 19,
-      amountSpent: '$1,209',
-      lastOrderDate: 'April 4, 2023',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      url: '#',
-      name: 'Larry June',
-      location: 'San Francisco, USA',
-      orders: 22,
-      amountSpent: '$1,400',
-      lastOrderDate: 'March 19, 2023',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Name', id: 'column-header--name'},
-    {title: 'Location', id: 'column-header--location'},
-    {
-      alignment: 'end',
-      id: 'column-header--order-count',
-      title: 'Order count',
-    },
-    {
-      alignment: 'end',
-      hidden: false,
-      id: 'column-header--amount-spent',
-      title: 'Amount spent',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, customer) => {
-      const groupVal = customer[groupKey];
-      if (!groups[groupVal]) {
-        position += 1;
-
-        groups[groupVal] = {
-          position,
-          customers: [],
-          id: resolveId(groupVal),
-        };
-      }
-
-      groups[groupVal].customers.push({
-        ...customer,
-        position: position + 1,
-      });
-
-      position += 1;
-      return groups;
-    }, {});
-
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const orders = groupRowsBy(
-    'lastOrderDate',
-    (date) => `last-order-date--${date.replace(',', '').split(' ').join('-')}`,
-  );
-
-  const rowMarkup = Object.keys(orders).map((orderDate, index) => {
-    const {customers, position, id: subheaderId} = orders[orderDate];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someCustomersSelected = customers.some(({id}) =>
-      selectedResources.includes(id),
+      </LegacyCard>
     );
+  },
+};
 
-    const allCustomersSelected = customers.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allCustomersSelected) {
-      selected = true;
-    } else if (someCustomersSelected) {
-      selected = 'indeterminate';
-    }
-
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === customers[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === customers[customers.length - 1].id,
-      ),
+export const WithNestedRows = {
+  render() {
+    const rows = [
+      {
+        id: '3411',
+        quantity: 11,
+        price: '$2,400',
+        size: 'Small Lorem ipsum dolor sit amet',
+        color: 'Orange Lorem ipsum dolor sit amet',
+      },
+      {
+        id: '2562',
+        quantity: 30,
+        price: '$975',
+        size: 'Medium',
+        color: 'Orange',
+      },
+      {
+        id: '4102',
+        quantity: 27,
+        price: '$2885',
+        size: 'Large',
+        color: 'Orange',
+      },
+      {
+        id: '2564',
+        quantity: 19,
+        price: '$1,209',
+        size: 'Small',
+        color: 'Red',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        quantity: 22,
+        price: '$1,400',
+        size: 'Small',
+        color: 'Green',
+      },
     ];
 
-    const disabled = customers.every(({disabled}) => disabled);
+    const columnHeadings = [
+      {title: 'Name', id: 'column-header--name'},
+      {
+        hidden: false,
+        id: 'column-header--price',
+        title: 'Price',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--quantity',
+        title: 'Available',
+      },
+    ];
 
-    return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          rowType="subheader"
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all customers whose last order was placed on ${orderDate}`}
-        >
-          <IndexTable.Cell scope="col" as="th" id={subheaderId}>
-            {`Last order placed: ${orderDate}`}
-          </IndexTable.Cell>
-          <IndexTable.Cell as="th" />
-          <IndexTable.Cell as="th" />
-          <IndexTable.Cell as="th" />
-        </IndexTable.Row>
-        {customers.map(
-          (
-            {id, name, location, orders, amountSpent, position, disabled},
-            rowIndex,
-          ) => {
-            return (
-              <IndexTable.Row
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell
-                  as="th"
-                  scope="row"
-                  headers={`${columnHeadings[0].id} ${subheaderId}`}
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, product) => {
+        const groupVal = product[groupKey];
+        if (!groups[groupVal]) {
+          position += 1;
+
+          groups[groupVal] = {
+            position,
+            products: [],
+            id: resolveId(groupVal),
+          };
+        }
+        groups[groupVal].products.push({
+          ...product,
+          position: position + 1,
+        });
+
+        position += 1;
+        return groups;
+      }, {});
+
+      return groups;
+    };
+
+    const resourceName = {
+      singular: 'product',
+      plural: 'products',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
+
+    const groupedProducts = groupRowsBy(
+      'color',
+      (color) => `color--${color.toLowerCase()}`,
+    );
+
+    const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
+      const {products, position, id: subheaderId} = groupedProducts[color];
+      let selected: IndexTableRowProps['selected'] = false;
+
+      const someProductsSelected = products.some(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      const allProductsSelected = products.every(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      if (allProductsSelected) {
+        selected = true;
+      } else if (someProductsSelected) {
+        selected = 'indeterminate';
+      }
+
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === products[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === products[products.length - 1].id,
+        ),
+      ];
+
+      const disabled = products.every(({disabled}) => disabled);
+
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            rowType="subheader"
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all products wich has color ${color}`}
+          >
+            <IndexTable.Cell>
+              <Text as="span" fontWeight="semibold">
+                {color}
+              </Text>
+            </IndexTable.Cell>
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+          </IndexTable.Row>
+          {products.map(
+            ({id, size, quantity, price, position, disabled}, rowIndex) => {
+              return (
+                <IndexTable.Row
+                  rowType="child"
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
                 >
-                  <Text variant="bodyMd" fontWeight="semibold" as="span">
-                    {name}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text variant="bodyMd" as="span">
-                    {location}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {orders}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {amountSpent}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
-    );
-  });
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-        selectable={false}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithNestedRows() {
-  const rows = [
-    {
-      id: '3411',
-      quantity: 11,
-      price: '$2,400',
-      size: 'Small Lorem ipsum dolor sit amet',
-      color: 'Orange Lorem ipsum dolor sit amet',
-    },
-    {
-      id: '2562',
-      quantity: 30,
-      price: '$975',
-      size: 'Medium',
-      color: 'Orange',
-    },
-    {
-      id: '4102',
-      quantity: 27,
-      price: '$2885',
-      size: 'Large',
-      color: 'Orange',
-    },
-    {
-      id: '2564',
-      quantity: 19,
-      price: '$1,209',
-      size: 'Small',
-      color: 'Red',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      quantity: 22,
-      price: '$1,400',
-      size: 'Small',
-      color: 'Green',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Name', id: 'column-header--name'},
-    {
-      hidden: false,
-      id: 'column-header--price',
-      title: 'Price',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--quantity',
-      title: 'Available',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, product) => {
-      const groupVal = product[groupKey];
-      if (!groups[groupVal]) {
-        position += 1;
-
-        groups[groupVal] = {
-          position,
-          products: [],
-          id: resolveId(groupVal),
-        };
-      }
-      groups[groupVal].products.push({
-        ...product,
-        position: position + 1,
-      });
-
-      position += 1;
-      return groups;
-    }, {});
-
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'product',
-    plural: 'products',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const groupedProducts = groupRowsBy(
-    'color',
-    (color) => `color--${color.toLowerCase()}`,
-  );
-
-  const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
-    const {products, position, id: subheaderId} = groupedProducts[color];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someProductsSelected = products.some(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    const allProductsSelected = products.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allProductsSelected) {
-      selected = true;
-    } else if (someProductsSelected) {
-      selected = 'indeterminate';
-    }
-
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === products[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === products[products.length - 1].id,
-      ),
-    ];
-
-    const disabled = products.every(({disabled}) => disabled);
-
-    return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          rowType="subheader"
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all products wich has color ${color}`}
-        >
-          <IndexTable.Cell>
-            <Text as="span" fontWeight="semibold">
-              {color}
-            </Text>
-          </IndexTable.Cell>
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-        </IndexTable.Row>
-        {products.map(
-          ({id, size, quantity, price, position, disabled}, rowIndex) => {
-            return (
-              <IndexTable.Row
-                rowType="child"
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell>
-                  <Text variant="bodyMd" as="span">
-                    {size}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" numeric>
-                    {price}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {quantity}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
-    );
-  });
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithNestedRowsStickyLastColumn() {
-  const rows = [
-    {
-      id: '3411',
-      quantity: 11,
-      price: '$2,400',
-      size: 'Small Lorem ipsum dolor sit amet',
-      color: 'Orange Lorem ipsum dolor sit amet',
-      vendor: 'Fit Lines',
-      channel: 'Point of Sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-    },
-    {
-      id: '2562',
-      quantity: 30,
-      price: '$975',
-      size: 'Medium',
-      color: 'Orange',
-      vendor: 'Fit Lines',
-      channel: 'Point of Sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-    },
-    {
-      id: '4102',
-      quantity: 27,
-      price: '$2885',
-      size: 'Large',
-      color: 'Orange',
-      vendor: 'Fit Lines',
-      channel: 'Point of Sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-    },
-    {
-      id: '2564',
-      quantity: 19,
-      price: '$1,209',
-      size: 'Small',
-      color: 'Red',
-      disabled: true,
-      vendor: 'Fit Lines',
-      channel: 'Point of Sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-    },
-    {
-      id: '2563',
-      quantity: 22,
-      price: '$1,400',
-      size: 'Small',
-      color: 'Green',
-      vendor: 'Fit Lines',
-      channel: 'Point of Sale',
-      paymentStatus: 'Refunded',
-      fulfillmentStatus: 'Fulfilled',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Name', id: 'column-header--size'},
-    {
-      hidden: false,
-      id: 'column-header--price',
-      title: 'Price',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--quantity',
-      title: 'Available',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--vendor',
-      title: 'Vendor',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--channel',
-      title: 'Channel',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--paymentStatus',
-      title: 'Status',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--fulfillmentStatus',
-      title: 'Fulfillment Status',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, product) => {
-      const groupVal = product[groupKey];
-      if (!groups[groupVal]) {
-        position += 1;
-
-        groups[groupVal] = {
-          position,
-          products: [],
-          id: resolveId(groupVal),
-        };
-      }
-      groups[groupVal].products.push({
-        ...product,
-        position: position + 1,
-      });
-
-      position += 1;
-      return groups;
-    }, {});
-
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'product',
-    plural: 'products',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const groupedProducts = groupRowsBy(
-    'color',
-    (color) => `color--${color.toLowerCase()}`,
-  );
-
-  const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
-    const {products, position, id: subheaderId} = groupedProducts[color];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someProductsSelected = products.some(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    const allProductsSelected = products.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allProductsSelected) {
-      selected = true;
-    } else if (someProductsSelected) {
-      selected = 'indeterminate';
-    }
-
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === products[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === products[products.length - 1].id,
-      ),
-    ];
-
-    const disabled = products.every(({disabled}) => disabled);
-
-    return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          rowType="subheader"
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all products wich has color ${color}`}
-        >
-          <IndexTable.Cell id={subheaderId}>
-            <Text as="span" fontWeight="semibold">
-              {color}
-            </Text>
-          </IndexTable.Cell>
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-        </IndexTable.Row>
-        {products.map(
-          (
-            {
-              id,
-              size,
-              quantity,
-              price,
-              position,
-              disabled,
-              vendor,
-              channel,
-              paymentStatus,
-              fulfillmentStatus,
+                  <IndexTable.Cell>
+                    <Text variant="bodyMd" as="span">
+                      {size}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" numeric>
+                      {price}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {quantity}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
             },
-            rowIndex,
-          ) => {
-            return (
-              <IndexTable.Row
-                rowType="child"
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell>
-                  <Text variant="bodyMd" as="span">
-                    {size}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" numeric>
-                    {price}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {quantity}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {vendor}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {channel}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {paymentStatus}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {fulfillmentStatus}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
-    );
-  });
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-        lastColumnSticky
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithNestedRowsNonSelectable() {
-  const rows = [
-    {
-      id: '3411',
-      quantity: 11,
-      price: '$2,400',
-      size: 'Small Lorem ipsum dolor sit amet',
-      color: 'Orange Lorem ipsum dolor sit amet',
-    },
-    {
-      id: '2562',
-      quantity: 30,
-      price: '$975',
-      size: 'Medium',
-      color: 'Orange',
-    },
-    {
-      id: '4102',
-      quantity: 27,
-      price: '$2885',
-      size: 'Large',
-      color: 'Orange',
-    },
-    {
-      id: '2564',
-      quantity: 19,
-      price: '$1,209',
-      size: 'Small',
-      color: 'Red',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      quantity: 22,
-      price: '$1,400',
-      size: 'Small',
-      color: 'Green',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Name', id: 'column-header--size'},
-    {
-      hidden: false,
-      id: 'column-header--price',
-      title: 'Price',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--quantity',
-      title: 'Available',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, product) => {
-      const groupVal = product[groupKey];
-
-      if (!groups[groupVal]) {
-        position += 1;
-
-        groups[groupVal] = {
-          position,
-          products: [],
-          id: resolveId(groupVal),
-        };
-      }
-
-      groups[groupVal].products.push({
-        ...product,
-        position: position + 1,
-      });
-
-      position += 1;
-      return groups;
-    }, {});
-
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'product',
-    plural: 'products',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const groupedProducts = groupRowsBy(
-    'color',
-    (color) => `color--${color.toLowerCase()}`,
-  );
-
-  const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
-    const {products, position, id: subheaderId} = groupedProducts[color];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someProductsSelected = products.some(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    const allProductsSelected = products.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allProductsSelected) {
-      selected = true;
-    } else if (someProductsSelected) {
-      selected = 'indeterminate';
-    }
-
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === products[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === products[products.length - 1].id,
-      ),
-    ];
-
-    const disabled = products.every(({disabled}) => disabled);
+          )}
+        </Fragment>
+      );
+    });
 
     return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          rowType="subheader"
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all products wich has color ${color}`}
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          onSelectionChange={handleSelectionChange}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
         >
-          <IndexTable.Cell id={subheaderId}>
-            <Text as="span" fontWeight="semibold">
-              {color}
-            </Text>
-          </IndexTable.Cell>
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-        </IndexTable.Row>
-        {products.map(
-          ({id, size, quantity, price, position, disabled}, rowIndex) => {
-            return (
-              <IndexTable.Row
-                rowType="child"
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell>
-                  <Text variant="bodyMd" as="span">
-                    {size}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" numeric>
-                    {price}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {quantity}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
     );
-  });
+  },
+};
 
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-        selectable={false}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithNestedRowsWithThumbnails() {
-  const rows = [
-    {
-      id: '3411',
-      quantity: 11,
-      price: '$2,400',
-      size: 'Small Lorem ipsum dolor sit amet',
-      color: 'Orange Lorem ipsum dolor sit amet',
-    },
-    {
-      id: '2562',
-      quantity: 30,
-      price: '$975',
-      size: 'Medium',
-      color: 'Orange',
-    },
-    {
-      id: '4102',
-      quantity: 27,
-      price: '$2885',
-      size: 'Large',
-      color: 'Orange',
-    },
-    {
-      id: '2564',
-      quantity: 19,
-      price: '$1,209',
-      size: 'Small',
-      color: 'Red',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      quantity: 22,
-      price: '$1,400',
-      size: 'Small',
-      color: 'Green',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Image', id: 'column-header--image'},
-    {title: 'Name', id: 'column-header--size'},
-    {
-      hidden: false,
-      id: 'column-header--price',
-      title: 'Price',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--quantity',
-      title: 'Available',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, product) => {
-      const groupVal = product[groupKey];
-      if (!groups[groupVal]) {
-        position += 1;
-
-        groups[groupVal] = {
-          position,
-          products: [],
-          id: resolveId(groupVal),
-        };
-      }
-      groups[groupVal].products.push({
-        ...product,
-        position: position + 1,
-      });
-
-      position += 1;
-      return groups;
-    }, {});
-
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'product',
-    plural: 'products',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const groupedProducts = groupRowsBy(
-    'color',
-    (color) => `color--${color.toLowerCase()}`,
-  );
-
-  const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
-    const {products, position, id: subheaderId} = groupedProducts[color];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someProductsSelected = products.some(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    const allProductsSelected = products.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allProductsSelected) {
-      selected = true;
-    } else if (someProductsSelected) {
-      selected = 'indeterminate';
-    }
-
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === products[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === products[products.length - 1].id,
-      ),
+export const WithNestedRowsStickyLastColumn = {
+  render() {
+    const rows = [
+      {
+        id: '3411',
+        quantity: 11,
+        price: '$2,400',
+        size: 'Small Lorem ipsum dolor sit amet',
+        color: 'Orange Lorem ipsum dolor sit amet',
+        vendor: 'Fit Lines',
+        channel: 'Point of Sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+      },
+      {
+        id: '2562',
+        quantity: 30,
+        price: '$975',
+        size: 'Medium',
+        color: 'Orange',
+        vendor: 'Fit Lines',
+        channel: 'Point of Sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+      },
+      {
+        id: '4102',
+        quantity: 27,
+        price: '$2885',
+        size: 'Large',
+        color: 'Orange',
+        vendor: 'Fit Lines',
+        channel: 'Point of Sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+      },
+      {
+        id: '2564',
+        quantity: 19,
+        price: '$1,209',
+        size: 'Small',
+        color: 'Red',
+        disabled: true,
+        vendor: 'Fit Lines',
+        channel: 'Point of Sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+      },
+      {
+        id: '2563',
+        quantity: 22,
+        price: '$1,400',
+        size: 'Small',
+        color: 'Green',
+        vendor: 'Fit Lines',
+        channel: 'Point of Sale',
+        paymentStatus: 'Refunded',
+        fulfillmentStatus: 'Fulfilled',
+      },
     ];
 
-    const disabled = products.every(({disabled}) => disabled);
-
-    return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          rowType="subheader"
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all products wich has color ${color}`}
-        >
-          <IndexTable.Cell>
-            <Thumbnail
-              source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-              size="medium"
-              alt="Black choker necklace"
-            />
-          </IndexTable.Cell>
-          <IndexTable.Cell id={subheaderId}>
-            <Text as="span" fontWeight="semibold">
-              {color}
-            </Text>
-          </IndexTable.Cell>
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-        </IndexTable.Row>
-        {products.map(
-          ({id, size, quantity, price, position, disabled}, rowIndex) => {
-            return (
-              <IndexTable.Row
-                rowType="child"
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell>
-                  <Thumbnail
-                    source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                    size="small"
-                    alt="Black choker necklace"
-                  />
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text variant="bodyMd" as="span">
-                    {size}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" numeric>
-                    {price}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {quantity}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
-    );
-  });
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-        selectable
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithNestedRowsWithThumbnailsNonSelectable() {
-  const rows = [
-    {
-      id: '3411',
-      quantity: 11,
-      price: '$2,400',
-      size: 'Small Lorem ipsum dolor sit amet',
-      color: 'Orange Lorem ipsum dolor sit amet',
-    },
-    {
-      id: '2562',
-      quantity: 30,
-      price: '$975',
-      size: 'Medium',
-      color: 'Orange',
-    },
-    {
-      id: '4102',
-      quantity: 27,
-      price: '$2885',
-      size: 'Large',
-      color: 'Orange',
-    },
-    {
-      id: '2564',
-      quantity: 19,
-      price: '$1,209',
-      size: 'Small',
-      color: 'Red',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      quantity: 22,
-      price: '$1,400',
-      size: 'Small',
-      color: 'Green',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Image', id: 'column-header--image'},
-    {title: 'Name', id: 'column-header--size'},
-    {
-      hidden: false,
-      id: 'column-header--price',
-      title: 'Price',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--quantity',
-      title: 'Available',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, product) => {
-      const groupVal = product[groupKey];
-      if (!groups[groupVal]) {
-        position += 1;
-
-        groups[groupVal] = {
-          position,
-          products: [],
-          id: resolveId(groupVal),
-        };
-      }
-      groups[groupVal].products.push({
-        ...product,
-        position: position + 1,
-      });
-
-      position += 1;
-      return groups;
-    }, {});
-
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'product',
-    plural: 'products',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const groupedProducts = groupRowsBy(
-    'color',
-    (color) => `color--${color.toLowerCase()}`,
-  );
-
-  const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
-    const {products, position, id: subheaderId} = groupedProducts[color];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someProductsSelected = products.some(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    const allProductsSelected = products.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allProductsSelected) {
-      selected = true;
-    } else if (someProductsSelected) {
-      selected = 'indeterminate';
-    }
-
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === products[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === products[products.length - 1].id,
-      ),
+    const columnHeadings = [
+      {title: 'Name', id: 'column-header--size'},
+      {
+        hidden: false,
+        id: 'column-header--price',
+        title: 'Price',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--quantity',
+        title: 'Available',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--vendor',
+        title: 'Vendor',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--channel',
+        title: 'Channel',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--paymentStatus',
+        title: 'Status',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--fulfillmentStatus',
+        title: 'Fulfillment Status',
+      },
     ];
 
-    const disabled = products.every(({disabled}) => disabled);
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, product) => {
+        const groupVal = product[groupKey];
+        if (!groups[groupVal]) {
+          position += 1;
 
-    return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          rowType="subheader"
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all products wich has color ${color}`}
-        >
-          <IndexTable.Cell>
-            <Thumbnail
-              source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-              size="medium"
-              alt="Black choker necklace"
-            />
-          </IndexTable.Cell>
-          <IndexTable.Cell id={subheaderId}>
-            <Text as="span" fontWeight="semibold">
-              {color}
-            </Text>
-          </IndexTable.Cell>
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-        </IndexTable.Row>
-        {products.map(
-          ({id, size, quantity, price, position, disabled}, rowIndex) => {
-            return (
-              <IndexTable.Row
-                rowType="child"
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell>
-                  <Thumbnail
-                    source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                    size="small"
-                    alt="Black choker necklace"
-                  />
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text variant="bodyMd" as="span">
-                    {size}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" numeric>
-                    {price}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {quantity}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
-    );
-  });
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
+          groups[groupVal] = {
+            position,
+            products: [],
+            id: resolveId(groupVal),
+          };
         }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-        selectable={false}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
+        groups[groupVal].products.push({
+          ...product,
+          position: position + 1,
+        });
 
-export function WithNestedRowsWithThumbnailsOneCellSelectable() {
-  const rows = [
-    {
-      id: '3411',
-      quantity: 11,
-      price: '$2,400',
-      size: 'Small Lorem ipsum dolor sit amet',
-      color: 'Orange Lorem ipsum dolor sit amet',
-    },
-    {
-      id: '2562',
-      quantity: 30,
-      price: '$975',
-      size: 'Medium',
-      color: 'Orange',
-    },
-    {
-      id: '4102',
-      quantity: 27,
-      price: '$2885',
-      size: 'Large',
-      color: 'Orange',
-    },
-    {
-      id: '2564',
-      quantity: 19,
-      price: '$1,209',
-      size: 'Small',
-      color: 'Red',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      quantity: 22,
-      price: '$1,400',
-      size: 'Small',
-      color: 'Green',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Name', id: 'column-header--size'},
-    {
-      hidden: false,
-      id: 'column-header--price',
-      title: 'Price',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--quantity',
-      title: 'Available',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, product) => {
-      const groupVal = product[groupKey];
-
-      if (!groups[groupVal]) {
         position += 1;
+        return groups;
+      }, {});
 
-        groups[groupVal] = {
-          position,
-          products: [],
-          id: resolveId(groupVal),
-        };
+      return groups;
+    };
+
+    const resourceName = {
+      singular: 'product',
+      plural: 'products',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
+
+    const groupedProducts = groupRowsBy(
+      'color',
+      (color) => `color--${color.toLowerCase()}`,
+    );
+
+    const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
+      const {products, position, id: subheaderId} = groupedProducts[color];
+      let selected: IndexTableRowProps['selected'] = false;
+
+      const someProductsSelected = products.some(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      const allProductsSelected = products.every(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      if (allProductsSelected) {
+        selected = true;
+      } else if (someProductsSelected) {
+        selected = 'indeterminate';
       }
 
-      groups[groupVal].products.push({
-        ...product,
-        position: position + 1,
-      });
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === products[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === products[products.length - 1].id,
+        ),
+      ];
 
-      position += 1;
-      return groups;
-    }, {});
+      const disabled = products.every(({disabled}) => disabled);
 
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'product',
-    plural: 'products',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const groupedProducts = groupRowsBy(
-    'color',
-    (color) => `color--${color.toLowerCase()}`,
-  );
-
-  const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
-    const {products, position, id: subheaderId} = groupedProducts[color];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someProductsSelected = products.some(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    const allProductsSelected = products.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allProductsSelected) {
-      selected = true;
-    } else if (someProductsSelected) {
-      selected = 'indeterminate';
-    }
-
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === products[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === products[products.length - 1].id,
-      ),
-    ];
-
-    const disabled = products.every(({disabled}) => disabled);
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            rowType="subheader"
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all products wich has color ${color}`}
+          >
+            <IndexTable.Cell id={subheaderId}>
+              <Text as="span" fontWeight="semibold">
+                {color}
+              </Text>
+            </IndexTable.Cell>
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+          </IndexTable.Row>
+          {products.map(
+            (
+              {
+                id,
+                size,
+                quantity,
+                price,
+                position,
+                disabled,
+                vendor,
+                channel,
+                paymentStatus,
+                fulfillmentStatus,
+              },
+              rowIndex,
+            ) => {
+              return (
+                <IndexTable.Row
+                  rowType="child"
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
+                >
+                  <IndexTable.Cell>
+                    <Text variant="bodyMd" as="span">
+                      {size}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" numeric>
+                      {price}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {quantity}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {vendor}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {channel}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {paymentStatus}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {fulfillmentStatus}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
 
     return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all products wich has color ${color}`}
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          onSelectionChange={handleSelectionChange}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
+          lastColumnSticky
         >
-          <IndexTable.Cell>
-            <InlineStack gap="400" blockAlign="center">
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithNestedRowsNonSelectable = {
+  render() {
+    const rows = [
+      {
+        id: '3411',
+        quantity: 11,
+        price: '$2,400',
+        size: 'Small Lorem ipsum dolor sit amet',
+        color: 'Orange Lorem ipsum dolor sit amet',
+      },
+      {
+        id: '2562',
+        quantity: 30,
+        price: '$975',
+        size: 'Medium',
+        color: 'Orange',
+      },
+      {
+        id: '4102',
+        quantity: 27,
+        price: '$2885',
+        size: 'Large',
+        color: 'Orange',
+      },
+      {
+        id: '2564',
+        quantity: 19,
+        price: '$1,209',
+        size: 'Small',
+        color: 'Red',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        quantity: 22,
+        price: '$1,400',
+        size: 'Small',
+        color: 'Green',
+      },
+    ];
+
+    const columnHeadings = [
+      {title: 'Name', id: 'column-header--size'},
+      {
+        hidden: false,
+        id: 'column-header--price',
+        title: 'Price',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--quantity',
+        title: 'Available',
+      },
+    ];
+
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, product) => {
+        const groupVal = product[groupKey];
+
+        if (!groups[groupVal]) {
+          position += 1;
+
+          groups[groupVal] = {
+            position,
+            products: [],
+            id: resolveId(groupVal),
+          };
+        }
+
+        groups[groupVal].products.push({
+          ...product,
+          position: position + 1,
+        });
+
+        position += 1;
+        return groups;
+      }, {});
+
+      return groups;
+    };
+
+    const resourceName = {
+      singular: 'product',
+      plural: 'products',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
+
+    const groupedProducts = groupRowsBy(
+      'color',
+      (color) => `color--${color.toLowerCase()}`,
+    );
+
+    const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
+      const {products, position, id: subheaderId} = groupedProducts[color];
+      let selected: IndexTableRowProps['selected'] = false;
+
+      const someProductsSelected = products.some(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      const allProductsSelected = products.every(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      if (allProductsSelected) {
+        selected = true;
+      } else if (someProductsSelected) {
+        selected = 'indeterminate';
+      }
+
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === products[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === products[products.length - 1].id,
+        ),
+      ];
+
+      const disabled = products.every(({disabled}) => disabled);
+
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            rowType="subheader"
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all products wich has color ${color}`}
+          >
+            <IndexTable.Cell id={subheaderId}>
+              <Text as="span" fontWeight="semibold">
+                {color}
+              </Text>
+            </IndexTable.Cell>
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+          </IndexTable.Row>
+          {products.map(
+            ({id, size, quantity, price, position, disabled}, rowIndex) => {
+              return (
+                <IndexTable.Row
+                  rowType="child"
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
+                >
+                  <IndexTable.Cell>
+                    <Text variant="bodyMd" as="span">
+                      {size}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" numeric>
+                      {price}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {quantity}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          onSelectionChange={handleSelectionChange}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
+          selectable={false}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithNestedRowsWithThumbnails = {
+  render() {
+    const rows = [
+      {
+        id: '3411',
+        quantity: 11,
+        price: '$2,400',
+        size: 'Small Lorem ipsum dolor sit amet',
+        color: 'Orange Lorem ipsum dolor sit amet',
+      },
+      {
+        id: '2562',
+        quantity: 30,
+        price: '$975',
+        size: 'Medium',
+        color: 'Orange',
+      },
+      {
+        id: '4102',
+        quantity: 27,
+        price: '$2885',
+        size: 'Large',
+        color: 'Orange',
+      },
+      {
+        id: '2564',
+        quantity: 19,
+        price: '$1,209',
+        size: 'Small',
+        color: 'Red',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        quantity: 22,
+        price: '$1,400',
+        size: 'Small',
+        color: 'Green',
+      },
+    ];
+
+    const columnHeadings = [
+      {title: 'Image', id: 'column-header--image'},
+      {title: 'Name', id: 'column-header--size'},
+      {
+        hidden: false,
+        id: 'column-header--price',
+        title: 'Price',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--quantity',
+        title: 'Available',
+      },
+    ];
+
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, product) => {
+        const groupVal = product[groupKey];
+        if (!groups[groupVal]) {
+          position += 1;
+
+          groups[groupVal] = {
+            position,
+            products: [],
+            id: resolveId(groupVal),
+          };
+        }
+        groups[groupVal].products.push({
+          ...product,
+          position: position + 1,
+        });
+
+        position += 1;
+        return groups;
+      }, {});
+
+      return groups;
+    };
+
+    const resourceName = {
+      singular: 'product',
+      plural: 'products',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
+
+    const groupedProducts = groupRowsBy(
+      'color',
+      (color) => `color--${color.toLowerCase()}`,
+    );
+
+    const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
+      const {products, position, id: subheaderId} = groupedProducts[color];
+      let selected: IndexTableRowProps['selected'] = false;
+
+      const someProductsSelected = products.some(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      const allProductsSelected = products.every(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      if (allProductsSelected) {
+        selected = true;
+      } else if (someProductsSelected) {
+        selected = 'indeterminate';
+      }
+
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === products[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === products[products.length - 1].id,
+        ),
+      ];
+
+      const disabled = products.every(({disabled}) => disabled);
+
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            rowType="subheader"
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all products wich has color ${color}`}
+          >
+            <IndexTable.Cell>
               <Thumbnail
                 source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
                 size="medium"
                 alt="Black choker necklace"
               />
+            </IndexTable.Cell>
+            <IndexTable.Cell id={subheaderId}>
               <Text as="span" fontWeight="semibold">
                 {color}
               </Text>
-            </InlineStack>
-          </IndexTable.Cell>
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-        </IndexTable.Row>
-        {products.map(
-          ({id, size, quantity, price, position, disabled}, rowIndex) => {
-            return (
-              <IndexTable.Row
-                rowType="child"
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell>
-                  <Box>
-                    <InlineStack gap="400" blockAlign="center">
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                        size="small"
-                        alt="Black choker necklace"
-                      />
-                      <Text variant="bodyMd" as="span">
-                        {size}
-                      </Text>
-                    </InlineStack>
-                  </Box>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" numeric>
-                    {price}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {quantity}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
-    );
-  });
-
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
-        }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-        selectable
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
-
-export function WithNestedRowsWithThumbnailsOneCellNonSelectable() {
-  const rows = [
-    {
-      id: '3411',
-      quantity: 11,
-      price: '$2,400',
-      size: 'Small Lorem ipsum dolor sit amet',
-      color: 'Orange Lorem ipsum dolor sit amet',
-    },
-    {
-      id: '2562',
-      quantity: 30,
-      price: '$975',
-      size: 'Medium',
-      color: 'Orange',
-    },
-    {
-      id: '4102',
-      quantity: 27,
-      price: '$2885',
-      size: 'Large',
-      color: 'Orange',
-    },
-    {
-      id: '2564',
-      quantity: 19,
-      price: '$1,209',
-      size: 'Small',
-      color: 'Red',
-      disabled: true,
-    },
-    {
-      id: '2563',
-      quantity: 22,
-      price: '$1,400',
-      size: 'Small',
-      color: 'Green',
-    },
-  ];
-
-  const columnHeadings = [
-    {title: 'Name', id: 'column-header--size'},
-    {
-      hidden: false,
-      id: 'column-header--price',
-      title: 'Price',
-    },
-    {
-      alignment: 'end',
-      id: 'column-header--quantity',
-      title: 'Available',
-    },
-  ];
-
-  const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
-    let position = -1;
-    const groups = rows.reduce((groups, product) => {
-      const groupVal = product[groupKey];
-      if (!groups[groupVal]) {
-        position += 1;
-
-        groups[groupVal] = {
-          position,
-          products: [],
-          id: resolveId(groupVal),
-        };
-      }
-      groups[groupVal].products.push({
-        ...product,
-        position: position + 1,
-      });
-
-      position += 1;
-      return groups;
-    }, {});
-
-    return groups;
-  };
-
-  const resourceName = {
-    singular: 'product',
-    plural: 'products',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
-
-  const groupedProducts = groupRowsBy(
-    'color',
-    (color) => `color--${color.toLowerCase()}`,
-  );
-
-  const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
-    const {products, position, id: subheaderId} = groupedProducts[color];
-    let selected: IndexTableRowProps['selected'] = false;
-
-    const someProductsSelected = products.some(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    const allProductsSelected = products.every(({id}) =>
-      selectedResources.includes(id),
-    );
-
-    if (allProductsSelected) {
-      selected = true;
-    } else if (someProductsSelected) {
-      selected = 'indeterminate';
-    }
-
-    const selectableRows = rows.filter(({disabled}) => !disabled);
-    const rowRange: IndexTableRowProps['selectionRange'] = [
-      selectableRows.findIndex((row) => row.id === products[0].id),
-      selectableRows.findIndex(
-        (row) => row.id === products[products.length - 1].id,
-      ),
-    ];
-
-    const disabled = products.every(({disabled}) => disabled);
+            </IndexTable.Cell>
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+          </IndexTable.Row>
+          {products.map(
+            ({id, size, quantity, price, position, disabled}, rowIndex) => {
+              return (
+                <IndexTable.Row
+                  rowType="child"
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
+                >
+                  <IndexTable.Cell>
+                    <Thumbnail
+                      source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                      size="small"
+                      alt="Black choker necklace"
+                    />
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text variant="bodyMd" as="span">
+                      {size}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" numeric>
+                      {price}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {quantity}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
 
     return (
-      <Fragment key={subheaderId}>
-        <IndexTable.Row
-          selectionRange={rowRange}
-          id={`Subheader-${index}`}
-          position={position}
-          selected={selected}
-          disabled={disabled}
-          accessibilityLabel={`Select all products wich has color ${color}`}
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          onSelectionChange={handleSelectionChange}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
+          selectable
         >
-          <IndexTable.Cell>
-            <InlineStack gap="400" blockAlign="center">
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithNestedRowsWithThumbnailsNonSelectable = {
+  render() {
+    const rows = [
+      {
+        id: '3411',
+        quantity: 11,
+        price: '$2,400',
+        size: 'Small Lorem ipsum dolor sit amet',
+        color: 'Orange Lorem ipsum dolor sit amet',
+      },
+      {
+        id: '2562',
+        quantity: 30,
+        price: '$975',
+        size: 'Medium',
+        color: 'Orange',
+      },
+      {
+        id: '4102',
+        quantity: 27,
+        price: '$2885',
+        size: 'Large',
+        color: 'Orange',
+      },
+      {
+        id: '2564',
+        quantity: 19,
+        price: '$1,209',
+        size: 'Small',
+        color: 'Red',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        quantity: 22,
+        price: '$1,400',
+        size: 'Small',
+        color: 'Green',
+      },
+    ];
+
+    const columnHeadings = [
+      {title: 'Image', id: 'column-header--image'},
+      {title: 'Name', id: 'column-header--size'},
+      {
+        hidden: false,
+        id: 'column-header--price',
+        title: 'Price',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--quantity',
+        title: 'Available',
+      },
+    ];
+
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, product) => {
+        const groupVal = product[groupKey];
+        if (!groups[groupVal]) {
+          position += 1;
+
+          groups[groupVal] = {
+            position,
+            products: [],
+            id: resolveId(groupVal),
+          };
+        }
+        groups[groupVal].products.push({
+          ...product,
+          position: position + 1,
+        });
+
+        position += 1;
+        return groups;
+      }, {});
+
+      return groups;
+    };
+
+    const resourceName = {
+      singular: 'product',
+      plural: 'products',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
+
+    const groupedProducts = groupRowsBy(
+      'color',
+      (color) => `color--${color.toLowerCase()}`,
+    );
+
+    const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
+      const {products, position, id: subheaderId} = groupedProducts[color];
+      let selected: IndexTableRowProps['selected'] = false;
+
+      const someProductsSelected = products.some(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      const allProductsSelected = products.every(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      if (allProductsSelected) {
+        selected = true;
+      } else if (someProductsSelected) {
+        selected = 'indeterminate';
+      }
+
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === products[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === products[products.length - 1].id,
+        ),
+      ];
+
+      const disabled = products.every(({disabled}) => disabled);
+
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            rowType="subheader"
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all products wich has color ${color}`}
+          >
+            <IndexTable.Cell>
               <Thumbnail
                 source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
                 size="medium"
                 alt="Black choker necklace"
               />
+            </IndexTable.Cell>
+            <IndexTable.Cell id={subheaderId}>
               <Text as="span" fontWeight="semibold">
                 {color}
               </Text>
-            </InlineStack>
-          </IndexTable.Cell>
-          <IndexTable.Cell />
-          <IndexTable.Cell />
-        </IndexTable.Row>
-        {products.map(
-          ({id, size, quantity, price, position, disabled}, rowIndex) => {
-            return (
-              <IndexTable.Row
-                rowType="child"
-                key={rowIndex}
-                id={id}
-                position={position}
-                selected={selectedResources.includes(id)}
-                disabled={disabled}
-              >
-                <IndexTable.Cell>
-                  <Box>
-                    <InlineStack gap="400" blockAlign="center">
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                        size="small"
-                        alt="Black choker necklace"
-                      />
-                      <Text variant="bodyMd" as="span">
-                        {size}
-                      </Text>
-                    </InlineStack>
-                  </Box>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" numeric>
-                    {price}
-                  </Text>
-                </IndexTable.Cell>
-                <IndexTable.Cell>
-                  <Text as="span" alignment="end" numeric variant="bodyMd">
-                    {quantity}
-                  </Text>
-                </IndexTable.Cell>
-              </IndexTable.Row>
-            );
-          },
-        )}
-      </Fragment>
+            </IndexTable.Cell>
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+          </IndexTable.Row>
+          {products.map(
+            ({id, size, quantity, price, position, disabled}, rowIndex) => {
+              return (
+                <IndexTable.Row
+                  rowType="child"
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
+                >
+                  <IndexTable.Cell>
+                    <Thumbnail
+                      source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                      size="small"
+                      alt="Black choker necklace"
+                    />
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text variant="bodyMd" as="span">
+                      {size}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" numeric>
+                      {price}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {quantity}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          onSelectionChange={handleSelectionChange}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
+          selectable={false}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
     );
-  });
+  },
+};
 
-  return (
-    <LegacyCard>
-      <IndexTable
-        condensed={useBreakpoints().smDown}
-        onSelectionChange={handleSelectionChange}
-        selectedItemsCount={
-          allResourcesSelected ? 'All' : selectedResources.length
+export const WithNestedRowsWithThumbnailsOneCellSelectable = {
+  render() {
+    const rows = [
+      {
+        id: '3411',
+        quantity: 11,
+        price: '$2,400',
+        size: 'Small Lorem ipsum dolor sit amet',
+        color: 'Orange Lorem ipsum dolor sit amet',
+      },
+      {
+        id: '2562',
+        quantity: 30,
+        price: '$975',
+        size: 'Medium',
+        color: 'Orange',
+      },
+      {
+        id: '4102',
+        quantity: 27,
+        price: '$2885',
+        size: 'Large',
+        color: 'Orange',
+      },
+      {
+        id: '2564',
+        quantity: 19,
+        price: '$1,209',
+        size: 'Small',
+        color: 'Red',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        quantity: 22,
+        price: '$1,400',
+        size: 'Small',
+        color: 'Green',
+      },
+    ];
+
+    const columnHeadings = [
+      {title: 'Name', id: 'column-header--size'},
+      {
+        hidden: false,
+        id: 'column-header--price',
+        title: 'Price',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--quantity',
+        title: 'Available',
+      },
+    ];
+
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, product) => {
+        const groupVal = product[groupKey];
+
+        if (!groups[groupVal]) {
+          position += 1;
+
+          groups[groupVal] = {
+            position,
+            products: [],
+            id: resolveId(groupVal),
+          };
         }
-        resourceName={resourceName}
-        itemCount={rows.length}
-        headings={columnHeadings as IndexTableProps['headings']}
-        selectable={false}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
 
-export function WithLongDataSetNonSelectable() {
-  const orders = Array.from(Array(100).keys()).map((i) => ({
-    id: `${i}`,
-    order: i,
-    date: 'Jul 20 at 4:34pm',
-    customer: 'Jaydon Stanton',
-    total: `$969.44${i}`,
-    paymentStatus: <Badge progress="complete">Paid</Badge>,
-    fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-  }));
+        groups[groupVal].products.push({
+          ...product,
+          position: position + 1,
+        });
 
-  const resourceName = {
-    singular: 'order',
-    plural: 'orders',
-  };
+        position += 1;
+        return groups;
+      }, {});
 
-  const rowMarkup = orders.map(
-    (
-      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
-      index,
-    ) => (
-      <IndexTable.Row id={id} key={id} position={index}>
-        <IndexTable.Cell>
-          <Text variant="bodyMd" fontWeight="bold" as="span">
-            {order}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{date}</IndexTable.Cell>
-        <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
+      return groups;
+    };
 
-  return (
-    <LegacyCard>
-      <IndexTable
-        resourceName={resourceName}
-        itemCount={orders.length}
-        headings={[
-          {title: 'Order'},
-          {title: 'Date'},
-          {title: 'Customer'},
-          {title: 'Total', alignment: 'end'},
-          {title: 'Payment status'},
-          {title: 'Fulfillment status'},
-        ]}
-        selectable={false}
-      >
-        {rowMarkup}
-      </IndexTable>
-    </LegacyCard>
-  );
-}
+    const resourceName = {
+      singular: 'product',
+      plural: 'products',
+    };
 
-export function WithLongDataSetSelectable() {
-  const orders = Array.from(Array(100).keys()).map((i) => ({
-    id: `${i}`,
-    order: i,
-    date: 'Jul 20 at 4:34pm',
-    customer: 'Jaydon Stanton',
-    total: `$969.44${i}`,
-    paymentStatus: <Badge progress="complete">Paid</Badge>,
-    fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-  }));
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
 
-  const resourceName = {
-    singular: 'order',
-    plural: 'orders',
-  };
+    const groupedProducts = groupRowsBy(
+      'color',
+      (color) => `color--${color.toLowerCase()}`,
+    );
 
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(orders);
+    const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
+      const {products, position, id: subheaderId} = groupedProducts[color];
+      let selected: IndexTableRowProps['selected'] = false;
 
-  const rowMarkup = orders.map(
-    (
-      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text variant="bodyMd" fontWeight="bold" as="span">
-            {order}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{date}</IndexTable.Cell>
-        <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
+      const someProductsSelected = products.some(({id}) =>
+        selectedResources.includes(id),
+      );
 
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
+      const allProductsSelected = products.every(({id}) =>
+        selectedResources.includes(id),
+      );
 
-  return (
-    <LegacyCard>
+      if (allProductsSelected) {
+        selected = true;
+      } else if (someProductsSelected) {
+        selected = 'indeterminate';
+      }
+
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === products[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === products[products.length - 1].id,
+        ),
+      ];
+
+      const disabled = products.every(({disabled}) => disabled);
+
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all products wich has color ${color}`}
+          >
+            <IndexTable.Cell>
+              <InlineStack gap="400" blockAlign="center">
+                <Thumbnail
+                  source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                  size="medium"
+                  alt="Black choker necklace"
+                />
+                <Text as="span" fontWeight="semibold">
+                  {color}
+                </Text>
+              </InlineStack>
+            </IndexTable.Cell>
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+          </IndexTable.Row>
+          {products.map(
+            ({id, size, quantity, price, position, disabled}, rowIndex) => {
+              return (
+                <IndexTable.Row
+                  rowType="child"
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
+                >
+                  <IndexTable.Cell>
+                    <Box>
+                      <InlineStack gap="400" blockAlign="center">
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                          size="small"
+                          alt="Black choker necklace"
+                        />
+                        <Text variant="bodyMd" as="span">
+                          {size}
+                        </Text>
+                      </InlineStack>
+                    </Box>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" numeric>
+                      {price}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {quantity}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          onSelectionChange={handleSelectionChange}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
+          selectable
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithNestedRowsWithThumbnailsOneCellNonSelectable = {
+  render() {
+    const rows = [
+      {
+        id: '3411',
+        quantity: 11,
+        price: '$2,400',
+        size: 'Small Lorem ipsum dolor sit amet',
+        color: 'Orange Lorem ipsum dolor sit amet',
+      },
+      {
+        id: '2562',
+        quantity: 30,
+        price: '$975',
+        size: 'Medium',
+        color: 'Orange',
+      },
+      {
+        id: '4102',
+        quantity: 27,
+        price: '$2885',
+        size: 'Large',
+        color: 'Orange',
+      },
+      {
+        id: '2564',
+        quantity: 19,
+        price: '$1,209',
+        size: 'Small',
+        color: 'Red',
+        disabled: true,
+      },
+      {
+        id: '2563',
+        quantity: 22,
+        price: '$1,400',
+        size: 'Small',
+        color: 'Green',
+      },
+    ];
+
+    const columnHeadings = [
+      {title: 'Name', id: 'column-header--size'},
+      {
+        hidden: false,
+        id: 'column-header--price',
+        title: 'Price',
+      },
+      {
+        alignment: 'end',
+        id: 'column-header--quantity',
+        title: 'Available',
+      },
+    ];
+
+    const groupRowsBy = (groupKey: string, resolveId: (groupVal) => string) => {
+      let position = -1;
+      const groups = rows.reduce((groups, product) => {
+        const groupVal = product[groupKey];
+        if (!groups[groupVal]) {
+          position += 1;
+
+          groups[groupVal] = {
+            position,
+            products: [],
+            id: resolveId(groupVal),
+          };
+        }
+        groups[groupVal].products.push({
+          ...product,
+          position: position + 1,
+        });
+
+        position += 1;
+        return groups;
+      }, {});
+
+      return groups;
+    };
+
+    const resourceName = {
+      singular: 'product',
+      plural: 'products',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(rows, {resourceFilter: ({disabled}) => !disabled});
+
+    const groupedProducts = groupRowsBy(
+      'color',
+      (color) => `color--${color.toLowerCase()}`,
+    );
+
+    const rowMarkup = Object.keys(groupedProducts).map((color, index) => {
+      const {products, position, id: subheaderId} = groupedProducts[color];
+      let selected: IndexTableRowProps['selected'] = false;
+
+      const someProductsSelected = products.some(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      const allProductsSelected = products.every(({id}) =>
+        selectedResources.includes(id),
+      );
+
+      if (allProductsSelected) {
+        selected = true;
+      } else if (someProductsSelected) {
+        selected = 'indeterminate';
+      }
+
+      const selectableRows = rows.filter(({disabled}) => !disabled);
+      const rowRange: IndexTableRowProps['selectionRange'] = [
+        selectableRows.findIndex((row) => row.id === products[0].id),
+        selectableRows.findIndex(
+          (row) => row.id === products[products.length - 1].id,
+        ),
+      ];
+
+      const disabled = products.every(({disabled}) => disabled);
+
+      return (
+        <Fragment key={subheaderId}>
+          <IndexTable.Row
+            selectionRange={rowRange}
+            id={`Subheader-${index}`}
+            position={position}
+            selected={selected}
+            disabled={disabled}
+            accessibilityLabel={`Select all products wich has color ${color}`}
+          >
+            <IndexTable.Cell>
+              <InlineStack gap="400" blockAlign="center">
+                <Thumbnail
+                  source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                  size="medium"
+                  alt="Black choker necklace"
+                />
+                <Text as="span" fontWeight="semibold">
+                  {color}
+                </Text>
+              </InlineStack>
+            </IndexTable.Cell>
+            <IndexTable.Cell />
+            <IndexTable.Cell />
+          </IndexTable.Row>
+          {products.map(
+            ({id, size, quantity, price, position, disabled}, rowIndex) => {
+              return (
+                <IndexTable.Row
+                  rowType="child"
+                  key={rowIndex}
+                  id={id}
+                  position={position}
+                  selected={selectedResources.includes(id)}
+                  disabled={disabled}
+                >
+                  <IndexTable.Cell>
+                    <Box>
+                      <InlineStack gap="400" blockAlign="center">
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                          size="small"
+                          alt="Black choker necklace"
+                        />
+                        <Text variant="bodyMd" as="span">
+                          {size}
+                        </Text>
+                      </InlineStack>
+                    </Box>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" numeric>
+                      {price}
+                    </Text>
+                  </IndexTable.Cell>
+                  <IndexTable.Cell>
+                    <Text as="span" alignment="end" numeric variant="bodyMd">
+                      {quantity}
+                    </Text>
+                  </IndexTable.Cell>
+                </IndexTable.Row>
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          condensed={useBreakpoints().smDown}
+          onSelectionChange={handleSelectionChange}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          resourceName={resourceName}
+          itemCount={rows.length}
+          headings={columnHeadings as IndexTableProps['headings']}
+          selectable={false}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithLongDataSetNonSelectable = {
+  render() {
+    const orders = Array.from(Array(100).keys()).map((i) => ({
+      id: `${i}`,
+      order: i,
+      date: 'Jul 20 at 4:34pm',
+      customer: 'Jaydon Stanton',
+      total: `$969.44${i}`,
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    }));
+
+    const resourceName = {
+      singular: 'order',
+      plural: 'orders',
+    };
+
+    const rowMarkup = orders.map(
+      (
+        {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+        index,
+      ) => (
+        <IndexTable.Row id={id} key={id} position={index}>
+          <IndexTable.Cell>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {order}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{date}</IndexTable.Cell>
+          <IndexTable.Cell>{customer}</IndexTable.Cell>
+          <IndexTable.Cell>{total}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={orders.length}
+          headings={[
+            {title: 'Order'},
+            {title: 'Date'},
+            {title: 'Customer'},
+            {title: 'Total', alignment: 'end'},
+            {title: 'Payment status'},
+            {title: 'Fulfillment status'},
+          ]}
+          selectable={false}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithLongDataSetSelectable = {
+  render() {
+    const orders = Array.from(Array(100).keys()).map((i) => ({
+      id: `${i}`,
+      order: i,
+      date: 'Jul 20 at 4:34pm',
+      customer: 'Jaydon Stanton',
+      total: `$969.44${i}`,
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    }));
+
+    const resourceName = {
+      singular: 'order',
+      plural: 'orders',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(orders);
+
+    const rowMarkup = orders.map(
+      (
+        {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {order}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{date}</IndexTable.Cell>
+          <IndexTable.Cell>{customer}</IndexTable.Cell>
+          <IndexTable.Cell>{total}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    return (
+      <LegacyCard>
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={orders.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Order', hidden: true},
+            {title: 'Date'},
+            {title: 'Customer'},
+            {title: 'Total', alignment: 'end'},
+            {title: 'Payment status'},
+            {title: 'Fulfillment status'},
+          ]}
+          bulkActions={bulkActions}
+          selectable
+        >
+          {rowMarkup}
+        </IndexTable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithinAModal = {
+  render() {
+    const [active, setActive] = useState(true);
+    const [checked, setChecked] = useState(false);
+
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+    const handleCheckbox = useCallback((value) => setChecked(value), []);
+
+    const activator = <Button onClick={toggleActive}>Open</Button>;
+
+    const orders = Array.from(Array(100).keys()).map((i) => ({
+      id: `${i}`,
+      order: i,
+      date: 'Jul 20 at 4:34pm',
+      customer: 'Jaydon Stanton',
+      total: `$969.44${i}`,
+      paymentStatus: <Badge progress="complete">Paid</Badge>,
+      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+    }));
+
+    const resourceName = {
+      singular: 'order',
+      plural: 'orders',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(orders);
+
+    const rowMarkup = orders.map(
+      (
+        {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {order}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{date}</IndexTable.Cell>
+          <IndexTable.Cell>{customer}</IndexTable.Cell>
+          <IndexTable.Cell>{total}</IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    const table = (
       <IndexTable
         resourceName={resourceName}
         itemCount={orders.length}
@@ -7217,225 +7409,135 @@ export function WithLongDataSetSelectable() {
       >
         {rowMarkup}
       </IndexTable>
-    </LegacyCard>
-  );
-}
+    );
 
-export function WithinAModal() {
-  const [active, setActive] = useState(true);
-  const [checked, setChecked] = useState(false);
-
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
-
-  const handleCheckbox = useCallback((value) => setChecked(value), []);
-
-  const activator = <Button onClick={toggleActive}>Open</Button>;
-
-  const orders = Array.from(Array(100).keys()).map((i) => ({
-    id: `${i}`,
-    order: i,
-    date: 'Jul 20 at 4:34pm',
-    customer: 'Jaydon Stanton',
-    total: `$969.44${i}`,
-    paymentStatus: <Badge progress="complete">Paid</Badge>,
-    fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-  }));
-
-  const resourceName = {
-    singular: 'order',
-    plural: 'orders',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(orders);
-
-  const rowMarkup = orders.map(
-    (
-      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text variant="bodyMd" fontWeight="bold" as="span">
-            {order}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{date}</IndexTable.Cell>
-        <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>{total}</IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  const table = (
-    <IndexTable
-      resourceName={resourceName}
-      itemCount={orders.length}
-      selectedItemsCount={
-        allResourcesSelected ? 'All' : selectedResources.length
-      }
-      onSelectionChange={handleSelectionChange}
-      headings={[
-        {title: 'Order', hidden: true},
-        {title: 'Date'},
-        {title: 'Customer'},
-        {title: 'Total', alignment: 'end'},
-        {title: 'Payment status'},
-        {title: 'Fulfillment status'},
-      ]}
-      bulkActions={bulkActions}
-      selectable
-    >
-      {rowMarkup}
-    </IndexTable>
-  );
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          noScroll
-          activator={activator}
-          open={active}
-          onClose={toggleActive}
-          title="Import customers by CSV"
-          primaryAction={{
-            content: 'Import customers',
-            onAction: toggleActive,
-          }}
-          secondaryActions={[
-            {
-              content: 'Cancel',
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            noScroll
+            activator={activator}
+            open={active}
+            onClose={toggleActive}
+            title="Import customers by CSV"
+            primaryAction={{
+              content: 'Import customers',
               onAction: toggleActive,
-            },
-          ]}
-        >
-          <Box>
-            <Scrollable style={{height: '65dvh'}}>{table}</Scrollable>
-          </Box>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function WithUnmountingTable() {
-  const [isShowing, setIsShowing] = useState(true);
-  const orders = [
-    {
-      id: '1020',
-      order: '#1020',
-      date: 'Jul 20 at 4:34pm',
-      customer: 'Jaydon Stanton',
-      total: '$969.44',
-      paymentStatus: <Badge progress="complete">Paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-    {
-      id: '1019',
-      order: '#1019',
-      date: 'Jul 20 at 3:46pm',
-      customer: 'Ruben Westerfelt',
-      total: '$701.19',
-      paymentStatus: <Badge progress="partiallyComplete">Partially paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-    {
-      id: '1018',
-      order: '#1018',
-      date: 'Jul 20 at 3.44pm',
-      customer: 'Leo Carder',
-      total: '$798.24',
-      paymentStatus: <Badge progress="complete">Paid</Badge>,
-      fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
-    },
-  ];
-  const resourceName = {
-    singular: 'order',
-    plural: 'orders',
-  };
-
-  const {selectedResources, allResourcesSelected, handleSelectionChange} =
-    useIndexResourceState(orders);
-
-  const rowMarkup = orders.map(
-    (
-      {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
-      index,
-    ) => (
-      <IndexTable.Row
-        id={id}
-        key={id}
-        selected={selectedResources.includes(id)}
-        position={index}
-      >
-        <IndexTable.Cell>
-          <Text variant="bodyMd" fontWeight="bold" as="span">
-            {order}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{date}</IndexTable.Cell>
-        <IndexTable.Cell>{customer}</IndexTable.Cell>
-        <IndexTable.Cell>
-          <Text as="span" alignment="end" numeric variant="bodyMd">
-            {total}
-          </Text>
-        </IndexTable.Cell>
-        <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
-        <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
-      </IndexTable.Row>
-    ),
-  );
-
-  return (
-    <>
-      {isShowing && (
-        <LegacyCard>
-          <IndexTable
-            resourceName={resourceName}
-            itemCount={orders.length}
-            selectedItemsCount={
-              allResourcesSelected ? 'All' : selectedResources.length
-            }
-            onSelectionChange={handleSelectionChange}
-            headings={[
-              {title: 'Order'},
-              {title: 'Date'},
-              {title: 'Customer'},
-              {title: 'Total', alignment: 'end'},
-              {title: 'Payment status'},
-              {title: 'Fulfillment status'},
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: toggleActive,
+              },
             ]}
           >
-            {rowMarkup}
-          </IndexTable>
-        </LegacyCard>
-      )}
-      <button onClick={() => setIsShowing(!isShowing)}>Toggle</button>
-    </>
-  );
-}
+            <Box>
+              <Scrollable style={{height: '65dvh'}}>{table}</Scrollable>
+            </Box>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const WithUnmountingTable = {
+  render() {
+    const [isShowing, setIsShowing] = useState(true);
+    const orders = [
+      {
+        id: '1020',
+        order: '#1020',
+        date: 'Jul 20 at 4:34pm',
+        customer: 'Jaydon Stanton',
+        total: '$969.44',
+        paymentStatus: <Badge progress="complete">Paid</Badge>,
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+      {
+        id: '1019',
+        order: '#1019',
+        date: 'Jul 20 at 3:46pm',
+        customer: 'Ruben Westerfelt',
+        total: '$701.19',
+        paymentStatus: (
+          <Badge progress="partiallyComplete">Partially paid</Badge>
+        ),
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+      {
+        id: '1018',
+        order: '#1018',
+        date: 'Jul 20 at 3.44pm',
+        customer: 'Leo Carder',
+        total: '$798.24',
+        paymentStatus: <Badge progress="complete">Paid</Badge>,
+        fulfillmentStatus: <Badge progress="incomplete">Unfulfilled</Badge>,
+      },
+    ];
+    const resourceName = {
+      singular: 'order',
+      plural: 'orders',
+    };
+
+    const {selectedResources, allResourcesSelected, handleSelectionChange} =
+      useIndexResourceState(orders);
+
+    const rowMarkup = orders.map(
+      (
+        {id, order, date, customer, total, paymentStatus, fulfillmentStatus},
+        index,
+      ) => (
+        <IndexTable.Row
+          id={id}
+          key={id}
+          selected={selectedResources.includes(id)}
+          position={index}
+        >
+          <IndexTable.Cell>
+            <Text variant="bodyMd" fontWeight="bold" as="span">
+              {order}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{date}</IndexTable.Cell>
+          <IndexTable.Cell>{customer}</IndexTable.Cell>
+          <IndexTable.Cell>
+            <Text as="span" alignment="end" numeric variant="bodyMd">
+              {total}
+            </Text>
+          </IndexTable.Cell>
+          <IndexTable.Cell>{paymentStatus}</IndexTable.Cell>
+          <IndexTable.Cell>{fulfillmentStatus}</IndexTable.Cell>
+        </IndexTable.Row>
+      ),
+    );
+
+    return (
+      <>
+        {isShowing && (
+          <LegacyCard>
+            <IndexTable
+              resourceName={resourceName}
+              itemCount={orders.length}
+              selectedItemsCount={
+                allResourcesSelected ? 'All' : selectedResources.length
+              }
+              onSelectionChange={handleSelectionChange}
+              headings={[
+                {title: 'Order'},
+                {title: 'Date'},
+                {title: 'Customer'},
+                {title: 'Total', alignment: 'end'},
+                {title: 'Payment status'},
+                {title: 'Fulfillment status'},
+              ]}
+            >
+              {rowMarkup}
+            </IndexTable>
+          </LegacyCard>
+        )}
+        <button onClick={() => setIsShowing(!isShowing)}>Toggle</button>
+      </>
+    );
+  },
+};

--- a/polaris-react/src/components/InlineError/InlineError.stories.tsx
+++ b/polaris-react/src/components/InlineError/InlineError.stories.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {InlineError} from '@shopify/polaris';
 
 export default {
   component: InlineError,
-} as ComponentMeta<typeof InlineError>;
+} as Meta<typeof InlineError>;
 
-export function Default() {
-  return <InlineError message="Store name is required" fieldID="myFieldID" />;
-}
+export const Default = {
+  render() {
+    return <InlineError message="Store name is required" fieldID="myFieldID" />;
+  },
+};

--- a/polaris-react/src/components/InlineGrid/InlineGrid.stories.tsx
+++ b/polaris-react/src/components/InlineGrid/InlineGrid.stories.tsx
@@ -1,129 +1,145 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Button, InlineGrid, Page} from '@shopify/polaris';
 import {ChevronLeftIcon, ChevronRightIcon} from '@shopify/polaris-icons';
 
 export default {
   component: InlineGrid,
-} as ComponentMeta<typeof InlineGrid>;
+} as Meta<typeof InlineGrid>;
 
-export function Default() {
-  return (
-    <Page fullWidth>
-      <InlineGrid>
-        <div style={{background: 'aquamarine'}}>one</div>
-        <div style={{background: 'aquamarine'}}>two</div>
-        <div style={{background: 'aquamarine'}}>three</div>
-        <div style={{background: 'aquamarine'}}>four</div>
-        <div style={{background: 'aquamarine'}}>five</div>
-        <div style={{background: 'aquamarine'}}>six</div>
-      </InlineGrid>
-    </Page>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <Page fullWidth>
+        <InlineGrid>
+          <div style={{background: 'aquamarine'}}>one</div>
+          <div style={{background: 'aquamarine'}}>two</div>
+          <div style={{background: 'aquamarine'}}>three</div>
+          <div style={{background: 'aquamarine'}}>four</div>
+          <div style={{background: 'aquamarine'}}>five</div>
+          <div style={{background: 'aquamarine'}}>six</div>
+        </InlineGrid>
+      </Page>
+    );
+  },
+};
 
-export function WithTemplateInlineGrid() {
-  return (
-    <Page fullWidth>
-      <InlineGrid
-        columns={{
-          xs: '1.5fr 0.5fr',
-          sm: '2fr 1fr',
-          md: '1fr 3fr auto 1fr',
-          lg: '1fr 4fr auto 2fr 3fr auto',
-        }}
-      >
-        <div style={{background: 'aquamarine'}}>Column one</div>
-        <div style={{background: 'aquamarine'}}>Column two</div>
-        <div style={{background: 'aquamarine'}}>Column three</div>
-        <div style={{background: 'aquamarine'}}>Column four</div>
-        <div style={{background: 'aquamarine'}}>Column five</div>
-        <div style={{background: 'aquamarine'}}>Column six</div>
-      </InlineGrid>
-    </Page>
-  );
-}
+export const WithTemplateInlineGrid = {
+  render() {
+    return (
+      <Page fullWidth>
+        <InlineGrid
+          columns={{
+            xs: '1.5fr 0.5fr',
+            sm: '2fr 1fr',
+            md: '1fr 3fr auto 1fr',
+            lg: '1fr 4fr auto 2fr 3fr auto',
+          }}
+        >
+          <div style={{background: 'aquamarine'}}>Column one</div>
+          <div style={{background: 'aquamarine'}}>Column two</div>
+          <div style={{background: 'aquamarine'}}>Column three</div>
+          <div style={{background: 'aquamarine'}}>Column four</div>
+          <div style={{background: 'aquamarine'}}>Column five</div>
+          <div style={{background: 'aquamarine'}}>Column six</div>
+        </InlineGrid>
+      </Page>
+    );
+  },
+};
 
-export function WithMixedPropTypes() {
-  return (
-    <Page fullWidth>
-      <InlineGrid
-        columns={{xs: 2, sm: '2fr 1fr', md: '2fr 1fr 1fr', lg: 6}}
-        gap={{xs: '200'}}
-      >
-        <div style={{background: 'aquamarine'}}>one</div>
-        <div style={{background: 'aquamarine'}}>two</div>
-        <div style={{background: 'aquamarine'}}>three</div>
-        <div style={{background: 'aquamarine'}}>four</div>
-        <div style={{background: 'aquamarine'}}>five</div>
-        <div style={{background: 'aquamarine'}}>six</div>
-      </InlineGrid>
-    </Page>
-  );
-}
+export const WithMixedPropTypes = {
+  render() {
+    return (
+      <Page fullWidth>
+        <InlineGrid
+          columns={{xs: 2, sm: '2fr 1fr', md: '2fr 1fr 1fr', lg: 6}}
+          gap={{xs: '200'}}
+        >
+          <div style={{background: 'aquamarine'}}>one</div>
+          <div style={{background: 'aquamarine'}}>two</div>
+          <div style={{background: 'aquamarine'}}>three</div>
+          <div style={{background: 'aquamarine'}}>four</div>
+          <div style={{background: 'aquamarine'}}>five</div>
+          <div style={{background: 'aquamarine'}}>six</div>
+        </InlineGrid>
+      </Page>
+    );
+  },
+};
 
-export function WithGap() {
-  return (
-    <Page fullWidth>
-      <InlineGrid columns={{xs: 3}} gap="500">
-        <div style={{background: 'aquamarine'}}>Column one</div>
-        <div style={{background: 'aquamarine'}}>Column two</div>
-        <div style={{background: 'aquamarine'}}>Column three</div>
-      </InlineGrid>
-    </Page>
-  );
-}
+export const WithGap = {
+  render() {
+    return (
+      <Page fullWidth>
+        <InlineGrid columns={{xs: 3}} gap="500">
+          <div style={{background: 'aquamarine'}}>Column one</div>
+          <div style={{background: 'aquamarine'}}>Column two</div>
+          <div style={{background: 'aquamarine'}}>Column three</div>
+        </InlineGrid>
+      </Page>
+    );
+  },
+};
 
-export function WithResponsiveGap() {
-  return (
-    <Page fullWidth>
-      <InlineGrid
-        columns={{xs: 3}}
-        gap={{xs: '025', sm: '400', md: '600', lg: '800', xl: '1000'}}
-      >
-        <div style={{background: 'aquamarine'}}>Column one</div>
-        <div style={{background: 'aquamarine'}}>Column two</div>
-        <div style={{background: 'aquamarine'}}>Column three</div>
-      </InlineGrid>
-    </Page>
-  );
-}
+export const WithResponsiveGap = {
+  render() {
+    return (
+      <Page fullWidth>
+        <InlineGrid
+          columns={{xs: 3}}
+          gap={{xs: '025', sm: '400', md: '600', lg: '800', xl: '1000'}}
+        >
+          <div style={{background: 'aquamarine'}}>Column one</div>
+          <div style={{background: 'aquamarine'}}>Column two</div>
+          <div style={{background: 'aquamarine'}}>Column three</div>
+        </InlineGrid>
+      </Page>
+    );
+  },
+};
 
-export function WithFreeAndFixedWidths() {
-  return (
-    <Page fullWidth>
-      <InlineGrid columns={{xs: '1fr auto auto'}} gap={{xs: '050'}}>
-        <div style={{background: 'aquamarine'}}>Column one</div>
-        <div style={{background: 'aquamarine'}}>
-          <Button icon={ChevronLeftIcon} accessibilityLabel="Previous" />
-        </div>
-        <div style={{background: 'aquamarine'}}>
-          <Button icon={ChevronRightIcon} accessibilityLabel="Next" />
-        </div>
-      </InlineGrid>
-    </Page>
-  );
-}
+export const WithFreeAndFixedWidths = {
+  render() {
+    return (
+      <Page fullWidth>
+        <InlineGrid columns={{xs: '1fr auto auto'}} gap={{xs: '050'}}>
+          <div style={{background: 'aquamarine'}}>Column one</div>
+          <div style={{background: 'aquamarine'}}>
+            <Button icon={ChevronLeftIcon} accessibilityLabel="Previous" />
+          </div>
+          <div style={{background: 'aquamarine'}}>
+            <Button icon={ChevronRightIcon} accessibilityLabel="Next" />
+          </div>
+        </InlineGrid>
+      </Page>
+    );
+  },
+};
 
-export function WithResponsiveInlineGrid() {
-  return (
-    <Page fullWidth>
-      <InlineGrid columns={{xs: 1, sm: 3}} gap="400">
-        <div style={{background: 'aquamarine'}}>Column one</div>
-        <div style={{background: 'aquamarine'}}>Column two</div>
-        <div style={{background: 'aquamarine'}}>Column three</div>
-      </InlineGrid>
-    </Page>
-  );
-}
+export const WithResponsiveInlineGrid = {
+  render() {
+    return (
+      <Page fullWidth>
+        <InlineGrid columns={{xs: 1, sm: 3}} gap="400">
+          <div style={{background: 'aquamarine'}}>Column one</div>
+          <div style={{background: 'aquamarine'}}>Column two</div>
+          <div style={{background: 'aquamarine'}}>Column three</div>
+        </InlineGrid>
+      </Page>
+    );
+  },
+};
 
-export function WithResponsiveColumnAlisases() {
-  return (
-    <Page fullWidth>
-      <InlineGrid columns={['oneThird', 'twoThirds']} gap="400">
-        <div style={{background: 'aquamarine'}}>Column one</div>
-        <div style={{background: 'aquamarine'}}>Column two</div>
-      </InlineGrid>
-    </Page>
-  );
-}
+export const WithResponsiveColumnAlisases = {
+  render() {
+    return (
+      <Page fullWidth>
+        <InlineGrid columns={['oneThird', 'twoThirds']} gap="400">
+          <div style={{background: 'aquamarine'}}>Column one</div>
+          <div style={{background: 'aquamarine'}}>Column two</div>
+        </InlineGrid>
+      </Page>
+    );
+  },
+};

--- a/polaris-react/src/components/InlineStack/InlineStack.stories.tsx
+++ b/polaris-react/src/components/InlineStack/InlineStack.stories.tsx
@@ -1,203 +1,239 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Box, Badge, Icon, InlineStack, Thumbnail} from '@shopify/polaris';
 import {FlowerIcon, ImageIcon} from '@shopify/polaris-icons';
 
 export default {
   component: InlineStack,
-} as ComponentMeta<typeof InlineStack>;
+} as Meta<typeof InlineStack>;
 
-export function Default() {
-  return (
-    <InlineStack>
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-      <Box>
-        <Icon source={FlowerIcon} tone="primary" />
-      </Box>
-    </InlineStack>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <InlineStack>
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+        <Box>
+          <Icon source={FlowerIcon} tone="primary" />
+        </Box>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithAlignStart() {
-  return (
-    <InlineStack align="start" blockAlign="center" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithAlignStart = {
+  render() {
+    return (
+      <InlineStack align="start" blockAlign="center" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithAlignCenter() {
-  return (
-    <InlineStack align="center" blockAlign="center" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithAlignCenter = {
+  render() {
+    return (
+      <InlineStack align="center" blockAlign="center" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithAlignEnd() {
-  return (
-    <InlineStack align="end" blockAlign="center" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithAlignEnd = {
+  render() {
+    return (
+      <InlineStack align="end" blockAlign="center" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithAlignSpaceAround() {
-  return (
-    <InlineStack align="space-around" gap="100">
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithAlignSpaceAround = {
+  render() {
+    return (
+      <InlineStack align="space-around" gap="100">
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithAlignSpaceBetween() {
-  return (
-    <InlineStack align="space-between" gap="100">
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithAlignSpaceBetween = {
+  render() {
+    return (
+      <InlineStack align="space-between" gap="100">
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithAlignSpaceEvenly() {
-  return (
-    <InlineStack align="space-evenly" gap="100">
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithAlignSpaceEvenly = {
+  render() {
+    return (
+      <InlineStack align="space-evenly" gap="100">
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithBlockAlignStart() {
-  return (
-    <InlineStack blockAlign="start" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithBlockAlignStart = {
+  render() {
+    return (
+      <InlineStack blockAlign="start" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithBlockAlignCenter() {
-  return (
-    <InlineStack blockAlign="center" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithBlockAlignCenter = {
+  render() {
+    return (
+      <InlineStack blockAlign="center" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithBlockAlignEnd() {
-  return (
-    <InlineStack blockAlign="end" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithBlockAlignEnd = {
+  render() {
+    return (
+      <InlineStack blockAlign="end" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithBlockAlignBaseline() {
-  return (
-    <InlineStack blockAlign="baseline" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithBlockAlignBaseline = {
+  render() {
+    return (
+      <InlineStack blockAlign="baseline" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithBlockAlignStretch() {
-  return (
-    <InlineStack blockAlign="stretch" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithBlockAlignStretch = {
+  render() {
+    return (
+      <InlineStack blockAlign="stretch" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithAlignCenterBlockAlignCenter() {
-  return (
-    <InlineStack align="center" blockAlign="center" gap="100">
-      <Thumbnail source={ImageIcon} alt="example" />
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithAlignCenterBlockAlignCenter = {
+  render() {
+    return (
+      <InlineStack align="center" blockAlign="center" gap="100">
+        <Thumbnail source={ImageIcon} alt="example" />
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithNonWrapping() {
-  return (
-    <InlineStack wrap={false} gap="100">
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
-    </InlineStack>
-  );
-}
+export const WithNonWrapping = {
+  render() {
+    return (
+      <InlineStack wrap={false} gap="100">
+        <Badge>Paid</Badge>
+        <Badge>Processing</Badge>
+        <Badge>Fulfilled</Badge>
+        <Badge>Completed</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithGap() {
-  return (
-    <InlineStack gap="800">
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
-    </InlineStack>
-  );
-}
+export const WithGap = {
+  render() {
+    return (
+      <InlineStack gap="800">
+        <Badge>Paid</Badge>
+        <Badge>Processing</Badge>
+        <Badge>Fulfilled</Badge>
+        <Badge>Completed</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithResponsiveGap() {
-  return (
-    <InlineStack gap={{xs: '200', md: '400'}}>
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
-    </InlineStack>
-  );
-}
+export const WithResponsiveGap = {
+  render() {
+    return (
+      <InlineStack gap={{xs: '200', md: '400'}}>
+        <Badge>Paid</Badge>
+        <Badge>Processing</Badge>
+        <Badge>Fulfilled</Badge>
+        <Badge>Completed</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithDirectionReversed() {
-  return (
-    <InlineStack direction="row-reverse" gap="200">
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithDirectionReversed = {
+  render() {
+    return (
+      <InlineStack direction="row-reverse" gap="200">
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};
 
-export function WithResponsiveDirectionReversed() {
-  return (
-    <InlineStack direction={{xs: 'row', md: 'row-reverse'}} gap="200">
-      <Badge>One</Badge>
-      <Badge>Two</Badge>
-      <Badge>Three</Badge>
-    </InlineStack>
-  );
-}
+export const WithResponsiveDirectionReversed = {
+  render() {
+    return (
+      <InlineStack direction={{xs: 'row', md: 'row-reverse'}} gap="200">
+        <Badge>One</Badge>
+        <Badge>Two</Badge>
+        <Badge>Three</Badge>
+      </InlineStack>
+    );
+  },
+};

--- a/polaris-react/src/components/KeyboardKey/KeyboardKey.stories.tsx
+++ b/polaris-react/src/components/KeyboardKey/KeyboardKey.stories.tsx
@@ -1,97 +1,103 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {KeyboardKey, Card, Text, BlockStack} from '@shopify/polaris';
 
 export default {
   component: KeyboardKey,
-} as ComponentMeta<typeof KeyboardKey>;
+} as Meta<typeof KeyboardKey>;
 
-export function Default() {
-  return (
-    <Card>
-      <div style={{display: 'flex', gap: '20px'}}>
-        <div style={{display: 'flex', flexDirection: 'column'}}>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey>⌘</KeyboardKey>
-            <KeyboardKey>s</KeyboardKey>
-          </div>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey>ctrl</KeyboardKey>
-            <KeyboardKey>s</KeyboardKey>
-          </div>
-        </div>
-
-        <div style={{display: 'flex', flexDirection: 'column'}}>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey>⌘</KeyboardKey>
-            <KeyboardKey>/</KeyboardKey>
-          </div>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey>ctrl</KeyboardKey>
-            <KeyboardKey>/</KeyboardKey>
-          </div>
-        </div>
-      </div>
-    </Card>
-  );
-}
-
-export function Small() {
-  return (
-    <Card>
-      <div style={{display: 'flex', gap: '20px'}}>
-        <div style={{display: 'flex', flexDirection: 'column'}}>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey size="small">⌘</KeyboardKey>
-            <KeyboardKey size="small">d</KeyboardKey>
-          </div>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey size="small">⌘</KeyboardKey>
-            <KeyboardKey size="small">h</KeyboardKey>
-          </div>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey size="small">⌘</KeyboardKey>
-            <KeyboardKey size="small">⌫</KeyboardKey>
-          </div>
-        </div>
-        <div style={{display: 'flex', flexDirection: 'column'}}>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey size="small">ctrl</KeyboardKey>
-            <KeyboardKey size="small">d</KeyboardKey>
-          </div>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey size="small">ctrl</KeyboardKey>
-            <KeyboardKey size="small">h</KeyboardKey>
-          </div>
-          <div style={{display: 'flex'}}>
-            <KeyboardKey size="small">ctrl</KeyboardKey>
-            <KeyboardKey size="small">⌫</KeyboardKey>
-          </div>
-        </div>
-      </div>
-    </Card>
-  );
-}
-
-export function All() {
-  return (
-    <BlockStack gap="200">
-      <Text as="h2" variant="headingMd">
-        Default
-      </Text>
+export const Default = {
+  render() {
+    return (
       <Card>
-        <KeyboardKey>ctrl</KeyboardKey>
-        <KeyboardKey>⌘</KeyboardKey>
-        <KeyboardKey>h</KeyboardKey>
+        <div style={{display: 'flex', gap: '20px'}}>
+          <div style={{display: 'flex', flexDirection: 'column'}}>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey>⌘</KeyboardKey>
+              <KeyboardKey>s</KeyboardKey>
+            </div>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey>ctrl</KeyboardKey>
+              <KeyboardKey>s</KeyboardKey>
+            </div>
+          </div>
+
+          <div style={{display: 'flex', flexDirection: 'column'}}>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey>⌘</KeyboardKey>
+              <KeyboardKey>/</KeyboardKey>
+            </div>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey>ctrl</KeyboardKey>
+              <KeyboardKey>/</KeyboardKey>
+            </div>
+          </div>
+        </div>
       </Card>
-      <Text as="h2" variant="headingMd">
-        Small
-      </Text>
+    );
+  },
+};
+
+export const Small = {
+  render() {
+    return (
       <Card>
-        <KeyboardKey size="small">ctrl</KeyboardKey>
-        <KeyboardKey size="small">⌘</KeyboardKey>
-        <KeyboardKey size="small">h</KeyboardKey>
+        <div style={{display: 'flex', gap: '20px'}}>
+          <div style={{display: 'flex', flexDirection: 'column'}}>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey size="small">⌘</KeyboardKey>
+              <KeyboardKey size="small">d</KeyboardKey>
+            </div>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey size="small">⌘</KeyboardKey>
+              <KeyboardKey size="small">h</KeyboardKey>
+            </div>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey size="small">⌘</KeyboardKey>
+              <KeyboardKey size="small">⌫</KeyboardKey>
+            </div>
+          </div>
+          <div style={{display: 'flex', flexDirection: 'column'}}>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey size="small">ctrl</KeyboardKey>
+              <KeyboardKey size="small">d</KeyboardKey>
+            </div>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey size="small">ctrl</KeyboardKey>
+              <KeyboardKey size="small">h</KeyboardKey>
+            </div>
+            <div style={{display: 'flex'}}>
+              <KeyboardKey size="small">ctrl</KeyboardKey>
+              <KeyboardKey size="small">⌫</KeyboardKey>
+            </div>
+          </div>
+        </div>
       </Card>
-    </BlockStack>
-  );
-}
+    );
+  },
+};
+
+export const All = {
+  render() {
+    return (
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingMd">
+          Default
+        </Text>
+        <Card>
+          <KeyboardKey>ctrl</KeyboardKey>
+          <KeyboardKey>⌘</KeyboardKey>
+          <KeyboardKey>h</KeyboardKey>
+        </Card>
+        <Text as="h2" variant="headingMd">
+          Small
+        </Text>
+        <Card>
+          <KeyboardKey size="small">ctrl</KeyboardKey>
+          <KeyboardKey size="small">⌘</KeyboardKey>
+          <KeyboardKey size="small">h</KeyboardKey>
+        </Card>
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/Layout/Layout.stories.tsx
+++ b/polaris-react/src/components/Layout/Layout.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Banner,
   Box,
@@ -16,483 +16,500 @@ import {
 
 export default {
   component: Layout,
-} as ComponentMeta<typeof Layout>;
+} as Meta<typeof Layout>;
 
-export function All() {
-  return (
-    <>
-      <Text as="h2" variant="headingXl">
-        One column
-      </Text>
-      <OneColumn />
-      <Box paddingBlockEnd="800" />
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <>
+        <Text as="h2" variant="headingXl">
+          One column
+        </Text>
+        <OneColumn.render />
+        <Box paddingBlockEnd="800" />
 
-      <Text as="h2" variant="headingXl">
-        Two columns with primary and secondary widths
-      </Text>
-      <TwoColumnsWithPrimaryAndSecondaryWidths />
-      <Box paddingBlockEnd="800" />
+        <Text as="h2" variant="headingXl">
+          Two columns with primary and secondary widths
+        </Text>
+        <TwoColumnsWithPrimaryAndSecondaryWidths.render />
+        <Box paddingBlockEnd="800" />
 
-      <Text as="h2" variant="headingXl">
-        Two columns with equal width
-      </Text>
-      <TwoColumnsWithEqualWidth />
-      <Box paddingBlockEnd="800" />
+        <Text as="h2" variant="headingXl">
+          Two columns with equal width
+        </Text>
+        <TwoColumnsWithEqualWidth.render />
+        <Box paddingBlockEnd="800" />
 
-      <Text as="h2" variant="headingXl">
-        Three columns with equal width
-      </Text>
-      <ThreeColumnsWithEqualWidth />
-      <Box paddingBlockEnd="800" />
+        <Text as="h2" variant="headingXl">
+          Three columns with equal width
+        </Text>
+        <ThreeColumnsWithEqualWidth.render />
+        <Box paddingBlockEnd="800" />
 
-      <Text as="h2" variant="headingXl">
-        Annotated
-      </Text>
-      <Annotated />
-      <Box paddingBlockEnd="800" />
+        <Text as="h2" variant="headingXl">
+          Annotated
+        </Text>
+        <Annotated.render />
+        <Box paddingBlockEnd="800" />
 
-      <Text as="h2" variant="headingXl">
-        Annotated with banner at the top
-      </Text>
-      <AnnotatedWithBannerAtTheTop />
-      <Box paddingBlockEnd="800" />
-    </>
-  );
-}
+        <Text as="h2" variant="headingXl">
+          Annotated with banner at the top
+        </Text>
+        <AnnotatedWithBannerAtTheTop.render />
+        <Box paddingBlockEnd="800" />
+      </>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function OneColumn() {
-  return (
-    <Page fullWidth>
-      <Layout>
-        <Layout.Section>
-          <LegacyCard title="Online store dashboard" sectioned>
-            <Text as="p" variant="bodyMd">
-              View a summary of your online store’s performance.
-            </Text>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </Page>
-  );
-}
-
-export function TwoColumnsWithPrimaryAndSecondaryWidths() {
-  return (
-    <Page fullWidth>
-      <Layout>
-        <Layout.Section>
-          <LegacyCard title="Order details" sectioned>
-            <Text as="p" variant="bodyMd">
-              Use to follow a normal section with a secondary section to create
-              a 2/3 + 1/3 layout on detail pages (such as individual product or
-              order pages). Can also be used on any page that needs to structure
-              a lot of content. This layout stacks the columns on small screens.
-            </Text>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard title="Tags" sectioned>
-            <Text as="p" variant="bodyMd">
-              Add tags to your order.
-            </Text>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </Page>
-  );
-}
-
-export function TwoColumnsWithEqualWidth() {
-  return (
-    <Page fullWidth>
-      <Layout>
-        <Layout.Section variant="oneHalf">
-          <LegacyCard title="Florida" actions={[{content: 'Manage'}]}>
-            <LegacyCard.Section>
-              <Text tone="subdued" as="span">
-                455 units available
+export const OneColumn = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Layout>
+          <Layout.Section>
+            <LegacyCard title="Online store dashboard" sectioned>
+              <Text as="p" variant="bodyMd">
+                View a summary of your online store’s performance.
               </Text>
-            </LegacyCard.Section>
-            <LegacyCard.Section title="Items">
-              <ResourceList
-                resourceName={{singular: 'product', plural: 'products'}}
-                items={[
-                  {
-                    id: '341',
-                    url: '#',
-                    name: 'Black & orange scarf',
-                    sku: '9234194023',
-                    quantity: '254',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
-                        alt="Black orange scarf"
-                      />
-                    ),
-                  },
-                  {
-                    id: '256',
-                    url: '#',
-                    name: 'Tucan scarf',
-                    sku: '9234194010',
-                    quantity: '201',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
-                        alt="Tucan scarf"
-                      />
-                    ),
-                  },
-                ]}
-                renderItem={(item) => {
-                  const {id, url, name, sku, media, quantity} = item;
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </Page>
+    );
+  },
+};
 
-                  return (
-                    <ResourceList.Item
-                      id={id}
-                      url={url}
-                      media={media}
-                      accessibilityLabel={`View details for ${name}`}
-                    >
-                      <h3>
-                        <Text fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
-                      <div>SKU: {sku}</div>
-                      <div>{quantity} available</div>
-                    </ResourceList.Item>
-                  );
-                }}
-              />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneHalf">
-          <LegacyCard title="Nevada" actions={[{content: 'Manage'}]}>
-            <LegacyCard.Section>
-              <Text tone="subdued" as="span">
-                301 units available
+export const TwoColumnsWithPrimaryAndSecondaryWidths = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Layout>
+          <Layout.Section>
+            <LegacyCard title="Order details" sectioned>
+              <Text as="p" variant="bodyMd">
+                Use to follow a normal section with a secondary section to
+                create a 2/3 + 1/3 layout on detail pages (such as individual
+                product or order pages). Can also be used on any page that needs
+                to structure a lot of content. This layout stacks the columns on
+                small screens.
               </Text>
-            </LegacyCard.Section>
-            <LegacyCard.Section title="Items">
-              <ResourceList
-                resourceName={{singular: 'product', plural: 'products'}}
-                items={[
-                  {
-                    id: '342',
-                    url: '#',
-                    name: 'Black & orange scarf',
-                    sku: '9234194023',
-                    quantity: '100',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
-                        alt="Black orange scarf"
-                      />
-                    ),
-                  },
-                  {
-                    id: '257',
-                    url: '#',
-                    name: 'Tucan scarf',
-                    sku: '9234194010',
-                    quantity: '201',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
-                        alt="Tucan scarf"
-                      />
-                    ),
-                  },
-                ]}
-                renderItem={(item) => {
-                  const {id, url, name, sku, media, quantity} = item;
-
-                  return (
-                    <ResourceList.Item
-                      id={id}
-                      url={url}
-                      media={media}
-                      accessibilityLabel={`View details for ${name}`}
-                    >
-                      <h3>
-                        <Text fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
-                      <div>SKU: {sku}</div>
-                      <div>{quantity} available</div>
-                    </ResourceList.Item>
-                  );
-                }}
-              />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </Page>
-  );
-}
-
-export function ThreeColumnsWithEqualWidth() {
-  return (
-    <Page fullWidth>
-      <Layout>
-        <Layout.Section variant="oneThird">
-          <LegacyCard title="Florida" actions={[{content: 'Manage'}]}>
-            <LegacyCard.Section>
-              <Text tone="subdued" as="span">
-                455 units available
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard title="Tags" sectioned>
+              <Text as="p" variant="bodyMd">
+                Add tags to your order.
               </Text>
-            </LegacyCard.Section>
-            <LegacyCard.Section title="Items">
-              <ResourceList
-                resourceName={{singular: 'product', plural: 'products'}}
-                items={[
-                  {
-                    id: '343',
-                    url: '#',
-                    name: 'Black & orange scarf',
-                    sku: '9234194023',
-                    quantity: '254',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
-                        alt="Black orange scarf"
-                      />
-                    ),
-                  },
-                  {
-                    id: '258',
-                    url: '#',
-                    name: 'Tucan scarf',
-                    sku: '9234194010',
-                    quantity: '201',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
-                        alt="Tucan scarf"
-                      />
-                    ),
-                  },
-                ]}
-                renderItem={(item) => {
-                  const {id, url, name, sku, media, quantity} = item;
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </Page>
+    );
+  },
+};
 
-                  return (
-                    <ResourceList.Item
-                      id={id}
-                      url={url}
-                      media={media}
-                      accessibilityLabel={`View details for ${name}`}
-                    >
-                      <h3>
-                        <Text fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
-                      <div>SKU: {sku}</div>
-                      <div>{quantity} available</div>
-                    </ResourceList.Item>
-                  );
-                }}
-              />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard title="Nevada" actions={[{content: 'Manage'}]}>
-            <LegacyCard.Section>
-              <Text tone="subdued" as="span">
-                301 units available
+export const TwoColumnsWithEqualWidth = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Layout>
+          <Layout.Section variant="oneHalf">
+            <LegacyCard title="Florida" actions={[{content: 'Manage'}]}>
+              <LegacyCard.Section>
+                <Text tone="subdued" as="span">
+                  455 units available
+                </Text>
+              </LegacyCard.Section>
+              <LegacyCard.Section title="Items">
+                <ResourceList
+                  resourceName={{singular: 'product', plural: 'products'}}
+                  items={[
+                    {
+                      id: '341',
+                      url: '#',
+                      name: 'Black & orange scarf',
+                      sku: '9234194023',
+                      quantity: '254',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+                          alt="Black orange scarf"
+                        />
+                      ),
+                    },
+                    {
+                      id: '256',
+                      url: '#',
+                      name: 'Tucan scarf',
+                      sku: '9234194010',
+                      quantity: '201',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
+                          alt="Tucan scarf"
+                        />
+                      ),
+                    },
+                  ]}
+                  renderItem={(item) => {
+                    const {id, url, name, sku, media, quantity} = item;
+
+                    return (
+                      <ResourceList.Item
+                        id={id}
+                        url={url}
+                        media={media}
+                        accessibilityLabel={`View details for ${name}`}
+                      >
+                        <h3>
+                          <Text fontWeight="bold" as="span">
+                            {name}
+                          </Text>
+                        </h3>
+                        <div>SKU: {sku}</div>
+                        <div>{quantity} available</div>
+                      </ResourceList.Item>
+                    );
+                  }}
+                />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneHalf">
+            <LegacyCard title="Nevada" actions={[{content: 'Manage'}]}>
+              <LegacyCard.Section>
+                <Text tone="subdued" as="span">
+                  301 units available
+                </Text>
+              </LegacyCard.Section>
+              <LegacyCard.Section title="Items">
+                <ResourceList
+                  resourceName={{singular: 'product', plural: 'products'}}
+                  items={[
+                    {
+                      id: '342',
+                      url: '#',
+                      name: 'Black & orange scarf',
+                      sku: '9234194023',
+                      quantity: '100',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+                          alt="Black orange scarf"
+                        />
+                      ),
+                    },
+                    {
+                      id: '257',
+                      url: '#',
+                      name: 'Tucan scarf',
+                      sku: '9234194010',
+                      quantity: '201',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
+                          alt="Tucan scarf"
+                        />
+                      ),
+                    },
+                  ]}
+                  renderItem={(item) => {
+                    const {id, url, name, sku, media, quantity} = item;
+
+                    return (
+                      <ResourceList.Item
+                        id={id}
+                        url={url}
+                        media={media}
+                        accessibilityLabel={`View details for ${name}`}
+                      >
+                        <h3>
+                          <Text fontWeight="bold" as="span">
+                            {name}
+                          </Text>
+                        </h3>
+                        <div>SKU: {sku}</div>
+                        <div>{quantity} available</div>
+                      </ResourceList.Item>
+                    );
+                  }}
+                />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </Page>
+    );
+  },
+};
+
+export const ThreeColumnsWithEqualWidth = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Layout>
+          <Layout.Section variant="oneThird">
+            <LegacyCard title="Florida" actions={[{content: 'Manage'}]}>
+              <LegacyCard.Section>
+                <Text tone="subdued" as="span">
+                  455 units available
+                </Text>
+              </LegacyCard.Section>
+              <LegacyCard.Section title="Items">
+                <ResourceList
+                  resourceName={{singular: 'product', plural: 'products'}}
+                  items={[
+                    {
+                      id: '343',
+                      url: '#',
+                      name: 'Black & orange scarf',
+                      sku: '9234194023',
+                      quantity: '254',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+                          alt="Black orange scarf"
+                        />
+                      ),
+                    },
+                    {
+                      id: '258',
+                      url: '#',
+                      name: 'Tucan scarf',
+                      sku: '9234194010',
+                      quantity: '201',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
+                          alt="Tucan scarf"
+                        />
+                      ),
+                    },
+                  ]}
+                  renderItem={(item) => {
+                    const {id, url, name, sku, media, quantity} = item;
+
+                    return (
+                      <ResourceList.Item
+                        id={id}
+                        url={url}
+                        media={media}
+                        accessibilityLabel={`View details for ${name}`}
+                      >
+                        <h3>
+                          <Text fontWeight="bold" as="span">
+                            {name}
+                          </Text>
+                        </h3>
+                        <div>SKU: {sku}</div>
+                        <div>{quantity} available</div>
+                      </ResourceList.Item>
+                    );
+                  }}
+                />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard title="Nevada" actions={[{content: 'Manage'}]}>
+              <LegacyCard.Section>
+                <Text tone="subdued" as="span">
+                  301 units available
+                </Text>
+              </LegacyCard.Section>
+              <LegacyCard.Section title="Items">
+                <ResourceList
+                  resourceName={{singular: 'product', plural: 'products'}}
+                  items={[
+                    {
+                      id: '344',
+                      url: '#',
+                      name: 'Black & orange scarf',
+                      sku: '9234194023',
+                      quantity: '100',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+                          alt="Black orange scarf"
+                        />
+                      ),
+                    },
+                    {
+                      id: '259',
+                      url: '#',
+                      name: 'Tucan scarf',
+                      sku: '9234194010',
+                      quantity: '201',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
+                          alt="Tucan scarf"
+                        />
+                      ),
+                    },
+                  ]}
+                  renderItem={(item) => {
+                    const {id, url, name, sku, media, quantity} = item;
+
+                    return (
+                      <ResourceList.Item
+                        id={id}
+                        url={url}
+                        media={media}
+                        accessibilityLabel={`View details for ${name}`}
+                      >
+                        <h3>
+                          <Text fontWeight="bold" as="span">
+                            {name}
+                          </Text>
+                        </h3>
+                        <div>SKU: {sku}</div>
+                        <div>{quantity} available</div>
+                      </ResourceList.Item>
+                    );
+                  }}
+                />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard title="Minneapolis" actions={[{content: 'Manage'}]}>
+              <LegacyCard.Section>
+                <Text tone="subdued" as="span">
+                  1931 units available
+                </Text>
+              </LegacyCard.Section>
+              <LegacyCard.Section title="Items">
+                <ResourceList
+                  resourceName={{singular: 'product', plural: 'products'}}
+                  items={[
+                    {
+                      id: '345',
+                      url: '#',
+                      name: 'Black & orange scarf',
+                      sku: '9234194023',
+                      quantity: '1230',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+                          alt="Black orange scarf"
+                        />
+                      ),
+                    },
+                    {
+                      id: '260',
+                      url: '#',
+                      name: 'Tucan scarf',
+                      sku: '9234194010',
+                      quantity: '701',
+                      media: (
+                        <Thumbnail
+                          source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
+                          alt="Tucan scarf"
+                        />
+                      ),
+                    },
+                  ]}
+                  renderItem={(item) => {
+                    const {id, url, name, sku, media, quantity} = item;
+
+                    return (
+                      <ResourceList.Item
+                        id={id}
+                        url={url}
+                        media={media}
+                        accessibilityLabel={`View details for ${name}`}
+                      >
+                        <h3>
+                          <Text fontWeight="bold" as="span">
+                            {name}
+                          </Text>
+                        </h3>
+                        <div>SKU: {sku}</div>
+                        <div>{quantity} available</div>
+                      </ResourceList.Item>
+                    );
+                  }}
+                />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </Page>
+    );
+  },
+};
+
+export const Annotated = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Layout>
+          <Layout.AnnotatedSection
+            id="storeDetails-annotated"
+            title="Store details"
+            description="Shopify and your customers will use this information to contact you."
+          >
+            <LegacyCard sectioned>
+              <FormLayout>
+                <TextField
+                  label="Store name"
+                  onChange={() => {}}
+                  autoComplete="off"
+                />
+                <TextField
+                  type="email"
+                  label="Account email"
+                  onChange={() => {}}
+                  autoComplete="email"
+                />
+              </FormLayout>
+            </LegacyCard>
+          </Layout.AnnotatedSection>
+        </Layout>
+      </Page>
+    );
+  },
+};
+
+export const AnnotatedWithBannerAtTheTop = {
+  render() {
+    return (
+      <Page fullWidth>
+        <Layout>
+          <Layout.Section>
+            <Banner title="Order archived" onDismiss={() => {}}>
+              <Text as="p" variant="bodyMd">
+                This order was archived on March 7, 2017 at 3:12pm EDT.
               </Text>
-            </LegacyCard.Section>
-            <LegacyCard.Section title="Items">
-              <ResourceList
-                resourceName={{singular: 'product', plural: 'products'}}
-                items={[
-                  {
-                    id: '344',
-                    url: '#',
-                    name: 'Black & orange scarf',
-                    sku: '9234194023',
-                    quantity: '100',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
-                        alt="Black orange scarf"
-                      />
-                    ),
-                  },
-                  {
-                    id: '259',
-                    url: '#',
-                    name: 'Tucan scarf',
-                    sku: '9234194010',
-                    quantity: '201',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
-                        alt="Tucan scarf"
-                      />
-                    ),
-                  },
-                ]}
-                renderItem={(item) => {
-                  const {id, url, name, sku, media, quantity} = item;
-
-                  return (
-                    <ResourceList.Item
-                      id={id}
-                      url={url}
-                      media={media}
-                      accessibilityLabel={`View details for ${name}`}
-                    >
-                      <h3>
-                        <Text fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
-                      <div>SKU: {sku}</div>
-                      <div>{quantity} available</div>
-                    </ResourceList.Item>
-                  );
-                }}
-              />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard title="Minneapolis" actions={[{content: 'Manage'}]}>
-            <LegacyCard.Section>
-              <Text tone="subdued" as="span">
-                1931 units available
-              </Text>
-            </LegacyCard.Section>
-            <LegacyCard.Section title="Items">
-              <ResourceList
-                resourceName={{singular: 'product', plural: 'products'}}
-                items={[
-                  {
-                    id: '345',
-                    url: '#',
-                    name: 'Black & orange scarf',
-                    sku: '9234194023',
-                    quantity: '1230',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
-                        alt="Black orange scarf"
-                      />
-                    ),
-                  },
-                  {
-                    id: '260',
-                    url: '#',
-                    name: 'Tucan scarf',
-                    sku: '9234194010',
-                    quantity: '701',
-                    media: (
-                      <Thumbnail
-                        source="https://burst.shopifycdn.com/photos/tucan-scarf_373x@2x.jpg"
-                        alt="Tucan scarf"
-                      />
-                    ),
-                  },
-                ]}
-                renderItem={(item) => {
-                  const {id, url, name, sku, media, quantity} = item;
-
-                  return (
-                    <ResourceList.Item
-                      id={id}
-                      url={url}
-                      media={media}
-                      accessibilityLabel={`View details for ${name}`}
-                    >
-                      <h3>
-                        <Text fontWeight="bold" as="span">
-                          {name}
-                        </Text>
-                      </h3>
-                      <div>SKU: {sku}</div>
-                      <div>{quantity} available</div>
-                    </ResourceList.Item>
-                  );
-                }}
-              />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </Page>
-  );
-}
-
-export function Annotated() {
-  return (
-    <Page fullWidth>
-      <Layout>
-        <Layout.AnnotatedSection
-          id="storeDetails-annotated"
-          title="Store details"
-          description="Shopify and your customers will use this information to contact you."
-        >
-          <LegacyCard sectioned>
-            <FormLayout>
-              <TextField
-                label="Store name"
-                onChange={() => {}}
-                autoComplete="off"
-              />
-              <TextField
-                type="email"
-                label="Account email"
-                onChange={() => {}}
-                autoComplete="email"
-              />
-            </FormLayout>
-          </LegacyCard>
-        </Layout.AnnotatedSection>
-      </Layout>
-    </Page>
-  );
-}
-
-export function AnnotatedWithBannerAtTheTop() {
-  return (
-    <Page fullWidth>
-      <Layout>
-        <Layout.Section>
-          <Banner title="Order archived" onDismiss={() => {}}>
-            <Text as="p" variant="bodyMd">
-              This order was archived on March 7, 2017 at 3:12pm EDT.
-            </Text>
-          </Banner>
-        </Layout.Section>
-        <Layout.AnnotatedSection
-          id="storeDetails-annotatedWithBanner"
-          title="Store details"
-          description="Shopify and your customers will use this information to contact you."
-        >
-          <LegacyCard sectioned>
-            <FormLayout>
-              <TextField
-                label="Store name"
-                onChange={() => {}}
-                autoComplete="off"
-              />
-              <TextField
-                type="email"
-                label="Account email"
-                onChange={() => {}}
-                autoComplete="email"
-              />
-            </FormLayout>
-          </LegacyCard>
-        </Layout.AnnotatedSection>
-      </Layout>
-    </Page>
-  );
-}
+            </Banner>
+          </Layout.Section>
+          <Layout.AnnotatedSection
+            id="storeDetails-annotatedWithBanner"
+            title="Store details"
+            description="Shopify and your customers will use this information to contact you."
+          >
+            <LegacyCard sectioned>
+              <FormLayout>
+                <TextField
+                  label="Store name"
+                  onChange={() => {}}
+                  autoComplete="off"
+                />
+                <TextField
+                  type="email"
+                  label="Account email"
+                  onChange={() => {}}
+                  autoComplete="email"
+                />
+              </FormLayout>
+            </LegacyCard>
+          </Layout.AnnotatedSection>
+        </Layout>
+      </Page>
+    );
+  },
+};

--- a/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.stories.tsx
@@ -1,6 +1,6 @@
 import type {PropsWithChildren} from 'react';
 import React, {useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   ActionList,
   Button,
@@ -21,554 +21,596 @@ import {ProductIcon, XIcon} from '@shopify/polaris-icons';
 
 export default {
   component: LegacyCard,
-} as ComponentMeta<typeof LegacyCard>;
+} as Meta<typeof LegacyCard>;
 
-export function Default() {
-  return (
-    <LegacyCard title="Online store dashboard" sectioned>
-      <Text as="p" variant="bodyMd">
-        View a summary of your online store’s performance.
-      </Text>
-    </LegacyCard>
-  );
-}
-
-export function WithHeaderActions() {
-  return (
-    <LegacyCard sectioned title="Variants" actions={[{content: 'Add variant'}]}>
-      <Text as="p" variant="bodyMd">
-        Add variants if this product comes in multiple versions, like different
-        sizes or colors.
-      </Text>
-    </LegacyCard>
-  );
-}
-
-export function WithFooterActions() {
-  return (
-    <LegacyCard
-      title="Shipment 1234"
-      secondaryFooterActions={[{content: 'Edit shipment'}]}
-      primaryFooterAction={{content: 'Add tracking number'}}
-    >
-      <LegacyCard.Section title="Items">
-        <List>
-          <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
-          <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
-        </List>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithMultipleFooterActions() {
-  return (
-    <LegacyCard
-      title="Shipment 1234"
-      secondaryFooterActions={[
-        {content: 'Cancel shipment', destructive: true},
-        {content: 'Add another shipment', disabled: true},
-      ]}
-      primaryFooterAction={{content: 'Add tracking number'}}
-    >
-      <LegacyCard.Section title="Items">
-        <List>
-          <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
-          <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
-        </List>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithCustomFooterActions() {
-  return (
-    <LegacyCard title="Secure your account with 2-step authentication">
-      <LegacyCard.Section>
-        <LegacyStack spacing="loose" vertical>
-          <Text as="p" variant="bodyMd">
-            Two-step authentication adds an extra layer of security when logging
-            in to your account. A special code will be required each time you
-            log in, ensuring only you can access your account.
-          </Text>
-          <LegacyStack distribution="trailing">
-            <ButtonGroup>
-              <Button>Enable two-step authentication</Button>
-              <Button variant="plain">Learn more</Button>
-            </ButtonGroup>
-          </LegacyStack>
-        </LegacyStack>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithDestructiveFooterAction() {
-  return (
-    <LegacyCard
-      title="Shipment 1234"
-      secondaryFooterActions={[
-        {content: 'Cancel shipment', tone: 'critical', variant: 'primary'},
-      ]}
-      primaryFooterAction={{content: 'Add tracking number'}}
-    >
-      <LegacyCard.Section title="Items">
-        <List>
-          <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
-          <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
-        </List>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithMultipleSections() {
-  return (
-    <LegacyCard title="Online store dashboard">
-      <LegacyCard.Section>
+export const Default = {
+  render() {
+    return (
+      <LegacyCard title="Online store dashboard" sectioned>
         <Text as="p" variant="bodyMd">
           View a summary of your online store’s performance.
         </Text>
-      </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
 
-      <LegacyCard.Section>
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance, including sales,
-          visitors, top products, and referrals.
-        </Text>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithMultipleTitledSections() {
-  return (
-    <LegacyCard title="Online store dashboard">
-      <LegacyCard.Section title="Reports">
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance.
-        </Text>
-      </LegacyCard.Section>
-
-      <LegacyCard.Section title="Summary">
-        <Text as="p" variant="bodyMd">
-          View a summary of your online store’s performance, including sales,
-          visitors, top products, and referrals.
-        </Text>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithSectionsAndActions() {
-  return (
-    <LegacyCard title="Customer">
-      <LegacyCard.Section>
-        <Text as="p" variant="bodyMd">
-          John Smith
-        </Text>
-      </LegacyCard.Section>
-      <LegacyCard.Section
-        title="Contact Information"
-        actions={[{content: 'Edit'}]}
+export const WithHeaderActions = {
+  render() {
+    return (
+      <LegacyCard
+        sectioned
+        title="Variants"
+        actions={[{content: 'Add variant'}]}
       >
         <Text as="p" variant="bodyMd">
-          john.smith@example.com
+          Add variants if this product comes in multiple versions, like
+          different sizes or colors.
         </Text>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithSubsection() {
-  return (
-    <LegacyCard title="Customer">
-      <LegacyCard.Section>
-        <Text as="p" variant="bodyMd">
-          John Smith
-        </Text>
-      </LegacyCard.Section>
-      <LegacyCard.Section title="Addresses">
-        <LegacyCard.Subsection>
-          123 First St
-          <br />
-          Somewhere
-          <br />
-          The Universe
-        </LegacyCard.Subsection>
-        <LegacyCard.Subsection>
-          123 Second St
-          <br />
-          Somewhere
-          <br />
-          The Universe
-        </LegacyCard.Subsection>
-      </LegacyCard.Section>
-      <LegacyCard.Section>
-        <LegacyCard.Subsection>
-          A single subsection without a sibling has no visual appearance
-        </LegacyCard.Subsection>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithDestructiveAction() {
-  return (
-    <LegacyCard title="Customer">
-      <LegacyCard.Section>
-        <Text as="p" variant="bodyMd">
-          John Smith
-        </Text>
-      </LegacyCard.Section>
-      <LegacyCard.Section
-        title="Contact Information"
-        actions={[{content: 'Delete', tone: 'critical'}, {content: 'Edit'}]}
+export const WithFooterActions = {
+  render() {
+    return (
+      <LegacyCard
+        title="Shipment 1234"
+        secondaryFooterActions={[{content: 'Edit shipment'}]}
+        primaryFooterAction={{content: 'Add tracking number'}}
       >
-        <Text as="p" variant="bodyMd">
-          john.smith@example.com
-        </Text>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
+        <LegacyCard.Section title="Items">
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithASubduedSection() {
-  return (
-    <LegacyCard title="Staff accounts">
-      <LegacyCard.Section>
-        <List>
-          <List.Item>Felix Crafford</List.Item>
-          <List.Item>Ezequiel Manno</List.Item>
-        </List>
-      </LegacyCard.Section>
-
-      <LegacyCard.Section subdued title="Deactivated staff accounts">
-        <List>
-          <List.Item>Felix Crafford</List.Item>
-          <List.Item>Ezequiel Manno</List.Item>
-        </List>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithSubduedForSecondaryContent() {
-  return (
-    <LegacyCard title="Deactivated staff accounts" sectioned subdued>
-      <List>
-        <List.Item>Felix Crafford</List.Item>
-        <List.Item>Ezequiel Manno</List.Item>
-      </List>
-    </LegacyCard>
-  );
-}
-
-export function WithSeparateHeader() {
-  return (
-    <LegacyCard>
-      <LegacyCard.Header
-        actions={[
-          {
-            content: 'Preview',
-          },
+export const WithMultipleFooterActions = {
+  render() {
+    return (
+      <LegacyCard
+        title="Shipment 1234"
+        secondaryFooterActions={[
+          {content: 'Cancel shipment', destructive: true},
+          {content: 'Add another shipment', disabled: true},
         ]}
-        title="Staff accounts"
+        primaryFooterAction={{content: 'Add tracking number'}}
       >
-        <Popover
-          active
-          activator={
-            <Button disclosure variant="plain">
-              Add account
-            </Button>
-          }
-          onClose={() => {}}
-        >
-          <ActionList items={[{content: 'Member'}, {content: 'Admin'}]} />
-        </Popover>
-      </LegacyCard.Header>
-      <LegacyCard.Section>
-        <List>
-          <List.Item>Felix Crafford</List.Item>
-          <List.Item>Ezequiel Manno</List.Item>
-        </List>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
+        <LegacyCard.Section title="Items">
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithCustomReactNodeTitle() {
-  return (
-    <LegacyCard title="Products">
-      <LegacyCard.Section
-        title={
-          <LegacyStack>
-            <Icon source={ProductIcon} />
-            <Text variant="headingSm" as="h3">
-              New Products
+export const WithCustomFooterActions = {
+  render() {
+    return (
+      <LegacyCard title="Secure your account with 2-step authentication">
+        <LegacyCard.Section>
+          <LegacyStack spacing="loose" vertical>
+            <Text as="p" variant="bodyMd">
+              Two-step authentication adds an extra layer of security when
+              logging in to your account. A special code will be required each
+              time you log in, ensuring only you can access your account.
             </Text>
+            <LegacyStack distribution="trailing">
+              <ButtonGroup>
+                <Button>Enable two-step authentication</Button>
+                <Button variant="plain">Learn more</Button>
+              </ButtonGroup>
+            </LegacyStack>
           </LegacyStack>
-        }
-      >
-        <List>
-          <List.Item>Socks</List.Item>
-          <List.Item>Super Shoes</List.Item>
-        </List>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithAllElements() {
-  return (
-    <LegacyCard
-      secondaryFooterActions={[{content: 'Dismiss'}]}
-      primaryFooterAction={{content: 'Export Report'}}
-    >
-      <LegacyCard.Header
-        actions={[
-          {
-            content: 'Total Sales',
-          },
+export const WithDestructiveFooterAction = {
+  render() {
+    return (
+      <LegacyCard
+        title="Shipment 1234"
+        secondaryFooterActions={[
+          {content: 'Cancel shipment', tone: 'critical', variant: 'primary'},
         ]}
-        title="Sales"
+        primaryFooterAction={{content: 'Add tracking number'}}
       >
-        <Popover
-          active={false}
-          activator={
-            <Button disclosure variant="plain">
-              View Sales
-            </Button>
-          }
-          onClose={() => {}}
+        <LegacyCard.Section title="Items">
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithMultipleSections = {
+  render() {
+    return (
+      <LegacyCard title="Online store dashboard">
+        <LegacyCard.Section>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </LegacyCard.Section>
+
+        <LegacyCard.Section>
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance, including sales,
+            visitors, top products, and referrals.
+          </Text>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithMultipleTitledSections = {
+  render() {
+    return (
+      <LegacyCard title="Online store dashboard">
+        <LegacyCard.Section title="Reports">
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance.
+          </Text>
+        </LegacyCard.Section>
+
+        <LegacyCard.Section title="Summary">
+          <Text as="p" variant="bodyMd">
+            View a summary of your online store’s performance, including sales,
+            visitors, top products, and referrals.
+          </Text>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSectionsAndActions = {
+  render() {
+    return (
+      <LegacyCard title="Customer">
+        <LegacyCard.Section>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </LegacyCard.Section>
+        <LegacyCard.Section
+          title="Contact Information"
+          actions={[{content: 'Edit'}]}
         >
-          <ActionList
-            items={[{content: 'Gross Sales'}, {content: 'Net Sales'}]}
-          />
-        </Popover>
-      </LegacyCard.Header>
-      <LegacyCard.Section>
-        <TextContainer>
-          You can use sales reports to see information about your customers’
-          orders based on criteria such as sales over time, by channel, or by
-          staff.
-        </TextContainer>
-      </LegacyCard.Section>
-      <LegacyCard.Section title="Total Sales Breakdown">
-        <ResourceList
-          resourceName={{singular: 'sale', plural: 'sales'}}
-          items={[
+          <Text as="p" variant="bodyMd">
+            john.smith@example.com
+          </Text>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSubsection = {
+  render() {
+    return (
+      <LegacyCard title="Customer">
+        <LegacyCard.Section>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </LegacyCard.Section>
+        <LegacyCard.Section title="Addresses">
+          <LegacyCard.Subsection>
+            123 First St
+            <br />
+            Somewhere
+            <br />
+            The Universe
+          </LegacyCard.Subsection>
+          <LegacyCard.Subsection>
+            123 Second St
+            <br />
+            Somewhere
+            <br />
+            The Universe
+          </LegacyCard.Subsection>
+        </LegacyCard.Section>
+        <LegacyCard.Section>
+          <LegacyCard.Subsection>
+            A single subsection without a sibling has no visual appearance
+          </LegacyCard.Subsection>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithDestructiveAction = {
+  render() {
+    return (
+      <LegacyCard title="Customer">
+        <LegacyCard.Section>
+          <Text as="p" variant="bodyMd">
+            John Smith
+          </Text>
+        </LegacyCard.Section>
+        <LegacyCard.Section
+          title="Contact Information"
+          actions={[{content: 'Delete', tone: 'critical'}, {content: 'Edit'}]}
+        >
+          <Text as="p" variant="bodyMd">
+            john.smith@example.com
+          </Text>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithASubduedSection = {
+  render() {
+    return (
+      <LegacyCard title="Staff accounts">
+        <LegacyCard.Section>
+          <List>
+            <List.Item>Felix Crafford</List.Item>
+            <List.Item>Ezequiel Manno</List.Item>
+          </List>
+        </LegacyCard.Section>
+
+        <LegacyCard.Section subdued title="Deactivated staff accounts">
+          <List>
+            <List.Item>Felix Crafford</List.Item>
+            <List.Item>Ezequiel Manno</List.Item>
+          </List>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSubduedForSecondaryContent = {
+  render() {
+    return (
+      <LegacyCard title="Deactivated staff accounts" sectioned subdued>
+        <List>
+          <List.Item>Felix Crafford</List.Item>
+          <List.Item>Ezequiel Manno</List.Item>
+        </List>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSeparateHeader = {
+  render() {
+    return (
+      <LegacyCard>
+        <LegacyCard.Header
+          actions={[
             {
-              sales: 'Orders',
-              amount: 'USD$0.00',
-              url: '#',
-            },
-            {
-              sales: 'Returns',
-              amount: '-USD$250.00',
-              url: '#',
+              content: 'Preview',
             },
           ]}
-          renderItem={(item) => {
-            const {sales, amount, url} = item;
-            return (
-              <ResourceList.Item
-                url={url}
-                accessibilityLabel={`View Sales for ${sales}`}
-              >
-                <LegacyStack>
-                  <LegacyStack.Item fill>{sales}</LegacyStack.Item>
-                  <LegacyStack.Item>{amount}</LegacyStack.Item>
-                </LegacyStack>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </LegacyCard.Section>
-      <LegacyCard.Section title="Deactivated reports" subdued>
-        <List>
-          <List.Item>Payouts</List.Item>
-          <List.Item>Total Sales By Channel</List.Item>
-        </List>
-      </LegacyCard.Section>
-      <LegacyCard.Section title="Note">
-        <TextContainer>
-          The sales reports are available only if your store is on the Shopify
-          plan or higher.
-        </TextContainer>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function WithFlushedSections() {
-  return (
-    <LegacyCard>
-      <LegacyCard.Section flush>
-        <Image
-          source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
-          alt="a sheet with purple and orange stripes"
-        />
-      </LegacyCard.Section>
-      <LegacyCard.Section subdued>
-        <TextContainer>
-          You can use sales reports to see information about your customers’
-          orders based on criteria such as sales over time, by channel, or by
-          staff.
-        </TextContainer>
-      </LegacyCard.Section>
-    </LegacyCard>
-  );
-}
-
-export function All() {
-  return (
-    <BlockStack gap="200">
-      <LegacyCard title="All headings">
-        <LegacyCard.Section title="Section 1 heading">
-          Section 1 content
-        </LegacyCard.Section>
-        <LegacyCard.Section title="Section 2 heading">
-          Section 2 content
-        </LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard title="Non-text first item">
-        <LegacyCard.Section>
-          <Box>
-            <LegacyCard.Section subdued>Section 1 content</LegacyCard.Section>
-          </Box>
-        </LegacyCard.Section>
-        <LegacyCard.Section title="Section 2 heading">
-          Section 2 content
-        </LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard>
-        <LegacyCard.Section>No titles Section 1 content</LegacyCard.Section>
-        <LegacyCard.Section>No titles Section 2 content</LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard>
-        <div>
-          <LegacyCard.Header title="Content wrapped in div" />
-          <LegacyCard.Section title="Section 1 heading">
-            Section 1 in div
-          </LegacyCard.Section>
-          <LegacyCard.Section title="Section 2 heading">
-            Section 2 in div
-          </LegacyCard.Section>
-        </div>
-      </LegacyCard>
-      <LegacyCard>
-        <div>
-          <LegacyCard.Section title="Section 1 heading">
-            Section 1 in div
-          </LegacyCard.Section>
-          <LegacyCard.Section title="Section 2 heading">
-            Section 2 in div
-          </LegacyCard.Section>
-        </div>
-      </LegacyCard>
-      <LegacyCard>
-        <div>
-          <h2>Custom header in an h2</h2>
-        </div>
-        <LegacyCard.Section>Section 1 content</LegacyCard.Section>
-        <LegacyCard.Section>Section 2 content</LegacyCard.Section>
-        <div>
-          <Text as="p" variant="bodyMd">
-            Custom footer in a p
-          </Text>
-        </div>
-      </LegacyCard>
-      <LegacyCard title="Sections are not siblings">
-        <div>
-          <LegacyCard.Section>
-            Section 1 content wrapped in its own div
-          </LegacyCard.Section>
-        </div>
-        <div>
-          <LegacyCard.Section>
-            Section 2 content wrapped in its own div
-          </LegacyCard.Section>
-        </div>
-      </LegacyCard>
-      <LegacyCard>
-        <div>Card content in div not in section</div>
-      </LegacyCard>
-      <LegacyCard>
-        <LegacyCard.Section subdued>
-          Subdued Section 1 content
-        </LegacyCard.Section>
-        <LegacyCard.Section>Section 2 content</LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard>
-        <LegacyCard.Section>Section 1 content</LegacyCard.Section>
-        <LegacyCard.Section subdued>
-          Subdued section 2 content
-        </LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard>
-        <LegacyCard.Section>Section 1 content</LegacyCard.Section>
-        <LegacyCard.Section subdued>
-          Subdued section 2 content
-        </LegacyCard.Section>
-        <LegacyCard.Section>Section 3 content</LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard title="Flush sections">
-        <LegacyCard.Section title="Section 1 heading">
-          Section 1 content
-        </LegacyCard.Section>
-        <LegacyCard.Section title="Flush section heading" flush>
-          This should be flush
-        </LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard title="Dynamic children padding adjustment">
-        <DynamicChildren />
-        <DynamicChildren />
-      </LegacyCard>
-      <LegacyCard title="Only one header section" />
-      <LegacyCard>
-        <LegacyCard.Section title="First outside section">
-          <BlockStack gap="200">
-            <Box>
-              <LegacyCard.Section subdued>
-                First nested section
-              </LegacyCard.Section>
-            </Box>
-            <Box>
-              <LegacyCard.Section subdued>
-                Second nested section
-              </LegacyCard.Section>
-            </Box>
-          </BlockStack>
-        </LegacyCard.Section>
-        <LegacyCard.Section title="Second outside section">
-          <BlockStack gap="200">
-            <Box>
-              <LegacyCard.Section subdued>
-                First nested section
-              </LegacyCard.Section>
-            </Box>
-            <Box>
-              <LegacyCard.Section subdued>
-                Second nested section
-              </LegacyCard.Section>
-            </Box>
-          </BlockStack>
-        </LegacyCard.Section>
-      </LegacyCard>
-      <LegacyCard>
-        <LegacyCard.Header title="Header with icon button child">
-          <Button
-            icon={XIcon}
-            variant="tertiary"
-            accessibilityLabel="Cancel button"
-          />
+          title="Staff accounts"
+        >
+          <Popover
+            active
+            activator={
+              <Button disclosure variant="plain">
+                Add account
+              </Button>
+            }
+            onClose={() => {}}
+          >
+            <ActionList items={[{content: 'Member'}, {content: 'Admin'}]} />
+          </Popover>
         </LegacyCard.Header>
+        <LegacyCard.Section>
+          <List>
+            <List.Item>Felix Crafford</List.Item>
+            <List.Item>Ezequiel Manno</List.Item>
+          </List>
+        </LegacyCard.Section>
       </LegacyCard>
-      <WithAllElements />
-    </BlockStack>
-  );
-}
+    );
+  },
+};
+
+export const WithCustomReactNodeTitle = {
+  render() {
+    return (
+      <LegacyCard title="Products">
+        <LegacyCard.Section
+          title={
+            <LegacyStack>
+              <Icon source={ProductIcon} />
+              <Text variant="headingSm" as="h3">
+                New Products
+              </Text>
+            </LegacyStack>
+          }
+        >
+          <List>
+            <List.Item>Socks</List.Item>
+            <List.Item>Super Shoes</List.Item>
+          </List>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithAllElements = {
+  render() {
+    return (
+      <LegacyCard
+        secondaryFooterActions={[{content: 'Dismiss'}]}
+        primaryFooterAction={{content: 'Export Report'}}
+      >
+        <LegacyCard.Header
+          actions={[
+            {
+              content: 'Total Sales',
+            },
+          ]}
+          title="Sales"
+        >
+          <Popover
+            active={false}
+            activator={
+              <Button disclosure variant="plain">
+                View Sales
+              </Button>
+            }
+            onClose={() => {}}
+          >
+            <ActionList
+              items={[{content: 'Gross Sales'}, {content: 'Net Sales'}]}
+            />
+          </Popover>
+        </LegacyCard.Header>
+        <LegacyCard.Section>
+          <TextContainer>
+            You can use sales reports to see information about your customers’
+            orders based on criteria such as sales over time, by channel, or by
+            staff.
+          </TextContainer>
+        </LegacyCard.Section>
+        <LegacyCard.Section title="Total Sales Breakdown">
+          <ResourceList
+            resourceName={{singular: 'sale', plural: 'sales'}}
+            items={[
+              {
+                sales: 'Orders',
+                amount: 'USD$0.00',
+                url: '#',
+              },
+              {
+                sales: 'Returns',
+                amount: '-USD$250.00',
+                url: '#',
+              },
+            ]}
+            renderItem={(item) => {
+              const {sales, amount, url} = item;
+              return (
+                <ResourceList.Item
+                  url={url}
+                  accessibilityLabel={`View Sales for ${sales}`}
+                >
+                  <LegacyStack>
+                    <LegacyStack.Item fill>{sales}</LegacyStack.Item>
+                    <LegacyStack.Item>{amount}</LegacyStack.Item>
+                  </LegacyStack>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </LegacyCard.Section>
+        <LegacyCard.Section title="Deactivated reports" subdued>
+          <List>
+            <List.Item>Payouts</List.Item>
+            <List.Item>Total Sales By Channel</List.Item>
+          </List>
+        </LegacyCard.Section>
+        <LegacyCard.Section title="Note">
+          <TextContainer>
+            The sales reports are available only if your store is on the Shopify
+            plan or higher.
+          </TextContainer>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithFlushedSections = {
+  render() {
+    return (
+      <LegacyCard>
+        <LegacyCard.Section flush>
+          <Image
+            source="https://burst.shopifycdn.com/photos/black-orange-stripes_373x@2x.jpg"
+            alt="a sheet with purple and orange stripes"
+          />
+        </LegacyCard.Section>
+        <LegacyCard.Section subdued>
+          <TextContainer>
+            You can use sales reports to see information about your customers’
+            orders based on criteria such as sales over time, by channel, or by
+            staff.
+          </TextContainer>
+        </LegacyCard.Section>
+      </LegacyCard>
+    );
+  },
+};
+
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="200">
+        <LegacyCard title="All headings">
+          <LegacyCard.Section title="Section 1 heading">
+            Section 1 content
+          </LegacyCard.Section>
+          <LegacyCard.Section title="Section 2 heading">
+            Section 2 content
+          </LegacyCard.Section>
+        </LegacyCard>
+        <LegacyCard title="Non-text first item">
+          <LegacyCard.Section>
+            <Box>
+              <LegacyCard.Section subdued>Section 1 content</LegacyCard.Section>
+            </Box>
+          </LegacyCard.Section>
+          <LegacyCard.Section title="Section 2 heading">
+            Section 2 content
+          </LegacyCard.Section>
+        </LegacyCard>
+        <LegacyCard>
+          <LegacyCard.Section>No titles Section 1 content</LegacyCard.Section>
+          <LegacyCard.Section>No titles Section 2 content</LegacyCard.Section>
+        </LegacyCard>
+        <LegacyCard>
+          <div>
+            <LegacyCard.Header title="Content wrapped in div" />
+            <LegacyCard.Section title="Section 1 heading">
+              Section 1 in div
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Section 2 heading">
+              Section 2 in div
+            </LegacyCard.Section>
+          </div>
+        </LegacyCard>
+        <LegacyCard>
+          <div>
+            <LegacyCard.Section title="Section 1 heading">
+              Section 1 in div
+            </LegacyCard.Section>
+            <LegacyCard.Section title="Section 2 heading">
+              Section 2 in div
+            </LegacyCard.Section>
+          </div>
+        </LegacyCard>
+        <LegacyCard>
+          <div>
+            <h2>Custom header in an h2</h2>
+          </div>
+          <LegacyCard.Section>Section 1 content</LegacyCard.Section>
+          <LegacyCard.Section>Section 2 content</LegacyCard.Section>
+          <div>
+            <Text as="p" variant="bodyMd">
+              Custom footer in a p
+            </Text>
+          </div>
+        </LegacyCard>
+        <LegacyCard title="Sections are not siblings">
+          <div>
+            <LegacyCard.Section>
+              Section 1 content wrapped in its own div
+            </LegacyCard.Section>
+          </div>
+          <div>
+            <LegacyCard.Section>
+              Section 2 content wrapped in its own div
+            </LegacyCard.Section>
+          </div>
+        </LegacyCard>
+        <LegacyCard>
+          <div>Card content in div not in section</div>
+        </LegacyCard>
+        <LegacyCard>
+          <LegacyCard.Section subdued>
+            Subdued Section 1 content
+          </LegacyCard.Section>
+          <LegacyCard.Section>Section 2 content</LegacyCard.Section>
+        </LegacyCard>
+        <LegacyCard>
+          <LegacyCard.Section>Section 1 content</LegacyCard.Section>
+          <LegacyCard.Section subdued>
+            Subdued section 2 content
+          </LegacyCard.Section>
+        </LegacyCard>
+        <LegacyCard>
+          <LegacyCard.Section>Section 1 content</LegacyCard.Section>
+          <LegacyCard.Section subdued>
+            Subdued section 2 content
+          </LegacyCard.Section>
+          <LegacyCard.Section>Section 3 content</LegacyCard.Section>
+        </LegacyCard>
+        <LegacyCard title="Flush sections">
+          <LegacyCard.Section title="Section 1 heading">
+            Section 1 content
+          </LegacyCard.Section>
+          <LegacyCard.Section title="Flush section heading" flush>
+            This should be flush
+          </LegacyCard.Section>
+        </LegacyCard>
+        <LegacyCard title="Dynamic children padding adjustment">
+          <DynamicChildren />
+          <DynamicChildren />
+        </LegacyCard>
+        <LegacyCard title="Only one header section" />
+        <LegacyCard>
+          <LegacyCard.Section title="First outside section">
+            <BlockStack gap="200">
+              <Box>
+                <LegacyCard.Section subdued>
+                  First nested section
+                </LegacyCard.Section>
+              </Box>
+              <Box>
+                <LegacyCard.Section subdued>
+                  Second nested section
+                </LegacyCard.Section>
+              </Box>
+            </BlockStack>
+          </LegacyCard.Section>
+          <LegacyCard.Section title="Second outside section">
+            <BlockStack gap="200">
+              <Box>
+                <LegacyCard.Section subdued>
+                  First nested section
+                </LegacyCard.Section>
+              </Box>
+              <Box>
+                <LegacyCard.Section subdued>
+                  Second nested section
+                </LegacyCard.Section>
+              </Box>
+            </BlockStack>
+          </LegacyCard.Section>
+        </LegacyCard>
+        <LegacyCard>
+          <LegacyCard.Header title="Header with icon button child">
+            <Button
+              icon={XIcon}
+              variant="tertiary"
+              accessibilityLabel="Cancel button"
+            />
+          </LegacyCard.Header>
+        </LegacyCard>
+        <WithAllElements.render />
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
 function DynamicChildren() {
   const [showChildren, setShowChildren] = useState(false);

--- a/polaris-react/src/components/LegacyFilters/LegacyFilters.stories.tsx
+++ b/polaris-react/src/components/LegacyFilters/LegacyFilters.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Avatar,
   Box,
@@ -25,1044 +25,330 @@ export default {
       },
     },
   },
-} as ComponentMeta<typeof LegacyFilters>;
+} as Meta<typeof LegacyFilters>;
 
-export function WithAResourceList() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
+export const WithAResourceList = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
 
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
 
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <LegacyFilters
-              queryValue={queryValue}
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-            />
-          }
-          items={[
-            {
-              id: 341,
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithADataTable(_, context) {
-  const [availability, setAvailability] = useState(null);
-  const [productType, setProductType] = useState(null);
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
-
-  const handleAvailabilityChange = useCallback(
-    (value) => setAvailability(value),
-    [],
-  );
-  const handleProductTypeChange = useCallback(
-    (value) => setProductType(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAvailabilityRemove = useCallback(() => setAvailability(null), []);
-  const handleProductTypeRemove = useCallback(() => setProductType(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAvailabilityRemove();
-    handleProductTypeRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAvailabilityRemove,
-    handleQueryValueRemove,
-    handleProductTypeRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'availability',
-      label: 'Availability',
-      filter: (
-        <ChoiceList
-          title="Availability"
-          titleHidden
-          choices={[
-            {label: 'Online Store', value: 'Online Store'},
-            {label: 'Point of Sale', value: 'Point of Sale'},
-            {label: 'Buy Button', value: 'Buy Button'},
-          ]}
-          selected={availability || []}
-          onChange={handleAvailabilityChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'productType',
-      label: 'Product type',
-      filter: (
-        <ChoiceList
-          title="Product type"
-          titleHidden
-          choices={[
-            {label: 'T-Shirt', value: 'T-Shirt'},
-            {label: 'Accessory', value: 'Accessory'},
-            {label: 'Gift card', value: 'Gift card'},
-          ]}
-          selected={productType || []}
-          onChange={handleProductTypeChange}
-          allowMultiple
-        />
-      ),
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters = [];
-  if (!isEmpty(availability)) {
-    const key = 'availability';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, availability),
-      onRemove: handleAvailabilityRemove,
-    });
-  }
-  if (!isEmpty(productType)) {
-    const key = 'productType';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, productType),
-      onRemove: handleProductTypeRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <Box padding="400">
-          <LegacyFilters
-            queryValue={queryValue}
-            filters={filters}
-            appliedFilters={appliedFilters}
-            onQueryChange={handleFiltersQueryChange}
-            onQueryClear={handleQueryValueRemove}
-            onClearAll={handleFiltersClearAll}
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
           />
-        </Box>
-        <DataTable
-          columnContentTypes={[
-            'text',
-            'numeric',
-            'numeric',
-            'numeric',
-            'numeric',
-          ]}
-          headings={[
-            'Product',
-            'Price',
-            'SKU Number',
-            'Net quantity',
-            'Net sales',
-          ]}
-          rows={[
-            ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-            ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-            [
-              'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-              '$445.00',
-              124518,
-              32,
-              '$14,240.00',
-            ],
-          ]}
-          totals={['', '', '', 255, '$155,830.00']}
-        />
-      </Card>
-    </div>
-  );
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
 
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'availability':
-        return value.map((val) => `Available on ${val}`).join(', ');
-      case 'productType':
-        return value.join(', ');
-      default:
-        return value;
+    const appliedFilters = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
     }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
     }
-  }
-}
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
 
-export function WithChildrenContent() {
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <LegacyFilters
+                queryValue={queryValue}
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+              />
+            }
+            items={[
+              {
+                id: 341,
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: 256,
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
 
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <LegacyFilters
-              queryValue={queryValue}
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleQueryValueChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleClearAll}
-            >
-              <div>
-                <Button
-                  onClick={() => console.log('New filter saved')}
-                  size="large"
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
                 >
-                  Save
-                </Button>
-              </div>
-            </LegacyFilters>
-          }
-          items={[
-            {
-              id: 341,
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
 
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
     }
-  }
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
     }
-  }
-}
+  },
+};
 
-export function Disabled() {
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
+export const WithADataTable = {
+  render(_, context) {
+    const [availability, setAvailability] = useState(null);
+    const [productType, setProductType] = useState(null);
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
 
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleAvailabilityChange = useCallback(
+      (value) => setAvailability(value),
+      [],
+    );
+    const handleProductTypeChange = useCallback(
+      (value) => setProductType(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAvailabilityRemove = useCallback(
+      () => setAvailability(null),
+      [],
+    );
+    const handleProductTypeRemove = useCallback(() => setProductType(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAvailabilityRemove();
+      handleProductTypeRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAvailabilityRemove,
+      handleQueryValueRemove,
+      handleProductTypeRemove,
+      handleTaggedWithRemove,
+    ]);
 
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
+    const filters = [
+      {
+        key: 'availability',
+        label: 'Availability',
+        filter: (
+          <ChoiceList
+            title="Availability"
+            titleHidden
+            choices={[
+              {label: 'Online Store', value: 'Online Store'},
+              {label: 'Point of Sale', value: 'Point of Sale'},
+              {label: 'Buy Button', value: 'Buy Button'},
+            ]}
+            selected={availability || []}
+            onChange={handleAvailabilityChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'productType',
+        label: 'Product type',
+        filter: (
+          <ChoiceList
+            title="Product type"
+            titleHidden
+            choices={[
+              {label: 'T-Shirt', value: 'T-Shirt'},
+              {label: 'Accessory', value: 'Accessory'},
+              {label: 'Gift card', value: 'Gift card'},
+            ]}
+            selected={productType || []}
+            onChange={handleProductTypeChange}
+            allowMultiple
+          />
+        ),
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+      },
+    ];
 
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <LegacyFilters
-              queryValue={queryValue}
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleQueryValueChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleClearAll}
-              disabled
-            >
-              <div>
-                <Button
-                  disabled
-                  onClick={() => console.log('New filter saved')}
-                  size="large"
-                >
-                  Save
-                </Button>
-              </div>
-            </LegacyFilters>
-          }
-          items={[
-            {
-              id: 341,
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
+    const appliedFilters = [];
+    if (!isEmpty(availability)) {
+      const key = 'availability';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, availability),
+        onRemove: handleAvailabilityRemove,
+      });
     }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    if (!isEmpty(productType)) {
+      const key = 'productType';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, productType),
+        onRemove: handleProductTypeRemove,
+      });
     }
-  }
-}
-
-export function SomeDisabled() {
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [vendor, setVendor] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleVendorChange = useCallback((value) => setVendor(value), []);
-
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleVendorRemove = useCallback(() => setVendor(null), []);
-
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-    handleVendorRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove, handleVendorRemove]);
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'vendor',
-      label: 'Vendor',
-      filter: (
-        <TextField
-          label="Vendor"
-          value={vendor}
-          onChange={handleVendorChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-      disabled: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <LegacyFilters
-              queryValue={queryValue}
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleQueryValueChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleClearAll}
-            >
-              <div>
-                <Button
-                  disabled
-                  size="large"
-                  onClick={() => console.log('New filter saved')}
-                >
-                  Save
-                </Button>
-              </div>
-            </LegacyFilters>
-          }
-          items={[
-            {
-              id: 341,
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
     }
-  }
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithoutClearButton() {
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-
-  const filters = [
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-      hideClearButton: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith',
-          label: disambiguateLabel('taggedWith', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <LegacyFilters
-              queryValue={queryValue}
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleQueryValueChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleClearAll}
-            >
-              <div>
-                <Button
-                  disabled
-                  size="large"
-                  onClick={() => console.log('New filter saved')}
-                >
-                  Save
-                </Button>
-              </div>
-            </LegacyFilters>
-          }
-          items={[
-            {
-              id: 341,
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithHelpText() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
-
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <Box padding="400">
             <LegacyFilters
               queryValue={queryValue}
               filters={filters}
@@ -1070,457 +356,1192 @@ export function WithHelpText() {
               onQueryChange={handleFiltersQueryChange}
               onQueryClear={handleQueryValueRemove}
               onClearAll={handleFiltersClearAll}
-              helpText="To reactivate filtering, remove your current filters."
-              disabled
             />
-          }
-          items={[
-            {
-              id: 341,
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
+          </Box>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Net quantity',
+              'Net sales',
+            ]}
+            rows={[
+              ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+              ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+              [
+                'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+                '$445.00',
+                124518,
+                32,
+                '$14,240.00',
+              ],
+            ]}
+            totals={['', '', '', 255, '$155,830.00']}
+          />
+        </Card>
+      </div>
+    );
 
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'availability':
+          return value.map((val) => `Available on ${val}`).join(', ');
+        case 'productType':
+          return value.join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithChildrenContent = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <LegacyFilters
+                queryValue={queryValue}
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleQueryValueChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleClearAll}
               >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
+                <div>
+                  <Button
+                    onClick={() => console.log('New filter saved')}
+                    size="large"
+                  >
+                    Save
+                  </Button>
+                </div>
+              </LegacyFilters>
+            }
+            items={[
+              {
+                id: 341,
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: 256,
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
 
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
     }
-  }
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
     }
-  }
-}
+  },
+};
 
-export function WithQueryFieldHidden() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
+export const Disabled = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
 
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
 
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
 
-  const appliedFilters = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
 
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <LegacyFilters
-              queryValue={queryValue}
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-              hideQueryField
-            />
-          }
-          items={[
-            {
-              id: 341,
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
 
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <LegacyFilters
+                queryValue={queryValue}
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleQueryValueChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleClearAll}
+                disabled
               >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
+                <div>
+                  <Button
+                    disabled
+                    onClick={() => console.log('New filter saved')}
+                    size="large"
+                  >
+                    Save
+                  </Button>
+                </div>
+              </LegacyFilters>
+            }
+            items={[
+              {
+                id: 341,
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: 256,
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
 
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
     }
-  }
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
     }
-  }
-}
+  },
+};
 
-export function WithQueryFieldDisabled() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
+export const SomeDisabled = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [vendor, setVendor] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
 
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleVendorChange = useCallback((value) => setVendor(value), []);
 
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleVendorRemove = useCallback(() => setVendor(null), []);
 
-  const appliedFilters = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+      handleVendorRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove, handleVendorRemove]);
 
-  return (
-    <div style={{height: '568px'}}>
-      <Card padding="0">
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <LegacyFilters
-              queryValue={queryValue}
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-              disableQueryField
-            />
-          }
-          items={[
-            {
-              id: 341,
-              url: '#',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: '#',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="md" name={name} />;
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'vendor',
+        label: 'Vendor',
+        filter: (
+          <TextField
+            label="Vendor"
+            value={vendor}
+            onChange={handleVendorChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+        disabled: true,
+      },
+    ];
 
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <LegacyFilters
+                queryValue={queryValue}
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleQueryValueChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleClearAll}
               >
-                <Text as="h3" fontWeight="bold">
-                  {name}
-                </Text>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
+                <div>
+                  <Button
+                    disabled
+                    size="large"
+                    onClick={() => console.log('New filter saved')}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </LegacyFilters>
+            }
+            items={[
+              {
+                id: 341,
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: 256,
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
 
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
-    }
-  }
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
     }
-  }
-}
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithoutClearButton = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+        hideClearButton: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <LegacyFilters
+                queryValue={queryValue}
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleQueryValueChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleClearAll}
+              >
+                <div>
+                  <Button
+                    disabled
+                    size="large"
+                    onClick={() => console.log('New filter saved')}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </LegacyFilters>
+            }
+            items={[
+              {
+                id: 341,
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: 256,
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithHelpText = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
+
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <LegacyFilters
+                queryValue={queryValue}
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+                helpText="To reactivate filtering, remove your current filters."
+                disabled
+              />
+            }
+            items={[
+              {
+                id: 341,
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: 256,
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithQueryFieldHidden = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
+
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <LegacyFilters
+                queryValue={queryValue}
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+                hideQueryField
+              />
+            }
+            items={[
+              {
+                id: 341,
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: 256,
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithQueryFieldDisabled = {
+  render() {
+    const [accountStatus, setAccountStatus] = useState(null);
+    const [moneySpent, setMoneySpent] = useState(null);
+    const [taggedWith, setTaggedWith] = useState(null);
+    const [queryValue, setQueryValue] = useState(null);
+
+    const handleAccountStatusChange = useCallback(
+      (value) => setAccountStatus(value),
+      [],
+    );
+    const handleMoneySpentChange = useCallback(
+      (value) => setMoneySpent(value),
+      [],
+    );
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleFiltersQueryChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleAccountStatusRemove = useCallback(
+      () => setAccountStatus(null),
+      [],
+    );
+    const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleFiltersClearAll = useCallback(() => {
+      handleAccountStatusRemove();
+      handleMoneySpentRemove();
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [
+      handleAccountStatusRemove,
+      handleMoneySpentRemove,
+      handleQueryValueRemove,
+      handleTaggedWithRemove,
+    ]);
+
+    const filters = [
+      {
+        key: 'accountStatus',
+        label: 'Account status',
+        filter: (
+          <ChoiceList
+            title="Account status"
+            titleHidden
+            choices={[
+              {label: 'Enabled', value: 'enabled'},
+              {label: 'Not invited', value: 'not invited'},
+              {label: 'Invited', value: 'invited'},
+              {label: 'Declined', value: 'declined'},
+            ]}
+            selected={accountStatus || []}
+            onChange={handleAccountStatusChange}
+            allowMultiple
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+      {
+        key: 'moneySpent',
+        label: 'Money spent',
+        filter: (
+          <RangeSlider
+            label="Money spent is between"
+            labelHidden
+            value={moneySpent || [0, 500]}
+            prefix="$"
+            output
+            min={0}
+            max={2000}
+            step={1}
+            onChange={handleMoneySpentChange}
+          />
+        ),
+      },
+    ];
+
+    const appliedFilters = [];
+    if (!isEmpty(accountStatus)) {
+      const key = 'accountStatus';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, accountStatus),
+        onRemove: handleAccountStatusRemove,
+      });
+    }
+    if (!isEmpty(moneySpent)) {
+      const key = 'moneySpent';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, moneySpent),
+        onRemove: handleMoneySpentRemove,
+      });
+    }
+    if (!isEmpty(taggedWith)) {
+      const key = 'taggedWith';
+      appliedFilters.push({
+        key,
+        label: disambiguateLabel(key, taggedWith),
+        onRemove: handleTaggedWithRemove,
+      });
+    }
+
+    return (
+      <div style={{height: '568px'}}>
+        <Card padding="0">
+          <ResourceList
+            resourceName={{singular: 'customer', plural: 'customers'}}
+            filterControl={
+              <LegacyFilters
+                queryValue={queryValue}
+                filters={filters}
+                appliedFilters={appliedFilters}
+                onQueryChange={handleFiltersQueryChange}
+                onQueryClear={handleQueryValueRemove}
+                onClearAll={handleFiltersClearAll}
+                disableQueryField
+              />
+            }
+            items={[
+              {
+                id: 341,
+                url: '#',
+                name: 'Mae Jemison',
+                location: 'Decatur, USA',
+              },
+              {
+                id: 256,
+                url: '#',
+                name: 'Ellen Ochoa',
+                location: 'Los Angeles, USA',
+              },
+            ]}
+            renderItem={(item) => {
+              const {id, url, name, location} = item;
+              const media = <Avatar customer size="md" name={name} />;
+
+              return (
+                <ResourceList.Item
+                  id={id}
+                  url={url}
+                  media={media}
+                  accessibilityLabel={`View details for ${name}`}
+                >
+                  <Text as="h3" fontWeight="bold">
+                    {name}
+                  </Text>
+                  <div>{location}</div>
+                </ResourceList.Item>
+              );
+            }}
+          />
+        </Card>
+      </div>
+    );
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'moneySpent':
+          return `Money spent is between $${value[0]} and $${value[1]}`;
+        case 'taggedWith':
+          return `Tagged with ${value}`;
+        case 'accountStatus':
+          return value.map((val) => `Customer ${val}`).join(', ');
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};

--- a/polaris-react/src/components/LegacyStack/LegacyStack.stories.tsx
+++ b/polaris-react/src/components/LegacyStack/LegacyStack.stories.tsx
@@ -1,96 +1,110 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Badge, Text, LegacyStack} from '@shopify/polaris';
 
 export default {
   component: LegacyStack,
-} as ComponentMeta<typeof LegacyStack>;
+} as Meta<typeof LegacyStack>;
 
-export function Default() {
-  return (
-    <LegacyStack>
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
-    </LegacyStack>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <LegacyStack>
+        <Badge>Paid</Badge>
+        <Badge>Processing</Badge>
+        <Badge>Fulfilled</Badge>
+        <Badge>Completed</Badge>
+      </LegacyStack>
+    );
+  },
+};
 
-export function NonWrapping() {
-  return (
-    <LegacyStack wrap={false}>
-      <Badge>Paid</Badge>
-      <Badge>Processing</Badge>
-      <Badge>Fulfilled</Badge>
-      <Badge>Completed</Badge>
-    </LegacyStack>
-  );
-}
+export const NonWrapping = {
+  render() {
+    return (
+      <LegacyStack wrap={false}>
+        <Badge>Paid</Badge>
+        <Badge>Processing</Badge>
+        <Badge>Fulfilled</Badge>
+        <Badge>Completed</Badge>
+      </LegacyStack>
+    );
+  },
+};
 
-export function Spacing() {
-  return (
-    <LegacyStack spacing="loose">
-      <Badge>Paid</Badge>
-      <Badge>Fulfilled</Badge>
-    </LegacyStack>
-  );
-}
+export const Spacing = {
+  render() {
+    return (
+      <LegacyStack spacing="loose">
+        <Badge>Paid</Badge>
+        <Badge>Fulfilled</Badge>
+      </LegacyStack>
+    );
+  },
+};
 
-export function VerticalCentering() {
-  return (
-    <LegacyStack alignment="center">
-      <Text variant="headingMd" as="h2">
-        Order
-        <br />
-        #1136
-        <br />
-        was paid
-      </Text>
-      <Badge>Paid</Badge>
-      <Badge>Fulfilled</Badge>
-    </LegacyStack>
-  );
-}
+export const VerticalCentering = {
+  render() {
+    return (
+      <LegacyStack alignment="center">
+        <Text variant="headingMd" as="h2">
+          Order
+          <br />
+          #1136
+          <br />
+          was paid
+        </Text>
+        <Badge>Paid</Badge>
+        <Badge>Fulfilled</Badge>
+      </LegacyStack>
+    );
+  },
+};
 
-export function FillAvailableSpaceProportionally() {
-  return (
-    <LegacyStack distribution="fill">
-      <Text variant="headingMd" as="h2">
-        Order #1136
-      </Text>
-      <Badge>Paid</Badge>
-      <Badge>Fulfilled</Badge>
-    </LegacyStack>
-  );
-}
-
-export function WhereItemsFillSpaceEvenly() {
-  return (
-    <LegacyStack distribution="fillEvenly">
-      <Text variant="headingMd" as="h2">
-        Order #1136
-      </Text>
-      <Badge>Paid</Badge>
-      <Badge>Fulfilled</Badge>
-    </LegacyStack>
-  );
-}
-
-export function WhereASingleItemFillsTheRemainingSpace() {
-  return (
-    <LegacyStack>
-      <LegacyStack.Item fill>
+export const FillAvailableSpaceProportionally = {
+  render() {
+    return (
+      <LegacyStack distribution="fill">
         <Text variant="headingMd" as="h2">
           Order #1136
         </Text>
-      </LegacyStack.Item>
-      <LegacyStack.Item>
         <Badge>Paid</Badge>
-      </LegacyStack.Item>
-      <LegacyStack.Item>
         <Badge>Fulfilled</Badge>
-      </LegacyStack.Item>
-    </LegacyStack>
-  );
-}
+      </LegacyStack>
+    );
+  },
+};
+
+export const WhereItemsFillSpaceEvenly = {
+  render() {
+    return (
+      <LegacyStack distribution="fillEvenly">
+        <Text variant="headingMd" as="h2">
+          Order #1136
+        </Text>
+        <Badge>Paid</Badge>
+        <Badge>Fulfilled</Badge>
+      </LegacyStack>
+    );
+  },
+};
+
+export const WhereASingleItemFillsTheRemainingSpace = {
+  render() {
+    return (
+      <LegacyStack>
+        <LegacyStack.Item fill>
+          <Text variant="headingMd" as="h2">
+            Order #1136
+          </Text>
+        </LegacyStack.Item>
+        <LegacyStack.Item>
+          <Badge>Paid</Badge>
+        </LegacyStack.Item>
+        <LegacyStack.Item>
+          <Badge>Fulfilled</Badge>
+        </LegacyStack.Item>
+      </LegacyStack>
+    );
+  },
+};

--- a/polaris-react/src/components/LegacyTabs/LegacyTabs.stories.tsx
+++ b/polaris-react/src/components/LegacyTabs/LegacyTabs.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Badge,
   LegacyCard,
@@ -10,273 +10,287 @@ import {
 
 export default {
   component: LegacyTabs,
-} as ComponentMeta<typeof LegacyTabs>;
+} as Meta<typeof LegacyTabs>;
 
-export function All() {
-  return (
-    <BlockStack gap="800">
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          Default
-        </Text>
-        <Default />
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="800">
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            Default
+          </Text>
+          <Default.render />
+        </BlockStack>
+
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With URL tabs
+          </Text>
+          <WithUrlTabs.render />
+        </BlockStack>
+
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            Fitted
+          </Text>
+          <Fitted.render />
+        </BlockStack>
+
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With badge content
+          </Text>
+          <WithBadgeContent.render />
+        </BlockStack>
+
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With custom disclosure
+          </Text>
+          <WithCustomDisclosure.render />
+        </BlockStack>
       </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With URL tabs
-        </Text>
-        <WithUrlTabs />
-      </BlockStack>
+export const Default = {
+  render() {
+    const [selected, setSelected] = useState(0);
 
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          Fitted
-        </Text>
-        <Fitted />
-      </BlockStack>
+    const handleTabChange = useCallback(
+      (selectedTabIndex) => setSelected(selectedTabIndex),
+      [],
+    );
 
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With badge content
-        </Text>
-        <WithBadgeContent />
-      </BlockStack>
+    const tabs = [
+      {
+        id: 'all-customers-1',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-content-1',
+      },
+      {
+        id: 'accepts-marketing-1',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-content-1',
+      },
+      {
+        id: 'repeat-customers-1',
+        content: 'Repeat customers',
+        panelID: 'repeat-customers-content-1',
+      },
+      {
+        id: 'prospects-1',
+        content: 'Prospects',
+        panelID: 'prospects-content-1',
+      },
+    ];
 
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With custom disclosure
-        </Text>
-        <WithCustomDisclosure />
-      </BlockStack>
-    </BlockStack>
-  );
-}
-
-export function Default() {
-  const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
-
-  const tabs = [
-    {
-      id: 'all-customers-1',
-      content: 'All',
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-content-1',
-    },
-    {
-      id: 'accepts-marketing-1',
-      content: 'Accepts marketing',
-      panelID: 'accepts-marketing-content-1',
-    },
-    {
-      id: 'repeat-customers-1',
-      content: 'Repeat customers',
-      panelID: 'repeat-customers-content-1',
-    },
-    {
-      id: 'prospects-1',
-      content: 'Prospects',
-      panelID: 'prospects-content-1',
-    },
-  ];
-
-  return (
-    <LegacyTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
-      <LegacyCard.Section title={tabs[selected].content}>
-        <Text as="p" variant="bodyMd">
-          Tab {selected} selected
-        </Text>
-      </LegacyCard.Section>
-    </LegacyTabs>
-  );
-}
-
-export function WithUrlTabs() {
-  const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
-
-  const tabs = [
-    {
-      id: 'all-customers-2',
-      content: 'All',
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-content-2',
-      url: '#',
-    },
-    {
-      id: 'accepts-marketing-2',
-      content: 'Accepts marketing',
-      panelID: 'accepts-marketing-content-2',
-      url: '#',
-    },
-    {
-      id: 'repeat-customers-2',
-      content: 'Repeat customers',
-      panelID: 'repeat-customers-content-2',
-      url: '#',
-    },
-    {
-      id: 'prospects-2',
-      content: 'Prospects',
-      panelID: 'prospects-content-2',
-      url: '#',
-    },
-  ];
-
-  return (
-    <LegacyTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
-      <LegacyCard.Section title={tabs[selected].content}>
-        <Text as="p" variant="bodyMd">
-          Tab {selected} selected
-        </Text>
-      </LegacyCard.Section>
-    </LegacyTabs>
-  );
-}
-
-export function Fitted() {
-  const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
-
-  const tabs = [
-    {
-      id: 'all-customers-fitted-3',
-      content: 'All',
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-fitted-content-3',
-    },
-    {
-      id: 'accepts-marketing-fitted-3',
-      content: 'Accepts marketing',
-      panelID: 'accepts-marketing-fitted-Ccontent-3',
-    },
-  ];
-
-  return (
-    <LegacyCard>
-      <LegacyTabs
-        tabs={tabs}
-        selected={selected}
-        onSelect={handleTabChange}
-        fitted
-      >
+    return (
+      <LegacyTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
         <LegacyCard.Section title={tabs[selected].content}>
           <Text as="p" variant="bodyMd">
             Tab {selected} selected
           </Text>
         </LegacyCard.Section>
       </LegacyTabs>
-    </LegacyCard>
-  );
-}
+    );
+  },
+};
 
-export function WithBadgeContent() {
-  const [selected, setSelected] = useState(0);
+export const WithUrlTabs = {
+  render() {
+    const [selected, setSelected] = useState(0);
 
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
+    const handleTabChange = useCallback(
+      (selectedTabIndex) => setSelected(selectedTabIndex),
+      [],
+    );
 
-  const tabs = [
-    {
-      id: 'all-customers-fitted-4',
-      content: (
-        <span>
-          All <Badge tone="new">10+</Badge>
-        </span>
-      ),
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-fitted-content-4',
-    },
-    {
-      id: 'accepts-marketing-fitted-4',
-      content: (
-        <span>
-          Accepts marketing <Badge tone="new">4</Badge>
-        </span>
-      ),
-      panelID: 'accepts-marketing-fitted-content-4',
-    },
-  ];
+    const tabs = [
+      {
+        id: 'all-customers-2',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-content-2',
+        url: '#',
+      },
+      {
+        id: 'accepts-marketing-2',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-content-2',
+        url: '#',
+      },
+      {
+        id: 'repeat-customers-2',
+        content: 'Repeat customers',
+        panelID: 'repeat-customers-content-2',
+        url: '#',
+      },
+      {
+        id: 'prospects-2',
+        content: 'Prospects',
+        panelID: 'prospects-content-2',
+        url: '#',
+      },
+    ];
 
-  return (
-    <LegacyCard>
-      <LegacyTabs
-        tabs={tabs}
-        selected={selected}
-        onSelect={handleTabChange}
-        fitted
-      >
+    return (
+      <LegacyTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
         <LegacyCard.Section title={tabs[selected].content}>
           <Text as="p" variant="bodyMd">
             Tab {selected} selected
           </Text>
         </LegacyCard.Section>
       </LegacyTabs>
-    </LegacyCard>
-  );
-}
+    );
+  },
+};
 
-export function WithCustomDisclosure() {
-  const [selected, setSelected] = useState(0);
+export const Fitted = {
+  render() {
+    const [selected, setSelected] = useState(0);
 
-  const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
-  );
+    const handleTabChange = useCallback(
+      (selectedTabIndex) => setSelected(selectedTabIndex),
+      [],
+    );
 
-  const tabs = [
-    {
-      id: 'all-customers-5',
-      content: 'All',
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-content-5',
-    },
-    {
-      id: 'accepts-marketing-5',
-      content: 'Accepts marketing',
-      panelID: 'accepts-marketing-content-5',
-    },
-    {
-      id: 'repeat-customers-5',
-      content: 'Repeat customers',
-      panelID: 'repeat-customers-content-5',
-    },
-    {
-      id: 'prospects-5',
-      content: 'Prospects',
-      panelID: 'prospects-content-5',
-    },
-  ];
+    const tabs = [
+      {
+        id: 'all-customers-fitted-3',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-fitted-content-3',
+      },
+      {
+        id: 'accepts-marketing-fitted-3',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-fitted-Ccontent-3',
+      },
+    ];
 
-  return (
-    <LegacyCard>
-      <LegacyTabs
-        tabs={tabs}
-        selected={selected}
-        onSelect={handleTabChange}
-        disclosureText="More views"
-      >
-        <LegacyCard.Section title={tabs[selected].content}>
-          <Text as="p" variant="bodyMd">
-            Tab {selected} selected
-          </Text>
-        </LegacyCard.Section>
-      </LegacyTabs>
-    </LegacyCard>
-  );
-}
+    return (
+      <LegacyCard>
+        <LegacyTabs
+          tabs={tabs}
+          selected={selected}
+          onSelect={handleTabChange}
+          fitted
+        >
+          <LegacyCard.Section title={tabs[selected].content}>
+            <Text as="p" variant="bodyMd">
+              Tab {selected} selected
+            </Text>
+          </LegacyCard.Section>
+        </LegacyTabs>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithBadgeContent = {
+  render() {
+    const [selected, setSelected] = useState(0);
+
+    const handleTabChange = useCallback(
+      (selectedTabIndex) => setSelected(selectedTabIndex),
+      [],
+    );
+
+    const tabs = [
+      {
+        id: 'all-customers-fitted-4',
+        content: (
+          <span>
+            All <Badge tone="new">10+</Badge>
+          </span>
+        ),
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-fitted-content-4',
+      },
+      {
+        id: 'accepts-marketing-fitted-4',
+        content: (
+          <span>
+            Accepts marketing <Badge tone="new">4</Badge>
+          </span>
+        ),
+        panelID: 'accepts-marketing-fitted-content-4',
+      },
+    ];
+
+    return (
+      <LegacyCard>
+        <LegacyTabs
+          tabs={tabs}
+          selected={selected}
+          onSelect={handleTabChange}
+          fitted
+        >
+          <LegacyCard.Section title={tabs[selected].content}>
+            <Text as="p" variant="bodyMd">
+              Tab {selected} selected
+            </Text>
+          </LegacyCard.Section>
+        </LegacyTabs>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithCustomDisclosure = {
+  render() {
+    const [selected, setSelected] = useState(0);
+
+    const handleTabChange = useCallback(
+      (selectedTabIndex) => setSelected(selectedTabIndex),
+      [],
+    );
+
+    const tabs = [
+      {
+        id: 'all-customers-5',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-content-5',
+      },
+      {
+        id: 'accepts-marketing-5',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-content-5',
+      },
+      {
+        id: 'repeat-customers-5',
+        content: 'Repeat customers',
+        panelID: 'repeat-customers-content-5',
+      },
+      {
+        id: 'prospects-5',
+        content: 'Prospects',
+        panelID: 'prospects-content-5',
+      },
+    ];
+
+    return (
+      <LegacyCard>
+        <LegacyTabs
+          tabs={tabs}
+          selected={selected}
+          onSelect={handleTabChange}
+          disclosureText="More views"
+        >
+          <LegacyCard.Section title={tabs[selected].content}>
+            <Text as="p" variant="bodyMd">
+              Tab {selected} selected
+            </Text>
+          </LegacyCard.Section>
+        </LegacyTabs>
+      </LegacyCard>
+    );
+  },
+};

--- a/polaris-react/src/components/Link/Link.stories.tsx
+++ b/polaris-react/src/components/Link/Link.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Banner, Link} from '@shopify/polaris';
 
 export default {
@@ -7,33 +7,41 @@ export default {
   parameters: {
     disableAnchorTargetOverride: true,
   },
-} as ComponentMeta<typeof Link>;
+} as Meta<typeof Link>;
 
-export function Default() {
-  return <Link url="https://help.shopify.com/manual">fulfilling orders</Link>;
-}
+export const Default = {
+  render() {
+    return <Link url="https://help.shopify.com/manual">fulfilling orders</Link>;
+  },
+};
 
-export function Monochrome() {
-  return (
-    <Link monochrome url="https://help.shopify.com/manual">
-      fulfilling orders
-    </Link>
-  );
-}
+export const Monochrome = {
+  render() {
+    return (
+      <Link monochrome url="https://help.shopify.com/manual">
+        fulfilling orders
+      </Link>
+    );
+  },
+};
 
-export function MonochromeInABanner() {
-  return (
-    <Banner>
-      Learn more about{' '}
-      <Link url="https://help.shopify.com/manual">fulfilling orders</Link>
-    </Banner>
-  );
-}
+export const MonochromeInABanner = {
+  render() {
+    return (
+      <Banner>
+        Learn more about{' '}
+        <Link url="https://help.shopify.com/manual">fulfilling orders</Link>
+      </Banner>
+    );
+  },
+};
 
-export function External() {
-  return (
-    <Link url="https://help.shopify.com/manual" external>
-      Shopify Help Center
-    </Link>
-  );
-}
+export const External = {
+  render() {
+    return (
+      <Link url="https://help.shopify.com/manual" external>
+        Shopify Help Center
+      </Link>
+    );
+  },
+};

--- a/polaris-react/src/components/List/List.stories.tsx
+++ b/polaris-react/src/components/List/List.stories.tsx
@@ -1,37 +1,43 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {List} from '@shopify/polaris';
 
 export default {
   component: List,
-} as ComponentMeta<typeof List>;
+} as Meta<typeof List>;
 
-export function Bulleted() {
-  return (
-    <List type="bullet">
-      <List.Item>Yellow shirt</List.Item>
-      <List.Item>Red shirt</List.Item>
-      <List.Item>Green shirt</List.Item>
-    </List>
-  );
-}
+export const Bulleted = {
+  render() {
+    return (
+      <List type="bullet">
+        <List.Item>Yellow shirt</List.Item>
+        <List.Item>Red shirt</List.Item>
+        <List.Item>Green shirt</List.Item>
+      </List>
+    );
+  },
+};
 
-export function Numbered() {
-  return (
-    <List type="number">
-      <List.Item>First item</List.Item>
-      <List.Item>Second item</List.Item>
-      <List.Item>Third Item</List.Item>
-    </List>
-  );
-}
+export const Numbered = {
+  render() {
+    return (
+      <List type="number">
+        <List.Item>First item</List.Item>
+        <List.Item>Second item</List.Item>
+        <List.Item>Third Item</List.Item>
+      </List>
+    );
+  },
+};
 
-export function ExtraTight() {
-  return (
-    <List gap="extraTight">
-      <List.Item>Yellow shirt</List.Item>
-      <List.Item>Red shirt</List.Item>
-      <List.Item>Green shirt</List.Item>
-    </List>
-  );
-}
+export const ExtraTight = {
+  render() {
+    return (
+      <List gap="extraTight">
+        <List.Item>Yellow shirt</List.Item>
+        <List.Item>Red shirt</List.Item>
+        <List.Item>Green shirt</List.Item>
+      </List>
+    );
+  },
+};

--- a/polaris-react/src/components/Listbox/Listbox.stories.tsx
+++ b/polaris-react/src/components/Listbox/Listbox.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   LegacyCard,
   EmptySearchResult,
@@ -18,464 +18,482 @@ import {PlusCircleIcon, SearchIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Listbox,
-} as ComponentMeta<typeof Listbox>;
+} as Meta<typeof Listbox>;
 
-export function All() {
-  return (
-    <BlockStack gap="800">
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          Default
-        </Text>
-        <Default />
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="800">
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            Default
+          </Text>
+          <Default.render />
+          <Box paddingBlockEnd="300" />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With loading
+          </Text>
+          <WithLoading.render />
+          <Box paddingBlockEnd="300" />
+        </BlockStack>
+
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With action
+          </Text>
+          <WithAction.render />
+          <Box paddingBlockEnd="300" />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With custom element
+          </Text>
+          <WithCustomOptions.render />
+          <Box paddingBlockEnd="300" />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With search
+          </Text>
+          <WithSearch.render />
+          <Box paddingBlockEnd="300" />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With disabled text option
+          </Text>
+          <WithDisabledTextOption.render />
+        </BlockStack>
         <Box paddingBlockEnd="300" />
       </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With loading
-        </Text>
-        <WithLoading />
-        <Box paddingBlockEnd="300" />
-      </BlockStack>
+export const Default = {
+  render() {
+    return (
+      <Listbox accessibilityLabel="Basic Listbox example">
+        <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
+        <Listbox.Option value="UniqueValue-2">Item 2</Listbox.Option>
+        <Listbox.Option value="UniqueValue-3">Item 3</Listbox.Option>
+      </Listbox>
+    );
+  },
+};
 
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With action
-        </Text>
-        <WithAction />
-        <Box paddingBlockEnd="300" />
-      </BlockStack>
+export const WithLoading = {
+  render() {
+    return (
+      <Listbox accessibilityLabel="Listbox with loading example">
+        <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
+        <Listbox.Option value="UniqueValue-2">Item 2</Listbox.Option>
+        <Listbox.Option value="UniqueValue-3">Item 3</Listbox.Option>
+        <Listbox.Loading accessibilityLabel="loading example" />
+      </Listbox>
+    );
+  },
+};
 
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With custom element
-        </Text>
-        <WithCustomOptions />
-        <Box paddingBlockEnd="300" />
-      </BlockStack>
+export const WithAction = {
+  render() {
+    return (
+      <Listbox accessibilityLabel="Listbox with Action example">
+        <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
+        <Listbox.Option value="UniqueValue-2" divider>
+          Item 2
+        </Listbox.Option>
+        <Listbox.Action value="ActionValue">
+          <LegacyStack spacing="tight">
+            <Icon source={PlusCircleIcon} tone="base" />
+            <div>Add item</div>
+          </LegacyStack>
+        </Listbox.Action>
+      </Listbox>
+    );
+  },
+};
 
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With search
-        </Text>
-        <WithSearch />
-        <Box paddingBlockEnd="300" />
-      </BlockStack>
-
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With disabled text option
-        </Text>
-        <WithDisabledTextOption />
-      </BlockStack>
-      <Box paddingBlockEnd="300" />
-    </BlockStack>
-  );
-}
-
-export function Default() {
-  return (
-    <Listbox accessibilityLabel="Basic Listbox example">
-      <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
-      <Listbox.Option value="UniqueValue-2">Item 2</Listbox.Option>
-      <Listbox.Option value="UniqueValue-3">Item 3</Listbox.Option>
-    </Listbox>
-  );
-}
-
-export function WithLoading() {
-  return (
-    <Listbox accessibilityLabel="Listbox with loading example">
-      <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
-      <Listbox.Option value="UniqueValue-2">Item 2</Listbox.Option>
-      <Listbox.Option value="UniqueValue-3">Item 3</Listbox.Option>
-      <Listbox.Loading accessibilityLabel="loading example" />
-    </Listbox>
-  );
-}
-
-export function WithAction() {
-  return (
-    <Listbox accessibilityLabel="Listbox with Action example">
-      <Listbox.Option value="UniqueValue-1">Item 1</Listbox.Option>
-      <Listbox.Option value="UniqueValue-2" divider>
-        Item 2
-      </Listbox.Option>
-      <Listbox.Action value="ActionValue">
-        <LegacyStack spacing="tight">
-          <Icon source={PlusCircleIcon} tone="base" />
-          <div>Add item</div>
-        </LegacyStack>
-      </Listbox.Action>
-    </Listbox>
-  );
-}
-
-export function WithCustomOptions() {
-  interface CustomerSegment {
-    id: string;
-    label: string;
-    value: string;
-    subscribers: number;
-  }
-
-  const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
-
-  const segments: CustomerSegment[] = [
-    {
-      label: 'All customers',
-      id: 'gid://shopify/CustomerSegment/1',
-      value: '0',
-      subscribers: 23,
-    },
-    {
-      label: 'VIP customers',
-      id: 'gid://shopify/CustomerSegment/2',
-      value: '1',
-      subscribers: 16,
-    },
-    {
-      label: 'New customers',
-      id: 'gid://shopify/CustomerSegment/3',
-      value: '2',
-      subscribers: 2,
-    },
-    {
-      label: 'Abandoned carts - last 30 days',
-      id: 'gid://shopify/CustomerSegment/4',
-      value: '3',
-      subscribers: 108,
-    },
-  ];
-
-  const handleSegmentSelect = (segmentIndex: string) => {
-    setSelectedSegmentIndex(Number(segmentIndex));
-  };
-
-  return (
-    <Listbox
-      onSelect={handleSegmentSelect}
-      accessibilityLabel="Listbox with custom element example"
-    >
-      {segments.map(({label, id, value, subscribers}) => {
-        const selected = segments[selectedSegmentIndex].value === value;
-
-        return (
-          <Listbox.Option key={id} value={value} selected={selected}>
-            <Listbox.TextOption selected={selected}>
-              <Box width="100%">
-                <InlineStack gap="200" align="space-between">
-                  {label}
-                  <Text as="span" tone="subdued">
-                    {`${subscribers} subscribers`}
-                  </Text>
-                </InlineStack>
-              </Box>
-            </Listbox.TextOption>
-          </Listbox.Option>
-        );
-      })}
-    </Listbox>
-  );
-}
-
-export function WithSearch() {
-  interface CustomerSegment {
-    id: string;
-    label: string;
-    value: string;
-  }
-
-  const actionValue = '__ACTION__';
-
-  const segments: CustomerSegment[] = [
-    {
-      label: 'All customers',
-      id: 'gid://shopify/CustomerSegment/1',
-      value: '0',
-    },
-    {
-      label: 'VIP customers',
-      id: 'gid://shopify/CustomerSegment/2',
-      value: '1',
-    },
-    {
-      label: 'New customers',
-      id: 'gid://shopify/CustomerSegment/3',
-      value: '2',
-    },
-    {
-      label: 'Abandoned carts - last 30 days',
-      id: 'gid://shopify/CustomerSegment/4',
-      value: '3',
-    },
-    {
-      label: 'Wholesale customers',
-      id: 'gid://shopify/CustomerSegment/5',
-      value: '4',
-    },
-    {
-      label: 'Email subscribers',
-      id: 'gid://shopify/CustomerSegment/6',
-      value: '5',
-    },
-    {
-      label: 'From New York',
-      id: 'gid://shopify/CustomerSegment/7',
-      value: '6',
-    },
-    {
-      label: 'Repeat buyers',
-      id: 'gid://shopify/CustomerSegment/8',
-      value: '7',
-    },
-    {
-      label: 'First time buyers',
-      id: 'gid://shopify/CustomerSegment/9',
-      value: '8',
-    },
-    {
-      label: 'From Canada',
-      id: 'gid://shopify/CustomerSegment/10',
-      value: '9',
-    },
-    {
-      label: 'Bought in last 60 days',
-      id: 'gid://shopify/CustomerSegment/11',
-      value: '10',
-    },
-    {
-      label: 'Bought last BFCM',
-      id: 'gid://shopify/CustomerSegment/12',
-      value: '11',
-    },
-  ];
-
-  const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
-    (_, index) => ({
-      label: `Other customers ${index + 13}`,
-      id: `gid://shopify/CustomerSegment/${index + 13}`,
-      value: `${index + 12}`,
-    }),
-  );
-
-  segments.push(...lazyLoadSegments);
-
-  const interval = 25;
-
-  const [showFooterAction, setShowFooterAction] = useState(true);
-  const [query, setQuery] = useState('');
-  const [lazyLoading, setLazyLoading] = useState(false);
-  const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
-  const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
-  const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
-  const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
-  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
-    [],
-  );
-
-  const handleClickShowAll = () => {
-    setShowFooterAction(false);
-    setVisibleOptionIndex(segments.length);
-  };
-
-  const handleFilterSegments = (query: string) => {
-    const nextFilteredSegments = segments.filter((segment: CustomerSegment) => {
-      return segment.label
-        .toLocaleLowerCase()
-        .includes(query.toLocaleLowerCase().trim());
-    });
-
-    setFilteredSegments(nextFilteredSegments);
-  };
-
-  const handleQueryChange = (query: string) => {
-    setQuery(query);
-
-    if (query.length >= 2) handleFilterSegments(query);
-  };
-
-  const handleQueryClear = () => {
-    handleQueryChange('');
-  };
-
-  const handleResetVisibleOptionIndex = () => {
-    setVisibleOptionIndex(interval);
-  };
-
-  const handleSegmentSelect = (segmentIndex: string) => {
-    if (segmentIndex === actionValue) {
-      return handleClickShowAll();
+export const WithCustomOptions = {
+  render() {
+    interface CustomerSegment {
+      id: string;
+      label: string;
+      value: string;
+      subscribers: number;
     }
 
-    setSelectedSegmentIndex(Number(segmentIndex));
-  };
+    const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
 
-  const handleActiveOptionChange = (_: string, domId: string) => {
-    setActiveOptionId(domId);
-  };
+    const segments: CustomerSegment[] = [
+      {
+        label: 'All customers',
+        id: 'gid://shopify/CustomerSegment/1',
+        value: '0',
+        subscribers: 23,
+      },
+      {
+        label: 'VIP customers',
+        id: 'gid://shopify/CustomerSegment/2',
+        value: '1',
+        subscribers: 16,
+      },
+      {
+        label: 'New customers',
+        id: 'gid://shopify/CustomerSegment/3',
+        value: '2',
+        subscribers: 2,
+      },
+      {
+        label: 'Abandoned carts - last 30 days',
+        id: 'gid://shopify/CustomerSegment/4',
+        value: '3',
+        subscribers: 108,
+      },
+    ];
 
-  /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
+    const handleSegmentSelect = (segmentIndex: string) => {
+      setSelectedSegmentIndex(Number(segmentIndex));
+    };
 
-  const handleLazyLoadSegments = () => {
-    if (willLoadMoreResults && !showFooterAction) {
-      setLazyLoading(true);
-
-      const options = query ? filteredSegments : segments;
-
-      setTimeout(() => {
-        const remainingOptionCount = options.length - visibleOptionIndex;
-        const nextVisibleOptionIndex =
-          remainingOptionCount >= interval
-            ? visibleOptionIndex + interval
-            : visibleOptionIndex + remainingOptionCount;
-
-        setLazyLoading(false);
-        setVisibleOptionIndex(nextVisibleOptionIndex);
-
-        if (remainingOptionCount <= interval) {
-          setWillLoadMoreResults(false);
-        }
-      }, 1000);
-    }
-  };
-
-  const listboxId = 'SearchableListbox';
-
-  const textFieldMarkup = (
-    <div style={{padding: '12px'}}>
-      <TextField
-        focused={showFooterAction}
-        clearButton
-        labelHidden
-        label="Customer segments"
-        placeholder="Search segments"
-        autoComplete="off"
-        value={query}
-        prefix={<Icon source={SearchIcon} />}
-        ariaActiveDescendant={activeOptionId}
-        ariaControls={listboxId}
-        onChange={handleQueryChange}
-        onClearButtonClick={handleQueryClear}
-      />
-    </div>
-  );
-
-  const segmentOptions = query ? filteredSegments : segments;
-
-  const segmentList =
-    segmentOptions.length > 0
-      ? segmentOptions
-          .slice(0, visibleOptionIndex)
-          .map(({label, id, value}) => {
-            const selected = segments[selectedSegmentIndex].value === value;
-
-            return (
-              <Listbox.Option key={id} value={value} selected={selected}>
-                <Listbox.TextOption selected={selected}>
-                  {label}
-                </Listbox.TextOption>
-              </Listbox.Option>
-            );
-          })
-      : null;
-
-  const showAllMarkup = showFooterAction ? (
-    <Listbox.Action value={actionValue}>
-      <span
-        style={{
-          color: 'var(--p-color-text-secondary)',
-        }}
+    return (
+      <Listbox
+        onSelect={handleSegmentSelect}
+        accessibilityLabel="Listbox with custom element example"
       >
-        Show all 111 segments
-      </span>
-    </Listbox.Action>
-  ) : null;
+        {segments.map(({label, id, value, subscribers}) => {
+          const selected = segments[selectedSegmentIndex].value === value;
 
-  const lazyLoadingMarkup = lazyLoading ? (
-    <Listbox.Loading
-      accessibilityLabel={`${
-        query ? 'Filtering' : 'Loading'
-      } customer segments`}
-    />
-  ) : null;
+          return (
+            <Listbox.Option key={id} value={value} selected={selected}>
+              <Listbox.TextOption selected={selected}>
+                <Box width="100%">
+                  <InlineStack gap="200" align="space-between">
+                    {label}
+                    <Text as="span" tone="subdued">
+                      {`${subscribers} subscribers`}
+                    </Text>
+                  </InlineStack>
+                </Box>
+              </Listbox.TextOption>
+            </Listbox.Option>
+          );
+        })}
+      </Listbox>
+    );
+  },
+};
 
-  const noResultsMarkup =
-    segmentOptions.length === 0 ? (
-      <EmptySearchResult
-        title=""
-        description={`No segments found matching "${query}"`}
+export const WithSearch = {
+  render() {
+    interface CustomerSegment {
+      id: string;
+      label: string;
+      value: string;
+    }
+
+    const actionValue = '__ACTION__';
+
+    const segments: CustomerSegment[] = [
+      {
+        label: 'All customers',
+        id: 'gid://shopify/CustomerSegment/1',
+        value: '0',
+      },
+      {
+        label: 'VIP customers',
+        id: 'gid://shopify/CustomerSegment/2',
+        value: '1',
+      },
+      {
+        label: 'New customers',
+        id: 'gid://shopify/CustomerSegment/3',
+        value: '2',
+      },
+      {
+        label: 'Abandoned carts - last 30 days',
+        id: 'gid://shopify/CustomerSegment/4',
+        value: '3',
+      },
+      {
+        label: 'Wholesale customers',
+        id: 'gid://shopify/CustomerSegment/5',
+        value: '4',
+      },
+      {
+        label: 'Email subscribers',
+        id: 'gid://shopify/CustomerSegment/6',
+        value: '5',
+      },
+      {
+        label: 'From New York',
+        id: 'gid://shopify/CustomerSegment/7',
+        value: '6',
+      },
+      {
+        label: 'Repeat buyers',
+        id: 'gid://shopify/CustomerSegment/8',
+        value: '7',
+      },
+      {
+        label: 'First time buyers',
+        id: 'gid://shopify/CustomerSegment/9',
+        value: '8',
+      },
+      {
+        label: 'From Canada',
+        id: 'gid://shopify/CustomerSegment/10',
+        value: '9',
+      },
+      {
+        label: 'Bought in last 60 days',
+        id: 'gid://shopify/CustomerSegment/11',
+        value: '10',
+      },
+      {
+        label: 'Bought last BFCM',
+        id: 'gid://shopify/CustomerSegment/12',
+        value: '11',
+      },
+    ];
+
+    const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
+      (_, index) => ({
+        label: `Other customers ${index + 13}`,
+        id: `gid://shopify/CustomerSegment/${index + 13}`,
+        value: `${index + 12}`,
+      }),
+    );
+
+    segments.push(...lazyLoadSegments);
+
+    const interval = 25;
+
+    const [showFooterAction, setShowFooterAction] = useState(true);
+    const [query, setQuery] = useState('');
+    const [lazyLoading, setLazyLoading] = useState(false);
+    const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
+    const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
+    const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
+    const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
+    const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
+      [],
+    );
+
+    const handleClickShowAll = () => {
+      setShowFooterAction(false);
+      setVisibleOptionIndex(segments.length);
+    };
+
+    const handleFilterSegments = (query: string) => {
+      const nextFilteredSegments = segments.filter(
+        (segment: CustomerSegment) => {
+          return segment.label
+            .toLocaleLowerCase()
+            .includes(query.toLocaleLowerCase().trim());
+        },
+      );
+
+      setFilteredSegments(nextFilteredSegments);
+    };
+
+    const handleQueryChange = (query: string) => {
+      setQuery(query);
+
+      if (query.length >= 2) handleFilterSegments(query);
+    };
+
+    const handleQueryClear = () => {
+      handleQueryChange('');
+    };
+
+    const handleResetVisibleOptionIndex = () => {
+      setVisibleOptionIndex(interval);
+    };
+
+    const handleSegmentSelect = (segmentIndex: string) => {
+      if (segmentIndex === actionValue) {
+        return handleClickShowAll();
+      }
+
+      setSelectedSegmentIndex(Number(segmentIndex));
+    };
+
+    const handleActiveOptionChange = (_: string, domId: string) => {
+      setActiveOptionId(domId);
+    };
+
+    /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
+
+    const handleLazyLoadSegments = () => {
+      if (willLoadMoreResults && !showFooterAction) {
+        setLazyLoading(true);
+
+        const options = query ? filteredSegments : segments;
+
+        setTimeout(() => {
+          const remainingOptionCount = options.length - visibleOptionIndex;
+          const nextVisibleOptionIndex =
+            remainingOptionCount >= interval
+              ? visibleOptionIndex + interval
+              : visibleOptionIndex + remainingOptionCount;
+
+          setLazyLoading(false);
+          setVisibleOptionIndex(nextVisibleOptionIndex);
+
+          if (remainingOptionCount <= interval) {
+            setWillLoadMoreResults(false);
+          }
+        }, 1000);
+      }
+    };
+
+    const listboxId = 'SearchableListbox';
+
+    const textFieldMarkup = (
+      <div style={{padding: '12px'}}>
+        <TextField
+          focused={showFooterAction}
+          clearButton
+          labelHidden
+          label="Customer segments"
+          placeholder="Search segments"
+          autoComplete="off"
+          value={query}
+          prefix={<Icon source={SearchIcon} />}
+          ariaActiveDescendant={activeOptionId}
+          ariaControls={listboxId}
+          onChange={handleQueryChange}
+          onClearButtonClick={handleQueryClear}
+        />
+      </div>
+    );
+
+    const segmentOptions = query ? filteredSegments : segments;
+
+    const segmentList =
+      segmentOptions.length > 0
+        ? segmentOptions
+            .slice(0, visibleOptionIndex)
+            .map(({label, id, value}) => {
+              const selected = segments[selectedSegmentIndex].value === value;
+
+              return (
+                <Listbox.Option key={id} value={value} selected={selected}>
+                  <Listbox.TextOption selected={selected}>
+                    {label}
+                  </Listbox.TextOption>
+                </Listbox.Option>
+              );
+            })
+        : null;
+
+    const showAllMarkup = showFooterAction ? (
+      <Listbox.Action value={actionValue}>
+        <span
+          style={{
+            color: 'var(--p-color-text-secondary)',
+          }}
+        >
+          Show all 111 segments
+        </span>
+      </Listbox.Action>
+    ) : null;
+
+    const lazyLoadingMarkup = lazyLoading ? (
+      <Listbox.Loading
+        accessibilityLabel={`${
+          query ? 'Filtering' : 'Loading'
+        } customer segments`}
       />
     ) : null;
 
-  const listboxMarkup = (
-    <Listbox
-      enableKeyboardControl
-      autoSelection={AutoSelection.FirstSelected}
-      accessibilityLabel="Search for and select a customer segment"
-      customListId={listboxId}
-      onSelect={handleSegmentSelect}
-      onActiveOptionChange={handleActiveOptionChange}
-    >
-      {segmentList}
-      {showAllMarkup}
-      {noResultsMarkup}
-      {lazyLoadingMarkup}
-    </Listbox>
-  );
+    const noResultsMarkup =
+      segmentOptions.length === 0 ? (
+        <EmptySearchResult
+          title=""
+          description={`No segments found matching "${query}"`}
+        />
+      ) : null;
 
-  return (
-    <LegacyCard>
-      <div
-        style={{
-          alignItems: 'stretch',
-          borderTop: '1px solid #DFE3E8',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'stretch',
-          position: 'relative',
-          width: '100%',
-          height: '100%',
-          overflow: 'hidden',
-        }}
+    const listboxMarkup = (
+      <Listbox
+        enableKeyboardControl
+        autoSelection={AutoSelection.FirstSelected}
+        accessibilityLabel="Search for and select a customer segment"
+        customListId={listboxId}
+        onSelect={handleSegmentSelect}
+        onActiveOptionChange={handleActiveOptionChange}
       >
-        {textFieldMarkup}
+        {segmentList}
+        {showAllMarkup}
+        {noResultsMarkup}
+        {lazyLoadingMarkup}
+      </Listbox>
+    );
 
-        <Scrollable
-          shadow
+    return (
+      <LegacyCard>
+        <div
           style={{
+            alignItems: 'stretch',
+            borderTop: '1px solid #DFE3E8',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'stretch',
             position: 'relative',
-            height: '262px',
-            padding: 'var(--p-space-200) 0',
-            borderBottomLeftRadius: 'var(--p-border-radius-200)',
-            borderBottomRightRadius: 'var(--p-border-radius-200)',
+            width: '100%',
+            height: '100%',
+            overflow: 'hidden',
           }}
-          onScrolledToBottom={handleLazyLoadSegments}
         >
-          {listboxMarkup}
-        </Scrollable>
-      </div>
-    </LegacyCard>
-  );
-}
+          {textFieldMarkup}
 
-export function WithDisabledTextOption() {
-  return (
-    <LegacyCard>
-      <Box paddingBlockStart="200" paddingBlockEnd="200">
-        <Listbox accessibilityLabel="Listbox with disabled item example">
-          <Listbox.Option value="UniqueValue-1">
-            <Listbox.TextOption>Item 1</Listbox.TextOption>
-          </Listbox.Option>
-          <Listbox.Option value="UniqueValue-2" disabled>
-            <Listbox.TextOption disabled>Item 2</Listbox.TextOption>
-          </Listbox.Option>
-          <Listbox.Option value="UniqueValue-3">
-            <Listbox.TextOption>Item 3</Listbox.TextOption>
-          </Listbox.Option>
-        </Listbox>
-      </Box>
-    </LegacyCard>
-  );
-}
+          <Scrollable
+            shadow
+            style={{
+              position: 'relative',
+              height: '262px',
+              padding: 'var(--p-space-200) 0',
+              borderBottomLeftRadius: 'var(--p-border-radius-200)',
+              borderBottomRightRadius: 'var(--p-border-radius-200)',
+            }}
+            onScrolledToBottom={handleLazyLoadSegments}
+          >
+            {listboxMarkup}
+          </Scrollable>
+        </div>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithDisabledTextOption = {
+  render() {
+    return (
+      <LegacyCard>
+        <Box paddingBlockStart="200" paddingBlockEnd="200">
+          <Listbox accessibilityLabel="Listbox with disabled item example">
+            <Listbox.Option value="UniqueValue-1">
+              <Listbox.TextOption>Item 1</Listbox.TextOption>
+            </Listbox.Option>
+            <Listbox.Option value="UniqueValue-2" disabled>
+              <Listbox.TextOption disabled>Item 2</Listbox.TextOption>
+            </Listbox.Option>
+            <Listbox.Option value="UniqueValue-3">
+              <Listbox.TextOption>Item 3</Listbox.TextOption>
+            </Listbox.Option>
+          </Listbox>
+        </Box>
+      </LegacyCard>
+    );
+  },
+};

--- a/polaris-react/src/components/Loading/Loading.stories.tsx
+++ b/polaris-react/src/components/Loading/Loading.stories.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Frame, Loading} from '@shopify/polaris';
 
 export default {
   component: Loading,
-} as ComponentMeta<typeof Loading>;
+} as Meta<typeof Loading>;
 
-export function Default() {
-  return (
-    <div style={{height: '100px'}}>
-      <Frame>
-        <Loading />
-      </Frame>
-    </div>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <div style={{height: '100px'}}>
+        <Frame>
+          <Loading />
+        </Frame>
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/MediaCard/MediaCard.stories.tsx
+++ b/polaris-react/src/components/MediaCard/MediaCard.stories.tsx
@@ -1,22 +1,215 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {MediaCard, BlockStack, VideoThumbnail} from '@shopify/polaris';
 
 export default {
   component: MediaCard,
-} as ComponentMeta<typeof MediaCard>;
+} as Meta<typeof MediaCard>;
 
-export function Default() {
-  return (
-    <MediaCard
-      title="Getting Started"
-      primaryAction={{
-        content: 'Learn about getting started',
-        onAction: () => {},
-      }}
-      description="Discover how Shopify can power up your entrepreneurial journey."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-    >
+export const Default = {
+  render() {
+    return (
+      <MediaCard
+        title="Getting Started"
+        primaryAction={{
+          content: 'Learn about getting started',
+          onAction: () => {},
+        }}
+        description="Discover how Shopify can power up your entrepreneurial journey."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+      >
+        <img
+          alt=""
+          width="100%"
+          height="100%"
+          style={{
+            objectFit: 'cover',
+            objectPosition: 'center',
+          }}
+          src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        />
+      </MediaCard>
+    );
+  },
+};
+
+export const WithSmallVisual = {
+  render() {
+    return (
+      <MediaCard
+        title="Getting Started"
+        primaryAction={{
+          content: 'Learn about getting started',
+          onAction: () => {},
+        }}
+        description="Discover how Shopify can power up your entrepreneurial journey."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+        size="small"
+      >
+        <img
+          alt=""
+          width="100%"
+          height="100%"
+          style={{
+            objectFit: 'cover',
+            objectPosition: 'center',
+          }}
+          src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        />
+      </MediaCard>
+    );
+  },
+};
+
+export const WithSecondaryAction = {
+  render() {
+    return (
+      <MediaCard
+        title="Get closer to launching your store"
+        primaryAction={{
+          content: 'Add a product',
+          onAction: () => {},
+        }}
+        secondaryAction={{
+          content: 'Learn more',
+          onAction: () => {},
+        }}
+        description="Start your business with eye-catching inventory."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+      >
+        <img
+          alt=""
+          width="100%"
+          height="100%"
+          style={{objectFit: 'cover', objectPosition: 'center'}}
+          src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        />
+      </MediaCard>
+    );
+  },
+};
+
+export const WithNoActions = {
+  render() {
+    return (
+      <MediaCard
+        title="Getting Started"
+        description="Discover how Shopify can power up your entrepreneurial journey."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+      >
+        <img
+          alt=""
+          width="100%"
+          height="100%"
+          style={{objectFit: 'cover', objectPosition: 'center'}}
+          src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        />
+      </MediaCard>
+    );
+  },
+};
+
+export const VideoCard = {
+  render() {
+    return (
+      <MediaCard
+        title="Turn your side-project into a business"
+        primaryAction={{
+          content: 'Learn more',
+          onAction: () => {},
+        }}
+        description="In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+      >
+        <VideoThumbnail
+          videoLength={80}
+          thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        />
+      </MediaCard>
+    );
+  },
+};
+
+export const PortraitVideoCard = {
+  render() {
+    return (
+      <MediaCard
+        portrait
+        title="Turn your side-project into a business"
+        primaryAction={{
+          content: 'Learn more',
+          onAction: () => {},
+        }}
+        description="In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+      >
+        <VideoThumbnail
+          videoLength={80}
+          thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        />
+      </MediaCard>
+    );
+  },
+};
+
+export const WithDismissButton = {
+  render() {
+    return (
+      <MediaCard
+        title="Getting Started"
+        primaryAction={{
+          content: 'Learn about getting started',
+          onAction: () => {},
+        }}
+        description="Discover how Shopify can power up your entrepreneurial journey."
+        onDismiss={() => console.log('clicked')}
+      >
+        <img
+          alt=""
+          width="100%"
+          height="100%"
+          style={{
+            objectFit: 'cover',
+            objectPosition: 'center',
+          }}
+          src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        />
+      </MediaCard>
+    );
+  },
+};
+
+export const WithDismissButtonAndPopoverActions = {
+  render() {
+    return (
+      <MediaCard
+        title="Getting Started"
+        primaryAction={{
+          content: 'Learn about getting started',
+          onAction: () => {},
+        }}
+        description="Discover how Shopify can power up your entrepreneurial journey."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+        onDismiss={() => console.log('clicked')}
+      >
+        <img
+          alt=""
+          width="100%"
+          height="100%"
+          style={{
+            objectFit: 'cover',
+            objectPosition: 'center',
+          }}
+          src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+        />
+      </MediaCard>
+    );
+  },
+};
+
+export const All = {
+  render() {
+    const image = (
       <img
         alt=""
         width="100%"
@@ -27,209 +220,34 @@ export function Default() {
         }}
         src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
       />
-    </MediaCard>
-  );
-}
+    );
 
-export function WithSmallVisual() {
-  return (
-    <MediaCard
-      title="Getting Started"
-      primaryAction={{
-        content: 'Learn about getting started',
-        onAction: () => {},
-      }}
-      description="Discover how Shopify can power up your entrepreneurial journey."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-      size="small"
-    >
-      <img
-        alt=""
-        width="100%"
-        height="100%"
-        style={{
-          objectFit: 'cover',
-          objectPosition: 'center',
+    const MediaCardExample = (props) => (
+      <MediaCard
+        primaryAction={{
+          content: 'Learn about getting started',
+          onAction: () => {},
         }}
-        src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-      />
-    </MediaCard>
-  );
-}
-
-export function WithSecondaryAction() {
-  return (
-    <MediaCard
-      title="Get closer to launching your store"
-      primaryAction={{
-        content: 'Add a product',
-        onAction: () => {},
-      }}
-      secondaryAction={{
-        content: 'Learn more',
-        onAction: () => {},
-      }}
-      description="Start your business with eye-catching inventory."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-    >
-      <img
-        alt=""
-        width="100%"
-        height="100%"
-        style={{objectFit: 'cover', objectPosition: 'center'}}
-        src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-      />
-    </MediaCard>
-  );
-}
-
-export function WithNoActions() {
-  return (
-    <MediaCard
-      title="Getting Started"
-      description="Discover how Shopify can power up your entrepreneurial journey."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-    >
-      <img
-        alt=""
-        width="100%"
-        height="100%"
-        style={{objectFit: 'cover', objectPosition: 'center'}}
-        src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-      />
-    </MediaCard>
-  );
-}
-
-export function VideoCard() {
-  return (
-    <MediaCard
-      title="Turn your side-project into a business"
-      primaryAction={{
-        content: 'Learn more',
-        onAction: () => {},
-      }}
-      description="In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-    >
-      <VideoThumbnail
-        videoLength={80}
-        thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-      />
-    </MediaCard>
-  );
-}
-
-export function PortraitVideoCard() {
-  return (
-    <MediaCard
-      portrait
-      title="Turn your side-project into a business"
-      primaryAction={{
-        content: 'Learn more',
-        onAction: () => {},
-      }}
-      description="In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-    >
-      <VideoThumbnail
-        videoLength={80}
-        thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-      />
-    </MediaCard>
-  );
-}
-
-export function WithDismissButton() {
-  return (
-    <MediaCard
-      title="Getting Started"
-      primaryAction={{
-        content: 'Learn about getting started',
-        onAction: () => {},
-      }}
-      description="Discover how Shopify can power up your entrepreneurial journey."
-      onDismiss={() => console.log('clicked')}
-    >
-      <img
-        alt=""
-        width="100%"
-        height="100%"
-        style={{
-          objectFit: 'cover',
-          objectPosition: 'center',
+        secondaryAction={{
+          content: 'Learn more',
+          onAction: () => {},
         }}
-        src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-      />
-    </MediaCard>
-  );
-}
+        description="Discover how Shopify can power up your entrepreneurial journey."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+        onDismiss={() => {}}
+        {...props}
+      >
+        {image}
+      </MediaCard>
+    );
 
-export function WithDismissButtonAndPopoverActions() {
-  return (
-    <MediaCard
-      title="Getting Started"
-      primaryAction={{
-        content: 'Learn about getting started',
-        onAction: () => {},
-      }}
-      description="Discover how Shopify can power up your entrepreneurial journey."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-      onDismiss={() => console.log('clicked')}
-    >
-      <img
-        alt=""
-        width="100%"
-        height="100%"
-        style={{
-          objectFit: 'cover',
-          objectPosition: 'center',
-        }}
-        src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-      />
-    </MediaCard>
-  );
-}
-
-export function All() {
-  const image = (
-    <img
-      alt=""
-      width="100%"
-      height="100%"
-      style={{
-        objectFit: 'cover',
-        objectPosition: 'center',
-      }}
-      src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-    />
-  );
-
-  const MediaCardExample = (props) => (
-    <MediaCard
-      primaryAction={{
-        content: 'Learn about getting started',
-        onAction: () => {},
-      }}
-      secondaryAction={{
-        content: 'Learn more',
-        onAction: () => {},
-      }}
-      description="Discover how Shopify can power up your entrepreneurial journey."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-      onDismiss={() => {}}
-      {...props}
-    >
-      {image}
-    </MediaCard>
-  );
-
-  return (
-    <BlockStack gap="500">
-      <MediaCardExample title="Default medium" />
-      <MediaCardExample title="Default small" size="small" />
-      <MediaCardExample title="Portrait medium" portrait />
-      <MediaCardExample title="Portrait small" portrait size="small" />
-    </BlockStack>
-  );
-}
+    return (
+      <BlockStack gap="500">
+        <MediaCardExample title="Default medium" />
+        <MediaCardExample title="Default small" size="small" />
+        <MediaCardExample title="Portrait medium" portrait />
+        <MediaCardExample title="Portrait small" portrait size="small" />
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/Modal/Modal.stories.tsx
+++ b/polaris-react/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useRef, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Banner,
   Button,
@@ -18,616 +18,642 @@ import {
 
 export default {
   component: Modal,
-} as ComponentMeta<typeof Modal>;
+} as Meta<typeof Modal>;
 
-export function Default() {
-  const [active, setActive] = useState(true);
+export const Default = {
+  render() {
+    const [active, setActive] = useState(true);
 
-  const handleChange = useCallback(() => setActive(!active), [active]);
+    const handleChange = useCallback(() => setActive(!active), [active]);
 
-  const activator = <Button onClick={handleChange}>Open</Button>;
+    const activator = <Button onClick={handleChange}>Open</Button>;
 
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          activator={activator}
-          open={active}
-          onClose={handleChange}
-          title="Reach more shoppers with Instagram product tags"
-          primaryAction={{
-            content: 'Add Instagram',
-            onAction: handleChange,
-          }}
-          secondaryActions={[
-            {
-              content: 'Learn more',
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            activator={activator}
+            open={active}
+            onClose={handleChange}
+            title="Reach more shoppers with Instagram product tags"
+            primaryAction={{
+              content: 'Add Instagram',
               onAction: handleChange,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <TextContainer>
-              Use Instagram posts to share your products with millions of
-              people. Let shoppers buy from your store without leaving
-              Instagram.
-            </TextContainer>
-          </Modal.Section>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function WithPrimaryAction() {
-  const discountLink = 'https://polaris.shopify.com/';
-
-  const [active, setActive] = useState(true);
-  const node = useRef(null);
-
-  const handleClick = useCallback(() => {
-    node.current && node.current.input.focus();
-  }, []);
-
-  const handleFocus = useCallback(() => {
-    if (node.current == null) {
-      return;
-    }
-    node.current.input.select();
-    document.execCommand('copy');
-  }, []);
-
-  const toggleModal = useCallback(() => setActive((active) => !active), []);
-
-  const activator = <Button onClick={toggleModal}>Open</Button>;
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          activator={activator}
-          open={active}
-          onClose={toggleModal}
-          title="Get a shareable link"
-          primaryAction={{
-            content: 'Close',
-            onAction: toggleModal,
-          }}
-        >
-          <Modal.Section>
-            <LegacyStack vertical>
-              <LegacyStack.Item>
-                <TextContainer>
-                  You can share this discount link with your customers via email
-                  or social media. Your discount will be automatically applied
-                  at checkout.
-                </TextContainer>
-              </LegacyStack.Item>
-              <LegacyStack.Item fill>
-                <TextField
-                  ref={node}
-                  label="Discount link"
-                  onFocus={handleFocus}
-                  value={discountLink}
-                  onChange={() => {}}
-                  autoComplete="off"
-                  connectedRight={
-                    <Button variant="primary" onClick={handleClick}>
-                      Copy link
-                    </Button>
-                  }
-                />
-              </LegacyStack.Item>
-            </LegacyStack>
-          </Modal.Section>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function WithDestructivePrimaryAction() {
-  const [active, setActive] = useState(true);
-
-  const toggleModal = useCallback(() => setActive((active) => !active), []);
-
-  const activator = <Button onClick={toggleModal}>Open</Button>;
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          activator={activator}
-          open={active}
-          onClose={toggleModal}
-          title="Discard all unsaved changes"
-          primaryAction={{
-            destructive: true,
-            content: 'Discard changes',
-            onAction: toggleModal,
-          }}
-          secondaryActions={[
-            {
-              content: 'Continue editing',
-              onAction: toggleModal,
-            },
-          ]}
-        >
-          <Modal.Section>
-            If you discard changes, you’ll delete any edits you made since you
-            last saved.
-          </Modal.Section>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function WithPrimaryAndSecondaryActions() {
-  const currentPage = 'current_page';
-  const allCustomers = 'all_customers';
-  const selectedCustomers = 'selected_customers';
-  const csvExcel = 'csv_excel';
-  const csvPlain = 'csv_plain';
-
-  const [active, setActive] = useState(true);
-  const [selectedExport, setSelectedExport] = useState([]);
-  const [selectedExportAs, setSelectedExportAs] = useState([]);
-
-  const handleModalChange = useCallback(() => setActive(!active), [active]);
-
-  const handleClose = () => {
-    handleModalChange();
-    handleSelectedExport([]);
-    handleSelectedExportAs([]);
-  };
-
-  const handleSelectedExport = useCallback(
-    (value) => setSelectedExport(value),
-    [],
-  );
-
-  const handleSelectedExportAs = useCallback(
-    (value) => setSelectedExportAs(value),
-    [],
-  );
-
-  const activator = <Button onClick={handleModalChange}>Open</Button>;
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          activator={activator}
-          open={active}
-          onClose={handleClose}
-          title="Export customers"
-          primaryAction={{
-            content: 'Export customers',
-            onAction: handleClose,
-          }}
-          secondaryActions={[
-            {
-              content: 'Cancel',
-              onAction: handleClose,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <LegacyStack vertical>
-              <LegacyStack.Item>
-                <ChoiceList
-                  title="Export"
-                  choices={[
-                    {label: 'Current page', value: currentPage},
-                    {label: 'All customers', value: allCustomers},
-                    {label: 'Selected customers', value: selectedCustomers},
-                  ]}
-                  selected={selectedExport}
-                  onChange={handleSelectedExport}
-                />
-              </LegacyStack.Item>
-              <LegacyStack.Item>
-                <ChoiceList
-                  title="Export as"
-                  choices={[
-                    {
-                      label:
-                        'CSV for Excel, Numbers, or other spreadsheet programs',
-                      value: csvExcel,
-                    },
-                    {label: 'Plain CSV file', value: csvPlain},
-                  ]}
-                  selected={selectedExportAs}
-                  onChange={handleSelectedExportAs}
-                />
-              </LegacyStack.Item>
-            </LegacyStack>
-          </Modal.Section>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function Large() {
-  const [active, setActive] = useState(true);
-  const [checked, setChecked] = useState(false);
-
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
-
-  const handleCheckbox = useCallback((value) => setChecked(value), []);
-
-  const activator = <Button onClick={toggleActive}>Open</Button>;
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          size="large"
-          activator={activator}
-          open={active}
-          onClose={toggleActive}
-          title="Import customers by CSV"
-          primaryAction={{
-            content: 'Import customers',
-            onAction: toggleActive,
-          }}
-          secondaryActions={[
-            {
-              content: 'Cancel',
-              onAction: toggleActive,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <LegacyStack vertical>
-              <DropZone
-                accept=".csv"
-                errorOverlayText="File type must be .csv"
-                type="file"
-                onDrop={() => {}}
-              >
-                <DropZone.FileUpload />
-              </DropZone>
-              <Checkbox
-                checked={checked}
-                label="Overwrite existing customers that have the same email or phone"
-                onChange={handleCheckbox}
-              />
-            </LegacyStack>
-          </Modal.Section>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function Small() {
-  const [active, setActive] = useState(true);
-  const [checked, setChecked] = useState(false);
-
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
-
-  const handleCheckbox = useCallback((value) => setChecked(value), []);
-
-  const activator = <Button onClick={toggleActive}>Open</Button>;
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          size="small"
-          activator={activator}
-          open={active}
-          onClose={toggleActive}
-          title="Import customers by CSV"
-          primaryAction={{
-            content: 'Import customers',
-            onAction: toggleActive,
-          }}
-          secondaryActions={[
-            {
-              content: 'Cancel',
-              onAction: toggleActive,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <LegacyStack vertical>
-              <DropZone
-                accept=".csv"
-                errorOverlayText="File type must be .csv"
-                type="file"
-                onDrop={() => {}}
-              >
-                <DropZone.FileUpload />
-              </DropZone>
-              <Checkbox
-                checked={checked}
-                label="Overwrite existing customers that have the same email or phone"
-                onChange={handleCheckbox}
-              />
-            </LegacyStack>
-          </Modal.Section>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function WithoutATitle() {
-  const [active, setActive] = useState(true);
-
-  const handleChange = useCallback(() => setActive(!active), [active]);
-
-  const activator = <Button onClick={handleChange}>Open</Button>;
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          title="Reach more shoppers with Instagram product tags"
-          titleHidden
-          activator={activator}
-          open={active}
-          onClose={handleChange}
-          primaryAction={{
-            content: 'Add Instagram',
-            onAction: handleChange,
-          }}
-          secondaryActions={[
-            {
-              content: 'Learn more',
-              onAction: handleChange,
-            },
-          ]}
-        >
-          <Modal.Section titleHidden>
-            <TextContainer>
-              Use Instagram posts to share your products with millions of
-              people. Let shoppers buy from your store without leaving
-              Instagram.
-            </TextContainer>
-          </Modal.Section>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function WithScrollListener() {
-  const [active, setActive] = useState(true);
-
-  const handleChange = useCallback(() => setActive(!active), [active]);
-
-  const handleScrollBottom = useCallback(
-    () => console.log('Scrolled to bottom'),
-    [],
-  );
-
-  const activator = <Button onClick={handleChange}>Open</Button>;
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          activator={activator}
-          open={active}
-          title="Scrollable content"
-          onClose={handleChange}
-          onScrolledToBottom={handleScrollBottom}
-        >
-          {Array.from({length: 50}, (_, index) => (
-            <Modal.Section key={index}>
+            }}
+            secondaryActions={[
+              {
+                content: 'Learn more',
+                onAction: handleChange,
+              },
+            ]}
+          >
+            <Modal.Section>
               <TextContainer>
-                Item <a href="#Content">#{index}</a>
+                Use Instagram posts to share your products with millions of
+                people. Let shoppers buy from your store without leaving
+                Instagram.
               </TextContainer>
             </Modal.Section>
-          ))}
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function WithActivatorRef() {
-  const [active, setActive] = useState(true);
-
-  const buttonRef = useRef(null);
-
-  const handleOpen = useCallback(() => setActive(true), []);
-
-  const handleClose = useCallback(() => {
-    setActive(false);
-  }, []);
-
-  const activator = (
-    <div ref={buttonRef}>
-      <Button onClick={handleOpen}>Open</Button>
-    </div>
-  );
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        {activator}
-        <Modal
-          activator={buttonRef}
-          open={active}
-          onClose={handleClose}
-          title="Reach more shoppers with Instagram product tags"
-          primaryAction={{
-            content: 'Add Instagram',
-            onAction: handleClose,
-          }}
-          secondaryActions={[
-            {
-              content: 'Learn more',
-              onAction: handleClose,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <TextContainer>
-              Use Instagram posts to share your products with millions of
-              people. Let shoppers buy from your store without leaving
-              Instagram.
-            </TextContainer>
-          </Modal.Section>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
-
-export function WithoutAnActivatorProp() {
-  const [active, setActive] = useState(true);
-
-  const button = useRef();
-
-  const handleOpen = useCallback(() => setActive(true), []);
-
-  const handleClose = useCallback(() => {
-    setActive(false);
-    requestAnimationFrame(() => button.current.querySelector('button').focus());
-  }, []);
-
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <div ref={button}>
-          <Button onClick={handleOpen}>Open</Button>
+          </Modal>
         </div>
-        <Modal
-          instant
-          open={active}
-          onClose={handleClose}
-          title="Reach more shoppers with Instagram product tags"
-          primaryAction={{
-            content: 'Add Instagram',
-            onAction: handleClose,
-          }}
-          secondaryActions={[
-            {
-              content: 'Learn more',
+      </Frame>
+    );
+  },
+};
+
+export const WithPrimaryAction = {
+  render() {
+    const discountLink = 'https://polaris.shopify.com/';
+
+    const [active, setActive] = useState(true);
+    const node = useRef(null);
+
+    const handleClick = useCallback(() => {
+      node.current && node.current.input.focus();
+    }, []);
+
+    const handleFocus = useCallback(() => {
+      if (node.current == null) {
+        return;
+      }
+      node.current.input.select();
+      document.execCommand('copy');
+    }, []);
+
+    const toggleModal = useCallback(() => setActive((active) => !active), []);
+
+    const activator = <Button onClick={toggleModal}>Open</Button>;
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            activator={activator}
+            open={active}
+            onClose={toggleModal}
+            title="Get a shareable link"
+            primaryAction={{
+              content: 'Close',
+              onAction: toggleModal,
+            }}
+          >
+            <Modal.Section>
+              <LegacyStack vertical>
+                <LegacyStack.Item>
+                  <TextContainer>
+                    You can share this discount link with your customers via
+                    email or social media. Your discount will be automatically
+                    applied at checkout.
+                  </TextContainer>
+                </LegacyStack.Item>
+                <LegacyStack.Item fill>
+                  <TextField
+                    ref={node}
+                    label="Discount link"
+                    onFocus={handleFocus}
+                    value={discountLink}
+                    onChange={() => {}}
+                    autoComplete="off"
+                    connectedRight={
+                      <Button variant="primary" onClick={handleClick}>
+                        Copy link
+                      </Button>
+                    }
+                  />
+                </LegacyStack.Item>
+              </LegacyStack>
+            </Modal.Section>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const WithDestructivePrimaryAction = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const toggleModal = useCallback(() => setActive((active) => !active), []);
+
+    const activator = <Button onClick={toggleModal}>Open</Button>;
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            activator={activator}
+            open={active}
+            onClose={toggleModal}
+            title="Discard all unsaved changes"
+            primaryAction={{
+              destructive: true,
+              content: 'Discard changes',
+              onAction: toggleModal,
+            }}
+            secondaryActions={[
+              {
+                content: 'Continue editing',
+                onAction: toggleModal,
+              },
+            ]}
+          >
+            <Modal.Section>
+              If you discard changes, you’ll delete any edits you made since you
+              last saved.
+            </Modal.Section>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const WithPrimaryAndSecondaryActions = {
+  render() {
+    const currentPage = 'current_page';
+    const allCustomers = 'all_customers';
+    const selectedCustomers = 'selected_customers';
+    const csvExcel = 'csv_excel';
+    const csvPlain = 'csv_plain';
+
+    const [active, setActive] = useState(true);
+    const [selectedExport, setSelectedExport] = useState([]);
+    const [selectedExportAs, setSelectedExportAs] = useState([]);
+
+    const handleModalChange = useCallback(() => setActive(!active), [active]);
+
+    const handleClose = () => {
+      handleModalChange();
+      handleSelectedExport([]);
+      handleSelectedExportAs([]);
+    };
+
+    const handleSelectedExport = useCallback(
+      (value) => setSelectedExport(value),
+      [],
+    );
+
+    const handleSelectedExportAs = useCallback(
+      (value) => setSelectedExportAs(value),
+      [],
+    );
+
+    const activator = <Button onClick={handleModalChange}>Open</Button>;
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            activator={activator}
+            open={active}
+            onClose={handleClose}
+            title="Export customers"
+            primaryAction={{
+              content: 'Export customers',
               onAction: handleClose,
-            },
-          ]}
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: handleClose,
+              },
+            ]}
+          >
+            <Modal.Section>
+              <LegacyStack vertical>
+                <LegacyStack.Item>
+                  <ChoiceList
+                    title="Export"
+                    choices={[
+                      {label: 'Current page', value: currentPage},
+                      {label: 'All customers', value: allCustomers},
+                      {label: 'Selected customers', value: selectedCustomers},
+                    ]}
+                    selected={selectedExport}
+                    onChange={handleSelectedExport}
+                  />
+                </LegacyStack.Item>
+                <LegacyStack.Item>
+                  <ChoiceList
+                    title="Export as"
+                    choices={[
+                      {
+                        label:
+                          'CSV for Excel, Numbers, or other spreadsheet programs',
+                        value: csvExcel,
+                      },
+                      {label: 'Plain CSV file', value: csvPlain},
+                    ]}
+                    selected={selectedExportAs}
+                    onChange={handleSelectedExportAs}
+                  />
+                </LegacyStack.Item>
+              </LegacyStack>
+            </Modal.Section>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const Large = {
+  render() {
+    const [active, setActive] = useState(true);
+    const [checked, setChecked] = useState(false);
+
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+    const handleCheckbox = useCallback((value) => setChecked(value), []);
+
+    const activator = <Button onClick={toggleActive}>Open</Button>;
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            size="large"
+            activator={activator}
+            open={active}
+            onClose={toggleActive}
+            title="Import customers by CSV"
+            primaryAction={{
+              content: 'Import customers',
+              onAction: toggleActive,
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: toggleActive,
+              },
+            ]}
+          >
+            <Modal.Section>
+              <LegacyStack vertical>
+                <DropZone
+                  accept=".csv"
+                  errorOverlayText="File type must be .csv"
+                  type="file"
+                  onDrop={() => {}}
+                >
+                  <DropZone.FileUpload />
+                </DropZone>
+                <Checkbox
+                  checked={checked}
+                  label="Overwrite existing customers that have the same email or phone"
+                  onChange={handleCheckbox}
+                />
+              </LegacyStack>
+            </Modal.Section>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const Small = {
+  render() {
+    const [active, setActive] = useState(true);
+    const [checked, setChecked] = useState(false);
+
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+    const handleCheckbox = useCallback((value) => setChecked(value), []);
+
+    const activator = <Button onClick={toggleActive}>Open</Button>;
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            size="small"
+            activator={activator}
+            open={active}
+            onClose={toggleActive}
+            title="Import customers by CSV"
+            primaryAction={{
+              content: 'Import customers',
+              onAction: toggleActive,
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: toggleActive,
+              },
+            ]}
+          >
+            <Modal.Section>
+              <LegacyStack vertical>
+                <DropZone
+                  accept=".csv"
+                  errorOverlayText="File type must be .csv"
+                  type="file"
+                  onDrop={() => {}}
+                >
+                  <DropZone.FileUpload />
+                </DropZone>
+                <Checkbox
+                  checked={checked}
+                  label="Overwrite existing customers that have the same email or phone"
+                  onChange={handleCheckbox}
+                />
+              </LegacyStack>
+            </Modal.Section>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const WithoutATitle = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const handleChange = useCallback(() => setActive(!active), [active]);
+
+    const activator = <Button onClick={handleChange}>Open</Button>;
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            title="Reach more shoppers with Instagram product tags"
+            titleHidden
+            activator={activator}
+            open={active}
+            onClose={handleChange}
+            primaryAction={{
+              content: 'Add Instagram',
+              onAction: handleChange,
+            }}
+            secondaryActions={[
+              {
+                content: 'Learn more',
+                onAction: handleChange,
+              },
+            ]}
+          >
+            <Modal.Section titleHidden>
+              <TextContainer>
+                Use Instagram posts to share your products with millions of
+                people. Let shoppers buy from your store without leaving
+                Instagram.
+              </TextContainer>
+            </Modal.Section>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const WithScrollListener = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const handleChange = useCallback(() => setActive(!active), [active]);
+
+    const handleScrollBottom = useCallback(
+      () => console.log('Scrolled to bottom'),
+      [],
+    );
+
+    const activator = <Button onClick={handleChange}>Open</Button>;
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            activator={activator}
+            open={active}
+            title="Scrollable content"
+            onClose={handleChange}
+            onScrolledToBottom={handleScrollBottom}
+          >
+            {Array.from({length: 50}, (_, index) => (
+              <Modal.Section key={index}>
+                <TextContainer>
+                  Item <a href="#Content">#{index}</a>
+                </TextContainer>
+              </Modal.Section>
+            ))}
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const WithActivatorRef = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const buttonRef = useRef(null);
+
+    const handleOpen = useCallback(() => setActive(true), []);
+
+    const handleClose = useCallback(() => {
+      setActive(false);
+    }, []);
+
+    const activator = (
+      <div ref={buttonRef}>
+        <Button onClick={handleOpen}>Open</Button>
+      </div>
+    );
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          {activator}
+          <Modal
+            activator={buttonRef}
+            open={active}
+            onClose={handleClose}
+            title="Reach more shoppers with Instagram product tags"
+            primaryAction={{
+              content: 'Add Instagram',
+              onAction: handleClose,
+            }}
+            secondaryActions={[
+              {
+                content: 'Learn more',
+                onAction: handleClose,
+              },
+            ]}
+          >
+            <Modal.Section>
+              <TextContainer>
+                Use Instagram posts to share your products with millions of
+                people. Let shoppers buy from your store without leaving
+                Instagram.
+              </TextContainer>
+            </Modal.Section>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const WithoutAnActivatorProp = {
+  render() {
+    const [active, setActive] = useState(true);
+
+    const button = useRef();
+
+    const handleOpen = useCallback(() => setActive(true), []);
+
+    const handleClose = useCallback(() => {
+      setActive(false);
+      requestAnimationFrame(() =>
+        button.current.querySelector('button').focus(),
+      );
+    }, []);
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <div ref={button}>
+            <Button onClick={handleOpen}>Open</Button>
+          </div>
+          <Modal
+            instant
+            open={active}
+            onClose={handleClose}
+            title="Reach more shoppers with Instagram product tags"
+            primaryAction={{
+              content: 'Add Instagram',
+              onAction: handleClose,
+            }}
+            secondaryActions={[
+              {
+                content: 'Learn more',
+                onAction: handleClose,
+              },
+            ]}
+          >
+            <Modal.Section>
+              <TextContainer>
+                Use Instagram posts to share your products with millions of
+                people. Let shoppers buy from your store without leaving
+                Instagram.
+              </TextContainer>
+            </Modal.Section>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
+
+export const WithLongContent = {
+  render() {
+    return (
+      <Frame>
+        <Modal
+          title="Long form modal"
+          open
+          onClose={() => {}}
+          primaryAction={{content: 'Save'}}
         >
           <Modal.Section>
-            <TextContainer>
-              Use Instagram posts to share your products with millions of
-              people. Let shoppers buy from your store without leaving
-              Instagram.
-            </TextContainer>
+            <Banner title="Payment details" />
+          </Modal.Section>
+          <Modal.Section>
+            <FormLayout>
+              <FormLayout.Group>
+                <TextField label="Payment method type" autoComplete="off" />
+                <TextField label="Card number" autoComplete="off" />
+              </FormLayout.Group>
+
+              <FormLayout.Group>
+                <TextField label="Expires" autoComplete="off" />
+                <TextField label="CVV" autoComplete="off" />
+              </FormLayout.Group>
+
+              <FormLayout.Group>
+                <TextField label="Country/region" autoComplete="off" />
+              </FormLayout.Group>
+
+              <FormLayout.Group>
+                <TextField label="First name" autoComplete="off" />
+                <TextField label="Last name" autoComplete="off" />
+              </FormLayout.Group>
+
+              <FormLayout.Group>
+                <TextField label="Address" autoComplete="off" />
+                <TextField label="Apartment, suite, etc." autoComplete="off" />
+              </FormLayout.Group>
+
+              <FormLayout.Group>
+                <TextField label="City" autoComplete="off" />
+                <TextField label="Province" autoComplete="off" />
+                <TextField label="Postal code" autoComplete="off" />
+              </FormLayout.Group>
+            </FormLayout>
           </Modal.Section>
         </Modal>
-      </div>
-    </Frame>
-  );
-}
+      </Frame>
+    );
+  },
+};
 
-export function WithLongContent() {
-  return (
-    <Frame>
-      <Modal
-        title="Long form modal"
-        open
-        onClose={() => {}}
-        primaryAction={{content: 'Save'}}
-      >
-        <Modal.Section>
-          <Banner title="Payment details" />
-        </Modal.Section>
-        <Modal.Section>
-          <FormLayout>
-            <FormLayout.Group>
-              <TextField label="Payment method type" autoComplete="off" />
-              <TextField label="Card number" autoComplete="off" />
-            </FormLayout.Group>
+export const WithLongContentNoScroll = {
+  render() {
+    return (
+      <Frame>
+        <Modal
+          title="Long form modal"
+          open
+          onClose={() => {}}
+          noScroll
+          primaryAction={{content: 'Save'}}
+        >
+          <Modal.Section>
+            <Banner title="Payment details" />
+          </Modal.Section>
+          <Modal.Section>
+            <FormLayout>
+              <FormLayout.Group>
+                <TextField label="Payment method type" autoComplete="off" />
+                <TextField label="Card number" autoComplete="off" />
+              </FormLayout.Group>
 
-            <FormLayout.Group>
-              <TextField label="Expires" autoComplete="off" />
-              <TextField label="CVV" autoComplete="off" />
-            </FormLayout.Group>
+              <FormLayout.Group>
+                <TextField label="Expires" autoComplete="off" />
+                <TextField label="CVV" autoComplete="off" />
+              </FormLayout.Group>
 
-            <FormLayout.Group>
-              <TextField label="Country/region" autoComplete="off" />
-            </FormLayout.Group>
+              <FormLayout.Group>
+                <TextField label="Country/region" autoComplete="off" />
+              </FormLayout.Group>
 
-            <FormLayout.Group>
-              <TextField label="First name" autoComplete="off" />
-              <TextField label="Last name" autoComplete="off" />
-            </FormLayout.Group>
+              <FormLayout.Group>
+                <TextField label="First name" autoComplete="off" />
+                <TextField label="Last name" autoComplete="off" />
+              </FormLayout.Group>
 
-            <FormLayout.Group>
-              <TextField label="Address" autoComplete="off" />
-              <TextField label="Apartment, suite, etc." autoComplete="off" />
-            </FormLayout.Group>
+              <FormLayout.Group>
+                <TextField label="Address" autoComplete="off" />
+                <TextField label="Apartment, suite, etc." autoComplete="off" />
+              </FormLayout.Group>
 
-            <FormLayout.Group>
-              <TextField label="City" autoComplete="off" />
-              <TextField label="Province" autoComplete="off" />
-              <TextField label="Postal code" autoComplete="off" />
-            </FormLayout.Group>
-          </FormLayout>
-        </Modal.Section>
-      </Modal>
-    </Frame>
-  );
-}
-
-export function WithLongContentNoScroll() {
-  return (
-    <Frame>
-      <Modal
-        title="Long form modal"
-        open
-        onClose={() => {}}
-        noScroll
-        primaryAction={{content: 'Save'}}
-      >
-        <Modal.Section>
-          <Banner title="Payment details" />
-        </Modal.Section>
-        <Modal.Section>
-          <FormLayout>
-            <FormLayout.Group>
-              <TextField label="Payment method type" autoComplete="off" />
-              <TextField label="Card number" autoComplete="off" />
-            </FormLayout.Group>
-
-            <FormLayout.Group>
-              <TextField label="Expires" autoComplete="off" />
-              <TextField label="CVV" autoComplete="off" />
-            </FormLayout.Group>
-
-            <FormLayout.Group>
-              <TextField label="Country/region" autoComplete="off" />
-            </FormLayout.Group>
-
-            <FormLayout.Group>
-              <TextField label="First name" autoComplete="off" />
-              <TextField label="Last name" autoComplete="off" />
-            </FormLayout.Group>
-
-            <FormLayout.Group>
-              <TextField label="Address" autoComplete="off" />
-              <TextField label="Apartment, suite, etc." autoComplete="off" />
-            </FormLayout.Group>
-
-            <FormLayout.Group>
-              <TextField label="City" autoComplete="off" />
-              <TextField label="Province" autoComplete="off" />
-              <TextField label="Postal code" autoComplete="off" />
-            </FormLayout.Group>
-          </FormLayout>
-        </Modal.Section>
-      </Modal>
-    </Frame>
-  );
-}
+              <FormLayout.Group>
+                <TextField label="City" autoComplete="off" />
+                <TextField label="Province" autoComplete="off" />
+                <TextField label="Postal code" autoComplete="off" />
+              </FormLayout.Group>
+            </FormLayout>
+          </Modal.Section>
+        </Modal>
+      </Frame>
+    );
+  },
+};
 
 const context = {
   logo: undefined,
@@ -639,97 +665,105 @@ const context = {
   setContextualSaveBar: () => {},
   removeContextualSaveBar: () => {},
 };
-export function EmbeddedIframe() {
-  return (
-    <FrameContext.Provider value={context}>
-      <div style={{height: '500px'}}>
-        <Modal
-          title="Embedded iFrame Modal"
-          open
-          onClose={() => {}}
-          noScroll
-          primaryAction={{content: 'Save'}}
-          src={`data:text/html;charset=utf-8,
-<style>
-  /* Modified from Josh's Custom CSS Reset https://www.joshwcomeau.com/css/custom-css-reset/ */
-  *, *::before, *::after { box-sizing: border-box; }
-  * { margin: 0; }
-  html, body { height: 100%; }
-  body { line-height: 1.5; -webkit-font-smoothing: antialiased; }
-</style>
-<main>
-  <h1>
-    Hello.
-  </h1>
-</main>`}
-        />
-      </div>
-    </FrameContext.Provider>
-  );
-}
+export const EmbeddedIframe = {
+  render() {
+    return (
+      <FrameContext.Provider value={context}>
+        <div style={{height: '500px'}}>
+          <Modal
+            title="Embedded iFrame Modal"
+            open
+            onClose={() => {}}
+            noScroll
+            primaryAction={{content: 'Save'}}
+            src={`data:text/html;charset=utf-8,
+  <style>
+    /* Modified from Josh's Custom CSS Reset https://www.joshwcomeau.com/css/custom-css-reset/ */
+    *, *::before, *::after { box-sizing: border-box; }
+    * { margin: 0; }
+    html, body { height: 100%; }
+    body { line-height: 1.5; -webkit-font-smoothing: antialiased; }
+  </style>
+  <main>
+    <h1>
+      Hello.
+    </h1>
+  </main>`}
+          />
+        </div>
+      </FrameContext.Provider>
+    );
+  },
+};
 
-export function SectionedProp() {
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          title="Sectioned modal"
-          open
-          onClose={() => {}}
-          sectioned
-          primaryAction={{content: 'Save'}}
-        >
-          <Text as="h1">First section</Text>
-          <Text as="p">Second section</Text>
-          <Modal.Section>
-            <Text as="p">Nested section</Text>
-          </Modal.Section>
-          <Text as="p">Fourth section</Text>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
+export const SectionedProp = {
+  render() {
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            title="Sectioned modal"
+            open
+            onClose={() => {}}
+            sectioned
+            primaryAction={{content: 'Save'}}
+          >
+            <Text as="h1">First section</Text>
+            <Text as="p">Second section</Text>
+            <Modal.Section>
+              <Text as="p">Nested section</Text>
+            </Modal.Section>
+            <Text as="p">Fourth section</Text>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
 
-export function Loading() {
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          title="Loading modal"
-          open
-          onClose={() => {}}
-          loading
-          primaryAction={{content: 'Save'}}
-        >
-          <Text as="h1">First section</Text>
-          <Text as="p">Second section</Text>
-          <Text as="p">Third section</Text>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
+export const Loading = {
+  render() {
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            title="Loading modal"
+            open
+            onClose={() => {}}
+            loading
+            primaryAction={{content: 'Save'}}
+          >
+            <Text as="h1">First section</Text>
+            <Text as="p">Second section</Text>
+            <Text as="p">Third section</Text>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};
 
-export function Fullscreen() {
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          title="Fullscreen modal"
-          open
-          onClose={() => {}}
-          sectioned
-          size="fullScreen"
-          primaryAction={{content: 'Save'}}
-        >
-          <Text as="h1">Fullscreen on small displays</Text>
-          <Text as="p">
-            When <code>(max-width: 47.9975em)</code>, the modal will be made{' '}
-            <code>height: 100%</code>
-          </Text>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
+export const Fullscreen = {
+  render() {
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            title="Fullscreen modal"
+            open
+            onClose={() => {}}
+            sectioned
+            size="fullScreen"
+            primaryAction={{content: 'Save'}}
+          >
+            <Text as="h1">Fullscreen on small displays</Text>
+            <Text as="p">
+              When <code>(max-width: 47.9975em)</code>, the modal will be made{' '}
+              <code>height: 100%</code>
+            </Text>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};

--- a/polaris-react/src/components/Navigation/Navigation.stories.tsx
+++ b/polaris-react/src/components/Navigation/Navigation.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Frame, Navigation, Text} from '@shopify/polaris';
 import {
   MinusCircleIcon,
@@ -24,1412 +24,1449 @@ import {
 export default {
   component: Navigation,
   parameters: {layout: 'fullscreen'},
-} as ComponentMeta<typeof Navigation>;
+} as Meta<typeof Navigation>;
 
-export function Default() {
-  const [selected, setSelected] = React.useState('home');
+export const Default = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
 
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              label: 'Home',
-              icon: HomeIcon,
-              matches: selected === 'home',
-              onClick: () => setSelected('home'),
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              badge: '15',
-              matches: selected === 'orders',
-              onClick: () => setSelected('orders'),
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Products',
-              icon: ProductIcon,
-              matches: selected === 'products',
-              onClick: () => setSelected('products'),
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function DisabledItemsWithoutUrls() {
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {icon: HomeIcon, label: 'Home', disabled: true},
-            {icon: OrderIcon, label: 'Orders', disabled: true},
-            {icon: ProductIcon, label: 'Products', disabled: true},
-            {icon: PersonIcon, label: 'Customers', disabled: true},
-            {icon: TargetIcon, label: 'Marketing', disabled: true},
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithMultipleSecondaryNavigations() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              label: 'Home',
-              icon: HomeFilledIcon,
-              matchedItemIcon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              label: 'Orders',
-              icon: OrderFilledIcon,
-              matchedItemIcon: OrderIcon,
-              badge: '15',
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  disabled: false,
-                  label: 'Drafts',
-                  onClick: () => setSelected('drafts'),
-                  matches: selected === 'drafts',
-                },
-                {
-                  url: '#',
-                  disabled: false,
-                  label: 'Shipping Labels',
-                  onClick: () => setSelected('shippinglabels'),
-                  matches: selected === 'shippinglabels',
-                },
-              ],
-            },
-            {
-              url: '#',
-              label: 'Products',
-              icon: ProductFilledIcon,
-              matchedItemIcon: ProductIcon,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Inventory',
-                  onClick: () => setSelected('inventory'),
-                  matches: selected === 'inventory',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Transfers',
-                  onClick: () => setSelected('transfers'),
-                  matches: selected === 'transfers',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Collections',
-                  onClick: () => setSelected('collections'),
-                  matches: selected === 'collections',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Gift cards',
-                  onClick: () => setSelected('giftcards'),
-                  matches: selected === 'giftcards',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Price lists',
-                  onClick: () => setSelected('pricelists'),
-                  matches: selected === 'pricelists',
-                },
-              ],
-            },
-            {
-              url: '#',
-              label: 'Marketing',
-              icon: TargetFilledIcon,
-              matchedItemIcon: TargetIcon,
-              onClick: () => setSelected('marketing'),
-              matches: selected === 'marketing',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  disabled: false,
-                  label: 'Reports',
-                  onClick: () => setSelected('reports'),
-                  matches: selected === 'reports',
-                },
-                {
-                  url: '#',
-                  disabled: false,
-                  label: 'Live view',
-                  onClick: () => setSelected('liveView'),
-                  matches: selected === 'liveView',
-                },
-              ],
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithAnActiveRootItemWithSecondaryNavigationItems() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              badge: '15',
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-            },
-            {
-              url: '#',
-              label: 'Products',
-              icon: ProductIcon,
-              selected: true,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Inventory',
-                  onClick: () => setSelected('inventory'),
-                  matches: selected === 'inventory',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Transfers',
-                  onClick: () => setSelected('transfers'),
-                  matches: selected === 'transfers',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Collections',
-                  onClick: () => setSelected('collections'),
-                  matches: selected === 'collections',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Gift cards',
-                  onClick: () => setSelected('giftcards'),
-                  matches: selected === 'giftcards',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Price lists',
-                  onClick: () => setSelected('pricelists'),
-                  matches: selected === 'pricelists',
-                },
-              ],
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithASecondaryActionForASectionAndASectionTitle() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Products',
-              icon: ProductIcon,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-            },
-          ]}
-        />
-        <Navigation.Section
-          title="Sales channels"
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Online Store',
-              icon: StoreOnlineIcon,
-            },
-          ]}
-          action={{
-            accessibilityLabel: 'Add sales channel',
-            icon: PlusCircleIcon,
-            onClick: () => {},
-          }}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithASecondaryActionForAnItem() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-              secondaryAction: {
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
                 url: '#',
-                accessibilityLabel: 'Add an order',
-                icon: PlusCircleIcon,
-                tooltip: {
-                  content: 'Add an order',
+                label: 'Home',
+                icon: HomeIcon,
+                matches: selected === 'home',
+                onClick: () => setSelected('home'),
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                badge: '15',
+                matches: selected === 'orders',
+                onClick: () => setSelected('orders'),
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Products',
+                icon: ProductIcon,
+                matches: selected === 'products',
+                onClick: () => setSelected('products'),
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const DisabledItemsWithoutUrls = {
+  render() {
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {icon: HomeIcon, label: 'Home', disabled: true},
+              {icon: OrderIcon, label: 'Orders', disabled: true},
+              {icon: ProductIcon, label: 'Products', disabled: true},
+              {icon: PersonIcon, label: 'Customers', disabled: true},
+              {icon: TargetIcon, label: 'Marketing', disabled: true},
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithMultipleSecondaryNavigations = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                label: 'Home',
+                icon: HomeFilledIcon,
+                matchedItemIcon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                label: 'Orders',
+                icon: OrderFilledIcon,
+                matchedItemIcon: OrderIcon,
+                badge: '15',
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    disabled: false,
+                    label: 'Drafts',
+                    onClick: () => setSelected('drafts'),
+                    matches: selected === 'drafts',
+                  },
+                  {
+                    url: '#',
+                    disabled: false,
+                    label: 'Shipping Labels',
+                    onClick: () => setSelected('shippinglabels'),
+                    matches: selected === 'shippinglabels',
+                  },
+                ],
+              },
+              {
+                url: '#',
+                label: 'Products',
+                icon: ProductFilledIcon,
+                matchedItemIcon: ProductIcon,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Inventory',
+                    onClick: () => setSelected('inventory'),
+                    matches: selected === 'inventory',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Transfers',
+                    onClick: () => setSelected('transfers'),
+                    matches: selected === 'transfers',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Collections',
+                    onClick: () => setSelected('collections'),
+                    matches: selected === 'collections',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Gift cards',
+                    onClick: () => setSelected('giftcards'),
+                    matches: selected === 'giftcards',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Price lists',
+                    onClick: () => setSelected('pricelists'),
+                    matches: selected === 'pricelists',
+                  },
+                ],
+              },
+              {
+                url: '#',
+                label: 'Marketing',
+                icon: TargetFilledIcon,
+                matchedItemIcon: TargetIcon,
+                onClick: () => setSelected('marketing'),
+                matches: selected === 'marketing',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    disabled: false,
+                    label: 'Reports',
+                    onClick: () => setSelected('reports'),
+                    matches: selected === 'reports',
+                  },
+                  {
+                    url: '#',
+                    disabled: false,
+                    label: 'Live view',
+                    onClick: () => setSelected('liveView'),
+                    matches: selected === 'liveView',
+                  },
+                ],
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithAnActiveRootItemWithSecondaryNavigationItems = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                badge: '15',
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+              },
+              {
+                url: '#',
+                label: 'Products',
+                icon: ProductIcon,
+                selected: true,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Inventory',
+                    onClick: () => setSelected('inventory'),
+                    matches: selected === 'inventory',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Transfers',
+                    onClick: () => setSelected('transfers'),
+                    matches: selected === 'transfers',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Collections',
+                    onClick: () => setSelected('collections'),
+                    matches: selected === 'collections',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Gift cards',
+                    onClick: () => setSelected('giftcards'),
+                    matches: selected === 'giftcards',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Price lists',
+                    onClick: () => setSelected('pricelists'),
+                    matches: selected === 'pricelists',
+                  },
+                ],
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithASecondaryActionForASectionAndASectionTitle = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Products',
+                icon: ProductIcon,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+              },
+            ]}
+          />
+          <Navigation.Section
+            title="Sales channels"
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Online Store',
+                icon: StoreOnlineIcon,
+              },
+            ]}
+            action={{
+              accessibilityLabel: 'Add sales channel',
+              icon: PlusCircleIcon,
+              onClick: () => {},
+            }}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithASecondaryActionForAnItem = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+                secondaryAction: {
+                  url: '#',
+                  accessibilityLabel: 'Add an order',
+                  icon: PlusCircleIcon,
+                  tooltip: {
+                    content: 'Add an order',
+                  },
                 },
               },
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Products',
-              icon: ProductIcon,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Products',
+                icon: ProductIcon,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
 
-export function WithMultipleSecondaryActionsForAnItem() {
-  const [selected, setSelected] = React.useState('home');
+export const WithMultipleSecondaryActionsForAnItem = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
 
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              badge: '123',
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Products',
-              icon: ProductIcon,
-              badge: '2',
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-              secondaryActions: [
-                {
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                badge: '123',
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Products',
+                icon: ProductIcon,
+                badge: '2',
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+                secondaryActions: [
+                  {
+                    url: '#',
+                    accessibilityLabel: 'Add a product',
+                    icon: PlusCircleIcon,
+                    tooltip: {
+                      content: 'Add a product',
+                    },
+                  },
+                ],
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Long multi-line label',
+                icon: PlusIcon,
+                badge: '125',
+                onClick: () => setSelected('longMultiLineLabel'),
+                matches: selected === 'longMultiLineLabel',
+                secondaryActions: [
+                  {
+                    url: '#',
+                    accessibilityLabel: 'Add a product',
+                    icon: PlusCircleIcon,
+                    tooltip: {
+                      content: 'Add a product',
+                    },
+                  },
+                  {
+                    accessibilityLabel: 'Remove a product',
+                    icon: MinusCircleIcon,
+                    onClick: () => {},
+                    tooltip: {
+                      content: 'Remove a product',
+                    },
+                  },
+                ],
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Long truncated single-line text label',
+                icon: PlusIcon,
+                truncateText: true,
+                onClick: () => setSelected('longTruncatedSingleLineTextLabel'),
+                matches: selected === 'longTruncatedSingleLineTextLabel',
+                secondaryActions: [
+                  {
+                    url: '#',
+                    accessibilityLabel: 'Add a product',
+                    icon: PlusCircleIcon,
+                    tooltip: {
+                      content: 'Add a product',
+                    },
+                  },
+                  {
+                    accessibilityLabel: 'Remove a product',
+                    icon: MinusCircleIcon,
+                    onClick: () => {
+                      console.log('plus clicked');
+                    },
+                    tooltip: {
+                      content: 'Remove a product',
+                    },
+                  },
+                ],
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'New item',
+                    onClick: () => setSelected('newItem'),
+                    matches: selected === 'newItem',
+                  },
+                ],
+              },
+              {
+                url: '#',
+                label: 'Floating actions on multi-line text label',
+                icon: PlusIcon,
+                badge: '15',
+                displayActionsOnHover: true,
+                onClick: () =>
+                  setSelected('floatingActionsOnMultiLineTextLabel'),
+                matches: selected === 'floatingActionsOnMultiLineTextLabel',
+                secondaryActions: [
+                  {
+                    url: '#',
+                    accessibilityLabel: 'Add a product',
+                    icon: PlusCircleIcon,
+                    tooltip: {
+                      content: 'Add a product',
+                    },
+                  },
+                  {
+                    accessibilityLabel: 'Remove a product',
+                    icon: MinusCircleIcon,
+                    onClick: () => {
+                      console.log('minor clicked');
+                    },
+                    tooltip: {
+                      content: 'Remove a product',
+                    },
+                  },
+                ],
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Collections',
+                    onClick: () => setSelected('collections'),
+                    matches: selected === 'collections',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Inventory',
+                    onClick: () => setSelected('inventory'),
+                    matches: selected === 'inventory',
+                  },
+                ],
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Floating actions on truncated single-line text label',
+                icon: PlusIcon,
+                badge: '15',
+                truncateText: true,
+                displayActionsOnHover: true,
+                onClick: () =>
+                  setSelected('floatingActionsOnTruncatedSingleLineTextLabel'),
+                matches:
+                  selected === 'floatingActionsOnTruncatedSingleLineTextLabel',
+                secondaryActions: [
+                  {
+                    url: '#',
+                    accessibilityLabel: 'Add a product',
+                    icon: PlusCircleIcon,
+                    tooltip: {
+                      content: 'Add a product',
+                    },
+                  },
+                  {
+                    url: '',
+                    accessibilityLabel: 'Remove a product',
+                    icon: MinusCircleIcon,
+                    onClick: () => {},
+                    tooltip: {
+                      content: 'Remove a product',
+                    },
+                  },
+                ],
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'One floating action on multi-line text label',
+                icon: PlusIcon,
+                displayActionsOnHover: true,
+                onClick: () =>
+                  setSelected('oneFloatingActionOnMultiLineTextLabel'),
+                matches: selected === 'oneFloatingActionOnMultiLineTextLabel',
+                secondaryActions: [
+                  {
+                    url: '#',
+                    accessibilityLabel: 'Add a product',
+                    icon: PlusCircleIcon,
+                    tooltip: {
+                      content: 'Add a product',
+                    },
+                  },
+                ],
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label:
+                  'One floating action on truncated single-line text label',
+                icon: PlusIcon,
+                badge: '15',
+                truncateText: true,
+                displayActionsOnHover: true,
+                onClick: () =>
+                  setSelected(
+                    'oneFloatingActionOnTruncatedSingleLineTextLabel',
+                  ),
+                matches:
+                  selected ===
+                  'oneFloatingActionOnTruncatedSingleLineTextLabel',
+                secondaryActions: [
+                  {
+                    url: '#',
+                    accessibilityLabel: 'Add a product',
+                    icon: PlusCircleIcon,
+                    tooltip: {
+                      content: 'Add a product',
+                    },
+                  },
+                ],
+              },
+              {
+                url: '#',
+                label: 'Marketing',
+                icon: TargetIcon,
+                badge: '15',
+                selected: true,
+                onClick: () => setSelected('marketing'),
+                matches: selected === 'marketing',
+                secondaryActions: [
+                  {
+                    url: '#',
+                    accessibilityLabel: 'View campaign',
+                    icon: ViewIcon,
+                    tooltip: {
+                      content: 'View campaign',
+                    },
+                  },
+                ],
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Logout',
+                icon: ExitIcon,
+                onClick: () => setSelected('logout'),
+                matches: selected === 'logout',
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithTruncationForVariousStates = {
+  render() {
+    const [selected, setSelected] = React.useState('longlabel');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                label: 'A very long label to ellipsize',
+                truncateText: true,
+                icon: OrderIcon,
+                selected: false,
+                onClick: () => setSelected('longlabel'),
+                matches: selected === 'longlabel',
+              },
+              {
+                url: '#',
+                label: 'Not truncated',
+                icon: OrderIcon,
+                selected: false,
+                onClick: () => setSelected('nottruncated'),
+                matches: selected === 'nottruncated',
+              },
+              {
+                url: '#',
+                label: 'Lengthy label with secondary action',
+                icon: OrderIcon,
+                selected: false,
+                truncateText: true,
+                onClick: () => setSelected('lengthylabelwithsecondaryaction'),
+                matches: selected === 'lengthylabelwithsecondaryaction',
+                secondaryAction: {
                   url: '#',
-                  accessibilityLabel: 'Add a product',
+                  accessibilityLabel: 'Add an order',
                   icon: PlusCircleIcon,
                   tooltip: {
-                    content: 'Add a product',
+                    content: 'Add a lengthy order',
                   },
                 },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Long multi-line label',
-              icon: PlusIcon,
-              badge: '125',
-              onClick: () => setSelected('longMultiLineLabel'),
-              matches: selected === 'longMultiLineLabel',
-              secondaryActions: [
-                {
+              },
+              {
+                url: '#',
+                label: 'Lengthy non-truncated label with secondary action',
+                icon: OrderIcon,
+                selected: false,
+                onClick: () =>
+                  setSelected('lengthynontruncatedlabelwithsecondaryaction'),
+                matches:
+                  selected === 'lengthynontruncatedlabelwithsecondaryaction',
+                secondaryAction: {
                   url: '#',
-                  accessibilityLabel: 'Add a product',
+                  accessibilityLabel: 'Add an order',
                   icon: PlusCircleIcon,
                   tooltip: {
-                    content: 'Add a product',
+                    content: 'Add a lengthy order',
                   },
                 },
-                {
-                  accessibilityLabel: 'Remove a product',
-                  icon: MinusCircleIcon,
-                  onClick: () => {},
-                  tooltip: {
-                    content: 'Remove a product',
-                  },
-                },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Long truncated single-line text label',
-              icon: PlusIcon,
-              truncateText: true,
-              onClick: () => setSelected('longTruncatedSingleLineTextLabel'),
-              matches: selected === 'longTruncatedSingleLineTextLabel',
-              secondaryActions: [
-                {
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Lengthy label with badge',
+                truncateText: true,
+                badge: 'Old',
+                icon: HomeIcon,
+                onClick: () => setSelected('lengthylabelwithbadge'),
+                matches: selected === 'lengthylabelwithbadge',
+              },
+              {
+                url: '#',
+                label: 'Lengthy label with secondary action',
+                icon: OrderIcon,
+                selected: false,
+                truncateText: true,
+                badge: 'Old',
+                onClick: () => setSelected('lengthylabelwithsecondaryaction'),
+                matches: selected === 'lengthylabelwithsecondaryaction',
+                secondaryAction: {
                   url: '#',
-                  accessibilityLabel: 'Add a product',
+                  accessibilityLabel: 'Add an order',
                   icon: PlusCircleIcon,
                   tooltip: {
-                    content: 'Add a product',
+                    content: 'Add a lengthy order',
                   },
                 },
-                {
-                  accessibilityLabel: 'Remove a product',
-                  icon: MinusCircleIcon,
-                  onClick: () => {
-                    console.log('plus clicked');
+              },
+              {
+                url: '#',
+                label: 'Truncated secondary navigation items',
+                icon: ProductIcon,
+                selected: true,
+                truncateText: true,
+                onClick: () => setSelected('truncatedsecondarynavigationitems'),
+                matches: selected === 'truncatedsecondarynavigationitems',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Something longer than collections',
+                    onClick: () => setSelected('somethinglonger'),
+                    matches: selected === 'somethinglonger',
                   },
-                  tooltip: {
-                    content: 'Remove a product',
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Inventory',
+                    onClick: () => setSelected('inventory'),
+                    matches: selected === 'inventory',
                   },
-                },
-              ],
-              subNavigationItems: [
-                {
+                ],
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithSectionRollup = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Products',
+                icon: ProductIcon,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+              },
+            ]}
+            rollup={{
+              after: 2,
+              view: 'view',
+              hide: 'hide',
+              activePath: '/',
+            }}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithSectionSeparator = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Products',
+                icon: ProductIcon,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+              },
+            ]}
+          />
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Online Store',
+                icon: StoreOnlineIcon,
+                onClick: () => setSelected('onlinestore'),
+                matches: selected === 'onlinestore',
+              },
+            ]}
+            separator
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithVariousStatesAndSecondaryElements = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Inactive item',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Item with indicator',
+                icon: HomeIcon,
+                onClick: () => setSelected('itemwithindicator'),
+                matches: selected === 'itemwithindicator',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    new: true,
+                    label: 'New item',
+                    onClick: () => setSelected('newitem'),
+                    matches: selected === 'newitem',
+                  },
+                ],
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'New item',
+                new: true,
+                icon: HomeIcon,
+                onClick: () => setSelected('newitem2'),
+                matches: selected === 'newitem2',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Badged item',
+                badge: 'Old',
+                icon: HomeIcon,
+                onClick: () => setSelected('badgeditem'),
+                matches: selected === 'badgeditem',
+              },
+              {
+                url: '#',
+                label: 'Active with secondary action',
+                icon: OrderIcon,
+                selected: true,
+                onClick: () => setSelected('activewithsecondaryaction'),
+                matches: selected === 'activewithsecondaryaction',
+                secondaryAction: {
                   url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'New item',
-                  onClick: () => setSelected('newItem'),
-                  matches: selected === 'newItem',
-                },
-              ],
-            },
-            {
-              url: '#',
-              label: 'Floating actions on multi-line text label',
-              icon: PlusIcon,
-              badge: '15',
-              displayActionsOnHover: true,
-              onClick: () => setSelected('floatingActionsOnMultiLineTextLabel'),
-              matches: selected === 'floatingActionsOnMultiLineTextLabel',
-              secondaryActions: [
-                {
-                  url: '#',
-                  accessibilityLabel: 'Add a product',
+                  accessibilityLabel: 'Add an order',
                   icon: PlusCircleIcon,
                   tooltip: {
-                    content: 'Add a product',
+                    content: 'Add an order',
                   },
                 },
-                {
-                  accessibilityLabel: 'Remove a product',
-                  icon: MinusCircleIcon,
-                  onClick: () => {
-                    console.log('minor clicked');
+              },
+              {
+                url: window.location.href,
+                label: 'Active item with sub navigation',
+                icon: ProductIcon,
+                selected: true,
+                onClick: () => setSelected('activeitemwithsubnavigation'),
+                matches: selected === 'activeitemwithsubnavigation',
+                subNavigationItems: [
+                  {
+                    url: window.location.href,
+                    selected: true,
+                    disabled: false,
+                    label: 'Selected sub item',
+                    onClick: () => setSelected('selectedsubitem'),
+                    matches: selected === 'selectedsubitem',
                   },
-                  tooltip: {
-                    content: 'Remove a product',
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Default sub item',
+                    onClick: () => setSelected('defaultsubitem'),
+                    matches: selected === 'defaultsubitem',
                   },
-                },
-              ],
-              subNavigationItems: [
-                {
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: true,
+                    label: 'Disabled sub item',
+                  },
+                ],
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Disabled item',
+                icon: PersonIcon,
+                disabled: true,
+              },
+              {
+                url: '#',
+                label: 'Overflow item',
+                icon: TargetIcon,
+                onClick: () => setSelected('overflowitem'),
+                matches: selected === 'overflowitem',
+              },
+            ]}
+            rollup={{
+              after: 7,
+              view: 'view',
+              hide: 'hide',
+              activePath: '/',
+            }}
+          />
+          <Navigation.Section
+            title="These icons should have the same color"
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Icon as svg',
+                icon: StoreOnlineIcon,
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Icon as img',
+                icon: '<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M1.791 2.253l-.597 3.583A1 1 0 0 0 2.18 7h.893a1.5 1.5 0 0 0 1.342-.83L5 5l.585 1.17A1.5 1.5 0 0 0 6.927 7h1.146a1.5 1.5 0 0 0 1.342-.83L10 5l.585 1.17a1.5 1.5 0 0 0 1.342.83h1.146a1.5 1.5 0 0 0 1.342-.83L15 5l.585 1.17a1.5 1.5 0 0 0 1.342.83h.893a1 1 0 0 0 .986-1.164l-.597-3.583A1.5 1.5 0 0 0 16.729 1H3.271a1.5 1.5 0 0 0-1.48 1.253zM4 18.5A1.5 1.5 0 0 1 5.5 17H8v-3h4v3h2.5a1.5 1.5 0 0 1 1.5 1.5v.5H4v-.5z"></path><path d="M2 9h2v4h12V9h2v4.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 2 13.5V9z"></path></svg>',
+              },
+              {
+                url: '#',
+                label: 'Icon as img – Active',
+                icon: '<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M1.791 2.253l-.597 3.583A1 1 0 0 0 2.18 7h.893a1.5 1.5 0 0 0 1.342-.83L5 5l.585 1.17A1.5 1.5 0 0 0 6.927 7h1.146a1.5 1.5 0 0 0 1.342-.83L10 5l.585 1.17a1.5 1.5 0 0 0 1.342.83h1.146a1.5 1.5 0 0 0 1.342-.83L15 5l.585 1.17a1.5 1.5 0 0 0 1.342.83h.893a1 1 0 0 0 .986-1.164l-.597-3.583A1.5 1.5 0 0 0 16.729 1H3.271a1.5 1.5 0 0 0-1.48 1.253zM4 18.5A1.5 1.5 0 0 1 5.5 17H8v-3h4v3h2.5a1.5 1.5 0 0 1 1.5 1.5v.5H4v-.5z"></path><path d="M2 9h2v4h12V9h2v4.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 2 13.5V9z"></path></svg>',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Other secondary action',
+                icon: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M2.771 14.055A8 8 0 1 1 16 8c0 2.385-1.086 4.629-2.704 5.983A7.956 7.956 0 0 1 7.991 16c-.613 0-2.022-.003-5-.01h-.928l.708-1.935zm5.973-6.757c-.554-.302-.837-.565-.837-.92 0-.446.4-.735 1.017-.735a3.62 3.62 0 0 1 1.365.302l.502-1.577S10.328 4 8.963 4C7.057 4 5.73 5.117 5.73 6.68c0 .894.618 1.565 1.442 2.05.67.382.901.658.901 1.065 0 .42-.334.762-.952.762-.915 0-1.79-.486-1.79-.486l-.54 1.577s.797.552 2.15.552c1.956 0 3.373-.986 3.373-2.76-.013-.959-.721-1.642-1.571-2.142z"/></svg>',
+                secondaryAction: {
                   url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Collections',
-                  onClick: () => setSelected('collections'),
-                  matches: selected === 'collections',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Inventory',
-                  onClick: () => setSelected('inventory'),
-                  matches: selected === 'inventory',
-                },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Floating actions on truncated single-line text label',
-              icon: PlusIcon,
-              badge: '15',
-              truncateText: true,
-              displayActionsOnHover: true,
-              onClick: () =>
-                setSelected('floatingActionsOnTruncatedSingleLineTextLabel'),
-              matches:
-                selected === 'floatingActionsOnTruncatedSingleLineTextLabel',
-              secondaryActions: [
-                {
-                  url: '#',
-                  accessibilityLabel: 'Add a product',
-                  icon: PlusCircleIcon,
-                  tooltip: {
-                    content: 'Add a product',
-                  },
-                },
-                {
-                  url: '',
-                  accessibilityLabel: 'Remove a product',
-                  icon: MinusCircleIcon,
-                  onClick: () => {},
-                  tooltip: {
-                    content: 'Remove a product',
-                  },
-                },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'One floating action on multi-line text label',
-              icon: PlusIcon,
-              displayActionsOnHover: true,
-              onClick: () =>
-                setSelected('oneFloatingActionOnMultiLineTextLabel'),
-              matches: selected === 'oneFloatingActionOnMultiLineTextLabel',
-              secondaryActions: [
-                {
-                  url: '#',
-                  accessibilityLabel: 'Add a product',
-                  icon: PlusCircleIcon,
-                  tooltip: {
-                    content: 'Add a product',
-                  },
-                },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'One floating action on truncated single-line text label',
-              icon: PlusIcon,
-              badge: '15',
-              truncateText: true,
-              displayActionsOnHover: true,
-              onClick: () =>
-                setSelected('oneFloatingActionOnTruncatedSingleLineTextLabel'),
-              matches:
-                selected === 'oneFloatingActionOnTruncatedSingleLineTextLabel',
-              secondaryActions: [
-                {
-                  url: '#',
-                  accessibilityLabel: 'Add a product',
-                  icon: PlusCircleIcon,
-                  tooltip: {
-                    content: 'Add a product',
-                  },
-                },
-              ],
-            },
-            {
-              url: '#',
-              label: 'Marketing',
-              icon: TargetIcon,
-              badge: '15',
-              selected: true,
-              onClick: () => setSelected('marketing'),
-              matches: selected === 'marketing',
-              secondaryActions: [
-                {
-                  url: '#',
-                  accessibilityLabel: 'View campaign',
+                  accessibilityLabel: 'View your online store',
                   icon: ViewIcon,
                   tooltip: {
-                    content: 'View campaign',
+                    content: 'View your online store',
                   },
                 },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Logout',
-              icon: ExitIcon,
-              onClick: () => setSelected('logout'),
-              matches: selected === 'logout',
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithTruncationForVariousStates() {
-  const [selected, setSelected] = React.useState('longlabel');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              label: 'A very long label to ellipsize',
-              truncateText: true,
-              icon: OrderIcon,
-              selected: false,
-              onClick: () => setSelected('longlabel'),
-              matches: selected === 'longlabel',
-            },
-            {
-              url: '#',
-              label: 'Not truncated',
-              icon: OrderIcon,
-              selected: false,
-              onClick: () => setSelected('nottruncated'),
-              matches: selected === 'nottruncated',
-            },
-            {
-              url: '#',
-              label: 'Lengthy label with secondary action',
-              icon: OrderIcon,
-              selected: false,
-              truncateText: true,
-              onClick: () => setSelected('lengthylabelwithsecondaryaction'),
-              matches: selected === 'lengthylabelwithsecondaryaction',
-              secondaryAction: {
+              },
+              {
                 url: '#',
-                accessibilityLabel: 'Add an order',
-                icon: PlusCircleIcon,
-                tooltip: {
-                  content: 'Add a lengthy order',
+                excludePaths: ['#'],
+                label: 'Square app-like icon',
+                icon: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M0.8 0C0.358172 0 0 0.358172 0 0.8V15.2C0 15.6418 0.358172 16 0.8 16H15.2C15.6418 16 16 15.6418 16 15.2V0.8C16 0.358172 15.6418 0 15.2 0H0.8ZM2.4 4.4C2.4 3.95817 2.75817 3.6 3.2 3.6H12.8C13.2418 3.6 13.6 3.95817 13.6 4.4V5.0786L8 8.2786L2.4 5.0786V4.4ZM8.79382 9.66779L13.6 6.9214V11.6C13.6 12.0418 13.2418 12.4 12.8 12.4H3.2C2.75817 12.4 2.4 12.0418 2.4 11.6V6.9214L7.20618 9.66779C7.69807 9.94887 8.30193 9.94887 8.79382 9.66779Z"/></svg>',
+                shouldResizeIcon: true,
+                secondaryAction: {
+                  url: '#',
+                  accessibilityLabel: 'View your online store',
+                  icon: ViewIcon,
+                  tooltip: {
+                    content: 'View your online store',
+                  },
                 },
               },
-            },
-            {
-              url: '#',
-              label: 'Lengthy non-truncated label with secondary action',
-              icon: OrderIcon,
-              selected: false,
-              onClick: () =>
-                setSelected('lengthynontruncatedlabelwithsecondaryaction'),
-              matches:
-                selected === 'lengthynontruncatedlabelwithsecondaryaction',
-              secondaryAction: {
+            ]}
+            action={{
+              accessibilityLabel: 'Add sales channel',
+              icon: PlusCircleIcon,
+              onClick: () => {},
+            }}
+            separator
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithAriaLabelledby = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/" ariaLabelledBy="label-id">
+          <Text id="label-id" as="span" visuallyHidden>
+            Hidden label
+          </Text>
+          <Navigation.Section
+            items={[
+              {
                 url: '#',
-                accessibilityLabel: 'Add an order',
-                icon: PlusCircleIcon,
-                tooltip: {
-                  content: 'Add a lengthy order',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                badge: '15',
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Products',
+                icon: ProductIcon,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const UsingIconIcons = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                badge: '15',
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Products',
+                icon: ProductIcon,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+              },
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Customers',
+                icon: PersonIcon,
+                onClick: () => setSelected('customers'),
+                matches: selected === 'customers',
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const WithBadgeAndSecondaryAction = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
+                url: '#',
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: HomeIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
+                secondaryAction: {
+                  url: '#',
+                  accessibilityLabel: 'View your online store',
+                  icon: ViewIcon,
+                  tooltip: {
+                    content: 'View your online store',
+                  },
                 },
               },
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Lengthy label with badge',
-              truncateText: true,
-              badge: 'Old',
-              icon: HomeIcon,
-              onClick: () => setSelected('lengthylabelwithbadge'),
-              matches: selected === 'lengthylabelwithbadge',
-            },
-            {
-              url: '#',
-              label: 'Lengthy label with secondary action',
-              icon: OrderIcon,
-              selected: false,
-              truncateText: true,
-              badge: 'Old',
-              onClick: () => setSelected('lengthylabelwithsecondaryaction'),
-              matches: selected === 'lengthylabelwithsecondaryaction',
-              secondaryAction: {
+              {
                 url: '#',
-                accessibilityLabel: 'Add an order',
-                icon: PlusCircleIcon,
-                tooltip: {
-                  content: 'Add a lengthy order',
-                },
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: OrderIcon,
+                badge: '15',
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Drafts',
+                    onClick: () => setSelected('drafts'),
+                    matches: selected === 'drafts',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Shipping labels',
+                    onClick: () => setSelected('shippinglabels'),
+                    matches: selected === 'shippinglabels',
+                  },
+                ],
               },
-            },
-            {
-              url: '#',
-              label: 'Truncated secondary navigation items',
-              icon: ProductIcon,
-              selected: true,
-              truncateText: true,
-              onClick: () => setSelected('truncatedsecondarynavigationitems'),
-              matches: selected === 'truncatedsecondarynavigationitems',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Something longer than collections',
-                  onClick: () => setSelected('somethinglonger'),
-                  matches: selected === 'somethinglonger',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Inventory',
-                  onClick: () => setSelected('inventory'),
-                  matches: selected === 'inventory',
-                },
-              ],
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithSectionRollup() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Products',
-              icon: ProductIcon,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-            },
-          ]}
-          rollup={{
-            after: 2,
-            view: 'view',
-            hide: 'hide',
-            activePath: '/',
-          }}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithSectionSeparator() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Products',
-              icon: ProductIcon,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-            },
-          ]}
-        />
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Online Store',
-              icon: StoreOnlineIcon,
-              onClick: () => setSelected('onlinestore'),
-              matches: selected === 'onlinestore',
-            },
-          ]}
-          separator
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithVariousStatesAndSecondaryElements() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Inactive item',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Item with indicator',
-              icon: HomeIcon,
-              onClick: () => setSelected('itemwithindicator'),
-              matches: selected === 'itemwithindicator',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  new: true,
-                  label: 'New item',
-                  onClick: () => setSelected('newitem'),
-                  matches: selected === 'newitem',
-                },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'New item',
-              new: true,
-              icon: HomeIcon,
-              onClick: () => setSelected('newitem2'),
-              matches: selected === 'newitem2',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Badged item',
-              badge: 'Old',
-              icon: HomeIcon,
-              onClick: () => setSelected('badgeditem'),
-              matches: selected === 'badgeditem',
-            },
-            {
-              url: '#',
-              label: 'Active with secondary action',
-              icon: OrderIcon,
-              selected: true,
-              onClick: () => setSelected('activewithsecondaryaction'),
-              matches: selected === 'activewithsecondaryaction',
-              secondaryAction: {
+              {
                 url: '#',
-                accessibilityLabel: 'Add an order',
-                icon: PlusCircleIcon,
-                tooltip: {
-                  content: 'Add an order',
+                excludePaths: ['#'],
+                label: 'Marketing',
+                icon: TargetIcon,
+                badge: '15',
+                onClick: () => setSelected('marketing'),
+                matches: selected === 'marketing',
+                secondaryAction: {
+                  url: '#',
+                  accessibilityLabel: 'View your online store',
+                  icon: ViewIcon,
+                  tooltip: {
+                    content: 'View your online store',
+                  },
                 },
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Reports',
+                    onClick: () => setSelected('reports'),
+                    matches: selected === 'reports',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Live view',
+                    onClick: () => setSelected('liveView'),
+                    matches: selected === 'liveView',
+                  },
+                ],
               },
-            },
-            {
-              url: window.location.href,
-              label: 'Active item with sub navigation',
-              icon: ProductIcon,
-              selected: true,
-              onClick: () => setSelected('activeitemwithsubnavigation'),
-              matches: selected === 'activeitemwithsubnavigation',
-              subNavigationItems: [
-                {
-                  url: window.location.href,
-                  selected: true,
-                  disabled: false,
-                  label: 'Selected sub item',
-                  onClick: () => setSelected('selectedsubitem'),
-                  matches: selected === 'selectedsubitem',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Default sub item',
-                  onClick: () => setSelected('defaultsubitem'),
-                  matches: selected === 'defaultsubitem',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: true,
-                  label: 'Disabled sub item',
-                },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Disabled item',
-              icon: PersonIcon,
-              disabled: true,
-            },
-            {
-              url: '#',
-              label: 'Overflow item',
-              icon: TargetIcon,
-              onClick: () => setSelected('overflowitem'),
-              matches: selected === 'overflowitem',
-            },
-          ]}
-          rollup={{
-            after: 7,
-            view: 'view',
-            hide: 'hide',
-            activePath: '/',
-          }}
-        />
-        <Navigation.Section
-          title="These icons should have the same color"
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Icon as svg',
-              icon: StoreOnlineIcon,
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Icon as img',
-              icon: '<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M1.791 2.253l-.597 3.583A1 1 0 0 0 2.18 7h.893a1.5 1.5 0 0 0 1.342-.83L5 5l.585 1.17A1.5 1.5 0 0 0 6.927 7h1.146a1.5 1.5 0 0 0 1.342-.83L10 5l.585 1.17a1.5 1.5 0 0 0 1.342.83h1.146a1.5 1.5 0 0 0 1.342-.83L15 5l.585 1.17a1.5 1.5 0 0 0 1.342.83h.893a1 1 0 0 0 .986-1.164l-.597-3.583A1.5 1.5 0 0 0 16.729 1H3.271a1.5 1.5 0 0 0-1.48 1.253zM4 18.5A1.5 1.5 0 0 1 5.5 17H8v-3h4v3h2.5a1.5 1.5 0 0 1 1.5 1.5v.5H4v-.5z"></path><path d="M2 9h2v4h12V9h2v4.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 2 13.5V9z"></path></svg>',
-            },
-            {
-              url: '#',
-              label: 'Icon as img – Active',
-              icon: '<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M1.791 2.253l-.597 3.583A1 1 0 0 0 2.18 7h.893a1.5 1.5 0 0 0 1.342-.83L5 5l.585 1.17A1.5 1.5 0 0 0 6.927 7h1.146a1.5 1.5 0 0 0 1.342-.83L10 5l.585 1.17a1.5 1.5 0 0 0 1.342.83h1.146a1.5 1.5 0 0 0 1.342-.83L15 5l.585 1.17a1.5 1.5 0 0 0 1.342.83h.893a1 1 0 0 0 .986-1.164l-.597-3.583A1.5 1.5 0 0 0 16.729 1H3.271a1.5 1.5 0 0 0-1.48 1.253zM4 18.5A1.5 1.5 0 0 1 5.5 17H8v-3h4v3h2.5a1.5 1.5 0 0 1 1.5 1.5v.5H4v-.5z"></path><path d="M2 9h2v4h12V9h2v4.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 2 13.5V9z"></path></svg>',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Other secondary action',
-              icon: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M2.771 14.055A8 8 0 1 1 16 8c0 2.385-1.086 4.629-2.704 5.983A7.956 7.956 0 0 1 7.991 16c-.613 0-2.022-.003-5-.01h-.928l.708-1.935zm5.973-6.757c-.554-.302-.837-.565-.837-.92 0-.446.4-.735 1.017-.735a3.62 3.62 0 0 1 1.365.302l.502-1.577S10.328 4 8.963 4C7.057 4 5.73 5.117 5.73 6.68c0 .894.618 1.565 1.442 2.05.67.382.901.658.901 1.065 0 .42-.334.762-.952.762-.915 0-1.79-.486-1.79-.486l-.54 1.577s.797.552 2.15.552c1.956 0 3.373-.986 3.373-2.76-.013-.959-.721-1.642-1.571-2.142z"/></svg>',
-              secondaryAction: {
+              {
                 url: '#',
-                accessibilityLabel: 'View your online store',
-                icon: ViewIcon,
-                tooltip: {
-                  content: 'View your online store',
-                },
+                label: 'Products',
+                icon: ProductIcon,
+                selected: true,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Collections',
+                    onClick: () => setSelected('collections'),
+                    matches: selected === 'collections',
+                  },
+                  {
+                    url: '#',
+                    disabled: false,
+                    label: 'Inventory',
+                    onClick: () => setSelected('inventory'),
+                    matches: selected === 'inventory',
+                  },
+                ],
               },
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Square app-like icon',
-              icon: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M0.8 0C0.358172 0 0 0.358172 0 0.8V15.2C0 15.6418 0.358172 16 0.8 16H15.2C15.6418 16 16 15.6418 16 15.2V0.8C16 0.358172 15.6418 0 15.2 0H0.8ZM2.4 4.4C2.4 3.95817 2.75817 3.6 3.2 3.6H12.8C13.2418 3.6 13.6 3.95817 13.6 4.4V5.0786L8 8.2786L2.4 5.0786V4.4ZM8.79382 9.66779L13.6 6.9214V11.6C13.6 12.0418 13.2418 12.4 12.8 12.4H3.2C2.75817 12.4 2.4 12.0418 2.4 11.6V6.9214L7.20618 9.66779C7.69807 9.94887 8.30193 9.94887 8.79382 9.66779Z"/></svg>',
-              shouldResizeIcon: true,
-              secondaryAction: {
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
+
+export const ItemWithMatchedIcon = {
+  render() {
+    const [selected, setSelected] = React.useState('home');
+
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            items={[
+              {
                 url: '#',
-                accessibilityLabel: 'View your online store',
-                icon: ViewIcon,
-                tooltip: {
-                  content: 'View your online store',
-                },
+                excludePaths: ['#'],
+                label: 'Home',
+                icon: StarFilledIcon,
+                matchedItemIcon: StarIcon,
+                onClick: () => setSelected('home'),
+                matches: selected === 'home',
               },
-            },
-          ]}
-          action={{
-            accessibilityLabel: 'Add sales channel',
-            icon: PlusCircleIcon,
-            onClick: () => {},
-          }}
-          separator
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithAriaLabelledby() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/" ariaLabelledBy="label-id">
-        <Text id="label-id" as="span" visuallyHidden>
-          Hidden label
-        </Text>
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              badge: '15',
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Products',
-              icon: ProductIcon,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function UsingIconIcons() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              badge: '15',
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Products',
-              icon: ProductIcon,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Customers',
-              icon: PersonIcon,
-              onClick: () => setSelected('customers'),
-              matches: selected === 'customers',
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function WithBadgeAndSecondaryAction() {
-  const [selected, setSelected] = React.useState('home');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: HomeIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-              secondaryAction: {
+              {
                 url: '#',
-                accessibilityLabel: 'View your online store',
-                icon: ViewIcon,
-                tooltip: {
-                  content: 'View your online store',
-                },
+                excludePaths: ['#'],
+                label: 'Orders',
+                icon: StarFilledIcon,
+                matchedItemIcon: StarIcon,
+                badge: '15',
+                onClick: () => setSelected('orders'),
+                matches: selected === 'orders',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Drafts',
+                    onClick: () => setSelected('drafts'),
+                    matches: selected === 'drafts',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Shipping labels',
+                    onClick: () => setSelected('shippinglabels'),
+                    matches: selected === 'shippinglabels',
+                  },
+                ],
               },
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: OrderIcon,
-              badge: '15',
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Drafts',
-                  onClick: () => setSelected('drafts'),
-                  matches: selected === 'drafts',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Shipping labels',
-                  onClick: () => setSelected('shippinglabels'),
-                  matches: selected === 'shippinglabels',
-                },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Marketing',
-              icon: TargetIcon,
-              badge: '15',
-              onClick: () => setSelected('marketing'),
-              matches: selected === 'marketing',
-              secondaryAction: {
+              {
                 url: '#',
-                accessibilityLabel: 'View your online store',
-                icon: ViewIcon,
-                tooltip: {
-                  content: 'View your online store',
-                },
+                excludePaths: ['#'],
+                label: 'Marketing',
+                icon: StarFilledIcon,
+                matchedItemIcon: StarIcon,
+                onClick: () => setSelected('marketing'),
+                matches: selected === 'marketing',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Reports',
+                    onClick: () => setSelected('reports'),
+                    matches: selected === 'reports',
+                  },
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Live view',
+                    onClick: () => setSelected('liveView'),
+                    matches: selected === 'liveView',
+                  },
+                ],
               },
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Reports',
-                  onClick: () => setSelected('reports'),
-                  matches: selected === 'reports',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Live view',
-                  onClick: () => setSelected('liveView'),
-                  matches: selected === 'liveView',
-                },
-              ],
-            },
-            {
-              url: '#',
-              label: 'Products',
-              icon: ProductIcon,
-              selected: true,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Collections',
-                  onClick: () => setSelected('collections'),
-                  matches: selected === 'collections',
-                },
-                {
-                  url: '#',
-                  disabled: false,
-                  label: 'Inventory',
-                  onClick: () => setSelected('inventory'),
-                  matches: selected === 'inventory',
-                },
-              ],
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
+              {
+                url: '#',
+                label: 'Products',
+                icon: StarFilledIcon,
+                matchedItemIcon: StarIcon,
+                onClick: () => setSelected('products'),
+                matches: selected === 'products',
+                subNavigationItems: [
+                  {
+                    url: '#',
+                    excludePaths: ['#'],
+                    disabled: false,
+                    label: 'Collections',
+                    onClick: () => setSelected('collections'),
+                    matches: selected === 'collections',
+                  },
+                  {
+                    url: '#',
+                    disabled: false,
+                    label: 'Inventory',
+                    onClick: () => setSelected('inventory'),
+                    matches: selected === 'inventory',
+                  },
+                ],
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};
 
-export function ItemWithMatchedIcon() {
-  const [selected, setSelected] = React.useState('home');
+export const ItemsWithoutUrl = {
+  render() {
+    const [selected, setSelected] = React.useState('all');
 
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          items={[
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Home',
-              icon: StarFilledIcon,
-              matchedItemIcon: StarIcon,
-              onClick: () => setSelected('home'),
-              matches: selected === 'home',
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Orders',
-              icon: StarFilledIcon,
-              matchedItemIcon: StarIcon,
-              badge: '15',
-              onClick: () => setSelected('orders'),
-              matches: selected === 'orders',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Drafts',
-                  onClick: () => setSelected('drafts'),
-                  matches: selected === 'drafts',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Shipping labels',
-                  onClick: () => setSelected('shippinglabels'),
-                  matches: selected === 'shippinglabels',
-                },
-              ],
-            },
-            {
-              url: '#',
-              excludePaths: ['#'],
-              label: 'Marketing',
-              icon: StarFilledIcon,
-              matchedItemIcon: StarIcon,
-              onClick: () => setSelected('marketing'),
-              matches: selected === 'marketing',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Reports',
-                  onClick: () => setSelected('reports'),
-                  matches: selected === 'reports',
-                },
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Live view',
-                  onClick: () => setSelected('liveView'),
-                  matches: selected === 'liveView',
-                },
-              ],
-            },
-            {
-              url: '#',
-              label: 'Products',
-              icon: StarFilledIcon,
-              matchedItemIcon: StarIcon,
-              onClick: () => setSelected('products'),
-              matches: selected === 'products',
-              subNavigationItems: [
-                {
-                  url: '#',
-                  excludePaths: ['#'],
-                  disabled: false,
-                  label: 'Collections',
-                  onClick: () => setSelected('collections'),
-                  matches: selected === 'collections',
-                },
-                {
-                  url: '#',
-                  disabled: false,
-                  label: 'Inventory',
-                  onClick: () => setSelected('inventory'),
-                  matches: selected === 'inventory',
-                },
-              ],
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
-
-export function ItemsWithoutUrl() {
-  const [selected, setSelected] = React.useState('all');
-
-  return (
-    <Frame>
-      <Navigation location="/">
-        <Navigation.Section
-          title="Templates"
-          items={[
-            {
-              label: 'All',
-              selected: selected === 'all',
-              onClick: () => setSelected('all'),
-            },
-            {
-              label: 'Announcements',
-              selected: selected === 'announcements',
-              onClick: () => setSelected('announcements'),
-            },
-            {
-              label: 'Holidays and occasions',
-              selected: selected === 'holidays',
-              onClick: () => setSelected('holidays'),
-            },
-            {
-              label: 'Newsletters',
-              selected: selected === 'newsletters',
-              onClick: () => setSelected('newsletters'),
-            },
-            {
-              label: 'Product highlights',
-              selected: selected === 'productHighlights',
-              onClick: () => setSelected('productHighlights'),
-            },
-            {
-              label: 'Promotions',
-              selected: selected === 'promotions',
-              onClick: () => setSelected('promotions'),
-              disabled: true,
-            },
-          ]}
-        />
-        <Navigation.Section
-          title="Custom"
-          items={[
-            {
-              label: 'Your templates',
-              selected: selected === 'yourTemplates',
-              onClick: () => setSelected('yourTemplates'),
-            },
-            {
-              label: 'Recent emails',
-              selected: selected === 'recentEmails',
-              onClick: () => setSelected('recentEmails'),
-            },
-          ]}
-        />
-      </Navigation>
-    </Frame>
-  );
-}
+    return (
+      <Frame>
+        <Navigation location="/">
+          <Navigation.Section
+            title="Templates"
+            items={[
+              {
+                label: 'All',
+                selected: selected === 'all',
+                onClick: () => setSelected('all'),
+              },
+              {
+                label: 'Announcements',
+                selected: selected === 'announcements',
+                onClick: () => setSelected('announcements'),
+              },
+              {
+                label: 'Holidays and occasions',
+                selected: selected === 'holidays',
+                onClick: () => setSelected('holidays'),
+              },
+              {
+                label: 'Newsletters',
+                selected: selected === 'newsletters',
+                onClick: () => setSelected('newsletters'),
+              },
+              {
+                label: 'Product highlights',
+                selected: selected === 'productHighlights',
+                onClick: () => setSelected('productHighlights'),
+              },
+              {
+                label: 'Promotions',
+                selected: selected === 'promotions',
+                onClick: () => setSelected('promotions'),
+                disabled: true,
+              },
+            ]}
+          />
+          <Navigation.Section
+            title="Custom"
+            items={[
+              {
+                label: 'Your templates',
+                selected: selected === 'yourTemplates',
+                onClick: () => setSelected('yourTemplates'),
+              },
+              {
+                label: 'Recent emails',
+                selected: selected === 'recentEmails',
+                onClick: () => setSelected('recentEmails'),
+              },
+            ]}
+          />
+        </Navigation>
+      </Frame>
+    );
+  },
+};

--- a/polaris-react/src/components/OptionList/OptionList.stories.tsx
+++ b/polaris-react/src/components/OptionList/OptionList.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Avatar,
   Box,
@@ -16,371 +16,97 @@ import {DiscountIcon} from '@shopify/polaris-icons';
 
 export default {
   component: OptionList,
-} as ComponentMeta<typeof OptionList>;
+} as Meta<typeof OptionList>;
 
-export function Default() {
-  const [selected, setSelected] = useState([]);
+export const Default = {
+  render() {
+    const [selected, setSelected] = useState([]);
 
-  const handleChange = useCallback((value) => setSelected(value), []);
+    const handleChange = useCallback((value) => setSelected(value), []);
 
-  return (
-    <LegacyCard>
-      <OptionList
-        title="Inventory Location"
-        onChange={handleChange}
-        options={[
-          {value: 'byward_market', label: 'Byward Market'},
-          {value: 'centretown', label: 'Centretown'},
-          {value: 'hintonburg', label: 'Hintonburg'},
-          {value: 'westboro', label: 'Westboro'},
-          {value: 'downtown', label: 'Downtown'},
-        ]}
-        selected={selected}
-      />
-    </LegacyCard>
-  );
-}
-
-export function Multiple() {
-  const [selected, setSelected] = useState([]);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
-
-  return (
-    <LegacyCard>
-      <OptionList
-        title="Manage sales channels availability"
-        onChange={handleChange}
-        options={[
-          {value: 'online_store', label: 'Online Store'},
-          {value: 'messenger', label: 'Messenger'},
-          {value: 'facebook', label: 'Facebook'},
-          {value: 'wholesale', label: 'Wholesale'},
-          {value: 'buzzfeed', label: 'BuzzFeed'},
-        ]}
-        selected={selected}
-        allowMultiple
-      />
-    </LegacyCard>
-  );
-}
-
-export function MultipleWithDisabledOption() {
-  const [selected, setSelected] = useState([]);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
-
-  return (
-    <LegacyCard>
-      <OptionList
-        title="Manage sales channels availability"
-        onChange={handleChange}
-        options={[
-          {value: 'online_store', label: 'Online Store'},
-          {value: 'messenger', label: 'Messenger', disabled: true},
-          {value: 'facebook', label: 'Facebook'},
-          {value: 'wholesale', label: 'Wholesale'},
-          {value: 'buzzfeed', label: 'BuzzFeed'},
-        ]}
-        selected={selected}
-        allowMultiple
-      />
-    </LegacyCard>
-  );
-}
-
-export function WithSections() {
-  const [selected, setSelected] = useState([]);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
-
-  return (
-    <LegacyCard>
-      <OptionList
-        onChange={handleChange}
-        sections={[
-          {
-            options: [
-              {value: 'type', label: 'Sale item type'},
-              {value: 'kind', label: 'Sale kind'},
-            ],
-          },
-          {
-            title: 'Traffic',
-            options: [
-              {value: 'source', label: 'Traffic referrer source'},
-              {value: 'host', label: 'Traffic referrer host'},
-              {value: 'path', label: 'Traffic referrer path'},
-            ],
-          },
-          {
-            title: 'Inventory Location',
-            options: [
-              {value: 'byward_market', label: 'Byward Market'},
-              {value: 'centretown', label: 'Centretown'},
-              {value: 'hintonburg', label: 'Hintonburg'},
-              {value: 'westboro', label: 'Westboro'},
-              {value: 'downtown', label: 'Downtown'},
-            ],
-          },
-        ]}
-        selected={selected}
-        allowMultiple
-      />
-    </LegacyCard>
-  );
-}
-
-export function InAPopover() {
-  const [selected, setSelected] = useState([]);
-  const [popoverActive, setPopoverActive] = useState(true);
-
-  const handleChange = useCallback((value) => setSelected(value), []);
-
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
-
-  const activator = (
-    <Button onClick={togglePopoverActive} disclosure>
-      Options
-    </Button>
-  );
-
-  return (
-    <div style={{height: '275px'}}>
-      <Popover
-        active={popoverActive}
-        activator={activator}
-        onClose={togglePopoverActive}
-      >
+    return (
+      <LegacyCard>
         <OptionList
           title="Inventory Location"
           onChange={handleChange}
           options={[
-            {
-              value: 'byward_market',
-              label: 'Byward Market',
-            },
+            {value: 'byward_market', label: 'Byward Market'},
             {value: 'centretown', label: 'Centretown'},
-            {
-              value: 'hintonburg',
-              label: 'Hintonburg',
-            },
+            {value: 'hintonburg', label: 'Hintonburg'},
             {value: 'westboro', label: 'Westboro'},
             {value: 'downtown', label: 'Downtown'},
           ]}
           selected={selected}
         />
-      </Popover>
-    </div>
-  );
-}
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithDisabledOption() {
-  const [selected, setSelected] = useState([]);
+export const Multiple = {
+  render() {
+    const [selected, setSelected] = useState([]);
 
-  const handleChange = useCallback((value) => setSelected(value), []);
+    const handleChange = useCallback((value) => setSelected(value), []);
 
-  return (
-    <LegacyCard>
-      <OptionList
-        title="Inventory Location"
-        onChange={handleChange}
-        options={[
-          {value: 'byward_market', label: 'Byward Market'},
-          {value: 'centretown', disabled: true, label: 'Centretown'},
-          {value: 'hintonburg', label: 'Hintonburg'},
-          {value: 'westboro', label: 'Westboro'},
-          {value: 'downtown', label: 'Downtown'},
-        ]}
-        selected={selected}
-      />
-    </LegacyCard>
-  );
-}
-
-export function All() {
-  return (
-    <BlockStack gap="200">
-      <Card padding="0">
+    return (
+      <LegacyCard>
         <OptionList
-          title="Default"
-          onChange={() => {}}
+          title="Manage sales channels availability"
+          onChange={handleChange}
           options={[
-            {value: 'byward_market', label: 'Byward Market'},
-            {value: 'centretown', disabled: true, label: 'Centretown'},
-            {value: 'hintonburg', label: 'Hintonburg'},
-            {value: 'westboro', label: 'Westboro'},
-            {value: 'downtown', label: 'Downtown'},
+            {value: 'online_store', label: 'Online Store'},
+            {value: 'messenger', label: 'Messenger'},
+            {value: 'facebook', label: 'Facebook'},
+            {value: 'wholesale', label: 'Wholesale'},
+            {value: 'buzzfeed', label: 'BuzzFeed'},
           ]}
-          selected={['byward_market']}
-        />
-      </Card>
-      <Card padding="0">
-        <OptionList
-          title="Mutiple"
-          onChange={() => {}}
-          options={[
-            {value: 'byward_market', label: 'Byward Market'},
-            {value: 'centretown', disabled: true, label: 'Centretown'},
-            {value: 'hintonburg', disabled: true, label: 'Hintonburg'},
-            {value: 'westboro', label: 'Westboro'},
-            {value: 'downtown', label: 'Downtown'},
-          ]}
-          selected={['byward_market', 'hintonburg']}
+          selected={selected}
           allowMultiple
         />
-      </Card>
-      <Card padding="0">
+      </LegacyCard>
+    );
+  },
+};
+
+export const MultipleWithDisabledOption = {
+  render() {
+    const [selected, setSelected] = useState([]);
+
+    const handleChange = useCallback((value) => setSelected(value), []);
+
+    return (
+      <LegacyCard>
         <OptionList
-          onChange={() => {}}
+          title="Manage sales channels availability"
+          onChange={handleChange}
           options={[
-            {value: 'byward_market', label: 'No title'},
-            {value: 'centretown', disabled: true, label: 'Centretown'},
-            {value: 'hintonburg', label: 'Hintonburg'},
-            {value: 'westboro', label: 'Westboro'},
-            {value: 'downtown', label: 'Downtown'},
+            {value: 'online_store', label: 'Online Store'},
+            {value: 'messenger', label: 'Messenger', disabled: true},
+            {value: 'facebook', label: 'Facebook'},
+            {value: 'wholesale', label: 'Wholesale'},
+            {value: 'buzzfeed', label: 'BuzzFeed'},
           ]}
-          selected={['byward_market']}
-        />
-      </Card>
-      <Card padding="0">
-        <OptionList
-          title="Top vertical alignment"
-          onChange={() => {}}
-          options={[
-            {
-              value: 'top',
-              label: 'Top',
-              media: (
-                <Thumbnail
-                  source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                  alt="Black choker necklace"
-                  size="small"
-                />
-              ),
-            },
-          ]}
-          selected={[]}
-          verticalAlign="top"
+          selected={selected}
           allowMultiple
         />
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSections = {
+  render() {
+    const [selected, setSelected] = useState([]);
+
+    const handleChange = useCallback((value) => setSelected(value), []);
+
+    return (
+      <LegacyCard>
         <OptionList
-          title="Center vertical alignment"
-          onChange={() => {}}
-          options={[
-            {
-              value: 'center',
-              label: 'Center',
-              media: (
-                <Thumbnail
-                  source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                  alt="Black choker necklace"
-                  size="small"
-                />
-              ),
-            },
-          ]}
-          selected={['center']}
-          verticalAlign="center"
-          allowMultiple
-        />
-        <OptionList
-          title="Bottom vertical alignment"
-          onChange={() => {}}
-          options={[
-            {
-              value: 'bottom',
-              label: 'Bottom',
-              media: (
-                <Thumbnail
-                  source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                  alt="Black choker necklace"
-                  size="small"
-                />
-              ),
-            },
-          ]}
-          selected={[]}
-          verticalAlign="bottom"
-          allowMultiple
-        />
-      </Card>
-      <Card padding="0">
-        <OptionList
-          title="Media"
-          onChange={() => {}}
+          onChange={handleChange}
           sections={[
             {
-              title: 'Icons',
-              options: [
-                {
-                  value: 'minor',
-                  label: 'Icon',
-                  media: <Icon source={DiscountIcon} />,
-                },
-                {
-                  value: 'major',
-                  label: 'Icon',
-                  media: <Icon source={DiscountIcon} />,
-                },
-              ],
-            },
-            {
-              title: 'Avatars',
-              options: [
-                {
-                  value: 'avatar_extra_small',
-                  label: 'Avatar extra small',
-                  media: <Avatar name="Hello World" size="xs" />,
-                },
-                {
-                  value: 'avatar_small',
-                  label: 'Avatar small',
-                  media: <Avatar name="Hello World" size="sm" />,
-                },
-              ],
-            },
-            {
-              title: 'Thumbnails',
-              options: [
-                {
-                  value: 'thumbnail_small',
-                  label: 'Thumbnail small',
-                  media: (
-                    <Thumbnail
-                      source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                      alt="Black choker necklace"
-                      size="small"
-                    />
-                  ),
-                },
-                {
-                  value: 'thumbnail_medium',
-                  label: 'Thumbnail medium',
-                  media: (
-                    <Thumbnail
-                      source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
-                      alt="Black choker necklace"
-                    />
-                  ),
-                },
-              ],
-            },
-          ]}
-          selected={['avatar_small']}
-          verticalAlign="center"
-        />
-      </Card>
-      <Card padding="0">
-        <OptionList
-          onChange={() => {}}
-          title="Sectioned multiselect"
-          sections={[
-            {
-              title: 'Type',
               options: [
                 {value: 'type', label: 'Sale item type'},
                 {value: 'kind', label: 'Sale kind'},
@@ -390,7 +116,7 @@ export function All() {
               title: 'Traffic',
               options: [
                 {value: 'source', label: 'Traffic referrer source'},
-                {value: 'host', disabled: true, label: 'Traffic referrer host'},
+                {value: 'host', label: 'Traffic referrer host'},
                 {value: 'path', label: 'Traffic referrer path'},
               ],
             },
@@ -405,34 +131,326 @@ export function All() {
               ],
             },
           ]}
-          selected={['source', 'host', 'westboro']}
+          selected={selected}
           allowMultiple
         />
-      </Card>
-      <Card padding="0">
+      </LegacyCard>
+    );
+  },
+};
+
+export const InAPopover = {
+  render() {
+    const [selected, setSelected] = useState([]);
+    const [popoverActive, setPopoverActive] = useState(true);
+
+    const handleChange = useCallback((value) => setSelected(value), []);
+
+    const togglePopoverActive = useCallback(
+      () => setPopoverActive((popoverActive) => !popoverActive),
+      [],
+    );
+
+    const activator = (
+      <Button onClick={togglePopoverActive} disclosure>
+        Options
+      </Button>
+    );
+
+    return (
+      <div style={{height: '275px'}}>
+        <Popover
+          active={popoverActive}
+          activator={activator}
+          onClose={togglePopoverActive}
+        >
+          <OptionList
+            title="Inventory Location"
+            onChange={handleChange}
+            options={[
+              {
+                value: 'byward_market',
+                label: 'Byward Market',
+              },
+              {value: 'centretown', label: 'Centretown'},
+              {
+                value: 'hintonburg',
+                label: 'Hintonburg',
+              },
+              {value: 'westboro', label: 'Westboro'},
+              {value: 'downtown', label: 'Downtown'},
+            ]}
+            selected={selected}
+          />
+        </Popover>
+      </div>
+    );
+  },
+};
+
+export const WithDisabledOption = {
+  render() {
+    const [selected, setSelected] = useState([]);
+
+    const handleChange = useCallback((value) => setSelected(value), []);
+
+    return (
+      <LegacyCard>
         <OptionList
-          onChange={() => {}}
-          title="Sectioned single select"
-          sections={[
-            {
-              title: 'Type',
-              options: [
-                {value: 'type', disabled: true, label: 'Sale item type'},
-                {value: 'kind', label: 'Sale kind'},
-              ],
-            },
-            {
-              title: 'Sectioned single select',
-              options: [
-                {value: 'source', label: 'Traffic referrer source'},
-                {value: 'host', label: 'Traffic referrer host'},
-                {value: 'path', label: 'Traffic referrer path'},
-              ],
-            },
+          title="Inventory Location"
+          onChange={handleChange}
+          options={[
+            {value: 'byward_market', label: 'Byward Market'},
+            {value: 'centretown', disabled: true, label: 'Centretown'},
+            {value: 'hintonburg', label: 'Hintonburg'},
+            {value: 'westboro', label: 'Westboro'},
+            {value: 'downtown', label: 'Downtown'},
           ]}
-          selected={['source']}
+          selected={selected}
         />
-      </Card>
-    </BlockStack>
-  );
-}
+      </LegacyCard>
+    );
+  },
+};
+
+export const All = {
+  render() {
+    return (
+      <BlockStack gap="200">
+        <Card padding="0">
+          <OptionList
+            title="Default"
+            onChange={() => {}}
+            options={[
+              {value: 'byward_market', label: 'Byward Market'},
+              {value: 'centretown', disabled: true, label: 'Centretown'},
+              {value: 'hintonburg', label: 'Hintonburg'},
+              {value: 'westboro', label: 'Westboro'},
+              {value: 'downtown', label: 'Downtown'},
+            ]}
+            selected={['byward_market']}
+          />
+        </Card>
+        <Card padding="0">
+          <OptionList
+            title="Mutiple"
+            onChange={() => {}}
+            options={[
+              {value: 'byward_market', label: 'Byward Market'},
+              {value: 'centretown', disabled: true, label: 'Centretown'},
+              {value: 'hintonburg', disabled: true, label: 'Hintonburg'},
+              {value: 'westboro', label: 'Westboro'},
+              {value: 'downtown', label: 'Downtown'},
+            ]}
+            selected={['byward_market', 'hintonburg']}
+            allowMultiple
+          />
+        </Card>
+        <Card padding="0">
+          <OptionList
+            onChange={() => {}}
+            options={[
+              {value: 'byward_market', label: 'No title'},
+              {value: 'centretown', disabled: true, label: 'Centretown'},
+              {value: 'hintonburg', label: 'Hintonburg'},
+              {value: 'westboro', label: 'Westboro'},
+              {value: 'downtown', label: 'Downtown'},
+            ]}
+            selected={['byward_market']}
+          />
+        </Card>
+        <Card padding="0">
+          <OptionList
+            title="Top vertical alignment"
+            onChange={() => {}}
+            options={[
+              {
+                value: 'top',
+                label: 'Top',
+                media: (
+                  <Thumbnail
+                    source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                    alt="Black choker necklace"
+                    size="small"
+                  />
+                ),
+              },
+            ]}
+            selected={[]}
+            verticalAlign="top"
+            allowMultiple
+          />
+          <OptionList
+            title="Center vertical alignment"
+            onChange={() => {}}
+            options={[
+              {
+                value: 'center',
+                label: 'Center',
+                media: (
+                  <Thumbnail
+                    source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                    alt="Black choker necklace"
+                    size="small"
+                  />
+                ),
+              },
+            ]}
+            selected={['center']}
+            verticalAlign="center"
+            allowMultiple
+          />
+          <OptionList
+            title="Bottom vertical alignment"
+            onChange={() => {}}
+            options={[
+              {
+                value: 'bottom',
+                label: 'Bottom',
+                media: (
+                  <Thumbnail
+                    source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                    alt="Black choker necklace"
+                    size="small"
+                  />
+                ),
+              },
+            ]}
+            selected={[]}
+            verticalAlign="bottom"
+            allowMultiple
+          />
+        </Card>
+        <Card padding="0">
+          <OptionList
+            title="Media"
+            onChange={() => {}}
+            sections={[
+              {
+                title: 'Icons',
+                options: [
+                  {
+                    value: 'minor',
+                    label: 'Icon',
+                    media: <Icon source={DiscountIcon} />,
+                  },
+                  {
+                    value: 'major',
+                    label: 'Icon',
+                    media: <Icon source={DiscountIcon} />,
+                  },
+                ],
+              },
+              {
+                title: 'Avatars',
+                options: [
+                  {
+                    value: 'avatar_extra_small',
+                    label: 'Avatar extra small',
+                    media: <Avatar name="Hello World" size="xs" />,
+                  },
+                  {
+                    value: 'avatar_small',
+                    label: 'Avatar small',
+                    media: <Avatar name="Hello World" size="sm" />,
+                  },
+                ],
+              },
+              {
+                title: 'Thumbnails',
+                options: [
+                  {
+                    value: 'thumbnail_small',
+                    label: 'Thumbnail small',
+                    media: (
+                      <Thumbnail
+                        source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                        alt="Black choker necklace"
+                        size="small"
+                      />
+                    ),
+                  },
+                  {
+                    value: 'thumbnail_medium',
+                    label: 'Thumbnail medium',
+                    media: (
+                      <Thumbnail
+                        source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                        alt="Black choker necklace"
+                      />
+                    ),
+                  },
+                ],
+              },
+            ]}
+            selected={['avatar_small']}
+            verticalAlign="center"
+          />
+        </Card>
+        <Card padding="0">
+          <OptionList
+            onChange={() => {}}
+            title="Sectioned multiselect"
+            sections={[
+              {
+                title: 'Type',
+                options: [
+                  {value: 'type', label: 'Sale item type'},
+                  {value: 'kind', label: 'Sale kind'},
+                ],
+              },
+              {
+                title: 'Traffic',
+                options: [
+                  {value: 'source', label: 'Traffic referrer source'},
+                  {
+                    value: 'host',
+                    disabled: true,
+                    label: 'Traffic referrer host',
+                  },
+                  {value: 'path', label: 'Traffic referrer path'},
+                ],
+              },
+              {
+                title: 'Inventory Location',
+                options: [
+                  {value: 'byward_market', label: 'Byward Market'},
+                  {value: 'centretown', label: 'Centretown'},
+                  {value: 'hintonburg', label: 'Hintonburg'},
+                  {value: 'westboro', label: 'Westboro'},
+                  {value: 'downtown', label: 'Downtown'},
+                ],
+              },
+            ]}
+            selected={['source', 'host', 'westboro']}
+            allowMultiple
+          />
+        </Card>
+        <Card padding="0">
+          <OptionList
+            onChange={() => {}}
+            title="Sectioned single select"
+            sections={[
+              {
+                title: 'Type',
+                options: [
+                  {value: 'type', disabled: true, label: 'Sale item type'},
+                  {value: 'kind', label: 'Sale kind'},
+                ],
+              },
+              {
+                title: 'Sectioned single select',
+                options: [
+                  {value: 'source', label: 'Traffic referrer source'},
+                  {value: 'host', label: 'Traffic referrer host'},
+                  {value: 'path', label: 'Traffic referrer path'},
+                ],
+              },
+            ]}
+            selected={['source']}
+          />
+        </Card>
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   DeleteIcon,
   PlusIcon,
@@ -20,515 +20,553 @@ import {
 
 export default {
   component: Page,
-} as ComponentMeta<typeof Page>;
+} as Meta<typeof Page>;
 
-export function Default() {
-  return (
-    <Page
-      backAction={{content: 'Products', url: '#'}}
-      title="3/4 inch Leather pet collar"
-      titleMetadata={<Badge tone="success">Paid</Badge>}
-      subtitle="Perfect for any pet"
-      compactTitle
-      primaryAction={{content: 'Save', disabled: true}}
-      secondaryActions={[
-        {
-          content: 'Delete',
-          destructive: true,
-          icon: DeleteIcon,
-          accessibilityLabel: 'Delete action label',
-          onAction: () => console.log('Delete action'),
-        },
-        {
-          content: 'View on your store',
-          icon: ViewIcon,
-          onAction: () => console.log('View on your store action'),
-        },
-      ]}
-      actionGroups={[
-        {
-          title: 'Promote',
-          icon: MenuVerticalIcon,
-          actions: [
-            {
-              content: 'Share on Facebook',
-              accessibilityLabel: 'Individual action label',
-              onAction: () => console.log('Share on Facebook action'),
-            },
-          ],
-        },
-      ]}
-      pagination={{
-        hasPrevious: true,
-        hasNext: true,
-      }}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithCustomPrimaryAction() {
-  return (
-    <Page
-      backAction={{content: 'Settings', url: '#'}}
-      title="General"
-      primaryAction={<Button variant="primary">Save</Button>}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithoutPrimaryActionInHeader() {
-  return (
-    <Page
-      backAction={{content: 'Orders', url: '#'}}
-      title="#1085"
-      secondaryActions={[
-        {content: 'Print'},
-        {content: 'Unarchive'},
-        {content: 'Cancel order'},
-      ]}
-      pagination={{
-        hasPrevious: true,
-        hasNext: true,
-      }}
-    >
-      <LegacyCard sectioned title="Fulfill order">
-        <LegacyStack alignment="center">
-          <LegacyStack.Item fill>
-            <Text as="p" variant="bodyMd">
-              Buy postage and ship remaining 2 items
-            </Text>
-          </LegacyStack.Item>
-          <Button variant="primary">Continue</Button>
-        </LegacyStack>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithDestructiveSecondaryAction() {
-  return (
-    <Page
-      title="General"
-      secondaryActions={[{content: 'Delete', tone: 'critical'}]}
-    >
-      <Text as="p" variant="bodyMd">
-        Page content
-      </Text>
-    </Page>
-  );
-}
-
-export function WithCustomSecondaryAction() {
-  return (
-    <Page title="General" secondaryActions={<Button>Save</Button>}>
-      <Text as="p" variant="bodyMd">
-        Page content
-      </Text>
-    </Page>
-  );
-}
-
-export function WithToolTipAction() {
-  return (
-    <Page
-      title="Product"
-      primaryAction={{
-        content: 'Save',
-      }}
-      secondaryActions={[
-        {
-          content: 'Import',
-          disabled: true,
-          helpText: 'You need permission to import products.',
-        },
-      ]}
-    >
-      <LegacyCard title="Product X" sectioned>
-        <Text as="p" variant="bodyMd">
-          Product X information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithBackActionOnAction() {
-  return (
-    <Page
-      backAction={{
-        content: 'Settings',
-        onAction: () => {
-          // eslint-disable-next-line no-alert
-          alert('Clicked back button');
-        },
-      }}
-      title="General"
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithSubtitle() {
-  return (
-    <Page
-      backAction={{content: 'Products', url: '#'}}
-      title="Invoice"
-      subtitle="Statement period: May 3, 2019 to June 2, 2019"
-      secondaryActions={[{content: 'Download', icon: ArrowDownIcon}]}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithSubtitleAndAdditionalMetadata() {
-  return (
-    <Page
-      backAction={{content: 'Products', url: '#'}}
-      title="Invoice"
-      subtitle="Statement period: May 3, 2019 to June 2, 2019"
-      additionalMetadata="Net payment due: Within 60 days of receipt"
-      secondaryActions={[{content: 'Download', icon: ArrowDownIcon}]}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithSubtitleAndAdditionalMetadataAndNoBackAction() {
-  return (
-    <Page
-      title="Invoice"
-      subtitle="Statement period: May 3, 2019 to June 2, 2019"
-      additionalMetadata="Net payment due: Within 60 days of receipt"
-      secondaryActions={[{content: 'Download', icon: ArrowDownIcon}]}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithExternalLink() {
-  return (
-    <Page
-      title="Jar With Lock-Lid"
-      primaryAction={{content: 'Save', disabled: true}}
-      secondaryActions={[
-        {
-          content: 'Promote',
-          external: true,
-          icon: ExternalIcon,
-          url: 'https://www.facebook.com/business/learn/facebook-page-build-audience',
-        },
-      ]}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithoutPagination() {
-  return (
-    <Page
-      backAction={{content: 'Settings', url: '#'}}
-      title="General"
-      primaryAction={{content: 'Save'}}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function FullWidth() {
-  return (
-    <Page
-      fullWidth
-      title="Orders"
-      primaryAction={{content: 'Create order', icon: PlusIcon}}
-      secondaryActions={[{content: 'Export'}]}
-      pagination={{
-        hasNext: true,
-      }}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function NarrowWidth() {
-  return (
-    <Page
-      narrowWidth
-      backAction={{content: 'Orders', url: '#'}}
-      title="Add payment method"
-      primaryAction={{content: 'Save', disabled: true}}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-      <PageActions
+export const Default = {
+  render() {
+    return (
+      <Page
+        backAction={{content: 'Products', url: '#'}}
+        title="3/4 inch Leather pet collar"
+        titleMetadata={<Badge tone="success">Paid</Badge>}
+        subtitle="Perfect for any pet"
+        compactTitle
         primaryAction={{content: 'Save', disabled: true}}
-        secondaryActions={[{content: 'Delete'}]}
-      />
-    </Page>
-  );
-}
-
-export function WithActionGroups() {
-  return (
-    <Page
-      title="Products"
-      actionGroups={[
-        {
-          title: 'Copy',
-          onClick: (openActions) => {
-            console.log('Copy action');
-            openActions();
+        secondaryActions={[
+          {
+            content: 'Delete',
+            destructive: true,
+            icon: DeleteIcon,
+            accessibilityLabel: 'Delete action label',
+            onAction: () => console.log('Delete action'),
           },
-          actions: [{content: 'Copy to clipboard'}],
-        },
-        {
-          title: 'Promote',
-          disabled: true,
-          actions: [{content: 'Share on Facebook'}],
-        },
-        {
-          title: 'More actions',
-          actions: [
-            {content: 'Duplicate'},
-            {content: 'Print'},
-            {content: 'Unarchive'},
-            {content: 'Cancel order'},
-          ],
-        },
-      ]}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithActionGroupsAndActions() {
-  return (
-    <Page
-      title="List of products"
-      subtitle="Brow Code Professional USA & Canada, Brow Code Professional New Zealand, and 8 other stores have charges on this bill"
-      secondaryActions={[
-        {
-          content: 'Send test',
-          onAction: () => {},
-        },
-        {
-          content: 'Confirm',
-          onAction: () => {},
-        },
-        {
-          content: 'Localize',
-          url: '/store/marcs-staffed-store/apps/translate-and-adapt/localize/email_template?id=10774151224&locale=fr',
-        },
-        {
-          content: 'Manage payment reminders',
-          url: '/store/marcs-staffed-store/settings/notifications/payment_reminders',
-        },
-      ]}
-      actionGroups={[
-        {
-          title: 'Copy',
-          onClick: (openActions) => {
-            console.log('Copy action');
-            openActions();
+          {
+            content: 'View on your store',
+            icon: ViewIcon,
+            onAction: () => console.log('View on your store action'),
           },
-          actions: [{content: 'Copy to clipboard'}],
-        },
-        {
-          title: 'Promote',
-          disabled: true,
-          actions: [{content: 'Share on Facebook'}],
-        },
-        {
-          title: 'Delete',
-          disabled: false,
-          actions: [{content: 'Delete or remove'}],
-        },
-        {
-          title: 'Other actions',
-          actions: [
-            {content: 'Duplicate'},
-            {content: 'Print'},
-            {content: 'Unarchive'},
-            {content: 'Cancel order'},
-          ],
-        },
-      ]}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
-
-export function WithActionGroupsAndActionsAndLongTitle() {
-  return (
-    <Page
-      title="List of products available on your online store"
-      secondaryActions={[
-        {
-          content: 'Send test',
-          onAction: () => {},
-        },
-        {
-          content: 'Confirm',
-          onAction: () => {},
-        },
-        {
-          content: 'Localize',
-          url: '/store/marcs-staffed-store/apps/translate-and-adapt/localize/email_template?id=10774151224&locale=fr',
-        },
-        {
-          content: 'Manage payment reminders',
-          url: '/store/marcs-staffed-store/settings/notifications/payment_reminders',
-        },
-      ]}
-      actionGroups={[
-        {
-          title: 'Copy',
-          onClick: (openActions) => {
-            console.log('Copy action');
-            openActions();
+        ]}
+        actionGroups={[
+          {
+            title: 'Promote',
+            icon: MenuVerticalIcon,
+            actions: [
+              {
+                content: 'Share on Facebook',
+                accessibilityLabel: 'Individual action label',
+                onAction: () => console.log('Share on Facebook action'),
+              },
+            ],
           },
-          actions: [{content: 'Copy to clipboard'}],
-        },
-        {
-          title: 'Promote',
-          disabled: true,
-          actions: [{content: 'Share on Facebook'}],
-        },
-        {
-          title: 'Delete',
-          disabled: false,
-          actions: [{content: 'Delete or remove'}],
-        },
-        {
-          title: 'Other actions',
-          actions: [
-            {content: 'Duplicate'},
-            {content: 'Print'},
-            {content: 'Unarchive'},
-            {content: 'Cancel order'},
-          ],
-        },
-      ]}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
+        ]}
+        pagination={{
+          hasPrevious: true,
+          hasNext: true,
+        }}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithContentAfterTitle() {
-  return (
-    <Page
-      backAction={{content: 'Products', url: '#'}}
-      title="Jar With Lock-Lid"
-      titleMetadata={<Badge tone="attention">Verified</Badge>}
-      primaryAction={{content: 'Save', disabled: true}}
-      secondaryActions={[
-        {content: 'Duplicate'},
-        {content: 'View on your store'},
-      ]}
-      pagination={{
-        hasPrevious: true,
-        hasNext: true,
-      }}
-    >
-      <LegacyCard title="Credit card" sectioned>
-        <Text as="p" variant="bodyMd">
-          Credit card information
-        </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
+export const WithCustomPrimaryAction = {
+  render() {
+    return (
+      <Page
+        backAction={{content: 'Settings', url: '#'}}
+        title="General"
+        primaryAction={<Button variant="primary">Save</Button>}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
 
-export function WithContentAfterTitleAndSubtitle() {
-  return (
-    <Page
-      backAction={{content: 'Products', url: '#'}}
-      title="Jar With Lock-Lid"
-      titleMetadata={
-        <Button disclosure size="large">
-          All locations
-        </Button>
-      }
-      subtitle="Created: May 3, 2019 to June 2, 2019"
-      primaryAction={{content: 'Save', disabled: true}}
-      secondaryActions={[
-        {content: 'Duplicate'},
-        {content: 'View on your store'},
-      ]}
-      pagination={{
-        hasPrevious: true,
-        hasNext: true,
-      }}
-    >
-      <LegacyCard title="Credit card" sectioned>
+export const WithoutPrimaryActionInHeader = {
+  render() {
+    return (
+      <Page
+        backAction={{content: 'Orders', url: '#'}}
+        title="#1085"
+        secondaryActions={[
+          {content: 'Print'},
+          {content: 'Unarchive'},
+          {content: 'Cancel order'},
+        ]}
+        pagination={{
+          hasPrevious: true,
+          hasNext: true,
+        }}
+      >
+        <LegacyCard sectioned title="Fulfill order">
+          <LegacyStack alignment="center">
+            <LegacyStack.Item fill>
+              <Text as="p" variant="bodyMd">
+                Buy postage and ship remaining 2 items
+              </Text>
+            </LegacyStack.Item>
+            <Button variant="primary">Continue</Button>
+          </LegacyStack>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithDestructiveSecondaryAction = {
+  render() {
+    return (
+      <Page
+        title="General"
+        secondaryActions={[{content: 'Delete', tone: 'critical'}]}
+      >
         <Text as="p" variant="bodyMd">
-          Credit card information
+          Page content
         </Text>
-      </LegacyCard>
-    </Page>
-  );
-}
+      </Page>
+    );
+  },
+};
+
+export const WithCustomSecondaryAction = {
+  render() {
+    return (
+      <Page title="General" secondaryActions={<Button>Save</Button>}>
+        <Text as="p" variant="bodyMd">
+          Page content
+        </Text>
+      </Page>
+    );
+  },
+};
+
+export const WithToolTipAction = {
+  render() {
+    return (
+      <Page
+        title="Product"
+        primaryAction={{
+          content: 'Save',
+        }}
+        secondaryActions={[
+          {
+            content: 'Import',
+            disabled: true,
+            helpText: 'You need permission to import products.',
+          },
+        ]}
+      >
+        <LegacyCard title="Product X" sectioned>
+          <Text as="p" variant="bodyMd">
+            Product X information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithBackActionOnAction = {
+  render() {
+    return (
+      <Page
+        backAction={{
+          content: 'Settings',
+          onAction: () => {
+            // eslint-disable-next-line no-alert
+            alert('Clicked back button');
+          },
+        }}
+        title="General"
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithSubtitle = {
+  render() {
+    return (
+      <Page
+        backAction={{content: 'Products', url: '#'}}
+        title="Invoice"
+        subtitle="Statement period: May 3, 2019 to June 2, 2019"
+        secondaryActions={[{content: 'Download', icon: ArrowDownIcon}]}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithSubtitleAndAdditionalMetadata = {
+  render() {
+    return (
+      <Page
+        backAction={{content: 'Products', url: '#'}}
+        title="Invoice"
+        subtitle="Statement period: May 3, 2019 to June 2, 2019"
+        additionalMetadata="Net payment due: Within 60 days of receipt"
+        secondaryActions={[{content: 'Download', icon: ArrowDownIcon}]}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithSubtitleAndAdditionalMetadataAndNoBackAction = {
+  render() {
+    return (
+      <Page
+        title="Invoice"
+        subtitle="Statement period: May 3, 2019 to June 2, 2019"
+        additionalMetadata="Net payment due: Within 60 days of receipt"
+        secondaryActions={[{content: 'Download', icon: ArrowDownIcon}]}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithExternalLink = {
+  render() {
+    return (
+      <Page
+        title="Jar With Lock-Lid"
+        primaryAction={{content: 'Save', disabled: true}}
+        secondaryActions={[
+          {
+            content: 'Promote',
+            external: true,
+            icon: ExternalIcon,
+            url: 'https://www.facebook.com/business/learn/facebook-page-build-audience',
+          },
+        ]}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithoutPagination = {
+  render() {
+    return (
+      <Page
+        backAction={{content: 'Settings', url: '#'}}
+        title="General"
+        primaryAction={{content: 'Save'}}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const FullWidth = {
+  render() {
+    return (
+      <Page
+        fullWidth
+        title="Orders"
+        primaryAction={{content: 'Create order', icon: PlusIcon}}
+        secondaryActions={[{content: 'Export'}]}
+        pagination={{
+          hasNext: true,
+        }}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const NarrowWidth = {
+  render() {
+    return (
+      <Page
+        narrowWidth
+        backAction={{content: 'Orders', url: '#'}}
+        title="Add payment method"
+        primaryAction={{content: 'Save', disabled: true}}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+        <PageActions
+          primaryAction={{content: 'Save', disabled: true}}
+          secondaryActions={[{content: 'Delete'}]}
+        />
+      </Page>
+    );
+  },
+};
+
+export const WithActionGroups = {
+  render() {
+    return (
+      <Page
+        title="Products"
+        actionGroups={[
+          {
+            title: 'Copy',
+            onClick: (openActions) => {
+              console.log('Copy action');
+              openActions();
+            },
+            actions: [{content: 'Copy to clipboard'}],
+          },
+          {
+            title: 'Promote',
+            disabled: true,
+            actions: [{content: 'Share on Facebook'}],
+          },
+          {
+            title: 'More actions',
+            actions: [
+              {content: 'Duplicate'},
+              {content: 'Print'},
+              {content: 'Unarchive'},
+              {content: 'Cancel order'},
+            ],
+          },
+        ]}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithActionGroupsAndActions = {
+  render() {
+    return (
+      <Page
+        title="List of products"
+        subtitle="Brow Code Professional USA & Canada, Brow Code Professional New Zealand, and 8 other stores have charges on this bill"
+        secondaryActions={[
+          {
+            content: 'Send test',
+            onAction: () => {},
+          },
+          {
+            content: 'Confirm',
+            onAction: () => {},
+          },
+          {
+            content: 'Localize',
+            url: '/store/marcs-staffed-store/apps/translate-and-adapt/localize/email_template?id=10774151224&locale=fr',
+          },
+          {
+            content: 'Manage payment reminders',
+            url: '/store/marcs-staffed-store/settings/notifications/payment_reminders',
+          },
+        ]}
+        actionGroups={[
+          {
+            title: 'Copy',
+            onClick: (openActions) => {
+              console.log('Copy action');
+              openActions();
+            },
+            actions: [{content: 'Copy to clipboard'}],
+          },
+          {
+            title: 'Promote',
+            disabled: true,
+            actions: [{content: 'Share on Facebook'}],
+          },
+          {
+            title: 'Delete',
+            disabled: false,
+            actions: [{content: 'Delete or remove'}],
+          },
+          {
+            title: 'Other actions',
+            actions: [
+              {content: 'Duplicate'},
+              {content: 'Print'},
+              {content: 'Unarchive'},
+              {content: 'Cancel order'},
+            ],
+          },
+        ]}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithActionGroupsAndActionsAndLongTitle = {
+  render() {
+    return (
+      <Page
+        title="List of products available on your online store"
+        secondaryActions={[
+          {
+            content: 'Send test',
+            onAction: () => {},
+          },
+          {
+            content: 'Confirm',
+            onAction: () => {},
+          },
+          {
+            content: 'Localize',
+            url: '/store/marcs-staffed-store/apps/translate-and-adapt/localize/email_template?id=10774151224&locale=fr',
+          },
+          {
+            content: 'Manage payment reminders',
+            url: '/store/marcs-staffed-store/settings/notifications/payment_reminders',
+          },
+        ]}
+        actionGroups={[
+          {
+            title: 'Copy',
+            onClick: (openActions) => {
+              console.log('Copy action');
+              openActions();
+            },
+            actions: [{content: 'Copy to clipboard'}],
+          },
+          {
+            title: 'Promote',
+            disabled: true,
+            actions: [{content: 'Share on Facebook'}],
+          },
+          {
+            title: 'Delete',
+            disabled: false,
+            actions: [{content: 'Delete or remove'}],
+          },
+          {
+            title: 'Other actions',
+            actions: [
+              {content: 'Duplicate'},
+              {content: 'Print'},
+              {content: 'Unarchive'},
+              {content: 'Cancel order'},
+            ],
+          },
+        ]}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithContentAfterTitle = {
+  render() {
+    return (
+      <Page
+        backAction={{content: 'Products', url: '#'}}
+        title="Jar With Lock-Lid"
+        titleMetadata={<Badge tone="attention">Verified</Badge>}
+        primaryAction={{content: 'Save', disabled: true}}
+        secondaryActions={[
+          {content: 'Duplicate'},
+          {content: 'View on your store'},
+        ]}
+        pagination={{
+          hasPrevious: true,
+          hasNext: true,
+        }}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};
+
+export const WithContentAfterTitleAndSubtitle = {
+  render() {
+    return (
+      <Page
+        backAction={{content: 'Products', url: '#'}}
+        title="Jar With Lock-Lid"
+        titleMetadata={
+          <Button disclosure size="large">
+            All locations
+          </Button>
+        }
+        subtitle="Created: May 3, 2019 to June 2, 2019"
+        primaryAction={{content: 'Save', disabled: true}}
+        secondaryActions={[
+          {content: 'Duplicate'},
+          {content: 'View on your store'},
+        ]}
+        pagination={{
+          hasPrevious: true,
+          hasNext: true,
+        }}
+      >
+        <LegacyCard title="Credit card" sectioned>
+          <Text as="p" variant="bodyMd">
+            Credit card information
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};

--- a/polaris-react/src/components/PageActions/PageActions.stories.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.stories.tsx
@@ -1,58 +1,66 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Button, PageActions} from '@shopify/polaris';
 
 export default {
   component: PageActions,
-} as ComponentMeta<typeof PageActions>;
+} as Meta<typeof PageActions>;
 
-export function Default() {
-  return (
-    <PageActions
-      primaryAction={{
-        content: 'Save',
-      }}
-      secondaryActions={[
-        {
-          content: 'Delete',
-          destructive: true,
-        },
-      ]}
-    />
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <PageActions
+        primaryAction={{
+          content: 'Save',
+        }}
+        secondaryActions={[
+          {
+            content: 'Delete',
+            destructive: true,
+          },
+        ]}
+      />
+    );
+  },
+};
 
-export function PrimaryActionOnly() {
-  return (
-    <PageActions
-      primaryAction={{
-        content: 'Save',
-      }}
-    />
-  );
-}
+export const PrimaryActionOnly = {
+  render() {
+    return (
+      <PageActions
+        primaryAction={{
+          content: 'Save',
+        }}
+      />
+    );
+  },
+};
 
-export function WithCustomPrimaryAction() {
-  return (
-    <PageActions
-      primaryAction={<Button variant="primary">Save</Button>}
-      secondaryActions={[
-        {
-          content: 'Delete',
-          destructive: true,
-        },
-      ]}
-    />
-  );
-}
+export const WithCustomPrimaryAction = {
+  render() {
+    return (
+      <PageActions
+        primaryAction={<Button variant="primary">Save</Button>}
+        secondaryActions={[
+          {
+            content: 'Delete',
+            destructive: true,
+          },
+        ]}
+      />
+    );
+  },
+};
 
-export function WithCustomSecondaryAction() {
-  return (
-    <PageActions
-      primaryAction={{
-        content: 'Save',
-      }}
-      secondaryActions={<Button>Save</Button>}
-    />
-  );
-}
+export const WithCustomSecondaryAction = {
+  render() {
+    return (
+      <PageActions
+        primaryAction={{
+          content: 'Save',
+        }}
+        secondaryActions={<Button>Save</Button>}
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/Pagination/Pagination.stories.tsx
+++ b/polaris-react/src/components/Pagination/Pagination.stories.tsx
@@ -1,105 +1,115 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Pagination} from '@shopify/polaris';
 
 export default {
   component: Pagination,
-} as ComponentMeta<typeof Pagination>;
+} as Meta<typeof Pagination>;
 
-export function Default() {
-  return (
-    <Pagination
-      hasPrevious
-      onPrevious={() => {
-        console.log('Previous');
-      }}
-      hasNext
-      onNext={() => {
-        console.log('Next');
-      }}
-    />
-  );
-}
-
-export function WithKeyboardNavigation() {
-  return (
-    <div style={{height: '100px'}}>
+export const Default = {
+  render() {
+    return (
       <Pagination
         hasPrevious
-        previousKeys={[74]}
-        previousTooltip="Previous (J)"
         onPrevious={() => {
           console.log('Previous');
         }}
         hasNext
-        nextKeys={[75]}
-        nextTooltip="Next (K)"
         onNext={() => {
           console.log('Next');
         }}
       />
-    </div>
-  );
-}
+    );
+  },
+};
 
-export function WithLabel() {
-  return (
-    <Pagination
-      label="Results"
-      hasPrevious
-      onPrevious={() => {
-        console.log('Previous');
-      }}
-      hasNext
-      onNext={() => {
-        console.log('Next');
-      }}
-    />
-  );
-}
+export const WithKeyboardNavigation = {
+  render() {
+    return (
+      <div style={{height: '100px'}}>
+        <Pagination
+          hasPrevious
+          previousKeys={[74]}
+          previousTooltip="Previous (J)"
+          onPrevious={() => {
+            console.log('Previous');
+          }}
+          hasNext
+          nextKeys={[75]}
+          nextTooltip="Next (K)"
+          onNext={() => {
+            console.log('Next');
+          }}
+        />
+      </div>
+    );
+  },
+};
 
-export function WithTableType() {
-  return (
-    <div
-      style={{
-        maxWidth: 'calc(700px + (2 * var(--p-space-400)))',
-        margin: '0 auto',
-      }}
-    >
+export const WithLabel = {
+  render() {
+    return (
       <Pagination
-        onPrevious={() => {
-          console.log('Previous');
-        }}
-        onNext={() => {
-          console.log('Next');
-        }}
-        type="table"
-        hasNext
-        label="1-50 of 8,450 orders"
-      />
-    </div>
-  );
-}
-
-export function WithTableTypeAndNoLabel() {
-  return (
-    <div
-      style={{
-        maxWidth: 'calc(700px + (2 * var(--p-space-400)))',
-        margin: '0 auto',
-      }}
-    >
-      <Pagination
-        onPrevious={() => {
-          console.log('Previous');
-        }}
-        onNext={() => {
-          console.log('Next');
-        }}
-        type="table"
-        hasNext
+        label="Results"
         hasPrevious
+        onPrevious={() => {
+          console.log('Previous');
+        }}
+        hasNext
+        onNext={() => {
+          console.log('Next');
+        }}
       />
-    </div>
-  );
-}
+    );
+  },
+};
+
+export const WithTableType = {
+  render() {
+    return (
+      <div
+        style={{
+          maxWidth: 'calc(700px + (2 * var(--p-space-400)))',
+          margin: '0 auto',
+        }}
+      >
+        <Pagination
+          onPrevious={() => {
+            console.log('Previous');
+          }}
+          onNext={() => {
+            console.log('Next');
+          }}
+          type="table"
+          hasNext
+          label="1-50 of 8,450 orders"
+        />
+      </div>
+    );
+  },
+};
+
+export const WithTableTypeAndNoLabel = {
+  render() {
+    return (
+      <div
+        style={{
+          maxWidth: 'calc(700px + (2 * var(--p-space-400)))',
+          margin: '0 auto',
+        }}
+      >
+        <Pagination
+          onPrevious={() => {
+            console.log('Previous');
+          }}
+          onNext={() => {
+            console.log('Next');
+          }}
+          type="table"
+          hasNext
+          hasPrevious
+        />
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/Popover/Popover.stories.tsx
+++ b/polaris-react/src/components/Popover/Popover.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   ActionList,
   Avatar,
@@ -24,874 +24,901 @@ import {SearchIcon, SelectIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Popover,
-} as ComponentMeta<typeof Popover>;
+} as Meta<typeof Popover>;
 
-export function All() {
-  return (
-    <BlockStack gap="800">
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With action list
-        </Text>
-        <WithActionList />
-      </BlockStack>
-
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With content and actions
-        </Text>
-        <WithContentAndActions />
-      </BlockStack>
-
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With form components
-        </Text>
-        <WithFormComponents />
-      </BlockStack>
-
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With lazy loaded list
-        </Text>
-        <WithLazyLoadedList />
-      </BlockStack>
-
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With scrollable lazy loaded list
-        </Text>
-        <WithScrollableLazyLoadedList />
-      </BlockStack>
-
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With searchable listbox
-        </Text>
-        <WithSearchableListbox />
-      </BlockStack>
-
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With loading smaller content
-        </Text>
-        <WithLoadingSmallerContent />
-      </BlockStack>
-
-      <BlockStack gap="200">
-        <Text as="h2" variant="headingXl">
-          With preferredPosition cover
-        </Text>
-        <WithCoverPositioning />
-      </BlockStack>
-    </BlockStack>
-  );
-}
-
-export function WithActionList() {
-  const [activePopover, setActivePopover] = useState(null);
-
-  const togglePopoverActive = useCallback((popover, isClosing) => {
-    const currentPopover = isClosing ? null : popover;
-    setActivePopover(currentPopover);
-  }, []);
-
-  const activator = (
-    <Button
-      id="button-1"
-      onClick={() => togglePopoverActive('popover1', false)}
-      disclosure
-    >
-      More actions
-    </Button>
-  );
-  const activator2 = (
-    <Button
-      id="button-2"
-      onClick={() => togglePopoverActive('popover2', false)}
-      disclosure
-    >
-      More actions
-    </Button>
-  );
-
-  return (
-    <div style={{height: '250px'}}>
-      <BlockStack gap="400">
-        <Popover
-          active={activePopover === 'popover1'}
-          activator={activator}
-          autofocusTarget="first-node"
-          onClose={() => togglePopoverActive('popover1', true)}
-        >
-          <ActionList
-            actionRole="menuitem"
-            items={[{content: 'Import file'}, {content: 'Export file'}]}
-          />
-        </Popover>
-        <Popover
-          active={activePopover === 'popover2'}
-          activator={activator2}
-          autofocusTarget="first-node"
-          onClose={() => togglePopoverActive('popover2', true)}
-        >
-          <ActionList
-            actionRole="menuitem"
-            items={[{content: 'Import file'}, {content: 'Export file'}]}
-          />
-        </Popover>
-      </BlockStack>
-    </div>
-  );
-}
-
-export function WithContentAndActions() {
-  const [popoverActive, setPopoverActive] = useState(true);
-
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
-
-  const textMarkup = (
-    <Text as="h2" variant="headingSm">
-      Available sales channels
-    </Text>
-  );
-
-  const activator = (
-    <Button onClick={togglePopoverActive} disclosure>
-      Sales channels
-    </Button>
-  );
-
-  return (
-    <div style={{height: '250px'}}>
-      <Popover
-        active={popoverActive}
-        activator={activator}
-        autofocusTarget="first-node"
-        onClose={togglePopoverActive}
-      >
-        <Popover.Pane fixed>
-          <Popover.Section>{textMarkup}</Popover.Section>
-        </Popover.Pane>
-        <Popover.Pane>
-          <ActionList
-            actionRole="menuitem"
-            items={[
-              {content: 'Online store'},
-              {content: 'Facebook'},
-              {content: 'Shopify POS'},
-            ]}
-          />
-        </Popover.Pane>
-      </Popover>
-    </div>
-  );
-}
-
-export function WithFormComponents() {
-  const [popoverActive, setPopoverActive] = useState(true);
-  const [tagValue, setTagValue] = useState('');
-
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
-
-  const handleTagValueChange = useCallback((value) => setTagValue(value), []);
-
-  const activator = (
-    <Button onClick={togglePopoverActive} disclosure>
-      Filter
-    </Button>
-  );
-
-  return (
-    <div style={{height: '280px'}}>
-      <Popover
-        active={popoverActive}
-        activator={activator}
-        onClose={togglePopoverActive}
-        ariaHaspopup={false}
-        sectioned
-      >
-        <FormLayout>
-          <Select label="Show all customers where:" options={['Tagged with']} />
-          <TextField
-            label="Tags"
-            value={tagValue}
-            onChange={handleTagValueChange}
-            autoComplete="off"
-          />
-          <Button size="slim">Add filter</Button>
-        </FormLayout>
-      </Popover>
-    </div>
-  );
-}
-
-export function WithLazyLoadedList() {
-  const [popoverActive, setPopoverActive] = useState(true);
-  const [visibleStaffIndex, setVisibleStaffIndex] = useState(5);
-  const staff = [
-    'Abbey Mayert',
-    'Abbi Senger',
-    'Abdul Goodwin',
-    'Abdullah Borer',
-    'Abe Nader',
-    'Abigayle Smith',
-    'Abner Torphy',
-    'Abraham Towne',
-    'Abraham Vik',
-    'Ada Fisher',
-    'Adah Pouros',
-    'Adam Waelchi',
-    'Adan Zemlak',
-    'Addie Wehner',
-    'Addison Wexler',
-    'Alex Hernandez',
-  ];
-
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
-
-  const handleScrolledToBottom = useCallback(() => {
-    const totalIndexes = staff.length;
-    const interval =
-      visibleStaffIndex + 3 < totalIndexes
-        ? 3
-        : totalIndexes - visibleStaffIndex;
-
-    if (interval > 0) {
-      setVisibleStaffIndex(visibleStaffIndex + interval);
-    }
-  }, [staff.length, visibleStaffIndex]);
-
-  const handleResourceListItemClick = useCallback(() => {}, []);
-
-  const activator = (
-    <Button onClick={togglePopoverActive} disclosure>
-      View staff
-    </Button>
-  );
-
-  const staffList = staff.slice(0, visibleStaffIndex).map((name) => ({
-    name,
-    initials: getInitials(name),
-  }));
-
-  return (
-    <LegacyCard sectioned>
-      <div style={{height: '280px'}}>
-        <Popover
-          sectioned
-          active={popoverActive}
-          activator={activator}
-          onClose={togglePopoverActive}
-          ariaHaspopup={false}
-        >
-          <Popover.Pane onScrolledToBottom={handleScrolledToBottom}>
-            <ResourceList items={staffList} renderItem={renderItem} />
-          </Popover.Pane>
-        </Popover>
-      </div>
-    </LegacyCard>
-  );
-
-  function renderItem({name, initials}) {
+export const All = {
+  render() {
     return (
-      <ResourceList.Item
-        id={name}
-        media={<Avatar size="xs" name={name} initials={initials} />}
-        verticalAlignment="center"
-        onClick={handleResourceListItemClick}
-      >
-        {name}
-      </ResourceList.Item>
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="800">
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With action list
+          </Text>
+          <WithActionList.render />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With content and actions
+          </Text>
+          <WithContentAndActions.render />
+        </BlockStack>
+
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With form components
+          </Text>
+          <WithFormComponents.render />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With lazy loaded list
+          </Text>
+          <WithLazyLoadedList.render />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With scrollable lazy loaded list
+          </Text>
+          <WithScrollableLazyLoadedList.render />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With searchable listbox
+          </Text>
+          <WithSearchableListbox.render />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With loading smaller content
+          </Text>
+          <WithLoadingSmallerContent.render />
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingXl">
+            With preferredPosition cover
+          </Text>
+          <WithCoverPositioning.render />
+        </BlockStack>
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
     );
-  }
+  },
+};
 
-  function getInitials(name) {
-    return name
-      .split(' ')
-      .map((surnameOrFamilyName) => {
-        return surnameOrFamilyName.slice(0, 1);
-      })
-      .join('');
-  }
-}
+export const WithActionList = {
+  render() {
+    const [activePopover, setActivePopover] = useState(null);
 
-export function WithScrollableLazyLoadedList() {
-  const [popoverActive, setPopoverActive] = useState(true);
-  const [visibleStaffIndex, setVisibleStaffIndex] = useState(5);
-  const staff = [
-    'Abbey Mayert',
-    'Abbi Senger',
-    'Abdul Goodwin',
-    'Abdullah Borer',
-    'Abe Nader',
-    'Abigayle Smith',
-    'Abner Torphy',
-    'Abraham Towne',
-    'Abraham Vik',
-    'Ada Fisher',
-    'Adah Pouros',
-    'Adam Waelchi',
-    'Adan Zemlak',
-    'Addie Wehner',
-    'Addison Wexler',
-    'Alex Hernandez',
-  ];
+    const togglePopoverActive = useCallback((popover, isClosing) => {
+      const currentPopover = isClosing ? null : popover;
+      setActivePopover(currentPopover);
+    }, []);
 
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
+    const activator = (
+      <Button
+        id="button-1"
+        onClick={() => togglePopoverActive('popover1', false)}
+        disclosure
+      >
+        More actions
+      </Button>
+    );
+    const activator2 = (
+      <Button
+        id="button-2"
+        onClick={() => togglePopoverActive('popover2', false)}
+        disclosure
+      >
+        More actions
+      </Button>
+    );
 
-  const handleScrolledToBottom = useCallback(() => {
-    const totalIndexes = staff.length;
-    const interval =
-      visibleStaffIndex + 3 < totalIndexes
-        ? 3
-        : totalIndexes - visibleStaffIndex;
+    return (
+      <div style={{height: '250px'}}>
+        <BlockStack gap="400">
+          <Popover
+            active={activePopover === 'popover1'}
+            activator={activator}
+            autofocusTarget="first-node"
+            onClose={() => togglePopoverActive('popover1', true)}
+          >
+            <ActionList
+              actionRole="menuitem"
+              items={[{content: 'Import file'}, {content: 'Export file'}]}
+            />
+          </Popover>
+          <Popover
+            active={activePopover === 'popover2'}
+            activator={activator2}
+            autofocusTarget="first-node"
+            onClose={() => togglePopoverActive('popover2', true)}
+          >
+            <ActionList
+              actionRole="menuitem"
+              items={[{content: 'Import file'}, {content: 'Export file'}]}
+            />
+          </Popover>
+        </BlockStack>
+      </div>
+    );
+  },
+};
 
-    console.log({interval});
+export const WithContentAndActions = {
+  render() {
+    const [popoverActive, setPopoverActive] = useState(true);
 
-    if (interval > 0) {
-      setVisibleStaffIndex(visibleStaffIndex + interval);
-    }
-  }, [staff.length, visibleStaffIndex]);
+    const togglePopoverActive = useCallback(
+      () => setPopoverActive((popoverActive) => !popoverActive),
+      [],
+    );
 
-  const handleResourceListItemClick = useCallback(() => {}, []);
+    const textMarkup = (
+      <Text as="h2" variant="headingSm">
+        Available sales channels
+      </Text>
+    );
 
-  const activator = (
-    <Button onClick={togglePopoverActive} disclosure>
-      View staff
-    </Button>
-  );
+    const activator = (
+      <Button onClick={togglePopoverActive} disclosure>
+        Sales channels
+      </Button>
+    );
 
-  const staffList = staff.slice(0, visibleStaffIndex).map((name) => ({
-    name,
-    initials: getInitials(name),
-  }));
-
-  return (
-    <LegacyCard sectioned>
-      <div style={{height: '280px'}}>
+    return (
+      <div style={{height: '250px'}}>
         <Popover
-          sectioned
           active={popoverActive}
           activator={activator}
+          autofocusTarget="first-node"
           onClose={togglePopoverActive}
-          ariaHaspopup={false}
         >
+          <Popover.Pane fixed>
+            <Popover.Section>{textMarkup}</Popover.Section>
+          </Popover.Pane>
           <Popover.Pane>
-            <Scrollable
-              shadow
-              style={{
-                position: 'relative',
-                width: '231px',
-                height: '262px',
-                padding: 'var(--p-space-200) 0',
-                borderBottomLeftRadius: 'var(--p-border-radius-200)',
-                borderBottomRightRadius: 'var(--p-border-radius-200)',
-              }}
-              onScrolledToBottom={handleScrolledToBottom}
-            >
-              <ResourceList items={staffList} renderItem={renderItem} />
-            </Scrollable>
+            <ActionList
+              actionRole="menuitem"
+              items={[
+                {content: 'Online store'},
+                {content: 'Facebook'},
+                {content: 'Shopify POS'},
+              ]}
+            />
           </Popover.Pane>
         </Popover>
       </div>
-    </LegacyCard>
-  );
-
-  function renderItem({name, initials}) {
-    return (
-      <ResourceList.Item
-        id={name}
-        media={<Avatar size="xs" name={name} initials={initials} />}
-        verticalAlignment="center"
-        onClick={handleResourceListItemClick}
-      >
-        {name}
-      </ResourceList.Item>
     );
-  }
+  },
+};
 
-  function getInitials(name) {
-    return name
-      .split(' ')
-      .map((surnameOrFamilyName) => {
-        return surnameOrFamilyName.slice(0, 1);
-      })
-      .join('');
-  }
-}
+export const WithFormComponents = {
+  render() {
+    const [popoverActive, setPopoverActive] = useState(true);
+    const [tagValue, setTagValue] = useState('');
 
-export function WithSearchableListbox() {
-  interface CustomerSegment {
-    id: string;
-    label: string;
-    value: string;
-  }
+    const togglePopoverActive = useCallback(
+      () => setPopoverActive((popoverActive) => !popoverActive),
+      [],
+    );
 
-  const actionValue = '__ACTION__';
+    const handleTagValueChange = useCallback((value) => setTagValue(value), []);
 
-  const segments: CustomerSegment[] = [
-    {
-      label: 'All customers',
-      id: 'gid://shopify/CustomerSegment/1',
-      value: '0',
-    },
-    {
-      label: 'VIP customers',
-      id: 'gid://shopify/CustomerSegment/2',
-      value: '1',
-    },
-    {
-      label: 'New customers',
-      id: 'gid://shopify/CustomerSegment/3',
-      value: '2',
-    },
-    {
-      label: 'Abandoned carts - last 30 days',
-      id: 'gid://shopify/CustomerSegment/4',
-      value: '3',
-    },
-    {
-      label: 'Wholesale customers',
-      id: 'gid://shopify/CustomerSegment/5',
-      value: '4',
-    },
-    {
-      label: 'Email subscribers',
-      id: 'gid://shopify/CustomerSegment/6',
-      value: '5',
-    },
-    {
-      label: 'From New York',
-      id: 'gid://shopify/CustomerSegment/7',
-      value: '6',
-    },
-    {
-      label: 'Repeat buyers',
-      id: 'gid://shopify/CustomerSegment/8',
-      value: '7',
-    },
-    {
-      label: 'First time buyers',
-      id: 'gid://shopify/CustomerSegment/9',
-      value: '8',
-    },
-    {
-      label: 'From Canada',
-      id: 'gid://shopify/CustomerSegment/10',
-      value: '9',
-    },
-    {
-      label: 'Bought in last 60 days',
-      id: 'gid://shopify/CustomerSegment/11',
-      value: '10',
-    },
-    {
-      label: 'Bought last BFCM',
-      id: 'gid://shopify/CustomerSegment/12',
-      value: '11',
-    },
-  ];
+    const activator = (
+      <Button onClick={togglePopoverActive} disclosure>
+        Filter
+      </Button>
+    );
 
-  const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
-    (_, index) => ({
-      label: `Other customers ${index + 13}`,
-      id: `gid://shopify/CustomerSegment/${index + 13}`,
-      value: `${index + 12}`,
-    }),
-  );
+    return (
+      <div style={{height: '280px'}}>
+        <Popover
+          active={popoverActive}
+          activator={activator}
+          onClose={togglePopoverActive}
+          ariaHaspopup={false}
+          sectioned
+        >
+          <FormLayout>
+            <Select
+              label="Show all customers where:"
+              options={['Tagged with']}
+            />
+            <TextField
+              label="Tags"
+              value={tagValue}
+              onChange={handleTagValueChange}
+              autoComplete="off"
+            />
+            <Button size="slim">Add filter</Button>
+          </FormLayout>
+        </Popover>
+      </div>
+    );
+  },
+};
 
-  segments.push(...lazyLoadSegments);
+export const WithLazyLoadedList = {
+  render() {
+    const [popoverActive, setPopoverActive] = useState(true);
+    const [visibleStaffIndex, setVisibleStaffIndex] = useState(5);
+    const staff = [
+      'Abbey Mayert',
+      'Abbi Senger',
+      'Abdul Goodwin',
+      'Abdullah Borer',
+      'Abe Nader',
+      'Abigayle Smith',
+      'Abner Torphy',
+      'Abraham Towne',
+      'Abraham Vik',
+      'Ada Fisher',
+      'Adah Pouros',
+      'Adam Waelchi',
+      'Adan Zemlak',
+      'Addie Wehner',
+      'Addison Wexler',
+      'Alex Hernandez',
+    ];
 
-  const interval = 25;
+    const togglePopoverActive = useCallback(
+      () => setPopoverActive((popoverActive) => !popoverActive),
+      [],
+    );
 
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const [showFooterAction, setShowFooterAction] = useState(true);
-  const [query, setQuery] = useState('');
-  const [lazyLoading, setLazyLoading] = useState(false);
-  const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
-  const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
-  const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
-  const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
-  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
-    [],
-  );
+    const handleScrolledToBottom = useCallback(() => {
+      const totalIndexes = staff.length;
+      const interval =
+        visibleStaffIndex + 3 < totalIndexes
+          ? 3
+          : totalIndexes - visibleStaffIndex;
 
-  const handleClickShowAll = () => {
-    setShowFooterAction(false);
-    setVisibleOptionIndex(interval);
-  };
+      if (interval > 0) {
+        setVisibleStaffIndex(visibleStaffIndex + interval);
+      }
+    }, [staff.length, visibleStaffIndex]);
 
-  const handleFilterSegments = (query: string) => {
-    const nextFilteredSegments = segments.filter((segment: CustomerSegment) => {
-      return segment.label
-        .toLocaleLowerCase()
-        .includes(query.toLocaleLowerCase().trim());
-    });
+    const handleResourceListItemClick = useCallback(() => {}, []);
 
-    setFilteredSegments(nextFilteredSegments);
-  };
+    const activator = (
+      <Button onClick={togglePopoverActive} disclosure>
+        View staff
+      </Button>
+    );
 
-  const handleQueryChange = (query: string) => {
-    setQuery(query);
+    const staffList = staff.slice(0, visibleStaffIndex).map((name) => ({
+      name,
+      initials: getInitials(name),
+    }));
 
-    if (query.length >= 2) handleFilterSegments(query);
-  };
+    return (
+      <LegacyCard sectioned>
+        <div style={{height: '280px'}}>
+          <Popover
+            sectioned
+            active={popoverActive}
+            activator={activator}
+            onClose={togglePopoverActive}
+            ariaHaspopup={false}
+          >
+            <Popover.Pane onScrolledToBottom={handleScrolledToBottom}>
+              <ResourceList items={staffList} renderItem={renderItem} />
+            </Popover.Pane>
+          </Popover>
+        </div>
+      </LegacyCard>
+    );
 
-  const handleQueryClear = () => {
-    handleQueryChange('');
-  };
-
-  const handleOpenPicker = () => {
-    setPickerOpen(true);
-  };
-
-  const handleClosePicker = () => {
-    setPickerOpen(false);
-    handleQueryChange('');
-  };
-
-  const handleSegmentSelect = (segmentIndex: string) => {
-    if (segmentIndex === actionValue) {
-      return handleClickShowAll();
+    function renderItem({name, initials}) {
+      return (
+        <ResourceList.Item
+          id={name}
+          media={<Avatar size="xs" name={name} initials={initials} />}
+          verticalAlignment="center"
+          onClick={handleResourceListItemClick}
+        >
+          {name}
+        </ResourceList.Item>
+      );
     }
 
-    setSelectedSegmentIndex(Number(segmentIndex));
-    handleClosePicker();
-  };
-
-  const handleActiveOptionChange = (_: string, domId: string) => {
-    setActiveOptionId(domId);
-  };
-
-  /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
-
-  const handleLazyLoadSegments = () => {
-    if (willLoadMoreResults && !showFooterAction) {
-      setLazyLoading(true);
-
-      const options = query ? filteredSegments : segments;
-
-      setTimeout(() => {
-        const remainingOptionCount = options.length - visibleOptionIndex;
-        const nextVisibleOptionIndex =
-          remainingOptionCount >= interval
-            ? visibleOptionIndex + interval
-            : visibleOptionIndex + remainingOptionCount;
-
-        setLazyLoading(false);
-        setVisibleOptionIndex(nextVisibleOptionIndex);
-
-        if (remainingOptionCount <= interval) {
-          setWillLoadMoreResults(false);
-        }
-      }, 1000);
+    function getInitials(name) {
+      return name
+        .split(' ')
+        .map((surnameOrFamilyName) => {
+          return surnameOrFamilyName.slice(0, 1);
+        })
+        .join('');
     }
-  };
+  },
+};
 
-  const listboxId = 'SearchableListboxInPopover';
+export const WithScrollableLazyLoadedList = {
+  render() {
+    const [popoverActive, setPopoverActive] = useState(true);
+    const [visibleStaffIndex, setVisibleStaffIndex] = useState(5);
+    const staff = [
+      'Abbey Mayert',
+      'Abbi Senger',
+      'Abdul Goodwin',
+      'Abdullah Borer',
+      'Abe Nader',
+      'Abigayle Smith',
+      'Abner Torphy',
+      'Abraham Towne',
+      'Abraham Vik',
+      'Ada Fisher',
+      'Adah Pouros',
+      'Adam Waelchi',
+      'Adan Zemlak',
+      'Addie Wehner',
+      'Addison Wexler',
+      'Alex Hernandez',
+    ];
 
-  /* Your app's feature/context specific activator here */
-  const activator = (
-    <div
-      style={{
-        fontSize: 'var(--p-font-size-500)',
-        color: 'var(--p-color-text)',
-        borderBottom: '1px dashed var(--p-color-border)',
-      }}
-    >
-      <Link monochrome removeUnderline onClick={handleOpenPicker}>
-        <Text as="h1" variant="headingXl">
-          {segments[selectedSegmentIndex].label}
-        </Text>
-      </Link>
-    </div>
-  );
+    const togglePopoverActive = useCallback(
+      () => setPopoverActive((popoverActive) => !popoverActive),
+      [],
+    );
 
-  const textFieldMarkup = (
-    <div style={{padding: '12px'}}>
-      <StopPropagation>
-        <TextField
-          focused={showFooterAction}
-          clearButton
-          labelHidden
-          label="Customer segments"
-          placeholder="Search segments"
-          autoComplete="off"
-          value={query}
-          prefix={<Icon source={SearchIcon} />}
-          ariaActiveDescendant={activeOptionId}
-          ariaControls={listboxId}
-          onChange={handleQueryChange}
-          onClearButtonClick={handleQueryClear}
-        />
-      </StopPropagation>
-    </div>
-  );
+    const handleScrolledToBottom = useCallback(() => {
+      const totalIndexes = staff.length;
+      const interval =
+        visibleStaffIndex + 3 < totalIndexes
+          ? 3
+          : totalIndexes - visibleStaffIndex;
 
-  const segmentOptions = query ? filteredSegments : segments;
+      console.log({interval});
 
-  const segmentList =
-    segmentOptions.length > 0
-      ? segmentOptions
-          .slice(0, visibleOptionIndex)
-          .map(({label, id, value}) => {
-            const selected = segments[selectedSegmentIndex].id === id;
+      if (interval > 0) {
+        setVisibleStaffIndex(visibleStaffIndex + interval);
+      }
+    }, [staff.length, visibleStaffIndex]);
 
-            return (
-              <Listbox.Option key={id} value={value} selected={selected}>
-                <Listbox.TextOption selected={selected}>
-                  {label}
-                </Listbox.TextOption>
-              </Listbox.Option>
-            );
-          })
-      : null;
+    const handleResourceListItemClick = useCallback(() => {}, []);
 
-  const showAllMarkup = showFooterAction ? (
-    <Listbox.Action value={actionValue}>
-      <span
+    const activator = (
+      <Button onClick={togglePopoverActive} disclosure>
+        View staff
+      </Button>
+    );
+
+    const staffList = staff.slice(0, visibleStaffIndex).map((name) => ({
+      name,
+      initials: getInitials(name),
+    }));
+
+    return (
+      <LegacyCard sectioned>
+        <div style={{height: '280px'}}>
+          <Popover
+            sectioned
+            active={popoverActive}
+            activator={activator}
+            onClose={togglePopoverActive}
+            ariaHaspopup={false}
+          >
+            <Popover.Pane>
+              <Scrollable
+                shadow
+                style={{
+                  position: 'relative',
+                  width: '231px',
+                  height: '262px',
+                  padding: 'var(--p-space-200) 0',
+                  borderBottomLeftRadius: 'var(--p-border-radius-200)',
+                  borderBottomRightRadius: 'var(--p-border-radius-200)',
+                }}
+                onScrolledToBottom={handleScrolledToBottom}
+              >
+                <ResourceList items={staffList} renderItem={renderItem} />
+              </Scrollable>
+            </Popover.Pane>
+          </Popover>
+        </div>
+      </LegacyCard>
+    );
+
+    function renderItem({name, initials}) {
+      return (
+        <ResourceList.Item
+          id={name}
+          media={<Avatar size="xs" name={name} initials={initials} />}
+          verticalAlignment="center"
+          onClick={handleResourceListItemClick}
+        >
+          {name}
+        </ResourceList.Item>
+      );
+    }
+
+    function getInitials(name) {
+      return name
+        .split(' ')
+        .map((surnameOrFamilyName) => {
+          return surnameOrFamilyName.slice(0, 1);
+        })
+        .join('');
+    }
+  },
+};
+
+export const WithSearchableListbox = {
+  render() {
+    interface CustomerSegment {
+      id: string;
+      label: string;
+      value: string;
+    }
+
+    const actionValue = '__ACTION__';
+
+    const segments: CustomerSegment[] = [
+      {
+        label: 'All customers',
+        id: 'gid://shopify/CustomerSegment/1',
+        value: '0',
+      },
+      {
+        label: 'VIP customers',
+        id: 'gid://shopify/CustomerSegment/2',
+        value: '1',
+      },
+      {
+        label: 'New customers',
+        id: 'gid://shopify/CustomerSegment/3',
+        value: '2',
+      },
+      {
+        label: 'Abandoned carts - last 30 days',
+        id: 'gid://shopify/CustomerSegment/4',
+        value: '3',
+      },
+      {
+        label: 'Wholesale customers',
+        id: 'gid://shopify/CustomerSegment/5',
+        value: '4',
+      },
+      {
+        label: 'Email subscribers',
+        id: 'gid://shopify/CustomerSegment/6',
+        value: '5',
+      },
+      {
+        label: 'From New York',
+        id: 'gid://shopify/CustomerSegment/7',
+        value: '6',
+      },
+      {
+        label: 'Repeat buyers',
+        id: 'gid://shopify/CustomerSegment/8',
+        value: '7',
+      },
+      {
+        label: 'First time buyers',
+        id: 'gid://shopify/CustomerSegment/9',
+        value: '8',
+      },
+      {
+        label: 'From Canada',
+        id: 'gid://shopify/CustomerSegment/10',
+        value: '9',
+      },
+      {
+        label: 'Bought in last 60 days',
+        id: 'gid://shopify/CustomerSegment/11',
+        value: '10',
+      },
+      {
+        label: 'Bought last BFCM',
+        id: 'gid://shopify/CustomerSegment/12',
+        value: '11',
+      },
+    ];
+
+    const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
+      (_, index) => ({
+        label: `Other customers ${index + 13}`,
+        id: `gid://shopify/CustomerSegment/${index + 13}`,
+        value: `${index + 12}`,
+      }),
+    );
+
+    segments.push(...lazyLoadSegments);
+
+    const interval = 25;
+
+    const [pickerOpen, setPickerOpen] = useState(false);
+    const [showFooterAction, setShowFooterAction] = useState(true);
+    const [query, setQuery] = useState('');
+    const [lazyLoading, setLazyLoading] = useState(false);
+    const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
+    const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
+    const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
+    const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
+    const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
+      [],
+    );
+
+    const handleClickShowAll = () => {
+      setShowFooterAction(false);
+      setVisibleOptionIndex(interval);
+    };
+
+    const handleFilterSegments = (query: string) => {
+      const nextFilteredSegments = segments.filter(
+        (segment: CustomerSegment) => {
+          return segment.label
+            .toLocaleLowerCase()
+            .includes(query.toLocaleLowerCase().trim());
+        },
+      );
+
+      setFilteredSegments(nextFilteredSegments);
+    };
+
+    const handleQueryChange = (query: string) => {
+      setQuery(query);
+
+      if (query.length >= 2) handleFilterSegments(query);
+    };
+
+    const handleQueryClear = () => {
+      handleQueryChange('');
+    };
+
+    const handleOpenPicker = () => {
+      setPickerOpen(true);
+    };
+
+    const handleClosePicker = () => {
+      setPickerOpen(false);
+      handleQueryChange('');
+    };
+
+    const handleSegmentSelect = (segmentIndex: string) => {
+      if (segmentIndex === actionValue) {
+        return handleClickShowAll();
+      }
+
+      setSelectedSegmentIndex(Number(segmentIndex));
+      handleClosePicker();
+    };
+
+    const handleActiveOptionChange = (_: string, domId: string) => {
+      setActiveOptionId(domId);
+    };
+
+    /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
+
+    const handleLazyLoadSegments = () => {
+      if (willLoadMoreResults && !showFooterAction) {
+        setLazyLoading(true);
+
+        const options = query ? filteredSegments : segments;
+
+        setTimeout(() => {
+          const remainingOptionCount = options.length - visibleOptionIndex;
+          const nextVisibleOptionIndex =
+            remainingOptionCount >= interval
+              ? visibleOptionIndex + interval
+              : visibleOptionIndex + remainingOptionCount;
+
+          setLazyLoading(false);
+          setVisibleOptionIndex(nextVisibleOptionIndex);
+
+          if (remainingOptionCount <= interval) {
+            setWillLoadMoreResults(false);
+          }
+        }, 1000);
+      }
+    };
+
+    const listboxId = 'SearchableListboxInPopover';
+
+    /* Your app's feature/context specific activator here */
+    const activator = (
+      <div
         style={{
-          color: 'var(--p-color-text-secondary)',
+          fontSize: 'var(--p-font-size-500)',
+          color: 'var(--p-color-text)',
+          borderBottom: '1px dashed var(--p-color-border)',
         }}
       >
-        Show all 111 segments
-      </span>
-    </Listbox.Action>
-  ) : null;
+        <Link monochrome removeUnderline onClick={handleOpenPicker}>
+          <Text as="h1" variant="headingXl">
+            {segments[selectedSegmentIndex].label}
+          </Text>
+        </Link>
+      </div>
+    );
 
-  const lazyLoadingMarkup = lazyLoading ? (
-    <Listbox.Loading
-      accessibilityLabel={`${
-        query ? 'Filtering' : 'Loading'
-      } customer segments`}
-    />
-  ) : null;
+    const textFieldMarkup = (
+      <div style={{padding: '12px'}}>
+        <StopPropagation>
+          <TextField
+            focused={showFooterAction}
+            clearButton
+            labelHidden
+            label="Customer segments"
+            placeholder="Search segments"
+            autoComplete="off"
+            value={query}
+            prefix={<Icon source={SearchIcon} />}
+            ariaActiveDescendant={activeOptionId}
+            ariaControls={listboxId}
+            onChange={handleQueryChange}
+            onClearButtonClick={handleQueryClear}
+          />
+        </StopPropagation>
+      </div>
+    );
 
-  const noResultsMarkup =
-    segmentOptions.length === 0 ? (
-      <EmptySearchResult
-        title=""
-        description={`No segments found matching "${query}"`}
+    const segmentOptions = query ? filteredSegments : segments;
+
+    const segmentList =
+      segmentOptions.length > 0
+        ? segmentOptions
+            .slice(0, visibleOptionIndex)
+            .map(({label, id, value}) => {
+              const selected = segments[selectedSegmentIndex].id === id;
+
+              return (
+                <Listbox.Option key={id} value={value} selected={selected}>
+                  <Listbox.TextOption selected={selected}>
+                    {label}
+                  </Listbox.TextOption>
+                </Listbox.Option>
+              );
+            })
+        : null;
+
+    const showAllMarkup = showFooterAction ? (
+      <Listbox.Action value={actionValue}>
+        <span
+          style={{
+            color: 'var(--p-color-text-secondary)',
+          }}
+        >
+          Show all 111 segments
+        </span>
+      </Listbox.Action>
+    ) : null;
+
+    const lazyLoadingMarkup = lazyLoading ? (
+      <Listbox.Loading
+        accessibilityLabel={`${
+          query ? 'Filtering' : 'Loading'
+        } customer segments`}
       />
     ) : null;
 
-  const listboxMarkup = (
-    <Listbox
-      enableKeyboardControl
-      autoSelection={AutoSelection.FirstSelected}
-      accessibilityLabel="Search for and select a customer segment"
-      customListId={listboxId}
-      onSelect={handleSegmentSelect}
-      onActiveOptionChange={handleActiveOptionChange}
-    >
-      {segmentList}
-      {showAllMarkup}
-      {noResultsMarkup}
-      {lazyLoadingMarkup}
-    </Listbox>
-  );
+    const noResultsMarkup =
+      segmentOptions.length === 0 ? (
+        <EmptySearchResult
+          title=""
+          description={`No segments found matching "${query}"`}
+        />
+      ) : null;
 
-  return (
-    <div style={{height: '400px'}}>
-      <Popover
-        active={pickerOpen}
-        activator={activator}
-        ariaHaspopup="listbox"
-        preferredAlignment="left"
-        autofocusTarget="first-node"
-        onClose={handleClosePicker}
+    const listboxMarkup = (
+      <Listbox
+        enableKeyboardControl
+        autoSelection={AutoSelection.FirstSelected}
+        accessibilityLabel="Search for and select a customer segment"
+        customListId={listboxId}
+        onSelect={handleSegmentSelect}
+        onActiveOptionChange={handleActiveOptionChange}
       >
-        <Popover.Pane fixed>
-          <div
-            style={{
-              alignItems: 'stretch',
-              borderTop: '1px solid #DFE3E8',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'stretch',
-              position: 'relative',
-              width: '100%',
-              height: '100%',
-              overflow: 'hidden',
-            }}
-          >
-            {textFieldMarkup}
+        {segmentList}
+        {showAllMarkup}
+        {noResultsMarkup}
+        {lazyLoadingMarkup}
+      </Listbox>
+    );
 
-            <Scrollable
-              shadow
+    return (
+      <div style={{height: '400px'}}>
+        <Popover
+          active={pickerOpen}
+          activator={activator}
+          ariaHaspopup="listbox"
+          preferredAlignment="left"
+          autofocusTarget="first-node"
+          onClose={handleClosePicker}
+        >
+          <Popover.Pane fixed>
+            <div
               style={{
+                alignItems: 'stretch',
+                borderTop: '1px solid #DFE3E8',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'stretch',
                 position: 'relative',
-                width: '310px',
-                height: '262px',
-                padding: 'var(--p-space-200) 0',
-                borderBottomLeftRadius: 'var(--p-border-radius-200)',
-                borderBottomRightRadius: 'var(--p-border-radius-200)',
+                width: '100%',
+                height: '100%',
+                overflow: 'hidden',
               }}
-              onScrolledToBottom={handleLazyLoadSegments}
             >
-              {listboxMarkup}
-            </Scrollable>
-          </div>
-        </Popover.Pane>
-      </Popover>
-    </div>
-  );
-}
+              {textFieldMarkup}
 
-export function WithLoadingSmallerContent() {
-  const [popoverActive, setPopoverActive] = useState(true);
-  const [loading, setLoading] = useState(false);
+              <Scrollable
+                shadow
+                style={{
+                  position: 'relative',
+                  width: '310px',
+                  height: '262px',
+                  padding: 'var(--p-space-200) 0',
+                  borderBottomLeftRadius: 'var(--p-border-radius-200)',
+                  borderBottomRightRadius: 'var(--p-border-radius-200)',
+                }}
+                onScrolledToBottom={handleLazyLoadSegments}
+              >
+                {listboxMarkup}
+              </Scrollable>
+            </div>
+          </Popover.Pane>
+        </Popover>
+      </div>
+    );
+  },
+};
 
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
+export const WithLoadingSmallerContent = {
+  render() {
+    const [popoverActive, setPopoverActive] = useState(true);
+    const [loading, setLoading] = useState(false);
 
-  const activator = (
-    <Button
-      onClick={() => {
-        setLoading(true);
-        togglePopoverActive();
-        window.setTimeout(() => {
-          setLoading(false);
-        }, 500);
-      }}
-      disclosure
-    >
-      Show server data
-    </Button>
-  );
+    const togglePopoverActive = useCallback(
+      () => setPopoverActive((popoverActive) => !popoverActive),
+      [],
+    );
 
-  return (
-    <div style={{height: '280px'}}>
-      <Popover
-        active={popoverActive}
-        activator={activator}
-        onClose={togglePopoverActive}
-        ariaHaspopup={false}
-        sectioned
+    const activator = (
+      <Button
+        onClick={() => {
+          setLoading(true);
+          togglePopoverActive();
+          window.setTimeout(() => {
+            setLoading(false);
+          }, 500);
+        }}
+        disclosure
       >
-        {loading ? (
-          <div style={{height: '200px'}}>
-            <Text as="p" variant="bodyMd">
-              Loading...
-            </Text>
-          </div>
-        ) : (
-          <div>
-            <Text as="p" variant="bodyMd">
-              Small content from the server
-            </Text>
-          </div>
-        )}
-      </Popover>
-    </div>
-  );
-}
+        Show server data
+      </Button>
+    );
 
-export function WithSubduedPane() {
-  const [popoverActive, setPopoverActive] = useState(true);
+    return (
+      <div style={{height: '280px'}}>
+        <Popover
+          active={popoverActive}
+          activator={activator}
+          onClose={togglePopoverActive}
+          ariaHaspopup={false}
+          sectioned
+        >
+          {loading ? (
+            <div style={{height: '200px'}}>
+              <Text as="p" variant="bodyMd">
+                Loading...
+              </Text>
+            </div>
+          ) : (
+            <div>
+              <Text as="p" variant="bodyMd">
+                Small content from the server
+              </Text>
+            </div>
+          )}
+        </Popover>
+      </div>
+    );
+  },
+};
 
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
+export const WithSubduedPane = {
+  render() {
+    const [popoverActive, setPopoverActive] = useState(true);
 
-  const activator = (
-    <Button
-      onClick={() => {
-        togglePopoverActive();
-      }}
-      disclosure
-    >
-      Show popover
-    </Button>
-  );
+    const togglePopoverActive = useCallback(
+      () => setPopoverActive((popoverActive) => !popoverActive),
+      [],
+    );
 
-  return (
-    <div style={{height: '280px'}}>
-      <Popover
-        active={popoverActive}
-        activator={activator}
-        onClose={togglePopoverActive}
+    const activator = (
+      <Button
+        onClick={() => {
+          togglePopoverActive();
+        }}
+        disclosure
       >
-        <Popover.Pane>
-          <Box padding="400">
-            <Text as="p">Popover content</Text>
-          </Box>
-        </Popover.Pane>
-        <Popover.Pane subdued>
-          <Box padding="400">
-            <Text as="p">Subdued popover pane</Text>
-          </Box>
-        </Popover.Pane>
-      </Popover>
-    </div>
-  );
-}
+        Show popover
+      </Button>
+    );
 
-export function WithCoverPositioning() {
-  const [popoverActive, setPopoverActive] = useState(true);
+    return (
+      <div style={{height: '280px'}}>
+        <Popover
+          active={popoverActive}
+          activator={activator}
+          onClose={togglePopoverActive}
+        >
+          <Popover.Pane>
+            <Box padding="400">
+              <Text as="p">Popover content</Text>
+            </Box>
+          </Popover.Pane>
+          <Popover.Pane subdued>
+            <Box padding="400">
+              <Text as="p">Subdued popover pane</Text>
+            </Box>
+          </Popover.Pane>
+        </Popover>
+      </div>
+    );
+  },
+};
 
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
+export const WithCoverPositioning = {
+  render() {
+    const [popoverActive, setPopoverActive] = useState(true);
 
-  const activator = (
-    <button
-      onClick={() => {
-        togglePopoverActive();
-      }}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 'var(--p-space-200)',
-        padding: 'var(--p-space-200) var(--p-space-300)',
-        borderRadius: 'var(--p-border-radius-300)',
-        border: 'var(--p-border-width-025) solid var(--p-color-border)',
-        background: 'var(--p-color-bg-surface)',
-      }}
-    >
-      Show popover
-      <Icon source={SelectIcon} tone="base" />
-    </button>
-  );
+    const togglePopoverActive = useCallback(
+      () => setPopoverActive((popoverActive) => !popoverActive),
+      [],
+    );
 
-  return (
-    <div style={{height: '280px'}}>
-      <Popover
-        active={popoverActive}
-        activator={activator}
-        onClose={togglePopoverActive}
-        preferredPosition="cover"
+    const activator = (
+      <button
+        onClick={() => {
+          togglePopoverActive();
+        }}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--p-space-200)',
+          padding: 'var(--p-space-200) var(--p-space-300)',
+          borderRadius: 'var(--p-border-radius-300)',
+          border: 'var(--p-border-width-025) solid var(--p-color-border)',
+          background: 'var(--p-color-bg-surface)',
+        }}
       >
-        <Popover.Pane>
-          <Box padding="200" paddingInline="300">
-            <Text as="p">Popover content</Text>
-          </Box>
+        Show popover
+        <Icon source={SelectIcon} tone="base" />
+      </button>
+    );
 
-          <Box padding="200" paddingInline="300">
-            <Text as="p">Popover content</Text>
-          </Box>
-        </Popover.Pane>
-      </Popover>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '280px'}}>
+        <Popover
+          active={popoverActive}
+          activator={activator}
+          onClose={togglePopoverActive}
+          preferredPosition="cover"
+        >
+          <Popover.Pane>
+            <Box padding="200" paddingInline="300">
+              <Text as="p">Popover content</Text>
+            </Box>
+
+            <Box padding="200" paddingInline="300">
+              <Text as="p">Popover content</Text>
+            </Box>
+          </Popover.Pane>
+        </Popover>
+      </div>
+    );
+  },
+};
 
 const StopPropagation = ({children}: React.PropsWithChildren<any>) => {
   const stopEventPropagation = (event: React.MouseEvent | React.TouchEvent) => {

--- a/polaris-react/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/polaris-react/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,33 +1,41 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {ProgressBar} from '@shopify/polaris';
 
 export default {
   component: ProgressBar,
-} as ComponentMeta<typeof ProgressBar>;
+} as Meta<typeof ProgressBar>;
 
-export function Default() {
-  return <ProgressBar progress={75} />;
-}
+export const Default = {
+  render() {
+    return <ProgressBar progress={75} />;
+  },
+};
 
-export function Small() {
-  return <ProgressBar progress={40} size="small" />;
-}
+export const Small = {
+  render() {
+    return <ProgressBar progress={40} size="small" />;
+  },
+};
 
-export function WithColors() {
-  return (
-    <div>
-      <ProgressBar progress={70} tone="primary" />
-      <br />
-      <ProgressBar progress={30} tone="success" />
-      <br />
-      <ProgressBar progress={30} tone="critical" />
-      <br />
-      <ProgressBar progress={30} tone="info" />
-    </div>
-  );
-}
+export const WithColors = {
+  render() {
+    return (
+      <div>
+        <ProgressBar progress={70} tone="primary" />
+        <br />
+        <ProgressBar progress={30} tone="success" />
+        <br />
+        <ProgressBar progress={30} tone="critical" />
+        <br />
+        <ProgressBar progress={30} tone="info" />
+      </div>
+    );
+  },
+};
 
-export function WithNoAnimation() {
-  return <ProgressBar progress={80} animated={false} />;
-}
+export const WithNoAnimation = {
+  render() {
+    return <ProgressBar progress={80} animated={false} />;
+  },
+};

--- a/polaris-react/src/components/RadioButton/RadioButton.stories.tsx
+++ b/polaris-react/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   RadioButton,
   LegacyStack,
@@ -12,163 +12,171 @@ import {
 
 export default {
   component: RadioButton,
-} as ComponentMeta<typeof RadioButton>;
+} as Meta<typeof RadioButton>;
 
-export function Default() {
-  const [value, setValue] = useState('disabled');
+export const Default = {
+  render() {
+    const [value, setValue] = useState('disabled');
 
-  const handleChange = useCallback(
-    (_checked, newValue) => setValue(newValue),
-    [],
-  );
+    const handleChange = useCallback(
+      (_checked, newValue) => setValue(newValue),
+      [],
+    );
 
-  return (
-    <LegacyStack vertical>
-      <RadioButton
-        label="Accounts are disabled"
-        helpText="Customers will only be able to check out as guests."
-        checked={value === 'disabled'}
-        id="disabled"
-        name="accounts"
-        onChange={handleChange}
-      />
-      <RadioButton
-        label="Accounts are optional"
-        helpText="Customers will be able to check out with a customer account or as a guest."
-        id="optional"
-        name="accounts"
-        checked={value === 'optional'}
-        onChange={handleChange}
-      />
-    </LegacyStack>
-  );
-}
+    return (
+      <LegacyStack vertical>
+        <RadioButton
+          label="Accounts are disabled"
+          helpText="Customers will only be able to check out as guests."
+          checked={value === 'disabled'}
+          id="disabled"
+          name="accounts"
+          onChange={handleChange}
+        />
+        <RadioButton
+          label="Accounts are optional"
+          helpText="Customers will be able to check out with a customer account or as a guest."
+          id="optional"
+          name="accounts"
+          checked={value === 'optional'}
+          onChange={handleChange}
+        />
+      </LegacyStack>
+    );
+  },
+};
 
-export function DisabledRadio() {
-  const handleChange = useCallback((_checked, newValue) => {
-    // eslint-disable-next-line no-alert
-    alert('This should never ever get called');
-  }, []);
-  return (
-    <LegacyStack vertical>
-      <RadioButton
-        label="Accounts are required"
-        id="required"
-        name="accounts"
-        checked
-        onChange={handleChange}
-        disabled
-      />
-      <RadioButton
-        label="Accounts are optional"
-        id="optional"
-        name="accounts"
-        onChange={handleChange}
-        disabled
-      />
-    </LegacyStack>
-  );
-}
+export const DisabledRadio = {
+  render() {
+    const handleChange = useCallback((_checked, newValue) => {
+      // eslint-disable-next-line no-alert
+      alert('This should never ever get called');
+    }, []);
+    return (
+      <LegacyStack vertical>
+        <RadioButton
+          label="Accounts are required"
+          id="required"
+          name="accounts"
+          checked
+          onChange={handleChange}
+          disabled
+        />
+        <RadioButton
+          label="Accounts are optional"
+          id="optional"
+          name="accounts"
+          onChange={handleChange}
+          disabled
+        />
+      </LegacyStack>
+    );
+  },
+};
 
-export function Magic() {
-  const [value, setValue] = useState('disabled');
+export const Magic = {
+  render() {
+    const [value, setValue] = useState('disabled');
 
-  const handleChange = useCallback(
-    (_checked, newValue) => setValue(newValue),
-    [],
-  );
+    const handleChange = useCallback(
+      (_checked, newValue) => setValue(newValue),
+      [],
+    );
 
-  return (
-    <LegacyStack vertical>
-      <RadioButton
-        label="Accounts are disabled"
-        helpText="Customers will only be able to check out as guests."
-        checked={value === 'disabled'}
-        id="disabled"
-        name="accounts"
-        onChange={handleChange}
-        tone="magic"
-      />
-      <RadioButton
-        label="Accounts are optional"
-        helpText="Customers will be able to check out with a customer account or as a guest."
-        id="optional"
-        name="accounts"
-        checked={value === 'optional'}
-        onChange={handleChange}
-        tone="magic"
-      />
-    </LegacyStack>
-  );
-}
+    return (
+      <LegacyStack vertical>
+        <RadioButton
+          label="Accounts are disabled"
+          helpText="Customers will only be able to check out as guests."
+          checked={value === 'disabled'}
+          id="disabled"
+          name="accounts"
+          onChange={handleChange}
+          tone="magic"
+        />
+        <RadioButton
+          label="Accounts are optional"
+          helpText="Customers will be able to check out with a customer account or as a guest."
+          id="optional"
+          name="accounts"
+          checked={value === 'optional'}
+          onChange={handleChange}
+          tone="magic"
+        />
+      </LegacyStack>
+    );
+  },
+};
 
-export function WithBleed() {
-  const [value1, setValue1] = useState('disabled');
-  const [value2, setValue2] = useState('disabled2');
-  const handleChange1 = useCallback(
-    (_checked, newValue) => setValue1(newValue),
-    [],
-  );
-  const handleChange2 = useCallback(
-    (_checked, newValue) => setValue2(newValue),
-    [],
-  );
+export const WithBleed = {
+  render() {
+    const [value1, setValue1] = useState('disabled');
+    const [value2, setValue2] = useState('disabled2');
+    const handleChange1 = useCallback(
+      (_checked, newValue) => setValue1(newValue),
+      [],
+    );
+    const handleChange2 = useCallback(
+      (_checked, newValue) => setValue2(newValue),
+      [],
+    );
 
-  return (
-    <BlockStack gap="800">
-      <BlockStack gap="200">
-        <Text as="h2">No Bleed</Text>
-        <Card padding="400">
-          <BlockStack gap="400">
-            <RadioButton
-              label="Accounts are disabled"
-              checked={value1 === 'disabled'}
-              id="disabled"
-              name="accounts"
-              onChange={handleChange1}
-            />
-            <RadioButton
-              label="Accounts are optional"
-              id="optional"
-              name="accounts"
-              checked={value1 === 'optional'}
-              onChange={handleChange1}
-            />
-          </BlockStack>
-        </Card>
+    return (
+      <BlockStack gap="800">
+        <BlockStack gap="200">
+          <Text as="h2">No Bleed</Text>
+          <Card padding="400">
+            <BlockStack gap="400">
+              <RadioButton
+                label="Accounts are disabled"
+                checked={value1 === 'disabled'}
+                id="disabled"
+                name="accounts"
+                onChange={handleChange1}
+              />
+              <RadioButton
+                label="Accounts are optional"
+                id="optional"
+                name="accounts"
+                checked={value1 === 'optional'}
+                onChange={handleChange1}
+              />
+            </BlockStack>
+          </Card>
+        </BlockStack>
+        <BlockStack gap="200">
+          <Text as="h2">Bleed</Text>
+          <Box width="min-content" background="bg-surface" borderRadius="300">
+            <div
+              // Flex to shrink the container to the height of the radio (ie;
+              // ignore line-height)
+              style={{padding: 'var(--p-space-800)', display: 'flex'}}
+            >
+              <RadioButton
+                label="Accounts are disabled"
+                labelHidden
+                checked={value2 === 'disabled2'}
+                id="disabled2"
+                name="accounts2"
+                onChange={handleChange2}
+                bleed="800"
+              />
+            </div>
+            <Divider />
+            <div style={{padding: 'var(--p-space-800)', display: 'flex'}}>
+              <RadioButton
+                label="Accounts are optional"
+                labelHidden
+                checked={value2 === 'optional2'}
+                id="optional2"
+                name="accounts2"
+                onChange={handleChange2}
+                bleed="800"
+              />
+            </div>
+          </Box>
+        </BlockStack>
       </BlockStack>
-      <BlockStack gap="200">
-        <Text as="h2">Bleed</Text>
-        <Box width="min-content" background="bg-surface" borderRadius="300">
-          <div
-            // Flex to shrink the container to the height of the radio (ie;
-            // ignore line-height)
-            style={{padding: 'var(--p-space-800)', display: 'flex'}}
-          >
-            <RadioButton
-              label="Accounts are disabled"
-              labelHidden
-              checked={value2 === 'disabled2'}
-              id="disabled2"
-              name="accounts2"
-              onChange={handleChange2}
-              bleed="800"
-            />
-          </div>
-          <Divider />
-          <div style={{padding: 'var(--p-space-800)', display: 'flex'}}>
-            <RadioButton
-              label="Accounts are optional"
-              labelHidden
-              checked={value2 === 'optional2'}
-              id="optional2"
-              name="accounts2"
-              onChange={handleChange2}
-              bleed="800"
-            />
-          </div>
-        </Box>
-      </BlockStack>
-    </BlockStack>
-  );
-}
+    );
+  },
+};

--- a/polaris-react/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/polaris-react/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Box,
   LegacyCard,
@@ -11,215 +11,225 @@ import {
 
 export default {
   component: RangeSlider,
-} as ComponentMeta<typeof RangeSlider>;
+} as Meta<typeof RangeSlider>;
 
-export function Default() {
-  const [rangeValue, setRangeValue] = useState(32);
+export const Default = {
+  render() {
+    const [rangeValue, setRangeValue] = useState(32);
 
-  const handleRangeSliderChange = useCallback(
-    (value) => setRangeValue(value),
-    [],
-  );
+    const handleRangeSliderChange = useCallback(
+      (value) => setRangeValue(value),
+      [],
+    );
 
-  return (
-    <LegacyCard sectioned title="Background color">
-      <RangeSlider
-        label="Opacity percentage"
-        value={rangeValue}
-        onChange={handleRangeSliderChange}
-        output
-      />
-    </LegacyCard>
-  );
-}
+    return (
+      <LegacyCard sectioned title="Background color">
+        <RangeSlider
+          label="Opacity percentage"
+          value={rangeValue}
+          onChange={handleRangeSliderChange}
+          output
+        />
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithMinAndMax() {
-  const [rangeValue, setRangeValue] = useState(0);
+export const WithMinAndMax = {
+  render() {
+    const [rangeValue, setRangeValue] = useState(0);
 
-  const handleRangeSliderChange = useCallback(
-    (value) => setRangeValue(value),
-    [],
-  );
+    const handleRangeSliderChange = useCallback(
+      (value) => setRangeValue(value),
+      [],
+    );
 
-  return (
-    <LegacyCard sectioned title="Navigation branding">
-      <RangeSlider
-        output
-        label="Logo offset"
-        min={-20}
-        max={20}
-        value={rangeValue}
-        onChange={handleRangeSliderChange}
-      />
-    </LegacyCard>
-  );
-}
-
-export function WithSteps() {
-  const [rangeValue, setRangeValue] = useState(4);
-
-  const handleRangeSliderChange = useCallback(
-    (value) => setRangeValue(value),
-    [],
-  );
-
-  return (
-    <LegacyCard sectioned title="Navigation branding">
-      <RangeSlider
-        output
-        label="Logo offset"
-        min={-20}
-        max={20}
-        step={4}
-        value={rangeValue}
-        onChange={handleRangeSliderChange}
-      />
-    </LegacyCard>
-  );
-}
-
-export function WithPrefixAndSuffix() {
-  const [rangeValue, setRangeValue] = useState(100);
-
-  const handleRangeSliderChange = useCallback(
-    (value) => setRangeValue(value),
-    [],
-  );
-
-  return (
-    <LegacyCard sectioned title="Text color">
-      <RangeSlider
-        output
-        label="Hue color mix"
-        min={0}
-        max={360}
-        value={rangeValue}
-        onChange={handleRangeSliderChange}
-        prefix={
-          <Text as="p" variant="bodyMd">
-            Hue
-          </Text>
-        }
-        suffix={
-          <Box minWidth="24px">
-            <Text as="span" variant="bodyMd">
-              {rangeValue}
-            </Text>
-          </Box>
-        }
-      />
-    </LegacyCard>
-  );
-}
-
-export function WithDualThumb() {
-  const initialValue = [900, 1000];
-  const prefix = '$';
-  const min = 0;
-  const max = 2000;
-  const step = 10;
-
-  const [intermediateTextFieldValue, setIntermediateTextFieldValue] =
-    useState(initialValue);
-  const [rangeValue, setRangeValue] = useState(initialValue);
-
-  const handleRangeSliderChange = useCallback((value) => {
-    setRangeValue(value);
-    setIntermediateTextFieldValue(value);
-  }, []);
-
-  const handleLowerTextFieldChange = useCallback(
-    (value) => {
-      const upperValue = rangeValue[1];
-      setIntermediateTextFieldValue([parseInt(value, 10), upperValue]);
-    },
-    [rangeValue],
-  );
-
-  const handleUpperTextFieldChange = useCallback(
-    (value) => {
-      const lowerValue = rangeValue[0];
-      setIntermediateTextFieldValue([lowerValue, parseInt(value, 10)]);
-    },
-    [rangeValue],
-  );
-
-  const handleLowerTextFieldBlur = useCallback(() => {
-    const upperValue = rangeValue[1];
-    const value = intermediateTextFieldValue[0];
-
-    setRangeValue([parseInt(value, 10), upperValue]);
-  }, [intermediateTextFieldValue, rangeValue]);
-
-  const handleUpperTextFieldBlur = useCallback(() => {
-    const lowerValue = rangeValue[0];
-    const value = intermediateTextFieldValue[1];
-
-    setRangeValue([lowerValue, parseInt(value, 10)]);
-  }, [intermediateTextFieldValue, rangeValue]);
-
-  const handleEnterKeyPress = useCallback(
-    (event) => {
-      const newValue = intermediateTextFieldValue;
-      const oldValue = rangeValue;
-
-      if (event.keyCode === Key.Enter && newValue !== oldValue) {
-        setRangeValue(newValue);
-      }
-    },
-    [intermediateTextFieldValue, rangeValue],
-  );
-
-  const lowerTextFieldValue =
-    intermediateTextFieldValue[0] === rangeValue[0]
-      ? rangeValue[0]
-      : intermediateTextFieldValue[0];
-
-  const upperTextFieldValue =
-    intermediateTextFieldValue[1] === rangeValue[1]
-      ? rangeValue[1]
-      : intermediateTextFieldValue[1];
-
-  return (
-    <LegacyCard sectioned title="Minimum requirements">
-      <div onKeyDown={handleEnterKeyPress}>
+    return (
+      <LegacyCard sectioned title="Navigation branding">
         <RangeSlider
           output
-          label="Money spent is between"
+          label="Logo offset"
+          min={-20}
+          max={20}
           value={rangeValue}
-          prefix={prefix}
-          min={min}
-          max={max}
-          step={step}
           onChange={handleRangeSliderChange}
         />
-        <LegacyStack distribution="equalSpacing" spacing="extraLoose">
-          <TextField
-            label="Min money spent"
-            type="number"
-            value={`${lowerTextFieldValue}`}
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithSteps = {
+  render() {
+    const [rangeValue, setRangeValue] = useState(4);
+
+    const handleRangeSliderChange = useCallback(
+      (value) => setRangeValue(value),
+      [],
+    );
+
+    return (
+      <LegacyCard sectioned title="Navigation branding">
+        <RangeSlider
+          output
+          label="Logo offset"
+          min={-20}
+          max={20}
+          step={4}
+          value={rangeValue}
+          onChange={handleRangeSliderChange}
+        />
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithPrefixAndSuffix = {
+  render() {
+    const [rangeValue, setRangeValue] = useState(100);
+
+    const handleRangeSliderChange = useCallback(
+      (value) => setRangeValue(value),
+      [],
+    );
+
+    return (
+      <LegacyCard sectioned title="Text color">
+        <RangeSlider
+          output
+          label="Hue color mix"
+          min={0}
+          max={360}
+          value={rangeValue}
+          onChange={handleRangeSliderChange}
+          prefix={
+            <Text as="p" variant="bodyMd">
+              Hue
+            </Text>
+          }
+          suffix={
+            <Box minWidth="24px">
+              <Text as="span" variant="bodyMd">
+                {rangeValue}
+              </Text>
+            </Box>
+          }
+        />
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithDualThumb = {
+  render() {
+    const initialValue = [900, 1000];
+    const prefix = '$';
+    const min = 0;
+    const max = 2000;
+    const step = 10;
+
+    const [intermediateTextFieldValue, setIntermediateTextFieldValue] =
+      useState(initialValue);
+    const [rangeValue, setRangeValue] = useState(initialValue);
+
+    const handleRangeSliderChange = useCallback((value) => {
+      setRangeValue(value);
+      setIntermediateTextFieldValue(value);
+    }, []);
+
+    const handleLowerTextFieldChange = useCallback(
+      (value) => {
+        const upperValue = rangeValue[1];
+        setIntermediateTextFieldValue([parseInt(value, 10), upperValue]);
+      },
+      [rangeValue],
+    );
+
+    const handleUpperTextFieldChange = useCallback(
+      (value) => {
+        const lowerValue = rangeValue[0];
+        setIntermediateTextFieldValue([lowerValue, parseInt(value, 10)]);
+      },
+      [rangeValue],
+    );
+
+    const handleLowerTextFieldBlur = useCallback(() => {
+      const upperValue = rangeValue[1];
+      const value = intermediateTextFieldValue[0];
+
+      setRangeValue([parseInt(value, 10), upperValue]);
+    }, [intermediateTextFieldValue, rangeValue]);
+
+    const handleUpperTextFieldBlur = useCallback(() => {
+      const lowerValue = rangeValue[0];
+      const value = intermediateTextFieldValue[1];
+
+      setRangeValue([lowerValue, parseInt(value, 10)]);
+    }, [intermediateTextFieldValue, rangeValue]);
+
+    const handleEnterKeyPress = useCallback(
+      (event) => {
+        const newValue = intermediateTextFieldValue;
+        const oldValue = rangeValue;
+
+        if (event.keyCode === Key.Enter && newValue !== oldValue) {
+          setRangeValue(newValue);
+        }
+      },
+      [intermediateTextFieldValue, rangeValue],
+    );
+
+    const lowerTextFieldValue =
+      intermediateTextFieldValue[0] === rangeValue[0]
+        ? rangeValue[0]
+        : intermediateTextFieldValue[0];
+
+    const upperTextFieldValue =
+      intermediateTextFieldValue[1] === rangeValue[1]
+        ? rangeValue[1]
+        : intermediateTextFieldValue[1];
+
+    return (
+      <LegacyCard sectioned title="Minimum requirements">
+        <div onKeyDown={handleEnterKeyPress}>
+          <RangeSlider
+            output
+            label="Money spent is between"
+            value={rangeValue}
             prefix={prefix}
             min={min}
             max={max}
             step={step}
-            onChange={handleLowerTextFieldChange}
-            onBlur={handleLowerTextFieldBlur}
-            autoComplete="off"
+            onChange={handleRangeSliderChange}
           />
-          <TextField
-            label="Max money spent"
-            type="number"
-            value={`${upperTextFieldValue}`}
-            prefix={prefix}
-            min={min}
-            max={max}
-            step={step}
-            onChange={handleUpperTextFieldChange}
-            onBlur={handleUpperTextFieldBlur}
-            autoComplete="off"
-          />
-        </LegacyStack>
-      </div>
-    </LegacyCard>
-  );
-}
+          <LegacyStack distribution="equalSpacing" spacing="extraLoose">
+            <TextField
+              label="Min money spent"
+              type="number"
+              value={`${lowerTextFieldValue}`}
+              prefix={prefix}
+              min={min}
+              max={max}
+              step={step}
+              onChange={handleLowerTextFieldChange}
+              onBlur={handleLowerTextFieldBlur}
+              autoComplete="off"
+            />
+            <TextField
+              label="Max money spent"
+              type="number"
+              value={`${upperTextFieldValue}`}
+              prefix={prefix}
+              min={min}
+              max={max}
+              step={step}
+              onChange={handleUpperTextFieldChange}
+              onBlur={handleUpperTextFieldBlur}
+              autoComplete="off"
+            />
+          </LegacyStack>
+        </div>
+      </LegacyCard>
+    );
+  },
+};

--- a/polaris-react/src/components/ResourceItem/ResourceItem.stories.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Avatar,
   LegacyCard,
@@ -11,359 +11,405 @@ import type {ResourceListProps} from '@shopify/polaris';
 
 export default {
   component: ResourceItem,
-} as ComponentMeta<typeof ResourceItem>;
+} as Meta<typeof ResourceItem>;
 
-export function Default() {
-  const [selectedItems, setSelectedItems] = useState<
-    ResourceListProps['selectedItems']
-  >([]);
+export const Default = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState<
+      ResourceListProps['selectedItems']
+    >([]);
 
-  return (
-    <LegacyCard>
-      <ResourceList
-        resourceName={{singular: 'blog post', plural: 'blog posts'}}
-        items={[
-          {
-            id: '6',
-            url: '#',
-            title: 'How To Get Value From Wireframes',
-            author: 'Jonathan Mangrove',
-          },
-        ]}
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        selectable
-        renderItem={(item) => {
-          const {id, url, title, author} = item;
-          const authorMarkup = author ? <div>by {author}</div> : null;
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              accessibilityLabel={`View details for ${title}`}
-              name={title}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {title}
-                </Text>
-              </h3>
-              {authorMarkup}
-            </ResourceItem>
-          );
-        }}
-      />
-    </LegacyCard>
-  );
-}
+    return (
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'blog post', plural: 'blog posts'}}
+          items={[
+            {
+              id: '6',
+              url: '#',
+              title: 'How To Get Value From Wireframes',
+              author: 'Jonathan Mangrove',
+            },
+          ]}
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          selectable
+          renderItem={(item) => {
+            const {id, url, title, author} = item;
+            const authorMarkup = author ? <div>by {author}</div> : null;
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                accessibilityLabel={`View details for ${title}`}
+                name={title}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {title}
+                  </Text>
+                </h3>
+                {authorMarkup}
+              </ResourceItem>
+            );
+          }}
+        />
+      </LegacyCard>
+    );
+  },
+};
 
-export function SelectableWithMedia() {
-  const [selectedItems, setSelectedItems] = useState<
-    ResourceListProps['selectedItems']
-  >([]);
+export const SelectableWithMedia = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState<
+      ResourceListProps['selectedItems']
+    >([]);
 
-  return (
-    <LegacyCard>
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        selectable
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        items={[
-          {
-            id: '145',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
-            name: 'Yi So-Yeon',
-            location: 'Gwangju, South Korea',
-          },
-          {
-            id: '146',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/woman-standing-in-front-of-yellow-background.jpg?width=746',
-            name: 'Jane Smith',
-            location: 'Manhattan, New York',
-          },
-          {
-            id: '147',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/relaxing-in-headphones.jpg?width=746',
-            name: 'Grace Baker',
-            location: 'Los Angeles, California',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, avatarSource, name, location} = item;
+    return (
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          selectable
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          items={[
+            {
+              id: '145',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
+              name: 'Yi So-Yeon',
+              location: 'Gwangju, South Korea',
+            },
+            {
+              id: '146',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/woman-standing-in-front-of-yellow-background.jpg?width=746',
+              name: 'Jane Smith',
+              location: 'Manhattan, New York',
+            },
+            {
+              id: '147',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/relaxing-in-headphones.jpg?width=746',
+              name: 'Grace Baker',
+              location: 'Los Angeles, California',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, avatarSource, name, location} = item;
 
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={
-                <Avatar customer size="md" name={name} source={avatarSource} />
-              }
-              accessibilityLabel={`View details for ${name}`}
-              name={name}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </LegacyCard>
-  );
-}
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={
+                  <Avatar
+                    customer
+                    size="md"
+                    name={name}
+                    source={avatarSource}
+                  />
+                }
+                accessibilityLabel={`View details for ${name}`}
+                name={name}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithMedia() {
-  return (
-    <LegacyCard>
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: '145',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
-            name: 'Yi So-Yeon',
-            location: 'Gwangju, South Korea',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, avatarSource, name, location} = item;
+export const WithMedia = {
+  render() {
+    return (
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
+            {
+              id: '145',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
+              name: 'Yi So-Yeon',
+              location: 'Gwangju, South Korea',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, avatarSource, name, location} = item;
 
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={
-                <Avatar customer size="md" name={name} source={avatarSource} />
-              }
-              accessibilityLabel={`View details for ${name}`}
-              name={name}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </LegacyCard>
-  );
-}
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={
+                  <Avatar
+                    customer
+                    size="md"
+                    name={name}
+                    source={avatarSource}
+                  />
+                }
+                accessibilityLabel={`View details for ${name}`}
+                name={name}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithShortcutActions() {
-  return (
-    <LegacyCard>
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: '145',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
-            name: 'Yi So-Yeon',
-            location: 'Gwangju, South Korea',
-            latestOrderUrl: '#latestOrderUrl',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, avatarSource, name, location, latestOrderUrl} = item;
+export const WithShortcutActions = {
+  render() {
+    return (
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
+            {
+              id: '145',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
+              name: 'Yi So-Yeon',
+              location: 'Gwangju, South Korea',
+              latestOrderUrl: '#latestOrderUrl',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, avatarSource, name, location, latestOrderUrl} =
+              item;
 
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={
-                <Avatar customer size="md" name={name} source={avatarSource} />
-              }
-              shortcutActions={[
-                {content: 'View latest order', url: latestOrderUrl},
-              ]}
-              accessibilityLabel={`View details for ${name}`}
-              name={name}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </LegacyCard>
-  );
-}
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={
+                  <Avatar
+                    customer
+                    size="md"
+                    name={name}
+                    source={avatarSource}
+                  />
+                }
+                shortcutActions={[
+                  {content: 'View latest order', url: latestOrderUrl},
+                ]}
+                accessibilityLabel={`View details for ${name}`}
+                name={name}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithPersistedShortcutActions() {
-  return (
-    <LegacyCard>
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: '145',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
-            name: 'Yi So-Yeon',
-            location: 'Gwangju, South Korea',
-            latestOrderUrl: '#latestOrderUrl',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, avatarSource, name, location, latestOrderUrl} = item;
-          const shortcutActions = latestOrderUrl
-            ? [{content: 'View latest order', url: latestOrderUrl}]
-            : undefined;
+export const WithPersistedShortcutActions = {
+  render() {
+    return (
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
+            {
+              id: '145',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
+              name: 'Yi So-Yeon',
+              location: 'Gwangju, South Korea',
+              latestOrderUrl: '#latestOrderUrl',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, avatarSource, name, location, latestOrderUrl} =
+              item;
+            const shortcutActions = latestOrderUrl
+              ? [{content: 'View latest order', url: latestOrderUrl}]
+              : undefined;
 
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={
-                <Avatar customer size="md" name={name} source={avatarSource} />
-              }
-              persistActions
-              shortcutActions={shortcutActions}
-              accessibilityLabel={`View details for ${name}`}
-              name={name}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </LegacyCard>
-  );
-}
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={
+                  <Avatar
+                    customer
+                    size="md"
+                    name={name}
+                    source={avatarSource}
+                  />
+                }
+                persistActions
+                shortcutActions={shortcutActions}
+                accessibilityLabel={`View details for ${name}`}
+                name={name}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithVerticalAlignment() {
-  return (
-    <LegacyCard>
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: '145',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
-            name: 'Yi So-Yeon',
-            location: 'Gwangju, South Korea',
-            lastOrder: 'Emerald Silk Gown',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, avatarSource, name, location, lastOrder} = item;
-          return (
-            <ResourceItem
-              verticalAlignment="center"
-              id={id}
-              url={url}
-              media={
-                <Avatar customer size="md" name={name} source={avatarSource} />
-              }
-              accessibilityLabel={`View details for ${name}`}
-              name={name}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-              <div>{lastOrder}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </LegacyCard>
-  );
-}
+export const WithVerticalAlignment = {
+  render() {
+    return (
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
+            {
+              id: '145',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
+              name: 'Yi So-Yeon',
+              location: 'Gwangju, South Korea',
+              lastOrder: 'Emerald Silk Gown',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, avatarSource, name, location, lastOrder} = item;
+            return (
+              <ResourceItem
+                verticalAlignment="center"
+                id={id}
+                url={url}
+                media={
+                  <Avatar
+                    customer
+                    size="md"
+                    name={name}
+                    source={avatarSource}
+                  />
+                }
+                accessibilityLabel={`View details for ${name}`}
+                name={name}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+                <div>{lastOrder}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </LegacyCard>
+    );
+  },
+};
 
-export function WithDisabledState() {
-  const [selectedItems, setSelectedItems] = useState<
-    ResourceListProps['selectedItems']
-  >([]);
+export const WithDisabledState = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState<
+      ResourceListProps['selectedItems']
+    >([]);
 
-  return (
-    <LegacyCard>
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        selectable
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        items={[
-          {
-            id: '145',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
-            name: 'Yi So-Yeon',
-            location: 'Gwangju, South Korea',
-          },
-          {
-            id: '146',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/woman-standing-in-front-of-yellow-background.jpg?width=746',
-            name: 'Jane Smith',
-            location: 'Manhattan, New York',
-          },
-          {
-            id: '147',
-            url: '#',
-            avatarSource:
-              'https://burst.shopifycdn.com/photos/relaxing-in-headphones.jpg?width=746',
-            name: 'Grace Baker',
-            location: 'Los Angeles, California',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, avatarSource, name, location} = item;
+    return (
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          selectable
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          items={[
+            {
+              id: '145',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
+              name: 'Yi So-Yeon',
+              location: 'Gwangju, South Korea',
+            },
+            {
+              id: '146',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/woman-standing-in-front-of-yellow-background.jpg?width=746',
+              name: 'Jane Smith',
+              location: 'Manhattan, New York',
+            },
+            {
+              id: '147',
+              url: '#',
+              avatarSource:
+                'https://burst.shopifycdn.com/photos/relaxing-in-headphones.jpg?width=746',
+              name: 'Grace Baker',
+              location: 'Los Angeles, California',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, avatarSource, name, location} = item;
 
-          return (
-            <ResourceItem
-              disabled={id === '145'}
-              id={id}
-              url={url}
-              media={
-                <Avatar customer size="md" name={name} source={avatarSource} />
-              }
-              accessibilityLabel={`View details for ${name}`}
-              name={name}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </LegacyCard>
-  );
-}
+            return (
+              <ResourceItem
+                disabled={id === '145'}
+                id={id}
+                url={url}
+                media={
+                  <Avatar
+                    customer
+                    size="md"
+                    name={name}
+                    source={avatarSource}
+                  />
+                }
+                accessibilityLabel={`View details for ${name}`}
+                name={name}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </LegacyCard>
+    );
+  },
+};

--- a/polaris-react/src/components/ResourceList/ResourceList.stories.tsx
+++ b/polaris-react/src/components/ResourceList/ResourceList.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Avatar,
   Button,
@@ -23,286 +23,213 @@ import {DeleteIcon} from '@shopify/polaris-icons';
 
 export default {
   component: ResourceList,
-} as ComponentMeta<typeof ResourceList>;
+} as Meta<typeof ResourceList>;
 
-export function Default() {
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: 100,
-            url: '#',
-            name: 'Mae Jemison',
-            location: 'Decatur, USA',
-          },
-          {
-            id: 200,
-            url: '#',
-            name: 'Ellen Ochoa',
-            location: 'Los Angeles, USA',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, name, location} = item;
-          const media = <Avatar customer size="md" name={name} />;
+export const Default = {
+  render() {
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
+            {
+              id: 100,
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: 200,
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="md" name={name} />;
 
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={media}
-              accessibilityLabel={`View details for ${name}`}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </Card>
+    );
+  },
+};
+
+export const WithEmptyState = {
+  render() {
+    const items = [];
+    const appliedFilters = [];
+    const filters = [];
+
+    const filterControl = (
+      <LegacyFilters
+        disabled={!items.length}
+        queryValue=""
+        filters={filters}
+        appliedFilters={appliedFilters}
       />
-    </Card>
-  );
-}
+    );
 
-export function WithEmptyState() {
-  const items = [];
-  const appliedFilters = [];
-  const filters = [];
-
-  const filterControl = (
-    <LegacyFilters
-      disabled={!items.length}
-      queryValue=""
-      filters={filters}
-      appliedFilters={appliedFilters}
-    />
-  );
-
-  const emptyStateMarkup =
-    !appliedFilters.length && !items.length ? (
-      <EmptyState
-        heading="Upload a file to get started"
-        action={{content: 'Upload files'}}
-        image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
-      >
-        <Text as="p" variant="bodyMd">
-          You can use the Files section to upload images, videos, and other
-          documents
-        </Text>
-      </EmptyState>
-    ) : undefined;
-
-  return (
-    <Page title="Files">
-      <Layout>
-        <Layout.Section>
-          <Card padding="0" roundedAbove="sm">
-            <ResourceList
-              emptyState={emptyStateMarkup}
-              items={items}
-              renderItem={() => {}}
-              filterControl={filterControl}
-              resourceName={{singular: 'file', plural: 'files'}}
-            />
-          </Card>
-        </Layout.Section>
-      </Layout>
-    </Page>
-  );
-}
-
-export function WithSelectionAndNoBulkActions() {
-  const [selectedItems, setSelectedItems] = useState([]);
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = [
-    {
-      id: 101,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-    },
-    {
-      id: 201,
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-    },
-  ];
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        renderItem={renderItem}
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        selectable
-      />
-    </Card>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
+    const emptyStateMarkup =
+      !appliedFilters.length && !items.length ? (
+        <EmptyState
+          heading="Upload a file to get started"
+          action={{content: 'Upload files'}}
+          image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
+        >
+          <Text as="p" variant="bodyMd">
+            You can use the Files section to upload images, videos, and other
+            documents
+          </Text>
+        </EmptyState>
+      ) : undefined;
 
     return (
-      <ResourceItem
-        id={id}
-        url={url}
-        media={media}
-        accessibilityLabel={`View details for ${name}`}
-      >
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
+      <Page title="Files">
+        <Layout>
+          <Layout.Section>
+            <Card padding="0" roundedAbove="sm">
+              <ResourceList
+                emptyState={emptyStateMarkup}
+                items={items}
+                renderItem={() => {}}
+                filterControl={filterControl}
+                resourceName={{singular: 'file', plural: 'files'}}
+              />
+            </Card>
+          </Layout.Section>
+        </Layout>
+      </Page>
     );
-  }
-}
+  },
+};
 
-export function WithBulkActions() {
-  const [selectedItems, setSelectedItems] = useState([]);
+export const WithSelectionAndNoBulkActions = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState([]);
 
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = [
-    {
-      id: 103,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-    },
-    {
-      id: 203,
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-    },
-  ];
-
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
-
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        renderItem={renderItem}
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        promotedBulkActions={promotedBulkActions}
-        bulkActions={bulkActions}
-      />
-    </Card>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
-
-    return (
-      <ResourceItem
-        id={id}
-        url={url}
-        media={media}
-        accessibilityLabel={`View details for ${name}`}
-      >
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
-    );
-  }
-}
-
-export function WithBulkActionsAndManyItems() {
-  const [selectedItems, setSelectedItems] = useState([]);
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = Array.from({length: 50}, (_, num) => {
-    return {
-      id: `${num}`,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$24,00',
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
     };
-  });
 
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
+    const items = [
+      {
+        id: 101,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+      },
+      {
+        id: 201,
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+      },
+    ];
 
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          renderItem={renderItem}
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          selectable
+        />
+      </Card>
+    );
 
-  return (
-    <BlockStack gap="400">
-      <Card padding="0">
+    function renderItem(item) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
+
+      return (
+        <ResourceItem
+          id={id}
+          url={url}
+          media={media}
+          accessibilityLabel={`View details for ${name}`}
+        >
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+  },
+};
+
+export const WithBulkActions = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState([]);
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const items = [
+      {
+        id: 103,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+      },
+      {
+        id: 203,
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+      },
+    ];
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
+
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    return (
+      <Card padding="0" roundedAbove="sm">
         <ResourceList
           resourceName={resourceName}
           items={items}
@@ -312,1198 +239,1309 @@ export function WithBulkActionsAndManyItems() {
           promotedBulkActions={promotedBulkActions}
           bulkActions={bulkActions}
         />
-        <Box padding="300" borderBlockStartWidth="025" borderColor="border">
-          <InlineStack align="space-between">
-            <div>Total inventory at all locations</div>
-            <div>32069 available</div>
-          </InlineStack>
-        </Box>
       </Card>
-      <Card padding="300">Content of another card</Card>
-    </BlockStack>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
-
-    return (
-      <ResourceItem
-        id={id}
-        url={url}
-        media={media}
-        accessibilityLabel={`View details for ${name}`}
-      >
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
     );
-  }
-}
 
-export function WithLoadingState() {
-  const [selectedItems, setSelectedItems] = useState([]);
+    function renderItem(item) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
 
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = [
-    {
-      id: 104,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-    },
-    {
-      id: 204,
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-    },
-  ];
-
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
-
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        renderItem={renderItem}
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        promotedBulkActions={promotedBulkActions}
-        bulkActions={bulkActions}
-        loading
-      />
-    </Card>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
-
-    return (
-      <ResourceItem
-        id={id}
-        url={url}
-        media={media}
-        accessibilityLabel={`View details for ${name}`}
-      >
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
-    );
-  }
-}
-
-export function WithTotalCount() {
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: 105,
-            url: '#',
-            name: 'Mae Jemison',
-            location: 'Decatur, USA',
-          },
-          {
-            id: 205,
-            url: '#',
-            name: 'Ellen Ochoa',
-            location: 'Los Angeles, USA',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, name, location} = item;
-          const media = <Avatar customer size="md" name={name} />;
-
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={media}
-              accessibilityLabel={`View details for ${name}`}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-        showHeader
-        totalItemsCount={50}
-      />
-    </Card>
-  );
-}
-
-export function WithHeaderContent() {
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        headerContent="Customer details shown below"
-        items={[
-          {
-            id: 105,
-            url: '#',
-            name: 'Mae Jemison',
-            location: 'Decatur, USA',
-          },
-          {
-            id: 205,
-            url: '#',
-            name: 'Ellen Ochoa',
-            location: 'Los Angeles, USA',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, name, location} = item;
-          const media = <Avatar customer size="md" name={name} />;
-
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={media}
-              accessibilityLabel={`View details for ${name}`}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-        showHeader
-      />
-    </Card>
-  );
-}
-
-export function WithSorting() {
-  const [sortValue, setSortValue] = useState('DATE_MODIFIED_DESC');
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = [
-    {
-      id: 106,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-    },
-    {
-      id: 206,
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-    },
-  ];
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        renderItem={renderItem}
-        sortValue={sortValue}
-        sortOptions={[
-          {label: 'Newest update', value: 'DATE_MODIFIED_DESC'},
-          {label: 'Oldest update', value: 'DATE_MODIFIED_ASC'},
-        ]}
-        onSortChange={(selected) => {
-          setSortValue(selected);
-          console.log(`Sort option changed to ${selected}.`);
-        }}
-      />
-    </Card>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
-
-    return (
-      <ResourceItem
-        id={id}
-        url={url}
-        media={media}
-        accessibilityLabel={`View details for ${name}`}
-      >
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
-    );
-  }
-}
-
-export function WithAlternateTool() {
-  const resourceName = {
-    singular: 'Customer',
-    plural: 'Customers',
-  };
-
-  const items = [
-    {
-      id: 107,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-    },
-    {
-      id: 207,
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-    },
-  ];
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        items={items}
-        renderItem={renderItem}
-        resourceName={resourceName}
-        alternateTool={<Button>Email customers</Button>}
-      />
-    </Card>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
-
-    return (
-      <ResourceItem
-        id={id}
-        url={url}
-        media={media}
-        accessibilityLabel={`View details for ${name}`}
-      >
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
-    );
-  }
-}
-
-export function WithFiltering() {
-  const [taggedWith, setTaggedWith] = useState('VIP');
-  const [queryValue, setQueryValue] = useState(null);
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = [
-    {
-      id: 108,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-    },
-    {
-      id: 208,
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-    },
-  ];
-
-  const filters = [
-    {
-      key: 'taggedWith1',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith1',
-          label: disambiguateLabel('taggedWith1', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  const filterControl = (
-    <LegacyFilters
-      queryValue={queryValue}
-      filters={filters}
-      appliedFilters={appliedFilters}
-      onQueryChange={setQueryValue}
-      onQueryClear={handleQueryValueRemove}
-      onClearAll={handleClearAll}
-    >
-      <div style={{paddingLeft: '8px'}}>
-        <Button onClick={() => console.log('New filter saved')}>Save</Button>
-      </div>
-    </LegacyFilters>
-  );
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        renderItem={renderItem}
-        filterControl={filterControl}
-      />
-    </Card>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
-
-    return (
-      <ResourceItem id={id} url={url} media={media}>
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
-    );
-  }
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith1':
-        return `Tagged with ${value}`;
-      default:
-        return value;
+      return (
+        <ResourceItem
+          id={id}
+          url={url}
+          media={media}
+          accessibilityLabel={`View details for ${name}`}
+        >
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
     }
-  }
+  },
+};
 
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
+export const WithBulkActionsAndManyItems = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState([]);
 
-export function WithACustomEmptySearchResultState() {
-  const [taggedWith, setTaggedWith] = useState('VIP');
-  const [queryValue, setQueryValue] = useState(null);
-  const [items, setItems] = useState([]);
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback((value) => {
-    setQueryValue(value);
-    setItems([]);
-  }, []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const filters = [
-    {
-      key: 'taggedWith2',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith2',
-          label: disambiguateLabel('taggedWith2', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  const filterControl = (
-    <LegacyFilters
-      queryValue={queryValue}
-      filters={filters}
-      appliedFilters={appliedFilters}
-      onQueryChange={handleQueryValueChange}
-      onQueryClear={handleQueryValueRemove}
-      onClearAll={handleClearAll}
-    >
-      <div style={{paddingLeft: '8px'}}>
-        <Button onClick={() => console.log('New filter saved')}>Save</Button>
-      </div>
-    </LegacyFilters>
-  );
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        renderItem={renderItem}
-        filterControl={filterControl}
-        emptySearchState={<div>This is a custom empty state</div>}
-      />
-    </Card>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
-
-    return (
-      <ResourceItem id={id} url={url} media={media}>
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
-    );
-  }
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith2':
-        return `Tagged with ${value}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithItemShortcutActions() {
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: 109,
-            url: '#',
-            name: 'Mae Jemison',
-            location: 'Decatur, USA',
-            latestOrderUrl: '#',
-          },
-          {
-            id: 209,
-            url: '#',
-            name: 'Ellen Ochoa',
-            location: 'Los Angeles, USA',
-            latestOrderUrl: '#',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, name, location, latestOrderUrl} = item;
-          const media = <Avatar customer size="md" name={name} />;
-          const shortcutActions = latestOrderUrl
-            ? [
-                {
-                  content: 'View latest order',
-                  accessibilityLabel: `View ${name}’s latest order`,
-                  url: latestOrderUrl,
-                },
-              ]
-            : null;
-
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={media}
-              accessibilityLabel={`View details for ${name}`}
-              shortcutActions={shortcutActions}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </Card>
-  );
-}
-
-export function WithPersistentItemShortcutActions() {
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: 110,
-            url: '#',
-            name: 'Mae Jemison',
-            location: 'Decatur, USA',
-            latestOrderUrl: '#',
-          },
-          {
-            id: 210,
-            url: '#',
-            name: 'Ellen Ochoa',
-            location: 'Los Angeles, USA',
-            latestOrderUrl: '#',
-          },
-        ]}
-        renderItem={(item) => {
-          const {id, url, name, location, latestOrderUrl} = item;
-          const media = <Avatar customer size="md" name={name} />;
-          const shortcutActions = latestOrderUrl
-            ? [
-                {
-                  content: 'View latest order',
-                  accessibilityLabel: `View ${name}’s latest order`,
-                  url: latestOrderUrl,
-                },
-              ]
-            : null;
-
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={media}
-              accessibilityLabel={`View details for ${name}`}
-              shortcutActions={shortcutActions}
-              persistActions
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </Card>
-  );
-}
-
-export function WithMultiselect() {
-  const [selectedItems, setSelectedItems] = useState([]);
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = [
-    {
-      id: 111,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-    },
-    {
-      id: 211,
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-    },
-    {
-      id: 311,
-      url: '#',
-      name: 'Joe Smith',
-      location: 'Arizona, USA',
-    },
-    {
-      id: 411,
-      url: '#',
-      name: 'Haden Jerado',
-      location: 'Decatur, USA',
-    },
-    {
-      id: 511,
-      url: '#',
-      name: 'Tom Thommas',
-      location: 'Florida, USA',
-    },
-    {
-      id: 611,
-      url: '#',
-      name: 'Emily Amrak',
-      location: 'Texas, USA',
-    },
-  ];
-
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
-
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        renderItem={renderItem}
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        promotedBulkActions={promotedBulkActions}
-        bulkActions={bulkActions}
-        resolveItemId={resolveItemIds}
-      />
-    </Card>
-  );
-
-  function renderItem(item, _, index) {
-    const {id, url, name, location} = item;
-    const media = <Avatar customer size="md" name={name} />;
-
-    return (
-      <ResourceItem
-        id={id}
-        url={url}
-        media={media}
-        sortOrder={index}
-        accessibilityLabel={`View details for ${name}`}
-      >
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
-    );
-  }
-
-  function resolveItemIds({id}) {
-    return id;
-  }
-}
-
-export function WithAllOfItsElements() {
-  const [selectedItems, setSelectedItems] = useState([]);
-  const [sortValue, setSortValue] = useState('DATE_MODIFIED_DESC');
-  const [taggedWith, setTaggedWith] = useState('VIP');
-  const [queryValue, setQueryValue] = useState(null);
-
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleClearAll = useCallback(() => {
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [handleQueryValueRemove, handleTaggedWithRemove]);
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = [
-    {
-      id: 112,
-      url: '#',
-      name: 'Mae Jemison',
-      location: 'Decatur, USA',
-      latestOrderUrl: '#',
-    },
-    {
-      id: 212,
-      url: '#',
-      name: 'Ellen Ochoa',
-      location: 'Los Angeles, USA',
-      latestOrderUrl: '#',
-    },
-  ];
-
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
-
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-
-  const filters = [
-    {
-      key: 'taggedWith3',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          autoComplete="off"
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-  ];
-
-  const appliedFilters = !isEmpty(taggedWith)
-    ? [
-        {
-          key: 'taggedWith3',
-          label: disambiguateLabel('taggedWith3', taggedWith),
-          onRemove: handleTaggedWithRemove,
-        },
-      ]
-    : [];
-
-  const filterControl = (
-    <LegacyFilters
-      queryValue={queryValue}
-      filters={filters}
-      appliedFilters={appliedFilters}
-      onQueryChange={handleQueryValueChange}
-      onQueryClear={handleQueryValueRemove}
-      onClearAll={handleClearAll}
-    >
-      <div style={{paddingLeft: '8px'}}>
-        <Button onClick={() => console.log('New filter saved')}>Save</Button>
-      </div>
-    </LegacyFilters>
-  );
-
-  return (
-    <Card padding="0" roundedAbove="sm">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        renderItem={renderItem}
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        promotedBulkActions={promotedBulkActions}
-        bulkActions={bulkActions}
-        sortValue={sortValue}
-        sortOptions={[
-          {label: 'Newest update', value: 'DATE_MODIFIED_DESC'},
-          {label: 'Oldest update', value: 'DATE_MODIFIED_ASC'},
-        ]}
-        onSortChange={(selected) => {
-          setSortValue(selected);
-          console.log(`Sort option changed to ${selected}.`);
-        }}
-        filterControl={filterControl}
-      />
-    </Card>
-  );
-
-  function renderItem(item) {
-    const {id, url, name, location, latestOrderUrl} = item;
-    const media = <Avatar customer size="md" name={name} />;
-    const shortcutActions = latestOrderUrl
-      ? [{content: 'View latest order', url: latestOrderUrl}]
-      : null;
-    return (
-      <ResourceItem
-        id={id}
-        url={url}
-        media={media}
-        accessibilityLabel={`View details for ${name}`}
-        shortcutActions={shortcutActions}
-        persistActions
-      >
-        <h3>
-          <Text fontWeight="bold" as="span">
-            {name}
-          </Text>
-        </h3>
-        <div>{location}</div>
-      </ResourceItem>
-    );
-  }
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'taggedWith3':
-        return `Tagged with ${value}`;
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-
-export function WithPagination() {
-  return (
-    <Card padding="0">
-      <ResourceList
-        resourceName={{singular: 'customer', plural: 'customers'}}
-        items={[
-          {
-            id: 100,
-            url: '#',
-            name: 'Mae Jemison',
-            location: 'Decatur, USA',
-          },
-          {
-            id: 200,
-            url: '#',
-            name: 'Ellen Ochoa',
-            location: 'Los Angeles, USA',
-          },
-        ]}
-        pagination={{
-          hasNext: true,
-          onNext: () => {},
-        }}
-        renderItem={(item) => {
-          const {id, url, name, location} = item;
-          const media = <Avatar customer size="md" name={name} />;
-
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={media}
-              accessibilityLabel={`View details for ${name}`}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </Card>
-  );
-}
-
-export function WithBulkActionsAndPagination() {
-  const [selectedItems, setSelectedItems] = useState<string[] | 'All'>([]);
-
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
-
-  const items = Array.from({length: 50}, (_, num) => {
-    return {
-      id: `${num}`,
-      url: '#',
-      name: `Mae Jemison ${num}`,
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$24,00',
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
     };
-  });
 
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
+    const items = Array.from({length: 50}, (_, num) => {
+      return {
+        id: `${num}`,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$24,00',
+      };
+    });
 
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
-  return (
-    <Card padding="0">
-      <ResourceList
-        resourceName={resourceName}
-        items={items}
-        bulkActions={bulkActions}
-        promotedBulkActions={promotedBulkActions}
-        selectedItems={selectedItems}
-        onSelectionChange={setSelectedItems}
-        pagination={{
-          hasNext: true,
-          onNext: () => {},
-        }}
-        renderItem={(item) => {
-          const {id, url, name, location} = item;
-          const media = <Avatar customer size="md" name={name} />;
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
 
-          return (
-            <ResourceItem
-              id={id}
-              url={url}
-              media={media}
-              accessibilityLabel={`View details for ${name}`}
-            >
-              <h3>
-                <Text fontWeight="bold" as="span">
-                  {name}
-                </Text>
-              </h3>
-              <div>{location}</div>
-            </ResourceItem>
-          );
-        }}
-      />
-    </Card>
-  );
-}
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
 
-export function WithinAModal() {
-  const [active, setActive] = useState(true);
-  const [checked, setChecked] = useState(false);
-  const [selectedItems, setSelectedItems] = useState<string[] | 'All'>([]);
+    return (
+      <BlockStack gap="400">
+        <Card padding="0">
+          <ResourceList
+            resourceName={resourceName}
+            items={items}
+            renderItem={renderItem}
+            selectedItems={selectedItems}
+            onSelectionChange={setSelectedItems}
+            promotedBulkActions={promotedBulkActions}
+            bulkActions={bulkActions}
+          />
+          <Box padding="300" borderBlockStartWidth="025" borderColor="border">
+            <InlineStack align="space-between">
+              <div>Total inventory at all locations</div>
+              <div>32069 available</div>
+            </InlineStack>
+          </Box>
+        </Card>
+        <Card padding="300">Content of another card</Card>
+      </BlockStack>
+    );
 
-  const toggleActive = () => setActive((active) => !active);
+    function renderItem(item) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
 
-  const activator = <Button onClick={toggleActive}>Open</Button>;
+      return (
+        <ResourceItem
+          id={id}
+          url={url}
+          media={media}
+          accessibilityLabel={`View details for ${name}`}
+        >
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+  },
+};
 
-  const resourceName = {
-    singular: 'customer',
-    plural: 'customers',
-  };
+export const WithLoadingState = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState([]);
 
-  const items = Array.from({length: 50}, (_, num) => {
-    return {
-      id: `${num}`,
-      url: '#',
-      name: `Mae Jemison ${num}`,
-      location: 'Decatur, USA',
-      orders: 20,
-      amountSpent: '$24,00',
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
     };
-  });
 
-  const promotedBulkActions = [
-    {
-      content: 'Edit customers',
-      onAction: () => console.log('Todo: implement bulk edit'),
-    },
-  ];
+    const items = [
+      {
+        id: 104,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+      },
+      {
+        id: 204,
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+      },
+    ];
 
-  const bulkActions = [
-    {
-      content: 'Add tags',
-      onAction: () => console.log('Todo: implement bulk add tags'),
-    },
-    {
-      content: 'Remove tags',
-      onAction: () => console.log('Todo: implement bulk remove tags'),
-    },
-    {
-      icon: DeleteIcon,
-      destructive: true,
-      content: 'Delete customers',
-      onAction: () => console.log('Todo: implement bulk delete'),
-    },
-  ];
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
 
-  const listMarkup = (
-    <ResourceList
-      resourceName={resourceName}
-      items={items}
-      bulkActions={bulkActions}
-      promotedBulkActions={promotedBulkActions}
-      selectedItems={selectedItems}
-      onSelectionChange={setSelectedItems}
-      renderItem={(item) => {
-        const {id, url, name, location} = item;
-        const media = <Avatar customer size="md" name={name} />;
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
 
-        return (
-          <ResourceItem
-            id={id}
-            url={url}
-            media={media}
-            accessibilityLabel={`View details for ${name}`}
-          >
-            <h3>
-              <Text fontWeight="bold" as="span">
-                {name}
-              </Text>
-            </h3>
-            <div>{location}</div>
-          </ResourceItem>
-        );
-      }}
-    />
-  );
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          renderItem={renderItem}
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          promotedBulkActions={promotedBulkActions}
+          bulkActions={bulkActions}
+          loading
+        />
+      </Card>
+    );
 
-  return (
-    <Frame>
-      <div style={{height: '500px'}}>
-        <Modal
-          noScroll
-          activator={activator}
-          open={active}
-          onClose={toggleActive}
-          title="Import customers by CSV"
-          primaryAction={{
-            content: 'Import customers',
-            onAction: toggleActive,
-          }}
-          secondaryActions={[
+    function renderItem(item) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
+
+      return (
+        <ResourceItem
+          id={id}
+          url={url}
+          media={media}
+          accessibilityLabel={`View details for ${name}`}
+        >
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+  },
+};
+
+export const WithTotalCount = {
+  render() {
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
             {
-              content: 'Cancel',
-              onAction: toggleActive,
+              id: 105,
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: 205,
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
             },
           ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="md" name={name} />;
+
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+          showHeader
+          totalItemsCount={50}
+        />
+      </Card>
+    );
+  },
+};
+
+export const WithHeaderContent = {
+  render() {
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          headerContent="Customer details shown below"
+          items={[
+            {
+              id: 105,
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: 205,
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="md" name={name} />;
+
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+          showHeader
+        />
+      </Card>
+    );
+  },
+};
+
+export const WithSorting = {
+  render() {
+    const [sortValue, setSortValue] = useState('DATE_MODIFIED_DESC');
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const items = [
+      {
+        id: 106,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+      },
+      {
+        id: 206,
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+      },
+    ];
+
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          renderItem={renderItem}
+          sortValue={sortValue}
+          sortOptions={[
+            {label: 'Newest update', value: 'DATE_MODIFIED_DESC'},
+            {label: 'Oldest update', value: 'DATE_MODIFIED_ASC'},
+          ]}
+          onSortChange={(selected) => {
+            setSortValue(selected);
+            console.log(`Sort option changed to ${selected}.`);
+          }}
+        />
+      </Card>
+    );
+
+    function renderItem(item) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
+
+      return (
+        <ResourceItem
+          id={id}
+          url={url}
+          media={media}
+          accessibilityLabel={`View details for ${name}`}
         >
-          <Box>
-            <Scrollable style={{height: '65dvh'}}>{listMarkup}</Scrollable>
-          </Box>
-        </Modal>
-      </div>
-    </Frame>
-  );
-}
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+  },
+};
+
+export const WithAlternateTool = {
+  render() {
+    const resourceName = {
+      singular: 'Customer',
+      plural: 'Customers',
+    };
+
+    const items = [
+      {
+        id: 107,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+      },
+      {
+        id: 207,
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+      },
+    ];
+
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          items={items}
+          renderItem={renderItem}
+          resourceName={resourceName}
+          alternateTool={<Button>Email customers</Button>}
+        />
+      </Card>
+    );
+
+    function renderItem(item) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
+
+      return (
+        <ResourceItem
+          id={id}
+          url={url}
+          media={media}
+          accessibilityLabel={`View details for ${name}`}
+        >
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+  },
+};
+
+export const WithFiltering = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState('VIP');
+    const [queryValue, setQueryValue] = useState(null);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const items = [
+      {
+        id: 108,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+      },
+      {
+        id: 208,
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+      },
+    ];
+
+    const filters = [
+      {
+        key: 'taggedWith1',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith1',
+            label: disambiguateLabel('taggedWith1', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    const filterControl = (
+      <LegacyFilters
+        queryValue={queryValue}
+        filters={filters}
+        appliedFilters={appliedFilters}
+        onQueryChange={setQueryValue}
+        onQueryClear={handleQueryValueRemove}
+        onClearAll={handleClearAll}
+      >
+        <div style={{paddingLeft: '8px'}}>
+          <Button onClick={() => console.log('New filter saved')}>Save</Button>
+        </div>
+      </LegacyFilters>
+    );
+
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          renderItem={renderItem}
+          filterControl={filterControl}
+        />
+      </Card>
+    );
+
+    function renderItem(item) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
+
+      return (
+        <ResourceItem id={id} url={url} media={media}>
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith1':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithACustomEmptySearchResultState = {
+  render() {
+    const [taggedWith, setTaggedWith] = useState('VIP');
+    const [queryValue, setQueryValue] = useState(null);
+    const [items, setItems] = useState([]);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback((value) => {
+      setQueryValue(value);
+      setItems([]);
+    }, []);
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const filters = [
+      {
+        key: 'taggedWith2',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith2',
+            label: disambiguateLabel('taggedWith2', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    const filterControl = (
+      <LegacyFilters
+        queryValue={queryValue}
+        filters={filters}
+        appliedFilters={appliedFilters}
+        onQueryChange={handleQueryValueChange}
+        onQueryClear={handleQueryValueRemove}
+        onClearAll={handleClearAll}
+      >
+        <div style={{paddingLeft: '8px'}}>
+          <Button onClick={() => console.log('New filter saved')}>Save</Button>
+        </div>
+      </LegacyFilters>
+    );
+
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          renderItem={renderItem}
+          filterControl={filterControl}
+          emptySearchState={<div>This is a custom empty state</div>}
+        />
+      </Card>
+    );
+
+    function renderItem(item) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
+
+      return (
+        <ResourceItem id={id} url={url} media={media}>
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith2':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithItemShortcutActions = {
+  render() {
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
+            {
+              id: 109,
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+              latestOrderUrl: '#',
+            },
+            {
+              id: 209,
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+              latestOrderUrl: '#',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location, latestOrderUrl} = item;
+            const media = <Avatar customer size="md" name={name} />;
+            const shortcutActions = latestOrderUrl
+              ? [
+                  {
+                    content: 'View latest order',
+                    accessibilityLabel: `View ${name}’s latest order`,
+                    url: latestOrderUrl,
+                  },
+                ]
+              : null;
+
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+                shortcutActions={shortcutActions}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </Card>
+    );
+  },
+};
+
+export const WithPersistentItemShortcutActions = {
+  render() {
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
+            {
+              id: 110,
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+              latestOrderUrl: '#',
+            },
+            {
+              id: 210,
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+              latestOrderUrl: '#',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location, latestOrderUrl} = item;
+            const media = <Avatar customer size="md" name={name} />;
+            const shortcutActions = latestOrderUrl
+              ? [
+                  {
+                    content: 'View latest order',
+                    accessibilityLabel: `View ${name}’s latest order`,
+                    url: latestOrderUrl,
+                  },
+                ]
+              : null;
+
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+                shortcutActions={shortcutActions}
+                persistActions
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </Card>
+    );
+  },
+};
+
+export const WithMultiselect = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState([]);
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const items = [
+      {
+        id: 111,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+      },
+      {
+        id: 211,
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+      },
+      {
+        id: 311,
+        url: '#',
+        name: 'Joe Smith',
+        location: 'Arizona, USA',
+      },
+      {
+        id: 411,
+        url: '#',
+        name: 'Haden Jerado',
+        location: 'Decatur, USA',
+      },
+      {
+        id: 511,
+        url: '#',
+        name: 'Tom Thommas',
+        location: 'Florida, USA',
+      },
+      {
+        id: 611,
+        url: '#',
+        name: 'Emily Amrak',
+        location: 'Texas, USA',
+      },
+    ];
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
+
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          renderItem={renderItem}
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          promotedBulkActions={promotedBulkActions}
+          bulkActions={bulkActions}
+          resolveItemId={resolveItemIds}
+        />
+      </Card>
+    );
+
+    function renderItem(item, _, index) {
+      const {id, url, name, location} = item;
+      const media = <Avatar customer size="md" name={name} />;
+
+      return (
+        <ResourceItem
+          id={id}
+          url={url}
+          media={media}
+          sortOrder={index}
+          accessibilityLabel={`View details for ${name}`}
+        >
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+
+    function resolveItemIds({id}) {
+      return id;
+    }
+  },
+};
+
+export const WithAllOfItsElements = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState([]);
+    const [sortValue, setSortValue] = useState('DATE_MODIFIED_DESC');
+    const [taggedWith, setTaggedWith] = useState('VIP');
+    const [queryValue, setQueryValue] = useState(null);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const items = [
+      {
+        id: 112,
+        url: '#',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        latestOrderUrl: '#',
+      },
+      {
+        id: 212,
+        url: '#',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        latestOrderUrl: '#',
+      },
+    ];
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
+
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    const filters = [
+      {
+        key: 'taggedWith3',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            autoComplete="off"
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith3',
+            label: disambiguateLabel('taggedWith3', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    const filterControl = (
+      <LegacyFilters
+        queryValue={queryValue}
+        filters={filters}
+        appliedFilters={appliedFilters}
+        onQueryChange={handleQueryValueChange}
+        onQueryClear={handleQueryValueRemove}
+        onClearAll={handleClearAll}
+      >
+        <div style={{paddingLeft: '8px'}}>
+          <Button onClick={() => console.log('New filter saved')}>Save</Button>
+        </div>
+      </LegacyFilters>
+    );
+
+    return (
+      <Card padding="0" roundedAbove="sm">
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          renderItem={renderItem}
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          promotedBulkActions={promotedBulkActions}
+          bulkActions={bulkActions}
+          sortValue={sortValue}
+          sortOptions={[
+            {label: 'Newest update', value: 'DATE_MODIFIED_DESC'},
+            {label: 'Oldest update', value: 'DATE_MODIFIED_ASC'},
+          ]}
+          onSortChange={(selected) => {
+            setSortValue(selected);
+            console.log(`Sort option changed to ${selected}.`);
+          }}
+          filterControl={filterControl}
+        />
+      </Card>
+    );
+
+    function renderItem(item) {
+      const {id, url, name, location, latestOrderUrl} = item;
+      const media = <Avatar customer size="md" name={name} />;
+      const shortcutActions = latestOrderUrl
+        ? [{content: 'View latest order', url: latestOrderUrl}]
+        : null;
+      return (
+        <ResourceItem
+          id={id}
+          url={url}
+          media={media}
+          accessibilityLabel={`View details for ${name}`}
+          shortcutActions={shortcutActions}
+          persistActions
+        >
+          <h3>
+            <Text fontWeight="bold" as="span">
+              {name}
+            </Text>
+          </h3>
+          <div>{location}</div>
+        </ResourceItem>
+      );
+    }
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith3':
+          return `Tagged with ${value}`;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  },
+};
+
+export const WithPagination = {
+  render() {
+    return (
+      <Card padding="0">
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          items={[
+            {
+              id: 100,
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: 200,
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          pagination={{
+            hasNext: true,
+            onNext: () => {},
+          }}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="md" name={name} />;
+
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </Card>
+    );
+  },
+};
+
+export const WithBulkActionsAndPagination = {
+  render() {
+    const [selectedItems, setSelectedItems] = useState<string[] | 'All'>([]);
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const items = Array.from({length: 50}, (_, num) => {
+      return {
+        id: `${num}`,
+        url: '#',
+        name: `Mae Jemison ${num}`,
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$24,00',
+      };
+    });
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
+
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+    return (
+      <Card padding="0">
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          bulkActions={bulkActions}
+          promotedBulkActions={promotedBulkActions}
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          pagination={{
+            hasNext: true,
+            onNext: () => {},
+          }}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="md" name={name} />;
+
+            return (
+              <ResourceItem
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <h3>
+                  <Text fontWeight="bold" as="span">
+                    {name}
+                  </Text>
+                </h3>
+                <div>{location}</div>
+              </ResourceItem>
+            );
+          }}
+        />
+      </Card>
+    );
+  },
+};
+
+export const WithinAModal = {
+  render() {
+    const [active, setActive] = useState(true);
+    const [checked, setChecked] = useState(false);
+    const [selectedItems, setSelectedItems] = useState<string[] | 'All'>([]);
+
+    const toggleActive = () => setActive((active) => !active);
+
+    const activator = <Button onClick={toggleActive}>Open</Button>;
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
+    };
+
+    const items = Array.from({length: 50}, (_, num) => {
+      return {
+        id: `${num}`,
+        url: '#',
+        name: `Mae Jemison ${num}`,
+        location: 'Decatur, USA',
+        orders: 20,
+        amountSpent: '$24,00',
+      };
+    });
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
+
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        icon: DeleteIcon,
+        destructive: true,
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    const listMarkup = (
+      <ResourceList
+        resourceName={resourceName}
+        items={items}
+        bulkActions={bulkActions}
+        promotedBulkActions={promotedBulkActions}
+        selectedItems={selectedItems}
+        onSelectionChange={setSelectedItems}
+        renderItem={(item) => {
+          const {id, url, name, location} = item;
+          const media = <Avatar customer size="md" name={name} />;
+
+          return (
+            <ResourceItem
+              id={id}
+              url={url}
+              media={media}
+              accessibilityLabel={`View details for ${name}`}
+            >
+              <h3>
+                <Text fontWeight="bold" as="span">
+                  {name}
+                </Text>
+              </h3>
+              <div>{location}</div>
+            </ResourceItem>
+          );
+        }}
+      />
+    );
+
+    return (
+      <Frame>
+        <div style={{height: '500px'}}>
+          <Modal
+            noScroll
+            activator={activator}
+            open={active}
+            onClose={toggleActive}
+            title="Import customers by CSV"
+            primaryAction={{
+              content: 'Import customers',
+              onAction: toggleActive,
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: toggleActive,
+              },
+            ]}
+          >
+            <Box>
+              <Scrollable style={{height: '65dvh'}}>{listMarkup}</Scrollable>
+            </Box>
+          </Modal>
+        </div>
+      </Frame>
+    );
+  },
+};

--- a/polaris-react/src/components/Scrollable/Scrollable.stories.tsx
+++ b/polaris-react/src/components/Scrollable/Scrollable.stories.tsx
@@ -1,5 +1,5 @@
 import React, {ComponentRef, useRef} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Button,
   LegacyCard,
@@ -15,1369 +15,97 @@ import type {ScrollableRef} from '@shopify/polaris';
 
 export default {
   component: Scrollable,
-} as ComponentMeta<typeof Scrollable>;
-
-export function Default() {
-  return (
-    <LegacyCard title="Terms of service" sectioned>
-      <Scrollable shadow style={{height: '200px'}} focusable>
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-      </Scrollable>
-    </LegacyCard>
-  );
-}
-
-export function WithHorizonalScrollPrevention() {
-  return (
-    <Scrollable
-      shadow
-      style={{height: '100px', width: '200px'}}
-      horizontal={false}
-    >
-      <div>
-        <Text as="p" variant="bodyMd">
-          Last updated on: September 6, 2022
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Welcome to Shopify! By signing up for a Shopify Account (as defined in
-          Section 1) or by using any Shopify Services (as defined below), you
-          are agreeing to be bound by the following terms and conditions (the “
-          <strong>Terms of Service</strong>”).
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          As used in these Terms of Service, “<strong>we</strong>”, “
-          <strong>us</strong>”, “<strong>our</strong>” and “
-          <strong>Shopify</strong>” means the applicable Shopify Contracting
-          Party (as defined in Section 13 below), and “<strong>you</strong>”
-          means the Shopify User (if registering for or using a Shopify Service
-          as an individual), or the business employing the Shopify User (if
-          registering for or using a Shopify Service as a business) and any of
-          its affiliates.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Shopify provides a complete commerce platform that enables merchants
-          to unify their commerce activities. Among other features, this
-          platform includes a range of tools for merchants to build and
-          customize online stores, sell in multiple places (including web,
-          mobile, social media, online marketplaces and other online locations
-          (“<strong>Online Services</strong>”) and in person (“
-          <strong>POS Services</strong>”)), manage products, inventory,
-          payments, fulfillment, shipping, business operations, marketing and
-          advertising, and engage with existing and potential customers. Any
-          such service or services offered by Shopify are referred to in these
-          Terms of Services as the “<strong>Service(s)</strong>”. Any new
-          features or tools which are added to the current Services will also be
-          subject to the Terms of Service. You can review the current version of
-          the Terms of Service at any time at
-          <a href="https://www.shopify.com/legal/terms">
-            https://www.shopify.com/legal/terms
-          </a>
-          .
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          You must read, agree with and accept all of the terms and conditions
-          contained or expressly referenced in these Terms of Service, including
-          Shopify’s
-          <a href="https://www.shopify.com/legal/aup">Acceptable Use Policy</a>
-          (“<strong>AUP</strong>”) and
-          <a href="https://www.shopify.com/legal/privacy">Privacy Policy</a>,
-          and, if applicable, the
-          <a href="https://www.shopify.com/legal/eu-terms">
-            Supplementary Terms of Service for E.U. Merchants
-          </a>
-          (“<strong>EU Terms</strong>”), the Shopify
-          <a href="https://www.shopify.com/legal/api-terms">
-            API License and Terms of Use
-          </a>
-          (“<strong>API Terms</strong>”) and the Shopify
-          <a href="https://www.shopify.com/legal/dpa">
-            Data Processing Addendum
-          </a>
-          (“<strong>DPA</strong>”) before you may sign up for a Shopify Account
-          or use any Shopify Service. Additionally, if you offer goods or
-          services in relation to COVID-19, you must read, acknowledge and agree
-          to the
-          <a href="/legal/rules-of-engagement-covid19">
-            Rules of Engagement for Sale of COVID-19 Related Products
-          </a>
-          .
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          <strong>
-            Everyday language summaries are provided for convenience only and
-            appear in bold near each section, but these summaries are not
-            legally binding. Please read the Terms of Service, including any
-            document referred to in these Terms of Service, for the complete
-            picture of your legal requirements. By using Shopify or any Shopify
-            services, you are agreeing to these terms. Be sure to occasionally
-            check back for updates.
-          </strong>
-        </Text>
-      </div>
-    </Scrollable>
-  );
-}
-
-export function WithGutterAndThinDragHandle() {
-  return (
-    <Scrollable
-      shadow
-      style={{height: '100px', width: '200px'}}
-      horizontal={false}
-      scrollbarGutter="stable"
-      scrollbarWidth="thin"
-    >
-      <div>
-        <Text as="p" variant="bodyMd">
-          Last updated on: September 6, 2022
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Welcome to Shopify! By signing up for a Shopify Account (as defined in
-          Section 1) or by using any Shopify Services (as defined below), you
-          are agreeing to be bound by the following terms and conditions (the “
-          <strong>Terms of Service</strong>”).
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          As used in these Terms of Service, “<strong>we</strong>”, “
-          <strong>us</strong>”, “<strong>our</strong>” and “
-          <strong>Shopify</strong>” means the applicable Shopify Contracting
-          Party (as defined in Section 13 below), and “<strong>you</strong>”
-          means the Shopify User (if registering for or using a Shopify Service
-          as an individual), or the business employing the Shopify User (if
-          registering for or using a Shopify Service as a business) and any of
-          its affiliates.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Shopify provides a complete commerce platform that enables merchants
-          to unify their commerce activities. Among other features, this
-          platform includes a range of tools for merchants to build and
-          customize online stores, sell in multiple places (including web,
-          mobile, social media, online marketplaces and other online locations
-          (“<strong>Online Services</strong>”) and in person (“
-          <strong>POS Services</strong>”)), manage products, inventory,
-          payments, fulfillment, shipping, business operations, marketing and
-          advertising, and engage with existing and potential customers. Any
-          such service or services offered by Shopify are referred to in these
-          Terms of Services as the “<strong>Service(s)</strong>”. Any new
-          features or tools which are added to the current Services will also be
-          subject to the Terms of Service. You can review the current version of
-          the Terms of Service at any time at
-          <a href="https://www.shopify.com/legal/terms">
-            https://www.shopify.com/legal/terms
-          </a>
-          .
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          You must read, agree with and accept all of the terms and conditions
-          contained or expressly referenced in these Terms of Service, including
-          Shopify’s
-          <a href="https://www.shopify.com/legal/aup">Acceptable Use Policy</a>
-          (“<strong>AUP</strong>”) and
-          <a href="https://www.shopify.com/legal/privacy">Privacy Policy</a>,
-          and, if applicable, the
-          <a href="https://www.shopify.com/legal/eu-terms">
-            Supplementary Terms of Service for E.U. Merchants
-          </a>
-          (“<strong>EU Terms</strong>”), the Shopify
-          <a href="https://www.shopify.com/legal/api-terms">
-            API License and Terms of Use
-          </a>
-          (“<strong>API Terms</strong>”) and the Shopify
-          <a href="https://www.shopify.com/legal/dpa">
-            Data Processing Addendum
-          </a>
-          (“<strong>DPA</strong>”) before you may sign up for a Shopify Account
-          or use any Shopify Service. Additionally, if you offer goods or
-          services in relation to COVID-19, you must read, acknowledge and agree
-          to the
-          <a href="/legal/rules-of-engagement-covid19">
-            Rules of Engagement for Sale of COVID-19 Related Products
-          </a>
-          .
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          <strong>
-            Everyday language summaries are provided for convenience only and
-            appear in bold near each section, but these summaries are not
-            legally binding. Please read the Terms of Service, including any
-            document referred to in these Terms of Service, for the complete
-            picture of your legal requirements. By using Shopify or any Shopify
-            services, you are agreeing to these terms. Be sure to occasionally
-            check back for updates.
-          </strong>
-        </Text>
-      </div>
-    </Scrollable>
-  );
-}
-
-export function ScrollToChildComponent() {
-  return (
-    <LegacyCard title="Terms of service" sectioned>
-      <Scrollable shadow style={{height: '200px'}}>
-        <ol>
-          <li>Account Terms</li>
-        </ol>
-        <Text as="p" variant="bodyMd">
-          You must be 18 years or older or at least the age of majority in the
-          jurisdiction where you reside or from which you use this Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          To access and use the Services, you must register for a Shopify
-          account (“Account”) by providing your full legal name, current
-          address, phone number, a valid email address, and any other
-          information indicated as required. Shopify may reject your application
-          for an Account, or cancel an existing Account, for any reason, in our
-          sole discretion.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge that Shopify will use the email address you provide as
-          the primary method for communication.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for keeping your password secure. Shopify cannot
-          and will not be liable for any loss or damage from your failure to
-          maintain the security of your Account and password.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for all activity and content such as photos,
-          images, videos, graphics, written content, audio files, code,
-          information, or data uploaded, collected, generated, stored,
-          displayed, distributed, transmitted or exhibited on or in connection
-          with your Account (“Materials”).
-        </Text>
-        <Text as="p" variant="bodyMd">
-          A breach or violation of any term in the Terms of Service, including
-          the AUP, as determined in the sole discretion of Shopify will result
-          in an immediate termination of your services.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for your Account and any Materials you upload to
-          the Shopify Service. Remember that with any violation of these terms
-          we will cancel your service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If we need to reach you, we will send you an email.
-        </Text>
-
-        <ol>
-          <li>Account Activation</li>
-        </ol>
-
-        <Scrollable.ScrollTo />
-        <strong>2.1 Shopify Account</strong>
-
-        <Text as="p" variant="bodyMd">
-          Subject to section 2.1.2, the person signing up for the Service will
-          be the contracting party (“Account Owner”) for the purposes of our
-          Terms of Service and will be the person who is authorized to use any
-          corresponding account we may provide to the Account Owner in
-          connection with the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          If you are signing up for the Service on behalf of your employer, your
-          employer shall be the Account Owner. If you are signing up for the
-          Service on behalf of your employer, then you represent and warrant
-          that you have the authority to bind your employer to our Terms of
-          Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.2 PayPal Express Checkout and Shopify Payments Accounts
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, Shopify will create a
-          PayPal Express Checkout account on your behalf, using your email
-          address. Depending on your location, Shopify may also create a Shopify
-          Payments account on your behalf.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge that PayPal Express Checkout and/or Shopify Payments
-          will be your default payments gateway(s) and that it is your sole
-          responsibility as the Account Owner to activate and maintain these
-          accounts. If you do not wish to keep either of the payment accounts
-          active, it is your responsibility to deactivate them. For the
-          avoidance of doubt, PayPal Express Checkout is a Third Party Service,
-          as defined in Section 15 of these Terms of Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.3 Apple Pay for Safari Account
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, Shopify will create an
-          Apple Pay for Safari (“Apple Pay”) account on your behalf, using the
-          URL(s) and business name associated with your Account. Depending on
-          your location, Shopify may activate your Apple Pay account on your
-          behalf, otherwise you will be required to activate your Apple Pay
-          account within your Account admin. If you do not wish to keep your
-          Apple Pay account active, it is your responsibility to deactivate it.
-          For the avoidance of doubt, Apple Pay is a Third Party Service, as
-          defined in Section 15 of these Terms of Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          If you use an Apple Pay supported payment gateway and your customers
-          have enabled Apple Pay on their device, customers may purchase goods
-          and services from your store using Apple Pay.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By using Apple Pay on your store, you are agreeing to be bound by the
-          Apple Pay Platform Web Merchant Terms and Conditions, as they may be
-          amended by Apple from time to time. If Apple amends the Apple Pay
-          Platform Web Merchant Terms and Conditions, the amended and restated
-          version will be posted here:
-          <a href="https://www.shopify.com/legal/apple-pay">
-            https://www.shopify.com/legal/apple-pay
-          </a>
-          . Such amendments to the Apple Pay Platform Web Merchant Terms are
-          effective as of the date of posting. Your continued use of Apple Pay
-          on your store after the amended Apple Pay Platform Web Merchant Terms
-          are posted constitutes your agreement to, and acceptance of, the
-          amended Apple Pay Platform Web Merchant Terms. If you do not agree to
-          any changes to the Apple Pay Platform Web Merchant Terms, de-activate
-          your Apple Pay account and do not continue to use Apple Pay on your
-          store.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.4 Google Payment
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, if you have been enrolled
-          in Shopify Payments, Shopify will also create a Google Payment account
-          on your behalf. If you do not wish to keep your Google Payment account
-          active, it is your responsibility to deactivate it. For the avoidance
-          of doubt, Google Payment is a Third Party Service, as defined in
-          Section 15 of these Terms of Service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If you use a Google Payment supported payment gateway and your
-          customers have enabled Google Payment, customers may purchase goods
-          and services from your store using Google Payment.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          By using Google Payment on your store, you are agreeing to be bound by
-          the Google Payment API Terms of Service, as they may be amended by
-          Google from time to time. If Google amends the Google Payment API
-          Terms of Service, the amended and restated version will be posted
-          here:
-          <a href="https://payments.developers.google.com/terms/sellertos">
-            https://payments.developers.google.com/terms/sellertos
-          </a>
-          . Such amendments to the Google Payment API Terms of Service are
-          effective as of the date of posting. Your continued use of Google
-          Payment on your store after the amended Google Payment API Terms of
-          Service are posted constitutes your agreement to, and acceptance of,
-          the amended Google Payment API Terms of Service. If you do not agree
-          to any changes to the Google Payment API Terms of Service, de-activate
-          your Google Payment account and do not continue to use Google Payment
-          on your store.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          2.5 Domain Names
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon purchasing a domain name through Shopify, domain registration
-          will be preset to automatically renew each year so long as your
-          Shopify Account remains active. You acknowledge that it is your sole
-          responsibility to deactivate the auto-renewal function should you
-          choose to do so.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The person signing up for the Shopify Service is responsible for the
-          account and is bound by these Terms of Service. If you signup on
-          behalf of your employer, your employer owns the account and is also
-          bound by our Terms of Service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          We automatically create accounts for you to accept payments. You are
-          responsible for activating and deactivating these accounts.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Any domain you purchase through us will automatically renew unless you
-          opt out.
-        </Text>
-
-        <ol>
-          <li>General Conditions</li>
-        </ol>
-        <Text as="p" variant="bodyMd">
-          You must read, agree with and accept all of the terms and conditions
-          contained in these Terms of Service, including the AUP and the Privacy
-          Policy before you may become a member of Shopify.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Technical support is only provided to paying Account holders and is
-          only available via email.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Terms of Service shall be governed by and interpreted in
-          accordance with the laws of the Province of Ontario and the laws of
-          Canada applicable therein, without regard to principles of conflicts
-          of laws. The parties irrevocably and unconditionally submit to the
-          exclusive jurisdiction of the courts of the Province of Ontario with
-          respect to any dispute or claim arising out of or in connection with
-          the Terms of Service. The United Nations Convention on Contracts for
-          the International Sale of Goods will not apply to these Terms of
-          Service and is hereby expressly excluded.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge and agree that Shopify may amend these Terms of
-          Service at any time by posting the relevant amended and restated Terms
-          of Service on Shopify’s website, available at
-          <a href="https://www.shopify.com/legal/terms">
-            https://www.shopify.com/legal/terms
-          </a>
-          and such amendments to the Terms of Service are effective as of the
-          date of posting. Your continued use of the Services after the amended
-          Terms of Service are posted to Shopify’s website constitutes your
-          agreement to, and acceptance of, the amended Terms of Service. If you
-          do not agree to any changes to the Terms of Service, do not continue
-          to use the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You may not use the Shopify service for any illegal or unauthorized
-          purpose nor may you, in the use of the Service, violate any laws in
-          your jurisdiction (including but not limited to copyright laws), the
-          laws applicable to you in your customer’s jurisdiction, or the laws of
-          Canada and the Province of Ontario. You will comply with all
-          applicable laws, rules and regulations in your use of the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You agree not to reproduce, duplicate, copy, sell, resell or exploit
-          any portion of the Service, use of the Service, or access to the
-          Service without the express written permission by Shopify.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You shall not purchase search engine or other pay per click keywords
-          (such as Google AdWords), or domain names that use Shopify or Shopify
-          trademarks and/or variations and misspellings thereof.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Questions about the Terms of Service should be sent to
-          <a href="mailto:support@shopify.com">support@shopify.com</a>.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You understand that your Materials (not including credit card
-          information), may be transferred unencrypted and involve (a)
-          transmissions over various networks; and (b) changes to conform and
-          adapt to technical requirements of connecting networks or devices.
-          Credit Card information is always encrypted during transfer over
-          networks.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge and agree that your use of the Service, including
-          information transmitted to or stored by Shopify, is governed by its
-          privacy policy at
-          <a href="https://www.shopify.com/legal/privacy">
-            https://www.shopify.com/legal/privacy
-          </a>
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Terms of Service may be available in languages other than English.
-          To the extent of any inconsistencies or conflicts between these
-          English Terms of Service and Shopify’s Terms of Service available in
-          another language, the most current English version of the Terms of
-          Service at
-          <a href="https://www.shopify.com/legal/terms">
-            https://www.shopify.com/legal/terms
-          </a>
-          will prevail.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Shopify service belongs to us. You are not allowed to rip it off
-          or use it for any illegal or sketchy purpose.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If a dispute arises the issue will be dealt with in the Province of
-          Ontario.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Your Materials may be transferred unencrypted and may be altered, but
-          credit card information is always encrypted.
-        </Text>
-      </Scrollable>
-    </LegacyCard>
-  );
-}
-
-export function WithScrollHint() {
-  return (
-    <LegacyCard title="Terms of service" sectioned>
-      <Scrollable hint shadow style={{height: '200px'}} focusable>
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-      </Scrollable>
-    </LegacyCard>
-  );
-}
-
-export function OnScrolledToBottom() {
-  return (
-    <LegacyCard title="Terms of service" sectioned>
-      <Scrollable
-        focusable
-        style={{height: '200px'}}
-        onScrolledToBottom={() => console.log('scrolled to bottom')}
-      >
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By signing up for the Shopify service (“Service”) or any of the
-          services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
-          the following terms and conditions (“Terms of Service”). The Services
-          offered by Shopify under the Terms of Service include various products
-          and services to help you create and manage a retail store, whether an
-          online store (“Online Services”), a physical retail store (“POS
-          Services”), or both. Any new features or tools which are added to the
-          current Service shall be also subject to the Terms of Service. You can
-          review the current version of the Terms of Service at any time at
-          https://www.shopify.com/legal/terms. Shopify reserves the right to
-          update and change the Terms of Service by posting updates and changes
-          to the Shopify website. You are advised to check the Terms of Service
-          from time to time for any updates or changes that may impact you.
-        </Text>
-      </Scrollable>
-    </LegacyCard>
-  );
-}
-
-export function UsingScrollToFromRef() {
-  const scrollRef = useRef<ScrollableRef>(null);
-
-  const handleOnClick = () => {
-    scrollRef.current?.scrollTo(0);
-  };
-
-  return (
-    <LegacyCard title="Terms of service" sectioned>
-      <Scrollable ref={scrollRef} shadow style={{height: '200px'}}>
-        <ol>
-          <li>Account Terms</li>
-        </ol>
-        <Text as="p" variant="bodyMd">
-          You must be 18 years or older or at least the age of majority in the
-          jurisdiction where you reside or from which you use this Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          To access and use the Services, you must register for a Shopify
-          account (“Account”) by providing your full legal name, current
-          address, phone number, a valid email address, and any other
-          information indicated as required. Shopify may reject your application
-          for an Account, or cancel an existing Account, for any reason, in our
-          sole discretion.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge that Shopify will use the email address you provide as
-          the primary method for communication.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for keeping your password secure. Shopify cannot
-          and will not be liable for any loss or damage from your failure to
-          maintain the security of your Account and password.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for all activity and content such as photos,
-          images, videos, graphics, written content, audio files, code,
-          information, or data uploaded, collected, generated, stored,
-          displayed, distributed, transmitted or exhibited on or in connection
-          with your Account (“Materials”).
-        </Text>
-        <Text as="p" variant="bodyMd">
-          A breach or violation of any term in the Terms of Service, including
-          the AUP, as determined in the sole discretion of Shopify will result
-          in an immediate termination of your services.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for your Account and any Materials you upload to
-          the Shopify Service. Remember that with any violation of these terms
-          we will cancel your service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If we need to reach you, we will send you an email.
-        </Text>
-
-        <ol>
-          <li>Account Activation</li>
-        </ol>
-
-        <strong>2.1 Shopify Account</strong>
-
-        <Text as="p" variant="bodyMd">
-          Subject to section 2.1.2, the person signing up for the Service will
-          be the contracting party (“Account Owner”) for the purposes of our
-          Terms of Service and will be the person who is authorized to use any
-          corresponding account we may provide to the Account Owner in
-          connection with the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          If you are signing up for the Service on behalf of your employer, your
-          employer shall be the Account Owner. If you are signing up for the
-          Service on behalf of your employer, then you represent and warrant
-          that you have the authority to bind your employer to our Terms of
-          Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.2 PayPal Express Checkout and Shopify Payments Accounts
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, Shopify will create a
-          PayPal Express Checkout account on your behalf, using your email
-          address. Depending on your location, Shopify may also create a Shopify
-          Payments account on your behalf.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge that PayPal Express Checkout and/or Shopify Payments
-          will be your default payments gateway(s) and that it is your sole
-          responsibility as the Account Owner to activate and maintain these
-          accounts. If you do not wish to keep either of the payment accounts
-          active, it is your responsibility to deactivate them. For the
-          avoidance of doubt, PayPal Express Checkout is a Third Party Service,
-          as defined in Section 15 of these Terms of Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.3 Apple Pay for Safari Account
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, Shopify will create an
-          Apple Pay for Safari (“Apple Pay”) account on your behalf, using the
-          URL(s) and business name associated with your Account. Depending on
-          your location, Shopify may activate your Apple Pay account on your
-          behalf, otherwise you will be required to activate your Apple Pay
-          account within your Account admin. If you do not wish to keep your
-          Apple Pay account active, it is your responsibility to deactivate it.
-          For the avoidance of doubt, Apple Pay is a Third Party Service, as
-          defined in Section 15 of these Terms of Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          If you use an Apple Pay supported payment gateway and your customers
-          have enabled Apple Pay on their device, customers may purchase goods
-          and services from your store using Apple Pay.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By using Apple Pay on your store, you are agreeing to be bound by the
-          Apple Pay Platform Web Merchant Terms and Conditions, as they may be
-          amended by Apple from time to time. If Apple amends the Apple Pay
-          Platform Web Merchant Terms and Conditions, the amended and restated
-          version will be posted here:
-          <a href="https://www.shopify.com/legal/apple-pay">
-            https://www.shopify.com/legal/apple-pay
-          </a>
-          . Such amendments to the Apple Pay Platform Web Merchant Terms are
-          effective as of the date of posting. Your continued use of Apple Pay
-          on your store after the amended Apple Pay Platform Web Merchant Terms
-          are posted constitutes your agreement to, and acceptance of, the
-          amended Apple Pay Platform Web Merchant Terms. If you do not agree to
-          any changes to the Apple Pay Platform Web Merchant Terms, de-activate
-          your Apple Pay account and do not continue to use Apple Pay on your
-          store.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.4 Google Payment
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, if you have been enrolled
-          in Shopify Payments, Shopify will also create a Google Payment account
-          on your behalf. If you do not wish to keep your Google Payment account
-          active, it is your responsibility to deactivate it. For the avoidance
-          of doubt, Google Payment is a Third Party Service, as defined in
-          Section 15 of these Terms of Service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If you use a Google Payment supported payment gateway and your
-          customers have enabled Google Payment, customers may purchase goods
-          and services from your store using Google Payment.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          By using Google Payment on your store, you are agreeing to be bound by
-          the Google Payment API Terms of Service, as they may be amended by
-          Google from time to time. If Google amends the Google Payment API
-          Terms of Service, the amended and restated version will be posted
-          here:
-          <a href="https://payments.developers.google.com/terms/sellertos">
-            https://payments.developers.google.com/terms/sellertos
-          </a>
-          . Such amendments to the Google Payment API Terms of Service are
-          effective as of the date of posting. Your continued use of Google
-          Payment on your store after the amended Google Payment API Terms of
-          Service are posted constitutes your agreement to, and acceptance of,
-          the amended Google Payment API Terms of Service. If you do not agree
-          to any changes to the Google Payment API Terms of Service, de-activate
-          your Google Payment account and do not continue to use Google Payment
-          on your store.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          2.5 Domain Names
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon purchasing a domain name through Shopify, domain registration
-          will be preset to automatically renew each year so long as your
-          Shopify Account remains active. You acknowledge that it is your sole
-          responsibility to deactivate the auto-renewal function should you
-          choose to do so.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The person signing up for the Shopify Service is responsible for the
-          account and is bound by these Terms of Service. If you signup on
-          behalf of your employer, your employer owns the account and is also
-          bound by our Terms of Service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          We automatically create accounts for you to accept payments. You are
-          responsible for activating and deactivating these accounts.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Any domain you purchase through us will automatically renew unless you
-          opt out.
-        </Text>
-
-        <ol>
-          <li>General Conditions</li>
-        </ol>
-        <Text as="p" variant="bodyMd">
-          You must read, agree with and accept all of the terms and conditions
-          contained in these Terms of Service, including the AUP and the Privacy
-          Policy before you may become a member of Shopify.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Technical support is only provided to paying Account holders and is
-          only available via email.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Terms of Service shall be governed by and interpreted in
-          accordance with the laws of the Province of Ontario and the laws of
-          Canada applicable therein, without regard to principles of conflicts
-          of laws. The parties irrevocably and unconditionally submit to the
-          exclusive jurisdiction of the courts of the Province of Ontario with
-          respect to any dispute or claim arising out of or in connection with
-          the Terms of Service. The United Nations Convention on Contracts for
-          the International Sale of Goods will not apply to these Terms of
-          Service and is hereby expressly excluded.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge and agree that Shopify may amend these Terms of
-          Service at any time by posting the relevant amended and restated Terms
-          of Service on Shopify’s website, available at
-          <a href="https://www.shopify.com/legal/terms">
-            https://www.shopify.com/legal/terms
-          </a>
-          and such amendments to the Terms of Service are effective as of the
-          date of posting. Your continued use of the Services after the amended
-          Terms of Service are posted to Shopify’s website constitutes your
-          agreement to, and acceptance of, the amended Terms of Service. If you
-          do not agree to any changes to the Terms of Service, do not continue
-          to use the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You may not use the Shopify service for any illegal or unauthorized
-          purpose nor may you, in the use of the Service, violate any laws in
-          your jurisdiction (including but not limited to copyright laws), the
-          laws applicable to you in your customer’s jurisdiction, or the laws of
-          Canada and the Province of Ontario. You will comply with all
-          applicable laws, rules and regulations in your use of the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You agree not to reproduce, duplicate, copy, sell, resell or exploit
-          any portion of the Service, use of the Service, or access to the
-          Service without the express written permission by Shopify.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You shall not purchase search engine or other pay per click keywords
-          (such as Google AdWords), or domain names that use Shopify or Shopify
-          trademarks and/or variations and misspellings thereof.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Questions about the Terms of Service should be sent to
-          <a href="mailto:support@shopify.com">support@shopify.com</a>.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You understand that your Materials (not including credit card
-          information), may be transferred unencrypted and involve (a)
-          transmissions over various networks; and (b) changes to conform and
-          adapt to technical requirements of connecting networks or devices.
-          Credit Card information is always encrypted during transfer over
-          networks.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge and agree that your use of the Service, including
-          information transmitted to or stored by Shopify, is governed by its
-          privacy policy at
-          <a href="https://www.shopify.com/legal/privacy">
-            https://www.shopify.com/legal/privacy
-          </a>
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Terms of Service may be available in languages other than English.
-          To the extent of any inconsistencies or conflicts between these
-          English Terms of Service and Shopify’s Terms of Service available in
-          another language, the most current English version of the Terms of
-          Service at
-          <a href="https://www.shopify.com/legal/terms">
-            https://www.shopify.com/legal/terms
-          </a>
-          will prevail.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Shopify service belongs to us. You are not allowed to rip it off
-          or use it for any illegal or sketchy purpose.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If a dispute arises the issue will be dealt with in the Province of
-          Ontario.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Your Materials may be transferred unencrypted and may be altered, but
-          credit card information is always encrypted.
-        </Text>
-        <Button onClick={handleOnClick}>Scroll to top</Button>
-      </Scrollable>
-    </LegacyCard>
-  );
-}
-
-export function UsingInstantScrollToFromRef() {
-  const scrollRef = useRef<ScrollableRef>(null);
-
-  const handleOnClick = () => {
-    scrollRef.current?.scrollTo(0, {behavior: 'instant'});
-  };
-
-  return (
-    <LegacyCard title="Terms of service" sectioned>
-      <Scrollable ref={scrollRef} shadow style={{height: '200px'}}>
-        <ol>
-          <li>Account Terms</li>
-        </ol>
-        <Text as="p" variant="bodyMd">
-          You must be 18 years or older or at least the age of majority in the
-          jurisdiction where you reside or from which you use this Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          To access and use the Services, you must register for a Shopify
-          account (“Account”) by providing your full legal name, current
-          address, phone number, a valid email address, and any other
-          information indicated as required. Shopify may reject your application
-          for an Account, or cancel an existing Account, for any reason, in our
-          sole discretion.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge that Shopify will use the email address you provide as
-          the primary method for communication.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for keeping your password secure. Shopify cannot
-          and will not be liable for any loss or damage from your failure to
-          maintain the security of your Account and password.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for all activity and content such as photos,
-          images, videos, graphics, written content, audio files, code,
-          information, or data uploaded, collected, generated, stored,
-          displayed, distributed, transmitted or exhibited on or in connection
-          with your Account (“Materials”).
-        </Text>
-        <Text as="p" variant="bodyMd">
-          A breach or violation of any term in the Terms of Service, including
-          the AUP, as determined in the sole discretion of Shopify will result
-          in an immediate termination of your services.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You are responsible for your Account and any Materials you upload to
-          the Shopify Service. Remember that with any violation of these terms
-          we will cancel your service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If we need to reach you, we will send you an email.
-        </Text>
-
-        <ol>
-          <li>Account Activation</li>
-        </ol>
-
-        <strong>2.1 Shopify Account</strong>
-
-        <Text as="p" variant="bodyMd">
-          Subject to section 2.1.2, the person signing up for the Service will
-          be the contracting party (“Account Owner”) for the purposes of our
-          Terms of Service and will be the person who is authorized to use any
-          corresponding account we may provide to the Account Owner in
-          connection with the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          If you are signing up for the Service on behalf of your employer, your
-          employer shall be the Account Owner. If you are signing up for the
-          Service on behalf of your employer, then you represent and warrant
-          that you have the authority to bind your employer to our Terms of
-          Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.2 PayPal Express Checkout and Shopify Payments Accounts
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, Shopify will create a
-          PayPal Express Checkout account on your behalf, using your email
-          address. Depending on your location, Shopify may also create a Shopify
-          Payments account on your behalf.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge that PayPal Express Checkout and/or Shopify Payments
-          will be your default payments gateway(s) and that it is your sole
-          responsibility as the Account Owner to activate and maintain these
-          accounts. If you do not wish to keep either of the payment accounts
-          active, it is your responsibility to deactivate them. For the
-          avoidance of doubt, PayPal Express Checkout is a Third Party Service,
-          as defined in Section 15 of these Terms of Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.3 Apple Pay for Safari Account
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, Shopify will create an
-          Apple Pay for Safari (“Apple Pay”) account on your behalf, using the
-          URL(s) and business name associated with your Account. Depending on
-          your location, Shopify may activate your Apple Pay account on your
-          behalf, otherwise you will be required to activate your Apple Pay
-          account within your Account admin. If you do not wish to keep your
-          Apple Pay account active, it is your responsibility to deactivate it.
-          For the avoidance of doubt, Apple Pay is a Third Party Service, as
-          defined in Section 15 of these Terms of Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          If you use an Apple Pay supported payment gateway and your customers
-          have enabled Apple Pay on their device, customers may purchase goods
-          and services from your store using Apple Pay.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          By using Apple Pay on your store, you are agreeing to be bound by the
-          Apple Pay Platform Web Merchant Terms and Conditions, as they may be
-          amended by Apple from time to time. If Apple amends the Apple Pay
-          Platform Web Merchant Terms and Conditions, the amended and restated
-          version will be posted here:
-          <a href="https://www.shopify.com/legal/apple-pay">
-            https://www.shopify.com/legal/apple-pay
-          </a>
-          . Such amendments to the Apple Pay Platform Web Merchant Terms are
-          effective as of the date of posting. Your continued use of Apple Pay
-          on your store after the amended Apple Pay Platform Web Merchant Terms
-          are posted constitutes your agreement to, and acceptance of, the
-          amended Apple Pay Platform Web Merchant Terms. If you do not agree to
-          any changes to the Apple Pay Platform Web Merchant Terms, de-activate
-          your Apple Pay account and do not continue to use Apple Pay on your
-          store.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          2.4 Google Payment
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon completion of sign up for the Service, if you have been enrolled
-          in Shopify Payments, Shopify will also create a Google Payment account
-          on your behalf. If you do not wish to keep your Google Payment account
-          active, it is your responsibility to deactivate it. For the avoidance
-          of doubt, Google Payment is a Third Party Service, as defined in
-          Section 15 of these Terms of Service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If you use a Google Payment supported payment gateway and your
-          customers have enabled Google Payment, customers may purchase goods
-          and services from your store using Google Payment.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          By using Google Payment on your store, you are agreeing to be bound by
-          the Google Payment API Terms of Service, as they may be amended by
-          Google from time to time. If Google amends the Google Payment API
-          Terms of Service, the amended and restated version will be posted
-          here:
-          <a href="https://payments.developers.google.com/terms/sellertos">
-            https://payments.developers.google.com/terms/sellertos
-          </a>
-          . Such amendments to the Google Payment API Terms of Service are
-          effective as of the date of posting. Your continued use of Google
-          Payment on your store after the amended Google Payment API Terms of
-          Service are posted constitutes your agreement to, and acceptance of,
-          the amended Google Payment API Terms of Service. If you do not agree
-          to any changes to the Google Payment API Terms of Service, de-activate
-          your Google Payment account and do not continue to use Google Payment
-          on your store.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          2.5 Domain Names
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Upon purchasing a domain name through Shopify, domain registration
-          will be preset to automatically renew each year so long as your
-          Shopify Account remains active. You acknowledge that it is your sole
-          responsibility to deactivate the auto-renewal function should you
-          choose to do so.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The person signing up for the Shopify Service is responsible for the
-          account and is bound by these Terms of Service. If you signup on
-          behalf of your employer, your employer owns the account and is also
-          bound by our Terms of Service.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          We automatically create accounts for you to accept payments. You are
-          responsible for activating and deactivating these accounts.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Any domain you purchase through us will automatically renew unless you
-          opt out.
-        </Text>
-
-        <ol>
-          <li>General Conditions</li>
-        </ol>
-        <Text as="p" variant="bodyMd">
-          You must read, agree with and accept all of the terms and conditions
-          contained in these Terms of Service, including the AUP and the Privacy
-          Policy before you may become a member of Shopify.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Technical support is only provided to paying Account holders and is
-          only available via email.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Terms of Service shall be governed by and interpreted in
-          accordance with the laws of the Province of Ontario and the laws of
-          Canada applicable therein, without regard to principles of conflicts
-          of laws. The parties irrevocably and unconditionally submit to the
-          exclusive jurisdiction of the courts of the Province of Ontario with
-          respect to any dispute or claim arising out of or in connection with
-          the Terms of Service. The United Nations Convention on Contracts for
-          the International Sale of Goods will not apply to these Terms of
-          Service and is hereby expressly excluded.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge and agree that Shopify may amend these Terms of
-          Service at any time by posting the relevant amended and restated Terms
-          of Service on Shopify’s website, available at
-          <a href="https://www.shopify.com/legal/terms">
-            https://www.shopify.com/legal/terms
-          </a>
-          and such amendments to the Terms of Service are effective as of the
-          date of posting. Your continued use of the Services after the amended
-          Terms of Service are posted to Shopify’s website constitutes your
-          agreement to, and acceptance of, the amended Terms of Service. If you
-          do not agree to any changes to the Terms of Service, do not continue
-          to use the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You may not use the Shopify service for any illegal or unauthorized
-          purpose nor may you, in the use of the Service, violate any laws in
-          your jurisdiction (including but not limited to copyright laws), the
-          laws applicable to you in your customer’s jurisdiction, or the laws of
-          Canada and the Province of Ontario. You will comply with all
-          applicable laws, rules and regulations in your use of the Service.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You agree not to reproduce, duplicate, copy, sell, resell or exploit
-          any portion of the Service, use of the Service, or access to the
-          Service without the express written permission by Shopify.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You shall not purchase search engine or other pay per click keywords
-          (such as Google AdWords), or domain names that use Shopify or Shopify
-          trademarks and/or variations and misspellings thereof.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Questions about the Terms of Service should be sent to
-          <a href="mailto:support@shopify.com">support@shopify.com</a>.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You understand that your Materials (not including credit card
-          information), may be transferred unencrypted and involve (a)
-          transmissions over various networks; and (b) changes to conform and
-          adapt to technical requirements of connecting networks or devices.
-          Credit Card information is always encrypted during transfer over
-          networks.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          You acknowledge and agree that your use of the Service, including
-          information transmitted to or stored by Shopify, is governed by its
-          privacy policy at
-          <a href="https://www.shopify.com/legal/privacy">
-            https://www.shopify.com/legal/privacy
-          </a>
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Terms of Service may be available in languages other than English.
-          To the extent of any inconsistencies or conflicts between these
-          English Terms of Service and Shopify’s Terms of Service available in
-          another language, the most current English version of the Terms of
-          Service at
-          <a href="https://www.shopify.com/legal/terms">
-            https://www.shopify.com/legal/terms
-          </a>
-          will prevail.
-        </Text>
-        <Text as="p" variant="bodyMd">
-          Which means
-        </Text>
-        <Text as="p" variant="bodyMd">
-          The Shopify service belongs to us. You are not allowed to rip it off
-          or use it for any illegal or sketchy purpose.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          If a dispute arises the issue will be dealt with in the Province of
-          Ontario.
-        </Text>
-
-        <Text as="p" variant="bodyMd">
-          Your Materials may be transferred unencrypted and may be altered, but
-          credit card information is always encrypted.
-        </Text>
-        <Button onClick={handleOnClick}>Scroll to top</Button>
-      </Scrollable>
-    </LegacyCard>
-  );
-}
-
-export function WithShadowOverComplexChildren() {
-  return (
-    <BlockStack gap="400">
-      <Text as="p" variant="bodyLg" fontWeight="bold">
-        NOTE: Red shadow is for demo/debug purposes only.
-        <br />
-        DO NOT do this in production.
-      </Text>
+} as Meta<typeof Scrollable>;
+
+export const Default = {
+  render() {
+    return (
+      <LegacyCard title="Terms of service" sectioned>
+        <Scrollable shadow style={{height: '200px'}} focusable>
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+        </Scrollable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithHorizonalScrollPrevention = {
+  render() {
+    return (
       <Scrollable
         shadow
-        style={{
-          height: '200px',
-          maxWidth: '40rem',
-          backgroundColor: 'var(--p-color-bg-surface)',
-          // Setting red here so the storybook is really obvious that the shadow
-          // overlays the content (particularly the banner)
-          /* @ts-expect-error TS doesn't understand CSS vars */
-          '--pc-scrollable-shadow-color': 'rgba(255, 0, 0, 0.85)',
-        }}
+        style={{height: '100px', width: '200px'}}
+        horizontal={false}
       >
-        <Box padding="400">
-          <Banner title="Payment details">
-            <Text as="p" variant="bodyMd">
-              Last updated on: September 6, 2022
-            </Text>
+        <div>
+          <Text as="p" variant="bodyMd">
+            Last updated on: September 6, 2022
+          </Text>
 
-            <Text as="p" variant="bodyMd">
-              Welcome to Shopify! By signing up for a Shopify Account (as
-              defined in Section 1) or by using any Shopify Services (as defined
-              below), you are agreeing to be bound by the following terms and
-              conditions (the “<strong>Terms of Service</strong>”).
-            </Text>
+          <Text as="p" variant="bodyMd">
+            Welcome to Shopify! By signing up for a Shopify Account (as defined
+            in Section 1) or by using any Shopify Services (as defined below),
+            you are agreeing to be bound by the following terms and conditions
+            (the “<strong>Terms of Service</strong>”).
+          </Text>
 
-            <Text as="p" variant="bodyMd">
-              As used in these Terms of Service, “<strong>we</strong>”, “
-              <strong>us</strong>”, “<strong>our</strong>” and “
-              <strong>Shopify</strong>” means the applicable Shopify Contracting
-              Party (as defined in Section 13 below), and “<strong>you</strong>”
-              means the Shopify User (if registering for or using a Shopify
-              Service as an individual), or the business employing the Shopify
-              User (if registering for or using a Shopify Service as a business)
-              and any of its affiliates.
-            </Text>
-          </Banner>
-
-          <FormLayout>
-            <FormLayout.Group>
-              <TextField label="First name" autoComplete="off" />
-              <TextField label="Last name" autoComplete="off" />
-            </FormLayout.Group>
-
-            <FormLayout.Group>
-              <TextField label="Address" autoComplete="off" />
-              <TextField label="Apartment, suite, etc." autoComplete="off" />
-            </FormLayout.Group>
-
-            <FormLayout.Group>
-              <TextField label="City" autoComplete="off" />
-              <TextField label="Province" autoComplete="off" />
-              <TextField label="Postal code" autoComplete="off" />
-            </FormLayout.Group>
-          </FormLayout>
+          <Text as="p" variant="bodyMd">
+            As used in these Terms of Service, “<strong>we</strong>”, “
+            <strong>us</strong>”, “<strong>our</strong>” and “
+            <strong>Shopify</strong>” means the applicable Shopify Contracting
+            Party (as defined in Section 13 below), and “<strong>you</strong>”
+            means the Shopify User (if registering for or using a Shopify
+            Service as an individual), or the business employing the Shopify
+            User (if registering for or using a Shopify Service as a business)
+            and any of its affiliates.
+          </Text>
 
           <Text as="p" variant="bodyMd">
             Shopify provides a complete commerce platform that enables merchants
@@ -1399,6 +127,7 @@ export function WithShadowOverComplexChildren() {
             </a>
             .
           </Text>
+
           <Text as="p" variant="bodyMd">
             You must read, agree with and accept all of the terms and conditions
             contained or expressly referenced in these Terms of Service,
@@ -1441,8 +170,1311 @@ export function WithShadowOverComplexChildren() {
               occasionally check back for updates.
             </strong>
           </Text>
-        </Box>
+        </div>
       </Scrollable>
-    </BlockStack>
-  );
-}
+    );
+  },
+};
+
+export const WithGutterAndThinDragHandle = {
+  render() {
+    return (
+      <Scrollable
+        shadow
+        style={{height: '100px', width: '200px'}}
+        horizontal={false}
+        scrollbarGutter="stable"
+        scrollbarWidth="thin"
+      >
+        <div>
+          <Text as="p" variant="bodyMd">
+            Last updated on: September 6, 2022
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Welcome to Shopify! By signing up for a Shopify Account (as defined
+            in Section 1) or by using any Shopify Services (as defined below),
+            you are agreeing to be bound by the following terms and conditions
+            (the “<strong>Terms of Service</strong>”).
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            As used in these Terms of Service, “<strong>we</strong>”, “
+            <strong>us</strong>”, “<strong>our</strong>” and “
+            <strong>Shopify</strong>” means the applicable Shopify Contracting
+            Party (as defined in Section 13 below), and “<strong>you</strong>”
+            means the Shopify User (if registering for or using a Shopify
+            Service as an individual), or the business employing the Shopify
+            User (if registering for or using a Shopify Service as a business)
+            and any of its affiliates.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Shopify provides a complete commerce platform that enables merchants
+            to unify their commerce activities. Among other features, this
+            platform includes a range of tools for merchants to build and
+            customize online stores, sell in multiple places (including web,
+            mobile, social media, online marketplaces and other online locations
+            (“<strong>Online Services</strong>”) and in person (“
+            <strong>POS Services</strong>”)), manage products, inventory,
+            payments, fulfillment, shipping, business operations, marketing and
+            advertising, and engage with existing and potential customers. Any
+            such service or services offered by Shopify are referred to in these
+            Terms of Services as the “<strong>Service(s)</strong>”. Any new
+            features or tools which are added to the current Services will also
+            be subject to the Terms of Service. You can review the current
+            version of the Terms of Service at any time at
+            <a href="https://www.shopify.com/legal/terms">
+              https://www.shopify.com/legal/terms
+            </a>
+            .
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            You must read, agree with and accept all of the terms and conditions
+            contained or expressly referenced in these Terms of Service,
+            including Shopify’s
+            <a href="https://www.shopify.com/legal/aup">
+              Acceptable Use Policy
+            </a>
+            (“<strong>AUP</strong>”) and
+            <a href="https://www.shopify.com/legal/privacy">Privacy Policy</a>,
+            and, if applicable, the
+            <a href="https://www.shopify.com/legal/eu-terms">
+              Supplementary Terms of Service for E.U. Merchants
+            </a>
+            (“<strong>EU Terms</strong>”), the Shopify
+            <a href="https://www.shopify.com/legal/api-terms">
+              API License and Terms of Use
+            </a>
+            (“<strong>API Terms</strong>”) and the Shopify
+            <a href="https://www.shopify.com/legal/dpa">
+              Data Processing Addendum
+            </a>
+            (“<strong>DPA</strong>”) before you may sign up for a Shopify
+            Account or use any Shopify Service. Additionally, if you offer goods
+            or services in relation to COVID-19, you must read, acknowledge and
+            agree to the
+            <a href="/legal/rules-of-engagement-covid19">
+              Rules of Engagement for Sale of COVID-19 Related Products
+            </a>
+            .
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            <strong>
+              Everyday language summaries are provided for convenience only and
+              appear in bold near each section, but these summaries are not
+              legally binding. Please read the Terms of Service, including any
+              document referred to in these Terms of Service, for the complete
+              picture of your legal requirements. By using Shopify or any
+              Shopify services, you are agreeing to these terms. Be sure to
+              occasionally check back for updates.
+            </strong>
+          </Text>
+        </div>
+      </Scrollable>
+    );
+  },
+};
+
+export const ScrollToChildComponent = {
+  render() {
+    return (
+      <LegacyCard title="Terms of service" sectioned>
+        <Scrollable shadow style={{height: '200px'}}>
+          <ol>
+            <li>Account Terms</li>
+          </ol>
+          <Text as="p" variant="bodyMd">
+            You must be 18 years or older or at least the age of majority in the
+            jurisdiction where you reside or from which you use this Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            To access and use the Services, you must register for a Shopify
+            account (“Account”) by providing your full legal name, current
+            address, phone number, a valid email address, and any other
+            information indicated as required. Shopify may reject your
+            application for an Account, or cancel an existing Account, for any
+            reason, in our sole discretion.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge that Shopify will use the email address you provide
+            as the primary method for communication.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for keeping your password secure. Shopify cannot
+            and will not be liable for any loss or damage from your failure to
+            maintain the security of your Account and password.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for all activity and content such as photos,
+            images, videos, graphics, written content, audio files, code,
+            information, or data uploaded, collected, generated, stored,
+            displayed, distributed, transmitted or exhibited on or in connection
+            with your Account (“Materials”).
+          </Text>
+          <Text as="p" variant="bodyMd">
+            A breach or violation of any term in the Terms of Service, including
+            the AUP, as determined in the sole discretion of Shopify will result
+            in an immediate termination of your services.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for your Account and any Materials you upload to
+            the Shopify Service. Remember that with any violation of these terms
+            we will cancel your service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If we need to reach you, we will send you an email.
+          </Text>
+
+          <ol>
+            <li>Account Activation</li>
+          </ol>
+
+          <Scrollable.ScrollTo />
+          <strong>2.1 Shopify Account</strong>
+
+          <Text as="p" variant="bodyMd">
+            Subject to section 2.1.2, the person signing up for the Service will
+            be the contracting party (“Account Owner”) for the purposes of our
+            Terms of Service and will be the person who is authorized to use any
+            corresponding account we may provide to the Account Owner in
+            connection with the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            If you are signing up for the Service on behalf of your employer,
+            your employer shall be the Account Owner. If you are signing up for
+            the Service on behalf of your employer, then you represent and
+            warrant that you have the authority to bind your employer to our
+            Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.2 PayPal Express Checkout and Shopify Payments Accounts
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, Shopify will create a
+            PayPal Express Checkout account on your behalf, using your email
+            address. Depending on your location, Shopify may also create a
+            Shopify Payments account on your behalf.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge that PayPal Express Checkout and/or Shopify Payments
+            will be your default payments gateway(s) and that it is your sole
+            responsibility as the Account Owner to activate and maintain these
+            accounts. If you do not wish to keep either of the payment accounts
+            active, it is your responsibility to deactivate them. For the
+            avoidance of doubt, PayPal Express Checkout is a Third Party
+            Service, as defined in Section 15 of these Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.3 Apple Pay for Safari Account
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, Shopify will create an
+            Apple Pay for Safari (“Apple Pay”) account on your behalf, using the
+            URL(s) and business name associated with your Account. Depending on
+            your location, Shopify may activate your Apple Pay account on your
+            behalf, otherwise you will be required to activate your Apple Pay
+            account within your Account admin. If you do not wish to keep your
+            Apple Pay account active, it is your responsibility to deactivate
+            it. For the avoidance of doubt, Apple Pay is a Third Party Service,
+            as defined in Section 15 of these Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            If you use an Apple Pay supported payment gateway and your customers
+            have enabled Apple Pay on their device, customers may purchase goods
+            and services from your store using Apple Pay.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By using Apple Pay on your store, you are agreeing to be bound by
+            the Apple Pay Platform Web Merchant Terms and Conditions, as they
+            may be amended by Apple from time to time. If Apple amends the Apple
+            Pay Platform Web Merchant Terms and Conditions, the amended and
+            restated version will be posted here:
+            <a href="https://www.shopify.com/legal/apple-pay">
+              https://www.shopify.com/legal/apple-pay
+            </a>
+            . Such amendments to the Apple Pay Platform Web Merchant Terms are
+            effective as of the date of posting. Your continued use of Apple Pay
+            on your store after the amended Apple Pay Platform Web Merchant
+            Terms are posted constitutes your agreement to, and acceptance of,
+            the amended Apple Pay Platform Web Merchant Terms. If you do not
+            agree to any changes to the Apple Pay Platform Web Merchant Terms,
+            de-activate your Apple Pay account and do not continue to use Apple
+            Pay on your store.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.4 Google Payment
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, if you have been
+            enrolled in Shopify Payments, Shopify will also create a Google
+            Payment account on your behalf. If you do not wish to keep your
+            Google Payment account active, it is your responsibility to
+            deactivate it. For the avoidance of doubt, Google Payment is a Third
+            Party Service, as defined in Section 15 of these Terms of Service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If you use a Google Payment supported payment gateway and your
+            customers have enabled Google Payment, customers may purchase goods
+            and services from your store using Google Payment.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            By using Google Payment on your store, you are agreeing to be bound
+            by the Google Payment API Terms of Service, as they may be amended
+            by Google from time to time. If Google amends the Google Payment API
+            Terms of Service, the amended and restated version will be posted
+            here:
+            <a href="https://payments.developers.google.com/terms/sellertos">
+              https://payments.developers.google.com/terms/sellertos
+            </a>
+            . Such amendments to the Google Payment API Terms of Service are
+            effective as of the date of posting. Your continued use of Google
+            Payment on your store after the amended Google Payment API Terms of
+            Service are posted constitutes your agreement to, and acceptance of,
+            the amended Google Payment API Terms of Service. If you do not agree
+            to any changes to the Google Payment API Terms of Service,
+            de-activate your Google Payment account and do not continue to use
+            Google Payment on your store.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            2.5 Domain Names
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon purchasing a domain name through Shopify, domain registration
+            will be preset to automatically renew each year so long as your
+            Shopify Account remains active. You acknowledge that it is your sole
+            responsibility to deactivate the auto-renewal function should you
+            choose to do so.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The person signing up for the Shopify Service is responsible for the
+            account and is bound by these Terms of Service. If you signup on
+            behalf of your employer, your employer owns the account and is also
+            bound by our Terms of Service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            We automatically create accounts for you to accept payments. You are
+            responsible for activating and deactivating these accounts.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Any domain you purchase through us will automatically renew unless
+            you opt out.
+          </Text>
+
+          <ol>
+            <li>General Conditions</li>
+          </ol>
+          <Text as="p" variant="bodyMd">
+            You must read, agree with and accept all of the terms and conditions
+            contained in these Terms of Service, including the AUP and the
+            Privacy Policy before you may become a member of Shopify.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Technical support is only provided to paying Account holders and is
+            only available via email.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Terms of Service shall be governed by and interpreted in
+            accordance with the laws of the Province of Ontario and the laws of
+            Canada applicable therein, without regard to principles of conflicts
+            of laws. The parties irrevocably and unconditionally submit to the
+            exclusive jurisdiction of the courts of the Province of Ontario with
+            respect to any dispute or claim arising out of or in connection with
+            the Terms of Service. The United Nations Convention on Contracts for
+            the International Sale of Goods will not apply to these Terms of
+            Service and is hereby expressly excluded.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge and agree that Shopify may amend these Terms of
+            Service at any time by posting the relevant amended and restated
+            Terms of Service on Shopify’s website, available at
+            <a href="https://www.shopify.com/legal/terms">
+              https://www.shopify.com/legal/terms
+            </a>
+            and such amendments to the Terms of Service are effective as of the
+            date of posting. Your continued use of the Services after the
+            amended Terms of Service are posted to Shopify’s website constitutes
+            your agreement to, and acceptance of, the amended Terms of Service.
+            If you do not agree to any changes to the Terms of Service, do not
+            continue to use the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You may not use the Shopify service for any illegal or unauthorized
+            purpose nor may you, in the use of the Service, violate any laws in
+            your jurisdiction (including but not limited to copyright laws), the
+            laws applicable to you in your customer’s jurisdiction, or the laws
+            of Canada and the Province of Ontario. You will comply with all
+            applicable laws, rules and regulations in your use of the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You agree not to reproduce, duplicate, copy, sell, resell or exploit
+            any portion of the Service, use of the Service, or access to the
+            Service without the express written permission by Shopify.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You shall not purchase search engine or other pay per click keywords
+            (such as Google AdWords), or domain names that use Shopify or
+            Shopify trademarks and/or variations and misspellings thereof.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Questions about the Terms of Service should be sent to
+            <a href="mailto:support@shopify.com">support@shopify.com</a>.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You understand that your Materials (not including credit card
+            information), may be transferred unencrypted and involve (a)
+            transmissions over various networks; and (b) changes to conform and
+            adapt to technical requirements of connecting networks or devices.
+            Credit Card information is always encrypted during transfer over
+            networks.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge and agree that your use of the Service, including
+            information transmitted to or stored by Shopify, is governed by its
+            privacy policy at
+            <a href="https://www.shopify.com/legal/privacy">
+              https://www.shopify.com/legal/privacy
+            </a>
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Terms of Service may be available in languages other than
+            English. To the extent of any inconsistencies or conflicts between
+            these English Terms of Service and Shopify’s Terms of Service
+            available in another language, the most current English version of
+            the Terms of Service at
+            <a href="https://www.shopify.com/legal/terms">
+              https://www.shopify.com/legal/terms
+            </a>
+            will prevail.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Shopify service belongs to us. You are not allowed to rip it off
+            or use it for any illegal or sketchy purpose.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If a dispute arises the issue will be dealt with in the Province of
+            Ontario.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Your Materials may be transferred unencrypted and may be altered,
+            but credit card information is always encrypted.
+          </Text>
+        </Scrollable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithScrollHint = {
+  render() {
+    return (
+      <LegacyCard title="Terms of service" sectioned>
+        <Scrollable hint shadow style={{height: '200px'}} focusable>
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+        </Scrollable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const OnScrolledToBottom = {
+  render() {
+    return (
+      <LegacyCard title="Terms of service" sectioned>
+        <Scrollable
+          focusable
+          style={{height: '200px'}}
+          onScrolledToBottom={() => console.log('scrolled to bottom')}
+        >
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By signing up for the Shopify service (“Service”) or any of the
+            services of Shopify Inc. (“Shopify”) you are agreeing to be bound by
+            the following terms and conditions (“Terms of Service”). The
+            Services offered by Shopify under the Terms of Service include
+            various products and services to help you create and manage a retail
+            store, whether an online store (“Online Services”), a physical
+            retail store (“POS Services”), or both. Any new features or tools
+            which are added to the current Service shall be also subject to the
+            Terms of Service. You can review the current version of the Terms of
+            Service at any time at https://www.shopify.com/legal/terms. Shopify
+            reserves the right to update and change the Terms of Service by
+            posting updates and changes to the Shopify website. You are advised
+            to check the Terms of Service from time to time for any updates or
+            changes that may impact you.
+          </Text>
+        </Scrollable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const UsingScrollToFromRef = {
+  render() {
+    const scrollRef = useRef<ScrollableRef>(null);
+
+    const handleOnClick = () => {
+      scrollRef.current?.scrollTo(0);
+    };
+
+    return (
+      <LegacyCard title="Terms of service" sectioned>
+        <Scrollable ref={scrollRef} shadow style={{height: '200px'}}>
+          <ol>
+            <li>Account Terms</li>
+          </ol>
+          <Text as="p" variant="bodyMd">
+            You must be 18 years or older or at least the age of majority in the
+            jurisdiction where you reside or from which you use this Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            To access and use the Services, you must register for a Shopify
+            account (“Account”) by providing your full legal name, current
+            address, phone number, a valid email address, and any other
+            information indicated as required. Shopify may reject your
+            application for an Account, or cancel an existing Account, for any
+            reason, in our sole discretion.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge that Shopify will use the email address you provide
+            as the primary method for communication.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for keeping your password secure. Shopify cannot
+            and will not be liable for any loss or damage from your failure to
+            maintain the security of your Account and password.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for all activity and content such as photos,
+            images, videos, graphics, written content, audio files, code,
+            information, or data uploaded, collected, generated, stored,
+            displayed, distributed, transmitted or exhibited on or in connection
+            with your Account (“Materials”).
+          </Text>
+          <Text as="p" variant="bodyMd">
+            A breach or violation of any term in the Terms of Service, including
+            the AUP, as determined in the sole discretion of Shopify will result
+            in an immediate termination of your services.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for your Account and any Materials you upload to
+            the Shopify Service. Remember that with any violation of these terms
+            we will cancel your service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If we need to reach you, we will send you an email.
+          </Text>
+
+          <ol>
+            <li>Account Activation</li>
+          </ol>
+
+          <strong>2.1 Shopify Account</strong>
+
+          <Text as="p" variant="bodyMd">
+            Subject to section 2.1.2, the person signing up for the Service will
+            be the contracting party (“Account Owner”) for the purposes of our
+            Terms of Service and will be the person who is authorized to use any
+            corresponding account we may provide to the Account Owner in
+            connection with the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            If you are signing up for the Service on behalf of your employer,
+            your employer shall be the Account Owner. If you are signing up for
+            the Service on behalf of your employer, then you represent and
+            warrant that you have the authority to bind your employer to our
+            Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.2 PayPal Express Checkout and Shopify Payments Accounts
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, Shopify will create a
+            PayPal Express Checkout account on your behalf, using your email
+            address. Depending on your location, Shopify may also create a
+            Shopify Payments account on your behalf.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge that PayPal Express Checkout and/or Shopify Payments
+            will be your default payments gateway(s) and that it is your sole
+            responsibility as the Account Owner to activate and maintain these
+            accounts. If you do not wish to keep either of the payment accounts
+            active, it is your responsibility to deactivate them. For the
+            avoidance of doubt, PayPal Express Checkout is a Third Party
+            Service, as defined in Section 15 of these Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.3 Apple Pay for Safari Account
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, Shopify will create an
+            Apple Pay for Safari (“Apple Pay”) account on your behalf, using the
+            URL(s) and business name associated with your Account. Depending on
+            your location, Shopify may activate your Apple Pay account on your
+            behalf, otherwise you will be required to activate your Apple Pay
+            account within your Account admin. If you do not wish to keep your
+            Apple Pay account active, it is your responsibility to deactivate
+            it. For the avoidance of doubt, Apple Pay is a Third Party Service,
+            as defined in Section 15 of these Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            If you use an Apple Pay supported payment gateway and your customers
+            have enabled Apple Pay on their device, customers may purchase goods
+            and services from your store using Apple Pay.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By using Apple Pay on your store, you are agreeing to be bound by
+            the Apple Pay Platform Web Merchant Terms and Conditions, as they
+            may be amended by Apple from time to time. If Apple amends the Apple
+            Pay Platform Web Merchant Terms and Conditions, the amended and
+            restated version will be posted here:
+            <a href="https://www.shopify.com/legal/apple-pay">
+              https://www.shopify.com/legal/apple-pay
+            </a>
+            . Such amendments to the Apple Pay Platform Web Merchant Terms are
+            effective as of the date of posting. Your continued use of Apple Pay
+            on your store after the amended Apple Pay Platform Web Merchant
+            Terms are posted constitutes your agreement to, and acceptance of,
+            the amended Apple Pay Platform Web Merchant Terms. If you do not
+            agree to any changes to the Apple Pay Platform Web Merchant Terms,
+            de-activate your Apple Pay account and do not continue to use Apple
+            Pay on your store.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.4 Google Payment
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, if you have been
+            enrolled in Shopify Payments, Shopify will also create a Google
+            Payment account on your behalf. If you do not wish to keep your
+            Google Payment account active, it is your responsibility to
+            deactivate it. For the avoidance of doubt, Google Payment is a Third
+            Party Service, as defined in Section 15 of these Terms of Service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If you use a Google Payment supported payment gateway and your
+            customers have enabled Google Payment, customers may purchase goods
+            and services from your store using Google Payment.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            By using Google Payment on your store, you are agreeing to be bound
+            by the Google Payment API Terms of Service, as they may be amended
+            by Google from time to time. If Google amends the Google Payment API
+            Terms of Service, the amended and restated version will be posted
+            here:
+            <a href="https://payments.developers.google.com/terms/sellertos">
+              https://payments.developers.google.com/terms/sellertos
+            </a>
+            . Such amendments to the Google Payment API Terms of Service are
+            effective as of the date of posting. Your continued use of Google
+            Payment on your store after the amended Google Payment API Terms of
+            Service are posted constitutes your agreement to, and acceptance of,
+            the amended Google Payment API Terms of Service. If you do not agree
+            to any changes to the Google Payment API Terms of Service,
+            de-activate your Google Payment account and do not continue to use
+            Google Payment on your store.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            2.5 Domain Names
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon purchasing a domain name through Shopify, domain registration
+            will be preset to automatically renew each year so long as your
+            Shopify Account remains active. You acknowledge that it is your sole
+            responsibility to deactivate the auto-renewal function should you
+            choose to do so.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The person signing up for the Shopify Service is responsible for the
+            account and is bound by these Terms of Service. If you signup on
+            behalf of your employer, your employer owns the account and is also
+            bound by our Terms of Service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            We automatically create accounts for you to accept payments. You are
+            responsible for activating and deactivating these accounts.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Any domain you purchase through us will automatically renew unless
+            you opt out.
+          </Text>
+
+          <ol>
+            <li>General Conditions</li>
+          </ol>
+          <Text as="p" variant="bodyMd">
+            You must read, agree with and accept all of the terms and conditions
+            contained in these Terms of Service, including the AUP and the
+            Privacy Policy before you may become a member of Shopify.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Technical support is only provided to paying Account holders and is
+            only available via email.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Terms of Service shall be governed by and interpreted in
+            accordance with the laws of the Province of Ontario and the laws of
+            Canada applicable therein, without regard to principles of conflicts
+            of laws. The parties irrevocably and unconditionally submit to the
+            exclusive jurisdiction of the courts of the Province of Ontario with
+            respect to any dispute or claim arising out of or in connection with
+            the Terms of Service. The United Nations Convention on Contracts for
+            the International Sale of Goods will not apply to these Terms of
+            Service and is hereby expressly excluded.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge and agree that Shopify may amend these Terms of
+            Service at any time by posting the relevant amended and restated
+            Terms of Service on Shopify’s website, available at
+            <a href="https://www.shopify.com/legal/terms">
+              https://www.shopify.com/legal/terms
+            </a>
+            and such amendments to the Terms of Service are effective as of the
+            date of posting. Your continued use of the Services after the
+            amended Terms of Service are posted to Shopify’s website constitutes
+            your agreement to, and acceptance of, the amended Terms of Service.
+            If you do not agree to any changes to the Terms of Service, do not
+            continue to use the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You may not use the Shopify service for any illegal or unauthorized
+            purpose nor may you, in the use of the Service, violate any laws in
+            your jurisdiction (including but not limited to copyright laws), the
+            laws applicable to you in your customer’s jurisdiction, or the laws
+            of Canada and the Province of Ontario. You will comply with all
+            applicable laws, rules and regulations in your use of the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You agree not to reproduce, duplicate, copy, sell, resell or exploit
+            any portion of the Service, use of the Service, or access to the
+            Service without the express written permission by Shopify.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You shall not purchase search engine or other pay per click keywords
+            (such as Google AdWords), or domain names that use Shopify or
+            Shopify trademarks and/or variations and misspellings thereof.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Questions about the Terms of Service should be sent to
+            <a href="mailto:support@shopify.com">support@shopify.com</a>.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You understand that your Materials (not including credit card
+            information), may be transferred unencrypted and involve (a)
+            transmissions over various networks; and (b) changes to conform and
+            adapt to technical requirements of connecting networks or devices.
+            Credit Card information is always encrypted during transfer over
+            networks.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge and agree that your use of the Service, including
+            information transmitted to or stored by Shopify, is governed by its
+            privacy policy at
+            <a href="https://www.shopify.com/legal/privacy">
+              https://www.shopify.com/legal/privacy
+            </a>
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Terms of Service may be available in languages other than
+            English. To the extent of any inconsistencies or conflicts between
+            these English Terms of Service and Shopify’s Terms of Service
+            available in another language, the most current English version of
+            the Terms of Service at
+            <a href="https://www.shopify.com/legal/terms">
+              https://www.shopify.com/legal/terms
+            </a>
+            will prevail.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Shopify service belongs to us. You are not allowed to rip it off
+            or use it for any illegal or sketchy purpose.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If a dispute arises the issue will be dealt with in the Province of
+            Ontario.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Your Materials may be transferred unencrypted and may be altered,
+            but credit card information is always encrypted.
+          </Text>
+          <Button onClick={handleOnClick}>Scroll to top</Button>
+        </Scrollable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const UsingInstantScrollToFromRef = {
+  render() {
+    const scrollRef = useRef<ScrollableRef>(null);
+
+    const handleOnClick = () => {
+      scrollRef.current?.scrollTo(0, {behavior: 'instant'});
+    };
+
+    return (
+      <LegacyCard title="Terms of service" sectioned>
+        <Scrollable ref={scrollRef} shadow style={{height: '200px'}}>
+          <ol>
+            <li>Account Terms</li>
+          </ol>
+          <Text as="p" variant="bodyMd">
+            You must be 18 years or older or at least the age of majority in the
+            jurisdiction where you reside or from which you use this Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            To access and use the Services, you must register for a Shopify
+            account (“Account”) by providing your full legal name, current
+            address, phone number, a valid email address, and any other
+            information indicated as required. Shopify may reject your
+            application for an Account, or cancel an existing Account, for any
+            reason, in our sole discretion.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge that Shopify will use the email address you provide
+            as the primary method for communication.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for keeping your password secure. Shopify cannot
+            and will not be liable for any loss or damage from your failure to
+            maintain the security of your Account and password.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for all activity and content such as photos,
+            images, videos, graphics, written content, audio files, code,
+            information, or data uploaded, collected, generated, stored,
+            displayed, distributed, transmitted or exhibited on or in connection
+            with your Account (“Materials”).
+          </Text>
+          <Text as="p" variant="bodyMd">
+            A breach or violation of any term in the Terms of Service, including
+            the AUP, as determined in the sole discretion of Shopify will result
+            in an immediate termination of your services.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You are responsible for your Account and any Materials you upload to
+            the Shopify Service. Remember that with any violation of these terms
+            we will cancel your service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If we need to reach you, we will send you an email.
+          </Text>
+
+          <ol>
+            <li>Account Activation</li>
+          </ol>
+
+          <strong>2.1 Shopify Account</strong>
+
+          <Text as="p" variant="bodyMd">
+            Subject to section 2.1.2, the person signing up for the Service will
+            be the contracting party (“Account Owner”) for the purposes of our
+            Terms of Service and will be the person who is authorized to use any
+            corresponding account we may provide to the Account Owner in
+            connection with the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            If you are signing up for the Service on behalf of your employer,
+            your employer shall be the Account Owner. If you are signing up for
+            the Service on behalf of your employer, then you represent and
+            warrant that you have the authority to bind your employer to our
+            Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.2 PayPal Express Checkout and Shopify Payments Accounts
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, Shopify will create a
+            PayPal Express Checkout account on your behalf, using your email
+            address. Depending on your location, Shopify may also create a
+            Shopify Payments account on your behalf.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge that PayPal Express Checkout and/or Shopify Payments
+            will be your default payments gateway(s) and that it is your sole
+            responsibility as the Account Owner to activate and maintain these
+            accounts. If you do not wish to keep either of the payment accounts
+            active, it is your responsibility to deactivate them. For the
+            avoidance of doubt, PayPal Express Checkout is a Third Party
+            Service, as defined in Section 15 of these Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.3 Apple Pay for Safari Account
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, Shopify will create an
+            Apple Pay for Safari (“Apple Pay”) account on your behalf, using the
+            URL(s) and business name associated with your Account. Depending on
+            your location, Shopify may activate your Apple Pay account on your
+            behalf, otherwise you will be required to activate your Apple Pay
+            account within your Account admin. If you do not wish to keep your
+            Apple Pay account active, it is your responsibility to deactivate
+            it. For the avoidance of doubt, Apple Pay is a Third Party Service,
+            as defined in Section 15 of these Terms of Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            If you use an Apple Pay supported payment gateway and your customers
+            have enabled Apple Pay on their device, customers may purchase goods
+            and services from your store using Apple Pay.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            By using Apple Pay on your store, you are agreeing to be bound by
+            the Apple Pay Platform Web Merchant Terms and Conditions, as they
+            may be amended by Apple from time to time. If Apple amends the Apple
+            Pay Platform Web Merchant Terms and Conditions, the amended and
+            restated version will be posted here:
+            <a href="https://www.shopify.com/legal/apple-pay">
+              https://www.shopify.com/legal/apple-pay
+            </a>
+            . Such amendments to the Apple Pay Platform Web Merchant Terms are
+            effective as of the date of posting. Your continued use of Apple Pay
+            on your store after the amended Apple Pay Platform Web Merchant
+            Terms are posted constitutes your agreement to, and acceptance of,
+            the amended Apple Pay Platform Web Merchant Terms. If you do not
+            agree to any changes to the Apple Pay Platform Web Merchant Terms,
+            de-activate your Apple Pay account and do not continue to use Apple
+            Pay on your store.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            2.4 Google Payment
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon completion of sign up for the Service, if you have been
+            enrolled in Shopify Payments, Shopify will also create a Google
+            Payment account on your behalf. If you do not wish to keep your
+            Google Payment account active, it is your responsibility to
+            deactivate it. For the avoidance of doubt, Google Payment is a Third
+            Party Service, as defined in Section 15 of these Terms of Service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If you use a Google Payment supported payment gateway and your
+            customers have enabled Google Payment, customers may purchase goods
+            and services from your store using Google Payment.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            By using Google Payment on your store, you are agreeing to be bound
+            by the Google Payment API Terms of Service, as they may be amended
+            by Google from time to time. If Google amends the Google Payment API
+            Terms of Service, the amended and restated version will be posted
+            here:
+            <a href="https://payments.developers.google.com/terms/sellertos">
+              https://payments.developers.google.com/terms/sellertos
+            </a>
+            . Such amendments to the Google Payment API Terms of Service are
+            effective as of the date of posting. Your continued use of Google
+            Payment on your store after the amended Google Payment API Terms of
+            Service are posted constitutes your agreement to, and acceptance of,
+            the amended Google Payment API Terms of Service. If you do not agree
+            to any changes to the Google Payment API Terms of Service,
+            de-activate your Google Payment account and do not continue to use
+            Google Payment on your store.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            2.5 Domain Names
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Upon purchasing a domain name through Shopify, domain registration
+            will be preset to automatically renew each year so long as your
+            Shopify Account remains active. You acknowledge that it is your sole
+            responsibility to deactivate the auto-renewal function should you
+            choose to do so.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The person signing up for the Shopify Service is responsible for the
+            account and is bound by these Terms of Service. If you signup on
+            behalf of your employer, your employer owns the account and is also
+            bound by our Terms of Service.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            We automatically create accounts for you to accept payments. You are
+            responsible for activating and deactivating these accounts.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Any domain you purchase through us will automatically renew unless
+            you opt out.
+          </Text>
+
+          <ol>
+            <li>General Conditions</li>
+          </ol>
+          <Text as="p" variant="bodyMd">
+            You must read, agree with and accept all of the terms and conditions
+            contained in these Terms of Service, including the AUP and the
+            Privacy Policy before you may become a member of Shopify.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Technical support is only provided to paying Account holders and is
+            only available via email.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Terms of Service shall be governed by and interpreted in
+            accordance with the laws of the Province of Ontario and the laws of
+            Canada applicable therein, without regard to principles of conflicts
+            of laws. The parties irrevocably and unconditionally submit to the
+            exclusive jurisdiction of the courts of the Province of Ontario with
+            respect to any dispute or claim arising out of or in connection with
+            the Terms of Service. The United Nations Convention on Contracts for
+            the International Sale of Goods will not apply to these Terms of
+            Service and is hereby expressly excluded.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge and agree that Shopify may amend these Terms of
+            Service at any time by posting the relevant amended and restated
+            Terms of Service on Shopify’s website, available at
+            <a href="https://www.shopify.com/legal/terms">
+              https://www.shopify.com/legal/terms
+            </a>
+            and such amendments to the Terms of Service are effective as of the
+            date of posting. Your continued use of the Services after the
+            amended Terms of Service are posted to Shopify’s website constitutes
+            your agreement to, and acceptance of, the amended Terms of Service.
+            If you do not agree to any changes to the Terms of Service, do not
+            continue to use the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You may not use the Shopify service for any illegal or unauthorized
+            purpose nor may you, in the use of the Service, violate any laws in
+            your jurisdiction (including but not limited to copyright laws), the
+            laws applicable to you in your customer’s jurisdiction, or the laws
+            of Canada and the Province of Ontario. You will comply with all
+            applicable laws, rules and regulations in your use of the Service.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You agree not to reproduce, duplicate, copy, sell, resell or exploit
+            any portion of the Service, use of the Service, or access to the
+            Service without the express written permission by Shopify.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You shall not purchase search engine or other pay per click keywords
+            (such as Google AdWords), or domain names that use Shopify or
+            Shopify trademarks and/or variations and misspellings thereof.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Questions about the Terms of Service should be sent to
+            <a href="mailto:support@shopify.com">support@shopify.com</a>.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You understand that your Materials (not including credit card
+            information), may be transferred unencrypted and involve (a)
+            transmissions over various networks; and (b) changes to conform and
+            adapt to technical requirements of connecting networks or devices.
+            Credit Card information is always encrypted during transfer over
+            networks.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            You acknowledge and agree that your use of the Service, including
+            information transmitted to or stored by Shopify, is governed by its
+            privacy policy at
+            <a href="https://www.shopify.com/legal/privacy">
+              https://www.shopify.com/legal/privacy
+            </a>
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Terms of Service may be available in languages other than
+            English. To the extent of any inconsistencies or conflicts between
+            these English Terms of Service and Shopify’s Terms of Service
+            available in another language, the most current English version of
+            the Terms of Service at
+            <a href="https://www.shopify.com/legal/terms">
+              https://www.shopify.com/legal/terms
+            </a>
+            will prevail.
+          </Text>
+          <Text as="p" variant="bodyMd">
+            Which means
+          </Text>
+          <Text as="p" variant="bodyMd">
+            The Shopify service belongs to us. You are not allowed to rip it off
+            or use it for any illegal or sketchy purpose.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            If a dispute arises the issue will be dealt with in the Province of
+            Ontario.
+          </Text>
+
+          <Text as="p" variant="bodyMd">
+            Your Materials may be transferred unencrypted and may be altered,
+            but credit card information is always encrypted.
+          </Text>
+          <Button onClick={handleOnClick}>Scroll to top</Button>
+        </Scrollable>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithShadowOverComplexChildren = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <Text as="p" variant="bodyLg" fontWeight="bold">
+          NOTE: Red shadow is for demo/debug purposes only.
+          <br />
+          DO NOT do this in production.
+        </Text>
+        <Scrollable
+          shadow
+          style={{
+            height: '200px',
+            maxWidth: '40rem',
+            backgroundColor: 'var(--p-color-bg-surface)',
+            // Setting red here so the storybook is really obvious that the shadow
+            // overlays the content (particularly the banner)
+            /* @ts-expect-error TS doesn't understand CSS vars */
+            '--pc-scrollable-shadow-color': 'rgba(255, 0, 0, 0.85)',
+          }}
+        >
+          <Box padding="400">
+            <Banner title="Payment details">
+              <Text as="p" variant="bodyMd">
+                Last updated on: September 6, 2022
+              </Text>
+
+              <Text as="p" variant="bodyMd">
+                Welcome to Shopify! By signing up for a Shopify Account (as
+                defined in Section 1) or by using any Shopify Services (as
+                defined below), you are agreeing to be bound by the following
+                terms and conditions (the “<strong>Terms of Service</strong>”).
+              </Text>
+
+              <Text as="p" variant="bodyMd">
+                As used in these Terms of Service, “<strong>we</strong>”, “
+                <strong>us</strong>”, “<strong>our</strong>” and “
+                <strong>Shopify</strong>” means the applicable Shopify
+                Contracting Party (as defined in Section 13 below), and “
+                <strong>you</strong>” means the Shopify User (if registering for
+                or using a Shopify Service as an individual), or the business
+                employing the Shopify User (if registering for or using a
+                Shopify Service as a business) and any of its affiliates.
+              </Text>
+            </Banner>
+
+            <FormLayout>
+              <FormLayout.Group>
+                <TextField label="First name" autoComplete="off" />
+                <TextField label="Last name" autoComplete="off" />
+              </FormLayout.Group>
+
+              <FormLayout.Group>
+                <TextField label="Address" autoComplete="off" />
+                <TextField label="Apartment, suite, etc." autoComplete="off" />
+              </FormLayout.Group>
+
+              <FormLayout.Group>
+                <TextField label="City" autoComplete="off" />
+                <TextField label="Province" autoComplete="off" />
+                <TextField label="Postal code" autoComplete="off" />
+              </FormLayout.Group>
+            </FormLayout>
+
+            <Text as="p" variant="bodyMd">
+              Shopify provides a complete commerce platform that enables
+              merchants to unify their commerce activities. Among other
+              features, this platform includes a range of tools for merchants to
+              build and customize online stores, sell in multiple places
+              (including web, mobile, social media, online marketplaces and
+              other online locations (“<strong>Online Services</strong>”) and in
+              person (“
+              <strong>POS Services</strong>”)), manage products, inventory,
+              payments, fulfillment, shipping, business operations, marketing
+              and advertising, and engage with existing and potential customers.
+              Any such service or services offered by Shopify are referred to in
+              these Terms of Services as the “<strong>Service(s)</strong>”. Any
+              new features or tools which are added to the current Services will
+              also be subject to the Terms of Service. You can review the
+              current version of the Terms of Service at any time at
+              <a href="https://www.shopify.com/legal/terms">
+                https://www.shopify.com/legal/terms
+              </a>
+              .
+            </Text>
+            <Text as="p" variant="bodyMd">
+              You must read, agree with and accept all of the terms and
+              conditions contained or expressly referenced in these Terms of
+              Service, including Shopify’s
+              <a href="https://www.shopify.com/legal/aup">
+                Acceptable Use Policy
+              </a>
+              (“<strong>AUP</strong>”) and
+              <a href="https://www.shopify.com/legal/privacy">Privacy Policy</a>
+              , and, if applicable, the
+              <a href="https://www.shopify.com/legal/eu-terms">
+                Supplementary Terms of Service for E.U. Merchants
+              </a>
+              (“<strong>EU Terms</strong>”), the Shopify
+              <a href="https://www.shopify.com/legal/api-terms">
+                API License and Terms of Use
+              </a>
+              (“<strong>API Terms</strong>”) and the Shopify
+              <a href="https://www.shopify.com/legal/dpa">
+                Data Processing Addendum
+              </a>
+              (“<strong>DPA</strong>”) before you may sign up for a Shopify
+              Account or use any Shopify Service. Additionally, if you offer
+              goods or services in relation to COVID-19, you must read,
+              acknowledge and agree to the
+              <a href="/legal/rules-of-engagement-covid19">
+                Rules of Engagement for Sale of COVID-19 Related Products
+              </a>
+              .
+            </Text>
+
+            <Text as="p" variant="bodyMd">
+              <strong>
+                Everyday language summaries are provided for convenience only
+                and appear in bold near each section, but these summaries are
+                not legally binding. Please read the Terms of Service, including
+                any document referred to in these Terms of Service, for the
+                complete picture of your legal requirements. By using Shopify or
+                any Shopify services, you are agreeing to these terms. Be sure
+                to occasionally check back for updates.
+              </strong>
+            </Text>
+          </Box>
+        </Scrollable>
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/Select/Select.stories.tsx
+++ b/polaris-react/src/components/Select/Select.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   LegacyCard,
   FormLayout,
@@ -15,305 +15,323 @@ import {CaretDownIcon, CaretUpIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Select,
-} as ComponentMeta<typeof Select>;
+} as Meta<typeof Select>;
 
-export function Default() {
-  const [selected, setSelected] = useState('today');
+export const Default = {
+  render() {
+    const [selected, setSelected] = useState('today');
 
-  const handleSelectChange = useCallback((value) => setSelected(value), []);
+    const handleSelectChange = useCallback((value) => setSelected(value), []);
 
-  const options = [
-    {label: 'Today', value: 'today'},
-    {label: 'Yesterday', value: 'yesterday'},
-    {label: 'Last 7 days', value: 'lastWeek'},
-  ];
+    const options = [
+      {label: 'Today', value: 'today'},
+      {label: 'Yesterday', value: 'yesterday'},
+      {label: 'Last 7 days', value: 'lastWeek'},
+    ];
 
-  return (
-    <Select
-      label="Date range"
-      options={options}
-      onChange={handleSelectChange}
-      value={selected}
-    />
-  );
-}
+    return (
+      <Select
+        label="Date range"
+        options={options}
+        onChange={handleSelectChange}
+        value={selected}
+      />
+    );
+  },
+};
 
-export function WithInlineLabel() {
-  const [selected, setSelected] = useState('newestUpdate');
+export const WithInlineLabel = {
+  render() {
+    const [selected, setSelected] = useState('newestUpdate');
 
-  const handleSelectChange = useCallback((value) => setSelected(value), []);
+    const handleSelectChange = useCallback((value) => setSelected(value), []);
 
-  const options = [
-    {label: 'Newest update', value: 'newestUpdate'},
-    {label: 'Oldest update', value: 'oldestUpdate'},
-    {label: 'Most spent', value: 'mostSpent'},
-    {label: 'Most orders', value: 'mostOrders'},
-    {label: 'Last name A–Z', value: 'lastNameAlpha'},
-    {label: 'Last name Z–A', value: 'lastNameReverseAlpha'},
-  ];
+    const options = [
+      {label: 'Newest update', value: 'newestUpdate'},
+      {label: 'Oldest update', value: 'oldestUpdate'},
+      {label: 'Most spent', value: 'mostSpent'},
+      {label: 'Most orders', value: 'mostOrders'},
+      {label: 'Last name A–Z', value: 'lastNameAlpha'},
+      {label: 'Last name Z–A', value: 'lastNameReverseAlpha'},
+    ];
 
-  return (
-    <Select
-      label="Sort by"
-      labelInline
-      options={options}
-      onChange={handleSelectChange}
-      value={selected}
-    />
-  );
-}
+    return (
+      <Select
+        label="Sort by"
+        labelInline
+        options={options}
+        onChange={handleSelectChange}
+        value={selected}
+      />
+    );
+  },
+};
 
-export function Disabled() {
-  return (
-    <Select
-      label="Date range"
-      disabled
-      options={[
-        {label: 'Today', value: 'today'},
-        {label: 'Yesterday', value: 'yesterday'},
-        {label: 'Last 7 days', value: 'lastWeek'},
-      ]}
-    />
-  );
-}
+export const Disabled = {
+  render() {
+    return (
+      <Select
+        label="Date range"
+        disabled
+        options={[
+          {label: 'Today', value: 'today'},
+          {label: 'Yesterday', value: 'yesterday'},
+          {label: 'Last 7 days', value: 'lastWeek'},
+        ]}
+      />
+    );
+  },
+};
 
-export function Magic() {
-  return (
-    <Select
-      label="Date range"
-      tone="magic"
-      options={[
-        {label: 'Today', value: 'today'},
-        {label: 'Yesterday', value: 'yesterday'},
-        {label: 'Last 7 days', value: 'lastWeek'},
-      ]}
-    />
-  );
-}
+export const Magic = {
+  render() {
+    return (
+      <Select
+        label="Date range"
+        tone="magic"
+        options={[
+          {label: 'Today', value: 'today'},
+          {label: 'Yesterday', value: 'yesterday'},
+          {label: 'Last 7 days', value: 'lastWeek'},
+        ]}
+      />
+    );
+  },
+};
 
-export function WithInlineLabelMagic() {
-  const [selected, setSelected] = useState('newestUpdate');
+export const WithInlineLabelMagic = {
+  render() {
+    const [selected, setSelected] = useState('newestUpdate');
 
-  const handleSelectChange = useCallback((value) => setSelected(value), []);
+    const handleSelectChange = useCallback((value) => setSelected(value), []);
 
-  const options = [
-    {label: 'Newest update', value: 'newestUpdate'},
-    {label: 'Oldest update', value: 'oldestUpdate'},
-    {label: 'Most spent', value: 'mostSpent'},
-    {label: 'Most orders', value: 'mostOrders'},
-    {label: 'Last name A–Z', value: 'lastNameAlpha'},
-    {label: 'Last name Z–A', value: 'lastNameReverseAlpha'},
-  ];
+    const options = [
+      {label: 'Newest update', value: 'newestUpdate'},
+      {label: 'Oldest update', value: 'oldestUpdate'},
+      {label: 'Most spent', value: 'mostSpent'},
+      {label: 'Most orders', value: 'mostOrders'},
+      {label: 'Last name A–Z', value: 'lastNameAlpha'},
+      {label: 'Last name Z–A', value: 'lastNameReverseAlpha'},
+    ];
 
-  return (
-    <Select
-      label="Sort by"
-      tone="magic"
-      labelInline
-      options={options}
-      onChange={handleSelectChange}
-      value={selected}
-    />
-  );
-}
+    return (
+      <Select
+        label="Sort by"
+        tone="magic"
+        labelInline
+        options={options}
+        onChange={handleSelectChange}
+        value={selected}
+      />
+    );
+  },
+};
 
-export function WithPrefix() {
-  const [selected, setSelected] = useState('enabled');
+export const WithPrefix = {
+  render() {
+    const [selected, setSelected] = useState('enabled');
 
-  const handleSelectChange = useCallback((value) => setSelected(value), []);
+    const handleSelectChange = useCallback((value) => setSelected(value), []);
 
-  const options = [
-    {
-      label: 'Increase',
-      value: 'Increase',
-      prefix: <Icon source={CaretUpIcon} />,
-    },
-    {
-      label: 'Decrease',
-      value: 'Decrease',
-      prefix: <Icon source={CaretDownIcon} />,
-    },
-  ];
+    const options = [
+      {
+        label: 'Increase',
+        value: 'Increase',
+        prefix: <Icon source={CaretUpIcon} />,
+      },
+      {
+        label: 'Decrease',
+        value: 'Decrease',
+        prefix: <Icon source={CaretDownIcon} />,
+      },
+    ];
 
-  return (
-    <Select
-      label="Permission"
-      options={options}
-      onChange={handleSelectChange}
-      value={selected}
-    />
-  );
-}
+    return (
+      <Select
+        label="Permission"
+        options={options}
+        onChange={handleSelectChange}
+        value={selected}
+      />
+    );
+  },
+};
 
-export function WithValidationError() {
-  const [selected, setSelected] = useState('');
+export const WithValidationError = {
+  render() {
+    const [selected, setSelected] = useState('');
 
-  const handleSelectChange = useCallback((value) => setSelected(value), []);
+    const handleSelectChange = useCallback((value) => setSelected(value), []);
 
-  return (
-    <Select
-      label="Province"
-      options={['Alberta']}
-      value={selected}
-      onChange={handleSelectChange}
-      error="Province is required"
-    />
-  );
-}
+    return (
+      <Select
+        label="Province"
+        options={['Alberta']}
+        value={selected}
+        onChange={handleSelectChange}
+        error="Province is required"
+      />
+    );
+  },
+};
 
-export function WithSeparateValidationError() {
-  const [weight, setWeight] = useState('12');
-  const [unit, setUnit] = useState('');
+export const WithSeparateValidationError = {
+  render() {
+    const [weight, setWeight] = useState('12');
+    const [unit, setUnit] = useState('');
 
-  const handleWeightChange = useCallback((value) => setWeight(value), []);
-  const handleUnitChange = useCallback((value) => setUnit(value), []);
+    const handleWeightChange = useCallback((value) => setWeight(value), []);
+    const handleUnitChange = useCallback((value) => setUnit(value), []);
 
-  const unitSelectID = 'unit';
-  const errorMessage = generateErrorMessage();
-  const formGroupMarkup = (
-    <LegacyStack vertical spacing="extraTight">
+    const unitSelectID = 'unit';
+    const errorMessage = generateErrorMessage();
+    const formGroupMarkup = (
+      <LegacyStack vertical spacing="extraTight">
+        <FormLayout>
+          <FormLayout.Group condensed>
+            <TextField
+              label="Product weight"
+              type="number"
+              value={weight}
+              onChange={handleWeightChange}
+              error={Boolean(!weight && unit)}
+              autoComplete="off"
+            />
+            <Select
+              id={unitSelectID}
+              label="Unit of measure"
+              placeholder="Select"
+              options={['oz', 'g', 'kg', 'lb']}
+              value={unit}
+              onChange={handleUnitChange}
+              error={Boolean(!unit && weight)}
+            />
+          </FormLayout.Group>
+        </FormLayout>
+        <InlineError message={errorMessage} fieldID={unitSelectID} />
+      </LegacyStack>
+    );
+
+    return <LegacyCard sectioned>{formGroupMarkup}</LegacyCard>;
+
+    function generateErrorMessage() {
+      const weightError =
+        !weight && unit ? 'The numeric weight of the product ' : '';
+      const unitError =
+        !unit && weight ? 'The unit of measure for the product weight' : '';
+
+      if (!weightError && !unitError) {
+        return '';
+      }
+
+      return (
+        <Text as="p" tone="critical" variant="bodyMd">
+          {`${weightError}${unitError} is required when weight based shipping rates are enabled. `}
+          <Link>Manage shipping</Link>
+        </Text>
+      );
+    }
+  },
+};
+
+export const All = {
+  render() {
+    return (
       <FormLayout>
-        <FormLayout.Group condensed>
-          <TextField
-            label="Product weight"
-            type="number"
-            value={weight}
-            onChange={handleWeightChange}
-            error={Boolean(!weight && unit)}
-            autoComplete="off"
+        <FormLayout.Group>
+          <Select
+            label="Default"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            onChange={() => {}}
           />
           <Select
-            id={unitSelectID}
-            label="Unit of measure"
-            placeholder="Select"
-            options={['oz', 'g', 'kg', 'lb']}
-            value={unit}
-            onChange={handleUnitChange}
-            error={Boolean(!unit && weight)}
+            label="Disabled"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            onChange={() => {}}
+            disabled
+            helpText="Help text"
+          />
+          <Select
+            label="Error"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            onChange={() => {}}
+            error="Province is required"
+          />
+          <Select
+            label="Magic"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            tone="magic"
+            onChange={() => {}}
+          />
+          <Select
+            label="Required"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            onChange={() => {}}
+            requiredIndicator
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <Select
+            label="Placeholder"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value=""
+            placeholder="Placeholder"
+            onChange={() => {}}
+          />
+          <Select
+            label="Label action"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            labelAction={{content: 'Action'}}
+            onChange={() => {}}
+          />
+          <Select
+            label="Help text"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            helpText="Help text"
+            onChange={() => {}}
+          />
+          <Select
+            label="Long text"
+            options={[
+              'Ontario',
+              'Newfoundland and Labrador and Newfoundland and Labrador and Newfoundland and Labrador',
+            ]}
+            value="Newfoundland and Labrador and Newfoundland and Labrador and Newfoundland and Labrador"
+            onChange={() => {}}
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <Select
+            label="Label inline"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            onChange={() => {}}
+            labelInline
+          />
+          <Select
+            label="Label inline magic"
+            tone="magic"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Ontario"
+            onChange={() => {}}
+            labelInline
+          />
+          <Select
+            label="Label hidden"
+            options={['Ontario', 'Newfoundland and Labrador']}
+            value="Label hidden"
+            onChange={() => {}}
+            labelHidden
           />
         </FormLayout.Group>
       </FormLayout>
-      <InlineError message={errorMessage} fieldID={unitSelectID} />
-    </LegacyStack>
-  );
-
-  return <LegacyCard sectioned>{formGroupMarkup}</LegacyCard>;
-
-  function generateErrorMessage() {
-    const weightError =
-      !weight && unit ? 'The numeric weight of the product ' : '';
-    const unitError =
-      !unit && weight ? 'The unit of measure for the product weight' : '';
-
-    if (!weightError && !unitError) {
-      return '';
-    }
-
-    return (
-      <Text as="p" tone="critical" variant="bodyMd">
-        {`${weightError}${unitError} is required when weight based shipping rates are enabled. `}
-        <Link>Manage shipping</Link>
-      </Text>
     );
-  }
-}
-
-export function All() {
-  return (
-    <FormLayout>
-      <FormLayout.Group>
-        <Select
-          label="Default"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          onChange={() => {}}
-        />
-        <Select
-          label="Disabled"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          onChange={() => {}}
-          disabled
-          helpText="Help text"
-        />
-        <Select
-          label="Error"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          onChange={() => {}}
-          error="Province is required"
-        />
-        <Select
-          label="Magic"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          tone="magic"
-          onChange={() => {}}
-        />
-        <Select
-          label="Required"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          onChange={() => {}}
-          requiredIndicator
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <Select
-          label="Placeholder"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value=""
-          placeholder="Placeholder"
-          onChange={() => {}}
-        />
-        <Select
-          label="Label action"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          labelAction={{content: 'Action'}}
-          onChange={() => {}}
-        />
-        <Select
-          label="Help text"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          helpText="Help text"
-          onChange={() => {}}
-        />
-        <Select
-          label="Long text"
-          options={[
-            'Ontario',
-            'Newfoundland and Labrador and Newfoundland and Labrador and Newfoundland and Labrador',
-          ]}
-          value="Newfoundland and Labrador and Newfoundland and Labrador and Newfoundland and Labrador"
-          onChange={() => {}}
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <Select
-          label="Label inline"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          onChange={() => {}}
-          labelInline
-        />
-        <Select
-          label="Label inline magic"
-          tone="magic"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Ontario"
-          onChange={() => {}}
-          labelInline
-        />
-        <Select
-          label="Label hidden"
-          options={['Ontario', 'Newfoundland and Labrador']}
-          value="Label hidden"
-          onChange={() => {}}
-          labelHidden
-        />
-      </FormLayout.Group>
-    </FormLayout>
-  );
-}
+  },
+};

--- a/polaris-react/src/components/SelectAllActions/SelectAllActions.stories.tsx
+++ b/polaris-react/src/components/SelectAllActions/SelectAllActions.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 
 // eslint-disable-next-line import/no-deprecated
 import {SelectAllActions} from './SelectAllActions';
@@ -8,73 +8,81 @@ export default {
   // eslint-disable-next-line import/no-deprecated
   component: SelectAllActions,
   // eslint-disable-next-line import/no-deprecated
-} as ComponentMeta<typeof SelectAllActions>;
+} as Meta<typeof SelectAllActions>;
 
-export function Default() {
-  const paginatedSelectAllAction = {
-    content: 'Select all',
-    onAction: () => console.log('paginatedSelectAllAction clicked'),
-  };
-  return (
-    <SelectAllActions
-      label="3 selected"
-      selectMode
-      isSticky
-      hasPagination={false}
-    />
-  );
-}
+export const Default = {
+  render() {
+    const paginatedSelectAllAction = {
+      content: 'Select all',
+      onAction: () => console.log('paginatedSelectAllAction clicked'),
+    };
+    return (
+      <SelectAllActions
+        label="3 selected"
+        selectMode
+        isSticky
+        hasPagination={false}
+      />
+    );
+  },
+};
 
-export function WithPaginatedSelectAllText() {
-  const paginatedSelectAllAction = {
-    content: 'Select all',
-    onAction: () => console.log('paginatedSelectAllAction clicked'),
-  };
-  return (
-    <SelectAllActions
-      label="3 selected"
-      selectMode
-      paginatedSelectAllText="50 items selected"
-      paginatedSelectAllAction={paginatedSelectAllAction}
-      isSticky
-      hasPagination={false}
-    />
-  );
-}
+export const WithPaginatedSelectAllText = {
+  render() {
+    const paginatedSelectAllAction = {
+      content: 'Select all',
+      onAction: () => console.log('paginatedSelectAllAction clicked'),
+    };
+    return (
+      <SelectAllActions
+        label="3 selected"
+        selectMode
+        paginatedSelectAllText="50 items selected"
+        paginatedSelectAllAction={paginatedSelectAllAction}
+        isSticky
+        hasPagination={false}
+      />
+    );
+  },
+};
 
-export function WithPagination() {
-  const paginatedSelectAllAction = {
-    content: 'Select all',
-    onAction: () => console.log('paginatedSelectAllAction clicked'),
-  };
-  return (
-    <SelectAllActions
-      label="3 selected"
-      selectMode
-      paginatedSelectAllText="Select all"
-      paginatedSelectAllAction={paginatedSelectAllAction}
-      isSticky
-      hasPagination
-    />
-  );
-}
+export const WithPagination = {
+  render() {
+    const paginatedSelectAllAction = {
+      content: 'Select all',
+      onAction: () => console.log('paginatedSelectAllAction clicked'),
+    };
+    return (
+      <SelectAllActions
+        label="3 selected"
+        selectMode
+        paginatedSelectAllText="Select all"
+        paginatedSelectAllAction={paginatedSelectAllAction}
+        isSticky
+        hasPagination
+      />
+    );
+  },
+};
 
-export function WithDeprecatedProps() {
-  const paginatedSelectAllAction = {
-    content: 'Select all',
-    onAction: () => console.log('paginatedSelectAllAction clicked'),
-  };
-  return (
-    <SelectAllActions
-      label="3 selected"
-      selectMode
-      paginatedSelectAllText="Select all"
-      paginatedSelectAllAction={paginatedSelectAllAction}
-      isSticky
-      hasPagination
-      accessibilityLabel="Select all items"
-      selected
-      onToggleAll={() => console.log('onToggleAll called')}
-    />
-  );
-}
+export const WithDeprecatedProps = {
+  render() {
+    const paginatedSelectAllAction = {
+      content: 'Select all',
+      onAction: () => console.log('paginatedSelectAllAction clicked'),
+    };
+    return (
+      <SelectAllActions
+        label="3 selected"
+        selectMode
+        paginatedSelectAllText="Select all"
+        paginatedSelectAllAction={paginatedSelectAllAction}
+        isSticky
+        hasPagination
+        accessibilityLabel="Select all items"
+        selected
+        onToggleAll={() => console.log('onToggleAll called')}
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/SettingToggle/SettingToggle.stories.tsx
+++ b/polaris-react/src/components/SettingToggle/SettingToggle.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   SettingToggle,
   Text,
@@ -15,246 +15,261 @@ import {InfoIcon} from '@shopify/polaris-icons';
 
 export default {
   component: SettingToggle,
-} as ComponentMeta<typeof SettingToggle>;
+} as Meta<typeof SettingToggle>;
 
-export function WithDeprecatedComponent() {
-  const [enabled, setEnabled] = useState(false);
+export const WithDeprecatedComponent = {
+  render() {
+    const [enabled, setEnabled] = useState(false);
 
-  const contentStatus = enabled ? 'Turn off' : 'Turn on';
+    const contentStatus = enabled ? 'Turn off' : 'Turn on';
 
-  const handleToggle = useCallback(() => setEnabled((enabled) => !enabled), []);
+    const handleToggle = useCallback(
+      () => setEnabled((enabled) => !enabled),
+      [],
+    );
 
-  return (
-    <SettingToggle
-      enabled={enabled}
-      action={{
-        content: contentStatus,
-        onAction: handleToggle,
-      }}
-    >
-      <Text as="p">
-        Simulate transactions to test your checkout and order flows. When test
-        mode is on, checkout does not accept real credit cards.
-      </Text>
-    </SettingToggle>
-  );
-}
+    return (
+      <SettingToggle
+        enabled={enabled}
+        action={{
+          content: contentStatus,
+          onAction: handleToggle,
+        }}
+      >
+        <Text as="p">
+          Simulate transactions to test your checkout and order flows. When test
+          mode is on, checkout does not accept real credit cards.
+        </Text>
+      </SettingToggle>
+    );
+  },
+};
 
-export function WithPrimitiveComponents() {
-  const [enabled, setEnabled] = useState(true);
+export const WithPrimitiveComponents = {
+  render() {
+    const [enabled, setEnabled] = useState(true);
 
-  const handleToggle = useCallback(() => setEnabled((enabled) => !enabled), []);
+    const handleToggle = useCallback(
+      () => setEnabled((enabled) => !enabled),
+      [],
+    );
 
-  const contentStatus = enabled ? 'Turn off' : 'Turn on';
+    const contentStatus = enabled ? 'Turn off' : 'Turn on';
 
-  const toggleId = 'setting-toggle-uuid';
-  const descriptionId = 'setting-toggle-description-uuid';
+    const toggleId = 'setting-toggle-uuid';
+    const descriptionId = 'setting-toggle-description-uuid';
 
-  const {mdDown} = useBreakpoints();
+    const {mdDown} = useBreakpoints();
 
-  const badgeTone = enabled ? 'success' : undefined;
+    const badgeTone = enabled ? 'success' : undefined;
 
-  const badgeContent = enabled ? 'On' : 'Off';
+    const badgeContent = enabled ? 'On' : 'Off';
 
-  const title = 'Test mode';
-  const description =
-    'Simulate transactions to test your checkout and order flows. When test mode is on, checkout does not accept real credit cards.';
+    const title = 'Test mode';
+    const description =
+      'Simulate transactions to test your checkout and order flows. When test mode is on, checkout does not accept real credit cards.';
 
-  const settingStatusMarkup = (
-    <Badge
-      tone={badgeTone}
-      toneAndProgressLabelOverride={`Setting is ${badgeContent}`}
-    >
-      {badgeContent}
-    </Badge>
-  );
+    const settingStatusMarkup = (
+      <Badge
+        tone={badgeTone}
+        toneAndProgressLabelOverride={`Setting is ${badgeContent}`}
+      >
+        {badgeContent}
+      </Badge>
+    );
 
-  const helpLink = (
-    <Button variant="plain" icon={InfoIcon} accessibilityLabel="Learn more" />
-  );
+    const helpLink = (
+      <Button variant="plain" icon={InfoIcon} accessibilityLabel="Learn more" />
+    );
 
-  const settingTitle = title ? (
-    <InlineStack gap="200" wrap={false}>
-      <InlineStack gap="200" align="start" blockAlign="baseline">
-        <label htmlFor={toggleId}>
-          <Text variant="headingMd" as="h6">
-            {title}
-          </Text>
-        </label>
-        <InlineStack gap="200" align="center" blockAlign="center">
-          {settingStatusMarkup}
-          {helpLink}
+    const settingTitle = title ? (
+      <InlineStack gap="200" wrap={false}>
+        <InlineStack gap="200" align="start" blockAlign="baseline">
+          <label htmlFor={toggleId}>
+            <Text variant="headingMd" as="h6">
+              {title}
+            </Text>
+          </label>
+          <InlineStack gap="200" align="center" blockAlign="center">
+            {settingStatusMarkup}
+            {helpLink}
+          </InlineStack>
         </InlineStack>
       </InlineStack>
-    </InlineStack>
-  ) : null;
+    ) : null;
 
-  const actionMarkup = (
-    <Button
-      role="switch"
-      id={toggleId}
-      ariaChecked={enabled ? 'true' : 'false'}
-      onClick={handleToggle}
-      size="slim"
-    >
-      {contentStatus}
-    </Button>
-  );
-
-  const headerMarkup = (
-    <Box width="100%">
-      <InlineStack
-        gap="1200"
-        align="space-between"
-        blockAlign="start"
-        wrap={false}
+    const actionMarkup = (
+      <Button
+        role="switch"
+        id={toggleId}
+        ariaChecked={enabled ? 'true' : 'false'}
+        onClick={handleToggle}
+        size="slim"
       >
-        {settingTitle}
-        {!mdDown ? (
-          <Box minWidth="fit-content">
-            <InlineStack align="end">{actionMarkup}</InlineStack>
+        {contentStatus}
+      </Button>
+    );
+
+    const headerMarkup = (
+      <Box width="100%">
+        <InlineStack
+          gap="1200"
+          align="space-between"
+          blockAlign="start"
+          wrap={false}
+        >
+          {settingTitle}
+          {!mdDown ? (
+            <Box minWidth="fit-content">
+              <InlineStack align="end">{actionMarkup}</InlineStack>
+            </Box>
+          ) : null}
+        </InlineStack>
+      </Box>
+    );
+
+    const descriptionMarkup = (
+      <BlockStack gap="400">
+        <Text id={descriptionId} variant="bodyMd" as="p" tone="subdued">
+          {description}
+        </Text>
+        {mdDown ? (
+          <Box width="100%">
+            <InlineStack align="start">{actionMarkup}</InlineStack>
           </Box>
         ) : null}
-      </InlineStack>
-    </Box>
-  );
-
-  const descriptionMarkup = (
-    <BlockStack gap="400">
-      <Text id={descriptionId} variant="bodyMd" as="p" tone="subdued">
-        {description}
-      </Text>
-      {mdDown ? (
-        <Box width="100%">
-          <InlineStack align="start">{actionMarkup}</InlineStack>
-        </Box>
-      ) : null}
-    </BlockStack>
-  );
-
-  return (
-    <Card>
-      <BlockStack gap={{xs: '400', sm: '500'}}>
-        <Box width="100%">
-          <BlockStack gap={{xs: '200', sm: '400'}}>
-            {headerMarkup}
-            {descriptionMarkup}
-          </BlockStack>
-        </Box>
-        <Text variant="bodyMd" as="p">
-          Your checkout is only accepting test payments.
-        </Text>
       </BlockStack>
-    </Card>
-  );
-}
+    );
 
-export function WithPrimitiveComponentsAndLongTitle() {
-  const [enabled, setEnabled] = useState(true);
-
-  const handleToggle = useCallback(() => setEnabled((enabled) => !enabled), []);
-
-  const contentStatus = enabled ? 'Turn off' : 'Turn on';
-
-  const toggleId = 'setting-toggle-uuid';
-  const descriptionId = 'setting-toggle-description-uuid';
-
-  const {mdDown} = useBreakpoints();
-
-  const badgeTone = enabled ? 'success' : undefined;
-
-  const badgeContent = enabled ? 'On' : 'Off';
-
-  const title =
-    'Test mode but with very long mega title that wraps to demonstrate how layout changes';
-  const description =
-    'Simulate transactions to test your checkout and order flows. When test mode is on, checkout does not accept real credit cards.';
-
-  const settingStatusMarkup = (
-    <Badge
-      tone={badgeTone}
-      toneAndProgressLabelOverride={`Setting is ${badgeContent}`}
-    >
-      {badgeContent}
-    </Badge>
-  );
-
-  const helpLink = (
-    <Button variant="plain" icon={InfoIcon} accessibilityLabel="Learn more" />
-  );
-
-  const settingTitle = title ? (
-    <InlineStack gap="200" wrap={false}>
-      <InlineStack gap="200" align="start" blockAlign="baseline">
-        <label htmlFor={toggleId}>
-          <Text variant="headingMd" as="h6">
-            {title}
+    return (
+      <Card>
+        <BlockStack gap={{xs: '400', sm: '500'}}>
+          <Box width="100%">
+            <BlockStack gap={{xs: '200', sm: '400'}}>
+              {headerMarkup}
+              {descriptionMarkup}
+            </BlockStack>
+          </Box>
+          <Text variant="bodyMd" as="p">
+            Your checkout is only accepting test payments.
           </Text>
-        </label>
-        <InlineStack gap="200" align="center" blockAlign="center">
-          {settingStatusMarkup}
-          {helpLink}
+        </BlockStack>
+      </Card>
+    );
+  },
+};
+
+export const WithPrimitiveComponentsAndLongTitle = {
+  render() {
+    const [enabled, setEnabled] = useState(true);
+
+    const handleToggle = useCallback(
+      () => setEnabled((enabled) => !enabled),
+      [],
+    );
+
+    const contentStatus = enabled ? 'Turn off' : 'Turn on';
+
+    const toggleId = 'setting-toggle-uuid';
+    const descriptionId = 'setting-toggle-description-uuid';
+
+    const {mdDown} = useBreakpoints();
+
+    const badgeTone = enabled ? 'success' : undefined;
+
+    const badgeContent = enabled ? 'On' : 'Off';
+
+    const title =
+      'Test mode but with very long mega title that wraps to demonstrate how layout changes';
+    const description =
+      'Simulate transactions to test your checkout and order flows. When test mode is on, checkout does not accept real credit cards.';
+
+    const settingStatusMarkup = (
+      <Badge
+        tone={badgeTone}
+        toneAndProgressLabelOverride={`Setting is ${badgeContent}`}
+      >
+        {badgeContent}
+      </Badge>
+    );
+
+    const helpLink = (
+      <Button variant="plain" icon={InfoIcon} accessibilityLabel="Learn more" />
+    );
+
+    const settingTitle = title ? (
+      <InlineStack gap="200" wrap={false}>
+        <InlineStack gap="200" align="start" blockAlign="baseline">
+          <label htmlFor={toggleId}>
+            <Text variant="headingMd" as="h6">
+              {title}
+            </Text>
+          </label>
+          <InlineStack gap="200" align="center" blockAlign="center">
+            {settingStatusMarkup}
+            {helpLink}
+          </InlineStack>
         </InlineStack>
       </InlineStack>
-    </InlineStack>
-  ) : null;
+    ) : null;
 
-  const actionMarkup = (
-    <Button
-      role="switch"
-      id={toggleId}
-      ariaChecked={enabled ? 'true' : 'false'}
-      onClick={handleToggle}
-      size="slim"
-    >
-      {contentStatus}
-    </Button>
-  );
-
-  const headerMarkup = (
-    <Box width="100%">
-      <InlineStack
-        gap="1200"
-        align="space-between"
-        blockAlign="start"
-        wrap={false}
+    const actionMarkup = (
+      <Button
+        role="switch"
+        id={toggleId}
+        ariaChecked={enabled ? 'true' : 'false'}
+        onClick={handleToggle}
+        size="slim"
       >
-        {settingTitle}
-        {!mdDown ? (
-          <Box minWidth="fit-content">
-            <InlineStack align="end">{actionMarkup}</InlineStack>
+        {contentStatus}
+      </Button>
+    );
+
+    const headerMarkup = (
+      <Box width="100%">
+        <InlineStack
+          gap="1200"
+          align="space-between"
+          blockAlign="start"
+          wrap={false}
+        >
+          {settingTitle}
+          {!mdDown ? (
+            <Box minWidth="fit-content">
+              <InlineStack align="end">{actionMarkup}</InlineStack>
+            </Box>
+          ) : null}
+        </InlineStack>
+      </Box>
+    );
+
+    const descriptionMarkup = (
+      <BlockStack gap="400">
+        <Text id={descriptionId} variant="bodyMd" as="p" tone="subdued">
+          {description}
+        </Text>
+        {mdDown ? (
+          <Box width="100%">
+            <InlineStack align="start">{actionMarkup}</InlineStack>
           </Box>
         ) : null}
-      </InlineStack>
-    </Box>
-  );
-
-  const descriptionMarkup = (
-    <BlockStack gap="400">
-      <Text id={descriptionId} variant="bodyMd" as="p" tone="subdued">
-        {description}
-      </Text>
-      {mdDown ? (
-        <Box width="100%">
-          <InlineStack align="start">{actionMarkup}</InlineStack>
-        </Box>
-      ) : null}
-    </BlockStack>
-  );
-
-  return (
-    <Card>
-      <BlockStack gap={{xs: '400', sm: '500'}}>
-        <Box width="100%">
-          <BlockStack gap={{xs: '200', sm: '400'}}>
-            {headerMarkup}
-            {descriptionMarkup}
-          </BlockStack>
-        </Box>
-        <Text variant="bodyMd" as="p">
-          Your checkout is only accepting test payments.
-        </Text>
       </BlockStack>
-    </Card>
-  );
-}
+    );
+
+    return (
+      <Card>
+        <BlockStack gap={{xs: '400', sm: '500'}}>
+          <Box width="100%">
+            <BlockStack gap={{xs: '200', sm: '400'}}>
+              {headerMarkup}
+              {descriptionMarkup}
+            </BlockStack>
+          </Box>
+          <Text variant="bodyMd" as="p">
+            Your checkout is only accepting test payments.
+          </Text>
+        </BlockStack>
+      </Card>
+    );
+  },
+};

--- a/polaris-react/src/components/ShadowBevel/ShadowBevel.stories.tsx
+++ b/polaris-react/src/components/ShadowBevel/ShadowBevel.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import type {BoxProps} from '@shopify/polaris';
 import {Box, BlockStack, InlineCode} from '@shopify/polaris';
 
@@ -7,82 +7,84 @@ import {ShadowBevel} from './ShadowBevel';
 
 export default {
   component: ShadowBevel,
-} as ComponentMeta<typeof ShadowBevel>;
+} as Meta<typeof ShadowBevel>;
 
-export function Default() {
-  const colors: BoxProps[] = [
-    {
-      background: 'bg-fill-success',
-      color: 'text-success-on-bg-fill',
-    },
-    {
-      background: 'bg-fill-info',
-      color: 'text-info-on-bg-fill',
-    },
-    {
-      background: 'bg-fill-warning',
-      color: 'text-warning-on-bg-fill',
-    },
-    {
-      background: 'bg-fill-critical',
-      color: 'text-critical-on-bg-fill',
-    },
-  ];
+export const Default = {
+  render() {
+    const colors: BoxProps[] = [
+      {
+        background: 'bg-fill-success',
+        color: 'text-success-on-bg-fill',
+      },
+      {
+        background: 'bg-fill-info',
+        color: 'text-info-on-bg-fill',
+      },
+      {
+        background: 'bg-fill-warning',
+        color: 'text-warning-on-bg-fill',
+      },
+      {
+        background: 'bg-fill-critical',
+        color: 'text-critical-on-bg-fill',
+      },
+    ];
 
-  return (
-    <BlockStack gap="500">
-      <ShadowBevel boxShadow="300" borderRadius="300">
-        <Box background="bg-surface" padding="400">
-          Default
-        </Box>
-      </ShadowBevel>
-
-      <ShadowBevel boxShadow="300" borderRadius="300" bevel={false}>
-        <Box background="bg-surface" padding="400">
-          With <InlineCode>bevel: false</InlineCode>
-        </Box>
-      </ShadowBevel>
-
-      <ShadowBevel
-        boxShadow="300"
-        borderRadius="300"
-        bevel={{xs: false, sm: true}}
-      >
-        <Box background="bg-surface" padding="400">
-          With <InlineCode>bevel: {'{xs: false, sm: true}'}</InlineCode>
-        </Box>
-      </ShadowBevel>
-
-      <ShadowBevel
-        boxShadow="300"
-        borderRadius="300"
-        bevel={{xs: false, sm: true, lg: false}}
-      >
-        <Box background="bg-surface" padding="400">
-          With{' '}
-          <InlineCode>bevel: {'{xs: false, sm: true, lg: false}'}</InlineCode>
-        </Box>
-      </ShadowBevel>
-
-      <ShadowBevel as="article" boxShadow="300" borderRadius="300">
-        <Box background="bg-surface" padding="400">
-          With <InlineCode>as: article</InlineCode>
-        </Box>
-      </ShadowBevel>
-
-      {colors.map(({background, color}) => (
-        <ShadowBevel
-          key={`${background}-${color}`}
-          boxShadow="300"
-          borderRadius="300"
-        >
-          <Box background={background} color={color} padding="400">
-            {background}
+    return (
+      <BlockStack gap="500">
+        <ShadowBevel boxShadow="300" borderRadius="300">
+          <Box background="bg-surface" padding="400">
+            Default
           </Box>
         </ShadowBevel>
-      ))}
 
-      <br />
-    </BlockStack>
-  );
-}
+        <ShadowBevel boxShadow="300" borderRadius="300" bevel={false}>
+          <Box background="bg-surface" padding="400">
+            With <InlineCode>bevel: false</InlineCode>
+          </Box>
+        </ShadowBevel>
+
+        <ShadowBevel
+          boxShadow="300"
+          borderRadius="300"
+          bevel={{xs: false, sm: true}}
+        >
+          <Box background="bg-surface" padding="400">
+            With <InlineCode>bevel: {'{xs: false, sm: true}'}</InlineCode>
+          </Box>
+        </ShadowBevel>
+
+        <ShadowBevel
+          boxShadow="300"
+          borderRadius="300"
+          bevel={{xs: false, sm: true, lg: false}}
+        >
+          <Box background="bg-surface" padding="400">
+            With{' '}
+            <InlineCode>bevel: {'{xs: false, sm: true, lg: false}'}</InlineCode>
+          </Box>
+        </ShadowBevel>
+
+        <ShadowBevel as="article" boxShadow="300" borderRadius="300">
+          <Box background="bg-surface" padding="400">
+            With <InlineCode>as: article</InlineCode>
+          </Box>
+        </ShadowBevel>
+
+        {colors.map(({background, color}) => (
+          <ShadowBevel
+            key={`${background}-${color}`}
+            boxShadow="300"
+            borderRadius="300"
+          >
+            <Box background={background} color={color} padding="400">
+              {background}
+            </Box>
+          </ShadowBevel>
+        ))}
+
+        <br />
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/Sheet/Sheet.stories.tsx
+++ b/polaris-react/src/components/Sheet/Sheet.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Button,
   LegacyCard,
@@ -21,509 +21,513 @@ import {XIcon, SearchIcon} from '@shopify/polaris-icons';
 export default {
   component: Sheet,
   parameters: {layout: 'fullscreen'},
-} as ComponentMeta<typeof Sheet>;
+} as Meta<typeof Sheet>;
 
-export function Default() {
-  const [sheetActive, setSheetActive] = useState(true);
-  const [title, setTitle] = useState('Big yellow socks');
-  const [description, setDescription] = useState(
-    "They’re big, yellow socks. What more could you possibly want from socks? These socks will change your life.\n\nThey’re made from light, hand-loomed cotton that’s so soft, you'll feel like you are walking on a cloud.",
-  );
-  const [salesChannels, setSalesChannels] = useState([
-    {value: 'onlineStore', label: 'Online Store'},
-    {value: 'facebook', label: 'Facebook'},
-    {value: 'googleShopping', label: 'Google shopping'},
-    {value: 'facebookMarketing', label: 'Facebook Marketing'},
-  ]);
-  const [selected, setSelected] = useState([]);
+export const Default = {
+  render() {
+    const [sheetActive, setSheetActive] = useState(true);
+    const [title, setTitle] = useState('Big yellow socks');
+    const [description, setDescription] = useState(
+      "They’re big, yellow socks. What more could you possibly want from socks? These socks will change your life.\n\nThey’re made from light, hand-loomed cotton that’s so soft, you'll feel like you are walking on a cloud.",
+    );
+    const [salesChannels, setSalesChannels] = useState([
+      {value: 'onlineStore', label: 'Online Store'},
+      {value: 'facebook', label: 'Facebook'},
+      {value: 'googleShopping', label: 'Google shopping'},
+      {value: 'facebookMarketing', label: 'Facebook Marketing'},
+    ]);
+    const [selected, setSelected] = useState([]);
 
-  const toggleSheetActive = useCallback(
-    () => setSheetActive((sheetActive) => !sheetActive),
-    [],
-  );
-  const handleSelectedChange = useCallback((value) => setSelected(value), []);
-  const handleTitleChange = useCallback((value) => setTitle(value), []);
-  const handleDescriptionChange = useCallback(
-    (value) => setDescription(value),
-    [],
-  );
+    const toggleSheetActive = useCallback(
+      () => setSheetActive((sheetActive) => !sheetActive),
+      [],
+    );
+    const handleSelectedChange = useCallback((value) => setSelected(value), []);
+    const handleTitleChange = useCallback((value) => setTitle(value), []);
+    const handleDescriptionChange = useCallback(
+      (value) => setDescription(value),
+      [],
+    );
 
-  const selectedSalesChannels = selected.map((key) => {
-    return salesChannels.reduce((accumulator, current) => {
-      accumulator[current.value] = current.label;
-      return accumulator;
-    }, {})[key];
-  });
-  const hasSelectedSalesChannels = selectedSalesChannels.length > 0;
-
-  const salesChannelsCardMarkup = hasSelectedSalesChannels ? (
-    <List>
-      {selectedSalesChannels.map((channel, index) => (
-        <List.Item key={index}>{channel}</List.Item>
-      ))}
-    </List>
-  ) : (
-    <div
-      style={{
-        alignItems: 'center',
-        display: 'flex',
-        justifyContent: 'space-between',
-        width: '100%',
-      }}
-    >
-      <Text as="p" variant="bodyMd">
-        No sales channels selected
-      </Text>
-      <Button onClick={toggleSheetActive}>Manage sales channels</Button>
-    </div>
-  );
-
-  const salesChannelAction = hasSelectedSalesChannels
-    ? [
-        {
-          onAction: toggleSheetActive,
-          content: 'Manage sales channels',
-        },
-      ]
-    : undefined;
-
-  return (
-    <Page narrowWidth>
-      <LegacyCard
-        sectioned
-        subdued
-        title="Product availability"
-        actions={salesChannelAction}
-      >
-        {salesChannelsCardMarkup}
-      </LegacyCard>
-      <Sheet
-        open={sheetActive}
-        onClose={toggleSheetActive}
-        accessibilityLabel="Manage sales channels"
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100%',
-          }}
-        >
-          <div
-            style={{
-              alignItems: 'center',
-              borderBottom: '1px solid #DFE3E8',
-              display: 'flex',
-              justifyContent: 'space-between',
-              padding: '1rem',
-              width: '100%',
-            }}
-          >
-            <Text variant="headingMd" as="h2">
-              Manage sales channels
-            </Text>
-            <Button
-              accessibilityLabel="Cancel"
-              icon={XIcon}
-              onClick={toggleSheetActive}
-              variant="plain"
-            />
-          </div>
-          <Scrollable style={{padding: '1rem', height: '100%'}}>
-            <ChoiceList
-              title="Select a sales channel"
-              name="salesChannelsList"
-              choices={salesChannels}
-              selected={selected}
-              titleHidden
-              allowMultiple
-              onChange={handleSelectedChange}
-            />
-          </Scrollable>
-          <div
-            style={{
-              alignItems: 'center',
-              borderTop: '1px solid #DFE3E8',
-              display: 'flex',
-              justifyContent: 'space-between',
-              padding: '1rem',
-              width: '100%',
-            }}
-          >
-            <Button onClick={toggleSheetActive}>Cancel</Button>
-            <Button variant="primary" onClick={toggleSheetActive}>
-              Done
-            </Button>
-          </div>
-        </div>
-      </Sheet>
-    </Page>
-  );
-}
-
-export function WithSearchableListbox() {
-  const actionValue = '__ACTION__';
-
-  interface CustomerSegment {
-    id: string;
-    label: string;
-    value: string;
-  }
-
-  const segments: CustomerSegment[] = [
-    {
-      label: 'All customers',
-      id: 'gid://shopify/CustomerSegment/1',
-      value: '0',
-    },
-    {
-      label: 'VIP customers',
-      id: 'gid://shopify/CustomerSegment/2',
-      value: '1',
-    },
-    {
-      label: 'New customers',
-      id: 'gid://shopify/CustomerSegment/3',
-      value: '2',
-    },
-    {
-      label: 'Abandoned carts - last 30 days',
-      id: 'gid://shopify/CustomerSegment/4',
-      value: '3',
-    },
-    {
-      label: 'Wholesale customers',
-      id: 'gid://shopify/CustomerSegment/5',
-      value: '4',
-    },
-    {
-      label: 'Email subscribers',
-      id: 'gid://shopify/CustomerSegment/6',
-      value: '5',
-    },
-    {
-      label: 'From New York',
-      id: 'gid://shopify/CustomerSegment/7',
-      value: '6',
-    },
-    {
-      label: 'Repeat buyers',
-      id: 'gid://shopify/CustomerSegment/8',
-      value: '7',
-    },
-    {
-      label: 'First time buyers',
-      id: 'gid://shopify/CustomerSegment/9',
-      value: '8',
-    },
-    {
-      label: 'From Canada',
-      id: 'gid://shopify/CustomerSegment/10',
-      value: '9',
-    },
-    {
-      label: 'Bought in last 60 days',
-      id: 'gid://shopify/CustomerSegment/11',
-      value: '10',
-    },
-    {
-      label: 'Bought last BFCM',
-      id: 'gid://shopify/CustomerSegment/12',
-      value: '11',
-    },
-  ];
-
-  const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
-    (_, index) => ({
-      label: `Other customers ${index + 13}`,
-      id: `gid://shopify/CustomerSegment/${index + 13}`,
-      value: `${index + 12}`,
-    }),
-  );
-
-  segments.push(...lazyLoadSegments);
-
-  const interval = 25;
-  const [sheetOpen, setSheetOpen] = useState(true);
-  const [showFooterAction, setShowFooterAction] = useState(true);
-  const [query, setQuery] = useState('');
-  const [lazyLoading, setLazyLoading] = useState(false);
-  const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
-  const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
-  const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
-  const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
-  const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
-    [],
-  );
-
-  const handleClickShowAll = () => {
-    setShowFooterAction(false);
-    setVisibleOptionIndex(segments.length);
-  };
-
-  const handleFilterSegments = (query: string) => {
-    const nextFilteredSegments = segments.filter((segment) => {
-      return segment.label
-        .toLocaleLowerCase()
-        .includes(query.toLocaleLowerCase().trim());
+    const selectedSalesChannels = selected.map((key) => {
+      return salesChannels.reduce((accumulator, current) => {
+        accumulator[current.value] = current.label;
+        return accumulator;
+      }, {})[key];
     });
+    const hasSelectedSalesChannels = selectedSalesChannels.length > 0;
 
-    setFilteredSegments(nextFilteredSegments);
-  };
-
-  const handleQueryChange = (query: string) => {
-    setQuery(query);
-
-    if (query.length >= 2) handleFilterSegments(query);
-  };
-
-  const handleQueryClear = () => {
-    handleQueryChange('');
-  };
-
-  const handleResetVisibleOptionIndex = () => {
-    setVisibleOptionIndex(interval);
-  };
-
-  const handleOpenSheet = () => {
-    setSheetOpen(true);
-  };
-
-  const handleCloseSheet = () => {
-    setSheetOpen(false);
-    handleQueryChange('');
-    handleResetVisibleOptionIndex();
-  };
-
-  const handleSegmentSelect = (segmentIndex: string) => {
-    if (segmentIndex === actionValue) {
-      return handleClickShowAll();
-    }
-
-    setSelectedSegmentIndex(Number(segmentIndex));
-    handleCloseSheet();
-  };
-
-  const handleActiveOptionChange = (_: string, domId: string) => {
-    setActiveOptionId(domId);
-  };
-
-  /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
-
-  const handleLazyLoadSegments = () => {
-    if (willLoadMoreResults && !showFooterAction) {
-      setLazyLoading(true);
-
-      const options = query ? filteredSegments : segments;
-
-      setTimeout(() => {
-        const remainingOptionCount = options.length - visibleOptionIndex;
-        const nextVisibleOptionIndex =
-          remainingOptionCount >= interval
-            ? visibleOptionIndex + interval
-            : visibleOptionIndex + remainingOptionCount;
-
-        setLazyLoading(false);
-        setVisibleOptionIndex(nextVisibleOptionIndex);
-
-        if (remainingOptionCount <= interval) {
-          setWillLoadMoreResults(false);
-        }
-      }, 1000);
-    }
-  };
-
-  const listboxId = 'SearchableListboxInSheet';
-
-  /* Your app's feature/context specific activator here */
-  const activator = (
-    <Button onClick={handleOpenSheet}>
-      {segments[selectedSegmentIndex].label}
-    </Button>
-  );
-
-  const textFieldMarkup = (
-    <div
-      style={{
-        padding: 'var(--p-space-400) var(--p-space-200)',
-        position: 'sticky',
-        zIndex: 'var(--p-z-index-12)',
-        width: '100%',
-        background: 'var(--p-color-bg-surface)',
-      }}
-    >
-      <StopPropagation>
-        <TextField
-          focused={showFooterAction}
-          clearButton
-          labelHidden
-          label="Customer segments"
-          placeholder="Search segments"
-          autoComplete="off"
-          value={query}
-          prefix={<Icon source={SearchIcon} />}
-          ariaActiveDescendant={activeOptionId}
-          ariaControls={listboxId}
-          onChange={handleQueryChange}
-          onClearButtonClick={handleQueryClear}
-        />
-      </StopPropagation>
-    </div>
-  );
-
-  const segmentOptions = query ? filteredSegments : segments;
-
-  const segmentList =
-    segmentOptions.length > 0
-      ? segmentOptions
-          .slice(0, visibleOptionIndex)
-          .map(({label, id, value}) => {
-            const selected = segments[selectedSegmentIndex].id === id;
-
-            return (
-              <Listbox.Option key={id} value={value} selected={selected}>
-                <Listbox.TextOption selected={selected}>
-                  {label}
-                </Listbox.TextOption>
-              </Listbox.Option>
-            );
-          })
-      : null;
-
-  const showAllMarkup = showFooterAction ? (
-    <Listbox.Action value={actionValue}>
-      <span style={{color: 'var(--p-color-text-emphasis)'}}>
-        Show all 111 segments
-      </span>
-    </Listbox.Action>
-  ) : null;
-
-  const lazyLoadingMarkup = lazyLoading ? (
-    <Listbox.Loading
-      accessibilityLabel={`${
-        query ? 'Filtering' : 'Loading'
-      } customer segments`}
-    />
-  ) : null;
-
-  const noResultsMarkup =
-    segmentOptions.length === 0 ? (
-      <EmptySearchResult
-        title=""
-        description={`No segments found matching "${query}"`}
-      />
-    ) : null;
-
-  const listboxMarkup = (
-    <div
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-      }}
-    >
-      <Listbox
-        enableKeyboardControl
-        autoSelection={AutoSelection.FirstSelected}
-        accessibilityLabel="Search for and select a customer segment"
-        customListId={listboxId}
-        onSelect={handleSegmentSelect}
-        onActiveOptionChange={handleActiveOptionChange}
+    const salesChannelsCardMarkup = hasSelectedSalesChannels ? (
+      <List>
+        {selectedSalesChannels.map((channel, index) => (
+          <List.Item key={index}>{channel}</List.Item>
+        ))}
+      </List>
+    ) : (
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          justifyContent: 'space-between',
+          width: '100%',
+        }}
       >
-        {segmentList}
-        {showAllMarkup}
-        {noResultsMarkup}
-        {lazyLoadingMarkup}
-      </Listbox>
-    </div>
-  );
+        <Text as="p" variant="bodyMd">
+          No sales channels selected
+        </Text>
+        <Button onClick={toggleSheetActive}>Manage sales channels</Button>
+      </div>
+    );
 
-  return (
-    <div style={{height: '265px'}}>
-      {activator}
-      <Sheet
-        open={sheetOpen}
-        accessibilityLabel="Flow action"
-        onClose={handleCloseSheet}
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-          }}
+    const salesChannelAction = hasSelectedSalesChannels
+      ? [
+          {
+            onAction: toggleSheetActive,
+            content: 'Manage sales channels',
+          },
+        ]
+      : undefined;
+
+    return (
+      <Page narrowWidth>
+        <LegacyCard
+          sectioned
+          subdued
+          title="Product availability"
+          actions={salesChannelAction}
+        >
+          {salesChannelsCardMarkup}
+        </LegacyCard>
+        <Sheet
+          open={sheetActive}
+          onClose={toggleSheetActive}
+          accessibilityLabel="Manage sales channels"
         >
           <div
             style={{
-              alignItems: 'flex-start',
-              borderBottom: '1px solid #DFE3E8',
               display: 'flex',
               flexDirection: 'column',
-              justifyContent: 'space-between',
-              width: '100%',
-              padding: 'var(--p-space-400)',
+              height: '100%',
             }}
           >
             <div
               style={{
                 alignItems: 'center',
+                borderBottom: '1px solid #DFE3E8',
                 display: 'flex',
                 justifyContent: 'space-between',
+                padding: '1rem',
                 width: '100%',
-                marginBottom: 'var(--p-space-200)',
               }}
             >
-              <Text as="h3" variant="headingSm" tone="subdued">
-                Action
+              <Text variant="headingMd" as="h2">
+                Manage sales channels
               </Text>
               <Button
                 accessibilityLabel="Cancel"
                 icon={XIcon}
-                onClick={handleCloseSheet}
+                onClick={toggleSheetActive}
                 variant="plain"
               />
             </div>
-            <TextContainer>
-              <Text variant="headingMd" as="h2">
-                Look up customer segmentation membership
-              </Text>
-              <Text tone="subdued" as="span">
-                Look up whether a customer is included in a segment.
-              </Text>
-            </TextContainer>
+            <Scrollable style={{padding: '1rem', height: '100%'}}>
+              <ChoiceList
+                title="Select a sales channel"
+                name="salesChannelsList"
+                choices={salesChannels}
+                selected={selected}
+                titleHidden
+                allowMultiple
+                onChange={handleSelectedChange}
+              />
+            </Scrollable>
+            <div
+              style={{
+                alignItems: 'center',
+                borderTop: '1px solid #DFE3E8',
+                display: 'flex',
+                justifyContent: 'space-between',
+                padding: '1rem',
+                width: '100%',
+              }}
+            >
+              <Button onClick={toggleSheetActive}>Cancel</Button>
+              <Button variant="primary" onClick={toggleSheetActive}>
+                Done
+              </Button>
+            </div>
           </div>
+        </Sheet>
+      </Page>
+    );
+  },
+};
+
+export const WithSearchableListbox = {
+  render() {
+    const actionValue = '__ACTION__';
+
+    interface CustomerSegment {
+      id: string;
+      label: string;
+      value: string;
+    }
+
+    const segments: CustomerSegment[] = [
+      {
+        label: 'All customers',
+        id: 'gid://shopify/CustomerSegment/1',
+        value: '0',
+      },
+      {
+        label: 'VIP customers',
+        id: 'gid://shopify/CustomerSegment/2',
+        value: '1',
+      },
+      {
+        label: 'New customers',
+        id: 'gid://shopify/CustomerSegment/3',
+        value: '2',
+      },
+      {
+        label: 'Abandoned carts - last 30 days',
+        id: 'gid://shopify/CustomerSegment/4',
+        value: '3',
+      },
+      {
+        label: 'Wholesale customers',
+        id: 'gid://shopify/CustomerSegment/5',
+        value: '4',
+      },
+      {
+        label: 'Email subscribers',
+        id: 'gid://shopify/CustomerSegment/6',
+        value: '5',
+      },
+      {
+        label: 'From New York',
+        id: 'gid://shopify/CustomerSegment/7',
+        value: '6',
+      },
+      {
+        label: 'Repeat buyers',
+        id: 'gid://shopify/CustomerSegment/8',
+        value: '7',
+      },
+      {
+        label: 'First time buyers',
+        id: 'gid://shopify/CustomerSegment/9',
+        value: '8',
+      },
+      {
+        label: 'From Canada',
+        id: 'gid://shopify/CustomerSegment/10',
+        value: '9',
+      },
+      {
+        label: 'Bought in last 60 days',
+        id: 'gid://shopify/CustomerSegment/11',
+        value: '10',
+      },
+      {
+        label: 'Bought last BFCM',
+        id: 'gid://shopify/CustomerSegment/12',
+        value: '11',
+      },
+    ];
+
+    const lazyLoadSegments: CustomerSegment[] = Array.from(Array(100)).map(
+      (_, index) => ({
+        label: `Other customers ${index + 13}`,
+        id: `gid://shopify/CustomerSegment/${index + 13}`,
+        value: `${index + 12}`,
+      }),
+    );
+
+    segments.push(...lazyLoadSegments);
+
+    const interval = 25;
+    const [sheetOpen, setSheetOpen] = useState(true);
+    const [showFooterAction, setShowFooterAction] = useState(true);
+    const [query, setQuery] = useState('');
+    const [lazyLoading, setLazyLoading] = useState(false);
+    const [willLoadMoreResults, setWillLoadMoreResults] = useState(true);
+    const [visibleOptionIndex, setVisibleOptionIndex] = useState(6);
+    const [activeOptionId, setActiveOptionId] = useState(segments[0].id);
+    const [selectedSegmentIndex, setSelectedSegmentIndex] = useState(0);
+    const [filteredSegments, setFilteredSegments] = useState<CustomerSegment[]>(
+      [],
+    );
+
+    const handleClickShowAll = () => {
+      setShowFooterAction(false);
+      setVisibleOptionIndex(segments.length);
+    };
+
+    const handleFilterSegments = (query: string) => {
+      const nextFilteredSegments = segments.filter((segment) => {
+        return segment.label
+          .toLocaleLowerCase()
+          .includes(query.toLocaleLowerCase().trim());
+      });
+
+      setFilteredSegments(nextFilteredSegments);
+    };
+
+    const handleQueryChange = (query: string) => {
+      setQuery(query);
+
+      if (query.length >= 2) handleFilterSegments(query);
+    };
+
+    const handleQueryClear = () => {
+      handleQueryChange('');
+    };
+
+    const handleResetVisibleOptionIndex = () => {
+      setVisibleOptionIndex(interval);
+    };
+
+    const handleOpenSheet = () => {
+      setSheetOpen(true);
+    };
+
+    const handleCloseSheet = () => {
+      setSheetOpen(false);
+      handleQueryChange('');
+      handleResetVisibleOptionIndex();
+    };
+
+    const handleSegmentSelect = (segmentIndex: string) => {
+      if (segmentIndex === actionValue) {
+        return handleClickShowAll();
+      }
+
+      setSelectedSegmentIndex(Number(segmentIndex));
+      handleCloseSheet();
+    };
+
+    const handleActiveOptionChange = (_: string, domId: string) => {
+      setActiveOptionId(domId);
+    };
+
+    /* This is just to illustrate lazy loading state vs loading state. This is an example, so we aren't fetching from GraphQL. You'd use `pageInfo.hasNextPage` from your GraphQL query data instead of this fake "willLoadMoreResults" state along with setting `first` your GraphQL query's variables to your app's default max edges limit (e.g., 250). */
+
+    const handleLazyLoadSegments = () => {
+      if (willLoadMoreResults && !showFooterAction) {
+        setLazyLoading(true);
+
+        const options = query ? filteredSegments : segments;
+
+        setTimeout(() => {
+          const remainingOptionCount = options.length - visibleOptionIndex;
+          const nextVisibleOptionIndex =
+            remainingOptionCount >= interval
+              ? visibleOptionIndex + interval
+              : visibleOptionIndex + remainingOptionCount;
+
+          setLazyLoading(false);
+          setVisibleOptionIndex(nextVisibleOptionIndex);
+
+          if (remainingOptionCount <= interval) {
+            setWillLoadMoreResults(false);
+          }
+        }, 1000);
+      }
+    };
+
+    const listboxId = 'SearchableListboxInSheet';
+
+    /* Your app's feature/context specific activator here */
+    const activator = (
+      <Button onClick={handleOpenSheet}>
+        {segments[selectedSegmentIndex].label}
+      </Button>
+    );
+
+    const textFieldMarkup = (
+      <div
+        style={{
+          padding: 'var(--p-space-400) var(--p-space-200)',
+          position: 'sticky',
+          zIndex: 'var(--p-z-index-12)',
+          width: '100%',
+          background: 'var(--p-color-bg-surface)',
+        }}
+      >
+        <StopPropagation>
+          <TextField
+            focused={showFooterAction}
+            clearButton
+            labelHidden
+            label="Customer segments"
+            placeholder="Search segments"
+            autoComplete="off"
+            value={query}
+            prefix={<Icon source={SearchIcon} />}
+            ariaActiveDescendant={activeOptionId}
+            ariaControls={listboxId}
+            onChange={handleQueryChange}
+            onClearButtonClick={handleQueryClear}
+          />
+        </StopPropagation>
+      </div>
+    );
+
+    const segmentOptions = query ? filteredSegments : segments;
+
+    const segmentList =
+      segmentOptions.length > 0
+        ? segmentOptions
+            .slice(0, visibleOptionIndex)
+            .map(({label, id, value}) => {
+              const selected = segments[selectedSegmentIndex].id === id;
+
+              return (
+                <Listbox.Option key={id} value={value} selected={selected}>
+                  <Listbox.TextOption selected={selected}>
+                    {label}
+                  </Listbox.TextOption>
+                </Listbox.Option>
+              );
+            })
+        : null;
+
+    const showAllMarkup = showFooterAction ? (
+      <Listbox.Action value={actionValue}>
+        <span style={{color: 'var(--p-color-text-emphasis)'}}>
+          Show all 111 segments
+        </span>
+      </Listbox.Action>
+    ) : null;
+
+    const lazyLoadingMarkup = lazyLoading ? (
+      <Listbox.Loading
+        accessibilityLabel={`${
+          query ? 'Filtering' : 'Loading'
+        } customer segments`}
+      />
+    ) : null;
+
+    const noResultsMarkup =
+      segmentOptions.length === 0 ? (
+        <EmptySearchResult
+          title=""
+          description={`No segments found matching "${query}"`}
+        />
+      ) : null;
+
+    const listboxMarkup = (
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <Listbox
+          enableKeyboardControl
+          autoSelection={AutoSelection.FirstSelected}
+          accessibilityLabel="Search for and select a customer segment"
+          customListId={listboxId}
+          onSelect={handleSegmentSelect}
+          onActiveOptionChange={handleActiveOptionChange}
+        >
+          {segmentList}
+          {showAllMarkup}
+          {noResultsMarkup}
+          {lazyLoadingMarkup}
+        </Listbox>
+      </div>
+    );
+
+    return (
+      <div style={{height: '265px'}}>
+        {activator}
+        <Sheet
+          open={sheetOpen}
+          accessibilityLabel="Flow action"
+          onClose={handleCloseSheet}
+        >
           <div
             style={{
-              alignItems: 'stretch',
-              borderTop: '1px solid #DFE3E8',
               display: 'flex',
               flexDirection: 'column',
-              justifyContent: 'stretch',
-              position: 'relative',
-              width: '100%',
-              height: '100%',
-              overflow: 'hidden',
             }}
           >
-            {textFieldMarkup}
-
-            <Scrollable
-              shadow
+            <div
               style={{
+                alignItems: 'flex-start',
+                borderBottom: '1px solid #DFE3E8',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'space-between',
+                width: '100%',
+                padding: 'var(--p-space-400)',
+              }}
+            >
+              <div
+                style={{
+                  alignItems: 'center',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  width: '100%',
+                  marginBottom: 'var(--p-space-200)',
+                }}
+              >
+                <Text as="h3" variant="headingSm" tone="subdued">
+                  Action
+                </Text>
+                <Button
+                  accessibilityLabel="Cancel"
+                  icon={XIcon}
+                  onClick={handleCloseSheet}
+                  variant="plain"
+                />
+              </div>
+              <TextContainer>
+                <Text variant="headingMd" as="h2">
+                  Look up customer segmentation membership
+                </Text>
+                <Text tone="subdued" as="span">
+                  Look up whether a customer is included in a segment.
+                </Text>
+              </TextContainer>
+            </div>
+            <div
+              style={{
+                alignItems: 'stretch',
+                borderTop: '1px solid #DFE3E8',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'stretch',
                 position: 'relative',
                 width: '100%',
-                height: '292px',
-                padding: 'var(--p-space-200) 0',
+                height: '100%',
+                overflow: 'hidden',
               }}
-              onScrolledToBottom={handleLazyLoadSegments}
             >
-              {listboxMarkup}
-            </Scrollable>
+              {textFieldMarkup}
+
+              <Scrollable
+                shadow
+                style={{
+                  position: 'relative',
+                  width: '100%',
+                  height: '292px',
+                  padding: 'var(--p-space-200) 0',
+                }}
+                onScrolledToBottom={handleLazyLoadSegments}
+              >
+                {listboxMarkup}
+              </Scrollable>
+            </div>
           </div>
-        </div>
-      </Sheet>
-    </div>
-  );
-}
+        </Sheet>
+      </div>
+    );
+  },
+};
 
 const StopPropagation = ({children}: React.PropsWithChildren<any>) => {
   const stopEventPropagation = (event: React.MouseEvent | React.TouchEvent) => {

--- a/polaris-react/src/components/SkeletonBodyText/SkeletonBodyText.stories.tsx
+++ b/polaris-react/src/components/SkeletonBodyText/SkeletonBodyText.stories.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {SkeletonBodyText} from '@shopify/polaris';
 
 export default {
   component: SkeletonBodyText,
-} as ComponentMeta<typeof SkeletonBodyText>;
+} as Meta<typeof SkeletonBodyText>;
 
-export function Default() {
-  return <SkeletonBodyText />;
-}
+export const Default = {
+  render() {
+    return <SkeletonBodyText />;
+  },
+};
 
-export function SingleLineContent() {
-  return <SkeletonBodyText lines={1} />;
-}
+export const SingleLineContent = {
+  render() {
+    return <SkeletonBodyText lines={1} />;
+  },
+};

--- a/polaris-react/src/components/SkeletonDisplayText/SkeletonDisplayText.stories.tsx
+++ b/polaris-react/src/components/SkeletonDisplayText/SkeletonDisplayText.stories.tsx
@@ -1,23 +1,31 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {SkeletonDisplayText} from '@shopify/polaris';
 
 export default {
   component: SkeletonDisplayText,
-} as ComponentMeta<typeof SkeletonDisplayText>;
+} as Meta<typeof SkeletonDisplayText>;
 
-export function MediumAndLarge() {
-  return <SkeletonDisplayText size="medium" />;
-}
+export const MediumAndLarge = {
+  render() {
+    return <SkeletonDisplayText size="medium" />;
+  },
+};
 
-export function ExtraLarge() {
-  return <SkeletonDisplayText size="extraLarge" />;
-}
+export const ExtraLarge = {
+  render() {
+    return <SkeletonDisplayText size="extraLarge" />;
+  },
+};
 
-export function Small() {
-  return <SkeletonDisplayText size="small" />;
-}
+export const Small = {
+  render() {
+    return <SkeletonDisplayText size="small" />;
+  },
+};
 
-export function MaxWidth() {
-  return <SkeletonDisplayText maxWidth="80%" />;
-}
+export const MaxWidth = {
+  render() {
+    return <SkeletonDisplayText maxWidth="80%" />;
+  },
+};

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.stories.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   LegacyCard,
   Layout,
@@ -11,242 +11,252 @@ import {
 
 export default {
   component: SkeletonPage,
-} as ComponentMeta<typeof SkeletonPage>;
+} as Meta<typeof SkeletonPage>;
 
-export function WithDynamicContent() {
-  return (
-    <SkeletonPage primaryAction>
-      <Layout>
-        <Layout.Section>
-          <LegacyCard sectioned>
-            <SkeletonBodyText />
-          </LegacyCard>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
+export const WithDynamicContent = {
+  render() {
+    return (
+      <SkeletonPage primaryAction>
+        <Layout>
+          <Layout.Section>
+            <LegacyCard sectioned>
               <SkeletonBodyText />
-            </TextContainer>
-          </LegacyCard>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
-              <SkeletonBodyText />
-            </TextContainer>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard>
-            <LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard sectioned>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
-                <SkeletonBodyText lines={2} />
+                <SkeletonBodyText />
               </TextContainer>
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={1} />
-            </LegacyCard.Section>
-          </LegacyCard>
-          <LegacyCard subdued>
-            <LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard sectioned>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
-                <SkeletonBodyText lines={2} />
+                <SkeletonBodyText />
               </TextContainer>
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={2} />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </SkeletonPage>
-  );
-}
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard>
+              <LegacyCard.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={1} />
+              </LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard subdued>
+              <LegacyCard.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={2} />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </SkeletonPage>
+    );
+  },
+};
 
-export function WithStaticContent() {
-  return (
-    <SkeletonPage title="Products" primaryAction>
-      <Layout>
-        <Layout.Section>
-          <LegacyCard sectioned>
-            <SkeletonBodyText />
-          </LegacyCard>
-          <LegacyCard sectioned title="Images">
-            <SkeletonBodyText />
-          </LegacyCard>
-          <LegacyCard sectioned title="Variants">
-            <SkeletonBodyText />
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard title="Sales channels">
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={2} />
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={1} />
-            </LegacyCard.Section>
-          </LegacyCard>
-          <LegacyCard title="Organization" subdued>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={2} />
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={2} />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </SkeletonPage>
-  );
-}
+export const WithStaticContent = {
+  render() {
+    return (
+      <SkeletonPage title="Products" primaryAction>
+        <Layout>
+          <Layout.Section>
+            <LegacyCard sectioned>
+              <SkeletonBodyText />
+            </LegacyCard>
+            <LegacyCard sectioned title="Images">
+              <SkeletonBodyText />
+            </LegacyCard>
+            <LegacyCard sectioned title="Variants">
+              <SkeletonBodyText />
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard title="Sales channels">
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={2} />
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={1} />
+              </LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard title="Organization" subdued>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={2} />
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={2} />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </SkeletonPage>
+    );
+  },
+};
 
-export function WithNarrowWidth() {
-  return (
-    <SkeletonPage primaryAction narrowWidth>
-      <Layout>
-        <Layout.Section>
-          <LegacyCard sectioned>
-            <SkeletonBodyText />
-          </LegacyCard>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
+export const WithNarrowWidth = {
+  render() {
+    return (
+      <SkeletonPage primaryAction narrowWidth>
+        <Layout>
+          <Layout.Section>
+            <LegacyCard sectioned>
               <SkeletonBodyText />
-            </TextContainer>
-          </LegacyCard>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
-              <SkeletonBodyText />
-            </TextContainer>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard>
-            <LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard sectioned>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
-                <SkeletonBodyText lines={2} />
+                <SkeletonBodyText />
               </TextContainer>
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={1} />
-            </LegacyCard.Section>
-          </LegacyCard>
-          <LegacyCard subdued>
-            <LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard sectioned>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
-                <SkeletonBodyText lines={2} />
+                <SkeletonBodyText />
               </TextContainer>
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={2} />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </SkeletonPage>
-  );
-}
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard>
+              <LegacyCard.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={1} />
+              </LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard subdued>
+              <LegacyCard.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={2} />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </SkeletonPage>
+    );
+  },
+};
 
-export function WithFullWidth() {
-  return (
-    <SkeletonPage primaryAction fullWidth>
-      <Layout>
-        <Layout.Section>
-          <LegacyCard sectioned>
-            <SkeletonBodyText />
-          </LegacyCard>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
+export const WithFullWidth = {
+  render() {
+    return (
+      <SkeletonPage primaryAction fullWidth>
+        <Layout>
+          <Layout.Section>
+            <LegacyCard sectioned>
               <SkeletonBodyText />
-            </TextContainer>
-          </LegacyCard>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
-              <SkeletonBodyText />
-            </TextContainer>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard>
-            <LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard sectioned>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
-                <SkeletonBodyText lines={2} />
+                <SkeletonBodyText />
               </TextContainer>
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={1} />
-            </LegacyCard.Section>
-          </LegacyCard>
-          <LegacyCard subdued>
-            <LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard sectioned>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
-                <SkeletonBodyText lines={2} />
+                <SkeletonBodyText />
               </TextContainer>
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={2} />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </SkeletonPage>
-  );
-}
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard>
+              <LegacyCard.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={1} />
+              </LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard subdued>
+              <LegacyCard.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={2} />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </SkeletonPage>
+    );
+  },
+};
 
-export function WithBackAction() {
-  return (
-    <SkeletonPage primaryAction backAction>
-      <Layout>
-        <Layout.Section>
-          <LegacyCard sectioned>
-            <SkeletonBodyText />
-          </LegacyCard>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
+export const WithBackAction = {
+  render() {
+    return (
+      <SkeletonPage primaryAction backAction>
+        <Layout>
+          <Layout.Section>
+            <LegacyCard sectioned>
               <SkeletonBodyText />
-            </TextContainer>
-          </LegacyCard>
-          <LegacyCard sectioned>
-            <TextContainer>
-              <SkeletonDisplayText size="small" />
-              <SkeletonBodyText />
-            </TextContainer>
-          </LegacyCard>
-        </Layout.Section>
-        <Layout.Section variant="oneThird">
-          <LegacyCard>
-            <LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard sectioned>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
-                <SkeletonBodyText lines={2} />
+                <SkeletonBodyText />
               </TextContainer>
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={1} />
-            </LegacyCard.Section>
-          </LegacyCard>
-          <LegacyCard subdued>
-            <LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard sectioned>
               <TextContainer>
                 <SkeletonDisplayText size="small" />
-                <SkeletonBodyText lines={2} />
+                <SkeletonBodyText />
               </TextContainer>
-            </LegacyCard.Section>
-            <LegacyCard.Section>
-              <SkeletonBodyText lines={2} />
-            </LegacyCard.Section>
-          </LegacyCard>
-        </Layout.Section>
-      </Layout>
-    </SkeletonPage>
-  );
-}
+            </LegacyCard>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <LegacyCard>
+              <LegacyCard.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={1} />
+              </LegacyCard.Section>
+            </LegacyCard>
+            <LegacyCard subdued>
+              <LegacyCard.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </LegacyCard.Section>
+              <LegacyCard.Section>
+                <SkeletonBodyText lines={2} />
+              </LegacyCard.Section>
+            </LegacyCard>
+          </Layout.Section>
+        </Layout>
+      </SkeletonPage>
+    );
+  },
+};

--- a/polaris-react/src/components/SkeletonTabs/SkeletonTabs.stories.tsx
+++ b/polaris-react/src/components/SkeletonTabs/SkeletonTabs.stories.tsx
@@ -6,51 +6,63 @@ export default {
   component: SkeletonTabs,
 } as Meta<typeof SkeletonTabs>;
 
-export function All() {
-  return (
-    <BlockStack gap="500">
-      <Default />
-      <WithACustomCount />
-      <InsideOfACard />
-      <InsideOfACardFitted />
-    </BlockStack>
-  );
-}
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="500">
+        <Default.render />
+        <WithACustomCount.render />
+        <InsideOfACard.render />
+        <InsideOfACardFitted.render />
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function Default() {
-  return <SkeletonTabs />;
-}
+export const Default = {
+  render() {
+    return <SkeletonTabs />;
+  },
+};
 
-export function WithACustomCount() {
-  return <SkeletonTabs count={4} />;
-}
+export const WithACustomCount = {
+  render() {
+    return <SkeletonTabs count={4} />;
+  },
+};
 
-export function InsideOfACard() {
-  return (
-    <LegacyCard>
-      <div>
-        <SkeletonTabs count={6} />
-        <LegacyCard.Section title="TabName">
-          <Text as="p" variant="bodyMd">
-            Tab X selected
-          </Text>
-        </LegacyCard.Section>
-      </div>
-    </LegacyCard>
-  );
-}
+export const InsideOfACard = {
+  render() {
+    return (
+      <LegacyCard>
+        <div>
+          <SkeletonTabs count={6} />
+          <LegacyCard.Section title="TabName">
+            <Text as="p" variant="bodyMd">
+              Tab X selected
+            </Text>
+          </LegacyCard.Section>
+        </div>
+      </LegacyCard>
+    );
+  },
+};
 
-export function InsideOfACardFitted() {
-  return (
-    <LegacyCard>
-      <div>
-        <SkeletonTabs fitted />
-        <LegacyCard.Section title="TabName">
-          <Text as="p" variant="bodyMd">
-            Tab X selected
-          </Text>
-        </LegacyCard.Section>
-      </div>
-    </LegacyCard>
-  );
-}
+export const InsideOfACardFitted = {
+  render() {
+    return (
+      <LegacyCard>
+        <div>
+          <SkeletonTabs fitted />
+          <LegacyCard.Section title="TabName">
+            <Text as="p" variant="bodyMd">
+              Tab X selected
+            </Text>
+          </LegacyCard.Section>
+        </div>
+      </LegacyCard>
+    );
+  },
+};

--- a/polaris-react/src/components/SkeletonThumbnail/SkeletonThumbnail.stories.tsx
+++ b/polaris-react/src/components/SkeletonThumbnail/SkeletonThumbnail.stories.tsx
@@ -1,34 +1,46 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {SkeletonThumbnail, BlockStack} from '@shopify/polaris';
 
-export function All() {
-  return (
-    <BlockStack gap="400">
-      <ExtraSmall />
-      <Small />
-      <Medium />
-      <Large />
-    </BlockStack>
-  );
-}
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="400">
+        <ExtraSmall.render />
+        <Small.render />
+        <Medium.render />
+        <Large.render />
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
 export default {
   component: SkeletonThumbnail,
-} as ComponentMeta<typeof SkeletonThumbnail>;
+} as Meta<typeof SkeletonThumbnail>;
 
-export function Medium() {
-  return <SkeletonThumbnail size="medium" />;
-}
+export const Medium = {
+  render() {
+    return <SkeletonThumbnail size="medium" />;
+  },
+};
 
-export function Large() {
-  return <SkeletonThumbnail size="large" />;
-}
+export const Large = {
+  render() {
+    return <SkeletonThumbnail size="large" />;
+  },
+};
 
-export function Small() {
-  return <SkeletonThumbnail size="small" />;
-}
+export const Small = {
+  render() {
+    return <SkeletonThumbnail size="small" />;
+  },
+};
 
-export function ExtraSmall() {
-  return <SkeletonThumbnail size="extraSmall" />;
-}
+export const ExtraSmall = {
+  render() {
+    return <SkeletonThumbnail size="extraSmall" />;
+  },
+};

--- a/polaris-react/src/components/Spinner/Spinner.stories.tsx
+++ b/polaris-react/src/components/Spinner/Spinner.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Button,
   LegacyCard,
@@ -12,91 +12,105 @@ import {
 
 export default {
   component: Spinner,
-} as ComponentMeta<typeof Spinner>;
+} as Meta<typeof Spinner>;
 
-export function All() {
-  return (
-    <>
-      <Default />
-      <Small />
-      <WithFocusManagement />
-    </>
-  );
-}
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <>
+        <Default.render />
+        <Small.render />
+        <WithFocusManagement.render />
+      </>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function Default() {
-  return <Spinner accessibilityLabel="Spinner example" size="large" />;
-}
+export const Default = {
+  render() {
+    return <Spinner accessibilityLabel="Spinner example" size="large" />;
+  },
+};
 
-export function Small() {
-  return <Spinner accessibilityLabel="Small spinner example" size="small" />;
-}
+export const Small = {
+  render() {
+    return <Spinner accessibilityLabel="Small spinner example" size="small" />;
+  },
+};
 
-export function WithFocusManagement() {
-  const tabs = useRef([
-    {
-      id: 'all-customers',
-      content: 'All',
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-content',
-    },
-    {
-      id: 'accepts-marketing',
-      content: 'Accepts marketing',
-      panelID: 'accepts-marketing-content',
-    },
-  ]);
+export const WithFocusManagement = {
+  render() {
+    const tabs = useRef([
+      {
+        id: 'all-customers',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-content',
+      },
+      {
+        id: 'accepts-marketing',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-content',
+      },
+    ]);
 
-  const [selected, setSelected] = useState(0);
-  const [loading, setLoading] = useState(false);
-  const [value, setValue] = useState('');
-  const [textFieldFocused, setTextFieldFocused] = useState(false);
+    const [selected, setSelected] = useState(0);
+    const [loading, setLoading] = useState(false);
+    const [value, setValue] = useState('');
+    const [textFieldFocused, setTextFieldFocused] = useState(false);
 
-  useEffect(() => {
-    setTextFieldFocused(!loading);
-  }, [loading]);
+    useEffect(() => {
+      setTextFieldFocused(!loading);
+    }, [loading]);
 
-  const handleTabChange = useCallback((selectedTab) => {
-    setLoading(true);
-    setSelected(selectedTab);
-    setTimeout(() => {
-      setValue('');
-      return setLoading(false);
-    }, 1500);
-  }, []);
+    const handleTabChange = useCallback((selectedTab) => {
+      setLoading(true);
+      setSelected(selectedTab);
+      setTimeout(() => {
+        setValue('');
+        return setLoading(false);
+      }, 1500);
+    }, []);
 
-  const handleUrlChange = useCallback((value) => setValue(value), []);
+    const handleUrlChange = useCallback((value) => setValue(value), []);
 
-  const handleSubmit = useCallback((_event) => setValue(''), []);
+    const handleSubmit = useCallback((_event) => setValue(''), []);
 
-  const label = selected ? 'Marketing' : 'Customers';
-  const sectionMarkup = loading ? (
-    <Spinner
-      accessibilityLabel="Loading form field"
-      hasFocusableParent={false}
-    />
-  ) : (
-    <Form noValidate onSubmit={handleSubmit}>
-      <FormLayout>
-        <TextField
-          value={value}
-          focused={textFieldFocused}
-          onChange={handleUrlChange}
-          label={label}
-          autoComplete="off"
-        />
-        <Button submit>Submit</Button>
-      </FormLayout>
-    </Form>
-  );
+    const label = selected ? 'Marketing' : 'Customers';
+    const sectionMarkup = loading ? (
+      <Spinner
+        accessibilityLabel="Loading form field"
+        hasFocusableParent={false}
+      />
+    ) : (
+      <Form noValidate onSubmit={handleSubmit}>
+        <FormLayout>
+          <TextField
+            value={value}
+            focused={textFieldFocused}
+            onChange={handleUrlChange}
+            label={label}
+            autoComplete="off"
+          />
+          <Button submit>Submit</Button>
+        </FormLayout>
+      </Form>
+    );
 
-  return (
-    <LegacyCard>
-      <Tabs tabs={tabs.current} selected={selected} onSelect={handleTabChange}>
-        <LegacyCard.Section title={tabs.current[selected].content}>
-          {sectionMarkup}
-        </LegacyCard.Section>
-      </Tabs>
-    </LegacyCard>
-  );
-}
+    return (
+      <LegacyCard>
+        <Tabs
+          tabs={tabs.current}
+          selected={selected}
+          onSelect={handleTabChange}
+        >
+          <LegacyCard.Section title={tabs.current[selected].content}>
+            {sectionMarkup}
+          </LegacyCard.Section>
+        </Tabs>
+      </LegacyCard>
+    );
+  },
+};

--- a/polaris-react/src/components/Tabs/Tabs.stories.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.stories.tsx
@@ -1,73 +1,48 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Tabs, BlockStack, LegacyCard, Text} from '@shopify/polaris';
 
 export default {
   component: Tabs,
-} as ComponentMeta<typeof Tabs>;
+} as Meta<typeof Tabs>;
 
-export function All() {
-  return (
-    <BlockStack gap="500">
-      <Default />
-      <InsideOfACard />
-      <Fitted />
-      <WithActions />
-      <WithBadgeContent />
-      <WithCustomDisclosure />
-    </BlockStack>
-  );
-}
-export function Default() {
-  const [selected, setSelected] = useState(0);
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="500">
+        <Default.render />
+        <InsideOfACard.render />
+        <Fitted.render />
+        <WithActions.render />
+        <WithBadgeContent.render />
+        <WithCustomDisclosure.render />
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
+export const Default = {
+  render() {
+    const [selected, setSelected] = useState(0);
 
-  const handleTabChange = (selectedTabIndex: number) =>
-    setSelected(selectedTabIndex);
+    const handleTabChange = (selectedTabIndex: number) =>
+      setSelected(selectedTabIndex);
 
-  const tabs = [
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ].map((item, index) => ({
-    content: item,
-    index,
-    id: `${item.split(' ').join('-')}-${index}-default`,
-  }));
+    const tabs = [
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ].map((item, index) => ({
+      content: item,
+      index,
+      id: `${item.split(' ').join('-')}-${index}-default`,
+    }));
 
-  return (
-    <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
-      <LegacyCard.Section title={tabs[selected].content}>
-        <Text as="p" variant="bodyMd">
-          Tab {selected} selected
-        </Text>
-      </LegacyCard.Section>
-    </Tabs>
-  );
-}
-
-export function InsideOfACard() {
-  const [selected, setSelected] = useState(0);
-
-  const handleTabChange = (selectedTabIndex: number) =>
-    setSelected(selectedTabIndex);
-
-  const tabs = [
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ].map((item, index) => ({
-    content: item,
-    index,
-    id: `${item.split(' ').join('-')}-${index}-inside-of-a-card`,
-  }));
-  return (
-    <LegacyCard>
+    return (
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
         <LegacyCard.Section title={tabs[selected].content}>
           <Text as="p" variant="bodyMd">
@@ -75,44 +50,79 @@ export function InsideOfACard() {
           </Text>
         </LegacyCard.Section>
       </Tabs>
-    </LegacyCard>
-  );
-}
+    );
+  },
+};
 
-export function Fitted() {
-  const [selected, setSelected] = useState(0);
+export const InsideOfACard = {
+  render() {
+    const [selected, setSelected] = useState(0);
 
-  const handleTabChange = useCallback(
-    (selectedTabIndex: number) => setSelected(selectedTabIndex),
-    [],
-  );
+    const handleTabChange = (selectedTabIndex: number) =>
+      setSelected(selectedTabIndex);
 
-  const tabs = [
-    {
-      id: 'all-customers-fitted',
-      content: 'All',
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-fitted-content',
-    },
-    {
-      id: 'accepts-marketing-fitted',
-      content: 'Accepts marketing',
-      panelID: 'accepts-marketing-fitted-content',
-    },
-  ];
+    const tabs = [
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+    ].map((item, index) => ({
+      content: item,
+      index,
+      id: `${item.split(' ').join('-')}-${index}-inside-of-a-card`,
+    }));
+    return (
+      <LegacyCard>
+        <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
+          <LegacyCard.Section title={tabs[selected].content}>
+            <Text as="p" variant="bodyMd">
+              Tab {selected} selected
+            </Text>
+          </LegacyCard.Section>
+        </Tabs>
+      </LegacyCard>
+    );
+  },
+};
 
-  return (
-    <LegacyCard>
-      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
-        <LegacyCard.Section title={tabs[selected].content}>
-          <Text as="p" variant="bodyMd">
-            Tab {selected} selected
-          </Text>
-        </LegacyCard.Section>
-      </Tabs>
-    </LegacyCard>
-  );
-}
+export const Fitted = {
+  render() {
+    const [selected, setSelected] = useState(0);
+
+    const handleTabChange = useCallback(
+      (selectedTabIndex: number) => setSelected(selectedTabIndex),
+      [],
+    );
+
+    const tabs = [
+      {
+        id: 'all-customers-fitted',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-fitted-content',
+      },
+      {
+        id: 'accepts-marketing-fitted',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-fitted-content',
+      },
+    ];
+
+    return (
+      <LegacyCard>
+        <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
+          <LegacyCard.Section title={tabs[selected].content}>
+            <Text as="p" variant="bodyMd">
+              Tab {selected} selected
+            </Text>
+          </LegacyCard.Section>
+        </Tabs>
+      </LegacyCard>
+    );
+  },
+};
 
 type AlphaTabAction =
   | 'rename'
@@ -121,176 +131,182 @@ type AlphaTabAction =
   | 'duplicate'
   | 'delete';
 
-export function WithActions() {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-  const [selected, setSelected] = useState(0);
+export const WithActions = {
+  render() {
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+    const [selected, setSelected] = useState(0);
 
-  const handleTabChange = (selectedTabIndex: number) =>
-    setSelected(selectedTabIndex);
+    const handleTabChange = (selectedTabIndex: number) =>
+      setSelected(selectedTabIndex);
 
-  const tabs = [
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-    'Returning customers',
-    'New customers',
-    'Abandoned checkouts',
-    'Online store',
-    'POS',
-    'Facebook',
-    'Instagram',
-    'Twitter',
-    'Pinterest',
-    'Google',
-    'Referral',
-  ].map((item, index) => ({
-    content: item,
-    index,
-    id: `${item.split(' ').join('-')}-${index}-with-actions`,
-    actions:
-      index === 0
-        ? []
-        : [
-            {
-              type: 'rename' as AlphaTabAction,
-              onAction: () => {},
-              onPrimaryAction: () => {},
-            },
-            {
-              type: 'duplicate' as AlphaTabAction,
-              onAction: () => {},
-              onPrimaryAction: () => {},
-            },
-            {
-              type: 'edit' as AlphaTabAction,
-              onAction: () => {},
-              onPrimaryAction: () => {},
-            },
-            {
-              type: 'edit-columns' as AlphaTabAction,
-              onAction: () => {},
-              onPrimaryAction: () => {},
-            },
-            {
-              type: 'delete' as AlphaTabAction,
-              onAction: () => {},
-              onPrimaryAction: () => {},
-            },
-          ],
-  }));
+    const tabs = [
+      'All',
+      'Unpaid',
+      'Open',
+      'Closed',
+      'Local delivery',
+      'Local pickup',
+      'Returning customers',
+      'New customers',
+      'Abandoned checkouts',
+      'Online store',
+      'POS',
+      'Facebook',
+      'Instagram',
+      'Twitter',
+      'Pinterest',
+      'Google',
+      'Referral',
+    ].map((item, index) => ({
+      content: item,
+      index,
+      id: `${item.split(' ').join('-')}-${index}-with-actions`,
+      actions:
+        index === 0
+          ? []
+          : [
+              {
+                type: 'rename' as AlphaTabAction,
+                onAction: () => {},
+                onPrimaryAction: () => {},
+              },
+              {
+                type: 'duplicate' as AlphaTabAction,
+                onAction: () => {},
+                onPrimaryAction: () => {},
+              },
+              {
+                type: 'edit' as AlphaTabAction,
+                onAction: () => {},
+                onPrimaryAction: () => {},
+              },
+              {
+                type: 'edit-columns' as AlphaTabAction,
+                onAction: () => {},
+                onPrimaryAction: () => {},
+              },
+              {
+                type: 'delete' as AlphaTabAction,
+                onAction: () => {},
+                onPrimaryAction: () => {},
+              },
+            ],
+    }));
 
-  return (
-    <Tabs
-      tabs={tabs}
-      selected={selected}
-      onSelect={handleTabChange}
-      canCreateNewView
-    />
-  );
-}
-
-export function WithBadgeContent() {
-  const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex: number) => setSelected(selectedTabIndex),
-    [],
-  );
-
-  const tabs = [
-    {
-      id: 'all-customers-with-badge',
-      badge: '10+',
-      content: 'All',
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-with-badge-content',
-    },
-    {
-      id: 'accepts-marketing-with-badge',
-      badge: '4',
-      content: 'Accepts marketing',
-      panelID: 'accepts-marketing-with-badge-content',
-    },
-  ];
-
-  return (
-    <LegacyCard>
-      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
-        <LegacyCard.Section title={tabs[selected].content}>
-          <Text as="p" variant="bodyMd">
-            Tab {selected} selected
-          </Text>
-        </LegacyCard.Section>
-      </Tabs>
-    </LegacyCard>
-  );
-}
-
-export function WithCustomDisclosure() {
-  const [selected, setSelected] = useState(0);
-
-  const handleTabChange = useCallback(
-    (selectedTabIndex: number) => setSelected(selectedTabIndex),
-    [],
-  );
-
-  const tabs = [
-    {
-      id: 'all-customers-with-custom-disclosure',
-      content: 'All',
-      accessibilityLabel: 'All customers',
-      panelID: 'all-customers-with-custom-disclosure-content',
-    },
-    {
-      id: 'accepts-marketing-with-custom-disclosure',
-      content: 'Accepts marketing',
-      panelID: 'accepts-marketing-with-custom-disclosure-content',
-    },
-    {
-      id: 'repeat-customers-with-custom-disclosure',
-      content: 'Repeat customers',
-      panelID: 'repeat-customers-with-custom-disclosure-content',
-    },
-    {
-      id: 'prospects-with-custom-disclosure',
-      content: 'Prospects',
-      panelID: 'prospects-with-custom-disclosure-content',
-    },
-    {
-      id: 'opt-out-marketing-with-custom-disclosure',
-      content: 'Opted out of marketing',
-      panelID: 'opt-out-with-custom-disclosure-content',
-    },
-    {
-      id: 'net-new-customers-with-custom-disclosure',
-      content: 'Net new customers',
-      panelID: 'net-new-customers-with-custom-disclosure-content',
-    },
-    {
-      id: 'churned-customers-with-custom-disclosure',
-      content: 'Churned customers',
-      panelID: 'churned=customers-with-custom-disclosure-content',
-    },
-  ];
-
-  return (
-    <LegacyCard>
+    return (
       <Tabs
         tabs={tabs}
         selected={selected}
         onSelect={handleTabChange}
-        disclosureText="Extra views"
-      >
-        <LegacyCard.Section title={tabs[selected].content}>
-          <Text as="p" variant="bodyMd">
-            Tab {selected} selected
-          </Text>
-        </LegacyCard.Section>
-      </Tabs>
-    </LegacyCard>
-  );
-}
+        canCreateNewView
+      />
+    );
+  },
+};
+
+export const WithBadgeContent = {
+  render() {
+    const [selected, setSelected] = useState(0);
+
+    const handleTabChange = useCallback(
+      (selectedTabIndex: number) => setSelected(selectedTabIndex),
+      [],
+    );
+
+    const tabs = [
+      {
+        id: 'all-customers-with-badge',
+        badge: '10+',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-with-badge-content',
+      },
+      {
+        id: 'accepts-marketing-with-badge',
+        badge: '4',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-with-badge-content',
+      },
+    ];
+
+    return (
+      <LegacyCard>
+        <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
+          <LegacyCard.Section title={tabs[selected].content}>
+            <Text as="p" variant="bodyMd">
+              Tab {selected} selected
+            </Text>
+          </LegacyCard.Section>
+        </Tabs>
+      </LegacyCard>
+    );
+  },
+};
+
+export const WithCustomDisclosure = {
+  render() {
+    const [selected, setSelected] = useState(0);
+
+    const handleTabChange = useCallback(
+      (selectedTabIndex: number) => setSelected(selectedTabIndex),
+      [],
+    );
+
+    const tabs = [
+      {
+        id: 'all-customers-with-custom-disclosure',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-with-custom-disclosure-content',
+      },
+      {
+        id: 'accepts-marketing-with-custom-disclosure',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-with-custom-disclosure-content',
+      },
+      {
+        id: 'repeat-customers-with-custom-disclosure',
+        content: 'Repeat customers',
+        panelID: 'repeat-customers-with-custom-disclosure-content',
+      },
+      {
+        id: 'prospects-with-custom-disclosure',
+        content: 'Prospects',
+        panelID: 'prospects-with-custom-disclosure-content',
+      },
+      {
+        id: 'opt-out-marketing-with-custom-disclosure',
+        content: 'Opted out of marketing',
+        panelID: 'opt-out-with-custom-disclosure-content',
+      },
+      {
+        id: 'net-new-customers-with-custom-disclosure',
+        content: 'Net new customers',
+        panelID: 'net-new-customers-with-custom-disclosure-content',
+      },
+      {
+        id: 'churned-customers-with-custom-disclosure',
+        content: 'Churned customers',
+        panelID: 'churned=customers-with-custom-disclosure-content',
+      },
+    ];
+
+    return (
+      <LegacyCard>
+        <Tabs
+          tabs={tabs}
+          selected={selected}
+          onSelect={handleTabChange}
+          disclosureText="Extra views"
+        >
+          <LegacyCard.Section title={tabs[selected].content}>
+            <Text as="p" variant="bodyMd">
+              Tab {selected} selected
+            </Text>
+          </LegacyCard.Section>
+        </Tabs>
+      </LegacyCard>
+    );
+  },
+};

--- a/polaris-react/src/components/Tag/Tag.stories.tsx
+++ b/polaris-react/src/components/Tag/Tag.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   InlineStack,
   Icon,
@@ -13,165 +13,183 @@ import {WandIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Tag,
-} as ComponentMeta<typeof Tag>;
+} as Meta<typeof Tag>;
 
-export function All() {
-  return (
-    <BlockStack gap="100">
-      <Text as="p">Default</Text>
-      <Default />
-      <br />
-      <Text as="p">Removable</Text>
-      <Removable />
-      <br />
-      <Text as="p">Clickable</Text>
-      <Clickable />
-      <br />
-      <Text as="p">With Link</Text>
-      <WithLink />
-      <br />
-      <Text as="p">With Custom Content</Text>
-      <WithCustomContent />
-      <br />
-      <Text as="p">Removable with Link</Text>
-      <RemovableWithLink />
-      <br />
-      <Text as="p">Removable large</Text>
-      <RemovableLarge />
-    </BlockStack>
-  );
-}
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="100">
+        <Text as="p">Default</Text>
+        <Default.render />
+        <br />
+        <Text as="p">Removable</Text>
+        <Removable.render />
+        <br />
+        <Text as="p">Clickable</Text>
+        <Clickable.render />
+        <br />
+        <Text as="p">With Link</Text>
+        <WithLink.render />
+        <br />
+        <Text as="p">With Custom Content</Text>
+        <WithCustomContent.render />
+        <br />
+        <Text as="p">Removable with Link</Text>
+        <RemovableWithLink.render />
+        <br />
+        <Text as="p">Removable large</Text>
+        <RemovableLarge.render />
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function Default() {
-  return (
-    <InlineStack gap="100">
-      <Tag>Wholesale</Tag>
-      <Tag disabled>Disabled</Tag>
-      <Tag url="#">With URL</Tag>
-    </InlineStack>
-  );
-}
-
-export function Removable() {
-  const [selectedTags, setSelectedTags] = useState([
-    'Rustic',
-    'Antique',
-    'Vinyl',
-    'Refurbished',
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at ipsum quam. Aliquam fermentum bibendum vestibulum. Vestibulum condimentum luctus metus, sed sagittis magna pellentesque eget. Duis dapibus pretium nisi, et venenatis tortor dignissim ut. Quisque eget lacus ac ex eleifend ultrices. Phasellus facilisis ex sit amet leo elementum condimentum. Ut vel maximus felis. Etiam eget diam eu eros blandit interdum. Sed eu metus sed justo aliquam iaculis ac sit amet ex. Curabitur justo magna, porttitor non pulvinar eu, malesuada at leo. Cras mollis consectetur eros, quis maximus lorem dignissim at. Proin in rhoncus massa. Vivamus lectus nunc, fringilla euismod risus commodo, mattis blandit nulla.',
-  ]);
-
-  const removeTag = useCallback(
-    (tag) => () => {
-      setSelectedTags((previousTags) =>
-        previousTags.filter((previousTag) => previousTag !== tag),
-      );
-    },
-    [],
-  );
-
-  const tagMarkup = selectedTags.map((option) => (
-    <Tag
-      key={option}
-      onRemove={removeTag(option)}
-      disabled={option === 'Antique'}
-    >
-      {option}
-    </Tag>
-  ));
-
-  return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;
-}
-
-export function Clickable() {
-  return (
-    <InlineStack gap="100">
-      <Tag onClick={() => console.log('Clicked')}>Wholesale</Tag>
-      <Tag onClick={() => console.log('Clicked')} disabled>
-        Wholesale (clickable disabled)
-      </Tag>
-    </InlineStack>
-  );
-}
-
-export function WithLink() {
-  return <Tag url="#">Wholesale</Tag>;
-}
-
-export function WithCustomContent() {
-  return (
-    <Tag url="#">
-      <InlineStack gap="050">
-        <Bleed marginInlineStart="100">
-          <Icon tone="base" source={WandIcon} />
-        </Bleed>
-        <span>Wholesale</span>
+export const Default = {
+  render() {
+    return (
+      <InlineStack gap="100">
+        <Tag>Wholesale</Tag>
+        <Tag disabled>Disabled</Tag>
+        <Tag url="#">With URL</Tag>
       </InlineStack>
-    </Tag>
-  );
-}
+    );
+  },
+};
 
-export function RemovableWithLink() {
-  const [selectedTags, setSelectedTags] = useState([
-    'Rustic',
-    'Antique',
-    'Vinyl',
-    'Refurbished',
-  ]);
+export const Removable = {
+  render() {
+    const [selectedTags, setSelectedTags] = useState([
+      'Rustic',
+      'Antique',
+      'Vinyl',
+      'Refurbished',
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at ipsum quam. Aliquam fermentum bibendum vestibulum. Vestibulum condimentum luctus metus, sed sagittis magna pellentesque eget. Duis dapibus pretium nisi, et venenatis tortor dignissim ut. Quisque eget lacus ac ex eleifend ultrices. Phasellus facilisis ex sit amet leo elementum condimentum. Ut vel maximus felis. Etiam eget diam eu eros blandit interdum. Sed eu metus sed justo aliquam iaculis ac sit amet ex. Curabitur justo magna, porttitor non pulvinar eu, malesuada at leo. Cras mollis consectetur eros, quis maximus lorem dignissim at. Proin in rhoncus massa. Vivamus lectus nunc, fringilla euismod risus commodo, mattis blandit nulla.',
+    ]);
 
-  const removeTag = useCallback(
-    (tag) => () => {
-      setSelectedTags((previousTags) =>
-        previousTags.filter((previousTag) => previousTag !== tag),
-      );
-    },
-    [],
-  );
+    const removeTag = useCallback(
+      (tag) => () => {
+        setSelectedTags((previousTags) =>
+          previousTags.filter((previousTag) => previousTag !== tag),
+        );
+      },
+      [],
+    );
 
-  const tagMarkup = selectedTags.map((option) => (
-    <Tag key={option} onRemove={removeTag(option)} url="#">
-      {option}
-    </Tag>
-  ));
+    const tagMarkup = selectedTags.map((option) => (
+      <Tag
+        key={option}
+        onRemove={removeTag(option)}
+        disabled={option === 'Antique'}
+      >
+        {option}
+      </Tag>
+    ));
 
-  return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;
-}
+    return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;
+  },
+};
 
-export function RemovableLarge() {
-  const [selectedTags, setSelectedTags] = useState([
-    'Rustic',
-    'Antique',
-    'Vinyl',
-    'Refurbished',
-  ]);
+export const Clickable = {
+  render() {
+    return (
+      <InlineStack gap="100">
+        <Tag onClick={() => console.log('Clicked')}>Wholesale</Tag>
+        <Tag onClick={() => console.log('Clicked')} disabled>
+          Wholesale (clickable disabled)
+        </Tag>
+      </InlineStack>
+    );
+  },
+};
 
-  const removeTag = useCallback(
-    (tag) => () => {
-      setSelectedTags((previousTags) =>
-        previousTags.filter((previousTag) => previousTag !== tag),
-      );
-    },
-    [],
-  );
+export const WithLink = {
+  render() {
+    return <Tag url="#">Wholesale</Tag>;
+  },
+};
 
-  const tagMarkup = selectedTags.map((option) => (
-    <Tag size="large" key={option} onRemove={removeTag(option)}>
-      {option}
-    </Tag>
-  ));
+export const WithCustomContent = {
+  render() {
+    return (
+      <Tag url="#">
+        <InlineStack gap="050">
+          <Bleed marginInlineStart="100">
+            <Icon tone="base" source={WandIcon} />
+          </Bleed>
+          <span>Wholesale</span>
+        </InlineStack>
+      </Tag>
+    );
+  },
+};
 
-  const tagWithLinkMarkup = selectedTags.map((option) => (
-    <Tag size="large" key={option} onRemove={removeTag(option)} url="#">
-      {option}
-    </Tag>
-  ));
+export const RemovableWithLink = {
+  render() {
+    const [selectedTags, setSelectedTags] = useState([
+      'Rustic',
+      'Antique',
+      'Vinyl',
+      'Refurbished',
+    ]);
 
-  return (
-    <BlockStack gap="100">
-      <Text as="p">Large</Text>
-      <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>
-      <Text as="p">Large with link</Text>
-      <LegacyStack spacing="tight">{tagWithLinkMarkup}</LegacyStack>
-    </BlockStack>
-  );
-}
+    const removeTag = useCallback(
+      (tag) => () => {
+        setSelectedTags((previousTags) =>
+          previousTags.filter((previousTag) => previousTag !== tag),
+        );
+      },
+      [],
+    );
+
+    const tagMarkup = selectedTags.map((option) => (
+      <Tag key={option} onRemove={removeTag(option)} url="#">
+        {option}
+      </Tag>
+    ));
+
+    return <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>;
+  },
+};
+
+export const RemovableLarge = {
+  render() {
+    const [selectedTags, setSelectedTags] = useState([
+      'Rustic',
+      'Antique',
+      'Vinyl',
+      'Refurbished',
+    ]);
+
+    const removeTag = useCallback(
+      (tag) => () => {
+        setSelectedTags((previousTags) =>
+          previousTags.filter((previousTag) => previousTag !== tag),
+        );
+      },
+      [],
+    );
+
+    const tagMarkup = selectedTags.map((option) => (
+      <Tag size="large" key={option} onRemove={removeTag(option)}>
+        {option}
+      </Tag>
+    ));
+
+    const tagWithLinkMarkup = selectedTags.map((option) => (
+      <Tag size="large" key={option} onRemove={removeTag(option)} url="#">
+        {option}
+      </Tag>
+    ));
+
+    return (
+      <BlockStack gap="100">
+        <Text as="p">Large</Text>
+        <LegacyStack spacing="tight">{tagMarkup}</LegacyStack>
+        <Text as="p">Large with link</Text>
+        <LegacyStack spacing="tight">{tagWithLinkMarkup}</LegacyStack>
+      </BlockStack>
+    );
+  },
+};

--- a/polaris-react/src/components/Text/Text.stories.tsx
+++ b/polaris-react/src/components/Text/Text.stories.tsx
@@ -1,165 +1,184 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {LegacyStack, Text} from '@shopify/polaris';
 
 export default {
   component: Text,
-} as ComponentMeta<typeof Text>;
+} as Meta<typeof Text>;
 
-export const Variants = () => (
-  <LegacyStack vertical>
-    <Text as="h2" variant="heading3xl">
-      Text with Heading3xl variant
-    </Text>
-    <Text as="h3" variant="heading2xl">
-      Text with Heading2xl variant
-    </Text>
-    <Text as="h4" variant="headingXl">
-      Text with HeadingXl variant
-    </Text>
-    <Text as="h5" variant="headingLg">
-      Text with HeadingLg variant
-    </Text>
-    <Text as="h6" variant="headingMd">
-      Text with HeadingMd variant
-    </Text>
-    <Text as="h6" variant="headingSm">
-      Text with HeadingSm variant
-    </Text>
-    <Text as="h6" variant="headingXs">
-      Text with HeadingXs variant
-    </Text>
-    <Text as="p" variant="bodyLg">
-      Text with BodyLg variant
-    </Text>
-    <Text as="p" variant="bodyMd">
-      Text with BodyMd variant
-    </Text>
-    <Text as="p" variant="bodySm">
-      Text with BodySm variant
-    </Text>
-    <Text as="p" variant="bodyXs">
-      Text with BodyXs variant
-    </Text>
-    <Text as="strong" variant="bodySm">
-      Text as a strong tag
-    </Text>
-  </LegacyStack>
-);
+export const Variants = {
+  render: () => (
+    <LegacyStack vertical>
+      <Text as="h2" variant="heading3xl">
+        Text with Heading3xl variant
+      </Text>
+      <Text as="h3" variant="heading2xl">
+        Text with Heading2xl variant
+      </Text>
+      <Text as="h4" variant="headingXl">
+        Text with HeadingXl variant
+      </Text>
+      <Text as="h5" variant="headingLg">
+        Text with HeadingLg variant
+      </Text>
+      <Text as="h6" variant="headingMd">
+        Text with HeadingMd variant
+      </Text>
+      <Text as="h6" variant="headingSm">
+        Text with HeadingSm variant
+      </Text>
+      <Text as="h6" variant="headingXs">
+        Text with HeadingXs variant
+      </Text>
+      <Text as="p" variant="bodyLg">
+        Text with BodyLg variant
+      </Text>
+      <Text as="p" variant="bodyMd">
+        Text with BodyMd variant
+      </Text>
+      <Text as="p" variant="bodySm">
+        Text with BodySm variant
+      </Text>
+      <Text as="p" variant="bodyXs">
+        Text with BodyXs variant
+      </Text>
+      <Text as="strong" variant="bodySm">
+        Text as a strong tag
+      </Text>
+    </LegacyStack>
+  ),
+};
 
-export const WithAlignment = () => (
-  <LegacyStack vertical>
-    <Text as="p" variant="bodyLg" alignment="start">
-      Manage your Shopify store on-the-go with real-time notifications, access
-      to your dashboard, and order management, all from your smartphone.
-    </Text>
-    <Text as="p" variant="bodyLg" alignment="center">
-      Manage your Shopify store on-the-go with real-time notifications, access
-      to your dashboard, and order management, all from your smartphone.
-    </Text>
-    <Text as="p" variant="bodyLg" alignment="end">
-      Manage your Shopify store on-the-go with real-time notifications, access
-      to your dashboard, and order management, all from your smartphone.
-    </Text>
-    <Text as="p" variant="bodyLg" alignment="justify">
-      Manage your Shopify store on-the-go with real-time notifications, access
-      to your dashboard, and order management, all from your smartphone.
-    </Text>
-  </LegacyStack>
-);
+export const WithAlignment = {
+  render: () => (
+    <LegacyStack vertical>
+      <Text as="p" variant="bodyLg" alignment="start">
+        Manage your Shopify store on-the-go with real-time notifications, access
+        to your dashboard, and order management, all from your smartphone.
+      </Text>
+      <Text as="p" variant="bodyLg" alignment="center">
+        Manage your Shopify store on-the-go with real-time notifications, access
+        to your dashboard, and order management, all from your smartphone.
+      </Text>
+      <Text as="p" variant="bodyLg" alignment="end">
+        Manage your Shopify store on-the-go with real-time notifications, access
+        to your dashboard, and order management, all from your smartphone.
+      </Text>
+      <Text as="p" variant="bodyLg" alignment="justify">
+        Manage your Shopify store on-the-go with real-time notifications, access
+        to your dashboard, and order management, all from your smartphone.
+      </Text>
+    </LegacyStack>
+  ),
+};
 
-export const WithFontWeight = () => (
-  <LegacyStack vertical>
-    <Text as="p" fontWeight="bold">
-      Sales this year
-    </Text>
-    <Text as="p" fontWeight="semibold">
-      Sales this year
-    </Text>
-    <Text as="p" fontWeight="medium">
-      Sales this year
-    </Text>
-    <Text as="p" fontWeight="regular">
-      Sales this year
-    </Text>
-  </LegacyStack>
-);
+export const WithFontWeight = {
+  render: () => (
+    <LegacyStack vertical>
+      <Text as="p" fontWeight="bold">
+        Sales this year
+      </Text>
+      <Text as="p" fontWeight="semibold">
+        Sales this year
+      </Text>
+      <Text as="p" fontWeight="medium">
+        Sales this year
+      </Text>
+      <Text as="p" fontWeight="regular">
+        Sales this year
+      </Text>
+    </LegacyStack>
+  ),
+};
 
-export const WithTone = () => (
-  <LegacyStack vertical>
-    <Text as="p" tone="subdued">
-      Use to de-emphasize a piece of text that is less important to merchants
-      than other nearby text. May also be used to indicate when normal content
-      is absent, for example, “No supplier listed”. Don’t use only for aesthetic
-      effect.
-    </Text>
-    <Text as="p" tone="success">
-      Use in combination with a symbol showing an increasing value to indicate
-      an upward trend.
-    </Text>
-    <Text as="p" tone="caution">
-      Use to denote something that needs attention, or that merchants need to
-      take action on.
-    </Text>
-    <Text as="p" tone="critical">
-      Use in combination with a symbol showing a decreasing value to indicate a
-      downward trend.
-    </Text>
-    <Text as="p" tone="magic">
-      Recommended for text generated by magic AI.
-    </Text>
-    <Text as="p" tone="magic-subdued">
-      Recommended for secondary-level prominence of text suggested by magic AI.
-    </Text>
-  </LegacyStack>
-);
+export const WithTone = {
+  render: () => (
+    <LegacyStack vertical>
+      <Text as="p" tone="subdued">
+        Use to de-emphasize a piece of text that is less important to merchants
+        than other nearby text. May also be used to indicate when normal content
+        is absent, for example, “No supplier listed”. Don’t use only for
+        aesthetic effect.
+      </Text>
+      <Text as="p" tone="success">
+        Use in combination with a symbol showing an increasing value to indicate
+        an upward trend.
+      </Text>
+      <Text as="p" tone="caution">
+        Use to denote something that needs attention, or that merchants need to
+        take action on.
+      </Text>
+      <Text as="p" tone="critical">
+        Use in combination with a symbol showing a decreasing value to indicate
+        a downward trend.
+      </Text>
+      <Text as="p" tone="magic">
+        Recommended for text generated by magic AI.
+      </Text>
+      <Text as="p" tone="magic-subdued">
+        Recommended for secondary-level prominence of text suggested by magic
+        AI.
+      </Text>
+    </LegacyStack>
+  ),
+};
 
-export const WithInheritance = () => (
-  <Text as="p" variant="heading2xl" tone="caution">
-    <Text as="span">This is a 2xl heading</Text>
-    <br />
-    <Text as="span">This is also a 2xl heading</Text>
-  </Text>
-);
-
-export const WithTruncate = () => (
-  <Text as="p" truncate>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam tincidunt vel
-    lorem nec pretium. Vestibulum ante ipsum primis in faucibus orci luctus et
-    ultrices posuere cubilia curae; Morbi sollicitudin ex nec imperdiet
-    pellentesque. Etiam dapibus ipsum non ligula molestie rhoncus. Vivamus eget
-    iaculis lectus. Sed porttitor leo at nulla mollis malesuada. Vestibulum ante
-    ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;
-    Vestibulum vestibulum porttitor mollis. Nam dictum ante sed lobortis
-    commodo. Ut luctus ut metus vel bibendum.
-  </Text>
-);
-
-export const ParentWithChild = () => (
-  <Text as="p" variant="bodySm" tone="subdued">
-    Parent Text component with{' '}
-    <Text as="span" fontWeight="bold">
-      bold
-    </Text>{' '}
-    children
-  </Text>
-);
-
-export const InADefinitionList = () => (
-  <dl>
-    <Text as="dt" variant="bodyLg">
-      Definition Title
+export const WithInheritance = {
+  render: () => (
+    <Text as="p" variant="heading2xl" tone="caution">
+      <Text as="span">This is a 2xl heading</Text>
+      <br />
+      <Text as="span">This is also a 2xl heading</Text>
     </Text>
-    <Text as="dd" variant="bodySm">
-      Definition Description
-    </Text>
-  </dl>
-);
+  ),
+};
 
-export const WithTextDecoration = () => (
-  <LegacyStack vertical>
-    <Text as="p" textDecorationLine="line-through">
-      $100.00
+export const WithTruncate = {
+  render: () => (
+    <Text as="p" truncate>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam tincidunt vel
+      lorem nec pretium. Vestibulum ante ipsum primis in faucibus orci luctus et
+      ultrices posuere cubilia curae; Morbi sollicitudin ex nec imperdiet
+      pellentesque. Etiam dapibus ipsum non ligula molestie rhoncus. Vivamus
+      eget iaculis lectus. Sed porttitor leo at nulla mollis malesuada.
+      Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+      cubilia curae; Vestibulum vestibulum porttitor mollis. Nam dictum ante sed
+      lobortis commodo. Ut luctus ut metus vel bibendum.
     </Text>
-  </LegacyStack>
-);
+  ),
+};
+
+export const ParentWithChild = {
+  render: () => (
+    <Text as="p" variant="bodySm" tone="subdued">
+      Parent Text component with{' '}
+      <Text as="span" fontWeight="bold">
+        bold
+      </Text>{' '}
+      children
+    </Text>
+  ),
+};
+
+export const InADefinitionList = {
+  render: () => (
+    <dl>
+      <Text as="dt" variant="bodyLg">
+        Definition Title
+      </Text>
+      <Text as="dd" variant="bodySm">
+        Definition Description
+      </Text>
+    </dl>
+  ),
+};
+
+export const WithTextDecoration = {
+  render: () => (
+    <LegacyStack vertical>
+      <Text as="p" textDecorationLine="line-through">
+        $100.00
+      </Text>
+    </LegacyStack>
+  ),
+};

--- a/polaris-react/src/components/TextContainer/TextContainer.stories.tsx
+++ b/polaris-react/src/components/TextContainer/TextContainer.stories.tsx
@@ -1,51 +1,58 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {Text, TextContainer} from '@shopify/polaris';
 
 export default {
   component: TextContainer,
-} as ComponentMeta<typeof TextContainer>;
+} as Meta<typeof TextContainer>;
 
-export function Default() {
-  return (
-    <TextContainer>
-      <Text variant="headingMd" as="h2">
-        Install the Shopify POS App
-      </Text>
-      <Text as="p" variant="bodyMd">
-        Shopify POS is the easiest way to sell your products in person.
-        Available for iPad, iPhone, and Android.
-      </Text>
-    </TextContainer>
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <TextContainer>
+        <Text variant="headingMd" as="h2">
+          Install the Shopify POS App
+        </Text>
+        <Text as="p" variant="bodyMd">
+          Shopify POS is the easiest way to sell your products in person.
+          Available for iPad, iPhone, and Android.
+        </Text>
+      </TextContainer>
+    );
+  },
+};
 
-export function Tight() {
-  return (
-    <TextContainer spacing="tight">
-      <Text variant="headingMd" as="h2">
-        Install the Shopify POS App
-      </Text>
-      <Text as="p" variant="bodyMd">
-        Shopify POS is the easiest way to sell your products in person.
-        Available for iPad, iPhone, and Android.
-      </Text>
-    </TextContainer>
-  );
-}
+export const Tight = {
+  render() {
+    return (
+      <TextContainer spacing="tight">
+        <Text variant="headingMd" as="h2">
+          Install the Shopify POS App
+        </Text>
+        <Text as="p" variant="bodyMd">
+          Shopify POS is the easiest way to sell your products in person.
+          Available for iPad, iPhone, and Android.
+        </Text>
+      </TextContainer>
+    );
+  },
+};
 
-export function Loose() {
-  return (
-    <TextContainer spacing="loose">
-      <Text as="p" variant="bodyMd">
-        Manage your Shopify store on-the-go with real-time notifications, access
-        to your dashboard, and order management, all from your smartphone.
-      </Text>
-      <Text as="p" variant="bodyMd">
-        Shopify POS is the fastest and easiest way to start accepting Visa,
-        Mastercard, American Express, and Discover right from your smartphone or
-        tablet.
-      </Text>
-    </TextContainer>
-  );
-}
+export const Loose = {
+  render() {
+    return (
+      <TextContainer spacing="loose">
+        <Text as="p" variant="bodyMd">
+          Manage your Shopify store on-the-go with real-time notifications,
+          access to your dashboard, and order management, all from your
+          smartphone.
+        </Text>
+        <Text as="p" variant="bodyMd">
+          Shopify POS is the fastest and easiest way to start accepting Visa,
+          Mastercard, American Express, and Discover right from your smartphone
+          or tablet.
+        </Text>
+      </TextContainer>
+    );
+  },
+};

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Button,
   LegacyCard,
@@ -25,762 +25,57 @@ import {
 
 export default {
   component: TextField,
-} as ComponentMeta<typeof TextField>;
+} as Meta<typeof TextField>;
 
-export function Default() {
-  const [value, setValue] = useState('Jaded Pixel');
+export const Default = {
+  render() {
+    const [value, setValue] = useState('Jaded Pixel');
 
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
 
-  return (
-    <TextField
-      label="Store name"
-      value={value}
-      onChange={handleChange}
-      autoComplete="off"
-    />
-  );
-}
-
-export function Magic() {
-  const [value, setValue] = useState('Jaded Pixel');
-  const [value1, setValue1] = useState('Jaded Pixel');
-  const [value2, setValue2] = useState('Jaded Pixel');
-
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
-  const handleChange1 = useCallback((newValue) => setValue1(newValue), []);
-  const handleChange2 = useCallback((newValue) => setValue2(newValue), []);
-
-  return (
-    <LegacyStack vertical>
+    return (
       <TextField
         label="Store name"
         value={value}
         onChange={handleChange}
         autoComplete="off"
-        tone="magic"
       />
-      <TextField
-        label="Prefix icon"
-        type="search"
-        value={value1}
-        onChange={handleChange1}
-        prefix={<Icon source={SearchIcon} />}
-        autoComplete="off"
-        tone="magic"
-      />
-      <TextField
-        label="Suffix icon"
-        value={value2}
-        onChange={handleChange2}
-        suffix={
-          <Tooltip content="Hello world">
-            <Icon source={QuestionCircleIcon} />
-          </Tooltip>
-        }
-        tone="magic"
-        autoComplete="off"
-      />
-    </LegacyStack>
-  );
-}
-
-export function Number() {
-  const [value, setValue] = useState('1.0');
-  const [value1, setValue1] = useState('1.0');
-
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
-  const handleChange1 = useCallback((newValue) => setValue1(newValue), []);
-
-  return (
-    <LegacyStack vertical>
-      <TextField
-        label="First Quantity"
-        type="number"
-        value={value}
-        onChange={handleChange}
-        autoComplete="off"
-      />
-      <TextField
-        label="Second Quantity"
-        type="number"
-        value={value1}
-        onChange={handleChange1}
-        autoComplete="off"
-      />
-    </LegacyStack>
-  );
-}
-
-export function Integer() {
-  const [value, setValue] = useState('1');
-
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
-
-  return (
-    <TextField
-      label="Integer"
-      type="integer"
-      value={value}
-      onChange={handleChange}
-      autoComplete="off"
-    />
-  );
-}
-
-export function Email() {
-  const [value, setValue] = useState('bernadette.lapresse@jadedpixel.com');
-
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
-
-  return (
-    <TextField
-      label="Email"
-      type="email"
-      value={value}
-      onChange={handleChange}
-      autoComplete="email"
-    />
-  );
-}
-
-export function Multiline() {
-  const [value, setValue] = useState('1776 Barnes Street\nOrlando, FL 32801');
-
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
-
-  return (
-    <TextField
-      label="Shipping address"
-      value={value}
-      onChange={handleChange}
-      multiline={4}
-      autoComplete="off"
-    />
-  );
-}
-
-export function WithHiddenLabel() {
-  const [value, setValue] = useState('12');
-  const [selected, setSelected] = useState('yes');
-
-  const handleTextChange = useCallback((newValue) => setValue(newValue), []);
-
-  const handleChoiceChange = useCallback(
-    (selections) => setSelected(selections[0]),
-    [],
-  );
-
-  return (
-    <FormLayout>
-      <ChoiceList
-        title="Gift card auto-expiration"
-        choices={[
-          {label: 'Gift cards never expire', value: 'no'},
-          {label: 'Gift cards expire', value: 'yes'},
-        ]}
-        selected={[selected]}
-        onChange={handleChoiceChange}
-      />
-      <TextField
-        label="Gift cards expire after"
-        type="number"
-        labelHidden
-        value={value}
-        disabled={selected === 'no'}
-        onChange={handleTextChange}
-        autoComplete="off"
-        connectedRight={
-          <Select
-            label="Unit of time"
-            labelHidden
-            options={['months after purchase']}
-          />
-        }
-      />
-    </FormLayout>
-  );
-}
-
-export function WithLabelAction() {
-  const [textFieldValue, setTextFieldValue] = useState('6201.11.0000');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <TextField
-      label="Tariff code"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      labelAction={{content: 'Look up codes'}}
-      autoComplete="off"
-    />
-  );
-}
-
-export function WithRightAlignedText() {
-  const [textFieldValue, setTextFieldValue] = useState('1');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <LegacyStack>
-      <LegacyStack.Item fill>Price</LegacyStack.Item>
-      <TextField
-        label="Price"
-        labelHidden
-        value={textFieldValue}
-        onChange={handleTextFieldChange}
-        autoComplete="off"
-        align="right"
-      />
-    </LegacyStack>
-  );
-}
-
-export function WithPlaceholderText() {
-  const [textFieldValue, setTextFieldValue] = useState('');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <TextField
-      label="Shipping zone name"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      placeholder="Example: North America, Europe"
-      autoComplete="off"
-    />
-  );
-}
-
-export function WithHelpText() {
-  const [textFieldValue, setTextFieldValue] = useState(
-    'bernadette.lapresse@jadedpixel.com',
-  );
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <TextField
-      label="Account email"
-      type="email"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      helpText="We’ll use this address if we need to contact you about your account."
-      autoComplete="email"
-    />
-  );
-}
-
-export function WithPrefixOrSuffix() {
-  const [textFieldValue, setTextFieldValue] = useState('2.00');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <LegacyStack vertical>
-      <TextField
-        label="Price"
-        type="number"
-        value={textFieldValue}
-        onChange={handleTextFieldChange}
-        prefix="$"
-        autoComplete="off"
-      />
-      <TextField
-        label="Price"
-        type="number"
-        value={textFieldValue}
-        onChange={handleTextFieldChange}
-        prefix="$"
-        autoComplete="off"
-        tone="magic"
-      />
-    </LegacyStack>
-  );
-}
-
-export function WithVerticalContent() {
-  const tags = ['Rustic', 'Antique', 'Vinyl', 'Refurbished'];
-  const [textFieldValue, setTextFieldValue] = useState('');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  const verticalContentMarkup =
-    tags.length > 0 ? (
-      <LegacyStack spacing="extraTight" alignment="center">
-        {tags.map((tag) => (
-          <Tag key={tag}>{tag}</Tag>
-        ))}
-      </LegacyStack>
-    ) : null;
-
-  return (
-    <TextField
-      label="Tags"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      placeholder="Search tags"
-      autoComplete="off"
-      verticalContent={verticalContentMarkup}
-    />
-  );
-}
-
-export function WithConnectedFields() {
-  const [textFieldValue, setTextFieldValue] = useState('10.6');
-  const [selectValue, setSelectValue] = useState('kg');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  const handleSelectChange = useCallback((value) => setSelectValue(value), []);
-
-  return (
-    <TextField
-      label="Weight"
-      type="number"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      autoComplete="off"
-      connectedLeft={
-        <Select
-          value={selectValue}
-          label="Weight unit"
-          onChange={handleSelectChange}
-          labelHidden
-          options={['kg', 'lb']}
-        />
-      }
-      connectedRight={<Button>Submit</Button>}
-    />
-  );
-}
-
-export function WithValidationError() {
-  const [textFieldValue, setTextFieldValue] = useState('');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <TextField
-      label="Store name"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      error="Store name is required"
-      autoComplete="off"
-    />
-  );
-}
-
-export function WithSeparateValidationError() {
-  const [textFieldValue, setTextFieldValue] = useState('');
-  const [selectTypeValue, setSelectTypeValue] = useState('Product type');
-  const [selectConditionValue, setSelectConditionValue] =
-    useState('is equal to');
-
-  const handleTextFieldValueChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  const handleSelectTypeChange = useCallback(
-    (value) => setSelectTypeValue(value),
-    [],
-  );
-
-  const handleSelectConditionChange = useCallback(
-    (value) => setSelectConditionValue(value),
-    [],
-  );
-
-  const textFieldID = 'ruleContent';
-  const isInvalid = isValueInvalid(textFieldValue);
-  const errorMessage = isInvalid
-    ? 'Enter 3 or more characters for product type is equal to'
-    : '';
-
-  const formGroupMarkup = (
-    <LegacyStack wrap={false} alignment="leading" spacing="loose">
-      <LegacyStack.Item fill>
-        <FormLayout>
-          <FormLayout.Group condensed>
-            <Select
-              labelHidden
-              label="Collection rule type"
-              options={['Product type']}
-              value={selectTypeValue}
-              onChange={handleSelectTypeChange}
-            />
-            <Select
-              labelHidden
-              label="Collection rule condition"
-              options={['is equal to']}
-              value={selectConditionValue}
-              onChange={handleSelectConditionChange}
-            />
-            <TextField
-              labelHidden
-              label="Collection rule content"
-              error={isInvalid}
-              id={textFieldID}
-              value={textFieldValue}
-              onChange={handleTextFieldValueChange}
-              autoComplete="off"
-            />
-          </FormLayout.Group>
-        </FormLayout>
-        <div style={{marginTop: '4px'}}>
-          <InlineError message={errorMessage} fieldID={textFieldID} />
-        </div>
-      </LegacyStack.Item>
-      <Button icon={DeleteIcon} accessibilityLabel="Remove item" />
-    </LegacyStack>
-  );
-
-  return (
-    <LegacyCard sectioned>
-      <FormLayout>{formGroupMarkup}</FormLayout>
-    </LegacyCard>
-  );
-
-  function isValueInvalid(content) {
-    if (!content) {
-      return true;
-    }
-
-    return content.length < 3;
-  }
-}
-
-export function Disabled() {
-  return <TextField label="Store name" disabled autoComplete="off" />;
-}
-
-export function WithCharacterCount() {
-  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <TextField
-      label="Store name"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      maxLength={20}
-      autoComplete="off"
-      showCharacterCount
-    />
-  );
-}
-
-export function WithClearButton() {
-  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  const handleClearButtonClick = useCallback(() => setTextFieldValue(''), []);
-
-  return (
-    <TextField
-      label="Store name"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      clearButton
-      onClearButtonClick={handleClearButtonClick}
-      autoComplete="off"
-    />
-  );
-}
-
-export function WithMonospacedFont() {
-  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <TextField
-      label="Store name"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      monospaced
-    />
-  );
-}
-
-export function WithValueSelectedOnFocus() {
-  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
-
-  const handleTextFieldChange = useCallback(
-    (value) => setTextFieldValue(value),
-    [],
-  );
-
-  return (
-    <TextField
-      label="Store name"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      selectTextOnFocus
-    />
-  );
-}
-
-export function WithInlineSuggestion() {
-  const suggestions = useMemo(
-    () => [
-      'Alabama',
-      'Alaska',
-      'American Samoa',
-      'Arizona',
-      'Arkansas',
-      'California',
-      'Colorado',
-      'Connecticut',
-      'Delaware',
-      'District of Columbia',
-      'Florida',
-      'Georgia',
-      'Guam',
-      'Hawaii',
-      'Idaho',
-      'Illinois',
-      'Indiana',
-      'Iowa',
-      'Kansas',
-      'Kentucky',
-      'Louisiana',
-      'Maine',
-      'Maryland',
-      'Massachusetts',
-      'Michigan',
-      'Minnesota',
-      'Icon Outlying Islands',
-      'Mississippi',
-      'Missouri',
-      'Montana',
-      'Nebraska',
-      'Nevada',
-      'New Hampshire',
-      'New Jersey',
-      'New Mexico',
-      'New York',
-      'North Carolina',
-      'North Dakota',
-      'Northern Mariana Islands',
-      'Ohio',
-      'Oklahoma',
-      'Oregon',
-      'Pennsylvania',
-      'Puerto Rico',
-      'Rhode Island',
-      'South Carolina',
-      'South Dakota',
-      'Tennessee',
-      'Texas',
-      'U.S. Virgin Islands',
-      'Utah',
-      'Vermont',
-      'Virginia',
-      'Washington',
-      'West Virginia',
-      'Wisconsin',
-      'Wyoming',
-    ],
-    [],
-  );
-
-  const [value, setValue] = useState('');
-  const [suggestion, setSuggestion] = useState<string | undefined>();
-
-  const handleChange = useCallback(
-    (value: string) => {
-      const suggestion =
-        value &&
-        suggestions.find((suggestion) =>
-          suggestion.toLowerCase().startsWith(value.toLowerCase()),
-        );
-
-      setValue(value);
-      setSuggestion(suggestion);
-    },
-    [suggestions],
-  );
-
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (event.key === 'Enter' || event.key === 'Tab') {
-        setValue(suggestion || value);
-        setSuggestion('');
-      } else if (event.key === 'Backspace') {
-        setValue(value);
-        setSuggestion('');
-      }
-    },
-    [value, suggestion],
-  );
-
-  return (
-    <div onKeyDown={handleKeyDown}>
-      <TextField
-        type="text"
-        label="State"
-        value={value}
-        onChange={handleChange}
-        suggestion={suggestion}
-        autoComplete="off"
-      />
-    </div>
-  );
-}
-
-export function All() {
-  return (
-    <FormLayout>
-      <FormLayout.Group>
+    );
+  },
+};
+
+export const Magic = {
+  render() {
+    const [value, setValue] = useState('Jaded Pixel');
+    const [value1, setValue1] = useState('Jaded Pixel');
+    const [value2, setValue2] = useState('Jaded Pixel');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+    const handleChange1 = useCallback((newValue) => setValue1(newValue), []);
+    const handleChange2 = useCallback((newValue) => setValue2(newValue), []);
+
+    return (
+      <LegacyStack vertical>
         <TextField
-          label="Default"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-        />
-        <TextField
-          label="Disabled"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-          helpText="Help text"
-          disabled
-        />
-        <TextField
-          label="Read only"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-          readOnly
-        />
-        <TextField
-          label="Error"
-          value="Value"
-          onChange={() => {}}
-          error="Error message."
-          autoComplete="off"
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Number"
-          type="number"
-          value="5"
-          onChange={() => {}}
-          autoComplete="off"
-        />
-        <TextField
-          label="With label action"
-          value="Value"
-          onChange={() => {}}
-          labelAction={{content: 'Action'}}
-          autoComplete="off"
-        />
-        <TextField
-          label="Placeholder"
-          value=""
-          onChange={() => {}}
-          placeholder="Example"
-          autoComplete="off"
-        />
-        <TextField
-          label="Help text"
-          type="email"
-          value="Value"
-          onChange={() => {}}
-          helpText="Help text."
-          autoComplete="email"
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Prefix"
-          type="number"
-          value="4"
-          onChange={() => {}}
-          prefix="$"
-          autoComplete="off"
-        />
-        <TextField
-          label="Prefix with magic"
-          type="number"
-          value="4"
-          onChange={() => {}}
-          prefix="$"
+          label="Store name"
+          value={value}
+          onChange={handleChange}
           autoComplete="off"
           tone="magic"
         />
         <TextField
           label="Prefix icon"
           type="search"
-          value="Value"
-          onChange={() => {}}
-          prefix={<Icon source={SearchIcon} />}
-          autoComplete="off"
-        />
-        <TextField
-          label="Prefix icon with magic"
-          type="search"
-          value="Value"
-          onChange={() => {}}
+          value={value1}
+          onChange={handleChange1}
           prefix={<Icon source={SearchIcon} />}
           autoComplete="off"
           tone="magic"
         />
         <TextField
-          label="Suffix tooltip"
-          value="Value"
-          onChange={() => {}}
-          suffix={
-            <Tooltip content="Hello world">
-              <Icon source={QuestionCircleIcon} />
-            </Tooltip>
-          }
-          autoComplete="off"
-        />
-        <TextField
-          label="Suffix tooltip with magic"
-          value="Value"
-          onChange={() => {}}
+          label="Suffix icon"
+          value={value2}
+          onChange={handleChange2}
           suffix={
             <Tooltip content="Hello world">
               <Icon source={QuestionCircleIcon} />
@@ -789,280 +84,1046 @@ export function All() {
           tone="magic"
           autoComplete="off"
         />
+      </LegacyStack>
+    );
+  },
+};
+
+export const Number = {
+  render() {
+    const [value, setValue] = useState('1.0');
+    const [value1, setValue1] = useState('1.0');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+    const handleChange1 = useCallback((newValue) => setValue1(newValue), []);
+
+    return (
+      <LegacyStack vertical>
         <TextField
-          label="Character count"
-          value="Value"
-          onChange={() => {}}
-          maxLength={20}
-          autoComplete="off"
-          showCharacterCount
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Clear button"
-          value="Value"
-          onChange={() => {}}
-          clearButton
-          onClearButtonClick={() => {}}
-          autoComplete="off"
-        />
-        <TextField
-          label="Required"
-          value="Value"
-          onChange={() => {}}
-          requiredIndicator
-          autoComplete="off"
-        />
-        <TextField
-          label="Monospaced"
-          value="Value"
-          onChange={() => {}}
-          monospaced
-          autoComplete="off"
-        />
-        <TextField
-          label="Borderless"
-          value="Value"
-          onChange={() => {}}
-          variant="borderless"
-          autoComplete="off"
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Shipping address"
-          value="Value"
-          onChange={() => {}}
-          multiline={4}
-          autoComplete="off"
-        />
-        <TextField
-          label="Multiline error"
-          value="Value"
-          onChange={() => {}}
-          error="Error message."
-          multiline={4}
-          autoComplete="off"
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Label hidden"
-          value=""
-          labelHidden
-          onChange={() => {}}
-          placeholder="Label hidden"
-          autoComplete="off"
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Connected"
+          label="First Quantity"
           type="number"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-          connectedLeft={<Button>Left</Button>}
-          connectedRight={<Button>Right</Button>}
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Search native"
-          type="search"
-          value="Value"
-          onChange={() => {}}
+          value={value}
+          onChange={handleChange}
           autoComplete="off"
         />
         <TextField
-          label="Date native"
-          type="date"
-          value="Value"
-          onChange={() => {}}
+          label="Second Quantity"
+          type="number"
+          value={value1}
+          onChange={handleChange1}
           autoComplete="off"
         />
-        <TextField
-          label="Date time native"
-          type="datetime-local"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Month native"
-          type="month"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-        />
-        <TextField
-          label="Time native"
-          type="time"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-        />
-        <TextField
-          label="Week native"
-          type="week"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-        />
-      </FormLayout.Group>
-      <FormLayout.Group>
-        <TextField
-          label="Slim variant"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-          size="slim"
-        />
-        <TextField
-          label="Borderless slim variant"
-          value="Value"
-          onChange={() => {}}
-          autoComplete="off"
-          variant="borderless"
-          size="slim"
-        />
-      </FormLayout.Group>
-    </FormLayout>
-  );
-}
+      </LegacyStack>
+    );
+  },
+};
 
-export function WithFormSubmit() {
-  const [adjustment, setAdjustment] = useState('0');
-  const [onHandTotal, setOnHandTotal] = useState(0);
+export const Integer = {
+  render() {
+    const [value, setValue] = useState('1');
 
-  return (
-    <BlockStack gap="200">
-      <Form
-        onSubmit={(event) => {
-          event.preventDefault();
-          setAdjustment('0');
-          setOnHandTotal(onHandTotal + parseInt(adjustment, 10));
-        }}
-      >
-        <FormLayout>
-          <Text as="h2" variant="headingSm">
-            On hand quantity ({onHandTotal.toString()})
-          </Text>
-          <TextField
-            label="Adjustment"
-            value={adjustment}
-            onChange={(value) => setAdjustment(value)}
-            autoComplete="off"
-            type="number"
-            selectTextOnFocus
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+    return (
+      <TextField
+        label="Integer"
+        type="integer"
+        value={value}
+        onChange={handleChange}
+        autoComplete="off"
+      />
+    );
+  },
+};
+
+export const Email = {
+  render() {
+    const [value, setValue] = useState('bernadette.lapresse@jadedpixel.com');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+    return (
+      <TextField
+        label="Email"
+        type="email"
+        value={value}
+        onChange={handleChange}
+        autoComplete="email"
+      />
+    );
+  },
+};
+
+export const Multiline = {
+  render() {
+    const [value, setValue] = useState('1776 Barnes Street\nOrlando, FL 32801');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+    return (
+      <TextField
+        label="Shipping address"
+        value={value}
+        onChange={handleChange}
+        multiline={4}
+        autoComplete="off"
+      />
+    );
+  },
+};
+
+export const WithHiddenLabel = {
+  render() {
+    const [value, setValue] = useState('12');
+    const [selected, setSelected] = useState('yes');
+
+    const handleTextChange = useCallback((newValue) => setValue(newValue), []);
+
+    const handleChoiceChange = useCallback(
+      (selections) => setSelected(selections[0]),
+      [],
+    );
+
+    return (
+      <FormLayout>
+        <ChoiceList
+          title="Gift card auto-expiration"
+          choices={[
+            {label: 'Gift cards never expire', value: 'no'},
+            {label: 'Gift cards expire', value: 'yes'},
+          ]}
+          selected={[selected]}
+          onChange={handleChoiceChange}
+        />
+        <TextField
+          label="Gift cards expire after"
+          type="number"
+          labelHidden
+          value={value}
+          disabled={selected === 'no'}
+          onChange={handleTextChange}
+          autoComplete="off"
+          connectedRight={
+            <Select
+              label="Unit of time"
+              labelHidden
+              options={['months after purchase']}
+            />
+          }
+        />
+      </FormLayout>
+    );
+  },
+};
+
+export const WithLabelAction = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('6201.11.0000');
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    return (
+      <TextField
+        label="Tariff code"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        labelAction={{content: 'Look up codes'}}
+        autoComplete="off"
+      />
+    );
+  },
+};
+
+export const WithRightAlignedText = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('1');
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    return (
+      <LegacyStack>
+        <LegacyStack.Item fill>Price</LegacyStack.Item>
+        <TextField
+          label="Price"
+          labelHidden
+          value={textFieldValue}
+          onChange={handleTextFieldChange}
+          autoComplete="off"
+          align="right"
+        />
+      </LegacyStack>
+    );
+  },
+};
+
+export const WithPlaceholderText = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('');
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    return (
+      <TextField
+        label="Shipping zone name"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        placeholder="Example: North America, Europe"
+        autoComplete="off"
+      />
+    );
+  },
+};
+
+export const WithHelpText = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState(
+      'bernadette.lapresse@jadedpixel.com',
+    );
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    return (
+      <TextField
+        label="Account email"
+        type="email"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        helpText="We’ll use this address if we need to contact you about your account."
+        autoComplete="email"
+      />
+    );
+  },
+};
+
+export const WithPrefixOrSuffix = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('2.00');
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    return (
+      <LegacyStack vertical>
+        <TextField
+          label="Price"
+          type="number"
+          value={textFieldValue}
+          onChange={handleTextFieldChange}
+          prefix="$"
+          autoComplete="off"
+        />
+        <TextField
+          label="Price"
+          type="number"
+          value={textFieldValue}
+          onChange={handleTextFieldChange}
+          prefix="$"
+          autoComplete="off"
+          tone="magic"
+        />
+      </LegacyStack>
+    );
+  },
+};
+
+export const WithVerticalContent = {
+  render() {
+    const tags = ['Rustic', 'Antique', 'Vinyl', 'Refurbished'];
+    const [textFieldValue, setTextFieldValue] = useState('');
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    const verticalContentMarkup =
+      tags.length > 0 ? (
+        <LegacyStack spacing="extraTight" alignment="center">
+          {tags.map((tag) => (
+            <Tag key={tag}>{tag}</Tag>
+          ))}
+        </LegacyStack>
+      ) : null;
+
+    return (
+      <TextField
+        label="Tags"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        placeholder="Search tags"
+        autoComplete="off"
+        verticalContent={verticalContentMarkup}
+      />
+    );
+  },
+};
+
+export const WithConnectedFields = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('10.6');
+    const [selectValue, setSelectValue] = useState('kg');
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    const handleSelectChange = useCallback(
+      (value) => setSelectValue(value),
+      [],
+    );
+
+    return (
+      <TextField
+        label="Weight"
+        type="number"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        autoComplete="off"
+        connectedLeft={
+          <Select
+            value={selectValue}
+            label="Weight unit"
+            onChange={handleSelectChange}
+            labelHidden
+            options={['kg', 'lb']}
           />
-          <Button
-            variant="primary"
-            submit
-            disabled={isNaN(parseInt(adjustment, 10))}
-          >
-            Save
-          </Button>
-        </FormLayout>
-      </Form>
-    </BlockStack>
-  );
-}
+        }
+        connectedRight={<Button>Submit</Button>}
+      />
+    );
+  },
+};
 
-export function With1PasswordDisabled() {
-  const [value, setValue] = useState('Jaded Pixel');
+export const WithValidationError = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('');
 
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
 
-  return (
-    <TextField
-      label="Store name"
-      value={value}
-      onChange={handleChange}
-      autoComplete="off"
-    />
-  );
-}
+    return (
+      <TextField
+        label="Store name"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        error="Store name is required"
+        autoComplete="off"
+      />
+    );
+  },
+};
 
-export function WithAutoSize() {
-  const [value, setValue] = useState('Jaded Pixel');
+export const WithSeparateValidationError = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('');
+    const [selectTypeValue, setSelectTypeValue] = useState('Product type');
+    const [selectConditionValue, setSelectConditionValue] =
+      useState('is equal to');
 
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
+    const handleTextFieldValueChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
 
-  return (
-    <TextField
-      label="Store name"
-      value={value}
-      onChange={handleChange}
-      autoComplete="off"
-      autoSize
-      suffix="in: Your stores"
-    />
-  );
-}
+    const handleSelectTypeChange = useCallback(
+      (value) => setSelectTypeValue(value),
+      [],
+    );
 
-export function WithAutoSizeAndDynamicSuffix() {
-  const [value, setValue] = useState('');
+    const handleSelectConditionChange = useCallback(
+      (value) => setSelectConditionValue(value),
+      [],
+    );
 
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
+    const textFieldID = 'ruleContent';
+    const isInvalid = isValueInvalid(textFieldValue);
+    const errorMessage = isInvalid
+      ? 'Enter 3 or more characters for product type is equal to'
+      : '';
 
-  const suffix = value ? 'in: Unfulfilled orders' : null;
+    const formGroupMarkup = (
+      <LegacyStack wrap={false} alignment="leading" spacing="loose">
+        <LegacyStack.Item fill>
+          <FormLayout>
+            <FormLayout.Group condensed>
+              <Select
+                labelHidden
+                label="Collection rule type"
+                options={['Product type']}
+                value={selectTypeValue}
+                onChange={handleSelectTypeChange}
+              />
+              <Select
+                labelHidden
+                label="Collection rule condition"
+                options={['is equal to']}
+                value={selectConditionValue}
+                onChange={handleSelectConditionChange}
+              />
+              <TextField
+                labelHidden
+                label="Collection rule content"
+                error={isInvalid}
+                id={textFieldID}
+                value={textFieldValue}
+                onChange={handleTextFieldValueChange}
+                autoComplete="off"
+              />
+            </FormLayout.Group>
+          </FormLayout>
+          <div style={{marginTop: '4px'}}>
+            <InlineError message={errorMessage} fieldID={textFieldID} />
+          </div>
+        </LegacyStack.Item>
+        <Button icon={DeleteIcon} accessibilityLabel="Remove item" />
+      </LegacyStack>
+    );
 
-  return (
-    <TextField
-      label="Search view"
-      value={value}
-      onChange={handleChange}
-      autoComplete="off"
-      autoSize
-      placeholder="Searching in Unfulfilled orders"
-      suffix={suffix}
-    />
-  );
-}
+    return (
+      <LegacyCard sectioned>
+        <FormLayout>{formGroupMarkup}</FormLayout>
+      </LegacyCard>
+    );
 
-export function WithAutoSizeAndOtherElements() {
-  const [value, setValue] = useState('Jaded Pixel');
+    function isValueInvalid(content) {
+      if (!content) {
+        return true;
+      }
 
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
+      return content.length < 3;
+    }
+  },
+};
 
-  const handleClearButtonClick = useCallback(() => setValue(''), []);
+export const Disabled = {
+  render() {
+    return <TextField label="Store name" disabled autoComplete="off" />;
+  },
+};
 
-  return (
-    <TextField
-      label="Search view"
-      value={value}
-      onChange={handleChange}
-      autoComplete="off"
-      clearButton
-      onClearButtonClick={handleClearButtonClick}
-      autoSize
-      suffix="in: Unfulfilled orders"
-      showCharacterCount
-      maxLength={128}
-    />
-  );
-}
+export const WithCharacterCount = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
 
-export function WithLoading() {
-  const [value, setValue] = useState('Jaded Pixel');
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
 
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
+    return (
+      <TextField
+        label="Store name"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        maxLength={20}
+        autoComplete="off"
+        showCharacterCount
+      />
+    );
+  },
+};
 
-  const handleClearButtonClick = useCallback(() => setValue(''), []);
+export const WithClearButton = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
 
-  return (
-    <TextField
-      label="Store name"
-      value={value}
-      onChange={handleChange}
-      autoComplete="off"
-      clearButton
-      onClearButtonClick={handleClearButtonClick}
-      loading
-    />
-  );
-}
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    const handleClearButtonClick = useCallback(() => setTextFieldValue(''), []);
+
+    return (
+      <TextField
+        label="Store name"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        clearButton
+        onClearButtonClick={handleClearButtonClick}
+        autoComplete="off"
+      />
+    );
+  },
+};
+
+export const WithMonospacedFont = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    return (
+      <TextField
+        label="Store name"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        monospaced
+      />
+    );
+  },
+};
+
+export const WithValueSelectedOnFocus = {
+  render() {
+    const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
+
+    const handleTextFieldChange = useCallback(
+      (value) => setTextFieldValue(value),
+      [],
+    );
+
+    return (
+      <TextField
+        label="Store name"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        selectTextOnFocus
+      />
+    );
+  },
+};
+
+export const WithInlineSuggestion = {
+  render() {
+    const suggestions = useMemo(
+      () => [
+        'Alabama',
+        'Alaska',
+        'American Samoa',
+        'Arizona',
+        'Arkansas',
+        'California',
+        'Colorado',
+        'Connecticut',
+        'Delaware',
+        'District of Columbia',
+        'Florida',
+        'Georgia',
+        'Guam',
+        'Hawaii',
+        'Idaho',
+        'Illinois',
+        'Indiana',
+        'Iowa',
+        'Kansas',
+        'Kentucky',
+        'Louisiana',
+        'Maine',
+        'Maryland',
+        'Massachusetts',
+        'Michigan',
+        'Minnesota',
+        'Icon Outlying Islands',
+        'Mississippi',
+        'Missouri',
+        'Montana',
+        'Nebraska',
+        'Nevada',
+        'New Hampshire',
+        'New Jersey',
+        'New Mexico',
+        'New York',
+        'North Carolina',
+        'North Dakota',
+        'Northern Mariana Islands',
+        'Ohio',
+        'Oklahoma',
+        'Oregon',
+        'Pennsylvania',
+        'Puerto Rico',
+        'Rhode Island',
+        'South Carolina',
+        'South Dakota',
+        'Tennessee',
+        'Texas',
+        'U.S. Virgin Islands',
+        'Utah',
+        'Vermont',
+        'Virginia',
+        'Washington',
+        'West Virginia',
+        'Wisconsin',
+        'Wyoming',
+      ],
+      [],
+    );
+
+    const [value, setValue] = useState('');
+    const [suggestion, setSuggestion] = useState<string | undefined>();
+
+    const handleChange = useCallback(
+      (value: string) => {
+        const suggestion =
+          value &&
+          suggestions.find((suggestion) =>
+            suggestion.toLowerCase().startsWith(value.toLowerCase()),
+          );
+
+        setValue(value);
+        setSuggestion(suggestion);
+      },
+      [suggestions],
+    );
+
+    const handleKeyDown = useCallback(
+      (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === 'Tab') {
+          setValue(suggestion || value);
+          setSuggestion('');
+        } else if (event.key === 'Backspace') {
+          setValue(value);
+          setSuggestion('');
+        }
+      },
+      [value, suggestion],
+    );
+
+    return (
+      <div onKeyDown={handleKeyDown}>
+        <TextField
+          type="text"
+          label="State"
+          value={value}
+          onChange={handleChange}
+          suggestion={suggestion}
+          autoComplete="off"
+        />
+      </div>
+    );
+  },
+};
+
+export const All = {
+  render() {
+    return (
+      <FormLayout>
+        <FormLayout.Group>
+          <TextField
+            label="Default"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            label="Disabled"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+            helpText="Help text"
+            disabled
+          />
+          <TextField
+            label="Read only"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+            readOnly
+          />
+          <TextField
+            label="Error"
+            value="Value"
+            onChange={() => {}}
+            error="Error message."
+            autoComplete="off"
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Number"
+            type="number"
+            value="5"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            label="With label action"
+            value="Value"
+            onChange={() => {}}
+            labelAction={{content: 'Action'}}
+            autoComplete="off"
+          />
+          <TextField
+            label="Placeholder"
+            value=""
+            onChange={() => {}}
+            placeholder="Example"
+            autoComplete="off"
+          />
+          <TextField
+            label="Help text"
+            type="email"
+            value="Value"
+            onChange={() => {}}
+            helpText="Help text."
+            autoComplete="email"
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Prefix"
+            type="number"
+            value="4"
+            onChange={() => {}}
+            prefix="$"
+            autoComplete="off"
+          />
+          <TextField
+            label="Prefix with magic"
+            type="number"
+            value="4"
+            onChange={() => {}}
+            prefix="$"
+            autoComplete="off"
+            tone="magic"
+          />
+          <TextField
+            label="Prefix icon"
+            type="search"
+            value="Value"
+            onChange={() => {}}
+            prefix={<Icon source={SearchIcon} />}
+            autoComplete="off"
+          />
+          <TextField
+            label="Prefix icon with magic"
+            type="search"
+            value="Value"
+            onChange={() => {}}
+            prefix={<Icon source={SearchIcon} />}
+            autoComplete="off"
+            tone="magic"
+          />
+          <TextField
+            label="Suffix tooltip"
+            value="Value"
+            onChange={() => {}}
+            suffix={
+              <Tooltip content="Hello world">
+                <Icon source={QuestionCircleIcon} />
+              </Tooltip>
+            }
+            autoComplete="off"
+          />
+          <TextField
+            label="Suffix tooltip with magic"
+            value="Value"
+            onChange={() => {}}
+            suffix={
+              <Tooltip content="Hello world">
+                <Icon source={QuestionCircleIcon} />
+              </Tooltip>
+            }
+            tone="magic"
+            autoComplete="off"
+          />
+          <TextField
+            label="Character count"
+            value="Value"
+            onChange={() => {}}
+            maxLength={20}
+            autoComplete="off"
+            showCharacterCount
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Clear button"
+            value="Value"
+            onChange={() => {}}
+            clearButton
+            onClearButtonClick={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            label="Required"
+            value="Value"
+            onChange={() => {}}
+            requiredIndicator
+            autoComplete="off"
+          />
+          <TextField
+            label="Monospaced"
+            value="Value"
+            onChange={() => {}}
+            monospaced
+            autoComplete="off"
+          />
+          <TextField
+            label="Borderless"
+            value="Value"
+            onChange={() => {}}
+            variant="borderless"
+            autoComplete="off"
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Shipping address"
+            value="Value"
+            onChange={() => {}}
+            multiline={4}
+            autoComplete="off"
+          />
+          <TextField
+            label="Multiline error"
+            value="Value"
+            onChange={() => {}}
+            error="Error message."
+            multiline={4}
+            autoComplete="off"
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Label hidden"
+            value=""
+            labelHidden
+            onChange={() => {}}
+            placeholder="Label hidden"
+            autoComplete="off"
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Connected"
+            type="number"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+            connectedLeft={<Button>Left</Button>}
+            connectedRight={<Button>Right</Button>}
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Search native"
+            type="search"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            label="Date native"
+            type="date"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            label="Date time native"
+            type="datetime-local"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Month native"
+            type="month"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            label="Time native"
+            type="time"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            label="Week native"
+            type="week"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+        </FormLayout.Group>
+        <FormLayout.Group>
+          <TextField
+            label="Slim variant"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+            size="slim"
+          />
+          <TextField
+            label="Borderless slim variant"
+            value="Value"
+            onChange={() => {}}
+            autoComplete="off"
+            variant="borderless"
+            size="slim"
+          />
+        </FormLayout.Group>
+      </FormLayout>
+    );
+  },
+};
+
+export const WithFormSubmit = {
+  render() {
+    const [adjustment, setAdjustment] = useState('0');
+    const [onHandTotal, setOnHandTotal] = useState(0);
+
+    return (
+      <BlockStack gap="200">
+        <Form
+          onSubmit={(event) => {
+            event.preventDefault();
+            setAdjustment('0');
+            setOnHandTotal(onHandTotal + parseInt(adjustment, 10));
+          }}
+        >
+          <FormLayout>
+            <Text as="h2" variant="headingSm">
+              On hand quantity ({onHandTotal.toString()})
+            </Text>
+            <TextField
+              label="Adjustment"
+              value={adjustment}
+              onChange={(value) => setAdjustment(value)}
+              autoComplete="off"
+              type="number"
+              selectTextOnFocus
+            />
+            <Button
+              variant="primary"
+              submit
+              disabled={isNaN(parseInt(adjustment, 10))}
+            >
+              Save
+            </Button>
+          </FormLayout>
+        </Form>
+      </BlockStack>
+    );
+  },
+};
+
+export const With1PasswordDisabled = {
+  render() {
+    const [value, setValue] = useState('Jaded Pixel');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+    return (
+      <TextField
+        label="Store name"
+        value={value}
+        onChange={handleChange}
+        autoComplete="off"
+      />
+    );
+  },
+};
+
+export const WithAutoSize = {
+  render() {
+    const [value, setValue] = useState('Jaded Pixel');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+    return (
+      <TextField
+        label="Store name"
+        value={value}
+        onChange={handleChange}
+        autoComplete="off"
+        autoSize
+        suffix="in: Your stores"
+      />
+    );
+  },
+};
+
+export const WithAutoSizeAndDynamicSuffix = {
+  render() {
+    const [value, setValue] = useState('');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+    const suffix = value ? 'in: Unfulfilled orders' : null;
+
+    return (
+      <TextField
+        label="Search view"
+        value={value}
+        onChange={handleChange}
+        autoComplete="off"
+        autoSize
+        placeholder="Searching in Unfulfilled orders"
+        suffix={suffix}
+      />
+    );
+  },
+};
+
+export const WithAutoSizeAndOtherElements = {
+  render() {
+    const [value, setValue] = useState('Jaded Pixel');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+    const handleClearButtonClick = useCallback(() => setValue(''), []);
+
+    return (
+      <TextField
+        label="Search view"
+        value={value}
+        onChange={handleChange}
+        autoComplete="off"
+        clearButton
+        onClearButtonClick={handleClearButtonClick}
+        autoSize
+        suffix="in: Unfulfilled orders"
+        showCharacterCount
+        maxLength={128}
+      />
+    );
+  },
+};
+
+export const WithLoading = {
+  render() {
+    const [value, setValue] = useState('Jaded Pixel');
+
+    const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+    const handleClearButtonClick = useCallback(() => setValue(''), []);
+
+    return (
+      <TextField
+        label="Store name"
+        value={value}
+        onChange={handleChange}
+        autoComplete="off"
+        clearButton
+        onClearButtonClick={handleClearButtonClick}
+        loading
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/ThemeProvider/ThemeProvider.stories.tsx
+++ b/polaris-react/src/components/ThemeProvider/ThemeProvider.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Frame,
   Icon,
@@ -12,86 +12,89 @@ import {HeartIcon, NotificationIcon} from '@shopify/polaris-icons';
 
 export default {
   component: ThemeProvider,
-} as ComponentMeta<typeof ThemeProvider>;
+} as Meta<typeof ThemeProvider>;
 
-export function Default() {
-  const [isHeartMenuOpen, setIsHeartMenuOpen] = useState(true);
+export const Default = {
+  render() {
+    const [isHeartMenuOpen, setIsHeartMenuOpen] = useState(true);
 
-  const toggleIsHeartMenuOpen = useCallback(
-    () => setIsHeartMenuOpen((isHeartMenuOpen) => !isHeartMenuOpen),
-    [],
-  );
+    const toggleIsHeartMenuOpen = useCallback(
+      () => setIsHeartMenuOpen((isHeartMenuOpen) => !isHeartMenuOpen),
+      [],
+    );
 
-  const [isNotificationsMenuOpen, setIsNotificationsMenuOpen] = useState(false);
+    const [isNotificationsMenuOpen, setIsNotificationsMenuOpen] =
+      useState(false);
 
-  const toggleIsNotificationsMenuOpen = useCallback(
-    () =>
-      setIsNotificationsMenuOpen(
-        (isNotificationsMenuOpen) => !isNotificationsMenuOpen,
-      ),
-    [],
-  );
+    const toggleIsNotificationsMenuOpen = useCallback(
+      () =>
+        setIsNotificationsMenuOpen(
+          (isNotificationsMenuOpen) => !isNotificationsMenuOpen,
+        ),
+      [],
+    );
 
-  const heartMenu = (
-    <ThemeProvider theme="light">
-      <TopBar.Menu
-        activatorContent={
-          <ThemeProvider theme="dark-experimental">
+    const heartMenu = (
+      <ThemeProvider theme="light">
+        <TopBar.Menu
+          activatorContent={
+            <ThemeProvider theme="dark-experimental">
+              <span>
+                <Icon source={HeartIcon} />
+                <Text as="span" visuallyHidden>
+                  Light theme popover button
+                </Text>
+              </span>
+            </ThemeProvider>
+          }
+          open={isHeartMenuOpen}
+          onOpen={toggleIsHeartMenuOpen}
+          onClose={toggleIsHeartMenuOpen}
+          actions={[
+            {
+              items: [{content: 'Light theme popover'}],
+            },
+          ]}
+        />
+      </ThemeProvider>
+    );
+
+    const notificationsMenu = (
+      <ThemeProvider theme="dark-experimental">
+        <TopBar.Menu
+          activatorContent={
             <span>
-              <Icon source={HeartIcon} />
+              <Icon source={NotificationIcon} />
               <Text as="span" visuallyHidden>
-                Light theme popover button
+                Dark theme popover button
               </Text>
             </span>
-          </ThemeProvider>
-        }
-        open={isHeartMenuOpen}
-        onOpen={toggleIsHeartMenuOpen}
-        onClose={toggleIsHeartMenuOpen}
-        actions={[
-          {
-            items: [{content: 'Light theme popover'}],
-          },
-        ]}
-      />
-    </ThemeProvider>
-  );
-
-  const notificationsMenu = (
-    <ThemeProvider theme="dark-experimental">
-      <TopBar.Menu
-        activatorContent={
-          <span>
-            <Icon source={NotificationIcon} />
-            <Text as="span" visuallyHidden>
-              Dark theme popover button
-            </Text>
-          </span>
-        }
-        open={isNotificationsMenuOpen}
-        onOpen={toggleIsNotificationsMenuOpen}
-        onClose={toggleIsNotificationsMenuOpen}
-        actions={[
-          {
-            items: [{content: 'Dark theme popover'}],
-          },
-        ]}
-      />
-    </ThemeProvider>
-  );
-
-  return (
-    <Frame
-      topBar={
-        <TopBar
-          secondaryMenu={
-            <InlineStack>
-              {heartMenu}
-              {notificationsMenu}
-            </InlineStack>
           }
+          open={isNotificationsMenuOpen}
+          onOpen={toggleIsNotificationsMenuOpen}
+          onClose={toggleIsNotificationsMenuOpen}
+          actions={[
+            {
+              items: [{content: 'Dark theme popover'}],
+            },
+          ]}
         />
-      }
-    />
-  );
-}
+      </ThemeProvider>
+    );
+
+    return (
+      <Frame
+        topBar={
+          <TopBar
+            secondaryMenu={
+              <InlineStack>
+                {heartMenu}
+                {notificationsMenu}
+              </InlineStack>
+            }
+          />
+        }
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/Thumbnail/Thumbnail.stories.tsx
+++ b/polaris-react/src/components/Thumbnail/Thumbnail.stories.tsx
@@ -1,65 +1,79 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {InlineStack, Thumbnail, BlockStack} from '@shopify/polaris';
 import {NoteIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Thumbnail,
-} as ComponentMeta<typeof Thumbnail>;
+} as Meta<typeof Thumbnail>;
 
-export function All() {
-  return (
-    <BlockStack gap="400">
-      <InlineStack gap="400" blockAlign="center">
-        <ExtraSmall />
-        <Small />
-        <Default />
-        <Large />
-      </InlineStack>
-      <WithComponentSource />
-    </BlockStack>
-  );
-}
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="400">
+        <InlineStack gap="400" blockAlign="center">
+          <ExtraSmall.render />
+          <Small.render />
+          <Default.render />
+          <Large.render />
+        </InlineStack>
+        <WithComponentSource.render />
+      </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-export function Default() {
-  return (
-    <Thumbnail
-      source="https://burst.shopifycdn.com/photos/light-up-sneakers-women.jpg"
-      alt="Light up sneakers women"
-    />
-  );
-}
+export const Default = {
+  render() {
+    return (
+      <Thumbnail
+        source="https://burst.shopifycdn.com/photos/light-up-sneakers-women.jpg"
+        alt="Light up sneakers women"
+      />
+    );
+  },
+};
 
-export function ExtraSmall() {
-  return (
-    <Thumbnail
-      source="https://burst.shopifycdn.com/photos/light-up-sneakers-women.jpg"
-      size="extraSmall"
-      alt="Light up sneakers women"
-    />
-  );
-}
+export const ExtraSmall = {
+  render() {
+    return (
+      <Thumbnail
+        source="https://burst.shopifycdn.com/photos/light-up-sneakers-women.jpg"
+        size="extraSmall"
+        alt="Light up sneakers women"
+      />
+    );
+  },
+};
 
-export function Small() {
-  return (
-    <Thumbnail
-      source="https://burst.shopifycdn.com/photos/light-up-sneakers-women.jpg"
-      size="small"
-      alt="Light up sneakers women"
-    />
-  );
-}
+export const Small = {
+  render() {
+    return (
+      <Thumbnail
+        source="https://burst.shopifycdn.com/photos/light-up-sneakers-women.jpg"
+        size="small"
+        alt="Light up sneakers women"
+      />
+    );
+  },
+};
 
-export function Large() {
-  return (
-    <Thumbnail
-      source="https://burst.shopifycdn.com/photos/light-up-sneakers-women.jpg"
-      size="large"
-      alt="Light up sneakers women"
-    />
-  );
-}
+export const Large = {
+  render() {
+    return (
+      <Thumbnail
+        source="https://burst.shopifycdn.com/photos/light-up-sneakers-women.jpg"
+        size="large"
+        alt="Light up sneakers women"
+      />
+    );
+  },
+};
 
-export function WithComponentSource() {
-  return <Thumbnail source={NoteIcon} size="large" alt="Small document" />;
-}
+export const WithComponentSource = {
+  render() {
+    return <Thumbnail source={NoteIcon} size="large" alt="Small document" />;
+  },
+};

--- a/polaris-react/src/components/Toast/Toast.stories.tsx
+++ b/polaris-react/src/components/Toast/Toast.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Button,
   ButtonGroup,
@@ -15,341 +15,363 @@ import {MagicIcon} from '@shopify/polaris-icons';
 
 export default {
   component: Toast,
-} as ComponentMeta<typeof Toast>;
+} as Meta<typeof Toast>;
 
-export function Default() {
-  const [active, setActive] = useState(false);
+export const Default = {
+  render() {
+    const [active, setActive] = useState(false);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const toastMarkup = active ? (
-    <Toast content="Message sent" onDismiss={toggleActive} />
-  ) : null;
+    const toastMarkup = active ? (
+      <Toast content="Message sent" onDismiss={toggleActive} />
+    ) : null;
 
-  return (
-    <div style={{height: '250px'}}>
-      <Frame>
-        <Page title="Default">
-          <Button onClick={toggleActive}>Show Toast</Button>
-          {toastMarkup}
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Default">
+            <Button onClick={toggleActive}>Show Toast</Button>
+            {toastMarkup}
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function MultipleMessages() {
-  const [activeToasts, setActiveToasts] = useState<number[]>([]);
+export const MultipleMessages = {
+  render() {
+    const [activeToasts, setActiveToasts] = useState<number[]>([]);
 
-  const toggleActive = (id: number) =>
-    setActiveToasts((activeToasts) => {
-      const isToastActive = activeToasts.includes(id);
-      return isToastActive
-        ? activeToasts.filter((activeToast) => activeToast !== id)
-        : [...activeToasts, id];
-    });
+    const toggleActive = (id: number) =>
+      setActiveToasts((activeToasts) => {
+        const isToastActive = activeToasts.includes(id);
+        return isToastActive
+          ? activeToasts.filter((activeToast) => activeToast !== id)
+          : [...activeToasts, id];
+      });
 
-  const toggleActiveOne = useCallback(() => toggleActive(1), []);
+    const toggleActiveOne = useCallback(() => toggleActive(1), []);
 
-  const toggleActiveTwo = useCallback(() => toggleActive(2), []);
+    const toggleActiveTwo = useCallback(() => toggleActive(2), []);
 
-  const toggleActiveThree = useCallback(() => toggleActive(3), []);
+    const toggleActiveThree = useCallback(() => toggleActive(3), []);
 
-  const toggleActiveFour = useCallback(() => toggleActive(4), []);
+    const toggleActiveFour = useCallback(() => toggleActive(4), []);
 
-  const toggleActiveFive = useCallback(() => toggleActive(5), []);
+    const toggleActiveFive = useCallback(() => toggleActive(5), []);
 
-  const toggleActiveSix = useCallback(() => toggleActive(6), []);
+    const toggleActiveSix = useCallback(() => toggleActive(6), []);
 
-  const toastDuration = 5000;
+    const toastDuration = 5000;
 
-  const toastMarkup1 = activeToasts.includes(1) ? (
-    <Toast
-      content="Message sent 1"
-      onDismiss={toggleActiveOne}
-      duration={toastDuration}
-    />
-  ) : null;
+    const toastMarkup1 = activeToasts.includes(1) ? (
+      <Toast
+        content="Message sent 1"
+        onDismiss={toggleActiveOne}
+        duration={toastDuration}
+      />
+    ) : null;
 
-  const toastMarkup2 = activeToasts.includes(2) ? (
-    <Toast
-      content="Image uploaded 2"
-      onDismiss={toggleActiveTwo}
-      duration={toastDuration}
-    />
-  ) : null;
+    const toastMarkup2 = activeToasts.includes(2) ? (
+      <Toast
+        content="Image uploaded 2"
+        onDismiss={toggleActiveTwo}
+        duration={toastDuration}
+      />
+    ) : null;
 
-  const toastMarkup3 = activeToasts.includes(3) ? (
-    <Toast
-      content="Notification sent 3"
-      onDismiss={toggleActiveThree}
-      duration={toastDuration}
-    />
-  ) : null;
+    const toastMarkup3 = activeToasts.includes(3) ? (
+      <Toast
+        content="Notification sent 3"
+        onDismiss={toggleActiveThree}
+        duration={toastDuration}
+      />
+    ) : null;
 
-  const toastMarkup4 = activeToasts.includes(4) ? (
-    <Toast
-      content="Content updated 4"
-      onDismiss={toggleActiveFour}
-      duration={toastDuration}
-    />
-  ) : null;
+    const toastMarkup4 = activeToasts.includes(4) ? (
+      <Toast
+        content="Content updated 4"
+        onDismiss={toggleActiveFour}
+        duration={toastDuration}
+      />
+    ) : null;
 
-  const toastMarkup5 = activeToasts.includes(5) ? (
-    <Toast
-      content="Server error 5"
-      error
-      onDismiss={toggleActiveFive}
-      duration={toastDuration}
-    />
-  ) : null;
+    const toastMarkup5 = activeToasts.includes(5) ? (
+      <Toast
+        content="Server error 5"
+        error
+        onDismiss={toggleActiveFive}
+        duration={toastDuration}
+      />
+    ) : null;
 
-  const toastMarkup6 = activeToasts.includes(6) ? (
-    <Toast
-      content="Sidekick enabled 6"
-      tone="magic"
-      onDismiss={toggleActiveSix}
-      duration={toastDuration}
-    />
-  ) : null;
+    const toastMarkup6 = activeToasts.includes(6) ? (
+      <Toast
+        content="Sidekick enabled 6"
+        tone="magic"
+        onDismiss={toggleActiveSix}
+        duration={toastDuration}
+      />
+    ) : null;
 
-  return (
-    <div style={{height: '250px'}}>
-      <Frame>
-        <Page title="Multiple Messages">
-          <ButtonGroup variant="segmented">
-            <Button onClick={toggleActiveOne}>Show toast 1</Button>
-            <Button onClick={toggleActiveTwo}>Show toast 2</Button>
-            <Button onClick={toggleActiveThree}>Show toast 3</Button>
-            <Button onClick={toggleActiveFour}>Show toast 4</Button>
-            <Button onClick={toggleActiveFive}>Show toast 5 (error)</Button>
-            <Button onClick={toggleActiveSix}>Show toast 6 (Magic) </Button>
-          </ButtonGroup>
-          {toastMarkup1}
-          {toastMarkup2}
-          {toastMarkup3}
-          {toastMarkup4}
-          {toastMarkup5}
-          {toastMarkup6}
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Multiple Messages">
+            <ButtonGroup variant="segmented">
+              <Button onClick={toggleActiveOne}>Show toast 1</Button>
+              <Button onClick={toggleActiveTwo}>Show toast 2</Button>
+              <Button onClick={toggleActiveThree}>Show toast 3</Button>
+              <Button onClick={toggleActiveFour}>Show toast 4</Button>
+              <Button onClick={toggleActiveFive}>Show toast 5 (error)</Button>
+              <Button onClick={toggleActiveSix}>Show toast 6 (Magic) </Button>
+            </ButtonGroup>
+            {toastMarkup1}
+            {toastMarkup2}
+            {toastMarkup3}
+            {toastMarkup4}
+            {toastMarkup5}
+            {toastMarkup6}
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function WithCustomDuration() {
-  const [active, setActive] = useState(false);
+export const WithCustomDuration = {
+  render() {
+    const [active, setActive] = useState(false);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const toastMarkup = active ? (
-    <Toast content="Message sent" onDismiss={toggleActive} duration={4500} />
-  ) : null;
+    const toastMarkup = active ? (
+      <Toast content="Message sent" onDismiss={toggleActive} duration={4500} />
+    ) : null;
 
-  return (
-    <div style={{height: '250px'}}>
-      <Frame>
-        <Page title="Custom Duration">
-          <Button onClick={toggleActive}>Show Toast</Button>
-          {toastMarkup}
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Custom Duration">
+            <Button onClick={toggleActive}>Show Toast</Button>
+            {toastMarkup}
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function WithAction() {
-  const [active, setActive] = useState(false);
+export const WithAction = {
+  render() {
+    const [active, setActive] = useState(false);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const toastMarkup = active ? (
-    <Toast
-      content="Image deleted"
-      action={{
-        content: 'Undo',
-        onAction: () => {},
-      }}
-      duration={10000}
-      onDismiss={toggleActive}
-    />
-  ) : null;
+    const toastMarkup = active ? (
+      <Toast
+        content="Image deleted"
+        action={{
+          content: 'Undo',
+          onAction: () => {},
+        }}
+        duration={10000}
+        onDismiss={toggleActive}
+      />
+    ) : null;
 
-  return (
-    <div style={{height: '250px'}}>
-      <Frame>
-        <Page title="Action">
-          <Button onClick={toggleActive}>Show Toast</Button>
-          {toastMarkup}
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Action">
+            <Button onClick={toggleActive}>Show Toast</Button>
+            {toastMarkup}
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function Error() {
-  const [active, setActive] = useState(false);
+export const Error = {
+  render() {
+    const [active, setActive] = useState(false);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const toastMarkup = active ? (
-    <Toast content="Server error" error onDismiss={toggleActive} />
-  ) : null;
+    const toastMarkup = active ? (
+      <Toast content="Server error" error onDismiss={toggleActive} />
+    ) : null;
 
-  return (
-    <div style={{height: '250px'}}>
-      <Frame>
-        <Page title="Error">
-          <Button onClick={toggleActive}>Show Toast</Button>
-          {toastMarkup}
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Error">
+            <Button onClick={toggleActive}>Show Toast</Button>
+            {toastMarkup}
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function InsideModal() {
-  const [toastActive, setToastActive] = useState(false);
-  const [toast2Active, setToast2Active] = useState(false);
-  const [modalActive, setModalActive] = useState(true);
+export const InsideModal = {
+  render() {
+    const [toastActive, setToastActive] = useState(false);
+    const [toast2Active, setToast2Active] = useState(false);
+    const [modalActive, setModalActive] = useState(true);
 
-  const handleChange = useCallback(
-    () => setModalActive(!modalActive),
-    [modalActive],
-  );
+    const handleChange = useCallback(
+      () => setModalActive(!modalActive),
+      [modalActive],
+    );
 
-  const toggleActive = useCallback(
-    () => setToastActive((toastActive) => !toastActive),
-    [],
-  );
+    const toggleActive = useCallback(
+      () => setToastActive((toastActive) => !toastActive),
+      [],
+    );
 
-  const toggle2Active = useCallback(
-    () => setToast2Active((toastActive) => !toastActive),
-    [],
-  );
+    const toggle2Active = useCallback(
+      () => setToast2Active((toastActive) => !toastActive),
+      [],
+    );
 
-  const activator = <Button onClick={handleChange}>Open</Button>;
+    const activator = <Button onClick={handleChange}>Open</Button>;
 
-  const toastMarkup = toastActive ? (
-    <Toast content="Message sent" onDismiss={toggleActive} />
-  ) : null;
+    const toastMarkup = toastActive ? (
+      <Toast content="Message sent" onDismiss={toggleActive} />
+    ) : null;
 
-  const toast2Markup = toast2Active ? (
-    <Toast content="Another sent" onDismiss={toggle2Active} />
-  ) : null;
+    const toast2Markup = toast2Active ? (
+      <Toast content="Another sent" onDismiss={toggle2Active} />
+    ) : null;
 
-  return (
-    <div style={{height: '500px'}}>
-      <Frame>
-        <Page title="Default">
-          {toastMarkup}
-          {toast2Markup}
-          <Modal
-            activator={activator}
-            open={modalActive}
-            onClose={handleChange}
-            title="Reach more shoppers with Instagram product tags"
-            primaryAction={{
-              content: 'Add Instagram',
-              onAction: handleChange,
-            }}
-            secondaryActions={[
-              {
-                content: 'Learn more',
+    return (
+      <div style={{height: '500px'}}>
+        <Frame>
+          <Page title="Default">
+            {toastMarkup}
+            {toast2Markup}
+            <Modal
+              activator={activator}
+              open={modalActive}
+              onClose={handleChange}
+              title="Reach more shoppers with Instagram product tags"
+              primaryAction={{
+                content: 'Add Instagram',
                 onAction: handleChange,
-              },
-            ]}
-          >
-            <Modal.Section>
-              <BlockStack gap="200">
-                <TextContainer>
-                  Use Instagram posts to share your products with millions of
-                  people. Let shoppers buy from your store without leaving
-                  Instagram.
-                </TextContainer>
-                <InlineStack gap="200">
-                  <Button onClick={toggleActive}>Show Toast</Button>
-                  <Button onClick={toggle2Active}>Show Other Toast</Button>
-                </InlineStack>
-              </BlockStack>
-            </Modal.Section>
-          </Modal>
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+              }}
+              secondaryActions={[
+                {
+                  content: 'Learn more',
+                  onAction: handleChange,
+                },
+              ]}
+            >
+              <Modal.Section>
+                <BlockStack gap="200">
+                  <TextContainer>
+                    Use Instagram posts to share your products with millions of
+                    people. Let shoppers buy from your store without leaving
+                    Instagram.
+                  </TextContainer>
+                  <InlineStack gap="200">
+                    <Button onClick={toggleActive}>Show Toast</Button>
+                    <Button onClick={toggle2Active}>Show Other Toast</Button>
+                  </InlineStack>
+                </BlockStack>
+              </Modal.Section>
+            </Modal>
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function Magic() {
-  const [active, setActive] = useState(false);
+export const Magic = {
+  render() {
+    const [active, setActive] = useState(false);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const toastMarkup = active ? (
-    <Toast
-      content="Magic message"
-      onDismiss={toggleActive}
-      tone="magic"
-      duration={3000000}
-    />
-  ) : null;
+    const toastMarkup = active ? (
+      <Toast
+        content="Magic message"
+        onDismiss={toggleActive}
+        tone="magic"
+        duration={3000000}
+      />
+    ) : null;
 
-  return (
-    <div style={{height: '250px'}}>
-      <Frame>
-        <Page title="Default">
-          <Button onClick={toggleActive}>Show Magic Toast</Button>
-          {toastMarkup}
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Default">
+            <Button onClick={toggleActive}>Show Magic Toast</Button>
+            {toastMarkup}
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function WithOnClick() {
-  const [active, setActive] = useState(false);
+export const WithOnClick = {
+  render() {
+    const [active, setActive] = useState(false);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const toastMarkup = active ? (
-    <Toast content="Message Toast" onClick={toggleActive} duration={3000000} />
-  ) : null;
+    const toastMarkup = active ? (
+      <Toast
+        content="Message Toast"
+        onClick={toggleActive}
+        duration={3000000}
+      />
+    ) : null;
 
-  return (
-    <div style={{height: '250px'}}>
-      <Frame>
-        <Page title="Default">
-          <Button onClick={toggleActive}>Show Magic Toast</Button>
-          {toastMarkup}
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Default">
+            <Button onClick={toggleActive}>Show Magic Toast</Button>
+            {toastMarkup}
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};
 
-export function MagicWithOnClick() {
-  const [active, setActive] = useState(false);
+export const MagicWithOnClick = {
+  render() {
+    const [active, setActive] = useState(false);
 
-  const toggleActive = useCallback(() => setActive((active) => !active), []);
+    const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-  const toastMarkup = active ? (
-    <Toast
-      content="Magic message"
-      tone="magic"
-      duration={3000000}
-      icon={MagicIcon}
-      onClick={toggleActive}
-    />
-  ) : null;
+    const toastMarkup = active ? (
+      <Toast
+        content="Magic message"
+        tone="magic"
+        duration={3000000}
+        icon={MagicIcon}
+        onClick={toggleActive}
+      />
+    ) : null;
 
-  return (
-    <div style={{height: '250px'}}>
-      <Frame>
-        <Page title="Default">
-          <Button onClick={toggleActive}>Show Magic Toast</Button>
-          {toastMarkup}
-        </Page>
-      </Frame>
-    </div>
-  );
-}
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Default">
+            <Button onClick={toggleActive}>Show Magic Toast</Button>
+            {toastMarkup}
+          </Page>
+        </Frame>
+      </div>
+    );
+  },
+};

--- a/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {QuestionCircleIcon} from '@shopify/polaris-icons';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {
   Button,
   ButtonGroup,
@@ -18,551 +18,586 @@ import type {TooltipProps} from '@shopify/polaris';
 
 export default {
   component: Tooltip,
-} as ComponentMeta<typeof Tooltip>;
+} as Meta<typeof Tooltip>;
 
-export function All() {
-  return (
-    <BlockStack gap="1600">
-      <Default />
-      <PreferredPosition />
-      <Width />
-      <Padding />
-      <BorderRadius />
-      <VisibleOnlyWithChildInteraction />
-      <WithHoverDelay />
-      <ActivatorAsDiv />
-      <WithSuffix />
-      <Alignment />
-      <HasUnderline />
-      <PersistOnClick />
-      <ActiveStates />
-    </BlockStack>
-  );
-}
-
-export function Default() {
-  return (
-    <Box paddingBlockStart="2400">
-      <Tooltip active content="This order has shipping labels.">
-        <Text variant="bodyLg" fontWeight="bold" as="span">
-          Order #1001
-        </Text>
-      </Tooltip>
-    </Box>
-  );
-}
-
-export function PreferredPosition() {
-  return (
-    <Box paddingBlockStart="2400">
-      <InlineStack gap="800">
-        <Tooltip
-          active
-          content="This content is positioned above the activator"
-          preferredPosition="above"
-        >
-          <InlineStack gap="100">
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              Tooltip positioned
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
-              above
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              the activator
-            </Text>
-            <Icon source={QuestionCircleIcon} tone="base" />
-          </InlineStack>
-        </Tooltip>
-        <Tooltip
-          active
-          content="This content is positioned above the activator"
-          preferredPosition="below"
-        >
-          <InlineStack gap="100">
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              Tooltip positioned
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
-              below
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              the activator
-            </Text>
-            <Icon source={QuestionCircleIcon} tone="base" />
-          </InlineStack>
-        </Tooltip>
-      </InlineStack>
-    </Box>
-  );
-}
-
-export function Width() {
-  return (
-    <Box paddingBlockStart="2400">
-      <InlineStack gap="800">
-        <Tooltip
-          active
-          content="This content has the default width and will break into a new line at 200px width"
-        >
-          <InlineStack gap="100">
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              Tooltip with
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
-              default
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              content width
-            </Text>
-            <Icon source={QuestionCircleIcon} tone="base" />
-          </InlineStack>
-        </Tooltip>
-        <Tooltip
-          active
-          content="This content has the wide width and will break into a new line at 275px width"
-          width="wide"
-        >
-          <InlineStack gap="100">
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              Tooltip with
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
-              wide
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              content width
-            </Text>
-            <Icon source={QuestionCircleIcon} tone="base" />
-          </InlineStack>
-        </Tooltip>
-      </InlineStack>
-    </Box>
-  );
-}
-
-export function Padding() {
-  return (
-    <Box paddingBlockStart="2400">
-      <InlineStack gap="800">
-        <Tooltip active content="This content has default padding">
-          <InlineStack gap="100">
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              Tooltip with
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
-              default
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              content padding
-            </Text>
-            <Icon source={QuestionCircleIcon} tone="base" />
-          </InlineStack>
-        </Tooltip>
-        <Tooltip
-          active
-          content="This content has padding of 4 (space-400 / 16px)"
-          padding="400"
-        >
-          <InlineStack gap="100">
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              Tooltip with
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
-              4
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              content padding
-            </Text>
-            <Icon source={QuestionCircleIcon} tone="base" />
-          </InlineStack>
-        </Tooltip>
-      </InlineStack>
-    </Box>
-  );
-}
-
-export function BorderRadius() {
-  return (
-    <Box paddingBlockStart="2400">
-      <InlineStack gap="800">
-        <Tooltip
-          active
-          content="This content has the default (radius-100) border radius"
-        >
-          <InlineStack gap="100">
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              Tooltip with
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
-              default
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              border radius
-            </Text>
-            <Icon source={QuestionCircleIcon} tone="base" />
-          </InlineStack>
-        </Tooltip>
-        <Tooltip
-          active
-          content="This content has a border radius of 200 (radius-200)"
-          borderRadius="200"
-        >
-          <InlineStack gap="100">
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              Tooltip with
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
-              2
-            </Text>{' '}
-            <Text variant="bodyLg" fontWeight="medium" as="span">
-              border radius
-            </Text>
-            <Icon source={QuestionCircleIcon} tone="base" />
-          </InlineStack>
-        </Tooltip>
-      </InlineStack>
-    </Box>
-  );
-}
-
-export function VisibleOnlyWithChildInteraction() {
-  return (
-    <Box paddingBlockStart="2400">
-      <div style={{width: '200px'}}>
-        <ButtonGroup variant="segmented" fullWidth>
-          <Tooltip content="Bold" dismissOnMouseOut>
-            <Button>B</Button>
-          </Tooltip>
-          <Tooltip content="Italic" dismissOnMouseOut>
-            <Button>I</Button>
-          </Tooltip>
-          <Tooltip content="Underline" dismissOnMouseOut>
-            <Button>U</Button>
-          </Tooltip>
-          <Tooltip content="Strikethrough" dismissOnMouseOut>
-            <Button>S</Button>
-          </Tooltip>
-        </ButtonGroup>
-        <TextField
-          label="Product title"
-          autoComplete="off"
-          labelHidden
-          multiline
-        />
-      </div>
-    </Box>
-  );
-}
-
-export function WithHoverDelay() {
-  return (
-    <BlockStack gap="400">
-      <BlockStack gap="200">
-        <Text variant="headingMd" fontWeight="bold" as="h1">
-          TEXT EXAMPLE
-        </Text>
-        <InlineStack>
-          <Tooltip content="This should appear right away.">
-            <Text variant="bodyMd" fontWeight="semibold" as="span">
-              No delay
-            </Text>
-          </Tooltip>
-        </InlineStack>
-        <InlineStack>
-          <Tooltip
-            hoverDelay={1000}
-            content="This should appear after 1 second."
-          >
-            <Text variant="bodyMd" fontWeight="semibold" as="span">
-              1 second hover delay
-            </Text>
-          </Tooltip>
-        </InlineStack>
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="1600">
+        <Default.render />
+        <PreferredPosition.render />
+        <Width.render />
+        <Padding.render />
+        <BorderRadius.render />
+        <VisibleOnlyWithChildInteraction.render />
+        <WithHoverDelay.render />
+        <ActivatorAsDiv.render />
+        <WithSuffix.render />
+        <Alignment.render />
+        <HasUnderline.render />
+        <PersistOnClick.render />
+        <ActiveStates.render />
       </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-      <BlockStack gap="200">
-        <Text variant="headingMd" fontWeight="bold" as="h1">
-          BUTTON EXAMPLE
-        </Text>
-        <InlineStack>
-          <Tooltip content="This should appear right away.">
-            <Button>No delay</Button>
+export const Default = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <Tooltip active content="This order has shipping labels.">
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Order #1001
+          </Text>
+        </Tooltip>
+      </Box>
+    );
+  },
+};
+
+export const PreferredPosition = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <InlineStack gap="800">
+          <Tooltip
+            active
+            content="This content is positioned above the activator"
+            preferredPosition="above"
+          >
+            <InlineStack gap="100">
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                Tooltip positioned
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
+                above
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                the activator
+              </Text>
+              <Icon source={QuestionCircleIcon} tone="base" />
+            </InlineStack>
+          </Tooltip>
+          <Tooltip
+            active
+            content="This content is positioned above the activator"
+            preferredPosition="below"
+          >
+            <InlineStack gap="100">
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                Tooltip positioned
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
+                below
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                the activator
+              </Text>
+              <Icon source={QuestionCircleIcon} tone="base" />
+            </InlineStack>
           </Tooltip>
         </InlineStack>
-        <InlineStack>
+      </Box>
+    );
+  },
+};
+
+export const Width = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <InlineStack gap="800">
           <Tooltip
-            hoverDelay={2000}
-            content="This should appear after 2 seconds."
+            active
+            content="This content has the default width and will break into a new line at 200px width"
           >
-            <Button>2 seconds hover delay</Button>
+            <InlineStack gap="100">
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                Tooltip with
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
+                default
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                content width
+              </Text>
+              <Icon source={QuestionCircleIcon} tone="base" />
+            </InlineStack>
+          </Tooltip>
+          <Tooltip
+            active
+            content="This content has the wide width and will break into a new line at 275px width"
+            width="wide"
+          >
+            <InlineStack gap="100">
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                Tooltip with
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
+                wide
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                content width
+              </Text>
+              <Icon source={QuestionCircleIcon} tone="base" />
+            </InlineStack>
           </Tooltip>
         </InlineStack>
-      </BlockStack>
-    </BlockStack>
-  );
-}
+      </Box>
+    );
+  },
+};
 
-export function ActivatorAsDiv() {
-  return (
-    <Box paddingBlockStart="2400">
-      <Tooltip
-        active
-        content="This tooltip is rendered as a div"
-        activatorWrapper="div"
-      >
-        <Text variant="bodyLg" fontWeight="bold" as="span">
-          Order #1001
-        </Text>
-      </Tooltip>
-    </Box>
-  );
-}
+export const Padding = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <InlineStack gap="800">
+          <Tooltip active content="This content has default padding">
+            <InlineStack gap="100">
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                Tooltip with
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
+                default
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                content padding
+              </Text>
+              <Icon source={QuestionCircleIcon} tone="base" />
+            </InlineStack>
+          </Tooltip>
+          <Tooltip
+            active
+            content="This content has padding of 4 (space-400 / 16px)"
+            padding="400"
+          >
+            <InlineStack gap="100">
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                Tooltip with
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
+                4
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                content padding
+              </Text>
+              <Icon source={QuestionCircleIcon} tone="base" />
+            </InlineStack>
+          </Tooltip>
+        </InlineStack>
+      </Box>
+    );
+  },
+};
 
-export function WithSuffix() {
-  return (
-    <Box padding="1600" background="bg-surface">
-      <InlineStack>
-        <ButtonGroup variant="segmented" fullWidth>
+export const BorderRadius = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <InlineStack gap="800">
           <Tooltip
-            content={
-              <InlineStack gap="200">
-                Bold
-                <Text as="span" variant="bodyMd" tone="subdued">
-                  ⌘B
-                </Text>
-              </InlineStack>
-            }
+            active
+            content="This content has the default (radius-100) border radius"
           >
-            <Button>B</Button>
+            <InlineStack gap="100">
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                Tooltip with
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
+                default
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                border radius
+              </Text>
+              <Icon source={QuestionCircleIcon} tone="base" />
+            </InlineStack>
           </Tooltip>
           <Tooltip
-            content={
-              <InlineStack gap="200">
-                Italic
-                <Text as="span" variant="bodyMd" tone="subdued">
-                  ⌘I
-                </Text>
-              </InlineStack>
-            }
+            active
+            content="This content has a border radius of 200 (radius-200)"
+            borderRadius="200"
           >
-            <Button>I</Button>
+            <InlineStack gap="100">
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                Tooltip with
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="bold" as="span" tone="success">
+                2
+              </Text>{' '}
+              <Text variant="bodyLg" fontWeight="medium" as="span">
+                border radius
+              </Text>
+              <Icon source={QuestionCircleIcon} tone="base" />
+            </InlineStack>
           </Tooltip>
-          <Tooltip
-            content={
-              <InlineStack gap="200">
-                Underline
-                <Text as="span" variant="bodyMd" tone="subdued">
-                  ⌘U
-                </Text>
-              </InlineStack>
-            }
-          >
-            <Button>U</Button>
-          </Tooltip>
-          <Tooltip
-            content={
-              <InlineStack gap="200">
-                Strikethrough
-                <Text as="span" variant="bodyMd" tone="subdued">
-                  ⌘S
-                </Text>
-              </InlineStack>
-            }
-          >
-            <Button>S</Button>
-          </Tooltip>
-          <Tooltip
-            content={
-              <InlineStack gap="200">
-                Bold
-                <Text as="span" variant="bodyMd" tone="subdued">
-                  ⌘B
-                </Text>
-              </InlineStack>
-            }
-            preferredPosition="below"
-          >
-            <Button>B</Button>
-          </Tooltip>
-          <Tooltip
-            content={
-              <InlineStack gap="200">
-                Italic
-                <Text as="span" variant="bodyMd" tone="subdued">
-                  ⌘I
-                </Text>
-              </InlineStack>
-            }
-            preferredPosition="below"
-          >
-            <Button>I</Button>
-          </Tooltip>
-          <Tooltip
-            content={
-              <InlineStack gap="200">
-                Underline
-                <Text as="span" variant="bodyMd" tone="subdued">
-                  ⌘U
-                </Text>
-              </InlineStack>
-            }
-            preferredPosition="below"
-          >
-            <Button>U</Button>
-          </Tooltip>
-          <Tooltip
-            content={
-              <InlineStack gap="200">
-                Strikethrough
-                <Text as="span" variant="bodyMd" tone="subdued">
-                  ⌘S
-                </Text>
-              </InlineStack>
-            }
-            preferredPosition="below"
-          >
-            <Button>S</Button>
-          </Tooltip>
-        </ButtonGroup>
-      </InlineStack>
-    </Box>
-  );
-}
+        </InlineStack>
+      </Box>
+    );
+  },
+};
 
-export function Alignment() {
-  return (
-    <Box paddingBlockStart="2400">
-      <InlineStack>
-        <ButtonGroup variant="segmented" fullWidth>
-          <Tooltip content="Content is longer than the activator">
-            <Button>Bold</Button>
-          </Tooltip>
-          <Tooltip content="Italic">
-            <Button>Italic</Button>
-          </Tooltip>
-          <Tooltip content="Underline">
-            <Button>Activator is longer than the Tooltip</Button>
-          </Tooltip>
-          <Tooltip content="Content is longer than the activator">
-            <Button>Strikethrough</Button>
-          </Tooltip>
-          <Tooltip content="Content is longer than the activator">
-            <Button>Strikethrough</Button>
-          </Tooltip>
-          <Tooltip content="Content is longer than the activator">
-            <Button>Strikethrough</Button>
-          </Tooltip>
-        </ButtonGroup>
-      </InlineStack>
-    </Box>
-  );
-}
+export const VisibleOnlyWithChildInteraction = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <div style={{width: '200px'}}>
+          <ButtonGroup variant="segmented" fullWidth>
+            <Tooltip content="Bold" dismissOnMouseOut>
+              <Button>B</Button>
+            </Tooltip>
+            <Tooltip content="Italic" dismissOnMouseOut>
+              <Button>I</Button>
+            </Tooltip>
+            <Tooltip content="Underline" dismissOnMouseOut>
+              <Button>U</Button>
+            </Tooltip>
+            <Tooltip content="Strikethrough" dismissOnMouseOut>
+              <Button>S</Button>
+            </Tooltip>
+          </ButtonGroup>
+          <TextField
+            label="Product title"
+            autoComplete="off"
+            labelHidden
+            multiline
+          />
+        </div>
+      </Box>
+    );
+  },
+};
 
-export function HasUnderline() {
-  return (
-    <Card padding="400">
-      <Tooltip active content="This tooltip has an underline" hasUnderline>
-        <Text variant="bodyLg" fontWeight="bold" as="span">
-          Order #1001
-        </Text>
-      </Tooltip>
-    </Card>
-  );
-}
-
-export function PersistOnClick() {
-  return (
-    <Box paddingBlockStart="2400">
-      <Tooltip
-        content="This tooltip can be clicked to stay open"
-        persistOnClick
-      >
-        <Text variant="bodyLg" fontWeight="bold" as="span">
-          Order #1001
-        </Text>
-      </Tooltip>
-    </Box>
-  );
-}
-
-export function ActiveStates() {
-  const [popoverActive, setPopoverActive] = useState(false);
-  const [tooltipActive, setTooltipActive] =
-    useState<TooltipProps['active']>(true);
-
-  return (
-    <Box paddingBlockStart="2400">
-      <InlineStack gap="2400">
-        <Tooltip content="This tooltip should never render" active={false}>
-          <Text variant="bodyLg" fontWeight="bold" as="span">
-            Active false
+export const WithHoverDelay = {
+  render() {
+    return (
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text variant="headingMd" fontWeight="bold" as="h1">
+            TEXT EXAMPLE
           </Text>
-        </Tooltip>
-        <Tooltip content="This tooltip should render on load and hover" active>
-          <Text variant="bodyLg" fontWeight="bold" as="span">
-            Active true
-          </Text>
-        </Tooltip>
-        <Tooltip
-          content="This tooltip should render on hover"
-          active={undefined}
-        >
-          <Text variant="bodyLg" fontWeight="bold" as="span">
-            Active undefined
-          </Text>
-        </Tooltip>
-        <Tooltip
-          content="This tooltip should hide when popover is active"
-          active={tooltipActive}
-        >
-          <Text variant="bodyLg" fontWeight="bold" as="span">
-            <Popover
-              active={popoverActive}
-              activator={
-                <button
-                  onClick={() => {
-                    setPopoverActive(true);
-                    setTooltipActive(false);
-                  }}
-                >
-                  Popover Activator
-                </button>
-              }
-              autofocusTarget="first-node"
-              preferredPosition="below"
-              preferredAlignment="left"
-              onClose={() => {
-                setPopoverActive(false);
-                setTooltipActive(true);
-              }}
+          <InlineStack>
+            <Tooltip content="This should appear right away.">
+              <Text variant="bodyMd" fontWeight="semibold" as="span">
+                No delay
+              </Text>
+            </Tooltip>
+          </InlineStack>
+          <InlineStack>
+            <Tooltip
+              hoverDelay={1000}
+              content="This should appear after 1 second."
             >
-              <div style={{padding: '12px'}}>
-                <BlockStack>
-                  <Text variant="bodyMd" fontWeight="bold" as="span">
-                    popoverActive: {popoverActive.toString()}
-                  </Text>
-                  <Text variant="bodyMd" fontWeight="bold" as="span">
-                    tooltipActive: {tooltipActive?.toString()}
-                  </Text>
-                </BlockStack>
-              </div>
-            </Popover>
+              <Text variant="bodyMd" fontWeight="semibold" as="span">
+                1 second hover delay
+              </Text>
+            </Tooltip>
+          </InlineStack>
+        </BlockStack>
+
+        <BlockStack gap="200">
+          <Text variant="headingMd" fontWeight="bold" as="h1">
+            BUTTON EXAMPLE
+          </Text>
+          <InlineStack>
+            <Tooltip content="This should appear right away.">
+              <Button>No delay</Button>
+            </Tooltip>
+          </InlineStack>
+          <InlineStack>
+            <Tooltip
+              hoverDelay={2000}
+              content="This should appear after 2 seconds."
+            >
+              <Button>2 seconds hover delay</Button>
+            </Tooltip>
+          </InlineStack>
+        </BlockStack>
+      </BlockStack>
+    );
+  },
+};
+
+export const ActivatorAsDiv = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <Tooltip
+          active
+          content="This tooltip is rendered as a div"
+          activatorWrapper="div"
+        >
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Order #1001
           </Text>
         </Tooltip>
-      </InlineStack>
-    </Box>
-  );
-}
+      </Box>
+    );
+  },
+};
 
-export function OneCharacter() {
-  return (
-    <Box paddingBlockStart="2400">
-      <Tooltip active content="j">
-        <Text variant="bodyLg" fontWeight="bold" as="span">
-          Order #1001
-        </Text>
-      </Tooltip>
-    </Box>
-  );
-}
+export const WithSuffix = {
+  render() {
+    return (
+      <Box padding="1600" background="bg-surface">
+        <InlineStack>
+          <ButtonGroup variant="segmented" fullWidth>
+            <Tooltip
+              content={
+                <InlineStack gap="200">
+                  Bold
+                  <Text as="span" variant="bodyMd" tone="subdued">
+                    ⌘B
+                  </Text>
+                </InlineStack>
+              }
+            >
+              <Button>B</Button>
+            </Tooltip>
+            <Tooltip
+              content={
+                <InlineStack gap="200">
+                  Italic
+                  <Text as="span" variant="bodyMd" tone="subdued">
+                    ⌘I
+                  </Text>
+                </InlineStack>
+              }
+            >
+              <Button>I</Button>
+            </Tooltip>
+            <Tooltip
+              content={
+                <InlineStack gap="200">
+                  Underline
+                  <Text as="span" variant="bodyMd" tone="subdued">
+                    ⌘U
+                  </Text>
+                </InlineStack>
+              }
+            >
+              <Button>U</Button>
+            </Tooltip>
+            <Tooltip
+              content={
+                <InlineStack gap="200">
+                  Strikethrough
+                  <Text as="span" variant="bodyMd" tone="subdued">
+                    ⌘S
+                  </Text>
+                </InlineStack>
+              }
+            >
+              <Button>S</Button>
+            </Tooltip>
+            <Tooltip
+              content={
+                <InlineStack gap="200">
+                  Bold
+                  <Text as="span" variant="bodyMd" tone="subdued">
+                    ⌘B
+                  </Text>
+                </InlineStack>
+              }
+              preferredPosition="below"
+            >
+              <Button>B</Button>
+            </Tooltip>
+            <Tooltip
+              content={
+                <InlineStack gap="200">
+                  Italic
+                  <Text as="span" variant="bodyMd" tone="subdued">
+                    ⌘I
+                  </Text>
+                </InlineStack>
+              }
+              preferredPosition="below"
+            >
+              <Button>I</Button>
+            </Tooltip>
+            <Tooltip
+              content={
+                <InlineStack gap="200">
+                  Underline
+                  <Text as="span" variant="bodyMd" tone="subdued">
+                    ⌘U
+                  </Text>
+                </InlineStack>
+              }
+              preferredPosition="below"
+            >
+              <Button>U</Button>
+            </Tooltip>
+            <Tooltip
+              content={
+                <InlineStack gap="200">
+                  Strikethrough
+                  <Text as="span" variant="bodyMd" tone="subdued">
+                    ⌘S
+                  </Text>
+                </InlineStack>
+              }
+              preferredPosition="below"
+            >
+              <Button>S</Button>
+            </Tooltip>
+          </ButtonGroup>
+        </InlineStack>
+      </Box>
+    );
+  },
+};
+
+export const Alignment = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <InlineStack>
+          <ButtonGroup variant="segmented" fullWidth>
+            <Tooltip content="Content is longer than the activator">
+              <Button>Bold</Button>
+            </Tooltip>
+            <Tooltip content="Italic">
+              <Button>Italic</Button>
+            </Tooltip>
+            <Tooltip content="Underline">
+              <Button>Activator is longer than the Tooltip</Button>
+            </Tooltip>
+            <Tooltip content="Content is longer than the activator">
+              <Button>Strikethrough</Button>
+            </Tooltip>
+            <Tooltip content="Content is longer than the activator">
+              <Button>Strikethrough</Button>
+            </Tooltip>
+            <Tooltip content="Content is longer than the activator">
+              <Button>Strikethrough</Button>
+            </Tooltip>
+          </ButtonGroup>
+        </InlineStack>
+      </Box>
+    );
+  },
+};
+
+export const HasUnderline = {
+  render() {
+    return (
+      <Card padding="400">
+        <Tooltip active content="This tooltip has an underline" hasUnderline>
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Order #1001
+          </Text>
+        </Tooltip>
+      </Card>
+    );
+  },
+};
+
+export const PersistOnClick = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <Tooltip
+          content="This tooltip can be clicked to stay open"
+          persistOnClick
+        >
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Order #1001
+          </Text>
+        </Tooltip>
+      </Box>
+    );
+  },
+};
+
+export const ActiveStates = {
+  render() {
+    const [popoverActive, setPopoverActive] = useState(false);
+    const [tooltipActive, setTooltipActive] =
+      useState<TooltipProps['active']>(true);
+
+    return (
+      <Box paddingBlockStart="2400">
+        <InlineStack gap="2400">
+          <Tooltip content="This tooltip should never render" active={false}>
+            <Text variant="bodyLg" fontWeight="bold" as="span">
+              Active false
+            </Text>
+          </Tooltip>
+          <Tooltip
+            content="This tooltip should render on load and hover"
+            active
+          >
+            <Text variant="bodyLg" fontWeight="bold" as="span">
+              Active true
+            </Text>
+          </Tooltip>
+          <Tooltip
+            content="This tooltip should render on hover"
+            active={undefined}
+          >
+            <Text variant="bodyLg" fontWeight="bold" as="span">
+              Active undefined
+            </Text>
+          </Tooltip>
+          <Tooltip
+            content="This tooltip should hide when popover is active"
+            active={tooltipActive}
+          >
+            <Text variant="bodyLg" fontWeight="bold" as="span">
+              <Popover
+                active={popoverActive}
+                activator={
+                  <button
+                    onClick={() => {
+                      setPopoverActive(true);
+                      setTooltipActive(false);
+                    }}
+                  >
+                    Popover Activator
+                  </button>
+                }
+                autofocusTarget="first-node"
+                preferredPosition="below"
+                preferredAlignment="left"
+                onClose={() => {
+                  setPopoverActive(false);
+                  setTooltipActive(true);
+                }}
+              >
+                <div style={{padding: '12px'}}>
+                  <BlockStack>
+                    <Text variant="bodyMd" fontWeight="bold" as="span">
+                      popoverActive: {popoverActive.toString()}
+                    </Text>
+                    <Text variant="bodyMd" fontWeight="bold" as="span">
+                      tooltipActive: {tooltipActive?.toString()}
+                    </Text>
+                  </BlockStack>
+                </div>
+              </Popover>
+            </Text>
+          </Tooltip>
+        </InlineStack>
+      </Box>
+    );
+  },
+};
+
+export const OneCharacter = {
+  render() {
+    return (
+      <Box paddingBlockStart="2400">
+        <Tooltip active content="j">
+          <Text variant="bodyLg" fontWeight="bold" as="span">
+            Order #1001
+          </Text>
+        </Tooltip>
+      </Box>
+    );
+  },
+};

--- a/polaris-react/src/components/TopBar/TopBar.stories.tsx
+++ b/polaris-react/src/components/TopBar/TopBar.stories.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {ActionList, Frame, Icon, TopBar, Text, Avatar} from '@shopify/polaris';
 import {ArrowLeftIcon, QuestionCircleIcon} from '@shopify/polaris-icons';
 
@@ -7,7 +7,7 @@ import type {UserMenuProps} from '../../../build/ts/latest/src/components/TopBar
 
 export default {
   component: TopBar,
-} as ComponentMeta<typeof TopBar>;
+} as Meta<typeof TopBar>;
 
 function TopBarWrapper({
   userActions,
@@ -142,80 +142,86 @@ function TopBarWrapper({
   );
 }
 
-export function Default() {
-  const userActions: UserMenuProps['actions'] = [
-    {
-      items: [{content: 'Back to Shopify', icon: ArrowLeftIcon}],
-    },
-    {
-      items: [{content: 'Community forums'}],
-    },
-  ];
-  return (
-    <TopBarWrapper
-      userActions={userActions}
-      name="Xquenda Andreev"
-      initials="XA"
-    />
-  );
-}
+export const Default = {
+  render() {
+    const userActions: UserMenuProps['actions'] = [
+      {
+        items: [{content: 'Back to Shopify', icon: ArrowLeftIcon}],
+      },
+      {
+        items: [{content: 'Community forums'}],
+      },
+    ];
+    return (
+      <TopBarWrapper
+        userActions={userActions}
+        name="Xquenda Andreev"
+        initials="XA"
+      />
+    );
+  },
+};
 
-export function WithCustomActivator() {
-  const userActions: UserMenuProps['actions'] = [
-    {
-      items: [{content: 'Back to Shopify', icon: ArrowLeftIcon}],
-    },
-    {
-      items: [{content: 'Community forums'}],
-    },
-  ];
+export const WithCustomActivator = {
+  render() {
+    const userActions: UserMenuProps['actions'] = [
+      {
+        items: [{content: 'Back to Shopify', icon: ArrowLeftIcon}],
+      },
+      {
+        items: [{content: 'Community forums'}],
+      },
+    ];
 
-  const customActivator = (
-    <>
-      <Avatar size="sm" initials="XA" name="Xquenda Andreev" />
-      <span style={{marginLeft: '0.5rem'}}>
-        <Text as="p" alignment="start" fontWeight="medium" truncate>
-          Xquenda Andreev
-        </Text>
-        <Text as="p" variant="bodySm" alignment="start" truncate>
-          Hem Canada
-        </Text>
-      </span>
-    </>
-  );
+    const customActivator = (
+      <>
+        <Avatar size="sm" initials="XA" name="Xquenda Andreev" />
+        <span style={{marginLeft: '0.5rem'}}>
+          <Text as="p" alignment="start" fontWeight="medium" truncate>
+            Xquenda Andreev
+          </Text>
+          <Text as="p" variant="bodySm" alignment="start" truncate>
+            Hem Canada
+          </Text>
+        </span>
+      </>
+    );
 
-  return (
-    <TopBarWrapper
-      userActions={userActions}
-      name="Xquenda Andreev"
-      detail="Hem Canada"
-      customActivator={customActivator}
-    />
-  );
-}
+    return (
+      <TopBarWrapper
+        userActions={userActions}
+        name="Xquenda Andreev"
+        detail="Hem Canada"
+        customActivator={customActivator}
+      />
+    );
+  },
+};
 
-export function WithMessage() {
-  const userActions: UserMenuProps['actions'] = [
-    {
-      items: [{content: 'Back to Shopify', icon: ArrowLeftIcon}],
-    },
-    {
-      items: [{content: 'Community forums'}],
-    },
-  ];
+export const WithMessage = {
+  render() {
+    const userActions: UserMenuProps['actions'] = [
+      {
+        items: [{content: 'Back to Shopify', icon: ArrowLeftIcon}],
+      },
+      {
+        items: [{content: 'Community forums'}],
+      },
+    ];
 
-  return (
-    <TopBarWrapper
-      userActions={userActions}
-      name="Xquenda Andreev"
-      detail="Hem Canada"
-      initials="XA"
-      message={{
-        title: 'Message title',
-        description: 'Message description',
-        link: {to: 'https://www.shopify.com', content: 'Link content'},
-        action: {content: 'Action content', onClick: () => {}},
-      }}
-    />
-  );
-}
+    return (
+      <TopBarWrapper
+        userActions={userActions}
+        name="Xquenda Andreev"
+        detail="Hem Canada"
+        initials="XA"
+        message={{
+          title: 'Message title',
+          description: 'Message description',
+          link: {to: 'https://www.shopify.com', content: 'Link content'},
+          action: {content: 'Action content', onClick: () => {}},
+        }}
+      />
+    );
+  },
+};

--- a/polaris-react/src/components/VideoThumbnail/VideoThumbnail.stories.tsx
+++ b/polaris-react/src/components/VideoThumbnail/VideoThumbnail.stories.tsx
@@ -1,90 +1,100 @@
 import React from 'react';
-import type {ComponentMeta} from '@storybook/react';
+import type {Meta} from '@storybook/react';
 import {MediaCard, Text, BlockStack, VideoThumbnail} from '@shopify/polaris';
 
 export default {
   component: VideoThumbnail,
-} as ComponentMeta<typeof VideoThumbnail>;
+} as Meta<typeof VideoThumbnail>;
 
-export function All() {
-  return (
-    <BlockStack gap="800">
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          Default
-        </Text>
-        <Default />
+export const All = {
+  render() {
+    return (
+      /* eslint-disable react/jsx-pascal-case */
+      <BlockStack gap="800">
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            Default
+          </Text>
+          <Default.render />
+        </BlockStack>
+
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            With progress
+          </Text>
+          <WithProgress.render />
+        </BlockStack>
+
+        <BlockStack gap="400">
+          <Text as="h2" variant="headingXl">
+            Outside media card
+          </Text>
+          <OutsideMediaCard.render />
+        </BlockStack>
       </BlockStack>
+      /* eslint-enable react/jsx-pascal-case */
+    );
+  },
+};
 
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          With progress
-        </Text>
-        <WithProgress />
-      </BlockStack>
+export const Default = {
+  render() {
+    return (
+      <MediaCard
+        title="Turn your side-project into a business"
+        primaryAction={{
+          content: 'Learn more',
+          onAction: () => {},
+        }}
+        description="In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+      >
+        <VideoThumbnail
+          videoLength={80}
+          thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+          onClick={() => {}}
+        />
+      </MediaCard>
+    );
+  },
+};
 
-      <BlockStack gap="400">
-        <Text as="h2" variant="headingXl">
-          Outside media card
-        </Text>
-        <OutsideMediaCard />
-      </BlockStack>
-    </BlockStack>
-  );
-}
+export const WithProgress = {
+  render() {
+    return (
+      <MediaCard
+        title="Turn your side-project into a business"
+        primaryAction={{
+          content: 'Learn more',
+          onAction: () => {},
+        }}
+        description="In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business."
+        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+      >
+        <VideoThumbnail
+          videoLength={80}
+          videoProgress={45}
+          showVideoProgress
+          thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+          onClick={() => {}}
+        />
+      </MediaCard>
+    );
+  },
+};
 
-export function Default() {
-  return (
-    <MediaCard
-      title="Turn your side-project into a business"
-      primaryAction={{
-        content: 'Learn more',
-        onAction: () => {},
-      }}
-      description="In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-    >
-      <VideoThumbnail
-        videoLength={80}
-        thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-        onClick={() => {}}
-      />
-    </MediaCard>
-  );
-}
-
-export function WithProgress() {
-  return (
-    <MediaCard
-      title="Turn your side-project into a business"
-      primaryAction={{
-        content: 'Learn more',
-        onAction: () => {},
-      }}
-      description="In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business."
-      popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
-    >
-      <VideoThumbnail
-        videoLength={80}
-        videoProgress={45}
-        showVideoProgress
-        thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-        onClick={() => {}}
-      />
-    </MediaCard>
-  );
-}
-
-export function OutsideMediaCard() {
-  return (
-    <div style={{height: '254px', width: '450px'}}>
-      <VideoThumbnail
-        videoLength={80}
-        videoProgress={45}
-        showVideoProgress
-        thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
-        onClick={() => {}}
-      />
-    </div>
-  );
-}
+export const OutsideMediaCard = {
+  render() {
+    return (
+      <div style={{height: '254px', width: '450px'}}>
+        <VideoThumbnail
+          videoLength={80}
+          videoProgress={45}
+          showVideoProgress
+          thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
+          onClick={() => {}}
+        />
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
> [!TIP]
> View this PR [_without_ whitespace changes](https://github.com/Shopify/polaris/pull/11930/files?w=1)

CSF v3 is [Storybook's new format](https://storybook.js.org/blog/storybook-csf3-is-here/) for stories supported in Storybook v7+.

A couple highlights of the new format:
- Clearer story configuration (each story is now an object instead of a function with some attached properties)
- Support for the [new `play` function](https://storybook.js.org/blog/component-story-format-3-0/#play-functions) to automate interactions

The changes in this PR were achieved in 3 steps (each added as a seperate commit for easier reviewing):

1. `Add csf-v3 internal migration`
    - A jscodeshift migration using our migration tool to move from the CSF 2 Function export format to CSF 3 Object export syntax (the official storybook migrator doesn't handle this)
2. `Add storybook lint rules`
    - Particularly to disable the _"Rules of hooks"_ error now that the components are defined in non-pascal function `render()`: https://github.com/storybookjs/storybook/issues/21115
3. `Migrate to CSF v3`
    - Run storybook's csf v3 migration:
        - ```sh
          pnpm dlx storybook@latest migrate csf-2-to-3 --glob="polaris-react/**/*.stories.tsx" --parser=tsx
          ```
    - Run the internal csf v3 migration:
        - ```sh
          pnpm --filter=@shopify/polaris-migrator build && pnpm --filter=@shopify/polaris-migrator start --force csf-v3 "../polaris-react/**/*.stories.tsx"
          ```
    - Format all changed files:
        - ```sh
          git diff --name-only --diff-filter=ACMR | sed 's| |\\ |g' | xargs pnpm exec prettier --write --ignore-unknown
          ```