### PR TITLE
[polaris-migrator] Add migration to support dirty prop on Modal

### DIFF
--- a/.changeset/tricky-wolves-do.md
+++ b/.changeset/tricky-wolves-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Temp changeset

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/basic-modal.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/basic-modal.input.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+
+export function App() {
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: () => {},
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: () => {},
+        },
+      ]}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/basic-modal.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/basic-modal.output.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+
+export function App() {
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: () => {},
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: () => {},
+        },
+      ]}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/transform.test.ts
@@ -26,6 +26,12 @@ const fixtures = [
   {
     name: 'with-use-route-form-import',
   },
+  {
+    name: 'with-use-route-form-import-and-dirty-object',
+  },
+  {
+    name: 'with-use-route-form-import-and-dirty-variable',
+  },
 ];
 
 for (const fixture of fixtures) {

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/transform.test.ts
@@ -1,0 +1,36 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'react-update-modal-component-dirty-prop';
+const fixtures = [
+  {
+    name: 'basic-modal',
+  },
+  {
+    name: 'with-form-state-import',
+  },
+  {
+    name: 'with-form-state-import-and-aliased-modal',
+  },
+  {
+    name: 'with-form-state-import-and-no-dirty-variable',
+  },
+  {
+    name: 'with-form-state-import-and-spread-props',
+  },
+  {
+    name: 'with-use-form-import',
+  },
+  {
+    name: 'with-use-form-import-and-shared-modal-import',
+  },
+  {
+    name: 'with-use-route-form-import',
+  },
+];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture: fixture.name,
+    transform,
+  });
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-aliased-modal.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-aliased-modal.input.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal as PolarisModal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import FormState from '~/shared/utilities/react-form-state';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-aliased-modal.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-aliased-modal.input.tsx
@@ -1,0 +1,36 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal as PolarisModal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import FormState from '~/shared/utilities/react-form-state';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  return (
+    <FormState>
+      {(formDetails) => {
+        return (
+          <PolarisModal
+            open={false}
+            onClose={() => {}}
+            title="Title"
+            primaryAction={{
+              content: 'Save',
+              onAction: () => {},
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: () => {},
+              },
+            ]}
+          >
+            <PolarisModal.Section>
+              <TextContainer>Lorem ipsum</TextContainer>
+            </PolarisModal.Section>
+          </PolarisModal>
+        );
+      }}
+    </FormState>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-aliased-modal.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-aliased-modal.output.tsx
@@ -1,0 +1,37 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal as PolarisModal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import FormState from '~/shared/utilities/react-form-state';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  return (
+    <FormState>
+      {(formDetails) => {
+        return (
+          <PolarisModal
+            open={false}
+            onClose={() => {}}
+            title="Title"
+            primaryAction={{
+              content: 'Save',
+              onAction: () => {},
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: () => {},
+              },
+            ]}
+            dirty={dirty}
+          >
+            <PolarisModal.Section>
+              <TextContainer>Lorem ipsum</TextContainer>
+            </PolarisModal.Section>
+          </PolarisModal>
+        );
+      }}
+    </FormState>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-aliased-modal.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-aliased-modal.output.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal as PolarisModal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import FormState from '~/shared/utilities/react-form-state';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.input.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import FormState from '~/shared/utilities/react-form-state';
+
+export function App() {
+  return (
+    <FormState>
+      {(formDetails) => {
+        return (
+          <Modal
+            open={false}
+            onClose={() => {}}
+            title="Title"
+            primaryAction={{
+              content: 'Save',
+              onAction: () => {},
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: () => {},
+              },
+            ]}
+          >
+            <Modal.Section>
+              <TextContainer>Lorem ipsum</TextContainer>
+            </Modal.Section>
+          </Modal>
+        );
+      }}
+    </FormState>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.input.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import FormState from '~/shared/utilities/react-form-state';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.output.tsx
@@ -9,7 +9,7 @@ export function App() {
     <FormState>
       {(formDetails) => {
         return (
-          /* Verify if `dirty` variable exists in the file */
+          /* polaris-migrator: Verify if `dirty` variable exists in the file */
           <Modal
             open={false}
             onClose={() => {}}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.output.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import FormState from '~/shared/utilities/react-form-state';
+
+export function App() {
+  return (
+    <FormState>
+      {(formDetails) => {
+        return (
+          /* Verify if `dirty` variable exists in the file */
+          <Modal
+            open={false}
+            onClose={() => {}}
+            title="Title"
+            primaryAction={{
+              content: 'Save',
+              onAction: () => {},
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: () => {},
+              },
+            ]}
+          >
+            <Modal.Section>
+              <TextContainer>Lorem ipsum</TextContainer>
+            </Modal.Section>
+          </Modal>
+        );
+      }}
+    </FormState>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-no-dirty-variable.output.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import FormState from '~/shared/utilities/react-form-state';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-spread-props.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-spread-props.input.tsx
@@ -1,0 +1,38 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import FormState from '~/shared/utilities/react-form-state';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  const modalProps = {
+    open: false,
+    onClose: () => {},
+    title: 'Title',
+    primaryAction: {
+      content: 'Save',
+      onAction: () => {},
+    },
+    secondaryActions: [
+      {
+        content: 'Cancel',
+        onAction: () => {},
+      },
+    ],
+  };
+
+  return (
+    <FormState>
+      {(formDetails) => {
+        return (
+          <Modal {...modalProps}>
+            <Modal.Section>
+              <TextContainer>Lorem ipsum</TextContainer>
+            </Modal.Section>
+          </Modal>
+        );
+      }}
+    </FormState>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-spread-props.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-spread-props.input.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import FormState from '~/shared/utilities/react-form-state';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-spread-props.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-spread-props.output.tsx
@@ -1,0 +1,39 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import FormState from '~/shared/utilities/react-form-state';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  const modalProps = {
+    open: false,
+    onClose: () => {},
+    title: 'Title',
+    primaryAction: {
+      content: 'Save',
+      onAction: () => {},
+    },
+    secondaryActions: [
+      {
+        content: 'Cancel',
+        onAction: () => {},
+      },
+    ],
+  };
+
+  return (
+    <FormState>
+      {(formDetails) => {
+        return (
+          /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+          <Modal {...modalProps}>
+            <Modal.Section>
+              <TextContainer>Lorem ipsum</TextContainer>
+            </Modal.Section>
+          </Modal>
+        );
+      }}
+    </FormState>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-spread-props.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import-and-spread-props.output.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import FormState from '~/shared/utilities/react-form-state';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import.input.tsx
@@ -1,0 +1,36 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import FormState from '~/shared/utilities/react-form-state';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  return (
+    <FormState>
+      {(formDetails) => {
+        return (
+          <Modal
+            open={false}
+            onClose={() => {}}
+            title="Title"
+            primaryAction={{
+              content: 'Save',
+              onAction: () => {},
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: () => {},
+              },
+            ]}
+          >
+            <Modal.Section>
+              <TextContainer>Lorem ipsum</TextContainer>
+            </Modal.Section>
+          </Modal>
+        );
+      }}
+    </FormState>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import.input.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import FormState from '~/shared/utilities/react-form-state';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import.output.tsx
@@ -1,0 +1,37 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import FormState from '~/shared/utilities/react-form-state';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  return (
+    <FormState>
+      {(formDetails) => {
+        return (
+          <Modal
+            open={false}
+            onClose={() => {}}
+            title="Title"
+            primaryAction={{
+              content: 'Save',
+              onAction: () => {},
+            }}
+            secondaryActions={[
+              {
+                content: 'Cancel',
+                onAction: () => {},
+              },
+            ]}
+            dirty={dirty}
+          >
+            <Modal.Section>
+              <TextContainer>Lorem ipsum</TextContainer>
+            </Modal.Section>
+          </Modal>
+        );
+      }}
+    </FormState>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-form-state-import.output.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import FormState from '~/shared/utilities/react-form-state';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import-and-shared-modal-import.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import-and-shared-modal-import.input.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import {Modal} from '~/shared/components/Modal';
 // @ts-expect-error

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import-and-shared-modal-import.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import-and-shared-modal-import.input.tsx
@@ -1,0 +1,33 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import {Modal} from '~/shared/components/Modal';
+// @ts-expect-error
+import {useForm} from '~/shared/utilities/react-form';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  const {reset, submit} = useForm();
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import-and-shared-modal-import.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import-and-shared-modal-import.output.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import {Modal} from '~/shared/components/Modal';
 // @ts-expect-error

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import-and-shared-modal-import.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import-and-shared-modal-import.output.tsx
@@ -1,0 +1,34 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import {Modal} from '~/shared/components/Modal';
+// @ts-expect-error
+import {useForm} from '~/shared/utilities/react-form';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  const {reset, submit} = useForm();
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+      dirty={dirty}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import.input.tsx
@@ -1,0 +1,31 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import {useForm} from '~/shared/utilities/react-form';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  const {reset, submit} = useForm();
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import.input.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import {useForm} from '~/shared/utilities/react-form';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import.output.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import {useForm} from '~/shared/utilities/react-form';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-form-import.output.tsx
@@ -1,0 +1,32 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import {useForm} from '~/shared/utilities/react-form';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  const {reset, submit} = useForm();
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+      dirty={dirty}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import-and-dirty-object.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import-and-dirty-object.input.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+
+// @ts-expect-error
+import {useRouteForm} from '~/shared/utilities/forms/useRouteForm';
+
+export function App() {
+  const {reset, dirty, submit} = useRouteForm();
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import-and-dirty-object.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import-and-dirty-object.output.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+
+// @ts-expect-error
+import {useRouteForm} from '~/shared/utilities/forms/useRouteForm';
+
+export function App() {
+  const {reset, dirty, submit} = useRouteForm();
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+      dirty={dirty}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import-and-dirty-variable.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import-and-dirty-variable.input.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+
+// @ts-expect-error
+import {useRouteForm} from '~/shared/utilities/forms/useRouteForm';
+
+export function App() {
+  const {reset, submit} = useRouteForm();
+  const dirty = false;
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import-and-dirty-variable.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import-and-dirty-variable.output.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+
+// @ts-expect-error
+import {useRouteForm} from '~/shared/utilities/forms/useRouteForm';
+
+export function App() {
+  const {reset, submit} = useRouteForm();
+  const dirty = false;
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+      dirty={dirty}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import.input.tsx
@@ -1,0 +1,31 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import {useRouteForm} from '~/shared/utilities/forms/useRouteForm';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  const {reset, submit} = useRouteForm();
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import.input.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import.input.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import {useRouteForm} from '~/shared/utilities/forms/useRouteForm';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import.output.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 // @ts-expect-error
 import {Modal, TextContainer} from '@shopify/polaris-internal';
+
 // @ts-expect-error
 import {useRouteForm} from '~/shared/utilities/forms/useRouteForm';
 

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import.output.tsx
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/tests/with-use-route-form-import.output.tsx
@@ -1,0 +1,32 @@
+import React, {useState} from 'react';
+// @ts-expect-error
+import {Modal, TextContainer} from '@shopify/polaris-internal';
+// @ts-expect-error
+import {useRouteForm} from '~/shared/utilities/forms/useRouteForm';
+
+export function App() {
+  const [dirty, setDirty] = useState(false);
+  const {reset, submit} = useRouteForm();
+  return (
+    <Modal
+      open={false}
+      onClose={() => {}}
+      title="Title"
+      primaryAction={{
+        content: 'Save',
+        onAction: submit,
+      }}
+      secondaryActions={[
+        {
+          content: 'Cancel',
+          onAction: reset,
+        },
+      ]}
+      dirty={dirty}
+    >
+      <Modal.Section>
+        <TextContainer>Lorem ipsum</TextContainer>
+      </Modal.Section>
+    </Modal>
+  );
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
@@ -21,6 +21,7 @@ const formUtilityImportSources = [
   '~/shared/utilities/react-form-state',
   '~/shared/utilities/forms/useRouteForm',
   '~/shared/utilities/react-form',
+  '~/shared/utilities/forms/useFormState',
 ];
 
 export default function transformer(fileInfo: FileInfo, {jscodeshift: j}: API) {

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
@@ -84,7 +84,7 @@ export default function transformer(fileInfo: FileInfo, {jscodeshift: j}: API) {
         insertCommentBefore(
           j,
           element,
-          'Verify if `dirty` variable exists in the file',
+          'polaris-migrator: Verify if `dirty` variable exists in the file',
         );
       }
     }

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
@@ -15,6 +15,7 @@ import {
 const modalImportSources = [
   '@shopify/polaris-internal',
   '~/shared/components/Modal',
+  '~/shared/components/Modal/Modal',
 ];
 
 const formUtilityImportSources = [

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
@@ -1,0 +1,94 @@
+import type {API, FileInfo} from 'jscodeshift';
+
+import {POLARIS_MIGRATOR_COMMENT} from '../../utilities/constants';
+import {
+  getImportSpecifierName,
+  hasImportDeclaration,
+} from '../../utilities/imports';
+import {
+  hasJSXAttribute,
+  insertCommentBefore,
+  insertJSXAttribute,
+  insertJSXComment,
+} from '../../utilities/jsx';
+
+const modalImportSources = [
+  '@shopify/polaris-internal',
+  '~/shared/components/Modal',
+];
+
+const formUtilityImportSources = [
+  '~/shared/utilities/react-form-state',
+  '~/shared/utilities/forms/useRouteForm',
+  '~/shared/utilities/react-form',
+];
+
+export default function transformer(fileInfo: FileInfo, {jscodeshift: j}: API) {
+  const source = j(fileInfo.source);
+
+  const hasModalImports = modalImportSources.some((importSource) =>
+    hasImportDeclaration(j, source, importSource),
+  );
+
+  if (!hasModalImports) {
+    return fileInfo.source;
+  }
+
+  const hasFormUtilityImports = formUtilityImportSources.some((importSource) =>
+    hasImportDeclaration(j, source, importSource),
+  );
+
+  if (!hasFormUtilityImports) {
+    return fileInfo.source;
+  }
+
+  const localElementNames = modalImportSources.reduce<string[]>(
+    (acc, importSource) => {
+      const localElementName = getImportSpecifierName(
+        j,
+        source,
+        'Modal',
+        importSource,
+      );
+      return localElementName ? [...acc, localElementName] : acc;
+    },
+    [],
+  );
+
+  const hasDirtyIdentifier = source
+    .find(j.Identifier)
+    .some((path) => path.node.name === 'dirty');
+
+  source.find(j.JSXElement).forEach((element) => {
+    if (element.node.openingElement.name.type !== 'JSXIdentifier') return;
+
+    if (!localElementNames.includes(element.node.openingElement.name.name))
+      return;
+
+    const allAttributes = element.node.openingElement.attributes ?? [];
+
+    if (allAttributes.some((attribute) => attribute.type !== 'JSXAttribute')) {
+      insertJSXComment(j, element, POLARIS_MIGRATOR_COMMENT);
+      return;
+    }
+
+    if (!hasJSXAttribute(j, element, 'dirty')) {
+      if (hasDirtyIdentifier) {
+        insertJSXAttribute(
+          j,
+          element,
+          'dirty',
+          j.jsxExpressionContainer(j.identifier('dirty')),
+        );
+      } else {
+        insertCommentBefore(
+          j,
+          element,
+          'Verify if `dirty` variable exists in the file',
+        );
+      }
+    }
+  });
+
+  return source.toSource();
+}

--- a/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-update-modal-component-dirty-prop/transform.ts
@@ -22,6 +22,7 @@ const formUtilityImportSources = [
   '~/shared/utilities/react-form-state',
   '~/shared/utilities/forms/useRouteForm',
   '~/shared/utilities/react-form',
+  '~/shared/utilities/react-form/hooks/form',
   '~/shared/utilities/forms/useFormState',
 ];
 

--- a/polaris-migrator/src/utilities/jsx.ts
+++ b/polaris-migrator/src/utilities/jsx.ts
@@ -1,4 +1,10 @@
-import type {ASTPath, Collection, JSXAttribute, JSXElement} from 'jscodeshift';
+import type {
+  ASTPath,
+  Collection,
+  JSXAttribute,
+  JSXElement,
+  JSXExpressionContainer,
+} from 'jscodeshift';
 import type core from 'jscodeshift';
 
 export function getJSXAttributes(
@@ -57,14 +63,16 @@ export function insertJSXAttribute(
   j: core.JSCodeshift,
   element: ASTPath<any>,
   attributeName: string,
-  attributeValue?: string,
+  attributeValue?: string | JSXExpressionContainer,
 ) {
   const newComponent = j.jsxElement(
     j.jsxOpeningElement(element.node.openingElement.name, [
       ...(element.node.openingElement.attributes || []),
       j.jsxAttribute(
         j.jsxIdentifier(attributeName),
-        attributeValue ? j.stringLiteral(attributeValue) : null,
+        typeof attributeValue === 'string'
+          ? j.stringLiteral(attributeValue)
+          : attributeValue || null,
       ),
     ]),
     element.node.closingElement,


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [1058](https://github.com/Shopify/polaris-internal/issues/1058).

### WHAT is this pull request doing?

Adds new migration to support `dirty` on Modal.
This is a temp migration and will not be committed to main.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
