### PR TITLE
[Mobile] Disabled text selection

### DIFF
--- a/.changeset/tall-parents-rhyme.md
+++ b/.changeset/tall-parents-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Disabled text selection in `Text` on smaller screens only

--- a/polaris-react/src/components/Text/Text.module.css
+++ b/polaris-react/src/components/Text/Text.module.css
@@ -1,6 +1,11 @@
 .root {
   margin: 0;
   text-align: inherit;
+  user-select: none;
+
+  @media (--p-breakpoints-md-up) {
+    user-select: initial;
+  }
 }
 
 .block {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/mobile/issues/33793

### WHAT is this pull request doing?

Disables text selection on small screens in order to be consistent with the behaviour on mobile.

### How to 🎩

- Go to [storybook](https://5d559397bae39100201eedc1-bdbixidfaf.chromatic.com/?path=/story/playground--details-page)
- Confirm text can be selected on a large screen
- Confirm text cannot be selected on a small screen

Large screen|Small screen
:---:|:---:
<img width="527" alt="Screenshot 2024-05-06 at 10 31 50 AM" src="https://github.com/Shopify/polaris/assets/3474483/d0f04830-ef98-4e56-bf70-d29b84e5a9e2">|<img width="527" alt="Screenshot 2024-05-06 at 10 31 50 AM" src="https://github.com/Shopify/polaris/assets/3474483/e9dc6973-0a3c-42ef-b467-b29c531ad7ef">

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
