### PR TITLE
Fix Suspense breakage due to a synchronous setState on mount

### DIFF
--- a/polaris-react/src/utilities/use-is-after-initial-mount.ts
+++ b/polaris-react/src/utilities/use-is-after-initial-mount.ts
@@ -1,4 +1,4 @@
-import {useState, useEffect} from 'react';
+import {useState, useEffect, startTransition} from 'react';
 
 /**
  * useIsAfterInitialMount will trigger a re-render to provide
@@ -18,7 +18,9 @@ export function useIsAfterInitialMount() {
   const [isAfterInitialMount, setIsAfterInitialMount] = useState(false);
 
   useEffect(() => {
-    setIsAfterInitialMount(true);
+    startTransition(() => {
+      setIsAfterInitialMount(true);
+    });
   }, []);
 
   return isAfterInitialMount;


### PR DESCRIPTION
Fixes #12272 

Currently hydration is broken inside a `<AppProvider>` when it has a long running promise being resolved. This is due to the setState on mount.

A startTransition resolves the issue.

See this repro repo: https://github.com/nick-potts/app-provider-remix-demo/blob/main/app/routes/broken.tsx
