### PR TITLE
Add link to v13 changelog

### DIFF
--- a/polaris.shopify.com/content/tools/polaris-migrator.mdx
+++ b/polaris.shopify.com/content/tools/polaris-migrator.mdx
@@ -68,7 +68,7 @@ npx @shopify/polaris-migrator v14-styles-replace-custom-property-font <path>
 
 ### @shopify/polaris-react v13.0.0
 
-If you are upgrading Polaris from v12 to v13 please follow our [migration guide](/version-guides/migrating-from-v12-to-v13).
+There are no migrations for `@shopify/polaris-react@13.0.0`. For a full list of changes, see [the v13.0.0 changelog](https://github.com/Shopify/polaris/blob/main/polaris-react/CHANGELOG.md#1300).
 
 ### @shopify/polaris-icons v8.0.0
 


### PR DESCRIPTION
There is no migration guide for v13, so add a link to the v13 changelog instead for those who have lost their way.