### PR TITLE
Update `useBreakpoints` to use a single set of event listeners

### DIFF
--- a/.changeset/big-colts-doubt.md
+++ b/.changeset/big-colts-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated `useBreakpoints` to use a single set of event listeners


### PR DESCRIPTION
This PR optimizes the `useBreakpoints` hook by ensuring that only a single set of event listeners is used across all instances of the hook. Previously, each instance of `useBreakpoints` would add its own set of listeners, leading to unnecessary redundancy and performance issues at scale.

Additionally, the updates introduce a `referenceCounter` variable at the module scope to ensure event listeners are cleaned up only when all instances of `useBreakpoints` have been unmounted. This counter is incremented every time an instance of `useBreakpoints` is mounted and decremented when an instance is unmounted.

The event listeners are added when the first instance of `useBreakpoints` is mounted (i.e., when `referenceCounter` is 1) and removed when the last instance is unmounted (i.e., when `referenceCounter` is 0). This ensures that we only have one set of listeners active at any given time, regardless of the number of `useBreakpoints` instances.