### PR TITLE
onBlur now firing for TextField when clearButton prop exists 

### DIFF
--- a/.changeset/little-owls-agree.md
+++ b/.changeset/little-owls-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+OnBlur now firing if you tab out of the clear button provided in the TextField component

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -394,6 +394,7 @@ export function TextField({
         type="button"
         className={styles.ClearButton}
         onClick={handleClearButtonPress}
+        onBlur={handleOnBlur}
         disabled={disabled}
       >
         <Text as="span" visuallyHidden>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #12964 

Added OnBlur to the button prop in the text field, such that when you tab out, via button, on blur will activate

https://github.com/user-attachments/assets/f028f027-654a-416b-a940-fba194fe516d

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes (unsure if required)
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide (unsure if required)
