### PR TITLE
Add optional titleFontWeight prop to Title component

### DIFF
--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -570,3 +570,21 @@ export const WithContentAfterTitleAndSubtitle = {
     );
   },
 };
+
+export const WithSemiboldTitle = {
+  render() {
+    return (
+      <Page
+        title="Semibold title"
+        titleFontWeight="semibold"
+        subtitle="This page uses a semibold title"
+      >
+        <LegacyCard title="Content" sectioned>
+          <Text as="p" variant="bodyMd">
+            Page content
+          </Text>
+        </LegacyCard>
+      </Page>
+    );
+  },
+};

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -67,6 +67,8 @@ export interface HeaderProps extends TitleProps {
   additionalMetadata?: React.ReactNode | string;
   /** Callback that returns true when secondary actions are rolled up into action groups, and false when not */
   onActionRollup?(hasRolledUp: boolean): void;
+  /** Title font weight */
+  titleFontWeight?: 'semibold' | 'bold';
 }
 
 const SHORT_TITLE = 20;
@@ -88,6 +90,7 @@ export function Header({
   actionGroups = [],
   compactTitle = false,
   onActionRollup,
+  titleFontWeight,
 }: HeaderProps) {
   const i18n = useI18n();
   const {isNavigationCollapsed} = useMediaQuery();
@@ -138,6 +141,7 @@ export function Header({
         titleMetadata={titleMetadata}
         compactTitle={compactTitle}
         hasSubtitleMaxWidth={hasActionGroupsOrSecondaryActions}
+        titleFontWeight={titleFontWeight}
       />
     </div>
   );
@@ -178,8 +182,8 @@ export function Header({
         onActionRollup={onActionRollup}
       />
     );
-  } else if (isReactElement(secondaryActions)) {
-    actionMenuMarkup = <>{secondaryActions}</>;
+  } else if (React.isValidElement(secondaryActions)) {
+    actionMenuMarkup = secondaryActions;
   }
 
   const navigationMarkup =

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
@@ -19,6 +19,8 @@ export interface TitleProps {
    * the presence of either the secondaryActions or actionGroups props on the
    * Header that consumes this component */
   hasSubtitleMaxWidth?: boolean;
+  /** Font weight for the title. Defaults to 'bold' */
+  titleFontWeight?: 'semibold' | 'bold';
 }
 
 export function Title({
@@ -27,6 +29,7 @@ export function Title({
   titleMetadata,
   compactTitle,
   hasSubtitleMaxWidth,
+  titleFontWeight = 'bold',
 }: TitleProps) {
   const className = classNames(
     styles.Title,
@@ -35,7 +38,7 @@ export function Title({
 
   const titleMarkup = title ? (
     <h1 className={className}>
-      <Text as="span" variant="headingLg" fontWeight="bold">
+      <Text as="span" variant="headingLg" fontWeight={titleFontWeight}>
         {title}
       </Text>
     </h1>

--- a/polaris-react/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
@@ -20,6 +20,22 @@ describe('<Title />', () => {
       const pageTitle = mountWithApp(<Title />);
       expect(pageTitle).not.toContainReactComponent(Text);
     });
+
+    it('uses bold font weight by default', () => {
+      const pageTitle = mountWithApp(<Title {...mockProps} />);
+      expect(pageTitle).toContainReactComponent(Text, {
+        fontWeight: 'bold',
+      });
+    });
+
+    it('uses semibold font weight when specified', () => {
+      const pageTitle = mountWithApp(
+        <Title {...mockProps} titleFontWeight="semibold" />,
+      );
+      expect(pageTitle).toContainReactComponent(Text, {
+        fontWeight: 'semibold',
+      });
+    });
   });
 
   describe('subtitle', () => {

--- a/polaris-react/src/components/Page/tests/Page.test.tsx
+++ b/polaris-react/src/components/Page/tests/Page.test.tsx
@@ -57,6 +57,15 @@ describe('<Page />', () => {
         title,
       });
     });
+
+    it('passes titleFontWeight to Header', () => {
+      const page = mountWithApp(
+        <Page {...mockProps} titleFontWeight="semibold" />,
+      );
+      expect(page).toContainReactComponent(Header, {
+        titleFontWeight: 'semibold',
+      });
+    });
   });
 
   describe('subtitle', () => {

--- a/polaris-react/tsconfig.json
+++ b/polaris-react/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "emitDeclarationOnly": true,
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "outDir": "build/ts",
     "rootDir": "./",
     "strictFunctionTypes": false,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?
These changes synchronize some font weights between internal and external Polaris implementations, enabling first-party apps (and others) to maintain visual parity with Shopify's core admin interface.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Polaris-internal's font-weights have changed for the following variables:
`font-weight-semibold` was updated to `600` (previously `650`)
`font-weight-bold` was updated to `650` (previously `700`)

This approach introduces an optional `titleFontWeight`prop to the `Title` component, keeping the default font-weight value the same as it currently is (`700`) while allow it to change to `650` if a less bold title is desired.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
