### PR TITLE
[Tag] Add secondary styling

### DIFF
--- a/.changeset/popular-gifts-shout.md
+++ b/.changeset/popular-gifts-shout.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Add secondary variant to Tag component

--- a/polaris-react/src/components/Tag/Tag.module.css
+++ b/polaris-react/src/components/Tag/Tag.module.css
@@ -65,6 +65,10 @@
     padding-right: 0;
     padding-inline-end: 0;
   }
+
+  &.secondary {
+    background-color: var(--p-color-bg-fill-secondary);
+  }
 }
 
 .Button {

--- a/polaris-react/src/components/Tag/Tag.stories.tsx
+++ b/polaris-react/src/components/Tag/Tag.stories.tsx
@@ -8,6 +8,7 @@ import {
   Bleed,
   BlockStack,
   Text,
+  Card,
 } from '@shopify/polaris';
 import {WandIcon} from '@shopify/polaris-icons';
 
@@ -40,6 +41,9 @@ export const All = {
         <br />
         <Text as="p">Removable large</Text>
         <RemovableLarge.render />
+        <br />
+        <Text as="p">Secondary</Text>
+        <Secondary.render />
       </BlockStack>
       /* eslint-enable react/jsx-pascal-case */
     );
@@ -190,6 +194,27 @@ export const RemovableLarge = {
         <Text as="p">Large with link</Text>
         <LegacyStack spacing="tight">{tagWithLinkMarkup}</LegacyStack>
       </BlockStack>
+    );
+  },
+};
+
+export const Secondary = {
+  render() {
+    return (
+      <Card>
+        <InlineStack gap="100">
+          <Tag secondary>Wholesale</Tag>
+          <Tag disabled secondary>
+            Disabled
+          </Tag>
+          <Tag secondary url="#">
+            With URL
+          </Tag>
+          <Tag secondary onRemove={() => {}}>
+            Removable
+          </Tag>
+        </InlineStack>
+      </Card>
     );
   },
 };

--- a/polaris-react/src/components/Tag/Tag.tsx
+++ b/polaris-react/src/components/Tag/Tag.tsx
@@ -24,6 +24,8 @@ export interface NonMutuallyExclusiveProps {
   url?: string;
   /** The size of the tag */
   size?: 'large';
+  /** Apply secondary styling  */
+  secondary?: boolean;
 }
 
 export type TagProps = NonMutuallyExclusiveProps &
@@ -40,6 +42,7 @@ export function Tag({
   accessibilityLabel,
   url,
   size,
+  secondary,
 }: TagProps) {
   const i18n = useI18n();
 
@@ -52,6 +55,7 @@ export function Tag({
     url && !disabled && styles.linkable,
     segmented && styles.segmented,
     size && styles[variationName('size', size)],
+    secondary && styles.secondary,
   );
 
   let tagTitle = accessibilityLabel;

--- a/polaris.shopify.com/content/components/selection-and-input/tag.mdx
+++ b/polaris.shopify.com/content/components/selection-and-input/tag.mdx
@@ -31,6 +31,9 @@ examples:
   - fileName: tag-removable-large.tsx
     title: Removable large
     description: A larger, removable attribute to an object that allows merchants to navigate to a resource.
+  - fileName: tag-secondary.tsx
+    title: Secondary
+    description: A less promenant variation of the default tag.
 previewImg: /images/components/selection-and-input/tag.png
 ---
 

--- a/polaris.shopify.com/pages/examples/tag-secondary.tsx
+++ b/polaris.shopify.com/pages/examples/tag-secondary.tsx
@@ -1,0 +1,15 @@
+import {Card, Tag, LegacyStack} from '@shopify/polaris';
+import React from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TagExample() {
+  return (
+    <Card>
+      <LegacyStack spacing="tight">
+        <Tag secondary>Secondary</Tag>
+      </LegacyStack>
+    </Card>
+  );
+}
+
+export default withPolarisExample(TagExample);


### PR DESCRIPTION
This PR introduces a `secondary` variant of the `Tag` component. I'm looking for feedback and feasibility in merging this in advance of the [Admin UI Foundations project](https://vault.shopify.io/gsd/projects/40609)

### WHY are these changes introduced?

We're run into an [issue](https://github.com/Shopify/web/pull/134161#discussion_r1681581778) where we have a component that contains both badges and tags and we'd like those to visually match. There's currently no way to achieve this without CSS overrides. Since we expect a secondary treatment to be coming I'm using this PR to test the waters in introducing this treatment now.

<img width="500" alt="Screenshot 2024-07-29 at 3 41 09 PM" src="https://github.com/user-attachments/assets/cfeafed6-a5ff-4480-911c-e7247d8efa62">

### WHAT is this pull request doing?

This adds a "secondary" variation of the Tag that is compatible with all other variants and lightens the background to use `bg-secondary` as shown:

<img width="365" alt="Screenshot 2024-07-29 at 3 46 30 PM" src="https://github.com/user-attachments/assets/d77e0b07-417f-493b-a36f-5cdc8896d7e5">

Note that on a secondary background the `Tag` background color will blend in

Currently includes:
- [x] added new variant and matching styling
- [x] added to storybook
- [x] added to polaris docs

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
