### PR TITLE
[FormLayout] Ensure Item container width is stable

### DIFF
--- a/.changeset/fresh-beds-roll.md
+++ b/.changeset/fresh-beds-roll.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed sibling `FormLayout.Item` widths not remaining equal when wrapped in `FormLayout.Group`

--- a/polaris-react/src/components/FormLayout/FormLayout.module.css
+++ b/polaris-react/src/components/FormLayout/FormLayout.module.css
@@ -1,7 +1,7 @@
 .Item {
   /* stylelint-disable-next-line -- Polaris component custom properties */
   --pc-form-layout-item-min-size: 220px;
-  flex: 1 1 auto;
+  flex: 1 1 0;
 
   &.grouped {
     /* stylelint-disable-next-line -- Polaris component custom properties */


### PR DESCRIPTION
### WHY are these changes introduced?

`FormLayout.Item` currently has an `auto` `flex-basis`, which means when the form initially renders grouped items are equal widths automatically as we expect, but individual items are allowed to grow when their content changes instead of maintaining the equal distribution in the available space. For example, a group of two `TextField` components starts out with the item containers being equal, but an item can expand unexpectedly when a `TextField` dynamically has an error message or if one `TextField` has help text and the other doesn't. 

[CodeSandbox reproduction](https://codesandbox.io/p/sandbox/falling-firefly-xmskmx?file=%2FApp.tsx%3A9%2C1) 

### WHAT is this pull request doing?

This PR sets `flex-basis` to `0`, ensuring sibling `FormLayout.Item`widths are stably equal when grouped.

| Before | After |
|--------|--------|
| ![Screenshot 2024-05-02 at 4 21 04 PM](https://github.com/Shopify/polaris/assets/18447883/c4c00c3a-18b3-4060-91aa-0292dd6d3f92)|![Screenshot 2024-05-02 at 4 21 09 PM](https://github.com/Shopify/polaris/assets/18447883/0e9d35a2-854f-4b98-aaad-774082cb91a5) |

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

🌀 [Spinstance](https://admin.web.form-layout-item-stable-width.chloe-rice.us.spin.dev/store/shop1/customers/new)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] ~Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)~
- [ ] ~Updated the component's `README.md` with documentation changes~
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
