### PR TITLE
[FullscreenBar] Fix invisible BackButton color within Styleguide

### DIFF
--- a/.changeset/unlucky-frogs-repair.md
+++ b/.changeset/unlucky-frogs-repair.md
@@ -1,0 +1,6 @@
+---
+'polaris.shopify.com': patch
+'@shopify/polaris': patch
+---
+
+Explicit color provided for `FullscreenBar > BackButton`.

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.module.css
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.module.css
@@ -13,6 +13,7 @@
   align-items: center;
   padding-left: var(--p-space-400);
   padding-right: var(--p-space-400);
+  color: var(--p-color-text);
   border-width: 0;
   border-right: var(--p-border-width-025) solid var(--p-color-border-secondary);
   background-color: var(--p-color-bg-surface);

--- a/polaris.shopify.com/src/components/Frame/Frame.tsx
+++ b/polaris.shopify.com/src/components/Frame/Frame.tsx
@@ -6,7 +6,7 @@ import {motion, AnimatePresence} from 'framer-motion';
 
 import GlobalSearch from '../GlobalSearch';
 import nav from '../../../.cache/nav';
-import {NavItem, Breakpoints} from '../../types';
+import {type NavItem, Breakpoints} from '../../types';
 
 import styles from './Frame.module.scss';
 import {className} from '../../utils/various';


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed while reviewing the Polaris Styleguide that the `FullscreenBar > BackButton` was... invisible. I then noticed:

1. It looks totally fine within the Code Sandbox
2. It also looks totally fine if the Styleguide is toggled to "light mode".

So, there must be some styling from outside the `<iframe />` that is causing this...

https://github.com/user-attachments/assets/a119354c-cbef-4828-a517-79fff96e1f10

### WHAT is this pull request doing?

I've simply applied `color: var(--p-color-text)` to the `BackButton`. This appears to resolve the issue without introducing any negative side effects... but of course, I may have gone about this incorrectly.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Please tophat this by running the Styleguide locally. You will want to make sure you blow away any previous `polaris` bundle that the Styleguide consumers. I simply did the following:

- `pnpm clean`
- `pnpm install`
- `pnpm build`
- `pnpm turbo run dev --filter=polaris.shopify.com`
- Then, visit the `FullscreenBar` page and toggle between `light/dark` mode from the Styleguide header.

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
   - Not sure if this is relevant?
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
   - Not relevant.
- [x] Updated the component's `README.md` with documentation changes
   - Not relevant.
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
