### PR TITLE
[EmptySpace] - Adding actionList props for primary and secondary actions to make Buttons work as Popovers

### DIFF
--- a/.changeset/twenty-ligers-look.md
+++ b/.changeset/twenty-ligers-look.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add new props `actionList` and `secondaryActionList` to the `EmptySpace` component

--- a/polaris-react/src/components/EmptyState/EmptyState.stories.tsx
+++ b/polaris-react/src/components/EmptyState/EmptyState.stories.tsx
@@ -28,6 +28,33 @@ export const Default = {
   },
 };
 
+export const WithButtonWithPopovers = {
+  render() {
+    return (
+      <LegacyCard sectioned>
+        <EmptyState
+          heading="Manage your inventory transfers"
+          action={{content: 'Add transfer'}}
+          secondaryAction={{
+            content: 'Learn more',
+            url: 'https://help.shopify.com',
+          }}
+          secondaryActionList={[
+            {content: 'Secondary action 1', url: 'https://help.shopify.com'},
+            {content: 'Secondary action 2'},
+          ]}
+          image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
+          actionList={[{content: 'First action'}, {content: 'Second action'}]}
+        >
+          <Text as="p" variant="bodyMd">
+            Track and receive your incoming inventory from suppliers.
+          </Text>
+        </EmptyState>
+      </LegacyCard>
+    );
+  },
+};
+
 export const WithSubduedFooterContext = {
   render() {
     return (

--- a/polaris-react/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/polaris-react/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {Button} from '../../Button';
+import {Popover} from '../../Popover';
 import {Image} from '../../Image';
 import {Text} from '../../Text';
 import {UnstyledLink} from '../../UnstyledLink';
@@ -92,6 +93,47 @@ describe('<EmptyState />', () => {
       expect(emptyState).toContainReactComponent(UnstyledLink, {
         plain: undefined,
       });
+    });
+  });
+
+  describe('actionList', () => {
+    it('renders a button with a Popover if an action and an action list are both set', () => {
+      const actionListExpected = [{content: 'Option 1'}, {content: 'Option 2'}];
+      const emptyState = mountWithApp(
+        <EmptyState
+          action={{content: 'Add transfer'}}
+          actionList={actionListExpected}
+          image={imgSrc}
+        />,
+      );
+      expect(emptyState.find('button')).toContainReactText('Add transfer');
+      expect(emptyState).toContainReactComponent(Popover);
+    });
+
+    it('does not render a Popover if an action list is not set', () => {
+      const emptyState = mountWithApp(
+        <EmptyState action={{content: 'Add transfer'}} image={imgSrc} />,
+      );
+      expect(emptyState).not.toContainReactComponent(Popover);
+    });
+
+    it('does not render anything if an action and an action list are not set', () => {
+      const emptyState = mountWithApp(<EmptyState image={imgSrc} />);
+      expect(emptyState.find('button')).toBeNull();
+      expect(emptyState).not.toContainReactComponent(Popover);
+    });
+
+    it('sets the Button url to undefined when an action list is set (so it works as a popover instead)', () => {
+      const actionListExpected = [{content: 'Option 1'}, {content: 'Option 2'}];
+      const emptyState = mountWithApp(
+        <EmptyState
+          action={{content: 'Add transfer', url: 'https://help.shopify.com'}}
+          actionList={actionListExpected}
+          image={imgSrc}
+        />,
+      );
+      expect(emptyState.find(Button)).toHaveReactProps({url: undefined});
+      expect(emptyState).toContainReactComponent(Popover);
     });
   });
 
@@ -199,6 +241,34 @@ describe('<EmptyState />', () => {
       );
 
       expect(emptyState.find(UnstyledLink)).toContainReactText('Learn more');
+    });
+  });
+
+  describe('secondaryActionList', () => {
+    it('renders a button with a Popover if a secondaryAction and a secondary action list are both set', () => {
+      const actionListExpected = [{content: 'Option 1'}, {content: 'Option 2'}];
+      const emptyState = mountWithApp(
+        <EmptyState
+          secondaryAction={{content: 'Add transfer'}}
+          secondaryActionList={actionListExpected}
+          image={imgSrc}
+        />,
+      );
+      expect(emptyState.find('button')).toContainReactText('Add transfer');
+      expect(emptyState).toContainReactComponent(Popover);
+    });
+
+    it('does not render a Popover if a secondary action list is not set', () => {
+      const emptyState = mountWithApp(
+        <EmptyState action={{content: 'Add transfer'}} image={imgSrc} />,
+      );
+      expect(emptyState).not.toContainReactComponent(Popover);
+    });
+
+    it('does not render anything if an action and an action list are not set', () => {
+      const emptyState = mountWithApp(<EmptyState image={imgSrc} />);
+      expect(emptyState.find('button')).toBeNull();
+      expect(emptyState).not.toContainReactComponent(Popover);
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

[App discovery in admin proposes to add dropdown](https://docs.google.com/presentation/d/1HJ-DAL8BUlMHU43bIa1zdU1L4KhjvmqG9kGfmGo51tw/edit#slide=id.g28b82603417_7_107) options to the primary button for the `EmptySpace` component to add more functionality to the component. In order to allow this we propose adding a set of props `actionList` and `secondaryActionList` (the latter to add the same functionality to the `secondaryAction` button) of the type `ActionListItemDescriptor[]`. When the prop is present the button works as a Popover and which displays the actions under each of the primary and secondary buttons. 

### WHAT is this pull request doing?

Adding new props `actionList` and `secondaryActionList`. Defines a function that builds the markup depends on how the props are presented. Adding a new story to the storyboard and tests that verify that the right elements are being displayed with the provided props.

<img width="517" alt="Screenshot 2024-05-30 at 07 53 26" src="https://github.com/Shopify/polaris/assets/713575/db1f1fb8-03f7-4641-a06a-9384c7b77640">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
