### PR TITLE
dependabot auto merge fix: use squash instead of merge, check status …

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -59,7 +59,38 @@ jobs:
             }`
             const data = {
               pullRequestId: response.repository.pullRequest.id,
-              mergeMethod: 'MERGE',
+              mergeMethod: 'SQUASH',
             }
 
-            await github.graphql(enableAutoMergeQuery, data)
+            const checkStatusQuery = `query($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pullRequestNumber) {
+                  commits(last: 1) {
+                    nodes {
+                      commit {
+                        statusCheckRollup {
+                          state
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }`
+
+            // Check if status checks are successful
+            const statusResponse = await github.graphql(checkStatusQuery, repoInfo)
+            const checkState = statusResponse.repository.pullRequest.commits.nodes[0]?.commit?.statusCheckRollup?.state
+
+            if (checkState !== 'SUCCESS') {
+              console.log('Status checks are not successful yet. Current state:', checkState)
+              core.setFailed('Status checks must pass before enabling auto-merge')
+              return
+            }
+
+            try {
+              await github.graphql(enableAutoMergeQuery, data)
+            } catch (error) {
+              console.log('Failed to enable auto-merge:', error.message)
+              core.setFailed(error.message)
+            }


### PR DESCRIPTION
Use squash instead of merge, check status first to avoid unstable status, add error logging
