### PR TITLE
Remove card shadows from smaller breakpoints

### DIFF
--- a/.changeset/stupid-otters-smile.md
+++ b/.changeset/stupid-otters-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Remove card shadows on mobile, replace useBreakpoints in Card with responsive props

--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -1,12 +1,10 @@
 import type {
   BreakpointsAlias,
   ColorBackgroundAlias,
-  BorderRadiusAliasOrScale,
   SpaceScale,
 } from '@shopify/polaris-tokens';
 import React from 'react';
 
-import {useBreakpoints} from '../../utilities/breakpoints';
 import type {ResponsiveProp} from '../../utilities/css';
 import {Box} from '../Box';
 import {ShadowBevel} from '../ShadowBevel';
@@ -39,16 +37,15 @@ export const Card = ({
   padding = {xs: '400'},
   roundedAbove = 'sm',
 }: CardProps) => {
-  const breakpoints = useBreakpoints();
-  const defaultBorderRadius: BorderRadiusAliasOrScale = '300';
-  const hasBorderRadius = Boolean(breakpoints[`${roundedAbove}Up`]);
-
   return (
     <WithinContentContext.Provider value>
       <ShadowBevel
         boxShadow="100"
-        borderRadius={hasBorderRadius ? defaultBorderRadius : '0'}
+        borderRadius="300"
         zIndex="32"
+        bevel={{
+          [roundedAbove]: true,
+        }}
       >
         <Box
           background={background}

--- a/polaris-react/src/components/Card/tests/Card.test.tsx
+++ b/polaris-react/src/components/Card/tests/Card.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
-import {setMediaWidth} from 'tests/utilities/breakpoints';
 
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {Card} from '..';
@@ -42,17 +41,29 @@ describe('Card', () => {
     expect(card).toContainReactComponentTimes('p', 2);
   });
 
-  it('sets default border radius when roundedAbove breakpoint passed in', () => {
-    setMediaWidth('breakpoints-sm');
+  it('cards are rounded sm and above by default', () => {
     const card = mountWithApp(
-      <Card roundedAbove="sm">
+      <Card>
         {heading}
         {subheading}
       </Card>,
     );
 
     expect(card).toContainReactComponent(ShadowBevel, {
-      borderRadius: '300',
+      bevel: {sm: true},
+    });
+  });
+
+  it('cards respect incoming roundedAbove prop', () => {
+    const card = mountWithApp(
+      <Card roundedAbove="md">
+        {heading}
+        {subheading}
+      </Card>,
+    );
+
+    expect(card).toContainReactComponent(ShadowBevel, {
+      bevel: {md: true},
     });
   });
 });

--- a/polaris-react/src/components/LegacyCard/LegacyCard.module.css
+++ b/polaris-react/src/components/LegacyCard/LegacyCard.module.css
@@ -1,11 +1,7 @@
 .LegacyCard {
   background-color: var(--p-color-bg-surface);
-  box-shadow: var(--p-shadow-300);
   outline: var(--p-border-width-025) solid transparent;
   overflow: clip;
-
-  @mixin shadow-bevel var(--p-shadow-100), var(--p-border-radius-0), null, '',
-    101;
 
   + .LegacyCard {
     margin-top: var(--p-space-400);
@@ -16,6 +12,7 @@
   }
 
   @media (--p-breakpoints-sm-up) {
+    box-shadow: var(--p-shadow-300);
     border-radius: var(--p-border-radius-200);
 
     @mixin shadow-bevel var(--p-shadow-100), var(--p-border-radius-300), null,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/11968

Re-implementation of https://github.com/Shopify/polaris/pull/11926

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Removes Card and LegacyCard default bevel styles below the sm breakpoint. Essentially if card corners aren’t rounded then shadow styles are removed as well.

Currently the Card component toggles border-radius at certain breakpoints with the roundedAbove prop (and defaults to the sm breakpoint). This PR also adds box-shadow to these toggled styles.

This is also removing the reliance on `useBreakpoints()` in the `Card` component. Currently the `borderRadius` does not apply on an initial SSR render because `useBreakpoints` relies on the client-side render to determine the browser size. So we default to the mobile style with square corners (and no shadow/bevel) on initial SSR before getting the rounded corners on client-side render.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
