### PR TITLE
use the provided GITHUB_TOKEN instead of a provided one

### DIFF
--- a/.github/workflows/deploy-polaris.shopify.com.yml
+++ b/.github/workflows/deploy-polaris.shopify.com.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Trigger deploy polaris.shopify.com
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
-          github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: "shopify",

--- a/.github/workflows/deploy-polaris.shopify.com.yml
+++ b/.github/workflows/deploy-polaris.shopify.com.yml
@@ -6,6 +6,12 @@ on:
       - main
     paths:
       - 'polaris.shopify.com/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy from'
+        required: true
+        default: 'main'
 
 jobs:
   trigger-deploy:
@@ -21,5 +27,5 @@ jobs:
               owner: "shopify",
               repo: "polaris-site-prod-kit",
               workflow_id: "build-and-deploy.yml",
-              ref: "main",
+              ref: "{{ inputs.branch }}",
             });


### PR DESCRIPTION
Recently updating these shopify provided github tokens to GITHUB_TOKEN, which is provided by github in the run context of the job, has been needed to get old jobs running: I think a credential changed or expired at the org scope.

Unsure if this will fix the problem, but should give us next steps.

Also added a `workflow_dispatch` to this action with a configurable branch name, so we can test the deploy flow from PRs in the future, no more CI golf.