### PR TITLE
[DropZone] Fix error on dragenter for glb/gltf files

### DIFF
--- a/.changeset/popular-knives-guess.md
+++ b/.changeset/popular-knives-guess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Update DropZone so it does not error on dragenter events for glb/gltf files

--- a/polaris-react/src/components/DropZone/tests/DropZone.test.tsx
+++ b/polaris-react/src/components/DropZone/tests/DropZone.test.tsx
@@ -90,6 +90,37 @@ describe('<DropZone />', () => {
     expect(spy).toHaveBeenCalledWith(files, acceptedFiles, rejectedFiles);
   });
 
+  it('calls the onDrop callback with files, acceptedFiles, and rejectedFiles when the accept prop is an extension', () => {
+    const dropZone = mountWithApp(<DropZone onDrop={spy} accept=".jpg" />);
+    const testFiles = [{type: 'image/jpeg', name: 'cat.jpg'}];
+    fireEvent({wrapper: dropZone, testFiles});
+    expect(spy).toHaveBeenCalledWith(testFiles, testFiles, []);
+  });
+
+  it('calls the onDrop callback with files, acceptedFiles, and rejectedFiles when the mime type is empty', () => {
+    const dropZone = mountWithApp(<DropZone onDrop={spy} accept=".glb" />);
+    const testFiles = [{type: '', name: 'cat.glb'}];
+    fireEvent({wrapper: dropZone, testFiles});
+    expect(spy).toHaveBeenCalledWith(testFiles, testFiles, []);
+  });
+
+  it('calls the onDrop callback with files, acceptedFiles, and rejectedFiles when the accept prop is a combination of mime types and extensions', () => {
+    const dropZone = mountWithApp(
+      <DropZone onDrop={spy} accept="image/jpeg,.glb" />,
+    );
+    const testFiles = [
+      {type: 'image/jpeg', name: 'cat.jpg'},
+      {type: '', name: 'cat.glb'},
+      {type: 'image/png', name: 'cat.png'},
+    ];
+    fireEvent({wrapper: dropZone, testFiles});
+    expect(spy).toHaveBeenCalledWith(
+      testFiles,
+      [testFiles[0], testFiles[1]],
+      [testFiles[2]],
+    );
+  });
+
   it('calls the onDropAccepted callback with acceptedFiles when it accepts only jpeg', () => {
     const dropZone = mountWithApp(
       <DropZone onDropAccepted={spy} accept="image/jpeg" />,
@@ -410,6 +441,20 @@ describe('<DropZone />', () => {
       );
       fireEvent({wrapper: dropZone, eventType: 'dragenter'});
       expect(dropZone).toContainReactComponent(Text, {
+        children: errorOverlayText,
+      });
+    });
+
+    it('does not render an error on dragenter event when file extensions are accepted', () => {
+      const dropZone = mountWithApp(
+        <DropZone
+          errorOverlayText={errorOverlayText}
+          accept=".glb"
+          variableHeight
+        />,
+      );
+      fireEvent({wrapper: dropZone, eventType: 'dragenter'});
+      expect(dropZone).not.toContainReactComponent(Text, {
         children: errorOverlayText,
       });
     });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6644 <!-- link to issue if one exists -->

The goal is to have correct filtering in the OS file picker and also correct dropzone overlay messaging. This is currently not possible for glb/gltf files because:

1. In order to have correct filtering in the OS file picker we have to pass an accept string that uses the file extension like `.glb` (the mime type does not work)
2. But if you drag a `.glb` file from the OS file picker into the dropzone, the overlay shows an error because the dragenter event gets an empty mime type and does not have access to the filename, so the validation against the `accept` string fails. Note that even though an error is shown, if you drop the file it is accepted

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

This PR makes it so that if the `accept` prop contains any file extensions (ie. starts with a `.`), then on dragenter events, file validation agains the `accept` string is skipped (the customValidator will still run). The file will be validated against the `accept` string once it is dropped, because at that point the file name is known.

BEFORE

With `accept` = `.glb`

- Clicking on the dropzone opens the OS file picker, which has all files greyed out except any that have a filename ending in `.glb`
- Dragging a `.glb` file from the OS file picker onto the dropzone component shows an error:
  <img width="899" alt="image" src="https://github.com/Shopify/polaris/assets/11131143/0b87bc0f-e748-4675-a39b-1e08547ccdb5">

AFTER

With the same `accept` prop:

- The OS file picker behaves the exact same
- There is no error shown if a file is dragged over the dropzone (note that this is true of any file type, validation is deferred until the file is dropped)

If the `accept` prop contains only MIME types (and no file extensions), the behaviour of dragging a file over the dropzone is the exact same as before this change.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Paste the following in the Playground:

```tsx
import React from 'react';

import {DropZone, Page} from '../src';

export const Playground = {
  tags: ['skip-tests'],
  render() {
    const [acceptedFiles, setAcceptedFiles] = React.useState<File[]>([]);
    const [rejectedFiles, setRejectedFiles] = React.useState<File[]>([]);

    return (
      <Page title="Playground">
        <DropZone
          accept=".glb"
          type="file"
          onDrop={(_, accepted, rejected) => {
            setAcceptedFiles(accepted);
            setRejectedFiles(rejected);
          }}
        >
          <div>
            Accepted Files: {acceptedFiles.map((file) => file.name).join(', ')}
          </div>
          <div>
            Rejected Files: {rejectedFiles.map((file) => file.name).join(', ')}
          </div>
        </DropZone>
      </Page>
    );
  },
};
```

1. Click on the dropzone to open the OS file picker. Only files with a `.glb` extension should be selectable.
2. Select the `.glb` file. It should show up in the `Accepted files` list
3. Drag a `.glb` file from the OS file picker into the dropzone. There should be no error overlay
4. Drop the file. It should show up in the `Accepted files` list
5. Drag a file that does not end in `.glb` from the OS file picker into the dropzone. There should be no error overlay
6. Drop the file. It should show up in the `Rejected files` list

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases) https://github.com/Shopify/web/pull/127610
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
