### PR TITLE
[Hackdays 36] Search from url

### DIFF
--- a/polaris.shopify.com/pages/search.tsx
+++ b/polaris.shopify.com/pages/search.tsx
@@ -1,0 +1,1 @@
+export {default} from './index'

--- a/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/polaris.shopify.com/src/components/GlobalSearch/GlobalSearch.tsx
@@ -8,6 +8,7 @@ import {
 import {useThrottle} from '../../utils/hooks';
 import styles from './GlobalSearch.module.scss';
 import {useRouter} from 'next/router';
+import {useSearchParams} from 'next/navigation'
 import IconGrid from '../IconGrid';
 import {Grid, GridItem} from '../Grid';
 import TokenList from '../TokenList';
@@ -129,6 +130,7 @@ function GlobalSearch() {
   const [currentResultIndex, setCurrentResultIndex] = useState(0);
   const [uuid, setUuid] = useState('');
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   let resultsInRenderedOrder: SearchResults = [];
 
@@ -168,6 +170,14 @@ function GlobalSearch() {
   useEffect(throttledSearch, [searchTerm, throttledSearch]);
 
   useEffect(() => scrollIntoView(), [currentResultIndex]);
+
+  useEffect(() => {
+    if (router.route === '/search' && searchParams.get('q')) {
+      setIsOpen(true);
+      setSearchTerm(searchParams.get('q') ?? '');
+
+    }
+  }, [router.route, searchParams]);
 
   useEffect(() => {
     const handler = () => setIsOpen(false);

--- a/polaris.shopify.com/src/utils/hooks.ts
+++ b/polaris.shopify.com/src/utils/hooks.ts
@@ -8,19 +8,30 @@ const COPY_TO_CLIPBOARD_TIMEOUT = 2000;
 
 export const useThrottle = (cb: Function, delay: number) => {
   const cbRef = useRef(cb);
+  const throttledFn = useRef(throttle((...args) => cbRef.current(...args), delay, {
+    leading: true,
+    trailing: true,
+  }));
 
+  // Update the current callback whenever it changes
   useEffect(() => {
     cbRef.current = cb;
-  });
+  }, [cb]);
 
-  return useCallback(
-    () =>
-      throttle((...args) => cbRef.current(...args), delay, {
-        leading: true,
-        trailing: true,
-      }),
-    [delay],
-  );
+  // Update the throttled function whenever the delay changes
+  useEffect(() => {
+    const throttled = throttle((...args) => cbRef.current(...args), delay, {
+      leading: true,
+      trailing: true,
+    });
+    throttledFn.current = throttled;
+
+    return () => {
+      throttled.cancel();
+    };
+  }, [delay]);
+
+  return throttledFn.current;
 };
 
 export const useCopyToClipboard = (stringToCopy: string) => {


### PR DESCRIPTION
### WHY are these changes introduced?

As a developer, my regular usage pattern of Polaris is: 

1. Go to polaris.shopify.com
2. Wait for load 
3. Type `/` to open the search
4. Write the search. 

But it can be more efficient, and we don't need to reinvent the wheel. You can go to [google.com/search?q=Shopify](google.com/search?q=Shopify). In Chrome, you can even type google.com + tab and write your search directly on the bar. 

This PR Implements the route `https://polaris.shopify.com/search?q={searchTerm}` intended to be used as a search-ready URL, now (and using the chrome site search config) the search experience can be: 

1. Open a new tab 
2. Write your site search shorcut ("pol" in my case) 
3. Write your search. 
4. Go! 

Demo 


[![Watch the video](https://github.com/Shopify/polaris/assets/5873627/2f7e6f7e-6308-4bad-abec-6d2168cba445
)](https://github.com/Shopify/polaris/assets/5873627/2f7e6f7e-6308-4bad-abec-6d2168cba445)



### WHAT is this pull request doing?

##### 1. Fix a [useThrottle hook](https://github.com/Shopify/polaris/pull/12327/commits/e9787022dc7bbf7e684eedd61e93977de9c60b6b)'s race condition that prevents the first event from being fire.

 _This is testable by going to polaris.com, opening the search and type one key; the result is the search non being fired_

##### 2. Create the search route 

1. Create a search component exporting the same index component. 
2. In the `<GlobalSearch/>` component, watch for the route and search term to open and fill the search.  

### How to 🎩

1. `cd polaris.shopify.com && pnpm dev` 
2. Go to `localhost:3000/search&q=Any Search term` 
3. You should see the search bar populated by default. 


### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
