### PR TITLE
Fix issue with popovers not working in embedded app modals when put inside of a details component

### DIFF
--- a/.changeset/funny-feet-roll.md
+++ b/.changeset/funny-feet-roll.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix issue with popovers not working in embedded app modals when put inside of a details component

--- a/polaris-react/src/components/Popover/Popover.tsx
+++ b/polaris-react/src/components/Popover/Popover.tsx
@@ -219,6 +219,16 @@ const PopoverComponent = forwardRef<PopoverPublicAPI, PopoverProps>(
       const observer = new ResizeObserver(setDisplayState);
       observer.observe(activatorContainer.current);
 
+      /**
+       * We want to observe the parent element when possible because it is the one controlling the display state of the popover.
+       * The parent element could be collapsed initially and then opened later on like in the case
+       * of using a `<details>` component.
+       */
+
+      observer.observe(
+        activatorContainer.current.parentElement || activatorContainer.current,
+      );
+
       setDisplayState();
 
       return () => {

--- a/polaris-react/src/components/Popover/tests/Popover.test.tsx
+++ b/polaris-react/src/components/Popover/tests/Popover.test.tsx
@@ -539,7 +539,7 @@ describe('<Popover />', () => {
       expect(popover).not.toContainReactComponent(PositionedOverlay);
     });
 
-    it('observes the resize event for the activator wrapper', () => {
+    it("observes the resize event for the activator wrapper's parent element", () => {
       const observe = jest.fn();
 
       // eslint-disable-next-line jest/prefer-spy-on
@@ -558,7 +558,9 @@ describe('<Popover />', () => {
         />,
       );
 
-      expect(observe).toHaveBeenCalledWith(popover.find('span')?.domNode);
+      expect(observe).toHaveBeenCalledWith(
+        popover.find('span')?.domNode?.parentElement,
+      );
     });
 
     it('disconnects the resize observer when component unmounts', () => {


### PR DESCRIPTION
Enable popover display state to be updated based on the parent's resize event.

https://github.com/user-attachments/assets/7702a0bc-88ef-4e01-8043-1239562c609c


### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/pull/12445#issuecomment-2275760015

### WHAT is this pull request doing?

Attach the resize observer to the parent element of the activator when available instead of the activator itself.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
