### PR TITLE
[Banner]  Measure `contentNode` on change rather than `window.onResize`

### DIFF
--- a/.changeset/weak-crabs-arrive.md
+++ b/.changeset/weak-crabs-arrive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Use callback ref to more accurately detect content changes in Banner

--- a/.changeset/weak-crabs-arrive.md
+++ b/.changeset/weak-crabs-arrive.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Use callback ref to more accurately detect content changes in Banner
+Fixed `Banner` not accurately detecting content changes

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -321,6 +321,29 @@ export const WithDynamicContent = {
   },
 };
 
+export const WithHiddenIcon = {
+  render() {
+    return (
+      <AllBanners
+        title={undefined}
+        hideIcon
+        onDismiss={() => {}}
+        children={
+          <>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </>
+        }
+      />
+    );
+  },
+};
+
 export const All = {
   render() {
     return (

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -290,6 +290,37 @@ export const CustomIcon = {
   },
 };
 
+export const WithDynamicContent = {
+  render() {
+    const [contentExpanded, setContentExpanded] = useState(false);
+
+    const toggleContent = () => setContentExpanded(!contentExpanded);
+
+    return (
+      <Banner tone="info">
+        <Text as="p" variant="bodyMd">
+          Here is the first line of content.{' '}
+          <Button variant="plain" onClick={toggleContent}>
+            {!contentExpanded
+              ? 'Expand for more content.'
+              : 'Collapse content.'}
+          </Button>
+        </Text>
+        {contentExpanded ? (
+          <>
+            <Text as="p" variant="bodyMd">
+              Here is more content.
+            </Text>
+            <Text as="p" variant="bodyMd">
+              And here is even more.
+            </Text>
+          </>
+        ) : null}
+      </Banner>
+    );
+  },
+};
+
 export const All = {
   render() {
     return (

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useContext,
-  useRef,
-  useState,
-  useEffect,
-} from 'react';
+import React, {forwardRef, useContext, useRef, useState} from 'react';
 import type {PropsWithChildren} from 'react';
 import type {ColorTextAlias} from '@shopify/polaris-tokens';
 import {XIcon} from '@shopify/polaris-icons';
@@ -246,33 +240,22 @@ export function InlineIconBanner({
 }: PropsWithChildren<Omit<BannerLayoutProps, 'textColor' | 'bannerTitle'>>) {
   const [blockAlign, setBlockAlign] =
     useState<InlineStackProps['blockAlign']>('center');
-  const contentNode = useRef<HTMLDivElement>(null);
   const iconNode = useRef<HTMLDivElement>(null);
   const dismissIconNode = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!contentNode.current) return;
+  const contentNodeCallback = (node: HTMLDivElement) => {
+    if (!node) return;
 
-    const observer = new ResizeObserver((entries) => {
-      const target = entries[0].target as HTMLDivElement;
-      const contentHeight = target.offsetHeight;
+    const contentHeight = node.offsetHeight;
+    const iconBoxHeight =
+      iconNode.current?.offsetHeight || dismissIconNode.current?.offsetHeight;
 
-      const iconBoxHeight =
-        iconNode.current?.offsetHeight || dismissIconNode.current?.offsetHeight;
+    if (!contentHeight || !iconBoxHeight) return;
 
-      if (!contentHeight || !iconBoxHeight) return;
-
-      contentHeight > iconBoxHeight
-        ? setBlockAlign('start')
-        : setBlockAlign('center');
-    });
-
-    observer.observe(contentNode.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
+    contentHeight > iconBoxHeight
+      ? setBlockAlign('start')
+      : setBlockAlign('center');
+  };
 
   return (
     <Box width="100%" padding="300" borderRadius="300">
@@ -290,7 +273,7 @@ export function InlineIconBanner({
                 </Box>
               </div>
             ) : null}
-            <Box ref={contentNode} width="100%">
+            <Box ref={contentNodeCallback} width="100%">
               <BlockStack gap="200">
                 <div>{children}</div>
                 {actionButtons}

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -4,7 +4,6 @@ import React, {
   useRef,
   useState,
   useEffect,
-  useCallback,
 } from 'react';
 import type {PropsWithChildren} from 'react';
 import type {ColorTextAlias} from '@shopify/polaris-tokens';
@@ -25,7 +24,6 @@ import {WithinContentContext} from '../../utilities/within-content-context';
 import {classNames} from '../../utilities/css';
 import {useBreakpoints} from '../../utilities/breakpoints';
 import {useI18n} from '../../utilities/i18n';
-import {useEventListener} from '../../utilities/use-event-listener';
 import {BlockStack} from '../BlockStack';
 
 import styles from './Banner.module.css';
@@ -252,20 +250,29 @@ export function InlineIconBanner({
   const iconNode = useRef<HTMLDivElement>(null);
   const dismissIconNode = useRef<HTMLDivElement>(null);
 
-  const handleResize = useCallback(() => {
-    const contentHeight = contentNode.current?.offsetHeight;
-    const iconBoxHeight =
-      iconNode.current?.offsetHeight || dismissIconNode.current?.offsetHeight;
+  useEffect(() => {
+    if (!contentNode.current) return;
 
-    if (!contentHeight || !iconBoxHeight) return;
+    const observer = new ResizeObserver((entries) => {
+      const target = entries[0].target as HTMLDivElement;
+      const contentHeight = target.offsetHeight;
 
-    contentHeight > iconBoxHeight
-      ? setBlockAlign('start')
-      : setBlockAlign('center');
+      const iconBoxHeight =
+        iconNode.current?.offsetHeight || dismissIconNode.current?.offsetHeight;
+
+      if (!contentHeight || !iconBoxHeight) return;
+
+      contentHeight > iconBoxHeight
+        ? setBlockAlign('start')
+        : setBlockAlign('center');
+    });
+
+    observer.observe(contentNode.current);
+
+    return () => {
+      observer.disconnect();
+    };
   }, []);
-
-  useEffect(() => handleResize(), [handleResize]);
-  useEventListener('resize', handleResize);
 
   return (
     <Box width="100%" padding="300" borderRadius="300">

--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -1,4 +1,10 @@
-import React, {forwardRef, useContext, useRef, useState} from 'react';
+import React, {
+  forwardRef,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import type {PropsWithChildren} from 'react';
 import type {ColorTextAlias} from '@shopify/polaris-tokens';
 import {XIcon} from '@shopify/polaris-icons';
@@ -242,20 +248,27 @@ export function InlineIconBanner({
     useState<InlineStackProps['blockAlign']>('center');
   const iconNode = useRef<HTMLDivElement>(null);
   const dismissIconNode = useRef<HTMLDivElement>(null);
+  const contentNode = useRef<HTMLDivElement>(null);
 
-  const contentNodeCallback = (node: HTMLDivElement) => {
-    if (!node) return;
+  useEffect(() => {
+    const updateLayout = () => {
+      const contentHeight = contentNode.current?.offsetHeight ?? 0;
+      const iconBoxHeight =
+        iconNode.current?.offsetHeight || dismissIconNode.current?.offsetHeight;
 
-    const contentHeight = node.offsetHeight;
-    const iconBoxHeight =
-      iconNode.current?.offsetHeight || dismissIconNode.current?.offsetHeight;
+      if (contentHeight && iconBoxHeight) {
+        setBlockAlign(contentHeight > iconBoxHeight ? 'start' : 'center');
+      }
+    };
 
-    if (!contentHeight || !iconBoxHeight) return;
+    const observer = new ResizeObserver(updateLayout);
 
-    contentHeight > iconBoxHeight
-      ? setBlockAlign('start')
-      : setBlockAlign('center');
-  };
+    if (iconNode.current) observer.observe(iconNode.current);
+    if (dismissIconNode.current) observer.observe(dismissIconNode.current);
+    if (contentNode.current) observer.observe(contentNode.current);
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <Box width="100%" padding="300" borderRadius="300">
@@ -273,7 +286,7 @@ export function InlineIconBanner({
                 </Box>
               </div>
             ) : null}
-            <Box ref={contentNodeCallback} width="100%">
+            <Box ref={contentNode} width="100%">
               <BlockStack gap="200">
                 <div>{children}</div>
                 {actionButtons}

--- a/polaris-react/tests/setup/environment.ts
+++ b/polaris-react/tests/setup/environment.ts
@@ -1,62 +1,5 @@
 export {};
 
-interface ResizeObserverMockType {
-  callback: ResizeObserverCallback;
-  observations: Element[];
-  observe: (target: Element) => void;
-  unobserve: (target: Element) => void;
-  disconnect: () => void;
-}
-
-class ResizeObserverMock implements ResizeObserverMockType {
-  callback: ResizeObserverCallback;
-  observations: Element[];
-
-  constructor(callback: ResizeObserverCallback) {
-    this.callback = callback;
-    this.observations = [];
-  }
-
-  observe(target: Element): void {
-    this.observations.push(target);
-    this.callback(
-      [
-        {
-          target,
-          contentRect: target.getBoundingClientRect(),
-          borderBoxSize: [
-            {
-              blockSize: target.clientHeight,
-              inlineSize: target.clientWidth,
-            },
-          ],
-          contentBoxSize: [
-            {
-              blockSize: target.clientHeight,
-              inlineSize: target.clientWidth,
-            },
-          ],
-          devicePixelContentBoxSize: [
-            {
-              blockSize: target.clientHeight,
-              inlineSize: target.clientWidth,
-            },
-          ],
-        },
-      ],
-      this,
-    );
-  }
-
-  unobserve(target: Element): void {
-    this.observations = this.observations.filter((obs) => obs !== target);
-  }
-
-  disconnect(): void {
-    this.observations = [];
-  }
-}
-
 if (typeof window !== 'undefined') {
   // Mocks for scrolling
   window.scroll = () => {};
@@ -67,8 +10,6 @@ if (typeof window !== 'undefined') {
     _features?: string,
     _replace?: boolean,
   ) => null;
-
-  window.ResizeObserver = ResizeObserverMock;
 }
 
 const IGNORE_ERROR_REGEXES = [

--- a/polaris-react/tests/setup/environment.ts
+++ b/polaris-react/tests/setup/environment.ts
@@ -1,5 +1,62 @@
 export {};
 
+interface ResizeObserverMockType {
+  callback: ResizeObserverCallback;
+  observations: Element[];
+  observe: (target: Element) => void;
+  unobserve: (target: Element) => void;
+  disconnect: () => void;
+}
+
+class ResizeObserverMock implements ResizeObserverMockType {
+  callback: ResizeObserverCallback;
+  observations: Element[];
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    this.observations = [];
+  }
+
+  observe(target: Element): void {
+    this.observations.push(target);
+    this.callback(
+      [
+        {
+          target,
+          contentRect: target.getBoundingClientRect(),
+          borderBoxSize: [
+            {
+              blockSize: target.clientHeight,
+              inlineSize: target.clientWidth,
+            },
+          ],
+          contentBoxSize: [
+            {
+              blockSize: target.clientHeight,
+              inlineSize: target.clientWidth,
+            },
+          ],
+          devicePixelContentBoxSize: [
+            {
+              blockSize: target.clientHeight,
+              inlineSize: target.clientWidth,
+            },
+          ],
+        },
+      ],
+      this,
+    );
+  }
+
+  unobserve(target: Element): void {
+    this.observations = this.observations.filter((obs) => obs !== target);
+  }
+
+  disconnect(): void {
+    this.observations = [];
+  }
+}
+
 if (typeof window !== 'undefined') {
   // Mocks for scrolling
   window.scroll = () => {};
@@ -10,6 +67,8 @@ if (typeof window !== 'undefined') {
     _features?: string,
     _replace?: boolean,
   ) => null;
+
+  window.ResizeObserver = ResizeObserverMock;
 }
 
 const IGNORE_ERROR_REGEXES = [


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/polaris/issues/11770 <!-- link to issue if one exists -->

This PR fixes an issue where the `blockAlign` value was not being properly updated when `contentNode.offsetHeight` would change. This was because the measurement/calculation would only trigger on `window.resize`, and would not trigger via other actions (such as a banner having content dynamically added/removed). 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

I've fixed this by using `ResizeObserver` to trigger recalculation whenever `contentNode` is resized, rather than the current `handleResize` which is only triggered on `window.resize`.


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

[Storybook link](https://5d559397bae39100201eedc1-wzruvmwjwa.chromatic.com/?path=/story/all-components-banner--with-dynamic-content)
[Web w/ snapshot](https://admin.web.pf-pdp-required-sku-follows.jay-laiche.us.spin.dev/store/shop1/products/2)
 
This includes an example story where the banner content is dynamically changed, resulting in `contentNode` changes, and triggering the correct `blockAlign` property applied. 

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
