### PR TITLE
Add name and value props to button

### DIFF
--- a/.changeset/pretty-seas-camp.md
+++ b/.changeset/pretty-seas-camp.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add name and value props to button

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -60,6 +60,8 @@ interface CommonButtonProps
     | 'onBlur'
     | 'onMouseEnter'
     | 'onTouchStart'
+    | 'name'
+    | 'value'
   > {
   className: UnstyledButtonProps['className'];
   onMouseUp: MouseUpBlurHandler;
@@ -88,6 +90,8 @@ type ActionButtonProps = Pick<
 
 export function Button({
   id,
+  name,
+  value,
   children,
   url,
   disabled,
@@ -207,6 +211,8 @@ export function Button({
   const commonProps: CommonButtonProps = {
     id,
     className,
+    name,
+    value,
     accessibilityLabel,
     ariaDescribedBy,
     role,

--- a/polaris-react/src/components/Button/tests/Button.test.tsx
+++ b/polaris-react/src/components/Button/tests/Button.test.tsx
@@ -47,6 +47,22 @@ describe('<Button />', () => {
     });
   });
 
+  describe('name', () => {
+    it('passes prop', () => {
+      const name = 'intent';
+      const button = mountWithApp(<Button name={name} />);
+      expect(button).toContainReactComponent(UnstyledButton, {name});
+    });
+  });
+
+  describe('value', () => {
+    it('passes prop', () => {
+      const value = 'create';
+      const button = mountWithApp(<Button value={value} />);
+      expect(button).toContainReactComponent(UnstyledButton, {value});
+    });
+  });
+
   describe('url', () => {
     it('passes prop', () => {
       const mockUrl = 'https://google.com';

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -53,6 +53,10 @@ export interface BaseButton {
   id?: string;
   /** A destination to link to, rendered in the href attribute of a link */
   url?: string;
+  /** Name of the button */
+  name?: string;
+  /** The value associated with the button's name when it's submitted with the form data */
+  value?: string;
   /** Forces url to open in a new tab */
   external?: boolean;
   /** Where to display the url */


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds `name` and `value` as valid props to the Button component (`UnstyledButton` included). 

Shopify offers the [Remix app template](https://github.com/Shopify/shopify-app-template-remix) to quickly bootstrap apps. With Remix you can only have a single action export per route, so in order to handle multiple forms per route you need a way to distinguish between which form was submitted in the action. 

The Remix docs suggests doing this by sending a form input with a value that indicates the action you want to take. Specifically, it [suggests](https://remix.run/docs/en/main/guides/faq#how-do-i-handle-multiple-forms-in-one-route) adding a `name` and `value` attribute to the submit button. With Polaris buttons, however, you can't pass a name or value. This PR allows them to be passed. Note that these props don't really do anything functionally if the button isn't used in a form to submit the form.

I should also point out that it's possible to use a hidden input `<input name="hello" value="world" type="hidden" />` to solve the use case above but in my opinion `name` and `value` on the submit button have more semantic meaning and it's less code.

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
