### PR TITLE
[docs site] Update TOC to scroll with page content

### DIFF
--- a/.changeset/tame-sheep-knock.md
+++ b/.changeset/tame-sheep-knock.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix ToC vertical overflow bug by enabling (1) independent TC scroll, and (2) ToC scroll tracking the current heading

--- a/polaris.shopify.com/src/components/Page/Page.module.scss
+++ b/polaris.shopify.com/src/components/Page/Page.module.scss
@@ -67,7 +67,9 @@
   top: calc(var(--header-height) + 4.25rem);
   padding: var(--p-space-400) var(--p-space-200) var(--p-space-200);
   width: var(--toc-width);
+  max-height: calc(100vh - var(--toc-top) - var(--p-space-200));
   overscroll-behavior: contain;
+  overflow-y: auto;
   border: 1.5px solid var(--border-color);
   border-radius: var(--p-border-radius-300);
 

--- a/polaris.shopify.com/src/components/Page/Page.module.scss
+++ b/polaris.shopify.com/src/components/Page/Page.module.scss
@@ -69,6 +69,7 @@
   width: var(--toc-width);
   max-height: calc(100vh - var(--toc-top) - var(--p-space-200));
   overscroll-behavior: contain;
+  scroll-behavior: smooth;
   overflow-y: auto;
   border: 1.5px solid var(--border-color);
   border-radius: var(--p-border-radius-300);

--- a/polaris.shopify.com/src/components/Page/Page.tsx
+++ b/polaris.shopify.com/src/components/Page/Page.tsx
@@ -1,3 +1,4 @@
+import {useRef, useCallback, useEffect, useState} from 'react';
 import {useTOC} from '../../utils/hooks';
 import {className, toPascalCase} from '../../utils/various';
 import Longform from '../Longform';
@@ -29,6 +30,7 @@ function Layout({
   editPageLinkPath,
   children,
 }: Props) {
+  const [TOCTop, setTOCTop] = useState<number | null>(null);
   const [tocItems] = useTOC(children);
   const {asPath} = useRouter();
 
@@ -41,6 +43,21 @@ function Layout({
     : '';
   const isComponentPage = asPath.includes('/components/');
   const componentTitle = toPascalCase(asPath.split('/').pop() ?? '');
+  const TOCWrapperRef = useRef<HTMLDivElement | null>(null);
+
+  const updateTOCTop = useCallback(() => {
+    if (TOCWrapperRef.current) {
+      setTOCTop(TOCWrapperRef.current.getBoundingClientRect().top);
+    }
+  }, []);
+
+  useEffect(() => {
+    updateTOCTop();
+    window.addEventListener('resize', updateTOCTop);
+    return () => {
+      window.removeEventListener('resize', updateTOCTop);
+    };
+  }, [updateTOCTop]);
 
   return (
     <Container className={className(styles.Page, showTOC && styles.showTOC)}>
@@ -73,7 +90,11 @@ function Layout({
         </footer>
       </Box>
       {showTOC && (
-        <div className={styles.TOCWrapper}>
+        <div
+          className={styles.TOCWrapper}
+          ref={TOCWrapperRef}
+          style={{'--toc-top': `${TOCTop}px`} as React.CSSProperties}
+        >
           <TOC items={tocItems} collapsibleTOC={collapsibleTOC} />
         </div>
       )}

--- a/polaris.shopify.com/src/components/TOC/TOC.tsx
+++ b/polaris.shopify.com/src/components/TOC/TOC.tsx
@@ -118,7 +118,7 @@ function TOC({items, collapsibleTOC = false}: Props) {
     }
   }
 
-  const detectLinkVisibility = useCallback((linkElement: HTMLAnchorElement) => {
+  const detectLinkVisibility = useCallback((linkElement: HTMLElement) => {
     if (!linkElement) return;
 
     const observer = new IntersectionObserver((entries) => {
@@ -136,7 +136,7 @@ function TOC({items, collapsibleTOC = false}: Props) {
     return () => observer.disconnect();
   }, []);
 
-  function scrollLinkIntoView(linkElement: HTMLAnchorElement) {
+  function scrollLinkIntoView(linkElement: HTMLElement) {
     if (!linkElement) return;
     linkElement.scrollIntoView();
   }

--- a/polaris.shopify.com/src/components/TOC/TOC.tsx
+++ b/polaris.shopify.com/src/components/TOC/TOC.tsx
@@ -108,11 +108,39 @@ function TOC({items, collapsibleTOC = false}: Props) {
     }
   }
 
+  function detectLinkVisibility(linkElement: HTMLAnchorElement) {
+    if (!linkElement) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        console.log({entry});
+        if (!entry.isIntersecting) {
+          // scroll.
+          console.log('not intersecting');
+          return;
+        } else {
+          console.log('intersecting');
+          return;
+        }
+      });
+      observer.disconnect();
+    });
+
+    observer.observe(linkElement);
+  }
+
   useEffect(() => {
     detectCurrentHeading();
     window.addEventListener('scroll', detectCurrentHeading);
     return () => window.removeEventListener('scroll', detectCurrentHeading);
   }, []);
+
+  if (idOfCurrentHeading) {
+    const currentHeadingLinkElement = document.getElementById(
+      `${idOfCurrentHeading}-link`,
+    );
+    detectLinkVisibility(currentHeadingLinkElement);
+  }
 
   useEffect(() => detectCurrentHeading(), [items]);
 
@@ -130,6 +158,7 @@ function TOC({items, collapsibleTOC = false}: Props) {
 
     return (
       <a
+        id={`${toId}-link`}
         className={className}
         href={`#${toId}`}
         onClick={(evt) => {

--- a/polaris.shopify.com/src/components/TOC/TOC.tsx
+++ b/polaris.shopify.com/src/components/TOC/TOC.tsx
@@ -46,11 +46,20 @@ function scanPageForCurrentHeading(): string | void {
 }
 
 function TOC({items, collapsibleTOC = false}: Props) {
+  const [isPointerInside, setIsPointerInside] = useState(false);
   const isNested = !!items.find((item) => item.children.length > 0);
   const [idOfCurrentHeading, setIdOfCurrentHeading] = useState<string>();
   const temporarilyIgnoreScrolling = useRef(false);
   const lastScrollY = useRef(0);
   const linkSuffix = '-link';
+
+  const handlePointerEnter = () => {
+    setIsPointerInside(true);
+  };
+
+  const handlePointerLeave = () => {
+    setIsPointerInside(false);
+  };
 
   const [manuallyExpandedSections, setManuallyExpandedSections] = useState<{
     [id: string]: boolean;
@@ -135,21 +144,19 @@ function TOC({items, collapsibleTOC = false}: Props) {
   useEffect(() => {
     detectCurrentHeading();
     window.addEventListener('scroll', detectCurrentHeading);
-    return () => {
-      window.removeEventListener('scroll', detectCurrentHeading);
-    };
+    return () => window.removeEventListener('scroll', detectCurrentHeading);
   }, []);
 
   useEffect(() => {
-    if (idOfCurrentHeading) {
+    if (idOfCurrentHeading && !isPointerInside) {
       const currentHeadingLinkElement = document.getElementById(
         `${idOfCurrentHeading}${linkSuffix}`,
-      ) as HTMLAnchorElement | null;
+      );
       if (currentHeadingLinkElement) {
         detectLinkVisibility(currentHeadingLinkElement);
       }
     }
-  }, [detectLinkVisibility, idOfCurrentHeading]);
+  }, [detectLinkVisibility, idOfCurrentHeading, isPointerInside]);
 
   useEffect(() => detectCurrentHeading(), [items]);
 
@@ -188,7 +195,11 @@ function TOC({items, collapsibleTOC = false}: Props) {
   };
 
   return (
-    <div className={classNames(styles.TOC, isNested && styles.isNested)}>
+    <div
+      className={classNames(styles.TOC, isNested && styles.isNested)}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+    >
       <ul>
         <Box
           style={{


### PR DESCRIPTION
 ℹ️  Pausing this work as their is another effort to update the documentation soon. Outstanding tasks documented below.


### WHY are these changes introduced?

Fixes #147

### WHAT is this pull request doing?

Updates the `TOC` component to:

- scroll independently of the page
- scroll below-the-fold links into view when the associated heading is visible on the page


### Other approaches considered


**1. Hide the `TOC` when there is not sufficient vertical space**

Rationale: we already hide the TOC below 1400px

Conclusion: The TOC height varies between pages. Hiding the TOC when there is not sufficient vertical space causes inconsistent UX between pages. 

**2. Break the TOC content into individual child pages**

Rationale: if content is so long it requires a TOC, that is too much content.

Conclusion: Due to the different structure of pages across the top-level sections, breaking all TOC content into child pages requires additional review of the IA, and a number of changes to the site components and structure (removing descriptons; curating order of sub-pages; handling subnav; handling index pages). This time investment was deemed excessive at present, given the TOC only overflows on a handful of pages. The usage of a TOC to break content into more manageable chunks is also consistent with shopify.dev IA. 
 
### Video tophat 📹 🎩 


https://github.com/user-attachments/assets/2f0f1ca3-af33-4c99-a6a6-d8c82b4384c9



### How to 🎩

1. Checkout branch
2. Run `pnpm turbo run dev --filter=polaris.shopify.com` 
3. On a page with vertical TOC overflow (`Content` > `ActionableLanguage`):
        - scroll the TOC to select links below the fold
        - scroll the TOC to show links below the fold, without a selection
        - scroll the page to a heading associated with a link below the fold 


🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) (Chrome MacOS; Safari MacOS; Firefox MacOS) 
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide

----- 

### ❗ Outstanding

The work remaining for this particular PR is to fix the bug shown below - when a cursor enters the TOC, no selection is made, and the cursor leaves the TOC, the page shifts. 
Suspected cause: `window` `scroll` event listener is triggering when the pointer is within the TOC. 

https://github.com/user-attachments/assets/db2b1e88-879c-477c-af62-e45df85aefed

----
