### PR TITLE
[Tooltip] fix originalActive strict truthy checks

### DIFF
--- a/.changeset/dry-mugs-suffer.md
+++ b/.changeset/dry-mugs-suffer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+fix strict boolean checks in Tooltip

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -114,7 +114,7 @@ export function Tooltip({
   const hoverOutTimeout = useRef<NodeJS.Timeout | null>(null);
 
   const handleFocus = useCallback(() => {
-    if (originalActive !== false) {
+    if (Boolean(originalActive) !== false) {
       setActiveTrue();
     }
   }, [originalActive, setActiveTrue]);
@@ -168,7 +168,7 @@ export function Tooltip({
   );
 
   useEffect(() => {
-    if (originalActive === false && active) {
+    if (Boolean(originalActive) === false && active) {
       handleClose();
       handleBlur();
     }


### PR DESCRIPTION
### WHY are these changes introduced?

When you pass in an `undefined` const to the `active` prop, the Tooltip shows up even though its `active` state should be falsy.

![Screenshot 2024-09-03 at 10 38 04](https://github.com/user-attachments/assets/3c35ef9d-0f7c-4576-992d-93612062343e)


### WHAT is this pull request doing?

Resolves https://github.com/Shopify/polaris/issues/12597

This PR changes a couple of places where the component strictly checks the truthiness of `originalActive` without coercing it to a `boolean` first.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
