### PR TITLE
Add `BreakpointsProvider` to `AppProvider`

### DIFF
--- a/.changeset/silent-houses-attack.md
+++ b/.changeset/silent-houses-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added `BreakpointsProvider` component

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -7,6 +7,7 @@ import {
 } from '@shopify/polaris-tokens';
 
 import {EphemeralPresenceManager} from '../EphemeralPresenceManager';
+import {BreakpointsProvider} from '../../utilities/breakpoints';
 import {MediaQueryProvider} from '../MediaQueryProvider';
 import {FocusManager} from '../FocusManager';
 import {PortalsManager} from '../PortalsManager';
@@ -190,15 +191,17 @@ export class AppProvider extends Component<AppProviderProps, State> {
               <ScrollLockManagerContext.Provider value={this.scrollLockManager}>
                 <StickyManagerContext.Provider value={this.stickyManager}>
                   <LinkContext.Provider value={link}>
-                    <MediaQueryProvider>
-                      <PortalsManager>
-                        <FocusManager>
-                          <EphemeralPresenceManager>
-                            {children}
-                          </EphemeralPresenceManager>
-                        </FocusManager>
-                      </PortalsManager>
-                    </MediaQueryProvider>
+                    <BreakpointsProvider>
+                      <MediaQueryProvider>
+                        <PortalsManager>
+                          <FocusManager>
+                            <EphemeralPresenceManager>
+                              {children}
+                            </EphemeralPresenceManager>
+                          </FocusManager>
+                        </PortalsManager>
+                      </MediaQueryProvider>
+                    </BreakpointsProvider>
                   </LinkContext.Provider>
                 </StickyManagerContext.Provider>
               </ScrollLockManagerContext.Provider>


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR ports the `useBreakpoints` logic to a `BreakpointsProvider` component to address performance degradation in the Admin. Previously, every instance of `useBreakpoints` added listeners for our directional breakpoints, whereas, the `BreakpointsProvider` instantiates the same logic once and disseminates the result via context.

TODO:
- [ ] Update tests

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
