### PR TITLE
Expose disabled in tooltip

### DIFF
--- a/.changeset/giant-mayflies-sniff.md
+++ b/.changeset/giant-mayflies-sniff.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+updated Tooltip component such that when content is null only children are rendered rather than tooltip itself

--- a/polaris-react/src/components/Tooltip/Tooltip.tsx
+++ b/polaris-react/src/components/Tooltip/Tooltip.tsx
@@ -22,8 +22,8 @@ export type BorderRadius = Extract<BorderRadiusAliasOrScale, '100' | '200'>;
 export interface TooltipProps {
   /** The element that will activate to tooltip */
   children?: React.ReactNode;
-  /** The content to display within the tooltip */
-  content: React.ReactNode;
+  /** The content to display within the tooltip. If null, the tooltip will not be rendered. */
+  content: React.ReactNode | null;
   /** Toggle whether the tooltip is visible */
   active?: boolean;
   /** Delay in milliseconds while hovering over an element before the tooltip is visible */
@@ -174,7 +174,7 @@ export function Tooltip({
     }
   }, [originalActive, active, handleClose, handleBlur]);
 
-  const portal = activatorNode ? (
+  const tooltipPortal = activatorNode ? (
     <Portal idPrefix="tooltip">
       <TooltipOverlay
         id={id}
@@ -224,7 +224,7 @@ export function Tooltip({
       className={wrapperClassNames}
     >
       {children}
-      {portal}
+      {content !== null && tooltipPortal}
     </WrapperComponent>
   );
 

--- a/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/polaris-react/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -509,6 +509,46 @@ describe('<Tooltip />', () => {
       });
     });
   });
+
+  describe('tooltip when content is null', () => {
+    it('does not render tooltip when content is null', () => {
+      const tooltip = mountWithApp(
+        <Tooltip content={null}>
+          <Link>link content</Link>
+        </Tooltip>,
+      );
+  
+      expect(tooltip).not.toContainReactComponent(TooltipOverlay);
+      expect(tooltip).toContainReactComponent(Link);
+    });
+  
+    it('renders tooltip when content changes from null to a value', () => {
+      const tooltip = mountWithApp(
+        <Tooltip content={null}>
+          <Link>link content</Link>
+        </Tooltip>,
+      );
+  
+      tooltip.setProps({content: 'New content'});
+      findWrapperComponent(tooltip)!.trigger('onMouseOver');
+  
+      expect(tooltip).toContainReactComponent(TooltipOverlay);
+    });
+  
+    it('removes tooltip when content changes to null', () => {
+      const tooltip = mountWithApp(
+        <Tooltip content="Initial content">
+          <Link>link content</Link>
+        </Tooltip>,
+      );
+  
+      findWrapperComponent(tooltip)!.trigger('onMouseOver');
+      expect(tooltip).toContainReactComponent(TooltipOverlay);
+  
+      tooltip.setProps({content: null});
+      expect(tooltip).not.toContainReactComponent(TooltipOverlay);
+    });
+  });
 });
 
 function findWrapperComponent(tooltip: any) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #13052

### WHAT is this pull request doing?

If the content is null for the Tooltip component, we no longer render the tooltip

https://github.com/user-attachments/assets/49518cc5-aa7b-46b6-9bfd-705db11cf208

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes (unsure if required)
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
