### PR TITLE
Remove codeowners on shopify/polaris-icons

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# Polaris icons migration
-/polaris-icons @alex-page @sam-b-rose @gwyneplaine
-/polaris-tokens @alex-page @sam-b-rose @gwyneplaine


### PR DESCRIPTION

### WHY are these changes introduced?

Codeowners are no longer needed for icons.

### WHAT is this pull request doing?

Removes codeowners for `@shopify/polaris-icons`
