### PR TITLE
[DO-NOT-MERGE/internal-only] AppCard components (Apps in Admin team)

### DIFF
--- a/.changeset/tame-waves-double.md
+++ b/.changeset/tame-waves-double.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Adds AppCard components

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -15,6 +15,26 @@
         "placeholder": "Search actions"
       }
     },
+    "AppCard": {
+      "accessibilityLabel": "{appTitle} app card"
+    },
+    "AppCardAction": {
+      "Actions": {
+        "install": "Install",
+        "installAlt": "Install app",
+        "open": "Open",
+        "openAlt": "Open app"
+      }
+    },
+    "AppCardBadge": {
+      "builtForShopify": "Built for Shopify"
+    },
+    "AppIcon": {
+      "accessibilityLabel": "View app details for the app",
+      "accessibilityLabelWithAppTitle": "View app details for app: {app}",
+      "alt": "App icon",
+      "altWithAppTitle": "{app} icon"
+    },
     "Avatar": {
       "label": "Avatar",
       "labelWithInitials": "Avatar with initials {initials}"
@@ -288,6 +308,9 @@
     },
     "SkeletonPage": {
       "loadingLabel": "Page loading"
+    },
+    "SkeletonAppCard": {
+      "loadingLabel": "App card loading"
     },
     "Tabs": {
       "newViewAccessibilityLabel": "Create new view",

--- a/polaris-react/src/components/AppCard/AppCard.module.css
+++ b/polaris-react/src/components/AppCard/AppCard.module.css
@@ -1,0 +1,8 @@
+.MetadataContainer {
+  flex: 1;
+  min-width: 0;
+}
+
+.ActionContainer {
+  display: flex;
+}

--- a/polaris-react/src/components/AppCard/AppCard.stories.tsx
+++ b/polaris-react/src/components/AppCard/AppCard.stories.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import type {ComponentMeta} from '@storybook/react';
+
+import {BlockStack} from '../BlockStack';
+import {Text} from '../Text';
+import {AppCardActionEnum} from '../AppCardAction';
+
+import {AppCard} from './AppCard';
+import type {AppCardProps} from './AppCard';
+import {AppCardSizingMode} from './types';
+
+const iconUrl =
+  'https://cdn.shopify.com/app-store/listing_images/532861601aa89a5e70f5d56d075e82ac/icon/CLq7q92-4_0CEAE=.png';
+
+const appCardProps: AppCardProps = {
+  action: {type: AppCardActionEnum.Install},
+  iconUrl,
+  title: 'Shop',
+  starRating: 4.8,
+  description:
+    'The Shop channel is your control center for managing and optimizing your brand presence on Shop.',
+  signifiers: ['built_for_shopify'],
+  pricingInfo: 'Free plan available',
+  onIconClick: () => {},
+  onTitleClick: () => {},
+};
+
+export default {
+  component: AppCard,
+} as ComponentMeta<typeof AppCard>;
+
+export function Default() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCard {...appCardProps} iconUrl={undefined} />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function OpenAction() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCard {...appCardProps} action={{type: AppCardActionEnum.Open}} />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function DisabledAction() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCard
+          {...appCardProps}
+          action={{type: AppCardActionEnum.Install, disabled: true}}
+        />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function LoadingAction() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCard
+          {...appCardProps}
+          action={{type: AppCardActionEnum.Install, loading: true}}
+        />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function Card_Sizes() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Small Card
+        </Text>
+        <AppCard {...appCardProps} size="sm" />
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Medium Card
+        </Text>
+        <AppCard {...appCardProps} size="md" />
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Large Card
+        </Text>
+        <AppCard {...appCardProps} size="lg" />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function Card_Variants() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Primary
+        </Text>
+        <AppCard {...appCardProps} variant="primary" />
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Secondary
+        </Text>
+        <AppCard {...appCardProps} variant="secondary" />
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          No Background
+        </Text>
+        <AppCard {...appCardProps} variant="noBackground" />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function OptionalMetadata() {
+  return (
+    <div style={{maxWidth: 500}}>
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            No Description
+          </Text>
+          <AppCard {...appCardProps} description={undefined} />
+        </BlockStack>
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            No Star Rating
+          </Text>
+          <AppCard {...appCardProps} starRating={undefined} />
+        </BlockStack>
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            No Pricing Info
+          </Text>
+          <AppCard {...appCardProps} pricingInfo={undefined} signifiers={[]} />
+        </BlockStack>
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Description Only
+          </Text>
+          <AppCard
+            {...appCardProps}
+            pricingInfo={undefined}
+            starRating={undefined}
+            signifiers={[]}
+          />
+        </BlockStack>
+        <BlockStack gap="200">
+          <Text as="h2" variant="headingSm">
+            Title Only
+          </Text>
+          <AppCard
+            {...appCardProps}
+            title="Shopify Shop App (Title Only)"
+            pricingInfo={undefined}
+            description={undefined}
+            starRating={undefined}
+            signifiers={[]}
+          />
+        </BlockStack>
+      </BlockStack>
+    </div>
+  );
+}
+
+export function Narrow() {
+  return (
+    <AppCard
+      {...appCardProps}
+      title="Shop App - Convert More Sales with Shop Pay's accelerated checkout"
+      sizingMode={AppCardSizingMode.AlwaysNarrow}
+    />
+  );
+}
+
+export function AdaptiveSizing() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Narrow: Parent Container {'<='} Small Breakpoint
+        </Text>
+        <div style={{maxWidth: '400px'}}>
+          <AppCard {...appCardProps} />
+        </div>
+
+        <Text as="h2" variant="headingSm">
+          Standard: Parent Container {'>'} Small Breakpoint
+        </Text>
+        <div style={{maxWidth: '500px'}}>
+          <AppCard {...appCardProps} />
+        </div>
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/polaris-react/src/components/AppCard/AppCard.tsx
+++ b/polaris-react/src/components/AppCard/AppCard.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import {AppIcon} from '../AppIcon';
+import {AppCardMetadata} from '../AppCardMetadata';
+import {BlockStack} from '../BlockStack';
+import {InlineStack} from '../InlineStack';
+import {AppCardAction} from '../AppCardAction';
+import type {AppCardActionType} from '../AppCardAction';
+import {useI18n} from '../../utilities/i18n';
+
+import type {AppCardVariant, AppCardSize} from './types';
+import {AppCardSizingMode} from './types';
+import styles from './AppCard.module.css';
+import {AppCardWrapper} from './components';
+import {useAppCardSizing} from './hooks';
+
+export interface AppCardProps {
+  as?: 'div' | 'li';
+  title: string;
+  iconUrl?: string;
+  action: AppCardActionType;
+  description?: string;
+  signifiers?: string[];
+  pricingInfo?: string;
+  starRating?: number;
+  variant?: AppCardVariant;
+  sizingMode?: AppCardSizingMode;
+  size?: AppCardSize;
+  onTitleClick?: () => void;
+  onIconClick?: () => void;
+}
+
+export function AppCard({
+  title,
+  description,
+  iconUrl,
+  signifiers = [],
+  action,
+  pricingInfo,
+  starRating,
+  variant = 'primary',
+  sizingMode = AppCardSizingMode.Adaptive,
+  size = 'md',
+  as = 'div',
+  onTitleClick,
+  onIconClick,
+}: AppCardProps) {
+  const {isNarrow, onNarrowChange} = useAppCardSizing(sizingMode);
+  const i18n = useI18n();
+
+  return (
+    <AppCardWrapper
+      as={as}
+      variant={variant}
+      onNarrowChange={onNarrowChange}
+      accessibilityLabel={
+        title
+          ? i18n.translate('Polaris.AppCard.accessibilityLabel', {
+              appTitle: title,
+            })
+          : undefined
+      }
+    >
+      <InlineStack gap="300">
+        <BlockStack align="start">
+          <AppIcon
+            onClick={onIconClick}
+            size={size}
+            appTitle={title}
+            source={iconUrl}
+          />
+        </BlockStack>
+        <div className={styles.MetadataContainer}>
+          <AppCardMetadata
+            onTitleClick={onTitleClick}
+            signifiers={signifiers}
+            truncate={isNarrow}
+            appTitle={title}
+            appDescription={isNarrow ? undefined : description}
+            pricingInfo={pricingInfo}
+            starRating={starRating}
+          />
+        </div>
+        <BlockStack align="center">
+          <AppCardAction
+            action={action}
+            variant={isNarrow ? 'narrow' : 'default'}
+          />
+        </BlockStack>
+      </InlineStack>
+    </AppCardWrapper>
+  );
+}

--- a/polaris-react/src/components/AppCard/components/AppCardMeasurer/AppCardMeasurer.tsx
+++ b/polaris-react/src/components/AppCard/components/AppCardMeasurer/AppCardMeasurer.tsx
@@ -1,0 +1,39 @@
+import React, {useCallback, useRef, useEffect} from 'react';
+
+import {useEventListener} from '../../../../utilities/use-event-listener';
+
+export interface AppCardMeasurements {
+  containerWidth: number;
+}
+
+export interface AppCardMeasurerProps {
+  children: React.ReactElement;
+  handleMeasurement(measurements: AppCardMeasurements): void;
+}
+
+export function AppCardMeasurer({
+  children,
+  handleMeasurement: handleMeasurementProp,
+}: AppCardMeasurerProps) {
+  const containerNode = useRef<HTMLDivElement>(null);
+
+  const handleMeasurement = useCallback(() => {
+    if (!containerNode.current) {
+      return;
+    }
+
+    const containerWidth = containerNode.current.offsetWidth;
+
+    handleMeasurementProp({
+      containerWidth,
+    });
+  }, [handleMeasurementProp]);
+
+  useEffect(() => {
+    handleMeasurement();
+  }, [handleMeasurement]);
+
+  useEventListener('resize', handleMeasurement);
+
+  return <div ref={containerNode}>{children}</div>;
+}

--- a/polaris-react/src/components/AppCard/components/AppCardMeasurer/index.ts
+++ b/polaris-react/src/components/AppCard/components/AppCardMeasurer/index.ts
@@ -1,0 +1,1 @@
+export * from './AppCardMeasurer';

--- a/polaris-react/src/components/AppCard/components/AppCardMeasurer/tests/AppCardMeasurer.test.tsx
+++ b/polaris-react/src/components/AppCard/components/AppCardMeasurer/tests/AppCardMeasurer.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {AppCardMeasurer} from '../AppCardMeasurer';
+
+let triggerEventListener: jest.Mock;
+jest.mock('../../../../../utilities/use-event-listener', () => {
+  return {
+    useEventListener: (_: string, cb: () => void) => {
+      triggerEventListener = jest.fn().mockImplementation(() => {
+        cb();
+      });
+    },
+  };
+});
+
+describe('<AppCardMeasurer />', () => {
+  const originalOffsetWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetWidth',
+  );
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 200,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'offsetWidth',
+      originalOffsetWidth ?? 0,
+    );
+
+    triggerEventListener.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it('renders children and triggers handleMeasurement', () => {
+    const onHandleMeasurement = jest.fn();
+    const measurer = mountWithApp(
+      <AppCardMeasurer handleMeasurement={onHandleMeasurement}>
+        <div>Test</div>
+      </AppCardMeasurer>,
+    );
+
+    expect(measurer).toContainReactComponent('div', {children: 'Test'});
+    expect(onHandleMeasurement).toHaveBeenCalledTimes(1);
+    expect(onHandleMeasurement).toHaveBeenCalledWith({containerWidth: 200});
+
+    onHandleMeasurement.mockRestore();
+  });
+
+  it('triggers handleMeasurement on resize event', () => {
+    const onHandleMeasurement = jest.fn();
+    mountWithApp(
+      <AppCardMeasurer handleMeasurement={onHandleMeasurement}>
+        <></>
+      </AppCardMeasurer>,
+    );
+
+    onHandleMeasurement.mockReset();
+
+    expect(onHandleMeasurement).not.toHaveBeenCalled();
+
+    triggerEventListener();
+
+    expect(onHandleMeasurement).toHaveBeenCalledTimes(1);
+
+    triggerEventListener();
+
+    expect(onHandleMeasurement).toHaveBeenCalledTimes(2);
+
+    onHandleMeasurement.mockRestore();
+  });
+});

--- a/polaris-react/src/components/AppCard/components/AppCardWrapper/AppCardWrapper.tsx
+++ b/polaris-react/src/components/AppCard/components/AppCardWrapper/AppCardWrapper.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {themeDefault, toPx} from '@shopify/polaris-tokens';
+
+import type {AppCardVariant} from '../../types';
+import type {AppCardMeasurements} from '../AppCardMeasurer';
+import {AppCardMeasurer} from '../AppCardMeasurer';
+import {debounce} from '../../../../utilities/debounce';
+import type {AppCardProps} from '../../AppCard';
+import type {BoxProps} from '../../../Box';
+import {Box} from '../../../Box';
+
+const DEBOUNCE_TIME_MS = 200;
+
+const DEFAULT_BOX_STYLE: BoxProps = {
+  background: 'bg-surface',
+  paddingBlockStart: '300',
+  paddingBlockEnd: '300',
+  paddingInlineStart: '400',
+  paddingInlineEnd: '400',
+  borderWidth: '025',
+  borderColor: 'border-brand',
+  borderRadius: '300',
+};
+
+const VARIANT_TO_BOX_PROPS_MAP: {[key in AppCardVariant]: BoxProps} = {
+  primary: {
+    ...DEFAULT_BOX_STYLE,
+  },
+  secondary: {
+    ...DEFAULT_BOX_STYLE,
+    background: 'bg-surface-secondary',
+  },
+  noBackground: {
+    ...DEFAULT_BOX_STYLE,
+    background: undefined,
+    paddingBlockStart: '0',
+    paddingBlockEnd: '0',
+    paddingInlineStart: '0',
+    paddingInlineEnd: '0',
+    borderWidth: '0',
+    borderColor: 'transparent',
+  },
+};
+
+export type AppCardWrapperProps = Pick<AppCardProps, 'variant' | 'as'> & {
+  children: React.ReactNode;
+  onNarrowChange?: (isNarrow: boolean) => void;
+  accessibilityLabel?: string;
+};
+
+export function AppCardWrapper({
+  variant = 'primary',
+  as = 'div',
+  children,
+  accessibilityLabel,
+  onNarrowChange = () => {},
+}: AppCardWrapperProps) {
+  const handleMeasurement = debounce(
+    ({containerWidth}: AppCardMeasurements) => {
+      const breakpointWidthInPx = toPx(
+        themeDefault.breakpoints['breakpoints-sm'],
+      );
+      const breakpointWidth = breakpointWidthInPx
+        ? parseFloat(breakpointWidthInPx)
+        : 0;
+
+      onNarrowChange(containerWidth <= breakpointWidth);
+    },
+    DEBOUNCE_TIME_MS,
+  );
+
+  return (
+    <AppCardMeasurer handleMeasurement={handleMeasurement}>
+      <Box
+        {...VARIANT_TO_BOX_PROPS_MAP[variant]}
+        aria-label={accessibilityLabel}
+        as={as}
+        role={as === 'div' ? 'group' : undefined}
+      >
+        {children}
+      </Box>
+    </AppCardMeasurer>
+  );
+}

--- a/polaris-react/src/components/AppCard/components/AppCardWrapper/index.ts
+++ b/polaris-react/src/components/AppCard/components/AppCardWrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './AppCardWrapper';

--- a/polaris-react/src/components/AppCard/components/AppCardWrapper/tests/AppCardWrapper.test.tsx
+++ b/polaris-react/src/components/AppCard/components/AppCardWrapper/tests/AppCardWrapper.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+import {timer} from '@shopify/jest-dom-mocks';
+
+import {AppCardWrapper} from '../AppCardWrapper';
+import {Box} from '../../../../Box';
+import {AppCardMeasurer} from '../../AppCardMeasurer';
+
+describe('<AppCardWrapper />', () => {
+  beforeEach(() => {
+    timer.mock();
+  });
+
+  afterEach(() => {
+    timer.restore();
+  });
+
+  it('renders default with children', () => {
+    const wrapper = mountWithApp(
+      <AppCardWrapper>
+        <div>Test</div>
+      </AppCardWrapper>,
+    );
+
+    expect(wrapper).toContainReactComponent('div', {children: 'Test'});
+    expect(wrapper).toContainReactComponent(Box, {
+      'aria-label': undefined,
+      as: 'div',
+      role: 'group',
+      background: 'bg-surface',
+      paddingBlockStart: '300',
+      paddingBlockEnd: '300',
+      paddingInlineStart: '400',
+      paddingInlineEnd: '400',
+      borderWidth: '025',
+      borderColor: 'border-brand',
+      borderRadius: '300',
+    });
+
+    expect(wrapper).toContainReactComponent(AppCardMeasurer, {
+      handleMeasurement: expect.any(Function),
+    });
+  });
+
+  it('renders secondary variant styled Box component', () => {
+    const wrapper = mountWithApp(
+      <AppCardWrapper variant="secondary">
+        <div>Test</div>
+      </AppCardWrapper>,
+    );
+
+    expect(wrapper).toContainReactComponent(Box, {
+      'aria-label': undefined,
+      as: 'div',
+      role: 'group',
+      background: 'bg-surface-secondary',
+      paddingBlockStart: '300',
+      paddingBlockEnd: '300',
+      paddingInlineStart: '400',
+      paddingInlineEnd: '400',
+      borderWidth: '025',
+      borderColor: 'border-brand',
+      borderRadius: '300',
+    });
+  });
+
+  it('renders noBackground variant styled Box component', () => {
+    const wrapper = mountWithApp(
+      <AppCardWrapper variant="noBackground">
+        <div>Test</div>
+      </AppCardWrapper>,
+    );
+
+    expect(wrapper).toContainReactComponent(Box, {
+      'aria-label': undefined,
+      as: 'div',
+      role: 'group',
+      background: undefined,
+      paddingBlockStart: '0',
+      paddingBlockEnd: '0',
+      paddingInlineStart: '0',
+      paddingInlineEnd: '0',
+      borderWidth: '0',
+      borderColor: 'transparent',
+      borderRadius: '300',
+    });
+  });
+
+  it('renders as listitem', () => {
+    const wrapper = mountWithApp(
+      <AppCardWrapper as="li">
+        <div>Test</div>
+      </AppCardWrapper>,
+    );
+
+    expect(wrapper).toContainReactComponent(Box, {
+      as: 'li',
+      role: undefined,
+    });
+  });
+
+  it('renders with accessibilityLabel', () => {
+    const wrapper = mountWithApp(
+      <AppCardWrapper accessibilityLabel="test">
+        <div>Test</div>
+      </AppCardWrapper>,
+    );
+
+    expect(wrapper).toContainReactComponent(Box, {
+      as: 'div',
+      role: 'group',
+      'aria-label': 'test',
+    });
+  });
+
+  it('triggers onNarrowChange with narrow value of false when containerWidth > 490px', () => {
+    const spy = jest.fn();
+    const wrapper = mountWithApp(
+      <AppCardWrapper onNarrowChange={spy}>
+        <div>Test</div>
+      </AppCardWrapper>,
+    );
+
+    wrapper
+      .find(AppCardMeasurer)
+      ?.trigger('handleMeasurement', {containerWidth: 491});
+
+    timer.runAllTimers();
+
+    expect(spy).toHaveBeenCalledWith(false);
+  });
+
+  it('triggers onNarrowChange with narrow value of true when containerWidth == 490px', () => {
+    const spy = jest.fn();
+    const wrapper = mountWithApp(
+      <AppCardWrapper onNarrowChange={spy}>
+        <div>Test</div>
+      </AppCardWrapper>,
+    );
+
+    wrapper
+      .find(AppCardMeasurer)
+      ?.trigger('handleMeasurement', {containerWidth: 490});
+
+    timer.runAllTimers();
+
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('triggers onNarrowChange with narrow value of true when containerWidth < 490px', () => {
+    const spy = jest.fn();
+    const wrapper = mountWithApp(
+      <AppCardWrapper onNarrowChange={spy}>
+        <div>Test</div>
+      </AppCardWrapper>,
+    );
+
+    wrapper
+      .find(AppCardMeasurer)
+      ?.trigger('handleMeasurement', {containerWidth: 300});
+
+    timer.runAllTimers();
+
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+});

--- a/polaris-react/src/components/AppCard/components/index.ts
+++ b/polaris-react/src/components/AppCard/components/index.ts
@@ -1,0 +1,2 @@
+export * from './AppCardMeasurer';
+export * from './AppCardWrapper';

--- a/polaris-react/src/components/AppCard/hooks/index.ts
+++ b/polaris-react/src/components/AppCard/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useAppCardSizing';

--- a/polaris-react/src/components/AppCard/hooks/useAppCardSizing.ts
+++ b/polaris-react/src/components/AppCard/hooks/useAppCardSizing.ts
@@ -1,0 +1,11 @@
+import {useState} from 'react';
+
+import {AppCardSizingMode} from '../types';
+
+export function useAppCardSizing(sizingMode: AppCardSizingMode) {
+  const [forceNarrow, setForceNarrow] = useState(false);
+  const onNarrowChange = (isNarrow: boolean) => setForceNarrow(isNarrow);
+  const isNarrow = sizingMode === AppCardSizingMode.AlwaysNarrow || forceNarrow;
+
+  return {onNarrowChange, isNarrow};
+}

--- a/polaris-react/src/components/AppCard/index.ts
+++ b/polaris-react/src/components/AppCard/index.ts
@@ -1,0 +1,5 @@
+export * from './AppCard';
+export * from './types';
+export {AppCardWrapper} from './components';
+export type {AppCardWrapperProps} from './components';
+export * from './hooks';

--- a/polaris-react/src/components/AppCard/tests/AppCard.test.tsx
+++ b/polaris-react/src/components/AppCard/tests/AppCard.test.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import type {AppCardProps} from '../AppCard';
+import {AppCard} from '../AppCard';
+import {AppCardWrapper} from '../components';
+import {AppCardAction, AppCardActionEnum} from '../../AppCardAction';
+import {AppIcon} from '../../AppIcon';
+import {AppCardMetadata} from '../../AppCardMetadata';
+import {AppCardSizingMode} from '../types';
+
+const iconUrl =
+  'https://cdn.shopify.com/app-store/listing_images/532861601aa89a5e70f5d56d075e82ac/icon/CLq7q92-4_0CEAE=.png';
+
+const appCardProps: AppCardProps = {
+  action: {type: AppCardActionEnum.Install},
+  iconUrl,
+  title: 'Shop',
+  starRating: 4.8,
+  description:
+    'The Shop channel is your control center for managing and optimizing your brand presence on Shop.',
+  signifiers: ['built_for_shopify'],
+  pricingInfo: 'Free plan available',
+};
+
+describe('<AppCard />', () => {
+  it('renders with default props', () => {
+    const card = mountWithApp(<AppCard {...appCardProps} />);
+
+    expect(card).toContainReactComponent(AppCardWrapper, {
+      as: 'div',
+      variant: 'primary',
+      onNarrowChange: expect.any(Function),
+      accessibilityLabel: 'Shop app card',
+    });
+
+    expect(card).toContainReactComponent(AppIcon, {
+      onClick: undefined,
+      size: 'md',
+      appTitle: 'Shop',
+      source: iconUrl,
+    });
+
+    expect(card).toContainReactComponent(AppCardMetadata, {
+      onTitleClick: undefined,
+      signifiers: ['built_for_shopify'],
+      truncate: false,
+      starRating: 4.8,
+      pricingInfo: 'Free plan available',
+      appTitle: 'Shop',
+      appDescription:
+        'The Shop channel is your control center for managing and optimizing your brand presence on Shop.',
+    });
+
+    expect(card).toContainReactComponent(AppCardAction, {
+      action: {
+        type: AppCardActionEnum.Install,
+      },
+      variant: 'default',
+    });
+  });
+
+  it('renders with secondary variant and size=sm', () => {
+    const card = mountWithApp(
+      <AppCard {...appCardProps} size="sm" variant="secondary" />,
+    );
+
+    expect(card).toContainReactComponent(AppCardWrapper, {
+      as: 'div',
+      variant: 'secondary',
+      onNarrowChange: expect.any(Function),
+      accessibilityLabel: 'Shop app card',
+    });
+
+    expect(card).toContainReactComponent(AppIcon, {
+      onClick: undefined,
+      size: 'sm',
+      appTitle: 'Shop',
+      source: iconUrl,
+    });
+
+    expect(card).toContainReactComponent(AppCardMetadata, {
+      onTitleClick: undefined,
+      signifiers: ['built_for_shopify'],
+      truncate: false,
+      appTitle: 'Shop',
+      starRating: 4.8,
+      pricingInfo: 'Free plan available',
+      appDescription:
+        'The Shop channel is your control center for managing and optimizing your brand presence on Shop.',
+    });
+
+    expect(card).toContainReactComponent(AppCardAction, {
+      action: {
+        type: AppCardActionEnum.Install,
+      },
+      variant: 'default',
+    });
+  });
+
+  it('renders with noBackground variant and size=lg', () => {
+    const card = mountWithApp(
+      <AppCard {...appCardProps} size="lg" variant="noBackground" />,
+    );
+
+    expect(card).toContainReactComponent(AppCardWrapper, {
+      as: 'div',
+      variant: 'noBackground',
+      onNarrowChange: expect.any(Function),
+      accessibilityLabel: 'Shop app card',
+    });
+
+    expect(card).toContainReactComponent(AppIcon, {
+      onClick: undefined,
+      size: 'lg',
+      appTitle: 'Shop',
+      source: iconUrl,
+    });
+
+    expect(card).toContainReactComponent(AppCardMetadata, {
+      onTitleClick: undefined,
+      signifiers: ['built_for_shopify'],
+      truncate: false,
+      appTitle: 'Shop',
+      starRating: 4.8,
+      pricingInfo: 'Free plan available',
+      appDescription:
+        'The Shop channel is your control center for managing and optimizing your brand presence on Shop.',
+    });
+
+    expect(card).toContainReactComponent(AppCardAction, {
+      action: {
+        type: AppCardActionEnum.Install,
+      },
+      variant: 'default',
+    });
+  });
+
+  it('renders Wrapper as listitem', () => {
+    const card = mountWithApp(<AppCard {...appCardProps} as="li" />);
+
+    expect(card).toContainReactComponent(AppCardWrapper, {
+      as: 'li',
+      variant: 'primary',
+      onNarrowChange: expect.any(Function),
+      accessibilityLabel: 'Shop app card',
+    });
+  });
+
+  it('renders narrow version of AppCard when sizingMode=always_narrow', () => {
+    const card = mountWithApp(
+      <AppCard {...appCardProps} sizingMode={AppCardSizingMode.AlwaysNarrow} />,
+    );
+
+    expect(card).toContainReactComponent(AppCardMetadata, {
+      onTitleClick: undefined,
+      signifiers: ['built_for_shopify'],
+      truncate: true,
+      appTitle: 'Shop',
+      starRating: 4.8,
+      pricingInfo: 'Free plan available',
+      appDescription: undefined,
+    });
+
+    expect(card).toContainReactComponent(AppCardAction, {
+      action: {
+        type: AppCardActionEnum.Install,
+      },
+      variant: 'narrow',
+    });
+  });
+
+  it('renders narrow version of AppCard when Wrapper returns true onNarrowChange', () => {
+    const card = mountWithApp(<AppCard {...appCardProps} />);
+
+    card.find(AppCardWrapper)?.trigger('onNarrowChange', true);
+
+    expect(card).toContainReactComponent(AppCardMetadata, {
+      onTitleClick: undefined,
+      signifiers: ['built_for_shopify'],
+      truncate: true,
+      appTitle: 'Shop',
+      starRating: 4.8,
+      pricingInfo: 'Free plan available',
+      appDescription: undefined,
+    });
+
+    expect(card).toContainReactComponent(AppCardAction, {
+      action: {
+        type: AppCardActionEnum.Install,
+      },
+      variant: 'narrow',
+    });
+  });
+
+  it('triggers onTitleClick when title is clicked within AppCardMetadata', () => {
+    const spy = jest.fn();
+    const card = mountWithApp(<AppCard {...appCardProps} onTitleClick={spy} />);
+
+    card.find(AppCardMetadata)?.trigger('onTitleClick');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it('triggers onIconClick when icon is clicked within AppIcon', () => {
+    const spy = jest.fn();
+    const card = mountWithApp(<AppCard {...appCardProps} onIconClick={spy} />);
+
+    card.find(AppIcon)?.trigger('onClick');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});

--- a/polaris-react/src/components/AppCard/types.ts
+++ b/polaris-react/src/components/AppCard/types.ts
@@ -1,0 +1,8 @@
+export type AppCardVariant = 'primary' | 'secondary' | 'noBackground';
+
+export enum AppCardSizingMode {
+  Adaptive = 'adaptive',
+  AlwaysNarrow = 'always_narrow',
+}
+
+export type AppCardSize = 'sm' | 'md' | 'lg';

--- a/polaris-react/src/components/AppCardAction/AppCardAction.stories.tsx
+++ b/polaris-react/src/components/AppCardAction/AppCardAction.stories.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import type {ComponentMeta} from '@storybook/react';
+
+import {Box} from '../Box';
+import {BlockStack} from '../BlockStack';
+import {Text} from '../Text';
+
+import {AppCardAction} from './AppCardAction';
+import {AppCardActionEnum} from './types';
+
+export default {
+  component: AppCardAction,
+} as ComponentMeta<typeof AppCardAction>;
+
+export function Default() {
+  return <AppCardAction />;
+}
+
+export function InstallAction() {
+  return (
+    <AppCardAction
+      action={{
+        type: AppCardActionEnum.Install,
+      }}
+    />
+  );
+}
+
+export function OpenAction() {
+  return (
+    <AppCardAction
+      action={{
+        type: AppCardActionEnum.Open,
+      }}
+    />
+  );
+}
+
+export function Variants() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Default
+        </Text>
+        <Box maxWidth="90px">
+          <AppCardAction variant="default" />
+        </Box>
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Narrow
+        </Text>
+        <Box maxWidth="90px">
+          <AppCardAction variant="narrow" />
+        </Box>
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Full
+        </Text>
+        <AppCardAction variant="full" />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function Sizes() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Micro
+        </Text>
+        <AppCardAction size="micro" />
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Slim
+        </Text>
+        <AppCardAction size="slim" />
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Medium
+        </Text>
+        <AppCardAction size="medium" />
+      </BlockStack>
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Large
+        </Text>
+        <AppCardAction size="large" />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function Disabled() {
+  return (
+    <AppCardAction action={{type: AppCardActionEnum.Install, disabled: true}} />
+  );
+}
+
+export function Loading() {
+  return (
+    <AppCardAction action={{type: AppCardActionEnum.Install, loading: true}} />
+  );
+}

--- a/polaris-react/src/components/AppCardAction/AppCardAction.tsx
+++ b/polaris-react/src/components/AppCardAction/AppCardAction.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {ImportIcon} from '@shopify/polaris-icons';
+
+import {Button} from '../Button';
+import {useI18n} from '../../utilities/i18n';
+
+import type {
+  AppCardActionType,
+  AppCardActionVariant,
+  AppCardActionSize,
+} from './types';
+import {AppCardActionEnum} from './types';
+
+export interface AppCardActionProps {
+  action?: AppCardActionType;
+  variant?: AppCardActionVariant;
+  size?: AppCardActionSize;
+}
+
+const STYLES_BY_ACTION: {
+  [key in AppCardActionEnum]: {
+    contentKey: string;
+    altKey: string;
+    icon?: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  };
+} = {
+  [AppCardActionEnum.Install]: {
+    contentKey: 'install',
+    altKey: 'installAlt',
+    icon: ImportIcon,
+  },
+  [AppCardActionEnum.Open]: {
+    contentKey: 'open',
+    altKey: 'openAlt',
+  },
+};
+
+export function AppCardAction({
+  action = {type: AppCardActionEnum.Install},
+  variant = 'default',
+  size = 'medium',
+}: AppCardActionProps) {
+  const i18n = useI18n();
+
+  const stylesForAction =
+    STYLES_BY_ACTION[action?.type ?? AppCardActionEnum.Install];
+
+  const translationKeyPrefix = 'Polaris.AppCardAction.Actions';
+
+  return (
+    <Button
+      accessibilityLabel={i18n.translate(
+        `${translationKeyPrefix}.${stylesForAction.altKey}`,
+      )}
+      disabled={action?.disabled ?? false}
+      loading={action?.loading ?? false}
+      size={size ?? 'medium'}
+      fullWidth={variant === 'full'}
+      icon={stylesForAction.icon}
+      onClick={action.onAction ?? (() => {})}
+    >
+      {variant !== 'narrow'
+        ? i18n.translate(
+            `${translationKeyPrefix}.${stylesForAction.contentKey}`,
+          )
+        : undefined}
+    </Button>
+  );
+}

--- a/polaris-react/src/components/AppCardAction/index.ts
+++ b/polaris-react/src/components/AppCardAction/index.ts
@@ -1,0 +1,2 @@
+export * from './AppCardAction';
+export * from './types';

--- a/polaris-react/src/components/AppCardAction/tests/AppCardAction.test.tsx
+++ b/polaris-react/src/components/AppCardAction/tests/AppCardAction.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {AppCardAction} from '../AppCardAction';
+import {Button} from '../../Button';
+import {AppCardActionEnum} from '../types';
+
+describe('<AppCardAction />', () => {
+  it('renders with default props', () => {
+    const action = mountWithApp(<AppCardAction />);
+
+    expect(action).toContainReactComponent(Button, {
+      accessibilityLabel: 'Install app',
+      disabled: false,
+      loading: false,
+      size: 'medium',
+      fullWidth: false,
+      icon: expect.any(Function),
+      onClick: expect.any(Function),
+      children: 'Install',
+    });
+  });
+
+  it('renders Open action', () => {
+    const action = mountWithApp(
+      <AppCardAction action={{type: AppCardActionEnum.Open}} />,
+    );
+
+    expect(action).toContainReactComponent(Button, {
+      accessibilityLabel: 'Open app',
+      disabled: false,
+      loading: false,
+      size: 'medium',
+      fullWidth: false,
+      icon: undefined,
+      onClick: expect.any(Function),
+      children: 'Open',
+    });
+  });
+
+  it('renders icon-only button with Install action when variant=narrow', () => {
+    const action = mountWithApp(<AppCardAction size="slim" variant="narrow" />);
+
+    expect(action).toContainReactComponent(Button, {
+      accessibilityLabel: 'Install app',
+      disabled: false,
+      loading: false,
+      size: 'slim',
+      fullWidth: false,
+      icon: expect.any(Function),
+      onClick: expect.any(Function),
+      children: undefined,
+    });
+  });
+
+  it('renders fullWidth button when variant=full', () => {
+    const action = mountWithApp(<AppCardAction variant="full" />);
+
+    expect(action).toContainReactComponent(Button, {
+      accessibilityLabel: 'Install app',
+      disabled: false,
+      loading: false,
+      size: 'medium',
+      fullWidth: true,
+      icon: expect.any(Function),
+      onClick: expect.any(Function),
+      children: 'Install',
+    });
+  });
+
+  it('renders disabled button when action.disabled=true', () => {
+    const action = mountWithApp(
+      <AppCardAction
+        action={{type: AppCardActionEnum.Install, disabled: true}}
+      />,
+    );
+
+    expect(action).toContainReactComponent(Button, {
+      accessibilityLabel: 'Install app',
+      disabled: true,
+      loading: false,
+      size: 'medium',
+      fullWidth: false,
+      icon: expect.any(Function),
+      onClick: expect.any(Function),
+      children: 'Install',
+    });
+  });
+
+  it('renders loading button when action.loading=true', () => {
+    const action = mountWithApp(
+      <AppCardAction
+        action={{type: AppCardActionEnum.Install, loading: true}}
+      />,
+    );
+
+    expect(action).toContainReactComponent(Button, {
+      accessibilityLabel: 'Install app',
+      disabled: false,
+      loading: true,
+      size: 'medium',
+      fullWidth: false,
+      icon: expect.any(Function),
+      onClick: expect.any(Function),
+      children: 'Install',
+    });
+  });
+
+  it('triggers action.onAction when action button is clicked', () => {
+    const spy = jest.fn();
+    const action = mountWithApp(
+      <AppCardAction
+        action={{type: AppCardActionEnum.Install, onAction: spy}}
+      />,
+    );
+
+    action.find(Button)?.trigger('onClick');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});

--- a/polaris-react/src/components/AppCardAction/types.ts
+++ b/polaris-react/src/components/AppCardAction/types.ts
@@ -1,0 +1,15 @@
+export enum AppCardActionEnum {
+  Install = 'install',
+  Open = 'open',
+}
+
+export interface AppCardActionType {
+  type: AppCardActionEnum;
+  disabled?: boolean;
+  onAction?: () => void;
+  loading?: boolean;
+}
+
+export type AppCardActionVariant = 'default' | 'narrow' | 'full';
+
+export type AppCardActionSize = 'micro' | 'slim' | 'medium' | 'large';

--- a/polaris-react/src/components/AppCardBadge/AppCardBadge.stories.tsx
+++ b/polaris-react/src/components/AppCardBadge/AppCardBadge.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import type {ComponentMeta} from '@storybook/react';
+
+import {AppCardBadge} from './AppCardBadge';
+import {AppCardBadgeEnum} from './types';
+
+export default {
+  component: AppCardBadge,
+} as ComponentMeta<typeof AppCardBadge>;
+
+export function BuiltForShopify() {
+  return <AppCardBadge type={AppCardBadgeEnum.BuiltForShopify} />;
+}

--- a/polaris-react/src/components/AppCardBadge/AppCardBadge.tsx
+++ b/polaris-react/src/components/AppCardBadge/AppCardBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import {useI18n} from '../../utilities/i18n';
+import {Badge} from '../Badge';
+
+import {AppCardBadgeEnum} from './types';
+
+export interface AppCardBadgeProps {
+  type: AppCardBadgeEnum;
+}
+
+export function AppCardBadge({type}: AppCardBadgeProps) {
+  const i18n = useI18n();
+
+  if (type === AppCardBadgeEnum.BuiltForShopify) {
+    const content = i18n.translate(`Polaris.AppCardBadge.builtForShopify`);
+    return <Badge tone="info">{content}</Badge>;
+  }
+  return null;
+}

--- a/polaris-react/src/components/AppCardBadge/index.ts
+++ b/polaris-react/src/components/AppCardBadge/index.ts
@@ -1,0 +1,2 @@
+export * from './AppCardBadge';
+export * from './types';

--- a/polaris-react/src/components/AppCardBadge/tests/AppCardBadge.test.tsx
+++ b/polaris-react/src/components/AppCardBadge/tests/AppCardBadge.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {AppCardBadge} from '../AppCardBadge';
+import {Badge} from '../../Badge';
+import {AppCardBadgeEnum} from '../types';
+
+describe('<AppCardBadge />', () => {
+  it('renders Built for Shopify badge', () => {
+    const badge = mountWithApp(
+      <AppCardBadge type={AppCardBadgeEnum.BuiltForShopify} />,
+    );
+
+    expect(badge).toContainReactComponent(Badge, {
+      children: 'Built for Shopify',
+    });
+  });
+});

--- a/polaris-react/src/components/AppCardBadge/types.ts
+++ b/polaris-react/src/components/AppCardBadge/types.ts
@@ -1,0 +1,3 @@
+export enum AppCardBadgeEnum {
+  BuiltForShopify = 'built_for_shopify',
+}

--- a/polaris-react/src/components/AppCardMetadata/AppCardMetadata.module.css
+++ b/polaris-react/src/components/AppCardMetadata/AppCardMetadata.module.css
@@ -1,0 +1,14 @@
+.Container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.TitleLink {
+  cursor: pointer;
+}
+
+.TitleLink :hover {
+  text-decoration: underline;
+}

--- a/polaris-react/src/components/AppCardMetadata/AppCardMetadata.stories.tsx
+++ b/polaris-react/src/components/AppCardMetadata/AppCardMetadata.stories.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import type {ComponentMeta} from '@storybook/react';
+
+import {BlockStack} from '../BlockStack';
+
+import {AppCardMetadata} from './AppCardMetadata';
+
+export default {
+  component: AppCardMetadata,
+} as ComponentMeta<typeof AppCardMetadata>;
+
+const defaultProps = {
+  pricingInfo: 'Free plan available',
+  starRating: 4.5,
+  appTitle: 'Shop',
+  appDescription:
+    'The Shop channel is your control center for managing and optimizing your brand presence on Shop.',
+};
+
+export function Default() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCardMetadata {...defaultProps} />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function NoDescription() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCardMetadata {...defaultProps} appDescription={undefined} />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function NoPricing() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCardMetadata {...defaultProps} pricingInfo={undefined} />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function NoStarRating() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCardMetadata {...defaultProps} starRating={undefined} />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function Truncated() {
+  return (
+    <div style={{maxWidth: '300px'}}>
+      <BlockStack gap="400">
+        <BlockStack gap="200">
+          <AppCardMetadata
+            {...defaultProps}
+            appTitle="Shop - a longer title on app should truncate with ellipsis"
+            truncate
+          />
+        </BlockStack>
+      </BlockStack>
+    </div>
+  );
+}
+
+export function BuiltForShopifySignifier() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCardMetadata {...defaultProps} signifiers={['built_for_shopify']} />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function LargeTitleVariant() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <AppCardMetadata
+          {...defaultProps}
+          signifiers={['built_for_shopify']}
+          titleVariant="large"
+        />
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/polaris-react/src/components/AppCardMetadata/AppCardMetadata.tsx
+++ b/polaris-react/src/components/AppCardMetadata/AppCardMetadata.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import {BlockStack} from '../BlockStack';
+import {InlineStack} from '../InlineStack';
+
+import styles from './AppCardMetadata.module.css';
+import {
+  AppCardAppTitle,
+  AppCardBadges,
+  AppCardDescription,
+  AppCardPricingInfo,
+  AppCardStarRating,
+} from './components';
+import type {AppCardMetadataTitleVariant} from './types';
+
+export interface AppCardMetadataProps {
+  appTitle: string;
+  appDescription?: string;
+  truncate?: boolean;
+  signifiers?: string[];
+  pricingInfo?: string;
+  starRating?: number;
+  onTitleClick?: () => void;
+  titleVariant?: AppCardMetadataTitleVariant;
+}
+
+export function AppCardMetadata({
+  titleVariant = 'default',
+  appTitle,
+  appDescription,
+  signifiers = [],
+  pricingInfo,
+  starRating,
+  truncate = false,
+  onTitleClick,
+}: AppCardMetadataProps) {
+  return (
+    <div className={styles.Container}>
+      <BlockStack align="center">
+        <AppCardAppTitle
+          appTitle={appTitle}
+          variant={titleVariant}
+          truncate={truncate}
+          onTitleClick={onTitleClick}
+        />
+        <InlineStack wrap={false} blockAlign="center" gap="100">
+          {starRating ? <AppCardStarRating starRating={starRating} /> : null}
+
+          {pricingInfo ? (
+            <AppCardPricingInfo pricingInfo={pricingInfo} truncate={truncate} />
+          ) : null}
+        </InlineStack>
+
+        {appDescription && <AppCardDescription description={appDescription} />}
+
+        <AppCardBadges signifiers={signifiers} />
+      </BlockStack>
+    </div>
+  );
+}

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardAppTitle/AppCardAppTitle.module.css
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardAppTitle/AppCardAppTitle.module.css
@@ -1,0 +1,17 @@
+.TitleContainer {
+  flex: 1;
+  min-width: 0;
+}
+
+.TitleLink {
+  color: var(--p-color-text);
+  text-decoration: none;
+}
+
+.TitleLink:not(.LinkDisabled) {
+  cursor: pointer;
+}
+
+.TitleLink:not(.LinkDisabled) :hover {
+  text-decoration: underline;
+}

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardAppTitle/AppCardAppTitle.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardAppTitle/AppCardAppTitle.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import type {AppCardMetadataTitleVariant, TextVariant} from '../../types';
+import {Text} from '../../../Text';
+import {classNames} from '../../../../utilities/css';
+
+import styles from './AppCardAppTitle.module.css';
+
+interface AppCardAppTitleProps {
+  appTitle: string;
+  variant?: AppCardMetadataTitleVariant;
+  onTitleClick?: () => void;
+  truncate?: boolean;
+}
+
+const VARIANT_TO_TEXT_VARIANT: {
+  [key in AppCardMetadataTitleVariant]: TextVariant;
+} = {
+  default: 'bodyMd',
+  large: 'headingSm',
+};
+
+export function AppCardAppTitle({
+  variant = 'default',
+  onTitleClick,
+  truncate = false,
+  appTitle,
+}: AppCardAppTitleProps) {
+  const textVariant = VARIANT_TO_TEXT_VARIANT[variant ?? 'default'];
+
+  const linkClassNames = classNames(
+    styles.TitleLink,
+    !onTitleClick ? styles.LinkDisabled : undefined,
+  );
+
+  const handleTitleClick = () => {
+    return onTitleClick ? onTitleClick() : undefined;
+  };
+
+  return (
+    <div className={styles.TitleContainer}>
+      <div
+        role={onTitleClick ? 'link' : undefined}
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={onTitleClick ? 0 : undefined}
+        className={linkClassNames}
+        onClick={handleTitleClick}
+      >
+        <Text truncate={truncate} variant={textVariant} as="h3">
+          {appTitle}
+        </Text>
+      </div>
+    </div>
+  );
+}

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardAppTitle/index.ts
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardAppTitle/index.ts
@@ -1,0 +1,1 @@
+export * from './AppCardAppTitle';

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardAppTitle/tests/AppCardAppTitle.test.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardAppTitle/tests/AppCardAppTitle.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {AppCardAppTitle} from '../AppCardAppTitle';
+import {Text} from '../../../../Text';
+
+describe('<AppCardAppTitle />', () => {
+  it('renders with default props', () => {
+    const title = mountWithApp(<AppCardAppTitle appTitle="Shop" />);
+
+    expect(title).toContainReactComponent('div', {
+      className: 'TitleLink LinkDisabled',
+      role: undefined,
+      tabIndex: undefined,
+      onClick: expect.any(Function),
+    });
+
+    expect(title).toContainReactComponent(Text, {
+      truncate: false,
+      variant: 'bodyMd',
+      children: 'Shop',
+    });
+  });
+
+  it('renders truncated title with large variant', () => {
+    const title = mountWithApp(
+      <AppCardAppTitle variant="large" truncate appTitle="Shop" />,
+    );
+
+    expect(title).toContainReactComponent('div', {
+      className: 'TitleLink LinkDisabled',
+      role: undefined,
+      tabIndex: undefined,
+      onClick: expect.any(Function),
+    });
+
+    expect(title).toContainReactComponent(Text, {
+      truncate: true,
+      variant: 'headingSm',
+      children: 'Shop',
+    });
+  });
+
+  it('renders title as a link', () => {
+    const title = mountWithApp(
+      <AppCardAppTitle appTitle="Shop" onTitleClick={() => {}} />,
+    );
+
+    expect(title).toContainReactComponent('div', {
+      className: 'TitleLink',
+      role: 'link',
+      tabIndex: 0,
+      onClick: expect.any(Function),
+    });
+  });
+
+  it('triggers onTitleClick on link click', () => {
+    const spy = jest.fn();
+    const title = mountWithApp(
+      <AppCardAppTitle appTitle="Shop" onTitleClick={spy} />,
+    );
+
+    title.find('div', {className: 'TitleLink'})?.trigger('onClick');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardBadges/AppCardBadges.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardBadges/AppCardBadges.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import {Box} from '../../../Box';
+import {InlineStack} from '../../../InlineStack';
+import {AppCardBadge, AppCardBadgeEnum} from '../../../AppCardBadge';
+
+interface AppCardBadgesProps {
+  signifiers?: string[];
+}
+
+export function AppCardBadges({signifiers = []}: AppCardBadgesProps) {
+  const badges = [];
+
+  if (signifiers.includes(AppCardBadgeEnum.BuiltForShopify)) {
+    badges.push(
+      <AppCardBadge
+        key={AppCardBadgeEnum.BuiltForShopify}
+        type={AppCardBadgeEnum.BuiltForShopify}
+      />,
+    );
+  }
+
+  return badges?.length ? (
+    <Box paddingBlockStart="100">
+      <InlineStack gap="300">{badges}</InlineStack>
+    </Box>
+  ) : null;
+}

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardBadges/index.ts
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardBadges/index.ts
@@ -1,0 +1,1 @@
+export * from './AppCardBadges';

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardBadges/tests/AppCardBadges.test.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardBadges/tests/AppCardBadges.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {AppCardBadges} from '../AppCardBadges';
+import {AppCardBadge, AppCardBadgeEnum} from '../../../../AppCardBadge';
+
+describe('<AppCardBadges />', () => {
+  it('renders with default props', () => {
+    const badges = mountWithApp(<AppCardBadges />);
+
+    expect(badges).not.toContainReactComponent(AppCardBadge);
+  });
+
+  it('renders Built for Shopify badge', () => {
+    const badges = mountWithApp(
+      <AppCardBadges signifiers={['built_for_shopify']} />,
+    );
+
+    expect(badges).toContainReactComponent(AppCardBadge, {
+      type: AppCardBadgeEnum.BuiltForShopify,
+    });
+  });
+});

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardDescription/AppCardDescription.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardDescription/AppCardDescription.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import {Text} from '../../../Text';
+
+interface AppCardDescriptionProps {
+  description: string;
+}
+
+export function AppCardDescription({description}: AppCardDescriptionProps) {
+  return (
+    <Text tone="subdued" variant="bodyMd" as="span">
+      {description}
+    </Text>
+  );
+}

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardDescription/index.ts
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardDescription/index.ts
@@ -1,0 +1,1 @@
+export * from './AppCardDescription';

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardDescription/tests/AppCardDescription.test.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardDescription/tests/AppCardDescription.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {Text} from '../../../../Text';
+import {AppCardDescription} from '../AppCardDescription';
+
+describe('<AppCardDescription />', () => {
+  it('renders description', () => {
+    const description = mountWithApp(
+      <AppCardDescription description="Test app description" />,
+    );
+
+    expect(description).toContainReactComponent(Text, {
+      children: 'Test app description',
+    });
+  });
+});

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardPricingInfo/AppCardPricingInfo.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardPricingInfo/AppCardPricingInfo.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import {Text} from '../../../Text';
+
+interface AppCardPricingInfoProps {
+  pricingInfo: string;
+  truncate?: boolean;
+}
+
+export function AppCardPricingInfo({
+  truncate = false,
+  pricingInfo,
+}: AppCardPricingInfoProps) {
+  return (
+    <Text truncate={truncate} tone="subdued" variant="bodyMd" as="span">
+      {pricingInfo}
+    </Text>
+  );
+}

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardPricingInfo/index.ts
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardPricingInfo/index.ts
@@ -1,0 +1,1 @@
+export * from './AppCardPricingInfo';

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardPricingInfo/tests/AppCardPricingInfo.test.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardPricingInfo/tests/AppCardPricingInfo.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {Text} from '../../../../Text';
+import {AppCardPricingInfo} from '../AppCardPricingInfo';
+
+describe('<AppCardPricingInfo />', () => {
+  it('renders pricing info', () => {
+    const pricingInfo = mountWithApp(
+      <AppCardPricingInfo pricingInfo="Free plan available" />,
+    );
+
+    expect(pricingInfo).toContainReactComponent(Text, {
+      children: 'Free plan available',
+      truncate: false,
+    });
+  });
+
+  it('renders truncated pricing info', () => {
+    const pricingInfo = mountWithApp(
+      <AppCardPricingInfo pricingInfo="Free plan available" truncate />,
+    );
+
+    expect(pricingInfo).toContainReactComponent(Text, {
+      children: 'Free plan available',
+      truncate: true,
+    });
+  });
+});

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardStarRating/AppCardStarRating.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardStarRating/AppCardStarRating.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {StarFilledIcon} from '@shopify/polaris-icons';
+
+import {InlineStack} from '../../../InlineStack';
+import {Icon} from '../../../Icon';
+import {Text} from '../../../Text';
+
+export interface AppCardStarRatingProps {
+  starRating: number;
+}
+
+export function AppCardStarRating({starRating}: AppCardStarRatingProps) {
+  return (
+    <InlineStack wrap={false} blockAlign="center">
+      <Text tone="subdued" variant="bodyMd" as="span">
+        {starRating}
+      </Text>
+      <div>
+        <Icon tone="success" source={StarFilledIcon} />
+      </div>
+    </InlineStack>
+  );
+}

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardStarRating/index.ts
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardStarRating/index.ts
@@ -1,0 +1,1 @@
+export * from './AppCardStarRating';

--- a/polaris-react/src/components/AppCardMetadata/components/AppCardStarRating/tests/AppCardStarRating.test.tsx
+++ b/polaris-react/src/components/AppCardMetadata/components/AppCardStarRating/tests/AppCardStarRating.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {AppCardStarRating} from '../AppCardStarRating';
+import {Text} from '../../../../Text';
+
+describe('<AppCardStarRating />', () => {
+  it('renders a star rating', () => {
+    const starRating = mountWithApp(<AppCardStarRating starRating={4.5} />);
+
+    expect(starRating).toContainReactComponent(Text, {
+      children: 4.5,
+    });
+  });
+});

--- a/polaris-react/src/components/AppCardMetadata/components/index.ts
+++ b/polaris-react/src/components/AppCardMetadata/components/index.ts
@@ -1,0 +1,5 @@
+export * from './AppCardBadges';
+export * from './AppCardAppTitle';
+export * from './AppCardDescription';
+export * from './AppCardPricingInfo';
+export * from './AppCardStarRating';

--- a/polaris-react/src/components/AppCardMetadata/index.ts
+++ b/polaris-react/src/components/AppCardMetadata/index.ts
@@ -1,0 +1,2 @@
+export * from './AppCardMetadata';
+export * from './types';

--- a/polaris-react/src/components/AppCardMetadata/tests/AppCardMetadata.test.tsx
+++ b/polaris-react/src/components/AppCardMetadata/tests/AppCardMetadata.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {AppCardMetadata} from '../AppCardMetadata';
+import {
+  AppCardAppTitle,
+  AppCardBadges,
+  AppCardDescription,
+  AppCardPricingInfo,
+  AppCardStarRating,
+} from '../components';
+
+describe('<AppCardMetadata />', () => {
+  it('renders with default props', () => {
+    const metadata = mountWithApp(<AppCardMetadata appTitle="Shop" />);
+
+    expect(metadata).toContainReactComponent(AppCardAppTitle, {
+      appTitle: 'Shop',
+      variant: 'default',
+      truncate: false,
+      onTitleClick: undefined,
+    });
+
+    expect(metadata).not.toContainReactComponent(AppCardStarRating);
+    expect(metadata).not.toContainReactComponent(AppCardPricingInfo);
+    expect(metadata).not.toContainReactComponent(AppCardDescription);
+
+    expect(metadata).toContainReactComponent(AppCardBadges, {
+      signifiers: [],
+    });
+  });
+
+  it('renders all Shop metadata using large title variant, but hides description', () => {
+    const metadata = mountWithApp(
+      <AppCardMetadata
+        titleVariant="large"
+        appTitle="Shop"
+        starRating={4.5}
+        pricingInfo="Free plan available"
+        signifiers={['built_for_shopify']}
+      />,
+    );
+
+    expect(metadata).toContainReactComponent(AppCardAppTitle, {
+      appTitle: 'Shop',
+      variant: 'large',
+      truncate: false,
+      onTitleClick: undefined,
+    });
+
+    expect(metadata).toContainReactComponent(AppCardStarRating, {
+      starRating: 4.5,
+    });
+    expect(metadata).toContainReactComponent(AppCardPricingInfo, {
+      pricingInfo: 'Free plan available',
+    });
+    expect(metadata).not.toContainReactComponent(AppCardDescription);
+
+    expect(metadata).toContainReactComponent(AppCardBadges, {
+      signifiers: ['built_for_shopify'],
+    });
+  });
+
+  it('renders all Shop metadata using large title variant, but hides pricingInfo', () => {
+    const metadata = mountWithApp(
+      <AppCardMetadata
+        titleVariant="large"
+        appTitle="Shop"
+        starRating={4.5}
+        appDescription="App description"
+        signifiers={['built_for_shopify']}
+      />,
+    );
+
+    expect(metadata).toContainReactComponent(AppCardAppTitle, {
+      appTitle: 'Shop',
+      variant: 'large',
+      truncate: false,
+      onTitleClick: undefined,
+    });
+
+    expect(metadata).toContainReactComponent(AppCardStarRating, {
+      starRating: 4.5,
+    });
+    expect(metadata).not.toContainReactComponent(AppCardPricingInfo);
+
+    expect(metadata).toContainReactComponent(AppCardDescription, {
+      description: 'App description',
+    });
+
+    expect(metadata).toContainReactComponent(AppCardBadges, {
+      signifiers: ['built_for_shopify'],
+    });
+  });
+
+  it('renders all Shop metadata using large title variant, but hides starRating', () => {
+    const metadata = mountWithApp(
+      <AppCardMetadata
+        titleVariant="large"
+        appTitle="Shop"
+        pricingInfo="Free plan available"
+        appDescription="App description"
+        signifiers={['built_for_shopify']}
+      />,
+    );
+
+    expect(metadata).toContainReactComponent(AppCardAppTitle, {
+      appTitle: 'Shop',
+      variant: 'large',
+      truncate: false,
+      onTitleClick: undefined,
+    });
+
+    expect(metadata).not.toContainReactComponent(AppCardStarRating);
+
+    expect(metadata).toContainReactComponent(AppCardPricingInfo, {
+      pricingInfo: 'Free plan available',
+    });
+
+    expect(metadata).toContainReactComponent(AppCardDescription, {
+      description: 'App description',
+    });
+
+    expect(metadata).toContainReactComponent(AppCardBadges, {
+      signifiers: ['built_for_shopify'],
+    });
+  });
+
+  it('truncates pricingInfo and title when truncate=true', () => {
+    const metadata = mountWithApp(
+      <AppCardMetadata
+        truncate
+        appTitle="Shop"
+        pricingInfo="Free plan available"
+      />,
+    );
+
+    expect(metadata).toContainReactComponent(AppCardPricingInfo, {
+      pricingInfo: 'Free plan available',
+      truncate: true,
+    });
+
+    expect(metadata).toContainReactComponent(AppCardAppTitle, {
+      appTitle: 'Shop',
+      variant: 'default',
+      truncate: true,
+      onTitleClick: undefined,
+    });
+  });
+
+  it('triggers onTitleClick callback when app title is clicked', () => {
+    const spy = jest.fn();
+    const metadata = mountWithApp(
+      <AppCardMetadata onTitleClick={spy} appTitle="Shop" />,
+    );
+
+    metadata.find(AppCardAppTitle)?.trigger('onTitleClick');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});

--- a/polaris-react/src/components/AppCardMetadata/types.ts
+++ b/polaris-react/src/components/AppCardMetadata/types.ts
@@ -1,0 +1,4 @@
+import type {TextProps} from '../Text';
+
+export type AppCardMetadataTitleVariant = 'default' | 'large';
+export type TextVariant = TextProps['variant'];

--- a/polaris-react/src/components/AppIcon/AppIcon.module.css
+++ b/polaris-react/src/components/AppIcon/AppIcon.module.css
@@ -1,0 +1,33 @@
+.Image {
+  outline: none;
+  border-radius: var(--p-width-300);
+  display: block;
+  background-color: var(--p-color-bg-fill-tertiary);
+  border-width: var(--p-width-050);
+  /* stylelint-disable-next-line -- custom border styling */
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.small {
+  width: 32px;
+  height: 32px;
+}
+
+.medium {
+  width: 40px;
+  height: 40px;
+}
+
+.large {
+  width: 56px;
+  height: 56px;
+}
+
+.xlarge {
+  width: 68px;
+  height: 68px;
+}
+
+.IconLink:not(.LinkDisabled) {
+  cursor: pointer;
+}

--- a/polaris-react/src/components/AppIcon/AppIcon.stories.tsx
+++ b/polaris-react/src/components/AppIcon/AppIcon.stories.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable no-alert */
+import React from 'react';
+import type {ComponentMeta} from '@storybook/react';
+
+import {AppIcon} from './AppIcon';
+
+const source =
+  'https://cdn.shopify.com/app-store/listing_images/532861601aa89a5e70f5d56d075e82ac/icon/CLq7q92-4_0CEAE=.png';
+
+export default {
+  component: AppIcon,
+} as ComponentMeta<typeof AppIcon>;
+
+export function Default() {
+  return <AppIcon source={source} onClick={() => alert('clicked')} />;
+}
+
+export function NoSource() {
+  return <AppIcon onClick={() => alert('clicked')} />;
+}
+
+export function Small() {
+  return <AppIcon source={source} size="sm" onClick={() => alert('clicked')} />;
+}
+
+export function Medium() {
+  return <AppIcon source={source} size="md" onClick={() => alert('clicked')} />;
+}
+
+export function Large() {
+  return <AppIcon source={source} size="lg" onClick={() => alert('clicked')} />;
+}
+
+export function XLarge() {
+  return <AppIcon source={source} size="xl" onClick={() => alert('clicked')} />;
+}
+
+export function Disabled() {
+  return <AppIcon source={source} size="xl" />;
+}

--- a/polaris-react/src/components/AppIcon/AppIcon.tsx
+++ b/polaris-react/src/components/AppIcon/AppIcon.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import {classNames} from '../../utilities/css';
+import {useI18n} from '../../utilities/i18n';
+import {Image} from '../Image';
+
+import styles from './AppIcon.module.css';
+import type {AppIconSize} from './types';
+
+export interface AppIconProps {
+  source?: string;
+  appTitle?: string;
+  onClick?: () => void;
+  size?: AppIconSize;
+}
+
+const getStyleFor = (size: AppIconSize) => {
+  if (size === 'sm') {
+    return styles.small;
+  } else if (size === 'md') {
+    return styles.medium;
+  } else if (size === 'lg') {
+    return styles.large;
+  } else if (size === 'xl') {
+    return styles.xlarge;
+  }
+
+  return styles.medium;
+};
+
+export function AppIcon({
+  source,
+  appTitle,
+  onClick,
+  size = 'md',
+}: AppIconProps) {
+  const i18n = useI18n();
+
+  const imageClassNames = classNames(styles.Image, getStyleFor(size));
+
+  const linkClassNames = classNames(
+    styles.IconLink,
+    !onClick ? styles.LinkDisabled : undefined,
+  );
+
+  const titleTranslationKey = `Polaris.AppIcon.${
+    appTitle ? 'accessibilityLabelWithAppTitle' : 'accessibilityLabel'
+  }`;
+
+  const altTranslationKey = `Polaris.AppIcon.${
+    appTitle ? 'altWithAppTitle' : 'alt'
+  }`;
+
+  const handleOnClick = () => {
+    return onClick ? onClick() : undefined;
+  };
+
+  return (
+    <div
+      aria-label={i18n.translate(titleTranslationKey, {
+        app: appTitle ?? '',
+      })}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={!onClick ? undefined : 0}
+      onClick={handleOnClick}
+      role={source ? 'link' : 'region'}
+      className={linkClassNames}
+    >
+      {source && (
+        <Image
+          className={imageClassNames}
+          source={source}
+          alt={i18n.translate(altTranslationKey, {app: appTitle ?? ''})}
+        />
+      )}
+      {!source && <div className={imageClassNames} />}
+    </div>
+  );
+}

--- a/polaris-react/src/components/AppIcon/index.ts
+++ b/polaris-react/src/components/AppIcon/index.ts
@@ -1,0 +1,2 @@
+export * from './AppIcon';
+export * from './types';

--- a/polaris-react/src/components/AppIcon/tests/AppIcon.test.tsx
+++ b/polaris-react/src/components/AppIcon/tests/AppIcon.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {AppIcon} from '../AppIcon';
+import {Image} from '../../Image';
+
+const source =
+  'https://cdn.shopify.com/app-store/listing_images/532861601aa89a5e70f5d56d075e82ac/icon/CLq7q92-4_0CEAE=.png';
+
+describe('<AppIcon />', () => {
+  it('renders with default props', () => {
+    const appIcon = mountWithApp(<AppIcon />);
+
+    expect(appIcon).toContainReactComponent('div', {
+      role: 'region',
+      onClick: expect.any(Function),
+      className: 'IconLink LinkDisabled',
+      'aria-label': 'View app details for the app',
+      tabIndex: undefined,
+    });
+
+    expect(appIcon).not.toContainReactComponent(Image);
+    expect(appIcon).toContainReactComponent('div', {
+      className: 'Image medium',
+    });
+  });
+
+  it('renders with an icon source and onClick callback', () => {
+    const appIcon = mountWithApp(
+      <AppIcon source={source} onClick={() => {}} />,
+    );
+
+    expect(appIcon).toContainReactComponent('div', {
+      role: 'link',
+      onClick: expect.any(Function),
+      className: 'IconLink',
+      'aria-label': 'View app details for the app',
+      tabIndex: 0,
+    });
+
+    expect(appIcon).toContainReactComponent(Image, {
+      className: 'Image medium',
+      source,
+      alt: 'App icon',
+    });
+  });
+
+  it('renders xlarge Shop app icon with an icon source', () => {
+    const appIcon = mountWithApp(
+      <AppIcon appTitle="Shop" size="xl" source={source} />,
+    );
+
+    expect(appIcon).toContainReactComponent('div', {
+      role: 'link',
+      onClick: expect.any(Function),
+      className: 'IconLink LinkDisabled',
+      'aria-label': 'View app details for app: Shop',
+      tabIndex: undefined,
+    });
+
+    expect(appIcon).toContainReactComponent(Image, {
+      className: 'Image xlarge',
+      source,
+      alt: 'Shop icon',
+    });
+  });
+
+  it('renders small Shop app icon with an icon source', () => {
+    const appIcon = mountWithApp(
+      <AppIcon appTitle="Shop" size="sm" source={source} />,
+    );
+
+    expect(appIcon).toContainReactComponent('div', {
+      role: 'link',
+      onClick: expect.any(Function),
+      className: 'IconLink LinkDisabled',
+      'aria-label': 'View app details for app: Shop',
+      tabIndex: undefined,
+    });
+
+    expect(appIcon).toContainReactComponent(Image, {
+      className: 'Image small',
+      source,
+      alt: 'Shop icon',
+    });
+  });
+
+  it('renders large Shop app icon with an icon source', () => {
+    const appIcon = mountWithApp(
+      <AppIcon appTitle="Shop" size="lg" source={source} />,
+    );
+
+    expect(appIcon).toContainReactComponent('div', {
+      role: 'link',
+      onClick: expect.any(Function),
+      className: 'IconLink LinkDisabled',
+      'aria-label': 'View app details for app: Shop',
+      tabIndex: undefined,
+    });
+
+    expect(appIcon).toContainReactComponent(Image, {
+      className: 'Image large',
+      source,
+      alt: 'Shop icon',
+    });
+  });
+
+  it('triggers onClick callback after clicking on icon', () => {
+    const spy = jest.fn();
+    const appIcon = mountWithApp(<AppIcon onClick={spy} source={source} />);
+
+    appIcon.find('div')?.trigger('onClick');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});

--- a/polaris-react/src/components/AppIcon/types.ts
+++ b/polaris-react/src/components/AppIcon/types.ts
@@ -1,0 +1,1 @@
+export type AppIconSize = 'sm' | 'md' | 'lg' | 'xl';

--- a/polaris-react/src/components/SkeletonAppCard/SkeletonAppCard.module.css
+++ b/polaris-react/src/components/SkeletonAppCard/SkeletonAppCard.module.css
@@ -1,0 +1,4 @@
+.MetadataContainer {
+  min-width: 0;
+  flex: 1;
+}

--- a/polaris-react/src/components/SkeletonAppCard/SkeletonAppCard.stories.tsx
+++ b/polaris-react/src/components/SkeletonAppCard/SkeletonAppCard.stories.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import type {ComponentMeta} from '@storybook/react';
+
+import {BlockStack} from '../BlockStack';
+import {Text} from '../Text';
+
+import {SkeletonAppCard} from './SkeletonAppCard';
+
+export default {
+  component: SkeletonAppCard,
+} as ComponentMeta<typeof SkeletonAppCard>;
+
+export function Default() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <SkeletonAppCard />
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function Sizes() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Small
+        </Text>
+        <div style={{maxWidth: '400px'}}>
+          <SkeletonAppCard size="sm" />
+        </div>
+
+        <Text as="h2" variant="headingSm">
+          Medium
+        </Text>
+        <div style={{maxWidth: '400px'}}>
+          <SkeletonAppCard size="md" />
+        </div>
+
+        <Text as="h2" variant="headingSm">
+          Large
+        </Text>
+        <div style={{maxWidth: '400px'}}>
+          <SkeletonAppCard size="lg" />
+        </div>
+      </BlockStack>
+    </BlockStack>
+  );
+}
+
+export function Variants() {
+  return (
+    <BlockStack gap="400">
+      <BlockStack gap="200">
+        <Text as="h2" variant="headingSm">
+          Primary
+        </Text>
+        <div style={{maxWidth: '400px'}}>
+          <SkeletonAppCard variant="primary" />
+        </div>
+
+        <Text as="h2" variant="headingSm">
+          Secondary
+        </Text>
+        <div style={{maxWidth: '400px'}}>
+          <SkeletonAppCard variant="secondary" />
+        </div>
+
+        <Text as="h2" variant="headingSm">
+          No Background
+        </Text>
+        <div style={{maxWidth: '400px'}}>
+          <SkeletonAppCard variant="noBackground" />
+        </div>
+      </BlockStack>
+    </BlockStack>
+  );
+}

--- a/polaris-react/src/components/SkeletonAppCard/SkeletonAppCard.tsx
+++ b/polaris-react/src/components/SkeletonAppCard/SkeletonAppCard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import {AppCardWrapper} from '../AppCard';
+import type {AppCardProps} from '../AppCard';
+import {SkeletonBodyText} from '../SkeletonBodyText';
+import {InlineStack} from '../InlineStack';
+import {BlockStack} from '../BlockStack';
+import {AppIcon} from '../AppIcon';
+import {useI18n} from '../../utilities/i18n';
+
+import styles from './SkeletonAppCard.module.css';
+
+type SkeletonAppCardProps = Pick<AppCardProps, 'size' | 'variant' | 'as'>;
+
+export function SkeletonAppCard({
+  variant = 'primary',
+  size = 'md',
+  as = 'div',
+}: SkeletonAppCardProps) {
+  const i18n = useI18n();
+  const numLines = Math.max(1, ['sm', 'md', 'lg'].indexOf(size) + 1);
+
+  const bodyTextLines = [];
+  for (let i = 1; i <= numLines; i += 1) {
+    bodyTextLines.push(<SkeletonBodyText lines={1} key={i} />);
+  }
+
+  const labelTranslationKey = `Polaris.SkeletonAppCard.loadingLabel`;
+
+  return (
+    <AppCardWrapper
+      variant={variant}
+      as={as}
+      accessibilityLabel={i18n.translate(labelTranslationKey)}
+    >
+      <InlineStack gap="300" blockAlign="center">
+        <AppIcon size={size} />
+        <div className={styles.MetadataContainer}>
+          <BlockStack align="center" gap="200">
+            {bodyTextLines}
+          </BlockStack>
+        </div>
+      </InlineStack>
+    </AppCardWrapper>
+  );
+}

--- a/polaris-react/src/components/SkeletonAppCard/index.ts
+++ b/polaris-react/src/components/SkeletonAppCard/index.ts
@@ -1,0 +1,1 @@
+export * from './SkeletonAppCard';

--- a/polaris-react/src/components/SkeletonAppCard/tests/SkeletonAppCard.test.tsx
+++ b/polaris-react/src/components/SkeletonAppCard/tests/SkeletonAppCard.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {SkeletonAppCard} from '../SkeletonAppCard';
+import {AppCardWrapper} from '../../AppCard';
+import {AppIcon} from '../../AppIcon';
+import {SkeletonBodyText} from '../../SkeletonBodyText';
+
+describe('<SkeletonAppCard />', () => {
+  it('renders with default props', () => {
+    const skeletonAppCard = mountWithApp(<SkeletonAppCard />);
+
+    expect(skeletonAppCard).toContainReactComponent(AppCardWrapper, {
+      variant: 'primary',
+      as: 'div',
+      accessibilityLabel: 'App card loading',
+    });
+
+    expect(skeletonAppCard).toContainReactComponent(AppIcon, {size: 'md'});
+
+    const skeletonLines = skeletonAppCard.findAll(SkeletonBodyText);
+
+    expect(skeletonLines).toHaveLength(2);
+  });
+
+  it('renders a large card using secondary variant as a li element', () => {
+    const skeletonAppCard = mountWithApp(
+      <SkeletonAppCard size="lg" variant="secondary" as="li" />,
+    );
+
+    expect(skeletonAppCard).toContainReactComponent(AppCardWrapper, {
+      variant: 'secondary',
+      as: 'li',
+      accessibilityLabel: 'App card loading',
+    });
+
+    expect(skeletonAppCard).toContainReactComponent(AppIcon, {size: 'lg'});
+
+    const skeletonLines = skeletonAppCard.findAll(SkeletonBodyText);
+
+    expect(skeletonLines).toHaveLength(3);
+  });
+
+  it('renders a small card using noBackground variant as a li element', () => {
+    const skeletonAppCard = mountWithApp(
+      <SkeletonAppCard size="sm" variant="noBackground" as="li" />,
+    );
+
+    expect(skeletonAppCard).toContainReactComponent(AppCardWrapper, {
+      variant: 'noBackground',
+      as: 'li',
+      accessibilityLabel: 'App card loading',
+    });
+
+    expect(skeletonAppCard).toContainReactComponent(AppIcon, {size: 'sm'});
+
+    const skeletonLines = skeletonAppCard.findAll(SkeletonBodyText);
+
+    expect(skeletonLines).toHaveLength(1);
+  });
+});

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -37,6 +37,27 @@ export {DEFAULT_LOCALE, SUPPORTED_LOCALES} from './configure';
 export {AppProvider} from './components/AppProvider';
 export type {AppProviderProps} from './components/AppProvider';
 
+export {
+  AppCard,
+  AppCardSizingMode,
+  AppCardWrapper,
+  useAppCardSizing,
+} from './components/AppCard';
+export type {AppCardProps, AppCardWrapperProps} from './components/AppCard';
+
+export {AppCardAction, AppCardActionEnum} from './components/AppCardAction';
+export type {
+  AppCardActionProps,
+  AppCardActionType,
+} from './components/AppCardAction';
+
+export {AppCardMetadata} from './components/AppCardMetadata';
+
+export {AppCardBadge, AppCardBadgeEnum} from './components/AppCardBadge';
+export type {AppCardBadgeProps} from './components/AppCardBadge';
+
+export {AppIcon} from './components/AppIcon';
+
 export {AccountConnection} from './components/AccountConnection';
 export type {AccountConnectionProps} from './components/AccountConnection';
 
@@ -334,6 +355,8 @@ export {DATA_ATTRIBUTE} from './components/shared';
 
 export {Sheet} from './components/Sheet';
 export type {SheetProps} from './components/Sheet';
+
+export {SkeletonAppCard} from './components/SkeletonAppCard';
 
 export {SkeletonBodyText} from './components/SkeletonBodyText';
 export type {SkeletonBodyTextProps} from './components/SkeletonBodyText';


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/apps-in-admin/issues/2128

See component diagrams here: https://www.figma.com/file/Mv1OaVzpRn0uS23gE5EMTP/Shared-App-Card-UI-Diagrams?type=whiteboard&t=qc1SxVDzAEju4C08-0

**Do not merge to @shopify/Polaris, team will be moving this to the internal-only repo soon**

**NOTE: I have not added docs/documentation yet, want to get feedback/review on overall structure first**

Spin URL for Storybook demo: https://polaris.app-card-polaris.ryan-schingeck.us.spin.dev/?path=/story/all-components-appcardmetadata--no-description 

Adds the following new components to Polaris to support our shared AppCard component:

1. App Card
<img width="533" alt="Screenshot 2024-04-24 at 3 36 10 PM" src="https://github.com/Shopify/polaris/assets/97745931/9c70db34-8f0c-43c7-ab2d-16d6650e12f6">

2. AppCardAction
<img width="100" alt="Screenshot 2024-04-24 at 3 36 26 PM" src="https://github.com/Shopify/polaris/assets/97745931/d73ed307-b801-49a8-9e03-dc0f5504e4ed">

3. AppCardBadge
<img width="123" alt="Screenshot 2024-04-24 at 3 36 42 PM" src="https://github.com/Shopify/polaris/assets/97745931/e9488cd5-93dd-40e5-ac36-cef38a161d2c">

4. AppCardMetadata
<img width="653" alt="Screenshot 2024-04-24 at 3 37 25 PM" src="https://github.com/Shopify/polaris/assets/97745931/a5b458c5-2859-43cd-a4a2-7f2a92dd01b2">

5. AppIcon
<img width="69" alt="Screenshot 2024-04-24 at 3 37 41 PM" src="https://github.com/Shopify/polaris/assets/97745931/0c3b0da2-503e-4e8d-9022-ee8e177ed8cf">

6. SkeletonAppCard
<img width="757" alt="Screenshot 2024-04-24 at 3 37 58 PM" src="https://github.com/Shopify/polaris/assets/97745931/07c02198-063c-4516-b57c-58c964a4e950">


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
