### PR TITLE
[Popover] fix scrolling position reseted on re-render

### DIFF
--- a/.changeset/brave-bobcats-hear.md
+++ b/.changeset/brave-bobcats-hear.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+- Fixed popover overlay losing scroll position on re-render

--- a/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -74,6 +74,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
   private contentNode = createRef<HTMLDivElement>();
   private enteringTimer?: number;
   private overlayRef: React.RefObject<PositionedOverlay>;
+  private lastContentStyles?: {height: number};
 
   constructor(props: PopoverOverlayProps) {
     super(props);
@@ -225,7 +226,10 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       positioning && styles[variationName('positioned', positioning)],
     );
 
-    const contentStyles = measuring ? undefined : {height: desiredHeight};
+    const contentStyles = measuring
+      ? this.lastContentStyles
+      : {height: desiredHeight};
+    this.lastContentStyles = contentStyles;
     const contentClassNames = classNames(
       styles.Content,
       fullHeight && styles['Content-fullHeight'],


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #11960

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

As Popover component re-renders which cause the [desiredHeight](https://github.com/Shopify/polaris/blob/995079cc7c5c5087d662609c75c11eea58920f6d/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx#L228) reseted to 0 and back to expected value. This seems to work fine if the popover's content is small without overflow. Yet, it creates an issue when there is a scrolling position in place. We can fix it by storing the last computed value and reuse it in order to avoid scrolling position resettled to 0

### How to 🎩

Set up storybook as per this sandbox - https://codesandbox.io/p/sandbox/amazing-paper-qrv23n

Open the sample popover component, then scroll to bottom and click on the bottom button to re-render the component. The scroll position should remain intact without being reseted to 0

Before:


https://github.com/Shopify/polaris/assets/17794897/0d05aa8b-c829-4650-8f77-616c7d51bd8c


After:


https://github.com/Shopify/polaris/assets/17794897/de2f7224-7525-4481-ab7e-e37f10348156



🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
