### PR TITLE
Update `Banner` mobile styles

### DIFF
--- a/.changeset/grumpy-cheetahs-hug.md
+++ b/.changeset/grumpy-cheetahs-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated `Banner` styling for small screens

--- a/polaris-react/src/components/Banner/Banner.module.css
+++ b/polaris-react/src/components/Banner/Banner.module.css
@@ -21,8 +21,6 @@
 }
 
 .withinPage {
-  @mixin shadow-bevel var(--p-shadow-200), var(--p-border-radius-0);
-
   @media (--p-breakpoints-sm-up) {
     @mixin shadow-bevel var(--p-shadow-200), var(--p-border-radius-300);
   }

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -299,8 +299,8 @@ export const All = {
         </Text>
         <AllBanners
           onDismiss={() => {}}
-          action={{content: 'Primary action'}}
-          secondaryAction={{content: 'Secondary action'}}
+          action={{content: 'Primary'}}
+          secondaryAction={{content: 'Secondary'}}
         />
         <Text as="h2" variant="headingMd">
           Default by status

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -108,6 +108,7 @@ export function BannerLayout({
   children,
 }: BannerProps) {
   const i18n = useI18n();
+  const {smUp} = useBreakpoints();
   const withinContentContainer = useContext(WithinContentContext);
   const isInlineIconBanner = !title && !withinContentContainer;
   const bannerTone = Object.keys(bannerAttributes).includes(tone)
@@ -133,7 +134,7 @@ export function BannerLayout({
     ),
     actionButtons:
       action || secondaryAction ? (
-        <ButtonGroup>
+        <ButtonGroup fullWidth={!smUp} gap={smUp ? 'tight' : 'extraTight'}>
           {action && (
             <Button onClick={action.onAction} {...action}>
               {action.content}
@@ -152,7 +153,13 @@ export function BannerLayout({
         icon={
           <span
             className={
-              styles[isInlineIconBanner ? 'icon-secondary' : bannerColors.icon]
+              styles[
+                isInlineIconBanner
+                  ? 'icon-secondary'
+                  : smUp
+                  ? bannerColors.icon
+                  : 'icon-secondary'
+              ]
             }
           >
             <Icon source={XIcon} />
@@ -201,7 +208,19 @@ export function DefaultBanner({
   const {smUp} = useBreakpoints();
   const hasContent = children || actionButtons;
 
-  return (
+  const xsOnlyBannerMarkup = (
+    <InlineIconBanner
+      backgroundColor={backgroundColor}
+      bannerTitle={bannerTitle}
+      bannerIcon={bannerIcon}
+      actionButtons={actionButtons}
+      dismissButton={dismissButton}
+    >
+      {children}
+    </InlineIconBanner>
+  );
+
+  const smUpBannerMarkup = (
     <Box width="100%">
       <BlockStack align="space-between">
         <Box
@@ -237,15 +256,20 @@ export function DefaultBanner({
       </BlockStack>
     </Box>
   );
+
+  const bannerMarkup = smUp ? smUpBannerMarkup : xsOnlyBannerMarkup;
+
+  return bannerMarkup;
 }
 
 export function InlineIconBanner({
   backgroundColor,
+  bannerTitle,
   bannerIcon,
   actionButtons,
   dismissButton,
   children,
-}: PropsWithChildren<Omit<BannerLayoutProps, 'textColor' | 'bannerTitle'>>) {
+}: PropsWithChildren<Omit<BannerLayoutProps, 'textColor'>>) {
   const [blockAlign, setBlockAlign] =
     useState<InlineStackProps['blockAlign']>('center');
   const contentNode = useRef<HTMLDivElement>(null);
@@ -285,7 +309,16 @@ export function InlineIconBanner({
             ) : null}
             <Box ref={contentNode} width="100%">
               <BlockStack gap="200">
-                <div>{children}</div>
+                {bannerTitle ? (
+                  <BlockStack gap="100">
+                    <Text as="h2" variant="headingMd" breakWord>
+                      {bannerTitle}
+                    </Text>
+                    {children}
+                  </BlockStack>
+                ) : (
+                  <div>{children}</div>
+                )}
                 {actionButtons}
               </BlockStack>
             </Box>

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -119,6 +119,20 @@ export function BannerLayout({
       withinContentContainer ? 'withinContentContainer' : 'withinPage'
     ];
 
+  let iconClassName = '';
+
+  if (smUp) {
+    if (isInlineIconBanner) {
+      iconClassName = 'icon-secondary';
+    } else {
+      iconClassName = bannerColors.icon;
+    }
+  } else if (withinContentContainer) {
+    iconClassName = bannerColors.icon;
+  } else {
+    iconClassName = 'icon-secondary';
+  }
+
   const sharedBannerProps: BannerLayoutProps = {
     backgroundColor: bannerColors.background,
     textColor: bannerColors.text,
@@ -151,17 +165,7 @@ export function BannerLayout({
       <Button
         variant="tertiary"
         icon={
-          <span
-            className={
-              styles[
-                isInlineIconBanner
-                  ? 'icon-secondary'
-                  : smUp
-                  ? bannerColors.icon
-                  : 'icon-secondary'
-              ]
-            }
-          >
+          <span className={styles[iconClassName]}>
             <Icon source={XIcon} />
           </span>
         }

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -279,6 +279,7 @@ export function InlineIconBanner({
   const contentNode = useRef<HTMLDivElement>(null);
   const iconNode = useRef<HTMLDivElement>(null);
   const dismissIconNode = useRef<HTMLDivElement>(null);
+  const {smUp} = useBreakpoints();
 
   const handleResize = useCallback(() => {
     const contentHeight = contentNode.current?.offsetHeight;
@@ -315,9 +316,9 @@ export function InlineIconBanner({
               <BlockStack gap="200">
                 {bannerTitle ? (
                   <BlockStack gap="100">
-                    <Text as="h2" variant="headingMd" breakWord>
+                    <Box paddingBlockStart={smUp ? '0' : '100'}>
                       {bannerTitle}
-                    </Text>
+                    </Box>
                     {children}
                   </BlockStack>
                 ) : (

--- a/polaris-react/src/components/Banner/tests/Banner.test.tsx
+++ b/polaris-react/src/components/Banner/tests/Banner.test.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef} from 'react';
 import {
   PlusCircleIcon,
-  CheckIcon,
+  CheckCircleIcon,
   AlertTriangleIcon,
   InfoIcon,
   AlertDiamondIcon,
@@ -356,7 +356,7 @@ describe('<Banner />', () => {
 
   describe('icon', () => {
     it.each([
-      ['success', CheckIcon],
+      ['success', CheckCircleIcon],
       ['info', InfoIcon],
       ['warning', AlertTriangleIcon],
       ['critical', AlertDiamondIcon],

--- a/polaris-react/src/components/Banner/utilities.ts
+++ b/polaris-react/src/components/Banner/utilities.ts
@@ -7,7 +7,7 @@ import {
   AlertDiamondIcon,
   InfoIcon,
   AlertTriangleIcon,
-  CheckIcon,
+  CheckCircleIcon,
 } from '@shopify/polaris-icons';
 import {useImperativeHandle, useRef, useState} from 'react';
 
@@ -39,7 +39,7 @@ export const bannerAttributes: {[key in BannerTone]: BannerAttributes} = {
       text: 'text-success',
       icon: 'text-success',
     },
-    icon: CheckIcon,
+    icon: CheckCircleIcon,
   },
   warning: {
     withinPage: {


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/mobile/issues/33410

### WHAT is this pull request doing?

- Removes shadow below `sm` breakpoint 
- Changes styling of banners with titles to match that of `InlineIconBanner`s below `sm` breakpoint
- Tightens spacing between of action buttons below `sm` breakpoint 
- Makes action buttons take up available space below `sm` breakpoint 

| Before (below `sm` breakpoint) | After (below `sm` breakpoint) | 
| -- | -- | 
|![5d559397bae39100201eedc1-dopnorbvqa chromatic com_iframe html_args= globals=viewport_0 id=all-components-banner--all viewMode=story(iPhone SE)](https://github.com/Shopify/polaris/assets/21976492/93b969b8-0505-4253-bd3d-64c3d35d75b7)|![5d559397bae39100201eedc1-wsfhiihlki chromatic com_iframe html_args= globals=viewport_0 id=all-components-banner--all viewMode=story(iPhone SE)](https://github.com/Shopify/polaris/assets/21976492/dddd2b7f-6e4e-4a69-8df6-85aa8427d219)| 

- 📕 [Storybook Before](https://5d559397bae39100201eedc1-dopnorbvqa.chromatic.com/?path=/story/all-components-banner--all&globals=viewport:0)
- 📕 [Storybook After](https://5d559397bae39100201eedc1-wsfhiihlki.chromatic.com/?path=/story/all-components-banner--all&globals=viewport:0)
