### PR TITLE
[Page][Breadcrumbs] Deprecate `title` and `backAction` props

### DIFF
--- a/.changeset/curly-mails-shout.md
+++ b/.changeset/curly-mails-shout.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Deprecated `title` prop in `Page.Title` and `backAction` prop in `Page.Header` and `Breadcrumbs`

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,7 +6,10 @@ import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {Button} from '../Button';
 
 export interface BreadcrumbsProps {
-  /** Back action link */
+  /**
+   * @deprecated Back action link
+   * Use `breadcrumbs` prop instead as documented [here](https://shopify.dev/docs/api/app-bridge/previous-versions/actions/titlebar#using-titlebar-with-polaris)
+   */
   backAction: CallbackAction | LinkAction;
 }
 

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -57,7 +57,10 @@ export interface HeaderProps extends TitleProps {
   primaryAction?: PrimaryAction | React.ReactNode;
   /** Page-level pagination */
   pagination?: PaginationProps;
-  /** A back action link */
+  /**
+   * @deprecated A back action link
+   * Use `breadcrumbs` prop instead as documented [here](https://shopify.dev/docs/api/app-bridge/previous-versions/actions/titlebar#using-titlebar-with-polaris)
+   */
   backAction?: BreadcrumbsProps['backAction'];
   /** Collection of secondary page-level actions */
   secondaryActions?: MenuActionDescriptor[] | React.ReactNode;

--- a/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/polaris-react/src/components/Page/components/Header/components/Title/Title.tsx
@@ -7,7 +7,10 @@ import {Text} from '../../../../../Text';
 import styles from './Title.module.css';
 
 export interface TitleProps {
-  /** Page title, in large type */
+  /**
+   * @deprecated Page title, in large type
+   * Use `breadcrumbs` prop instead as documented [here](https://shopify.dev/docs/api/app-bridge/previous-versions/actions/titlebar#using-titlebar-with-polaris)
+   */
   title?: string;
   /** Page subtitle, in regular type */
   subtitle?: string;


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [polaris#769](https://github.com/shop/issues-polaris-internal/issues/769).
Resolves [polaris#16](https://github.com/shop/issues-polaris-internal/issues/16).

### WHAT is this pull request doing?

Deprecates the following:

- `Page.Title` component `title` prop
- `Page.Header` component `backAction` prop
- `Breadcrumbs` component `backAction` prop

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
