### PR TITLE
[Card] Add overflowX and overflowY props for horizontal and vertical clipping

### DIFF
--- a/.changeset/sharp-queens-fly.md
+++ b/.changeset/sharp-queens-fly.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add `overflowX` and `overflowY` properties to the `Card`

--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import {useBreakpoints} from '../../utilities/breakpoints';
 import type {ResponsiveProp} from '../../utilities/css';
+import type {BoxProps} from '../Box';
 import {Box} from '../Box';
 import {ShadowBevel} from '../ShadowBevel';
 import {WithinContentContext} from '../../utilities/within-content-context';
@@ -31,6 +32,14 @@ export interface CardProps {
    * @default 'sm'
    */
   roundedAbove?: BreakpointsAlias;
+  /** Clip or scroll horizontal overflow of children content
+   * @default 'clip'
+   */
+  overflowX?: BoxProps['overflowX'];
+  /** Clip or scroll vertical overflow of children content
+   * @default 'clip'
+   */
+  overflowY?: BoxProps['overflowY'];
 }
 
 export const Card = ({
@@ -38,6 +47,8 @@ export const Card = ({
   background = 'bg-surface',
   padding = {xs: '400'},
   roundedAbove = 'sm',
+  overflowX = 'clip',
+  overflowY = 'clip',
 }: CardProps) => {
   const breakpoints = useBreakpoints();
   const defaultBorderRadius: BorderRadiusAliasOrScale = '300';
@@ -53,8 +64,8 @@ export const Card = ({
         <Box
           background={background}
           padding={padding}
-          overflowX="clip"
-          overflowY="clip"
+          overflowX={overflowX}
+          overflowY={overflowY}
           minHeight="100%"
         >
           {children}

--- a/polaris-react/src/components/Card/tests/Card.test.tsx
+++ b/polaris-react/src/components/Card/tests/Card.test.tsx
@@ -5,6 +5,7 @@ import {setMediaWidth} from 'tests/utilities/breakpoints';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {Card} from '..';
 import {ShadowBevel} from '../../ShadowBevel';
+import {Box} from '../../Box';
 
 const heading = <p>Online store dashboard</p>;
 const subheading = <p>View a summary of your online store performance</p>;
@@ -53,6 +54,28 @@ describe('Card', () => {
 
     expect(card).toContainReactComponent(ShadowBevel, {
       borderRadius: '300',
+    });
+  });
+
+  it('uses default overflow values if none provided', () => {
+    const card = mountWithApp(<Card>{heading}</Card>);
+    expect(card).toContainReactComponent(Box, {
+      overflowX: 'clip',
+      overflowY: 'clip',
+    });
+  });
+
+  it('forwards overflowX and overflowY props to Box', () => {
+    const card = mountWithApp(
+      <Card overflowX="hidden" overflowY="clip">
+        {heading}
+        {subheading}
+      </Card>,
+    );
+
+    expect(card).toContainReactComponent(Box, {
+      overflowX: 'hidden',
+      overflowY: 'clip',
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

This PR addresses issues raised around the Card component having hardcoded overflow behavior (e.g., overflow: hidden or clip), limiting layout flexibility.

It fixes [issue #13951](https://github.com/Shopify/polaris/issues/13951) by enabling configuration of horizontal and vertical clipping behavior to support cases like sticky children or internal scrolling.

### WHAT is this pull request doing?
Adds two new optional props to Card:

- overflowX — controls horizontal overflow behavior ('clip', 'hidden', 'scroll')
- overflowY — controls vertical overflow behavior (same options)

Both props default to 'clip' to preserve existing visual behavior.
The props are forwarded to the underlying <Box> component.

No visual appearance changes unless you override overflow behavior. There are no screenshots since UI layout remains visually identical by default.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
