### PR TITLE
Fix example code generation for Codesandbox Button

### DIFF
--- a/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx
+++ b/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx
@@ -4,7 +4,7 @@ import styles from './CodesandboxButton.module.scss';
 const getAppCode = (code: string) => {
   const lineWithFunctionName = code
     .split('\n')
-    .filter((name) => name.match(/function .*Example/g))?.[0];
+    .filter((name) => name.match(/function\s+(\w+)\s*\(/))?.[0];
   const functionName = lineWithFunctionName
     ? lineWithFunctionName.replace('function ', '').replace('() {', '')
     : 'Example';


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #12251

This PR fixes an issue where clicking **edit in CodeSandbox** on any component example results in a broken CodeSandbox example where the component is exported as Example, as opposed to it's proper name. 

In the images below you will see that clicking **edit in Codesandbox** for a `CardWithSection` in production results in a `export default Example` line at the bottom.

<img width="645" alt="Screenshot 2024-06-13 at 3 53 46 PM" src="https://github.com/Shopify/polaris/assets/4572275/631c4704-807e-4b0f-9643-c7b29f9ed03b">

### WHAT is this pull request doing?

This PR fixes the issue by finding the proper name in the code example

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
