### PR TITLE
Support iOS dynamic type for all screen sizes

### DIFF
--- a/.changeset/kind-lemons-search.md
+++ b/.changeset/kind-lemons-search.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated at-rule for supporting iOS dynamic type for all screen sizes.

--- a/polaris-react/src/components/AppProvider/global.css
+++ b/polaris-react/src/components/AppProvider/global.css
@@ -110,11 +110,9 @@ html {
   system font and then define font-families and rem-based
   font-sizes on descendant elements:
 */
-@supports (font: -apple-system-body) {
-  @media (--p-breakpoints-sm-down) {
-    html {
-      font: -apple-system-body;
-    }
+@supports (font: -apple-system-body) and (-webkit-touch-callout: none) {
+  html {
+    font: -apple-system-body;
   }
 }
 


### PR DESCRIPTION
This PR replaces the `@media` with a `@supports` rule to enable dynamic type for iOS devices larger than mobile (e.g., iPad).

See [`-webkit-touch-callout` MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout)

Related to @davebcn87's [comment here](https://github.com/Shopify/polaris-internal/issues/1586#issuecomment-2060578828)