### PR TITLE
Support overlays in react portals in different document

### DIFF
--- a/.changeset/four-kids-nail.md
+++ b/.changeset/four-kids-nail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fixed issues with Popover, Tooltip, Color Picker and Drop Zone not working correctly when used inside Modals for embedded apps.

--- a/polaris-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/ColorPicker.tsx
@@ -5,8 +5,6 @@ import {clamp} from '../../utilities/clamp';
 import {classNames} from '../../utilities/css';
 import {hsbToRgb} from '../../utilities/color-transformers';
 import type {HSBColor, HSBAColor} from '../../utilities/color-types';
-// eslint-disable-next-line import/no-deprecated
-import {EventListener} from '../EventListener';
 
 import {AlphaPicker, HuePicker, Slidable} from './components';
 import type {SlidableProps} from './components';
@@ -67,11 +65,20 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
     {leading: true, trailing: true, maxWait: RESIZE_DEBOUNCE_TIME_MS},
   );
 
+  private observer?: ResizeObserver;
+
+  componentWillUnmount() {
+    this.observer?.disconnect();
+  }
+
   componentDidMount() {
     const {colorNode} = this;
-    if (colorNode == null) {
+    if (!colorNode) {
       return;
     }
+
+    this.observer = new ResizeObserver(this.handleResize);
+    this.observer.observe(colorNode);
 
     this.setState({
       pickerSize: {
@@ -135,7 +142,6 @@ export class ColorPicker extends PureComponent<ColorPickerProps, State> {
         </div>
         <HuePicker hue={hue} onChange={this.handleHueChange} />
         {alphaSliderMarkup}
-        <EventListener event="resize" handler={this.handleResize} />
       </div>
     );
   }

--- a/polaris-react/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
+++ b/polaris-react/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
@@ -25,6 +25,24 @@ export class AlphaPicker extends PureComponent<AlphaPickerProps, State> {
     draggerHeight: 0,
   };
 
+  private node: HTMLElement | null = null;
+  private observer?: ResizeObserver;
+
+  componentWillUnmount() {
+    this.observer?.disconnect();
+  }
+
+  componentDidMount() {
+    if (!this.node) {
+      return;
+    }
+
+    this.observer = new ResizeObserver(this.setSliderHeight);
+    this.observer.observe(this.node);
+
+    this.setSliderHeight();
+  }
+
   render() {
     const {color, alpha} = this.props;
     const {sliderHeight, draggerHeight} = this.state;
@@ -33,7 +51,7 @@ export class AlphaPicker extends PureComponent<AlphaPickerProps, State> {
     const background = alphaGradientForColor(color);
 
     return (
-      <div className={styles.AlphaPicker} ref={this.setSliderHeight}>
+      <div className={styles.AlphaPicker} ref={this.setNode}>
         <div className={styles.ColorLayer} style={{background}} />
         <Slidable
           draggerY={draggerY}
@@ -45,8 +63,17 @@ export class AlphaPicker extends PureComponent<AlphaPickerProps, State> {
     );
   }
 
-  private setSliderHeight = (node: HTMLElement | null) => {
-    if (node == null) {
+  private setNode = (node: HTMLElement | null) => {
+    if (!node) {
+      return;
+    }
+
+    this.node = node;
+  };
+
+  private setSliderHeight = () => {
+    const {node} = this;
+    if (!node) {
       return;
     }
 

--- a/polaris-react/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/polaris-react/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -79,6 +79,40 @@ describe('<AlphaPicker />', () => {
       });
     });
   });
+
+  describe('Iframe React portal bug fix', () => {
+    it('observes the resize event for the activator wrapper', () => {
+      const observe = jest.fn();
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe,
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      }));
+
+      const alphaPicker = mountWithApp(<AlphaPicker {...mockProps} />);
+
+      expect(observe).toHaveBeenCalledWith(alphaPicker.find('div')?.domNode);
+    });
+
+    it('disconnects the resize observer when component unmounts', () => {
+      const disconnect = jest.fn();
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect,
+      }));
+
+      const alphaPicker = mountWithApp(<AlphaPicker {...mockProps} />);
+
+      alphaPicker.unmount();
+
+      expect(disconnect).toHaveBeenCalled();
+    });
+  });
 });
 
 function noop() {}

--- a/polaris-react/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
+++ b/polaris-react/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
@@ -22,13 +22,31 @@ export class HuePicker extends PureComponent<HuePickerProps, State> {
     draggerHeight: 0,
   };
 
+  private node: HTMLElement | null = null;
+  private observer?: ResizeObserver;
+
+  componentWillUnmount() {
+    this.observer?.disconnect();
+  }
+
+  componentDidMount() {
+    if (!this.node) {
+      return;
+    }
+
+    this.observer = new ResizeObserver(this.setSliderHeight);
+    this.observer.observe(this.node);
+
+    this.setSliderHeight();
+  }
+
   render() {
     const {hue} = this.props;
     const {sliderHeight, draggerHeight} = this.state;
     const draggerY = calculateDraggerY(hue, sliderHeight, draggerHeight);
 
     return (
-      <div className={styles.HuePicker} ref={this.setSliderHeight}>
+      <div className={styles.HuePicker} ref={this.setNode}>
         <Slidable
           draggerY={draggerY}
           draggerX={0}
@@ -39,8 +57,18 @@ export class HuePicker extends PureComponent<HuePickerProps, State> {
     );
   }
 
-  private setSliderHeight = (node: HTMLElement | null) => {
-    if (node == null) {
+  private setNode = (node: HTMLElement | null) => {
+    if (!node) {
+      return;
+    }
+
+    this.node = node;
+  };
+
+  private setSliderHeight = () => {
+    const {node} = this;
+
+    if (!node) {
       return;
     }
 

--- a/polaris-react/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/polaris-react/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -67,6 +67,40 @@ describe('<HuePicker />', () => {
       });
     });
   });
+
+  describe('Iframe React portal bug fix', () => {
+    it('observes the resize event for the activator wrapper', () => {
+      const observe = jest.fn();
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe,
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      }));
+
+      const huePicker = mountWithApp(<HuePicker {...mockProps} />);
+
+      expect(observe).toHaveBeenCalledWith(huePicker.find('div')?.domNode);
+    });
+
+    it('disconnects the resize observer when component unmounts', () => {
+      const disconnect = jest.fn();
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect,
+      }));
+
+      const huePicker = mountWithApp(<HuePicker {...mockProps} />);
+
+      huePicker.unmount();
+
+      expect(disconnect).toHaveBeenCalled();
+    });
+  });
 });
 
 function noop() {}

--- a/polaris-react/src/components/ColorPicker/components/Slidable/tests/Slidable.test.tsx
+++ b/polaris-react/src/components/ColorPicker/components/Slidable/tests/Slidable.test.tsx
@@ -1,6 +1,9 @@
+/* eslint-disable import/no-deprecated */
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
+import {EventListener} from '../../../../EventListener';
+import styles from '../../../ColorPicker.module.css';
 import {Slidable} from '../Slidable';
 
 describe('<Slidable />', () => {
@@ -9,5 +12,132 @@ describe('<Slidable />', () => {
     const slidable = mountWithApp(<Slidable onChange={spy} />);
     slidable.find('div')!.trigger('onMouseDown', {});
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  describe('Iframe React portal bug fix', () => {
+    it('observes the resize event for the activator', () => {
+      const observe = jest.fn();
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe,
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      }));
+
+      const slidable = mountWithApp(<Slidable onChange={jest.fn()} />);
+
+      expect(observe).toHaveBeenCalledWith(slidable.find('div')?.domNode);
+    });
+
+    it('disconnects the resize observer when component unmounts', () => {
+      const disconnect = jest.fn();
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect,
+      }));
+
+      const slidable = mountWithApp(<Slidable onChange={jest.fn()} />);
+
+      slidable.unmount();
+
+      expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('passes the node.ownerDocument.defaultView as the window for all event listeners after resize observer fires', () => {
+      let resizeCallback: () => void;
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation((callback) => {
+        resizeCallback = callback;
+        return {
+          observe: jest.fn(),
+          unobserve: jest.fn(),
+          disconnect: jest.fn(),
+        };
+      });
+
+      const slidable = mountWithApp(<Slidable onChange={jest.fn()} />);
+      const node = slidable.find('div')?.domNode;
+
+      slidable.act(() => resizeCallback());
+
+      slidable.forceUpdate();
+
+      slidable.find('div')!.trigger('onMouseDown', {
+        type: 'mousedown',
+        clientX: 1,
+        clientY: 1,
+      });
+
+      // We can't assert using `toContainReactComponent` because the matcher blows up trying to assert on window as an argument
+      expect(
+        slidable
+          .find(EventListener, {
+            event: 'mousemove',
+          })!
+          .prop('window'),
+      ).toStrictEqual(node!.ownerDocument.defaultView);
+
+      expect(
+        slidable
+          .find(EventListener, {
+            event: 'touchmove',
+          })!
+          .prop('window'),
+      ).toStrictEqual(node!.ownerDocument.defaultView);
+
+      expect(
+        slidable
+          .find(EventListener, {
+            event: 'mouseup',
+          })!
+          .prop('window'),
+      ).toStrictEqual(node!.ownerDocument.defaultView);
+
+      expect(
+        slidable
+          .find(EventListener, {
+            event: 'touchend',
+          })!
+          .prop('window'),
+      ).toStrictEqual(node!.ownerDocument.defaultView);
+
+      expect(
+        slidable
+          .find(EventListener, {
+            event: 'touchcancel',
+          })!
+          .prop('window'),
+      ).toStrictEqual(node!.ownerDocument.defaultView);
+    });
+
+    it('calls provided onDraggerHeight after resize observer fires', () => {
+      let resizeCallback: () => void;
+      const onDraggerHeight = jest.fn();
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation((callback) => {
+        resizeCallback = callback;
+        return {
+          observe: jest.fn(),
+          unobserve: jest.fn(),
+          disconnect: jest.fn(),
+        };
+      });
+
+      const slidable = mountWithApp(
+        <Slidable onChange={jest.fn()} onDraggerHeight={onDraggerHeight} />,
+      );
+
+      slidable.act(() => resizeCallback());
+
+      expect(onDraggerHeight).toHaveBeenCalledWith(
+        slidable.find('div', {className: styles.Dragger})?.domNode?.clientWidth,
+      );
+    });
   });
 });

--- a/polaris-react/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/polaris-react/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -5,6 +5,7 @@ import {mountWithApp} from 'tests/utilities';
 import {EventListener} from '../../EventListener';
 import {Slidable, AlphaPicker} from '../components';
 import {ColorPicker} from '../ColorPicker';
+import styles from '../ColorPicker.module.css';
 
 const red = {
   hue: 0,
@@ -177,6 +178,45 @@ describe('<ColorPicker />', () => {
       window.dispatchEvent(event);
 
       expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Iframe React portal bug fix', () => {
+    it('observes the resize event for the activator wrapper', () => {
+      const observe = jest.fn();
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe,
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      }));
+
+      const colorPicker = mountWithApp(
+        <ColorPicker color={red} onChange={jest.fn()} />,
+      );
+
+      expect(observe).toHaveBeenCalledWith(
+        colorPicker.find('div', {className: styles.MainColor})?.domNode,
+      );
+    });
+
+    it('disconnects the resize observer when component unmounts', () => {
+      const disconnect = jest.fn();
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect,
+      }));
+
+      const colorPicker = mountWithApp(
+        <ColorPicker color={red} onChange={jest.fn()} />,
+      );
+
+      colorPicker.unmount();
+
+      expect(disconnect).toHaveBeenCalled();
     });
   });
 });

--- a/polaris-react/src/components/EventListener/EventListener.tsx
+++ b/polaris-react/src/components/EventListener/EventListener.tsx
@@ -4,6 +4,7 @@ interface BaseEventProps {
   event: string;
   capture?: boolean;
   handler(event: Event): void;
+  window?: Window | null;
 }
 
 export interface EventListenerProps extends BaseEventProps {
@@ -30,12 +31,19 @@ export class EventListener extends PureComponent<EventListenerProps, never> {
   }
 
   private attachListener() {
-    const {event, handler, capture, passive} = this.props;
+    const {event, handler, capture, passive, window: customWindow} = this.props;
+    const window = customWindow || globalThis.window;
     window.addEventListener(event, handler, {capture, passive});
   }
 
   private detachListener(prevProps?: BaseEventProps) {
-    const {event, handler, capture} = prevProps || this.props;
+    const {
+      event,
+      handler,
+      capture,
+      window: customWindow,
+    } = prevProps || this.props;
+    const window = customWindow || globalThis.window;
     window.removeEventListener(event, handler, capture);
   }
 }

--- a/polaris-react/src/components/EventListener/tests/EventListener.test.tsx
+++ b/polaris-react/src/components/EventListener/tests/EventListener.test.tsx
@@ -35,6 +35,27 @@ describe('<EventListener />', () => {
     window.dispatchEvent(new Event('resize'));
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it('uses the custom window if provided', () => {
+    const myWindow = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    const wrapper = mountWithApp(
+      <EventListener
+        event="resize"
+        handler={jest.fn()}
+        window={myWindow as any}
+      />,
+    );
+
+    expect(myWindow.addEventListener).toHaveBeenCalled();
+
+    wrapper.unmount();
+
+    expect(myWindow.removeEventListener).toHaveBeenCalled();
+  });
 });
 
 function noop() {}

--- a/polaris-react/src/components/KeypressListener/KeypressListener.tsx
+++ b/polaris-react/src/components/KeypressListener/KeypressListener.tsx
@@ -7,6 +7,7 @@ export interface NonMutuallyExclusiveProps {
   keyCode: Key;
   handler(event: KeyboardEvent): void;
   keyEvent?: KeyEvent;
+  document?: Document;
 }
 
 export type KeypressListenerProps = NonMutuallyExclusiveProps &
@@ -23,6 +24,7 @@ export function KeypressListener({
   keyEvent = 'keyup',
   options,
   useCapture,
+  document: ownerDocument = globalThis.document,
 }: KeypressListenerProps) {
   const tracked = useRef({handler, keyCode});
 
@@ -38,15 +40,19 @@ export function KeypressListener({
   }, []);
 
   useEffect(() => {
-    document.addEventListener(keyEvent, handleKeyEvent, useCapture || options);
+    ownerDocument.addEventListener(
+      keyEvent,
+      handleKeyEvent,
+      useCapture || options,
+    );
     return () => {
-      document.removeEventListener(
+      ownerDocument.removeEventListener(
         keyEvent,
         handleKeyEvent,
         useCapture || options,
       );
     };
-  }, [keyEvent, handleKeyEvent, useCapture, options]);
+  }, [keyEvent, handleKeyEvent, useCapture, options, ownerDocument]);
 
   return null;
 }

--- a/polaris-react/src/components/KeypressListener/tests/KeypressListener.test.tsx
+++ b/polaris-react/src/components/KeypressListener/tests/KeypressListener.test.tsx
@@ -83,6 +83,27 @@ describe('<KeypressListener />', () => {
 
     expect(listenerOptionsMap.keyup).toStrictEqual(eventOptions);
   });
+
+  it('uses the custom document if provided', () => {
+    const myDocument = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    const wrapper = mountWithApp(
+      <KeypressListener
+        handler={jest.fn()}
+        keyCode={Key.Escape}
+        document={myDocument as any}
+      />,
+    );
+
+    expect(myDocument.addEventListener).toHaveBeenCalled();
+
+    wrapper.unmount();
+
+    expect(myDocument.removeEventListener).toHaveBeenCalled();
+  });
 });
 
 function noop() {}

--- a/polaris-react/src/components/PositionedOverlay/utilities/math.ts
+++ b/polaris-react/src/components/PositionedOverlay/utilities/math.ts
@@ -172,7 +172,10 @@ export function intersectionWithViewport(
   });
 }
 
-export function windowRect() {
+export function windowRect(node?: HTMLElement) {
+  const document = node?.ownerDocument || globalThis.document;
+  const window = document.defaultView || globalThis.window;
+
   return new Rect({
     top: window.scrollY,
     left: window.scrollX,

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -236,8 +236,9 @@ export function Tooltip({
       return;
     }
 
-    node.firstElementChild instanceof HTMLElement &&
-      setActivatorNode(node.firstElementChild);
+    if (node.firstElementChild) {
+      setActivatorNode(node.firstElementChild as HTMLElement);
+    }
 
     activatorContainerRef.current = node;
   }

--- a/polaris-react/src/utilities/geometry.ts
+++ b/polaris-react/src/utilities/geometry.ts
@@ -38,19 +38,25 @@ export class Rect {
 export function getRectForNode(
   node: Element | React.ReactNode | Window | Document,
 ): Rect {
-  if (!(node instanceof Element)) {
+  /**
+   * NOTE: We cannot do node instanceof Element because it will fail when inside of an iframe.
+   * Technically we can do `node instanceof node.ownerDocument.defaultView.Element`but this will
+   * fail when node isn't an Element. We might as well try to run `getBoundingClientRect` and then
+   * have a fallback for when that breaks.
+   */
+  try {
+    const rect = (node as Element).getBoundingClientRect();
+
+    return new Rect({
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+    });
+  } catch (_) {
     return new Rect({
       width: window.innerWidth,
       height: window.innerHeight,
     });
   }
-
-  const rect = node.getBoundingClientRect();
-
-  return new Rect({
-    top: rect.top,
-    left: rect.left,
-    width: rect.width,
-    height: rect.height,
-  });
 }

--- a/polaris-react/src/utilities/is-element-in-viewport.ts
+++ b/polaris-react/src/utilities/is-element-in-viewport.ts
@@ -1,5 +1,6 @@
 export function isElementInViewport(element: Element) {
   const {top, left, bottom, right} = element.getBoundingClientRect();
+  const window = element.ownerDocument.defaultView || globalThis.window;
 
   return (
     top >= 0 &&

--- a/polaris-react/tests/setup/environment.ts
+++ b/polaris-react/tests/setup/environment.ts
@@ -47,3 +47,12 @@ console.warn = (...args: any[]) => {
 
   originalConsoleWarn(...args);
 };
+
+if (typeof HTMLElement !== 'undefined') {
+  // Patch for offsetParent for jsdom, needed for Popover
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    get() {
+      return this.parentNode;
+    },
+  });
+}

--- a/polaris-react/tests/setup/tests.ts
+++ b/polaris-react/tests/setup/tests.ts
@@ -11,6 +11,13 @@ if (typeof window !== 'undefined' && !matchMedia.isMocked()) {
 
 // eslint-disable-next-line jest/require-top-level-describe
 beforeEach(() => {
+  // eslint-disable-next-line jest/prefer-spy-on
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+
   if (typeof window !== 'undefined' && !matchMedia.isMocked()) {
     matchMedia.mock();
   }


### PR DESCRIPTION
### WHY are these changes introduced?
Fix issues related to overlays not working correct in App Bridge modals as outlined in this [doc](https://docs.google.com/document/d/1eocCl07pk8xt7rvUaGDWZzfJxxeJ2yRi1ul0x0ezkDM/edit).

These specific issues will be fixed
- https://github.com/Shopify/shopify-app-bridge/issues/316
- https://github.com/Shopify/shopify-app-bridge/issues/264#issuecomment-2129535852
- https://github.com/Shopify/shopify-app-bridge/issues/238#issuecomment-1980064764
- https://github.com/Shopify/shopify-app-bridge/issues/301

### WHAT is this pull request doing?

Currently Overlays are broken when rendered using React portals. This PR fixes the issue by doing the following: 
- ensuring all references to `document` are updated to be `node.ownerDocument` instead so the positioning can be calculated correctly inside of iframes
- ensuring wherever we do `instanceOf HTMLElement` we instead just check to see if the node is present or try to call the related methods (`getBoundingClientRect`) with a fallback as the `instanceof` check will fail when using React portals for iframe content since iframes have their own globals

This PR only touches the related utils for Overlays but there are other references to `document` and `instanceOf HTMLElement` we should also update.

Expected usage with App Bridge v4, note that you have to wrap the modal's content with the AppProvider from Polaris so that the portals are created in the correct place.

For example, here's a modal with tooltips inside:

```jsx
import {AppProvider} from '@shopify/polaris';
import {Modal} from '@shopify/app-bridge-react';

function App() {
  return (
    <Modal>
      <AppProvider i18n={{}}>
        <div style={{padding: '75px 0'}}>
          <Tooltip content="This order has shipping labels.">
            <Text fontWeight="bold" as="span">
              Order #1001
            </Text>
          </Tooltip>
          <ButtonGroup variant="segmented" fullWidth>
            <Tooltip content="Bold" dismissOnMouseOut>
              <Button>B</Button>
            </Tooltip>
            <Tooltip content="Italic" dismissOnMouseOut>
              <Button>I</Button>
            </Tooltip>
            <Tooltip content="Underline" dismissOnMouseOut>
              <Button>U</Button>
            </Tooltip>
            <Tooltip content="Strikethrough" dismissOnMouseOut>
              <Button>S</Button>
            </Tooltip>
          </ButtonGroup>
        </div>
      </AppProvider>
    </Modal>
  );
}

```

**Before**

https://github.com/user-attachments/assets/f7b7a7df-f25f-422c-a5bc-d1a8d7f12167


**After**
https://github.com/user-attachments/assets/6c1bf97a-e8f4-4715-9960-9f5709222f75

https://github.com/user-attachments/assets/ebc4755e-cc3b-413a-aaf5-9f39cc7b7ad0


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

1. Open the App Bridge Playground: https://admin.shopify.com/store/trish-dev/apps/app-bridge-next-playground-4/react/index.html
2. Open all the custom content modals and do a smoke test to verify overlay components are rendered on top with correct sizing and click events are working

### 🎩 checklist

- [X] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [X] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
~- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)~
~- [ ] Updated the component's `README.md` with documentation changes~
~- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide~
