### PR TITLE
Move reference to unreleased v14 to the v14.0.0 branch

### DIFF
--- a/polaris.shopify.com/content/tools/polaris-migrator.mdx
+++ b/polaris.shopify.com/content/tools/polaris-migrator.mdx
@@ -39,8 +39,6 @@ npx @shopify/polaris-migrator <migration> <path>
 
 ### @shopify/polaris-react v14.0.0
 
-If you are upgrading Polaris from v13 to v14 please follow our [migration guide](/version-guides/migrating-from-v13-to-v14).
-
 #### `v14-styles-replace-custom-property-font`
 
 Replace deprecated font CSS custom properties with corresponding Polaris custom property replacement values.


### PR DESCRIPTION
It's already in the `v14.0.0` branch, not sure how it made its way into `main`.